### PR TITLE
Limit content of the Kafka Connect distribution

### DIFF
--- a/distro/connect-converter/pom.xml
+++ b/distro/connect-converter/pom.xml
@@ -48,16 +48,19 @@
             <groupId>org.glassfish.jersey.ext.microprofile</groupId>
             <artifactId>jersey-mp-rest-client</artifactId>
             <version>${version.jersey}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.ext.microprofile</groupId>
             <artifactId>jersey-mp-config</artifactId>
             <version>${version.jersey}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.config</groupId>
             <artifactId>geronimo-config-impl</artifactId>
             <version>${version.geronimo.config}</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/distro/connect-converter/src/assembly/converter-distribution.xml
+++ b/distro/connect-converter/src/assembly/converter-distribution.xml
@@ -9,20 +9,36 @@
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
   <dependencySets>
-      <dependencySet>
-          <unpack>false</unpack>
-          <scope>runtime</scope>
-          <useProjectArtifact>false</useProjectArtifact>
-          <useTransitiveFiltering>true</useTransitiveFiltering>
-          <excludes>
-              <!-- Exclude dependencies of Kafka APIs, since they will be available in the runtime -->
-              <exclude>org.apache.kafka:kafka-clients:*</exclude>
-              <exclude>org.apache.kafka:connect-api:*</exclude>
-              <!-- Connect JSON needs to be kept due to classloading conflicts of Jackson data mapper
-              <exclude>org.apache.kafka:connect-json:*</exclude>
-              -->
-          </excludes>
-  </dependencySet>
+    <dependencySet>
+      <unpack>false</unpack>
+      <scope>compile</scope>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useTransitiveFiltering>true</useTransitiveFiltering>
+      <excludes>
+        <!-- Exclude dependencies of Kafka APIs, since they will be available in the runtime -->
+        <exclude>org.apache.kafka:kafka-clients:*</exclude>
+        <exclude>org.apache.kafka:connect-api:*</exclude>
+        <!-- Connect JSON needs to be kept due to classloading conflicts of Jackson data mapper
+        <exclude>org.apache.kafka:connect-json:*</exclude>
+        -->
+      </excludes>
+    </dependencySet>
+    <dependencySet>
+      <unpack>false</unpack>
+      <scope>runtime</scope>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useTransitiveFiltering>true</useTransitiveFiltering>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <excludes>
+        <!-- Exclude dependencies of Kafka APIs, since they will be available in the runtime -->
+        <exclude>org.apache.kafka:kafka-clients:*</exclude>
+        <exclude>org.apache.kafka:connect-api:*</exclude>
+        <!-- Connect JSON needs to be kept due to classloading conflicts of Jackson data mapper
+        <exclude>org.apache.kafka:connect-json:*</exclude>
+        -->
+      </excludes>
+    </dependencySet>
+
   </dependencySets>
   <fileSets>
     <fileSet>


### PR DESCRIPTION
Current content of Kafka connect zip is:

<details>
  <summary><b>content.zip</b></summary>
<pre><code>
annotations-13.0.jar
aopalliance-repackaged-2.6.1.jar
apicurio-registry-client-1.2.0-SNAPSHOT.jar
apicurio-registry-common-1.2.0-SNAPSHOT.jar
apicurio-registry-utils-converter-1.2.0-SNAPSHOT.jar
apicurio-registry-utils-serde-1.2.0-SNAPSHOT.jar
avro-1.9.2.jar
btf-1.2.jar
cdi-api-2.0.jar
checker-qual-2.5.2.jar
commons-compress-1.19.jar
connect-json-2.4.0.jar
failureaccess-1.0.1.jar
geronimo-config-impl-1.2.2.jar
guava-27.0.1-jre.jar
hk2-api-2.6.1.jar
hk2-locator-2.6.1.jar
hk2-utils-2.6.1.jar
istack-commons-runtime-3.0.10.jar
jackson-annotations-2.10.2.jar
jackson-core-2.10.2.jar
jackson-coreutils-1.6.jar
jackson-databind-2.10.2.jar
jackson-datatype-jdk8-2.10.2.jar
jackson-jaxrs-base-2.10.2.jar
jackson-jaxrs-json-provider-2.10.2.jar
jackson-module-jaxb-annotations-2.10.2.jar
jakarta.activation-1.2.1.jar
jakarta.activation-api-1.2.1.jar
jakarta.annotation-api-1.3.5.jar
jakarta.inject-2.6.1.jar
jakarta.json-1.1.6.jar
jakarta.json-1.1.6-module.jar
jakarta.json-api-1.1.5.jar
jakarta.json.bind-api-1.0.2.jar
jakarta.validation-api-2.0.2.jar
jakarta.ws.rs-api-2.1.6.jar
javassist-3.25.0-GA.jar
javax.el-api-3.0.0.jar
javax.inject-1.jar
javax.interceptor-api-1.2.jar
jaxb-runtime-2.3.3-b02.jar
jboss-jaxb-api_2.3_spec-2.0.0.Final.jar
jboss-jaxrs-api_2.1_spec-2.0.1.Final.jar
jboss-logging-3.3.2.Final.jar
jersey-cdi1x-2.30.1.jar
jersey-client-2.30.1.jar
jersey-common-2.30.1.jar
jersey-hk2-2.30.1.jar
jersey-media-jaxb-2.30.1.jar
jersey-media-json-binding-2.30.1.jar
jersey-mp-config-2.30.1.jar
jersey-mp-rest-client-2.30.1.jar
jersey-server-2.30.1.jar
json-patch-1.9.jar
jsonp-jaxrs-1.1.5.jar
kotlin-reflect-1.3.20.jar
kotlin-stdlib-1.3.20.jar
kotlin-stdlib-common-1.3.20.jar
listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
medeia-validator-core-1.1.1.jar
medeia-validator-jackson-1.1.1.jar
microprofile-config-api-1.4.jar
microprofile-rest-client-api-1.4.1.jar
msg-simple-1.1.jar
osgi-resource-locator-1.0.3.jar
protobuf-java-3.11.4.jar
resteasy-jackson2-provider-4.5.3.Final.jar
resteasy-jaxb-provider-4.5.3.Final.jar
txw2-2.3.3-b02.jar
yasson-1.0.6.jar
</code></pre>
</details>

This PR classifies in 2 different groups the dependencies:
1. Service Registry artifacts
2. Third party depenencies

And turns off the inclusion of transitive dependencies for the third parties, avoiding the inclusion of dubious required artifacts like `jersey-server`. See current list here: https://gist.github.com/EricWittmann/fd387227db9b4105aa71ad0279918a9a

This is the new list of artifacts, way shorter.

<details>
  <summary><b>Reduced list</b></summary>
<pre><code>
annotations-13.0.jar
apicurio-registry-client-1.2.0-SNAPSHOT.jar
apicurio-registry-common-1.2.0-SNAPSHOT.jar
apicurio-registry-utils-converter-1.2.0-SNAPSHOT.jar
apicurio-registry-utils-serde-1.2.0-SNAPSHOT.jar
avro-1.9.2.jar
commons-compress-1.19.jar
connect-json-2.4.0.jar
geronimo-config-impl-1.2.2.jar
jackson-annotations-2.10.2.jar
jackson-core-2.10.2.jar
jackson-databind-2.10.2.jar
jackson-datatype-jdk8-2.10.2.jar
jboss-jaxrs-api_2.1_spec-2.0.1.Final.jar
jersey-mp-config-2.30.1.jar
jersey-mp-rest-client-2.30.1.jar
kotlin-reflect-1.3.20.jar
kotlin-stdlib-1.3.20.jar
kotlin-stdlib-common-1.3.20.jar
medeia-validator-core-1.1.1.jar
medeia-validator-jackson-1.1.1.jar
protobuf-java-3.11.4.jar
</code></pre>
</details>

**Mind: the list of dependencies with `<scope>runtime</scope>` might need to be extended, and to fully validate this, a real test with Kafka Connect is required.