### PR TITLE
[MO] - [template] -> exposing cluster

### DIFF
--- a/distro/openshift-template/apicurio-registry-template-kafka.yml
+++ b/distro/openshift-template/apicurio-registry-template-kafka.yml
@@ -31,14 +31,15 @@ objects:
       template: apicurio-registry-kafka
     name: apicurio-registry-kafka
   spec:
+    selector:
+      app: apicurio-registry-kafka
     ports:
     - port: 8080
       protocol: TCP
       targetPort: 8080
-    selector:
-      app: apicurio-registry-kafka
+      nodePort: 32222
+    type: NodePort
     sessionAffinity: None
-    type: ClusterIP
   status:
     loadBalancer: {}
 # Registry Deployment Configuration

--- a/tests/src/main/java/io/apicurio/tests/RegistryFacade.java
+++ b/tests/src/main/java/io/apicurio/tests/RegistryFacade.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Future;
 public class RegistryFacade {
     static final Logger LOGGER = LoggerFactory.getLogger(RegistryFacade.class);
 
-    public static final String DEFAULT_REGISTRY_JAR_PATH = "../app/target/apicurio-registry-app-1.0.2-SNAPSHOT-runner.jar";
+    public static final String DEFAULT_REGISTRY_JAR_PATH = "../app/target/apicurio-registry-app-1.0.5-SNAPSHOT-runner.jar";
     public static final String DEFAULT_REGISTRY_PORT = "8080";
     public static final String DEFAULT_REGISTRY_URL = "localhost";
 


### PR DESCRIPTION
#### Type of change
- apicurio-registry-template-kafka.yml exposing port of registries

#### Description
- This PR adding external listener to be able communicate with registries outside of the cluster.