### PR TITLE
Renamed the confluent and ibm rest compatibility endpoints

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/CompatibilityResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/CompatibilityResource.java
@@ -40,7 +40,7 @@ import javax.ws.rs.container.Suspended;
 /**
  * @author Ales Justin
  */
-@Path("/confluent/compatibility")
+@Path("/ccompat/compatibility")
 @Consumes({RestConstants.JSON, RestConstants.SR})
 @Produces({RestConstants.JSON, RestConstants.SR})
 public class CompatibilityResource extends AbstractResource {

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/ConfigResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/ConfigResource.java
@@ -31,7 +31,7 @@ import javax.ws.rs.core.HttpHeaders;
 /**
  * @author Ales Justin
  */
-@Path("/confluent/config")
+@Path("/ccompat/config")
 @Consumes({RestConstants.JSON, RestConstants.SR})
 @Produces({RestConstants.JSON, RestConstants.SR})
 public class ConfigResource extends AbstractResource {

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/ModeResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/ModeResource.java
@@ -31,7 +31,7 @@ import javax.ws.rs.core.HttpHeaders;
 /**
  * @author Ales Justin
  */
-@Path("/confluent/mode")
+@Path("/ccompat/mode")
 @Consumes({RestConstants.JSON, RestConstants.SR})
 @Produces({RestConstants.JSON, RestConstants.SR})
 public class ModeResource extends AbstractResource {

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/SchemasResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/SchemasResource.java
@@ -27,7 +27,7 @@ import javax.ws.rs.Produces;
 /**
  * @author Ales Justin
  */
-@Path("/confluent/schemas")
+@Path("/ccompat/schemas")
 @Consumes({RestConstants.JSON, RestConstants.SR})
 @Produces({RestConstants.JSON, RestConstants.SR})
 public class SchemasResource extends AbstractResource {

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/SubjectVersionsResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/SubjectVersionsResource.java
@@ -38,7 +38,7 @@ import javax.ws.rs.core.HttpHeaders;
 /**
  * @author Ales Justin
  */
-@Path("/confluent/subjects/{subject}/versions")
+@Path("/ccompat/subjects/{subject}/versions")
 @Consumes({RestConstants.JSON, RestConstants.SR})
 @Produces({RestConstants.JSON, RestConstants.SR})
 public class SubjectVersionsResource extends AbstractResource {

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/SubjectsResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/SubjectsResource.java
@@ -36,7 +36,7 @@ import javax.ws.rs.core.HttpHeaders;
 /**
  * @author Ales Justin
  */
-@Path("/confluent/subjects")
+@Path("/ccompat/subjects")
 @Consumes({RestConstants.JSON, RestConstants.SR})
 @Produces({RestConstants.JSON, RestConstants.SR})
 public class SubjectsResource extends AbstractResource {

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/Api.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/Api.java
@@ -1,11 +1,11 @@
-package io.apicurio.registry.cibm.api;
+package io.apicurio.registry.ibmcompat.api;
 
-import io.apicurio.registry.cibm.model.AnyOfStateModificationEnabledModification;
-import io.apicurio.registry.cibm.model.NewSchema;
-import io.apicurio.registry.cibm.model.NewSchemaVersion;
-import io.apicurio.registry.cibm.model.Schema;
-import io.apicurio.registry.cibm.model.SchemaInfo;
-import io.apicurio.registry.cibm.model.SchemaListItem;
+import io.apicurio.registry.ibmcompat.model.AnyOfStateModificationEnabledModification;
+import io.apicurio.registry.ibmcompat.model.NewSchema;
+import io.apicurio.registry.ibmcompat.model.NewSchemaVersion;
+import io.apicurio.registry.ibmcompat.model.Schema;
+import io.apicurio.registry.ibmcompat.model.SchemaInfo;
+import io.apicurio.registry.ibmcompat.model.SchemaListItem;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
 
 import java.util.List;
@@ -29,7 +29,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
-@Path("/cibm")
+@Path("/ibmcompat")
 public class Api {
 
     @Inject

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/ApiService.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/ApiService.java
@@ -1,11 +1,11 @@
-package io.apicurio.registry.cibm.api;
+package io.apicurio.registry.ibmcompat.api;
 
-import io.apicurio.registry.cibm.model.AnyOfStateModificationEnabledModification;
-import io.apicurio.registry.cibm.model.NewSchema;
-import io.apicurio.registry.cibm.model.NewSchemaVersion;
-import io.apicurio.registry.cibm.model.Schema;
-import io.apicurio.registry.cibm.model.SchemaInfo;
-import io.apicurio.registry.cibm.model.SchemaListItem;
+import io.apicurio.registry.ibmcompat.model.AnyOfStateModificationEnabledModification;
+import io.apicurio.registry.ibmcompat.model.NewSchema;
+import io.apicurio.registry.ibmcompat.model.NewSchemaVersion;
+import io.apicurio.registry.ibmcompat.model.Schema;
+import io.apicurio.registry.ibmcompat.model.SchemaInfo;
+import io.apicurio.registry.ibmcompat.model.SchemaListItem;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
 
 import java.util.List;

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiServiceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiServiceImpl.java
@@ -1,13 +1,5 @@
-package io.apicurio.registry.cibm.api.impl;
+package io.apicurio.registry.ibmcompat.api.impl;
 
-import io.apicurio.registry.cibm.api.ApiService;
-import io.apicurio.registry.cibm.model.AnyOfStateModificationEnabledModification;
-import io.apicurio.registry.cibm.model.NewSchema;
-import io.apicurio.registry.cibm.model.NewSchemaVersion;
-import io.apicurio.registry.cibm.model.Schema;
-import io.apicurio.registry.cibm.model.SchemaInfo;
-import io.apicurio.registry.cibm.model.SchemaListItem;
-import io.apicurio.registry.cibm.model.SchemaVersion;
 import io.apicurio.registry.rules.RuleApplicationType;
 import io.apicurio.registry.rules.RulesService;
 import io.apicurio.registry.storage.ArtifactMetaDataDto;
@@ -16,6 +8,14 @@ import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.StoredArtifact;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.ibmcompat.api.ApiService;
+import io.apicurio.registry.ibmcompat.model.AnyOfStateModificationEnabledModification;
+import io.apicurio.registry.ibmcompat.model.NewSchema;
+import io.apicurio.registry.ibmcompat.model.NewSchemaVersion;
+import io.apicurio.registry.ibmcompat.model.Schema;
+import io.apicurio.registry.ibmcompat.model.SchemaInfo;
+import io.apicurio.registry.ibmcompat.model.SchemaListItem;
+import io.apicurio.registry.ibmcompat.model.SchemaVersion;
 import io.apicurio.registry.types.Current;
 import io.apicurio.registry.util.ArtifactIdGenerator;
 

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/AnyOfStateModificationEnabledModification.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/AnyOfStateModificationEnabledModification.java
@@ -1,4 +1,4 @@
-package io.apicurio.registry.cibm.model;
+package io.apicurio.registry.ibmcompat.model;
 
 /**
  * @author Ales Justin

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/EnabledModification.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/EnabledModification.java
@@ -1,4 +1,4 @@
-package io.apicurio.registry.cibm.model;
+package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/NewSchema.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/NewSchema.java
@@ -1,4 +1,4 @@
-package io.apicurio.registry.cibm.model;
+package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/NewSchemaVersion.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/NewSchemaVersion.java
@@ -1,4 +1,4 @@
-package io.apicurio.registry.cibm.model;
+package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/Schema.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/Schema.java
@@ -1,4 +1,4 @@
-package io.apicurio.registry.cibm.model;
+package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaInfo.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaInfo.java
@@ -1,18 +1,21 @@
-package io.apicurio.registry.cibm.model;
+package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
-public class SchemaSummary {
+public class SchemaInfo {
 
     private String id;
     private String name;
     private SchemaState state;
-    private boolean enabled;
+    private Boolean enabled;
+    private List<SchemaVersion> versions = new ArrayList<SchemaVersion>();
 
     /**
      * Lower-case URL-encoded version of the schema name.
@@ -63,12 +66,26 @@ public class SchemaSummary {
 
     @JsonProperty("enabled")
     @NotNull
-    public boolean isEnabled() {
+    public Boolean getEnabled() {
         return enabled;
     }
 
-    public void setEnabled(boolean enabled) {
+    public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
+    }
+
+    /**
+     *
+     **/
+
+    @JsonProperty("versions")
+    @NotNull
+    public List<SchemaVersion> getVersions() {
+        return versions;
+    }
+
+    public void setVersions(List<SchemaVersion> versions) {
+        this.versions = versions;
     }
 
 
@@ -80,27 +97,29 @@ public class SchemaSummary {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        SchemaSummary schemaSummary = (SchemaSummary) o;
-        return Objects.equals(id, schemaSummary.id) &&
-               Objects.equals(name, schemaSummary.name) &&
-               Objects.equals(state, schemaSummary.state) &&
-               Objects.equals(enabled, schemaSummary.enabled);
+        SchemaInfo schemaInfo = (SchemaInfo) o;
+        return Objects.equals(id, schemaInfo.id) &&
+               Objects.equals(name, schemaInfo.name) &&
+               Objects.equals(state, schemaInfo.state) &&
+               Objects.equals(enabled, schemaInfo.enabled) &&
+               Objects.equals(versions, schemaInfo.versions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, state, enabled);
+        return Objects.hash(id, name, state, enabled, versions);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("class SchemaSummary {\n");
+        sb.append("class SchemaInfo {\n");
 
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    state: ").append(toIndentedString(state)).append("\n");
         sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
+        sb.append("    versions: ").append(toIndentedString(versions)).append("\n");
         sb.append("}");
         return sb.toString();
     }
@@ -109,7 +128,7 @@ public class SchemaSummary {
      * Convert the given object to string with each line indented by 4 spaces
      * (except the first line).
      */
-    protected String toIndentedString(java.lang.Object o) {
+    private String toIndentedString(java.lang.Object o) {
         if (o == null) {
             return "null";
         }

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaListItem.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaListItem.java
@@ -1,4 +1,4 @@
-package io.apicurio.registry.cibm.model;
+package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaState.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaState.java
@@ -1,4 +1,4 @@
-package io.apicurio.registry.cibm.model;
+package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaSummary.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaSummary.java
@@ -1,21 +1,18 @@
-package io.apicurio.registry.cibm.model;
+package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
-public class SchemaInfo {
+public class SchemaSummary {
 
     private String id;
     private String name;
     private SchemaState state;
-    private Boolean enabled;
-    private List<SchemaVersion> versions = new ArrayList<SchemaVersion>();
+    private boolean enabled;
 
     /**
      * Lower-case URL-encoded version of the schema name.
@@ -66,26 +63,12 @@ public class SchemaInfo {
 
     @JsonProperty("enabled")
     @NotNull
-    public Boolean getEnabled() {
+    public boolean isEnabled() {
         return enabled;
     }
 
-    public void setEnabled(Boolean enabled) {
+    public void setEnabled(boolean enabled) {
         this.enabled = enabled;
-    }
-
-    /**
-     *
-     **/
-
-    @JsonProperty("versions")
-    @NotNull
-    public List<SchemaVersion> getVersions() {
-        return versions;
-    }
-
-    public void setVersions(List<SchemaVersion> versions) {
-        this.versions = versions;
     }
 
 
@@ -97,29 +80,27 @@ public class SchemaInfo {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        SchemaInfo schemaInfo = (SchemaInfo) o;
-        return Objects.equals(id, schemaInfo.id) &&
-               Objects.equals(name, schemaInfo.name) &&
-               Objects.equals(state, schemaInfo.state) &&
-               Objects.equals(enabled, schemaInfo.enabled) &&
-               Objects.equals(versions, schemaInfo.versions);
+        SchemaSummary schemaSummary = (SchemaSummary) o;
+        return Objects.equals(id, schemaSummary.id) &&
+               Objects.equals(name, schemaSummary.name) &&
+               Objects.equals(state, schemaSummary.state) &&
+               Objects.equals(enabled, schemaSummary.enabled);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, state, enabled, versions);
+        return Objects.hash(id, name, state, enabled);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("class SchemaInfo {\n");
+        sb.append("class SchemaSummary {\n");
 
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    state: ").append(toIndentedString(state)).append("\n");
         sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
-        sb.append("    versions: ").append(toIndentedString(versions)).append("\n");
         sb.append("}");
         return sb.toString();
     }
@@ -128,7 +109,7 @@ public class SchemaInfo {
      * Convert the given object to string with each line indented by 4 spaces
      * (except the first line).
      */
-    private String toIndentedString(java.lang.Object o) {
+    protected String toIndentedString(java.lang.Object o) {
         if (o == null) {
             return "null";
         }

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaVersion.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaVersion.java
@@ -1,4 +1,4 @@
-package io.apicurio.registry.cibm.model;
+package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/StateModification.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/StateModification.java
@@ -1,4 +1,4 @@
-package io.apicurio.registry.cibm.model;
+package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/app/src/test/java/io/apicurio/registry/ConfluentClientTest.java
+++ b/app/src/test/java/io/apicurio/registry/ConfluentClientTest.java
@@ -43,7 +43,7 @@ import java.util.function.Consumer;
 public class ConfluentClientTest extends AbstractResourceTestBase {
 
     private SchemaRegistryClient buildClient() {
-        return new CachedSchemaRegistryClient("http://localhost:8081/confluent", 3);
+        return new CachedSchemaRegistryClient("http://localhost:8081/ccompat", 3);
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/SerdeMixTest.java
+++ b/app/src/test/java/io/apicurio/registry/SerdeMixTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 public class SerdeMixTest extends AbstractResourceTestBase {
 
     private SchemaRegistryClient buildClient() {
-        return new CachedSchemaRegistryClient("http://localhost:8081/confluent", 3);
+        return new CachedSchemaRegistryClient("http://localhost:8081/ccompat", 3);
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/SubjectsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/SubjectsResourceTest.java
@@ -29,7 +29,7 @@ public class SubjectsResourceTest extends AbstractResourceTestBase {
     @Test    
     public void testListSubjectsEndpoint() {
         given()
-            .when().contentType(CT_JSON).get("/confluent/subjects")
+            .when().contentType(CT_JSON).get("/ccompat/subjects")
             .then()
             .statusCode(200)
             .body(anything());

--- a/app/src/test/java/io/apicurio/registry/cluster/ClusterIT.java
+++ b/app/src/test/java/io/apicurio/registry/cluster/ClusterIT.java
@@ -71,8 +71,8 @@ public class ClusterIT {
         Properties properties = getClusterProperties();
         Assumptions.assumeTrue(properties != null);
 
-        SchemaRegistryClient client1 = new CachedSchemaRegistryClient("http://localhost:8080/confluent", 3);
-        SchemaRegistryClient client2 = new CachedSchemaRegistryClient("http://localhost:8081/confluent", 3);
+        SchemaRegistryClient client1 = new CachedSchemaRegistryClient("http://localhost:8080/ccompat", 3);
+        SchemaRegistryClient client2 = new CachedSchemaRegistryClient("http://localhost:8081/ccompat", 3);
 
         String subject = UUID.randomUUID().toString();
         Schema schema = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}");

--- a/app/src/test/java/io/apicurio/registry/ibmcompat/IBMClientTest.java
+++ b/app/src/test/java/io/apicurio/registry/ibmcompat/IBMClientTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.apicurio.registry.cibm;
+package io.apicurio.registry.ibmcompat;
 
 import io.apicurio.registry.AbstractResourceTestBase;
 import io.quarkus.test.junit.QuarkusTest;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 public class IBMClientTest extends AbstractResourceTestBase {
 
     private SchemaRegistryRestAPIClient buildClient() throws Exception {
-        return new SchemaRegistryRestAPIClient("http://localhost:8081/cibm", "<API_KEY>", true);
+        return new SchemaRegistryRestAPIClient("http://localhost:8081/ibmcompat", "<API_KEY>", true);
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/ibmcompat/SchemaRegistryRestAPIClient.java
+++ b/app/src/test/java/io/apicurio/registry/ibmcompat/SchemaRegistryRestAPIClient.java
@@ -3,7 +3,7 @@
  * (C) Copyright IBM Corp. 2019  All Rights Reserved.
  *
  */
-package io.apicurio.registry.cibm;
+package io.apicurio.registry.ibmcompat;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/tests/src/main/java/io/apicurio/tests/serdes/KafkaClients.java
+++ b/tests/src/main/java/io/apicurio/tests/serdes/KafkaClients.java
@@ -69,7 +69,7 @@ public class KafkaClients {
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer);
         // Schema Registry location.
         if (valueSerializer.contains("confluent")) {
-            props.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://" + RegistryFacade.REGISTRY_URL + ":" + RegistryFacade.REGISTRY_PORT + "/confluent");
+            props.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://" + RegistryFacade.REGISTRY_URL + ":" + RegistryFacade.REGISTRY_PORT + "/ccompat");
             props.put(KafkaAvroSerializerConfig.VALUE_SUBJECT_NAME_STRATEGY, artifactIdStrategy);
         } else {
             props.put(AbstractKafkaSerDe.REGISTRY_URL_CONFIG_PARAM, "http://" + RegistryFacade.REGISTRY_URL + ":" + RegistryFacade.REGISTRY_PORT);
@@ -91,7 +91,7 @@ public class KafkaClients {
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer);
         //Schema registry location.
         if (valueDeserializer.contains("confluent")) {
-            props.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://" + RegistryFacade.REGISTRY_URL + ":" + RegistryFacade.REGISTRY_PORT + "/confluent");
+            props.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://" + RegistryFacade.REGISTRY_URL + ":" + RegistryFacade.REGISTRY_PORT + "/ccompat");
         } else {
             props.put(AbstractKafkaSerDe.REGISTRY_URL_CONFIG_PARAM, "http://" + RegistryFacade.REGISTRY_URL + ":" + RegistryFacade.REGISTRY_PORT);
         }

--- a/tests/src/main/java/io/apicurio/tests/utils/subUtils/ArtifactUtils.java
+++ b/tests/src/main/java/io/apicurio/tests/utils/subUtils/ArtifactUtils.java
@@ -192,18 +192,18 @@ public class ArtifactUtils {
     // ================================================================================
 
     public static Response getAllSchemas(int returnCode) {
-        return BaseHttpUtils.postRequest(RestConstants.JSON, "", "/confluent/subjects", returnCode);
+        return BaseHttpUtils.postRequest(RestConstants.JSON, "", "/ccompat/subjects", returnCode);
     }
 
     public static Response getLatestVersionSchema(String nameOfSchema) {
-        return BaseHttpUtils.postRequest(RestConstants.JSON, "", "/confluent/subjects/" + nameOfSchema + "/versions/latest", 200);
+        return BaseHttpUtils.postRequest(RestConstants.JSON, "", "/ccompat/subjects/" + nameOfSchema + "/versions/latest", 200);
     }
 
     public static Response createSchema(String schemeDefinition, String schemaName, int returnCode) {
-        return BaseHttpUtils.postRequest(RestConstants.JSON, schemeDefinition, "/confluent/subjects/" + schemaName + "/versions", returnCode);
+        return BaseHttpUtils.postRequest(RestConstants.JSON, schemeDefinition, "/ccompat/subjects/" + schemaName + "/versions", returnCode);
     }
 
     public static Response updateSchemaMetadata(String schemaName, String metadata, int returnCode) {
-        return putRequest(RestConstants.JSON, metadata, "/confluent/subjects/" + schemaName + "/meta", returnCode);
+        return putRequest(RestConstants.JSON, metadata, "/ccompat/subjects/" + schemaName + "/meta", returnCode);
     }
 }

--- a/tests/src/main/java/io/apicurio/tests/utils/subUtils/GlobalRuleUtils.java
+++ b/tests/src/main/java/io/apicurio/tests/utils/subUtils/GlobalRuleUtils.java
@@ -69,14 +69,14 @@ public class GlobalRuleUtils {
     // ================================================
 
     public static Response testCompatibility(String body, String schemaName, int returnCode) {
-        return BaseHttpUtils.rulesPostRequest(RestConstants.SR, body, "/confluent/compatibility/subjects/" + schemaName + "/versions/latest", returnCode);
+        return BaseHttpUtils.rulesPostRequest(RestConstants.SR, body, "/ccompat/compatibility/subjects/" + schemaName + "/versions/latest", returnCode);
     }
 
     public static Response createGlobalCompatibilityConfig(String typeOfCompatibility) {
-        return BaseHttpUtils.putRequest(RestConstants.SR, "{\"compatibility\":\"" + typeOfCompatibility + "\"}", "/confluent/config", 200);
+        return BaseHttpUtils.putRequest(RestConstants.SR, "{\"compatibility\":\"" + typeOfCompatibility + "\"}", "/ccompat/config", 200);
     }
 
     public static Response getGlobalCompatibilityConfig() {
-        return BaseHttpUtils.getRequest(RestConstants.JSON, "/confluent/config", 204);
+        return BaseHttpUtils.getRequest(RestConstants.JSON, "/ccompat/config", 204);
     }
 }

--- a/tests/src/test/java/io/apicurio/tests/BaseIT.java
+++ b/tests/src/test/java/io/apicurio/tests/BaseIT.java
@@ -72,7 +72,7 @@ public abstract class BaseIT implements TestSeparator, Constants {
         RestAssured.baseURI = "http://" + RegistryFacade.REGISTRY_URL + ":" + RegistryFacade.REGISTRY_PORT;
         LOGGER.info("Registry app is running on {}:{}", RegistryFacade.REGISTRY_URL, RegistryFacade.REGISTRY_PORT);
         RestAssured.defaultParser = Parser.JSON;
-        confluentService = new CachedSchemaRegistryClient("http://" + RegistryFacade.REGISTRY_URL + ":" + RegistryFacade.REGISTRY_PORT + "/confluent", 3);
+        confluentService = new CachedSchemaRegistryClient("http://" + RegistryFacade.REGISTRY_URL + ":" + RegistryFacade.REGISTRY_PORT + "/ccompat", 3);
         apicurioService = RegistryClient.create("http://"  + RegistryFacade.REGISTRY_URL + ":" + RegistryFacade.REGISTRY_PORT);
 
         clearAllConfluentSubjects();


### PR DESCRIPTION
They are now:  `/ccompat` and `/ibmcompat`