### PR TITLE
move converters test to tests module

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -139,11 +139,6 @@
         </dependency>
         <dependency>
             <groupId>io.apicurio</groupId>
-            <artifactId>apicurio-registry-utils-converter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-maven-plugin</artifactId>
             <type>maven-plugin</type>
             <scope>test</scope>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -148,6 +148,11 @@
             <artifactId>apicurio-registry-utils-serde</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-utils-converter</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/src/test/java/io/apicurio/tests/BaseIT.java
+++ b/tests/src/test/java/io/apicurio/tests/BaseIT.java
@@ -211,4 +211,8 @@ public abstract class BaseIT implements TestSeparator, Constants {
             confluentService.deleteSubject(confluentSubject);
         }
     }
+
+    protected String generateArtifactId() {
+        return TestUtils.generateArtifactId();
+    }
 }

--- a/tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
+++ b/tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.apicurio.registry;
+package io.apicurio.tests.converters;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,17 +39,20 @@ import io.apicurio.registry.utils.serde.avro.DefaultAvroDatumProvider;
 import io.apicurio.registry.utils.serde.strategy.AutoRegisterIdStrategy;
 import io.apicurio.registry.utils.serde.strategy.TopicRecordIdStrategy;
 import io.apicurio.registry.utils.tests.RegistryServiceTest;
-import io.quarkus.test.junit.QuarkusTest;
+import io.apicurio.tests.BaseIT;
+
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.storage.Converter;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 
 import static io.apicurio.registry.utils.tests.TestUtils.retry;
 import static io.apicurio.registry.utils.tests.TestUtils.waitForSchema;
 import static io.apicurio.registry.utils.tests.TestUtils.waitForSchemaCustom;
+import static io.apicurio.tests.Constants.CLUSTER;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -66,10 +69,10 @@ import java.util.function.Supplier;
 /**
  * @author Ales Justin
  */
-@QuarkusTest
-public class RegistryConverterTest extends AbstractResourceTestBase {
+@Tag(CLUSTER)
+public class RegistryConverterIT extends BaseIT {
 
-    @RegistryServiceTest
+    @RegistryServiceTest(localOnly = false)
     public void testConfiguration(Supplier<RegistryService> supplier) throws Exception {
         Schema schema = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"myrecord4\",\"fields\":[{\"name\":\"bar\",\"type\":\"string\"}]}");
 
@@ -137,7 +140,7 @@ public class RegistryConverterTest extends AbstractResourceTestBase {
         }
     }
 
-    @RegistryServiceTest
+    @RegistryServiceTest(localOnly = false)
     public void testAvro(Supplier<RegistryService> supplier) throws Exception {
         RegistryService service = supplier.get();
         try (AvroKafkaSerializer<GenericData.Record> serializer = new AvroKafkaSerializer<GenericData.Record>(service).setGlobalIdStrategy(new AutoRegisterIdStrategy<>());
@@ -164,7 +167,7 @@ public class RegistryConverterTest extends AbstractResourceTestBase {
         }
     }
 
-    @RegistryServiceTest
+    @RegistryServiceTest(localOnly = false)
     public void testPrettyJson(Supplier<RegistryService> supplier) throws Exception {
         testJson(
             supplier.get(),
@@ -181,7 +184,7 @@ public class RegistryConverterTest extends AbstractResourceTestBase {
         );
     }
 
-    @RegistryServiceTest
+    @RegistryServiceTest(localOnly = false)
     public void testCompactJson(Supplier<RegistryService> supplier) throws Exception {
         testJson(
             supplier.get(),


### PR DESCRIPTION
Moves RegistryConverterTest to tests module and modifies it to be a IT so can be included in QE process