### PR TITLE
JPA storage can return list of all artifacts

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/ArtifactsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ArtifactsResourceImpl.java
@@ -26,10 +26,7 @@ import static io.apicurio.registry.metrics.MetricIDs.REST_REQUEST_RESPONSE_TIME_
 import static org.eclipse.microprofile.metrics.MetricUnits.MILLISECONDS;
 
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.SortedSet;
+import java.util.*;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
@@ -192,6 +189,14 @@ public class ArtifactsResourceImpl implements ArtifactsResource {
         Objects.requireNonNull(data.getState());
         storage.updateArtifactState(artifactId, data.getState());
     }
+
+    /**
+     * @see io.apicurio.registry.rest.ArtifactsResource#getArtifactIds()
+     */
+    @Override
+    public Set<String> getArtifactIds() {
+        return storage.getArtifactIds();
+    }    
 
     /**
      * @see io.apicurio.registry.rest.ArtifactsResource#updateArtifactVersionState(java.lang.Integer, java.lang.String, io.apicurio.registry.rest.beans.UpdateState)

--- a/client/src/main/java/io/apicurio/registry/client/CachedRegistryService.java
+++ b/client/src/main/java/io/apicurio/registry/client/CachedRegistryService.java
@@ -17,11 +17,7 @@
 package io.apicurio.registry.client;
 
 import java.io.InputStream;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -137,6 +133,11 @@ class CachedRegistryService implements RegistryService {
             globalAMD.put(amd.getGlobalId(), amd);
             return amd;
         });
+    }
+
+    @Override
+    public Set<String> getArtifactIds() {
+        return getDelegate().getArtifactIds();
     }
 
     @Override

--- a/common/src/main/java/io/apicurio/registry/rest/ArtifactsResource.java
+++ b/common/src/main/java/io/apicurio/registry/rest/ArtifactsResource.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.rest;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.Consumes;
@@ -300,6 +301,17 @@ public interface ArtifactsResource {
   CompletionStage<ArtifactMetaData> createArtifact(
       @HeaderParam("X-Registry-ArtifactType") ArtifactType xRegistryArtifactType,
       @HeaderParam("X-Registry-ArtifactId") String xRegistryArtifactId, InputStream data);
+
+  /**
+   * Returns a list of ids of all artifacts in the registry.
+   *
+   * This operation can fail for the following reasons:
+   *
+   * * A server error occurred (HTTP error `500`)
+   */
+  @GET
+  @Produces("application/json")
+  Set<String> getArtifactIds();  
 
   /**
    * Returns the latest version of the artifact in its raw form.  The `Content-Type` of the

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -890,6 +890,32 @@
                 "summary": "Create artifact",
                 "description": "Creates a new artifact by posting the artifact content.  The body of the request should\nbe the raw content of the artifact.  This will typically be in JSON format for *most*\nof the supported types, but may be in another format for a few (for example, `PROTOBUF`).\n\nThe registry will attempt to figure out what kind of artifact is being added from the\nfollowing supported list:\n\n* Avro (`AVRO`)\n* Protobuf (`PROTOBUF`)\n* Protobuf File Descriptor (`PROTOBUF_FD`)\n* JSON Schema (`JSON`)\n* Kafka Connect (`KCONNECT`)\n* OpenAPI (`OPENAPI`)\n* AsyncAPI (`ASYNCAPI`)\n* GraphQL (`GRAPHQL`)\n\nAlternatively, the artifact type can be indicated by explicitly specifying the type using \nthe `X-Registry-ArtifactType` HTTP request header or by including a hint in the request's \n`Content-Type`.  For example:\n\n```\nContent-Type: application/json; artifactType=AVRO\n```\n\nThis operation may fail for one of the following reasons:\n\n* An invalid `ArtifactType` was indicated (HTTP error `400`)\n* The content violates one of the configured global rules (HTTP error `409`)\n* A server error occurred (HTTP error `500`)\n",
                 "x-codegen-async": true
+            },
+            "get": {
+                "tags": [
+                    "Artifacts"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Returns the ids of the artifacts in the registry."
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/ServerError"
+                    }
+                },
+                "operationId": "getArtifactIds",
+                "summary": "List all artifact ids",
+                "description": "Returns a list of ids of all artifacts in the registry."
             }
         },
         "/artifacts/{artifactId}": {


### PR DESCRIPTION
the method `getArtifactIds()` is there, but it is not defined in the `openapi.json`. This PR adds the GET endpoint to return all published artifacts, and links it to the existing JPA implementation