### PR TITLE
Rename, so Confluent client understands it ootb. Afaik, we don't (yet…

### DIFF
--- a/app/src/main/resources/META-INF/openapi.json
+++ b/app/src/main/resources/META-INF/openapi.json
@@ -1128,7 +1128,7 @@
                 "description": "All error responses, whether `4xx` or `5xx` will include one of these as the response\nbody.",
                 "type": "object",
                 "properties": {
-                    "code": {
+                    "error_code": {
                         "format": "int32",
                         "type": "integer"
                     },
@@ -1137,7 +1137,7 @@
                     }
                 },
                 "example": {
-                    "code": 12345,
+                    "error_code": 12345,
                     "message": "An error occurred somewhere."
                 }
             },

--- a/app/src/test/java/io/apicurio/registry/ArtifactsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/ArtifactsResourceTest.java
@@ -69,7 +69,7 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
                 .post("/artifacts")
             .then()
                 .statusCode(409)
-                .body("code", equalTo(409))
+                .body("error_code", equalTo(409))
                 .body("message", equalTo("An artifact with ID 'testCreateArtifact/EmptyAPI/2' already exists."));
 
         // Try to create an artifact with an invalid artifact type
@@ -120,7 +120,7 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
                 .get("/artifacts/{artifactId}")
             .then()
                 .statusCode(404)
-                .body("code", equalTo(404))
+                .body("error_code", equalTo(404))
                 .body("message", equalTo("No artifact with ID 'testGetArtifact/MissingAPI' was found."));
     }
 
@@ -199,7 +199,7 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
                 .get("/artifacts/{artifactId}")
             .then()
                 .statusCode(404)
-                .body("code", equalTo(404))
+                .body("error_code", equalTo(404))
                 .body("message", equalTo("No artifact with ID 'testDeleteArtifact/EmptyAPI' was found."));
     
         // Try to delete an artifact that doesn't exist.
@@ -483,7 +483,7 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
                 .post("/artifacts/{artifactId}/rules")
             .then()
                 .statusCode(409)
-                .body("code", equalTo(409))
+                .body("error_code", equalTo(409))
                 .body("message", equalTo("A rule named 'VALIDITY' already exists."));
         
         // Add another rule
@@ -561,7 +561,7 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
 //            .then()
 //                .statusCode(404)
 //                .contentType(ContentType.JSON)
-//                .body("code", equalTo(404))
+//                .body("error_code", equalTo(404))
 //                .body("message", equalTo("No rule named 'RuleDoesNotExist' was found."));
 
         // Delete a rule
@@ -581,7 +581,7 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
             .then()
                 .statusCode(404)
                 .contentType(ContentType.JSON)
-                .body("code", equalTo(404))
+                .body("error_code", equalTo(404))
                 .body("message", equalTo("No rule named 'COMPATIBILITY' was found."));
 
         // Get the list of rules (should be 1 of them)
@@ -657,7 +657,7 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
                 .get("/artifacts/{artifactId}/meta")
             .then()
                 .statusCode(404)
-                .body("code", equalTo(404))
+                .body("error_code", equalTo(404))
                 .body("message", equalTo("No artifact with ID 'testGetArtifactMetaData/MissingAPI' was found."));
         
         // Update the artifact meta-data

--- a/app/src/test/java/io/apicurio/registry/FullApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/FullApiTest.java
@@ -69,7 +69,7 @@ public class FullApiTest extends AbstractResourceTestBase {
                 .post("/artifacts")
             .then()
                 .statusCode(400)
-                .body("code", equalTo(400))
+                .body("error_code", equalTo(400))
                 .body("message", equalTo("Syntax violation for OpenAPI artifact."));
 
     }
@@ -104,7 +104,7 @@ public class FullApiTest extends AbstractResourceTestBase {
                 .post("/artifacts")
             .then()
                 .statusCode(400)
-                .body("code", equalTo(400))
+                .body("error_code", equalTo(400))
                 .body("message", equalTo("Syntax violation for Protobuf artifact."));
 
     }

--- a/app/src/test/java/io/apicurio/registry/RulesResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/RulesResourceTest.java
@@ -61,7 +61,7 @@ public class RulesResourceTest extends AbstractResourceTestBase {
             .when().contentType(CT_JSON).body(rule).post("/rules")
             .then()
             .statusCode(409)
-            .body("code", equalTo(409))
+            .body("error_code", equalTo(409))
             .body("message", equalTo("A rule named 'VALIDITY' already exists."));
         
         // Add another global rule
@@ -120,7 +120,7 @@ public class RulesResourceTest extends AbstractResourceTestBase {
 //            .then()
 //            .statusCode(404)
 //            .contentType(ContentType.JSON)
-//            .body("code", equalTo(404))
+//            .body("error_code", equalTo(404))
 //            .body("message", equalTo("No rule named 'RuleDoesNotExist' was found."));
 
         // Delete a rule
@@ -136,7 +136,7 @@ public class RulesResourceTest extends AbstractResourceTestBase {
             .then()
             .statusCode(404)
             .contentType(ContentType.JSON)
-            .body("code", equalTo(404))
+            .body("error_code", equalTo(404))
             .body("message", equalTo("No rule named 'COMPATIBILITY' was found."));
 
         // Get the list of rules (should be 1 of them)

--- a/common/src/main/java/io/apicurio/registry/rest/beans/Error.java
+++ b/common/src/main/java/io/apicurio/registry/rest/beans/Error.java
@@ -15,22 +15,22 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "code",
+    "error_code",
     "message"
 })
 public class Error {
 
-    @JsonProperty("code")
+    @JsonProperty("error_code")
     private Integer code;
     @JsonProperty("message")
     private String message;
 
-    @JsonProperty("code")
+    @JsonProperty("error_code")
     public Integer getCode() {
         return code;
     }
 
-    @JsonProperty("code")
+    @JsonProperty("error_code")
     public void setCode(Integer code) {
         this.code = code;
     }

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -1299,7 +1299,7 @@
                 "description": "All error responses, whether `4xx` or `5xx` will include one of these as the response\nbody.",
                 "type": "object",
                 "properties": {
-                    "code": {
+                    "error_code": {
                         "format": "int32",
                         "type": "integer"
                     },
@@ -1308,7 +1308,7 @@
                     }
                 },
                 "example": {
-                    "code": 12345,
+                    "error_code": 12345,
                     "message": "An error occurred somewhere."
                 }
             },


### PR DESCRIPTION
…) rely on the "code".