### PR TITLE
Throw RuntimeException instead of NPE

### DIFF
--- a/app/src/test/java/io/apicurio/registry/AbstractRegistryTestBase.java
+++ b/app/src/test/java/io/apicurio/registry/AbstractRegistryTestBase.java
@@ -47,7 +47,7 @@ public abstract class AbstractRegistryTestBase {
             Assertions.assertNotNull(stream, "Resource not found: " + resourceName);
             return new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8)).lines().collect(Collectors.joining("\n"));
         } catch (IOException e) {
-            return null;
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Throw RuntimeException instead of NPE, @alesj fyi

requested in https://github.com/Apicurio/apicurio-registry/pull/265#pullrequestreview-356636483