### PR TITLE
Avoid manual sync of ignored exceptions for liveness

### DIFF
--- a/app/src/main/java/io/apicurio/registry/metrics/PersistenceExceptionLivenessInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/PersistenceExceptionLivenessInterceptor.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.metrics;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -8,13 +9,19 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
+import io.apicurio.registry.rest.RegistryExceptionMapper;
 import io.apicurio.registry.storage.AlreadyExistsException;
 import io.apicurio.registry.storage.ArtifactAlreadyExistsException;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
+import io.apicurio.registry.storage.InvalidArtifactStateException;
 import io.apicurio.registry.storage.NotFoundException;
+import io.apicurio.registry.storage.RegistryStorageException;
 import io.apicurio.registry.storage.RuleAlreadyExistsException;
 import io.apicurio.registry.storage.RuleNotFoundException;
+import io.apicurio.registry.storage.StorageException;
 import io.apicurio.registry.storage.VersionNotFoundException;
+
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 
 /**
  * Fail liveness check if the number of exceptions thrown by storage is too high.
@@ -25,17 +32,25 @@ import io.apicurio.registry.storage.VersionNotFoundException;
 @PersistenceExceptionLivenessApply
 public class PersistenceExceptionLivenessInterceptor {
 
-//    private static final Logger log = LoggerFactory.getLogger(PersistenceExceptionLivenessInterceptor.class);
-
-    private static final Set<Class<? extends Exception>> IGNORED = new HashSet<>();
+    private static final Set<Class<? extends Throwable>> IGNORED = new HashSet<>();
 
     static {
+        // Inherit from io.apicurio.registry.rest.RegistryExceptionMapper
+        // to avoid manual sync, even though some exceptions may be irrelevant
+        for (Map.Entry<Class<? extends Throwable>, Integer> entry : RegistryExceptionMapper.getCodeMap().entrySet()) {
+            if(entry.getValue() != HTTP_INTERNAL_ERROR) // Sanity check
+                IGNORED.add(entry.getKey());
+        }
+        // Additional ignored exceptions (may be already included)
         IGNORED.add(AlreadyExistsException.class);
         IGNORED.add(ArtifactAlreadyExistsException.class);
         IGNORED.add(ArtifactNotFoundException.class);
+        IGNORED.add(InvalidArtifactStateException.class);
         IGNORED.add(NotFoundException.class);
+        IGNORED.add(RegistryStorageException.class);
         IGNORED.add(RuleAlreadyExistsException.class);
         IGNORED.add(RuleNotFoundException.class);
+        IGNORED.add(StorageException.class);
         IGNORED.add(VersionNotFoundException.class);
     }
 
@@ -53,5 +68,4 @@ public class PersistenceExceptionLivenessInterceptor {
             throw ex;
         }
     }
-
 }

--- a/app/src/main/java/io/apicurio/registry/rest/RegistryExceptionMapper.java
+++ b/app/src/main/java/io/apicurio/registry/rest/RegistryExceptionMapper.java
@@ -35,6 +35,7 @@ import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
@@ -56,7 +57,7 @@ public class RegistryExceptionMapper implements ExceptionMapper<Throwable> {
 
     private static final Logger log = LoggerFactory.getLogger(RegistryExceptionMapper.class);
 
-    private static final Map<Class<?>, Integer> CODE_MAP = new HashMap<>();
+    private static final Map<Class<? extends Throwable>, Integer> CODE_MAP = new HashMap<>();
 
     @Inject
     ResponseErrorLivenessCheck liveness;
@@ -72,6 +73,10 @@ public class RegistryExceptionMapper implements ExceptionMapper<Throwable> {
         CODE_MAP.put(RuleNotFoundException.class, HTTP_NOT_FOUND);
         CODE_MAP.put(RuleViolationException.class, HTTP_BAD_REQUEST);
         CODE_MAP.put(VersionNotFoundException.class, HTTP_NOT_FOUND);
+    }
+
+    public static Map<Class<? extends Throwable>, Integer> getCodeMap() {
+        return Collections.unmodifiableMap(CODE_MAP);
     }
 
     /**


### PR DESCRIPTION
There is another possible approach - to just check if the exception is a sub-type of `StorageException`, because other exceptions inherit from it. But in that case we wouldn't be able to ignore unrelated exceptions. I can do a combination of these. WDYT?
