### PR TITLE
Get Meta-Data By Content now uses canonicalized content

### DIFF
--- a/app/src/main/java/io/apicurio/registry/content/ContentCanonicalizer.java
+++ b/app/src/main/java/io/apicurio/registry/content/ContentCanonicalizer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.content;
+
+/**
+ * Canonicalize some content!  This means converting content to its canonical form for
+ * the purpose of comparison.  Should remove things like formatting and should sort 
+ * fields when ordering is not important.
+ * 
+ * @author eric.wittmann@gmail.com
+ */
+public interface ContentCanonicalizer {
+    
+    /**
+     * Called to convert the given content to its canonical form.
+     * @param content
+     */
+    public ContentHandle canonicalize(ContentHandle content);
+
+}

--- a/app/src/main/java/io/apicurio/registry/content/ContentCanonicalizerFactory.java
+++ b/app/src/main/java/io/apicurio/registry/content/ContentCanonicalizerFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.content;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.apicurio.registry.content.canon.AvroContentCanonicalizer;
+import io.apicurio.registry.content.canon.JsonContentCanonicalizer;
+import io.apicurio.registry.content.canon.NoOpContentCanonicalizer;
+import io.apicurio.registry.types.ArtifactType;
+
+/**
+ * Factory for creating canonicalizers.
+ * @author eric.wittmann@gmail.com
+ */
+@ApplicationScoped
+public class ContentCanonicalizerFactory {
+
+    private ContentCanonicalizer avro = new AvroContentCanonicalizer();
+    private ContentCanonicalizer noop = new NoOpContentCanonicalizer();
+    private ContentCanonicalizer json = new JsonContentCanonicalizer();
+    
+    /**
+     * Creates a canonicalizer for a given artifact type.
+     * @param type
+     */
+    public ContentCanonicalizer create(ArtifactType type) {
+        switch (type) {
+            case ASYNCAPI:
+                return json;
+            case AVRO:
+                return avro;
+            case JSON:
+                return json;
+            case OPENAPI:
+                return json;
+            case PROTOBUF:
+                return noop;
+            case PROTOBUF_FD:
+                return noop;
+            default:
+                break;
+        }
+        throw new RuntimeException("No content canonicalizer found for: " + type);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/content/canon/AvroContentCanonicalizer.java
+++ b/app/src/main/java/io/apicurio/registry/content/canon/AvroContentCanonicalizer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.content.canon;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.avro.Schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.apicurio.registry.content.ContentCanonicalizer;
+import io.apicurio.registry.content.ContentHandle;
+
+/**
+ * An Avro implementation of a content Canonicalizer. This will use Jackson to remove any formatting that is
+ * not needed (i.e. whitespace). It will also order the list of fields, since that is not important.
+ * 
+ * @author eric.wittmann@gmail.com
+ */
+public class AvroContentCanonicalizer implements ContentCanonicalizer {
+
+    private final ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+
+    private final Comparator<JsonNode> fieldComparator = (n1, n2) -> {
+        String name1 = n1.get("name").textValue();
+        String name2 = n2.get("name").textValue();
+        return name1.compareTo(name2);
+    };
+
+    /**
+     * @see io.apicurio.registry.content.ContentCanonicalizer#canonicalize(io.apicurio.registry.content.ContentHandle)
+     */
+    @Override
+    public ContentHandle canonicalize(ContentHandle content) {
+        try {
+            JsonNode root = mapper.readTree(content.content());
+
+            // reorder "fields" property
+            JsonNode fieldsNode = root.get("fields");
+            if (fieldsNode != null) {
+                Set<JsonNode> fields = new TreeSet<>(fieldComparator);
+                Iterator<JsonNode> elements = fieldsNode.elements();
+                while (elements.hasNext()) {
+                    fields.add(elements.next());
+                }
+                ArrayNode array = new ArrayNode(mapper.getNodeFactory());
+                fields.forEach(array::add);
+                ObjectNode.class.cast(root).replace("fields", array);
+            }
+
+            String converted = mapper.writeValueAsString(mapper.treeToValue(root, Object.class));
+            return ContentHandle.create(converted);
+        } catch (Throwable t) {
+            // best effort
+            return ContentHandle.create(new Schema.Parser().parse(content.content()).toString());
+        }
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/content/canon/JsonContentCanonicalizer.java
+++ b/app/src/main/java/io/apicurio/registry/content/canon/JsonContentCanonicalizer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.content.canon;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.apicurio.registry.content.ContentCanonicalizer;
+import io.apicurio.registry.content.ContentHandle;
+
+/**
+ * A common JSON content canonicalizer.  This will remove any extra formatting such as whitespace
+ * and also sort all fields/properties for all objects (because ordering of properties does not
+ * matter in JSON).
+ * 
+ * @author eric.wittmann@gmail.com
+ */
+public class JsonContentCanonicalizer implements ContentCanonicalizer {
+
+    private final ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+
+    /**
+     * @see io.apicurio.registry.content.ContentCanonicalizer#canonicalize(io.apicurio.registry.content.ContentHandle)
+     */
+    @Override
+    public ContentHandle canonicalize(ContentHandle content) {
+        try {
+            JsonNode root = readAsJsonNode(content);
+            processJsonNode(root);
+            String converted = mapper.writeValueAsString(mapper.treeToValue(root, Object.class));
+            return ContentHandle.create(converted);
+        } catch (Throwable t) {
+            return content;
+        }
+    }
+
+    /**
+     * Perform any additional processing on the JSON node.  The base JSON canonicalizer 
+     * does nothing extra.
+     * @param node
+     */
+    protected void processJsonNode(JsonNode node) {
+    }
+
+    /**
+     * @param content
+     * @return
+     * @throws IOException
+     */
+    private JsonNode readAsJsonNode(ContentHandle content) throws IOException {
+        return mapper.readTree(content.content());
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/content/canon/NoOpContentCanonicalizer.java
+++ b/app/src/main/java/io/apicurio/registry/content/canon/NoOpContentCanonicalizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.content.canon;
+
+import io.apicurio.registry.content.ContentCanonicalizer;
+import io.apicurio.registry.content.ContentHandle;
+
+/**
+ * A canonicalizer that passes through the content unchanged.
+ * @author eric.wittmann@gmail.com
+ */
+public class NoOpContentCanonicalizer implements ContentCanonicalizer {
+    
+    /**
+     * @see io.apicurio.registry.content.ContentCanonicalizer#canonicalize(io.apicurio.registry.content.ContentHandle)
+     */
+    @Override
+    public ContentHandle canonicalize(ContentHandle content) {
+        return content;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/metrics/PersistenceExceptionLivenessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/PersistenceExceptionLivenessCheck.java
@@ -27,7 +27,7 @@ public class PersistenceExceptionLivenessCheck extends AbstractErrorCounterHealt
      * before the liveness check fails.
      */
     @ConfigProperty(name = "registry.metrics.PersistenceExceptionLivenessCheck.errorThreshold", defaultValue = "1")
-    private Integer configErrorThreshold;
+    Integer configErrorThreshold;
 
     /**
      * The counter is reset after some time without errors.
@@ -36,13 +36,13 @@ public class PersistenceExceptionLivenessCheck extends AbstractErrorCounterHealt
      * TODO report the absolute count as a metric?
      */
     @ConfigProperty(name = "registry.metrics.PersistenceExceptionLivenessCheck.counterResetWindowDurationSec", defaultValue = "60")
-    private Integer configCounterResetWindowDurationSec;
+    Integer configCounterResetWindowDurationSec;
 
     /**
      * If set to a positive value, reset the liveness status after this time window passes without any further errors.
      */
     @ConfigProperty(name = "registry.metrics.PersistenceExceptionLivenessCheck.statusResetWindowDurationSec", defaultValue = "300")
-    private Integer configStatusResetWindowDurationSec;
+    Integer configStatusResetWindowDurationSec;
 
     @PostConstruct
     void init() {

--- a/app/src/main/java/io/apicurio/registry/metrics/PersistenceTimeoutReadinessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/PersistenceTimeoutReadinessCheck.java
@@ -28,7 +28,7 @@ public class PersistenceTimeoutReadinessCheck extends AbstractErrorCounterHealth
      * before the readiness check fails.
      */
     @ConfigProperty(name = "registry.metrics.PersistenceTimeoutReadinessCheck.errorThreshold", defaultValue = "1")
-    private Integer configErrorThreshold;
+    Integer configErrorThreshold;
 
     /**
      * The counter is reset after some time without errors.
@@ -37,19 +37,19 @@ public class PersistenceTimeoutReadinessCheck extends AbstractErrorCounterHealth
      * TODO report the absolute count as a metric?
      */
     @ConfigProperty(name = "registry.metrics.PersistenceTimeoutReadinessCheck.counterResetWindowDurationSec", defaultValue = "60")
-    private Integer configCounterResetWindowDurationSec;
+    Integer configCounterResetWindowDurationSec;
 
     /**
      * If set to a positive value, reset the readiness status after this time window passes without any further errors.
      */
     @ConfigProperty(name = "registry.metrics.PersistenceTimeoutReadinessCheck.statusResetWindowDurationSec", defaultValue = "300")
-    private Integer configStatusResetWindowDurationSec;
+    Integer configStatusResetWindowDurationSec;
 
     /**
      * Set the operation duration in seconds, after which it's considered an error.
      */
     @ConfigProperty(name = "registry.metrics.PersistenceTimeoutReadinessCheck.timeoutSec", defaultValue = "5")
-    private Integer configTimeoutSec;
+    Integer configTimeoutSec;
 
     private Duration timeoutSec;
 

--- a/app/src/main/java/io/apicurio/registry/metrics/ResponseErrorLivenessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/ResponseErrorLivenessCheck.java
@@ -25,7 +25,7 @@ public class ResponseErrorLivenessCheck extends AbstractErrorCounterHealthCheck 
      * before the liveness check fails.
      */
     @ConfigProperty(name = "registry.metrics.ResponseErrorLivenessCheck.errorThreshold", defaultValue = "1")
-    private Integer configErrorThreshold;
+    Integer configErrorThreshold;
 
     /**
      * The counter is reset after some time without errors.
@@ -34,13 +34,13 @@ public class ResponseErrorLivenessCheck extends AbstractErrorCounterHealthCheck 
      * TODO report the absolute count as a metric?
      */
     @ConfigProperty(name = "registry.metrics.ResponseErrorLivenessCheck.counterResetWindowDurationSec", defaultValue = "60")
-    private Integer configCounterResetWindowDurationSec;
+    Integer configCounterResetWindowDurationSec;
 
     /**
      * If set to a positive value, reset the liveness status after this time window passes without any further errors.
      */
     @ConfigProperty(name = "registry.metrics.ResponseErrorLivenessCheck.statusResetWindowDurationSec", defaultValue = "300")
-    private Integer configStatusResetWindowDurationSec;
+    Integer configStatusResetWindowDurationSec;
 
     @PostConstruct
     void init() {

--- a/app/src/main/java/io/apicurio/registry/metrics/ResponseTimeoutReadinessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/ResponseTimeoutReadinessCheck.java
@@ -39,7 +39,7 @@ public class ResponseTimeoutReadinessCheck extends AbstractErrorCounterHealthChe
      * before the readiness check fails.
      */
     @ConfigProperty(name = "registry.metrics.ResponseTimeoutReadinessCheck.errorThreshold", defaultValue = "1")
-    private Integer configErrorThreshold;
+    Integer configErrorThreshold;
 
     /**
      * The counter is reset after some time without errors.
@@ -48,20 +48,20 @@ public class ResponseTimeoutReadinessCheck extends AbstractErrorCounterHealthChe
      * TODO report the absolute count as a metric?
      */
     @ConfigProperty(name = "registry.metrics.ResponseTimeoutReadinessCheck.counterResetWindowDurationSec", defaultValue = "60")
-    private Integer configCounterResetWindowDurationSec;
+    Integer configCounterResetWindowDurationSec;
 
     /**
      * If set to a positive value, reset the readiness status after this time window passes without any further errors.
      */
     @ConfigProperty(name = "registry.metrics.ResponseTimeoutReadinessCheck.statusResetWindowDurationSec", defaultValue = "300")
-    private Integer configStatusResetWindowDurationSec;
+    Integer configStatusResetWindowDurationSec;
 
     /**
      * Set the request duration in seconds, after which it's considered an error.
      * TODO This may be expected on some endpoints. Add a way to ignore those.
      */
     @ConfigProperty(name = "registry.metrics.ResponseTimeoutReadinessCheck.timeoutSec", defaultValue = "10")
-    private Integer configTimeoutSec;
+    Integer configTimeoutSec;
 
     private Duration timeoutSec;
 

--- a/app/src/test/java/io/apicurio/registry/content/ContentCanonicalizerFactoryTest.java
+++ b/app/src/test/java/io/apicurio/registry/content/ContentCanonicalizerFactoryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.content;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.types.ArtifactType;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+class ContentCanonicalizerFactoryTest {
+
+    /**
+     * Test method for {@link io.apicurio.registry.content.ContentCanonicalizerFactory#create(io.apicurio.registry.types.ArtifactType)}.
+     */
+    @Test
+    void testOpenAPI() {
+        ContentCanonicalizerFactory factory = new ContentCanonicalizerFactory();
+        ContentCanonicalizer canonicalizer = factory.create(ArtifactType.OPENAPI);
+        
+        String before = "{\r\n" + 
+                "    \"openapi\": \"3.0.2\",\r\n" + 
+                "    \"info\": {\r\n" + 
+                "        \"title\": \"Empty 3.0 API\",\r\n" + 
+                "        \"version\": \"1.0.0\"\r\n" + 
+                "    },\r\n" + 
+                "    \"paths\": {\r\n" + 
+                "        \"/\": {}\r\n" + 
+                "    },\r\n" + 
+                "    \"components\": {}\r\n" + 
+                "}";
+        String expected = "{\"components\":{},\"info\":{\"title\":\"Empty 3.0 API\",\"version\":\"1.0.0\"},\"openapi\":\"3.0.2\",\"paths\":{\"/\":{}}}";
+        
+        ContentHandle content = ContentHandle.create(before);
+        String actual = canonicalizer.canonicalize(content).content();
+        Assertions.assertEquals(expected, actual);
+    }
+
+    /**
+     * Test method for {@link io.apicurio.registry.content.ContentCanonicalizerFactory#create(io.apicurio.registry.types.ArtifactType)}.
+     */
+    @Test
+    void testAvro() {
+        ContentCanonicalizerFactory factory = new ContentCanonicalizerFactory();
+        ContentCanonicalizer canonicalizer = factory.create(ArtifactType.AVRO);
+        
+        String before = "{\r\n" + 
+                "     \"type\": \"record\",\r\n" + 
+                "     \"namespace\": \"com.example\",\r\n" + 
+                "     \"name\": \"FullName\",\r\n" + 
+                "     \"fields\": [\r\n" + 
+                "       { \"name\": \"first\", \"type\": \"string\" },\r\n" + 
+                "       { \"name\": \"middle\", \"type\": \"string\" },\r\n" + 
+                "       { \"name\": \"last\", \"type\": \"string\" }\r\n" + 
+                "     ]\r\n" + 
+                "} ";
+        String expected = "{\"fields\":[{\"name\":\"first\",\"type\":\"string\"},{\"name\":\"last\",\"type\":\"string\"},{\"name\":\"middle\",\"type\":\"string\"}],\"name\":\"FullName\",\"namespace\":\"com.example\",\"type\":\"record\"}";
+        
+        ContentHandle content = ContentHandle.create(before);
+        String actual = canonicalizer.canonicalize(content).content();
+        Assertions.assertEquals(expected, actual);
+    }
+
+    /**
+     * Test method for {@link io.apicurio.registry.content.ContentCanonicalizerFactory#create(io.apicurio.registry.types.ArtifactType)}.
+     */
+    @Test
+    void testProtobuf() {
+        ContentCanonicalizerFactory factory = new ContentCanonicalizerFactory();
+        ContentCanonicalizer canonicalizer = factory.create(ArtifactType.PROTOBUF);
+        
+        String before = "message SearchRequest {\r\n" + 
+                "  required string query = 1;\r\n" + 
+                "  optional int32 page_number = 2;\r\n" + 
+                "  optional int32 result_per_page = 3;\r\n" + 
+                "}";
+        String expected = before;
+        
+        ContentHandle content = ContentHandle.create(before);
+        String actual = canonicalizer.canonicalize(content).content();
+        Assertions.assertEquals(expected, actual);
+    }
+
+}

--- a/app/src/test/resources/application.properties
+++ b/app/src/test/resources/application.properties
@@ -10,9 +10,9 @@ quarkus.datasource.max-size=12
 quarkus.datasource.url=jdbc:h2:tcp://localhost:9123/mem:registry;DB_CLOSE_DELAY=-1;IFEXISTS=FALSE;
 
 quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.log.sql=false
 quarkus.hibernate-orm.log.jdbc-warnings=true
-quarkus.hibernate-orm.statistics=true
+quarkus.hibernate-orm.statistics=false
 
 h2.jar.file.path=${project.parent.basedir}/storage/jpa/target/h2.jar
 h2.port=9123

--- a/common/src/main/java/io/apicurio/registry/rest/ArtifactsResource.java
+++ b/common/src/main/java/io/apicurio/registry/rest/ArtifactsResource.java
@@ -71,8 +71,7 @@ public interface ArtifactsResource {
   @POST
   @Produces("application/json")
   @Consumes({"application/json", "application/x-protobuf", "application/x-protobuffer"})
-  ArtifactMetaData getArtifactMetaDataByContent(@PathParam("artifactId") String artifactId,
-      InputStream data);
+  ArtifactMetaData getArtifactMetaDataByContent(@PathParam("artifactId") String artifactId, InputStream data);
 
   /**
    * Returns information about a single rule configured for an artifact.  This is useful

--- a/storage/jpa/src/main/java/io/apicurio/registry/storage/impl/jpa/JPARegistryStorage.java
+++ b/storage/jpa/src/main/java/io/apicurio/registry/storage/impl/jpa/JPARegistryStorage.java
@@ -352,7 +352,6 @@ public class JPARegistryStorage implements RegistryStorage {
      */
     @Override
     public ArtifactMetaDataDto getArtifactMetaData(String artifactId, ContentHandle content) throws ArtifactNotFoundException, RegistryStorageException {
-        System.out.println("========== getArtifactMetaData -- " + artifactId);
         try {
             requireNonNull(artifactId);
             
@@ -389,7 +388,6 @@ public class JPARegistryStorage implements RegistryStorage {
                 .update(artifact)
                 .toArtifactMetaDataDto();
         } catch (Exception e) {
-            e.printStackTrace();
             throw new RegistryStorageException(e);
         }
     }

--- a/storage/jpa/src/main/java/io/apicurio/registry/storage/impl/jpa/JPARegistryStorage.java
+++ b/storage/jpa/src/main/java/io/apicurio/registry/storage/impl/jpa/JPARegistryStorage.java
@@ -16,6 +16,8 @@
 
 package io.apicurio.registry.storage.impl.jpa;
 
+import io.apicurio.registry.content.ContentCanonicalizer;
+import io.apicurio.registry.content.ContentCanonicalizerFactory;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.metrics.PersistenceExceptionLivenessApply;
 import io.apicurio.registry.metrics.PersistenceTimeoutReadinessApply;
@@ -63,6 +65,9 @@ import javax.transaction.Transactional;
 public class JPARegistryStorage implements RegistryStorage {
 
 //    private static Logger log = LoggerFactory.getLogger(JPARegistryStorage.class);
+    
+    @Inject
+    ContentCanonicalizerFactory ccFactory;
 
     @Inject
     EntityManager entityManager;
@@ -140,23 +145,6 @@ public class JPARegistryStorage implements RegistryStorage {
         } catch (NoResultException ex) {
             throw new ArtifactNotFoundException(artifactId, ex);
         }
-    }
-
-    private Artifact _getArtifact(String artifactId, byte[] content) {
-        requireNonNull(artifactId);
-        requireNonNull(content);
-        List<Artifact> list = entityManager.createQuery(
-            "SELECT a FROM Artifact a " +
-            "WHERE a.artifactId = :artifact_id " +
-            "ORDER BY a.version DESC ", Artifact.class)
-                                           .setParameter("artifact_id", artifactId)
-                                           .getResultList();
-        for (Artifact artifact : list) {
-            if (Arrays.equals(content, artifact.getContent())) {
-                return artifact;
-            }
-        }
-        throw new ArtifactNotFoundException(artifactId);
     }
 
     private boolean _artifactExists(String artifactId) {
@@ -359,18 +347,50 @@ public class JPARegistryStorage implements RegistryStorage {
         }
     }
 
+    /**
+     * @see io.apicurio.registry.storage.RegistryStorage#getArtifactMetaData(java.lang.String, io.apicurio.registry.content.ContentHandle)
+     */
     @Override
     public ArtifactMetaDataDto getArtifactMetaData(String artifactId, ContentHandle content) throws ArtifactNotFoundException, RegistryStorageException {
+        System.out.println("========== getArtifactMetaData -- " + artifactId);
         try {
             requireNonNull(artifactId);
+            
+            // Get the meta-data for the artifact
+            ArtifactMetaDataDto metaData = getArtifactMetaData(artifactId);
 
-            Artifact artifact = _getArtifact(artifactId, content.bytes());
+            // Create a canonicalizer for the artifact based on its type, and then 
+            // canonicalize the inbound content
+            ContentCanonicalizer canonicalizer = ccFactory.create(metaData.getType());
+            ContentHandle canonicalContent = canonicalizer.canonicalize(content);
+            byte[] canonicalBytes = canonicalContent.bytes();
+
+            Artifact artifact = null;
+            List<Artifact> list = entityManager.createQuery(
+                    "SELECT a FROM Artifact a " +
+                    "WHERE a.artifactId = :artifact_id " +
+                    "ORDER BY a.version DESC ", Artifact.class)
+               .setParameter("artifact_id", artifactId)
+               .getResultList();
+            for (Artifact candidateArtifact : list) {
+                ContentHandle candidateContent = ContentHandle.create(candidateArtifact.getContent());
+                ContentHandle canonicalCandidateContent = canonicalizer.canonicalize(candidateContent);
+                byte[] candidateBytes = canonicalCandidateContent.bytes();
+                if (Arrays.equals(canonicalBytes, candidateBytes)) {
+                    artifact = candidateArtifact;
+                }
+            }
+
+            if (artifact == null) {
+                throw new ArtifactNotFoundException(artifactId);
+            }
 
             return new MetaDataMapperUpdater(_getMetaData(artifactId, null))
                 .update(artifact)
                 .toArtifactMetaDataDto();
-        } catch (PersistenceException ex) {
-            throw new RegistryStorageException(ex);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RegistryStorageException(e);
         }
     }
 


### PR DESCRIPTION
This is a modified version of @alesj's implementation.  It does not store the canonical content.  Instead, it pushes the conversion of content from as-is to canonical format only when matching by content.  So the canonicalizer is only run when matching.  Original content is always stored.

A refinement is still probably required - to hash the canonical content and store the hash for fast initial comparison.  That is not yet done.