### PR TITLE
[WIP] Initial impl of "serde" for JSON Schema.  Fixes #180

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,9 @@
         
         <!-- GraphQL -->
         <graphql.version>14.0</graphql.version>
+        
+        <!-- JSON Schema Validator -->
+        <medeia-validator-jackson.version>1.1.0</medeia-validator-jackson.version>
 
 		<!-- Dependency versions -->
 		<lombok.version>1.18.10</lombok.version>
@@ -309,6 +312,13 @@
                 <groupId>com.graphql-java</groupId>
                 <artifactId>graphql-java</artifactId>
                 <version>${graphql.version}</version>
+            </dependency>
+            
+            <!-- JSON Schema Validator -->
+            <dependency>
+                <groupId>com.worldturner.medeia</groupId>
+                <artifactId>medeia-validator-jackson</artifactId>
+                <version>${medeia-validator-jackson.version}</version>
             </dependency>
 
 			<!-- Search -->

--- a/utils/serde/pom.xml
+++ b/utils/serde/pom.xml
@@ -37,5 +37,10 @@
             <artifactId>avro</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.worldturner.medeia</groupId>
+            <artifactId>medeia-validator-jackson</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/AbstractKafkaSerDe.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/AbstractKafkaSerDe.java
@@ -109,6 +109,9 @@ public abstract class AbstractKafkaSerDe<T extends AbstractKafkaSerDe<T>> implem
         }
         if (idHandler == null) {
             Object idh = configs.get(REGISTRY_ID_HANDLER_CONFIG_PARAM);
+            if (idh == null) {
+                idh = DefaultIdHandler.class.getName();
+            }
             instantiate(IdHandler.class, idh, this::setIdHandler);
 
             if (Utils.isTrue(configs.get(REGISTRY_CONFLUENT_ID_HANDLER_CONFIG_PARAM))) {

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/JsonSchemaKafkaDeserializer.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/JsonSchemaKafkaDeserializer.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.serde;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.worldturner.medeia.api.StringSchemaSource;
+import com.worldturner.medeia.api.jackson.MedeiaJacksonApi;
+import com.worldturner.medeia.schema.validation.SchemaValidator;
+
+import io.apicurio.registry.client.RegistryService;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public class JsonSchemaKafkaDeserializer<T> extends AbstractKafkaSerDe<JsonSchemaKafkaDeserializer<T>> implements Deserializer<T> {
+
+    public static final String REGISTRY_JSON_SCHEMA_DESERIALIZER_VALIDATION_ENABLED = "apicurio.registry.serdes.json-schema.validation-enabled";
+
+    private static MedeiaJacksonApi api = new MedeiaJacksonApi();
+    private static ObjectMapper mapper = new ObjectMapper();
+    
+    private boolean validationEnabled = false;
+
+    /**
+     * Constructor.
+     */
+    public JsonSchemaKafkaDeserializer() {
+        this(null);
+    }
+
+    /**
+     * Constructor.
+     * @param client
+     */
+    public JsonSchemaKafkaDeserializer(RegistryService client) {
+        super(client);
+    }
+
+    /**
+     * @see org.apache.kafka.common.serialization.Deserializer#configure(java.util.Map, boolean)
+     */
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        super.configure(configs);
+
+        Object ve = configs.get(REGISTRY_JSON_SCHEMA_DESERIALIZER_VALIDATION_ENABLED);
+        this.validationEnabled = ve != null && ("true".equals(ve) || ve.equals(Boolean.TRUE));
+    }
+    
+    /**
+     * @see org.apache.kafka.common.serialization.Deserializer#deserialize(java.lang.String, byte[])
+     */
+    @Override
+    public T deserialize(String topic, byte[] data) {
+        throw new UnsupportedOperationException();
+    }
+    
+    /**
+     * @see org.apache.kafka.common.serialization.Deserializer#deserialize(java.lang.String, org.apache.kafka.common.header.Headers, byte[])
+     */
+    @Override
+    public T deserialize(String topic, Headers headers, byte[] data) {
+        if (data == null) {
+            return null;
+        }
+        
+        try {
+            JsonParser parser = mapper.getFactory().createParser(data);
+            if (validationEnabled) {
+                String artifactId = getArtifactId(headers);
+                Integer version = getVersion(headers);
+                String schemaContent = loadSchema(artifactId, version);
+                // TODO cache the SchemaValidator instance - keyed on artifactId+version
+                SchemaValidator schema = api.loadSchema(new StringSchemaSource(schemaContent));
+                parser = api.decorateJsonParser(schema, parser);
+            }
+            
+            Class<T> messageType = getMessageType(headers);
+
+            return mapper.readValue(parser, messageType);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Gets the artifact id from the headers.  Throws if not found.
+     * @param headers
+     */
+    private String getArtifactId(Headers headers) {
+        Header header = headers.lastHeader(JsonSchemaSerDeConstants.HEADER_ARTIFACT_ID);
+        if (header == null) {
+            throw new RuntimeException("ArtifactId not found in headers.");
+        }
+        return new String(header.value(), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Gets the artifact version from the headers.  Returns null if not found.
+     * @param headers
+     */
+    private Integer getVersion(Headers headers) {
+        Header header = headers.lastHeader(JsonSchemaSerDeConstants.HEADER_VERSION);
+        if (header == null) {
+            return null;
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(4);
+        buffer.put(header.value());
+        return buffer.getInt();
+    }
+
+    /**
+     * Loads the schema from the registry.
+     * @param artifactId
+     * @param version
+     */
+    private String loadSchema(String artifactId, Integer version) {
+        String schema;
+        Response artifact;
+        
+        if (version == null) {
+            artifact = getClient().getLatestArtifact(artifactId);
+        } else {
+            artifact = getClient().getArtifactVersion(version, artifactId);
+        }
+        
+        if (artifact.getStatus() != 200) {
+            throw new RuntimeException("Failed to get schema from registry: [" + artifact.getStatus() + "] " + 
+                    artifact.getStatusInfo().getReasonPhrase());
+        }
+        
+        schema = artifact.readEntity(String.class);
+        return schema;
+    }
+
+    /**
+     * Gets the message type from the headers.  Throws if not found.
+     * @param headers
+     */
+    @SuppressWarnings("unchecked")
+    private Class<T> getMessageType(Headers headers) {
+        Header header = headers.lastHeader(JsonSchemaSerDeConstants.HEADER_MSG_TYPE);
+        if (header == null) {
+            throw new RuntimeException("Message Type not found in headers.");
+        }
+        String msgTypeName = new String(header.value(), StandardCharsets.UTF_8);
+        
+        try {
+            return (Class<T>) Thread.currentThread().getContextClassLoader().loadClass(msgTypeName);
+        } catch (ClassNotFoundException e) {}
+        try {
+            return (Class<T>) Class.forName(msgTypeName);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/JsonSchemaKafkaSerializer.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/JsonSchemaKafkaSerializer.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.serde;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.worldturner.medeia.api.StringSchemaSource;
+import com.worldturner.medeia.api.jackson.MedeiaJacksonApi;
+import com.worldturner.medeia.schema.validation.SchemaValidator;
+
+import io.apicurio.registry.client.RegistryService;
+
+/**
+ * An implementation of the Kafka Serializer for JSON Schema use-cases. This serializer assumes that the
+ * user's application needs to serialize a Java Bean to JSON data using Jackson. In addition to standard
+ * serialization of the bean, this implementation can also optionally validate it against a JSON schema.
+ * 
+ * @author eric.wittmann@gmail.com
+ */
+public class JsonSchemaKafkaSerializer<T> extends AbstractKafkaSerDe<JsonSchemaKafkaSerializer<T>> implements Serializer<T> {
+    
+    public static final String REGISTRY_JSON_SCHEMA_SERIALIZER_VALIDATION_ENABLED = "apicurio.registry.serdes.json-schema.validation-enabled";
+
+    private static MedeiaJacksonApi api = new MedeiaJacksonApi();
+    private static ObjectMapper mapper = new ObjectMapper();
+    
+    private boolean validationEnabled = false;
+
+    /**
+     * Constructor.
+     */
+    public JsonSchemaKafkaSerializer() {
+    }
+
+    /**
+     * Constructor.
+     * @param client
+     */
+    public JsonSchemaKafkaSerializer(RegistryService client) {
+        super(client);
+    }
+
+    /**
+     * @see org.apache.kafka.common.serialization.Serializer#configure(java.util.Map, boolean)
+     */
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        super.configure(configs);
+        
+        Object ve = configs.get(REGISTRY_JSON_SCHEMA_SERIALIZER_VALIDATION_ENABLED);
+        this.validationEnabled = ve != null && ("true".equals(ve) || ve.equals(Boolean.TRUE));
+    }
+    
+    /**
+     * @see org.apache.kafka.common.serialization.Serializer#serialize(java.lang.String, java.lang.Object)
+     */
+    @Override
+    public byte[] serialize(String topic, T data) {
+        // Headers are required when sending data using this serdes impl
+        throw new UnsupportedOperationException();
+    }
+    
+    /**
+     * @see org.apache.kafka.common.serialization.Serializer#serialize(java.lang.String, org.apache.kafka.common.header.Headers, java.lang.Object)
+     */
+    @Override
+    public byte[] serialize(String topic, Headers headers, T data) {
+        if (data == null) {
+            return new byte[0];
+        }
+
+        // Now serialize the data
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            JsonGenerator generator = mapper.getFactory().createGenerator(baos);
+            if (validationEnabled) {
+                String artifactId = getArtifactId(topic, data);
+                Integer version = getArtifactVersion(artifactId, topic, data);
+                addSchemaHeaders(headers, artifactId, version);
+
+                String schema = loadSchema(artifactId, version);
+                SchemaValidator schemaValidator = api.loadSchema(new StringSchemaSource(schema));
+                // TODO cache the SchemaValidator - keyed on artifactId+version
+                generator = api.decorateJsonGenerator(schemaValidator, generator);
+            }
+            addTypeHeaders(headers, data);
+
+            mapper.writeValue(generator, data);
+            
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new SerializationException(e);
+        }
+    }
+
+    /**
+     * Figure out the artifact ID from the topic name and data.
+     * @param topic
+     * @param data
+     */
+    private String getArtifactId(String topic, T data) {
+        // TODO support other options - other impls use a strategy for this
+        return topic;
+    }
+
+    /**
+     * Figure out which version of the artifact to use, specifically.  If this returns
+     * null then the latest version will be used.
+     * @param artifactId
+     * @param topic
+     * @param data
+     */
+    private Integer getArtifactVersion(String artifactId, String topic, T data) {
+        // TODO how can we know what artifact version we need?  passed in via config?
+        return null;
+    }
+
+    /**
+     * Adds appropriate information to the Headers so that the deserializer can function properly.
+     * @param headers
+     * @param artifactId
+     * @param version
+     */
+    private void addSchemaHeaders(Headers headers, String artifactId, Integer version) {
+        headers.add(JsonSchemaSerDeConstants.HEADER_ARTIFACT_ID, artifactId.getBytes(StandardCharsets.UTF_8));
+        if (version != null) {
+            ByteBuffer buff = ByteBuffer.allocate(4);
+            buff.putInt(version.intValue());
+            headers.add(JsonSchemaSerDeConstants.HEADER_VERSION, buff.array());
+        }
+    }
+
+    /**
+     * Adds appropriate information to the Headers so that the deserializer can function properly.
+     * @param headers
+     * @param data
+     */
+    private void addTypeHeaders(Headers headers, T data) {
+        headers.add(JsonSchemaSerDeConstants.HEADER_MSG_TYPE, data.getClass().getName().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Gets the schema from the registry.
+     * @param artifactId
+     * @param version
+     */
+    private String loadSchema(String artifactId, Integer version) {
+        String schema;
+        Response artifact;
+        
+        if (version == null) {
+            artifact = getClient().getLatestArtifact(artifactId);
+        } else {
+            artifact = getClient().getArtifactVersion(version, artifactId);
+        }
+        
+        if (artifact.getStatus() != 200) {
+            throw new RuntimeException("Failed to get schema from registry: [" + artifact.getStatus() + "] " + 
+                    artifact.getStatusInfo().getReasonPhrase());
+        }
+        
+        schema = artifact.readEntity(String.class);
+        return schema;
+    }
+
+}

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/JsonSchemaSerDeConstants.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/JsonSchemaSerDeConstants.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.serde;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public final class JsonSchemaSerDeConstants {
+    
+    public static final String HEADER_ARTIFACT_ID = "apicurio.artifactId";
+    public static final String HEADER_VERSION = "apicurio.version";
+    public static final String HEADER_MSG_TYPE = "apicurio.messageType";
+
+}

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/strategy/GlobalIdStrategy.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/strategy/GlobalIdStrategy.java
@@ -47,7 +47,7 @@ public interface GlobalIdStrategy<T> {
     /**
      * Create InputStream from schema.
      * By default we just take string bytes.
-     *
+     * 
      * @param schema the schema
      * @return schema's input stream
      */
@@ -55,6 +55,7 @@ public interface GlobalIdStrategy<T> {
         if (schema instanceof byte[]) {
             return new ByteArrayInputStream((byte[]) schema);
         } else {
+            // TODO Calling "toString()" here will work for Avro, but is unlikely to work for other schemas
             return new ByteArrayInputStream(schema.toString().getBytes(UTF_8));
         }
     }

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/strategy/SimpleTopicIdStrategy.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/strategy/SimpleTopicIdStrategy.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.serde.strategy;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public class SimpleTopicIdStrategy<T> implements ArtifactIdStrategy<T> {
+    @Override
+    public String artifactId(String topic, boolean isKey, T schema) {
+        return topic;
+    }
+}


### PR DESCRIPTION
This implementation optionally supports validation of the messages either when producing or when consuming.  Validation is the only thing the schema is used for.  Turning off validation will disable usage of the registry.