### PR TITLE
updates the proto serdes impl so it stores the protobuf schemas in proto encoding in the registry.

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/MetaDataKeys.java
+++ b/app/src/main/java/io/apicurio/registry/storage/MetaDataKeys.java
@@ -18,6 +18,7 @@ package io.apicurio.registry.storage;
 
 import io.apicurio.registry.types.ArtifactType;
 
+import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 
@@ -82,7 +83,11 @@ public class MetaDataKeys {
         return dto;
     }
 
-    public static String toContent(Map<String, String> cMap) {
-        return cMap.get(CONTENT);
+    public static byte[] toContent(Map<String, String> cMap) {
+        String encoded = cMap.get(CONTENT);
+        if (encoded == null) {
+            return null;
+        }
+        return Base64.getDecoder().decode(encoded);
     }
 }

--- a/app/src/test/java/io/apicurio/registry/RegistrySerdeTest.java
+++ b/app/src/test/java/io/apicurio/registry/RegistrySerdeTest.java
@@ -184,7 +184,6 @@ public class RegistrySerdeTest extends AbstractResourceTestBase {
     }
 
     @Test
-    @Disabled("proto is not really schema registry friendly ...")
     public void testProto() throws Exception {
         try (RegistryService service = RegistryClient.create("http://localhost:8081")) {
             try (Serializer<TestCmmn.UUID> serializer = new ProtobufKafkaSerializer<TestCmmn.UUID>(service).setGlobalIdStrategy(new AutoRegisterIdStrategy<>());

--- a/app/src/test/java/io/apicurio/registry/RegistrySerdeTest.java
+++ b/app/src/test/java/io/apicurio/registry/RegistrySerdeTest.java
@@ -194,15 +194,15 @@ public class RegistrySerdeTest extends AbstractResourceTestBase {
 
                 byte[] bytes = serializer.serialize("foo", record);
                 DynamicMessage dm = deserializer.deserialize("foo", bytes);
-                Descriptors.Descriptor descriptor = TestCmmn.UUID.getDescriptor();
+                Descriptors.Descriptor descriptor = dm.getDescriptorForType();
 
                 Descriptors.FieldDescriptor lsb = descriptor.findFieldByName("lsb");
                 Assertions.assertNotNull(lsb);
-                Assertions.assertEquals(2, dm.getField(lsb));
+                Assertions.assertEquals(2L, dm.getField(lsb));
 
                 Descriptors.FieldDescriptor msb = descriptor.findFieldByName("msb");
                 Assertions.assertNotNull(msb);
-                Assertions.assertEquals(1, dm.getField(msb));
+                Assertions.assertEquals(1L, dm.getField(msb));
             }
 
         }

--- a/utils/serde/pom.xml
+++ b/utils/serde/pom.xml
@@ -38,4 +38,37 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${os-maven-plugin.version}</version>
+            </extension>
+        </extensions>
+
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>${proto-plugin.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <!--<goal>test-compile</goal>-->
+                        </goals>
+                        <configuration>
+                            <protocArtifact>
+                                com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
+                            </protocArtifact>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/ProtobufKafkaDeserializer.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/ProtobufKafkaDeserializer.java
@@ -16,14 +16,18 @@
 
 package io.apicurio.registry.utils.serde;
 
-import com.google.protobuf.DescriptorProtos;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+
+import javax.ws.rs.core.Response;
+
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
-import com.google.protobuf.InvalidProtocolBufferException;
-import io.apicurio.registry.client.RegistryService;
 
-import java.nio.ByteBuffer;
-import javax.ws.rs.core.Response;
+import io.apicurio.registry.client.RegistryService;
+import io.apicurio.registry.utils.serde.proto.Serde;
 
 /**
  * @author Ales Justin
@@ -46,13 +50,31 @@ public class ProtobufKafkaDeserializer extends AbstractKafkaDeserializer<byte[],
     @Override
     protected DynamicMessage readData(byte[] schema, ByteBuffer buffer, int start, int length) {
         try {
-            DescriptorProtos.DescriptorProto proto = DescriptorProtos.DescriptorProto.parseFrom(schema);
-            Descriptors.Descriptor descriptor = proto.getDescriptorForType(); // TODO -- wrong descriptor!
+
+            Serde.Schema s = Serde.Schema.parseFrom(schema);
+            Descriptors.FileDescriptor fileDescriptor = toFileDescriptor(s);
+
             byte[] bytes = new byte[length];
             System.arraycopy(buffer.array(), start, bytes, 0, length);
-            return DynamicMessage.parseFrom(descriptor, bytes);
-        } catch (InvalidProtocolBufferException e) {
+            ByteArrayInputStream is = new ByteArrayInputStream(bytes);
+
+            Serde.Ref ref = Serde.Ref.parseDelimitedFrom(is);
+
+            Descriptors.Descriptor descriptor = fileDescriptor.findMessageTypeByName(ref.getName());
+            return DynamicMessage.parseFrom(descriptor, is);
+
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        } catch (Descriptors.DescriptorValidationException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    private Descriptors.FileDescriptor toFileDescriptor(Serde.Schema s) throws Descriptors.DescriptorValidationException {
+        ArrayList<Descriptors.FileDescriptor> imports = new ArrayList<>();
+        for (Serde.Schema i : s.getImportList()) {
+            imports.add(toFileDescriptor(i));
+        }
+        return Descriptors.FileDescriptor.buildFrom(s.getFile(), imports.toArray(new Descriptors.FileDescriptor[0]));
     }
 }

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/ProtobufKafkaSerializer.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/ProtobufKafkaSerializer.java
@@ -16,21 +16,23 @@
 
 package io.apicurio.registry.utils.serde;
 
-import com.google.protobuf.DescriptorProtos;
-import com.google.protobuf.Descriptors;
-import com.google.protobuf.Message;
-import io.apicurio.registry.client.RegistryService;
-import io.apicurio.registry.types.ArtifactType;
-import io.apicurio.registry.utils.serde.strategy.ArtifactIdStrategy;
-import io.apicurio.registry.utils.serde.strategy.GlobalIdStrategy;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+
+import io.apicurio.registry.client.RegistryService;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.utils.serde.proto.Serde;
+import io.apicurio.registry.utils.serde.strategy.ArtifactIdStrategy;
+import io.apicurio.registry.utils.serde.strategy.GlobalIdStrategy;
+
 /**
  * @author Ales Justin
+ * @author Hiram Chirino
  */
 public class ProtobufKafkaSerializer<U extends Message> extends AbstractKafkaSerializer<byte[], U, ProtobufKafkaSerializer<U>> {
     public ProtobufKafkaSerializer() {
@@ -47,14 +49,26 @@ public class ProtobufKafkaSerializer<U extends Message> extends AbstractKafkaSer
     @Override
     protected byte[] toSchema(U data) {
         try {
+
+            Serde.Schema schema = toSchemaProto(data.getDescriptorForType().getFile());
+
+            // Convert to a byte[]
             ByteArrayOutputStream out = new ByteArrayOutputStream();
-            Descriptors.Descriptor descriptor = data.getDescriptorForType();
-            DescriptorProtos.DescriptorProto proto = descriptor.toProto();
-            proto.writeTo(out);
+            schema.writeTo(out);
             return out.toByteArray();
+
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private Serde.Schema toSchemaProto(Descriptors.FileDescriptor file) {
+        Serde.Schema.Builder b = Serde.Schema.newBuilder();
+        b.setFile(file.toProto());
+        for (Descriptors.FileDescriptor d : file.getDependencies()) {
+            b.addImport(toSchemaProto(d));
+        }
+        return b.build();
     }
 
     @Override
@@ -64,6 +78,10 @@ public class ProtobufKafkaSerializer<U extends Message> extends AbstractKafkaSer
 
     @Override
     protected void serializeData(byte[] schema, U data, OutputStream out) throws IOException {
+        Serde.Ref ref = Serde.Ref.newBuilder()
+                .setName(data.getDescriptorForType().getName())
+                .build();
+        ref.writeDelimitedTo(out);
         data.writeTo(out);
     }
 }

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/strategy/GlobalIdStrategy.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/strategy/GlobalIdStrategy.java
@@ -16,6 +16,8 @@
 
 package io.apicurio.registry.utils.serde.strategy;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.apicurio.registry.client.RegistryService;
 import io.apicurio.registry.types.ArtifactType;
 
@@ -50,6 +52,10 @@ public interface GlobalIdStrategy<T> {
      * @return schema's input stream
      */
     default InputStream toStream(T schema) {
-        return new ByteArrayInputStream(schema.toString().getBytes());
+        if (schema.getClass() == byte[].class) {
+            return new ByteArrayInputStream((byte[]) schema);
+        } else {
+            return new ByteArrayInputStream(schema.toString().getBytes(UTF_8));
+        }
     }
 }

--- a/utils/serde/src/main/proto/serde.proto
+++ b/utils/serde/src/main/proto/serde.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package io.apicurio.registry.utils.serde.proto;
+import "google/protobuf/descriptor.proto";
+option optimize_for = SPEED;
+option java_package = "io.apicurio.registry.utils.serde.proto";
+
+message Schema {
+    google.protobuf.FileDescriptorProto file = 1;
+    repeated Schema import = 2;
+}
+
+message Ref {
+    string name = 1;
+}


### PR DESCRIPTION
Not ideal since this proto encoding is not a human readable version of the proto schema.  Not sure there is an easy way to get the original 
proto schema given the proto buf java apis.