### PR TITLE
Added support for Kafka Connect schemas

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -71,6 +71,16 @@
             <scope>compile</scope>
         </dependency>
         
+        <!-- Kafka Connect -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-json</artifactId>
+        </dependency>
+        
         <!-- GraphQL -->
         <dependency>
             <groupId>com.graphql-java</groupId>

--- a/app/src/main/java/io/apicurio/registry/content/ContentCanonicalizerFactory.java
+++ b/app/src/main/java/io/apicurio/registry/content/ContentCanonicalizerFactory.java
@@ -21,6 +21,7 @@ import javax.enterprise.context.ApplicationScoped;
 import io.apicurio.registry.content.canon.AvroContentCanonicalizer;
 import io.apicurio.registry.content.canon.GraphQLContentCanonicalizer;
 import io.apicurio.registry.content.canon.JsonContentCanonicalizer;
+import io.apicurio.registry.content.canon.KafkaConnectContentCanonicalizer;
 import io.apicurio.registry.content.canon.NoOpContentCanonicalizer;
 import io.apicurio.registry.types.ArtifactType;
 
@@ -33,6 +34,7 @@ public class ContentCanonicalizerFactory {
 
     private ContentCanonicalizer avro = new AvroContentCanonicalizer();
     private ContentCanonicalizer noop = new NoOpContentCanonicalizer();
+    private ContentCanonicalizer kconnect = new KafkaConnectContentCanonicalizer();
     private ContentCanonicalizer json = new JsonContentCanonicalizer();
     private ContentCanonicalizer graphql = new GraphQLContentCanonicalizer();
     
@@ -48,6 +50,8 @@ public class ContentCanonicalizerFactory {
                 return avro;
             case JSON:
                 return json;
+            case KCONNECT:
+                return kconnect;
             case OPENAPI:
                 return json;
             case PROTOBUF:

--- a/app/src/main/java/io/apicurio/registry/content/canon/KafkaConnectContentCanonicalizer.java
+++ b/app/src/main/java/io/apicurio/registry/content/canon/KafkaConnectContentCanonicalizer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.content.canon;
+
+/**
+ * A Kafka Connect schema content canonicalizer.
+ * 
+ * @author eric.wittmann@gmail.com
+ */
+public class KafkaConnectContentCanonicalizer extends JsonContentCanonicalizer {
+
+}

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/ArtifactTypeAdapterFactory.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/ArtifactTypeAdapterFactory.java
@@ -35,6 +35,7 @@ public class ArtifactTypeAdapterFactory {
         ADAPTERS.put(ArtifactType.PROTOBUF, new ProtobufArtifactTypeAdapter());
         ADAPTERS.put(ArtifactType.PROTOBUF_FD, new ProtobufFdArtifactTypeAdapter());
         ADAPTERS.put(ArtifactType.JSON, new JsonArtifactTypeAdapter());
+        ADAPTERS.put(ArtifactType.KCONNECT, NoopArtifactTypeAdapter.INSTANCE);
         ADAPTERS.put(ArtifactType.OPENAPI, NoopArtifactTypeAdapter.INSTANCE);
         ADAPTERS.put(ArtifactType.ASYNCAPI, NoopArtifactTypeAdapter.INSTANCE);
         ADAPTERS.put(ArtifactType.GRAPHQL, NoopArtifactTypeAdapter.INSTANCE);

--- a/app/src/main/java/io/apicurio/registry/rules/validity/ContentValidatorFactory.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/ContentValidatorFactory.java
@@ -37,6 +37,8 @@ public class ContentValidatorFactory {
     @Inject
     JsonSchemaContentValidator jsonValidator;
     @Inject
+    KafkaConnectContentValidator kconnectValidator;
+    @Inject
     OpenApiContentValidator openapiValidator;
     @Inject
     AsyncApiContentValidator asyncValidator;
@@ -51,6 +53,8 @@ public class ContentValidatorFactory {
                 return avroValidator;
             case JSON:
                 return jsonValidator;
+            case KCONNECT:
+                return kconnectValidator;
             case OPENAPI:
                 return openapiValidator;
             case PROTOBUF:

--- a/app/src/main/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidator.java
@@ -19,6 +19,8 @@ package io.apicurio.registry.rules.validity;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 
@@ -31,6 +33,7 @@ import io.apicurio.registry.content.ContentHandle;
  * A content validator implementation for the Kafka Connect schema content type.
  * @author eric.wittmann@gmail.com
  */
+@ApplicationScoped
 public class KafkaConnectContentValidator implements ContentValidator {
     
     private static final ObjectMapper mapper = new ObjectMapper();

--- a/app/src/main/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.rules.validity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.apicurio.registry.content.ContentHandle;
+
+/**
+ * A content validator implementation for the Kafka Connect schema content type.
+ * @author eric.wittmann@gmail.com
+ */
+public class KafkaConnectContentValidator implements ContentValidator {
+    
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final JsonConverter jsonConverter = new JsonConverter();
+    static {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put("converter.type", "key");
+        configs.put(JsonConverterConfig.SCHEMAS_CACHE_SIZE_CONFIG, new Integer(0));
+        jsonConverter.configure(configs);
+    }
+
+    /**
+     * Constructor.
+     */
+    public KafkaConnectContentValidator() {
+    }
+
+    /**
+     * @see io.apicurio.registry.rules.validity.ContentValidator#validate(io.apicurio.registry.rules.validity.ValidityLevel, io.apicurio.registry.content.ContentHandle)
+     */
+    @Override
+    public void validate(ValidityLevel level, ContentHandle artifactContent) throws InvalidContentException {
+        if (level == ValidityLevel.SYNTAX_ONLY || level == ValidityLevel.FULL) {
+            try {
+                JsonNode jsonNode = mapper.readTree(artifactContent.content());
+                jsonConverter.asConnectSchema(jsonNode);
+            } catch (Exception e) {
+                throw new InvalidContentException("Syntax violation for Kafka Connect Schema artifact.", e);
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/util/ArtifactTypeUtil.java
+++ b/app/src/main/java/io/apicurio/registry/util/ArtifactTypeUtil.java
@@ -79,6 +79,8 @@ public final class ArtifactTypeUtil {
             if (tree.has("$schema") && tree.get("$schema").asText().contains("json-schema.org")) {
                 return ArtifactType.JSON;
             }
+            // Kafka Connect??
+            // TODO detect Kafka Connect schemas
             // Avro
             return ArtifactType.AVRO;
         } catch (Exception e) {

--- a/app/src/test/java/io/apicurio/registry/content/ContentCanonicalizerFactoryTest.java
+++ b/app/src/test/java/io/apicurio/registry/content/ContentCanonicalizerFactoryTest.java
@@ -143,5 +143,33 @@ class ContentCanonicalizerFactoryTest {
         String actual = canonicalizer.canonicalize(content).content();
         Assertions.assertEquals(expected, actual);
     }
+    
+
+    /**
+     * Test method for {@link io.apicurio.registry.content.ContentCanonicalizerFactory#create(io.apicurio.registry.types.ArtifactType)}.
+     */
+    @Test
+    void testKafkaConnect() {
+        ContentCanonicalizerFactory factory = new ContentCanonicalizerFactory();
+        ContentCanonicalizer canonicalizer = factory.create(ArtifactType.KCONNECT);
+        
+        String before = "{\r\n" + 
+                "    \"type\": \"struct\",\r\n" + 
+                "    \"fields\": [\r\n" + 
+                "        {\r\n" + 
+                "            \"type\": \"string\",\r\n" + 
+                "            \"optional\": false,\r\n" + 
+                "            \"field\": \"bar\"\r\n" + 
+                "        }\r\n" + 
+                "    ],\r\n" + 
+                "    \"optional\": false\r\n" + 
+                "}";
+        String expected = "{\"fields\":[{\"field\":\"bar\",\"optional\":false,\"type\":\"string\"}],\"optional\":false,\"type\":\"struct\"}";
+        
+        ContentHandle content = ContentHandle.create(before);
+        String actual = canonicalizer.canonicalize(content).content();
+        Assertions.assertEquals(expected, actual);
+    }
+
 
 }

--- a/app/src/test/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidatorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.rules.validity;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.AbstractRegistryTestBase;
+import io.apicurio.registry.content.ContentHandle;
+
+/**
+ * Tests the Kafka Connect content validator.
+ * @author eric.wittmann@gmail.com
+ */
+public class KafkaConnectContentValidatorTest extends AbstractRegistryTestBase {
+
+    @Test
+    public void testValidSyntax() throws Exception {
+        ContentHandle content = resourceToContentHandle("kconnect-valid.json");
+        KafkaConnectContentValidator validator = new KafkaConnectContentValidator();
+        validator.validate(ValidityLevel.SYNTAX_ONLY, content);
+    }
+
+    @Test
+    public void testInvalidSyntax() throws Exception {
+        ContentHandle content = resourceToContentHandle("kconnect-invalid.json");
+        KafkaConnectContentValidator validator = new KafkaConnectContentValidator();
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            validator.validate(ValidityLevel.SYNTAX_ONLY, content);
+        });
+    }
+
+}

--- a/app/src/test/resources/io/apicurio/registry/rules/validity/kconnect-invalid.json
+++ b/app/src/test/resources/io/apicurio/registry/rules/validity/kconnect-invalid.json
@@ -1,0 +1,10 @@
+{
+	"fields": [
+		{
+			"type": "string",
+			"optional": false,
+			"field": "bar"
+		}
+	],
+	"optional": false
+}

--- a/app/src/test/resources/io/apicurio/registry/rules/validity/kconnect-valid.json
+++ b/app/src/test/resources/io/apicurio/registry/rules/validity/kconnect-valid.json
@@ -1,0 +1,11 @@
+{
+	"type": "struct",
+	"fields": [
+		{
+			"type": "string",
+			"optional": false,
+			"field": "bar"
+		}
+	],
+	"optional": false
+}

--- a/common/src/main/java/io/apicurio/registry/rest/ArtifactsResource.java
+++ b/common/src/main/java/io/apicurio/registry/rest/ArtifactsResource.java
@@ -1,9 +1,18 @@
 package io.apicurio.registry.rest;
 
+import io.apicurio.registry.rest.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.beans.EditableMetaData;
+import io.apicurio.registry.rest.beans.Rule;
+import io.apicurio.registry.rest.beans.UpdateState;
+import io.apicurio.registry.rest.beans.VersionMetaData;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.RuleType;
 import java.io.InputStream;
+import java.lang.Integer;
+import java.lang.Long;
+import java.lang.String;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -15,26 +24,17 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
-import io.apicurio.registry.rest.beans.ArtifactMetaData;
-import io.apicurio.registry.rest.beans.EditableMetaData;
-import io.apicurio.registry.rest.beans.Rule;
-import io.apicurio.registry.rest.beans.UpdateState;
-import io.apicurio.registry.rest.beans.VersionMetaData;
-import io.apicurio.registry.types.ArtifactType;
-import io.apicurio.registry.types.RuleType;
-
 /**
  * A JAX-RS interface.  An implementation of this interface must be provided.
  */
 @Path("/artifacts")
 public interface ArtifactsResource {
-
   /**
    * Gets the metadata for an artifact in the registry.  The returned metadata will include
    * both generated (read-only) and editable metadata (such as name and description).
-   * <p>
+   *
    * This operation can fail for the following reasons:
-   * <p>
+   *
    * * No artifact with this `artifactId` exists (HTTP error `404`)
    * * A server error occurred (HTTP error `500`)
    */
@@ -275,6 +275,7 @@ public interface ArtifactsResource {
    * * Protobuf (`PROTOBUF`)
    * * Protobuf File Descriptor (`PROTOBUF_FD`)
    * * JSON Schema (`JSON`)
+   * * Kafka Connect (`KCONNECT`)
    * * OpenAPI (`OPENAPI`)
    * * AsyncAPI (`ASYNCAPI`)
    * * GraphQL (`GRAPHQL`)
@@ -329,6 +330,7 @@ public interface ArtifactsResource {
    * * Protobuf (`PROTOBUF`)
    * * Protobuf File Descriptor (`PROTOBUF_FD`)
    * * JSON Schema (`JSON`)
+   * * Kafka Connect (`KCONNECT`)
    * * OpenAPI (`OPENAPI`)
    * * AsyncAPI (`ASYNCAPI`)
    * * GraphQL (`GRAPHQL`)
@@ -399,6 +401,7 @@ public interface ArtifactsResource {
    * * Protobuf (`PROTOBUF`)
    * * Protobuf File Descriptor (`PROTOBUF_FD`)
    * * JSON Schema (`JSON`)
+   * * Kafka Connect (`KCONNECT`)
    * * OpenAPI (`OPENAPI`)
    * * AsyncAPI (`ASYNCAPI`)
    * * GraphQL (`GRAPHQL`)
@@ -444,6 +447,7 @@ public interface ArtifactsResource {
    * * Protobuf (`PROTOBUF`)
    * * Protobuf File Descriptor (`PROTOBUF_FD`)
    * * JSON Schema (`JSON`)
+   * * Kafka Connect (`KCONNECT`)
    * * OpenAPI (`OPENAPI`)
    * * AsyncAPI (`ASYNCAPI`)
    * * GraphQL (`GRAPHQL`)
@@ -473,7 +477,7 @@ public interface ArtifactsResource {
 
   /**
    * Updates the state of the artifact.  This can be used to, for example, mark the latest
-   * version of an Artifact as `DEPRECATED`.  The operation will change the state of the
+   * version of an artifact as `DEPRECATED`.  The operation will change the state of the
    * latest version of the artifact.  If multiple versions exist, only the most recent will
    * be changed.
    *
@@ -500,7 +504,7 @@ public interface ArtifactsResource {
   void updateArtifactState(@PathParam("artifactId") String artifactId, UpdateState data);
 
   /**
-   * Used to update the state of a specific version of an Artifact.  For example, this can
+   * Used to update the state of a specific version of an artifact.  For example, this can
    * be used to "disable" a specific version.
    *
    * The following state changes are supported:

--- a/common/src/main/java/io/apicurio/registry/rest/ArtifactsResource.java
+++ b/common/src/main/java/io/apicurio/registry/rest/ArtifactsResource.java
@@ -1,18 +1,9 @@
 package io.apicurio.registry.rest;
 
-import io.apicurio.registry.rest.beans.ArtifactMetaData;
-import io.apicurio.registry.rest.beans.EditableMetaData;
-import io.apicurio.registry.rest.beans.Rule;
-import io.apicurio.registry.rest.beans.UpdateState;
-import io.apicurio.registry.rest.beans.VersionMetaData;
-import io.apicurio.registry.types.ArtifactType;
-import io.apicurio.registry.types.RuleType;
 import java.io.InputStream;
-import java.lang.Integer;
-import java.lang.Long;
-import java.lang.String;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -23,6 +14,14 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
+
+import io.apicurio.registry.rest.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.beans.EditableMetaData;
+import io.apicurio.registry.rest.beans.Rule;
+import io.apicurio.registry.rest.beans.UpdateState;
+import io.apicurio.registry.rest.beans.VersionMetaData;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.RuleType;
 
 /**
  * A JAX-RS interface.  An implementation of this interface must be provided.

--- a/common/src/main/java/io/apicurio/registry/rest/beans/ArtifactMetaData.java
+++ b/common/src/main/java/io/apicurio/registry/rest/beans/ArtifactMetaData.java
@@ -1,6 +1,7 @@
 
 package io.apicurio.registry.rest.beans;
 
+import java.util.Date;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -38,27 +39,35 @@ public class ArtifactMetaData {
     /**
      * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdBy")
     private String createdBy;
     /**
+     * 
      * (Required)
+     * 
      */
     @JsonProperty("createdOn")
-    private long createdOn;
+    private Date createdOn;
     /**
+     * 
      * (Required)
+     * 
      */
     @JsonProperty("modifiedBy")
     private String modifiedBy;
     /**
+     * 
      * (Required)
+     * 
      */
     @JsonProperty("modifiedOn")
-    private long modifiedOn;
+    private Date modifiedOn;
     /**
+     * 
      * (Required)
+     * 
      */
     @JsonProperty("id")
     @JsonPropertyDescription("")
@@ -86,7 +95,7 @@ public class ArtifactMetaData {
      */
     @JsonProperty("globalId")
     @JsonPropertyDescription("")
-    private Long globalId;
+    private Integer globalId;
     /**
      * Describes the state of an artifact or artifact version.  The following states
      * are possible:
@@ -147,20 +156,24 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("createdOn")
-    public long getCreatedOn() {
+    public Date getCreatedOn() {
         return createdOn;
     }
 
     /**
+     * 
      * (Required)
+     * 
      */
     @JsonProperty("createdOn")
-    public void setCreatedOn(long createdOn) {
+    public void setCreatedOn(Date createdOn) {
         this.createdOn = createdOn;
     }
 
     /**
+     * 
      * (Required)
+     * 
      */
     @JsonProperty("modifiedBy")
     public String getModifiedBy() {
@@ -183,20 +196,24 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("modifiedOn")
-    public long getModifiedOn() {
+    public Date getModifiedOn() {
         return modifiedOn;
     }
 
     /**
+     * 
      * (Required)
+     * 
      */
     @JsonProperty("modifiedOn")
-    public void setModifiedOn(long modifiedOn) {
+    public void setModifiedOn(Date modifiedOn) {
         this.modifiedOn = modifiedOn;
     }
 
     /**
+     * 
      * (Required)
+     * 
      */
     @JsonProperty("id")
     public String getId() {
@@ -259,7 +276,7 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("globalId")
-    public Long getGlobalId() {
+    public Integer getGlobalId() {
         return globalId;
     }
 
@@ -269,7 +286,7 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("globalId")
-    public void setGlobalId(Long globalId) {
+    public void setGlobalId(Integer globalId) {
         this.globalId = globalId;
     }
 
@@ -303,20 +320,4 @@ public class ArtifactMetaData {
         this.state = state;
     }
 
-    @Override
-    public String toString() {
-        return "ArtifactMetaData{" +
-                "name='" + name + '\'' +
-                ", description='" + description + '\'' +
-                ", createdBy='" + createdBy + '\'' +
-                ", createdOn=" + createdOn +
-                ", modifiedBy='" + modifiedBy + '\'' +
-                ", modifiedOn=" + modifiedOn +
-                ", id='" + id + '\'' +
-                ", version=" + version +
-                ", type=" + type +
-                ", globalId=" + globalId +
-                ", state=" + state +
-                '}';
-    }
 }

--- a/common/src/main/java/io/apicurio/registry/rest/beans/ArtifactMetaData.java
+++ b/common/src/main/java/io/apicurio/registry/rest/beans/ArtifactMetaData.java
@@ -1,7 +1,6 @@
 
 package io.apicurio.registry.rest.beans;
 
-import java.util.Date;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -49,7 +48,7 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("createdOn")
-    private Date createdOn;
+    private long createdOn;
     /**
      * 
      * (Required)
@@ -63,7 +62,7 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("modifiedOn")
-    private Date modifiedOn;
+    private long modifiedOn;
     /**
      * 
      * (Required)
@@ -95,7 +94,7 @@ public class ArtifactMetaData {
      */
     @JsonProperty("globalId")
     @JsonPropertyDescription("")
-    private Integer globalId;
+    private Long globalId;
     /**
      * Describes the state of an artifact or artifact version.  The following states
      * are possible:
@@ -156,7 +155,7 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("createdOn")
-    public Date getCreatedOn() {
+    public long getCreatedOn() {
         return createdOn;
     }
 
@@ -166,7 +165,7 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("createdOn")
-    public void setCreatedOn(Date createdOn) {
+    public void setCreatedOn(long createdOn) {
         this.createdOn = createdOn;
     }
 
@@ -196,7 +195,7 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("modifiedOn")
-    public Date getModifiedOn() {
+    public long getModifiedOn() {
         return modifiedOn;
     }
 
@@ -206,7 +205,7 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("modifiedOn")
-    public void setModifiedOn(Date modifiedOn) {
+    public void setModifiedOn(long modifiedOn) {
         this.modifiedOn = modifiedOn;
     }
 
@@ -276,7 +275,7 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("globalId")
-    public Integer getGlobalId() {
+    public Long getGlobalId() {
         return globalId;
     }
 
@@ -286,7 +285,7 @@ public class ArtifactMetaData {
      * 
      */
     @JsonProperty("globalId")
-    public void setGlobalId(Integer globalId) {
+    public void setGlobalId(Long globalId) {
         this.globalId = globalId;
     }
 
@@ -320,4 +319,20 @@ public class ArtifactMetaData {
         this.state = state;
     }
 
+    @Override
+    public String toString() {
+        return "ArtifactMetaData{" +
+                "name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", createdBy='" + createdBy + '\'' +
+                ", createdOn=" + createdOn +
+                ", modifiedBy='" + modifiedBy + '\'' +
+                ", modifiedOn=" + modifiedOn +
+                ", id='" + id + '\'' +
+                ", version=" + version +
+                ", type=" + type +
+                ", globalId=" + globalId +
+                ", state=" + state +
+                '}';
+    }
 }

--- a/common/src/main/java/io/apicurio/registry/rest/beans/Rule.java
+++ b/common/src/main/java/io/apicurio/registry/rest/beans/Rule.java
@@ -30,7 +30,6 @@ public class Rule {
     private String config;
     /**
      * 
-     * 
      */
     @JsonProperty("type")
     @JsonPropertyDescription("")
@@ -58,7 +57,6 @@ public class Rule {
 
     /**
      * 
-     * 
      */
     @JsonProperty("type")
     public RuleType getType() {
@@ -66,7 +64,6 @@ public class Rule {
     }
 
     /**
-     * 
      * 
      */
     @JsonProperty("type")

--- a/common/src/main/java/io/apicurio/registry/rest/beans/VersionMetaData.java
+++ b/common/src/main/java/io/apicurio/registry/rest/beans/VersionMetaData.java
@@ -1,7 +1,6 @@
 
 package io.apicurio.registry.rest.beans;
 
-import java.util.Date;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -53,7 +52,7 @@ public class VersionMetaData {
      * 
      */
     @JsonProperty("createdOn")
-    private Date createdOn;
+    private long createdOn;
     /**
      * 
      * (Required)
@@ -69,7 +68,7 @@ public class VersionMetaData {
      */
     @JsonProperty("globalId")
     @JsonPropertyDescription("")
-    private Integer globalId;
+    private Long globalId;
     /**
      * Describes the state of an artifact or artifact version.  The following states
      * are possible:
@@ -150,7 +149,7 @@ public class VersionMetaData {
      * 
      */
     @JsonProperty("createdOn")
-    public Date getCreatedOn() {
+    public long getCreatedOn() {
         return createdOn;
     }
 
@@ -160,7 +159,7 @@ public class VersionMetaData {
      * 
      */
     @JsonProperty("createdOn")
-    public void setCreatedOn(Date createdOn) {
+    public void setCreatedOn(long createdOn) {
         this.createdOn = createdOn;
     }
 
@@ -190,7 +189,7 @@ public class VersionMetaData {
      * 
      */
     @JsonProperty("globalId")
-    public Integer getGlobalId() {
+    public Long getGlobalId() {
         return globalId;
     }
 
@@ -200,7 +199,7 @@ public class VersionMetaData {
      * 
      */
     @JsonProperty("globalId")
-    public void setGlobalId(Integer globalId) {
+    public void setGlobalId(Long globalId) {
         this.globalId = globalId;
     }
 

--- a/common/src/main/java/io/apicurio/registry/rest/beans/VersionMetaData.java
+++ b/common/src/main/java/io/apicurio/registry/rest/beans/VersionMetaData.java
@@ -1,6 +1,7 @@
 
 package io.apicurio.registry.rest.beans;
 
+import java.util.Date;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -42,17 +43,21 @@ public class VersionMetaData {
     /**
      * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdBy")
     private String createdBy;
     /**
+     * 
      * (Required)
+     * 
      */
     @JsonProperty("createdOn")
-    private long createdOn;
+    private Date createdOn;
     /**
+     * 
      * (Required)
+     * 
      */
     @JsonProperty("type")
     @JsonPropertyDescription("")
@@ -64,7 +69,7 @@ public class VersionMetaData {
      */
     @JsonProperty("globalId")
     @JsonPropertyDescription("")
-    private Long globalId;
+    private Integer globalId;
     /**
      * Describes the state of an artifact or artifact version.  The following states
      * are possible:
@@ -142,25 +147,25 @@ public class VersionMetaData {
     /**
      * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdOn")
-    public long getCreatedOn() {
+    public Date getCreatedOn() {
         return createdOn;
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdOn")
-    public void setCreatedOn(long createdOn) {
+    public void setCreatedOn(Date createdOn) {
         this.createdOn = createdOn;
     }
 
     /**
-     *
+     * 
      * (Required)
      * 
      */
@@ -185,7 +190,7 @@ public class VersionMetaData {
      * 
      */
     @JsonProperty("globalId")
-    public Long getGlobalId() {
+    public Integer getGlobalId() {
         return globalId;
     }
 
@@ -195,7 +200,7 @@ public class VersionMetaData {
      * 
      */
     @JsonProperty("globalId")
-    public void setGlobalId(Long globalId) {
+    public void setGlobalId(Integer globalId) {
         this.globalId = globalId;
     }
 
@@ -228,4 +233,5 @@ public class VersionMetaData {
     public void setState(ArtifactState state) {
         this.state = state;
     }
+
 }

--- a/common/src/main/java/io/apicurio/registry/types/ArtifactType.java
+++ b/common/src/main/java/io/apicurio/registry/types/ArtifactType.java
@@ -14,7 +14,8 @@ public enum ArtifactType {
     JSON("JSON"),
     OPENAPI("OPENAPI"),
     ASYNCAPI("ASYNCAPI"),
-    GRAPHQL("GRAPHQL");
+    GRAPHQL("GRAPHQL"),
+    KCONNECT("KCONNECT");
     private final String value;
     private final static Map<String, ArtifactType> CONSTANTS = new HashMap<String, ArtifactType>();
 

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -2,8 +2,8 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Apicurio Registry API",
-        "version": "1.0.0",
-        "description": "Apicurio Registry is a datastore for standard event schemas and API designs. It enables developers to manage and share the structure of their data using a REST interface. For example, client applications can dynamically pull the latest updates from the registry without needing to redeploy. Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. For example, this includes rules for content validation and version compatibility.\n\nThe Apicurio Registry REST API enables client applications to access the artifacts in the registry. It provides create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata. \n\nThe supported artifact types include:\n- Apache Avro schema\n- Google protocol buffers \n- JSON Schema\n- OpenAPI specification\n- AsyncAPI specification\n- GraphQL specification\n\n",
+        "version": "1.1.2",
+        "description": "Apicurio Registry is a datastore for standard event schemas and API designs. It enables developers to manage and share the structure of their data using a REST interface. For example, client applications can dynamically pull the latest updates from the registry without needing to redeploy. Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. For example, this includes rules for content validation and version compatibility.\n\nThe Apicurio Registry REST API enables client applications to access the artifacts in the registry. It provides create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata. \n\nThe supported artifact types include:\n- Apache Avro schema\n- Google protocol buffers\n- JSON Schema\n- Kafka Connect schema\n- GraphQL schema\n- OpenAPI specification\n- AsyncAPI specification\n",
         "contact": {
             "name": "Apicurio",
             "url": "https://github.com/apicurio/apicurio-registry",
@@ -16,7 +16,7 @@
     },
     "paths": {
         "/artifacts/{artifactId}/meta": {
-            "summary": "Manage the meta-data of a single artifact.",
+            "summary": "Manage the metadata of a single artifact.",
             "get": {
                 "tags": [
                     "Metadata"
@@ -388,7 +388,7 @@
             ]
         },
         "/artifacts/{artifactId}/versions/{version}/meta": {
-            "summary": "Manage the meta-data for a single version of an artifact in the registry.",
+            "summary": "Manage the metadata for a single version of an artifact in the registry.",
             "get": {
                 "tags": [
                     "Metadata"
@@ -758,7 +758,7 @@
             "summary": "Manage the collection of artifacts in the registry.",
             "post": {
                 "requestBody": {
-                    "description": "The content of the artifact being created. This is often, but not always, JSON data\nrepresenting one of the supported artifact types:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)\n",
+                    "description": "The content of the artifact being created. This is often, but not always, JSON data\nrepresenting one of the supported artifact types:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)\n",
                     "content": {
                         "application/json": {
                             "examples": {
@@ -840,7 +840,7 @@
                 "parameters": [
                     {
                         "name": "X-Registry-ArtifactType",
-                        "description": "This header parameter can be used to indicate the type of the artifact being added.  Possible\nvalues include:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
+                        "description": "This header parameter can be used to indicate the type of the artifact being added.  Possible\nvalues include:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
                         "schema": {
                             "enum": [
                                 "AVRO",
@@ -849,7 +849,8 @@
                                 "JSON",
                                 "OPENAPI",
                                 "ASYNCAPI",
-                                "GRAPHQL"
+                                "GRAPHQL",
+                                "KCONNECT"
                             ],
                             "type": "string"
                         },
@@ -887,7 +888,7 @@
                 },
                 "operationId": "createArtifact",
                 "summary": "Create artifact",
-                "description": "Creates a new artifact by posting the artifact content.  The body of the request should\nbe the raw content of the artifact.  This will typically be in JSON format for *most*\nof the supported types, but may be in another format for a few (for example, `PROTOBUF`).\n\nThe registry will attempt to figure out what kind of artifact is being added from the\nfollowing supported list:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)\n\nAlternatively, the artifact type can be indicated by explicitly specifying the type using \nthe `X-Registry-ArtifactType` HTTP request header or by including a hint in the request's \n`Content-Type`.  For example:\n\n```\nContent-Type: application/json; artifactType=AVRO\n```\n\nThis operation may fail for one of the following reasons:\n\n* An invalid `ArtifactType` was indicated (HTTP error `400`)\n* The content violates one of the configured global rules (HTTP error `409`)\n* A server error occurred (HTTP error `500`)\n",
+                "description": "Creates a new artifact by posting the artifact content.  The body of the request should\nbe the raw content of the artifact.  This will typically be in JSON format for *most*\nof the supported types, but may be in another format for a few (for example, `PROTOBUF`).\n\nThe registry will attempt to figure out what kind of artifact is being added from the\nfollowing supported list:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)\n\nAlternatively, the artifact type can be indicated by explicitly specifying the type using \nthe `X-Registry-ArtifactType` HTTP request header or by including a hint in the request's \n`Content-Type`.  For example:\n\n```\nContent-Type: application/json; artifactType=AVRO\n```\n\nThis operation may fail for one of the following reasons:\n\n* An invalid `ArtifactType` was indicated (HTTP error `400`)\n* The content violates one of the configured global rules (HTTP error `409`)\n* A server error occurred (HTTP error `500`)\n",
                 "x-codegen-async": true
             }
         },
@@ -944,7 +945,7 @@
             },
             "put": {
                 "requestBody": {
-                    "description": "The new content of the artifact being updated. This is often, but not always, JSON data\nrepresenting one of the supported artifact types:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
+                    "description": "The new content of the artifact being updated. This is often, but not always, JSON data\nrepresenting one of the supported artifact types:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
                     "content": {
                         "application/json": {
                             "examples": {
@@ -1026,7 +1027,7 @@
                 "parameters": [
                     {
                         "name": "X-Registry-ArtifactType",
-                        "description": "This header parameter can be used to indicate the type of the artifact being added.  Possible\nvalues include:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
+                        "description": "This header parameter can be used to indicate the type of the artifact being added.  Possible\nvalues include:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
                         "schema": {
                             "enum": [
                                 "AVRO",
@@ -1035,7 +1036,8 @@
                                 "JSON",
                                 "OPENAPI",
                                 "ASYNCAPI",
-                                "GRAPHQL"
+                                "GRAPHQL",
+                                "KCONNECT"
                             ],
                             "type": "string"
                         },
@@ -1066,7 +1068,7 @@
                 },
                 "operationId": "updateArtifact",
                 "summary": "Update artifact",
-                "description": "Updates an artifact by uploading new content.  The body of the request should\nbe the raw content of the artifact.  This will typically be in JSON format for *most*\nof the supported types, but may be in another format for a few (for example, `PROTOBUF`).\n\nThe registry will attempt to figure out what kind of artifact is being added from the\nfollowing supported list:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)\n\nAlternatively, the artifact type can be indicated by explicitly specifying the type using \nthe `X-Registry-ArtifactType` HTTP request header or by including a hint in the request's \n`Content-Type`.  For example:\n\n```\nContent-Type: application/json; artifactType=AVRO\n```\n\nThe update could fail for a number of reasons including:\n\n* No artifact with the `artifactId` exists (HTTP error `404`)\n* The new content violates one of the rules configured for the artifact (HTTP error `409`)\n* The provided artifact type is not recognized (HTTP error `404`)\n* A server error occurred (HTTP error `500`)\n\nWhen successful, this creates a new version of the artifact, making it the most recent\n(and therefore official) version of the artifact.",
+                "description": "Updates an artifact by uploading new content.  The body of the request should\nbe the raw content of the artifact.  This will typically be in JSON format for *most*\nof the supported types, but may be in another format for a few (for example, `PROTOBUF`).\n\nThe registry will attempt to figure out what kind of artifact is being added from the\nfollowing supported list:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)\n\nAlternatively, the artifact type can be indicated by explicitly specifying the type using \nthe `X-Registry-ArtifactType` HTTP request header or by including a hint in the request's \n`Content-Type`.  For example:\n\n```\nContent-Type: application/json; artifactType=AVRO\n```\n\nThe update could fail for a number of reasons including:\n\n* No artifact with the `artifactId` exists (HTTP error `404`)\n* The new content violates one of the rules configured for the artifact (HTTP error `409`)\n* The provided artifact type is not recognized (HTTP error `404`)\n* A server error occurred (HTTP error `500`)\n\nWhen successful, this creates a new version of the artifact, making it the most recent\n(and therefore official) version of the artifact.",
                 "x-codegen-async": true
             },
             "delete": {
@@ -1144,7 +1146,7 @@
             },
             "post": {
                 "requestBody": {
-                    "description": "The content of the artifact version being created. This is often, but not always, JSON data\nrepresenting one of the supported artifact types:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
+                    "description": "The content of the artifact version being created. This is often, but not always, JSON data\nrepresenting one of the supported artifact types:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
                     "content": {
                         "application/json": {
                             "examples": {
@@ -1226,7 +1228,7 @@
                 "parameters": [
                     {
                         "name": "X-Registry-ArtifactType",
-                        "description": "This header parameter can be used to indicate the type of the artifact being added.  Possible\nvalues include:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
+                        "description": "This header parameter can be used to indicate the type of the artifact being added.  Possible\nvalues include:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
                         "schema": {
                             "enum": [
                                 "AVRO",
@@ -1235,7 +1237,8 @@
                                 "JSON",
                                 "OPENAPI",
                                 "ASYNCAPI",
-                                "GRAPHQL"
+                                "GRAPHQL",
+                                "KCONNECT"
                             ],
                             "type": "string"
                         },
@@ -1265,7 +1268,7 @@
                 },
                 "operationId": "createArtifactVersion",
                 "summary": "Create artifact version",
-                "description": "Creates a new version of the artifact by uploading new content.  The configured rules for\nthe artifact will be applied, and if they all pass, the new content will be added as the \nmost recent version of the artifact.  If any of the rules fail, an error will be returned.\n\nThe body of the request should be the raw content of the new artifact version.  This \nwill typically be in JSON format for *most* of the supported types, but may be in another \nformat for a few (for example, `PROTOBUF`).\n\nThe registry will attempt to figure out what kind of artifact is being added from the\nfollowing supported list:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)\n\nAlternatively, the artifact type can be indicated be explicitly specifying the type \nusing the `X-Registry-ArtifactType` HTTP request header or by including a hint in the \nrequest's `Content-Type`.\n\nFor example:\n\n```\nContent-Type: application/json; artifactType=AVRO\n```\n\nThis operation can fail for the following reasons:\n\n* No artifact with this `artifactId` exists (HTTP error `404`)\n* The new content violates one of the rules configured for the artifact (HTTP error `409`)\n* A server error occurred (HTTP error `500`)\n",
+                "description": "Creates a new version of the artifact by uploading new content.  The configured rules for\nthe artifact will be applied, and if they all pass, the new content will be added as the \nmost recent version of the artifact.  If any of the rules fail, an error will be returned.\n\nThe body of the request should be the raw content of the new artifact version.  This \nwill typically be in JSON format for *most* of the supported types, but may be in another \nformat for a few (for example, `PROTOBUF`).\n\nThe registry will attempt to figure out what kind of artifact is being added from the\nfollowing supported list:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)\n\nAlternatively, the artifact type can be indicated be explicitly specifying the type \nusing the `X-Registry-ArtifactType` HTTP request header or by including a hint in the \nrequest's `Content-Type`.\n\nFor example:\n\n```\nContent-Type: application/json; artifactType=AVRO\n```\n\nThis operation can fail for the following reasons:\n\n* No artifact with this `artifactId` exists (HTTP error `404`)\n* The new content violates one of the rules configured for the artifact (HTTP error `409`)\n* A server error occurred (HTTP error `500`)\n",
                 "x-codegen-async": true
             },
             "parameters": [
@@ -1383,7 +1386,7 @@
             "summary": "Test whether content would pass update rules.",
             "put": {
                 "requestBody": {
-                    "description": "The content of the artifact being tested. This is often, but not always, JSON data\nrepresenting one of the supported artifact types:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
+                    "description": "The content of the artifact being tested. This is often, but not always, JSON data\nrepresenting one of the supported artifact types:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
                     "content": {
                         "application/json": {
 
@@ -1403,7 +1406,7 @@
                 "parameters": [
                     {
                         "name": "X-Registry-ArtifactType",
-                        "description": "This header parameter can be used to indicate the type of the artifact being added.  Possible\nvalues include:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
+                        "description": "This header parameter can be used to indicate the type of the artifact being added.  Possible\nvalues include:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)",
                         "schema": {
                             "enum": [
                                 "AVRO",
@@ -1412,7 +1415,8 @@
                                 "JSON",
                                 "OPENAPI",
                                 "ASYNCAPI",
-                                "GRAPHQL"
+                                "GRAPHQL",
+                                "KCONNECT"
                             ],
                             "type": "string"
                         },
@@ -1435,7 +1439,7 @@
                 },
                 "operationId": "testUpdateArtifact",
                 "summary": "Test update artifact",
-                "description": "Tests whether an update to the artifact's content *would* succeed for the provided content.\nUltimately, this will apply any rules configured for the artifact against the given content\nto determine whether the rules would pass or fail, but without actually updating the artifact\ncontent.\n\nThe body of the request should be the raw content of the artifact.  This will typically be \nin JSON format for *most* of the supported types, but may be in another format for a few \n(for example, `PROTOBUF`).\n\nThe registry will attempt to figure out what kind of artifact is being added from the\nfollowing supported list:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)\n\nAlternatively, the artifact type can be indicated by explicitly specifying the type using \nthe `X-Registry-ArtifactType` HTTP request header or by including a hint in the request's \n`Content-Type`.  For example:\n\n```\nContent-Type: application/json; artifactType=AVRO\n```\n\nThe update could fail for a number of reasons including:\n\n* No artifact with the `artifactId` exists (HTTP error `404`)\n* The new content violates one of the rules configured for the artifact (HTTP error `409`)\n* The provided artifact type is not recognized (HTTP error `404`)\n* A server error occurred (HTTP error `500`)\n\nWhen successful, this operation simply returns a *No Content* response."
+                "description": "Tests whether an update to the artifact's content *would* succeed for the provided content.\nUltimately, this will apply any rules configured for the artifact against the given content\nto determine whether the rules would pass or fail, but without actually updating the artifact\ncontent.\n\nThe body of the request should be the raw content of the artifact.  This will typically be \nin JSON format for *most* of the supported types, but may be in another format for a few \n(for example, `PROTOBUF`).\n\nThe registry will attempt to figure out what kind of artifact is being added from the\nfollowing supported list:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)\n\nAlternatively, the artifact type can be indicated by explicitly specifying the type using \nthe `X-Registry-ArtifactType` HTTP request header or by including a hint in the request's \n`Content-Type`.  For example:\n\n```\nContent-Type: application/json; artifactType=AVRO\n```\n\nThe update could fail for a number of reasons including:\n\n* No artifact with the `artifactId` exists (HTTP error `404`)\n* The new content violates one of the rules configured for the artifact (HTTP error `409`)\n* The provided artifact type is not recognized (HTTP error `404`)\n* A server error occurred (HTTP error `500`)\n\nWhen successful, this operation simply returns a *No Content* response."
             },
             "parameters": [
                 {
@@ -1450,7 +1454,7 @@
             ]
         },
         "/artifacts/{artifactId}/state": {
-            "summary": "Manage the state of an Artifact.",
+            "summary": "Manage the state of an artifact.",
             "put": {
                 "requestBody": {
                     "content": {
@@ -1480,8 +1484,8 @@
                     }
                 },
                 "operationId": "updateArtifactState",
-                "summary": "Update Artifact State",
-                "description": "Updates the state of the artifact.  This can be used to, for example, mark the latest\nversion of an Artifact as `DEPRECATED`.  The operation will change the state of the\nlatest version of the artifact.  If multiple versions exist, only the most recent will\nbe changed.\n\nThe following state changes are supported:\n\n* Enabled -> Disabled\n* Enabled -> Deprecated\n* Enabled -> Deleted\n* Disabled -> Enabled\n* Disabled -> Deleted\n* Disabled -> Deprecated\n* Deprecated -> Deleted\n\nThis operation can fail for the following reasons:\n\n* No artifact with this `artifactId` exists (HTTP error `404`)\n* Artifact cannot transition to the given state (HTTP error `400`)\n* A server error occurred (HTTP error `500`)\n"
+                "summary": "Update artifact state",
+                "description": "Updates the state of the artifact.  This can be used to, for example, mark the latest\nversion of an artifact as `DEPRECATED`.  The operation will change the state of the\nlatest version of the artifact.  If multiple versions exist, only the most recent will\nbe changed.\n\nThe following state changes are supported:\n\n* Enabled -> Disabled\n* Enabled -> Deprecated\n* Enabled -> Deleted\n* Disabled -> Enabled\n* Disabled -> Deleted\n* Disabled -> Deprecated\n* Deprecated -> Deleted\n\nThis operation can fail for the following reasons:\n\n* No artifact with this `artifactId` exists (HTTP error `404`)\n* Artifact cannot transition to the given state (HTTP error `400`)\n* A server error occurred (HTTP error `500`)\n"
             },
             "parameters": [
                 {
@@ -1526,8 +1530,8 @@
                     }
                 },
                 "operationId": "updateArtifactVersionState",
-                "summary": "Update Artifact Version State",
-                "description": "Used to update the state of a specific version of an Artifact.  For example, this can\nbe used to \"disable\" a specific version.\n\nThe following state changes are supported:\n\n* Enabled -> Disabled\n* Enabled -> Deprecated\n* Enabled -> Deleted\n* Disabled -> Enabled\n* Disabled -> Deleted\n* Disabled -> Deprecated\n* Deprecated -> Deleted\n\nThis operation can fail for the following reasons:\n\n* No artifact with this `artifactId` exists (HTTP error `404`)\n* No version with this `version` exists (HTTP error `404`)\n* Artifact version cannot transition to the given state (HTTP error `400`)\n* A server error occurred (HTTP error `500`)\n"
+                "summary": "Update artifact version state",
+                "description": "Used to update the state of a specific version of an artifact.  For example, this can\nbe used to \"disable\" a specific version.\n\nThe following state changes are supported:\n\n* Enabled -> Disabled\n* Enabled -> Deprecated\n* Enabled -> Deleted\n* Disabled -> Enabled\n* Disabled -> Deleted\n* Disabled -> Deprecated\n* Deprecated -> Deleted\n\nThis operation can fail for the following reasons:\n\n* No artifact with this `artifactId` exists (HTTP error `404`)\n* No version with this `version` exists (HTTP error `404`)\n* Artifact version cannot transition to the given state (HTTP error `400`)\n* A server error occurred (HTTP error `500`)\n"
             },
             "parameters": [
                 {
@@ -1751,7 +1755,8 @@
                     "JSON",
                     "OPENAPI",
                     "ASYNCAPI",
-                    "GRAPHQL"
+                    "GRAPHQL",
+                    "KCONNECT"
                 ],
                 "type": "string",
                 "example": "AVRO",
@@ -1871,7 +1876,7 @@
         },
         {
             "name": "Global rules",
-            "description": "Global rules can be configured in the registry to govern how artifact content can \nevolve over time (as artifact content is **updated**). Global rules will be applied \nwhenever an artifact is added to the registry, and also whenever an artfiact's \ncontent is updated (only if that artifact doesn't have its own specific rules \nconfigured). This section describes the operations used to manage the global rules."
+            "description": "Global rules can be configured in the registry to govern how artifact content can \nevolve over time (as artifact content is **updated**). Global rules will be applied \nwhenever an artifact is added to the registry, and also whenever an artifact's \ncontent is updated (only if that artifact doesn't have its own specific rules \nconfigured). This section describes the operations used to manage the global rules."
         }
     ]
 }

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/ExtJsonConverter.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/ExtJsonConverter.java
@@ -92,7 +92,7 @@ public class ExtJsonConverter extends AbstractKafkaStrategyAwareSerDe<String, Ex
     public byte[] fromConnectData(String topic, Schema schema, Object value) {
         String schemaString = jsonConverter.asJsonSchema(schema).toString();
         String artifactId = getArtifactIdStrategy().artifactId(topic, isKey(), schemaString);
-        long globalId = getGlobalIdStrategy().findId(getClient(), artifactId, ArtifactType.JSON, schemaString);
+        long globalId = getGlobalIdStrategy().findId(getClient(), artifactId, ArtifactType.KCONNECT, schemaString);
 
         byte[] payload = jsonConverter.fromConnectData(topic, schema, value);
 


### PR DESCRIPTION
Kafka Connect uses a schema format that is JSON based but is not JSON Schema.  It's also apparently not Avro, but it's similar to Avro.  This PR adds registry support for this JSON based schema language.