### PR TITLE
Better YAML and XML support

### DIFF
--- a/app/src/main/java/io/apicurio/registry/util/ContentTypeUtil.java
+++ b/app/src/main/java/io/apicurio/registry/util/ContentTypeUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.util;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.apicurio.registry.content.ContentHandle;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public final class ContentTypeUtil {
+
+    private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+    private static final ObjectMapper jsonMapper = new ObjectMapper();
+
+    /**
+     * Returns true if the Content-Type of the inbound request is "application/json".
+     * @param request
+     */
+    public static final boolean isApplicationJson(HttpServletRequest request) {
+        String ct = request.getContentType();
+        if (ct == null) {
+            return false;
+        }
+        return ct.contains("application/json");
+    }
+
+    /**
+     * Returns true if the Content-Type of the inbound request is "application/x-yaml".
+     * @param request
+     */
+    public static final boolean isApplicationYaml(HttpServletRequest request) {
+        String ct = request.getContentType();
+        if (ct == null) {
+            return false;
+        }
+        return ct.contains("application/x-yaml");
+    }
+    
+    public static final ContentHandle yamlToJson(ContentHandle yaml) {
+        try {
+            JsonNode root = yamlMapper.readTree(yaml.stream());
+            return ContentHandle.create(jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(root));
+        } catch (Throwable t) {
+            return yaml;
+        }
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/util/ContentTypeUtil.java
+++ b/app/src/main/java/io/apicurio/registry/util/ContentTypeUtil.java
@@ -28,6 +28,10 @@ import io.apicurio.registry.content.ContentHandle;
  * @author eric.wittmann@gmail.com
  */
 public final class ContentTypeUtil {
+    
+    public static final String CT_APPLICATION_JSON = "application/json";
+    public static final String CT_APPLICATION_YAML = "application/x-yaml";
+    public static final String CT_APPLICATION_XML = "application/xml";
 
     private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
     private static final ObjectMapper jsonMapper = new ObjectMapper();
@@ -41,7 +45,7 @@ public final class ContentTypeUtil {
         if (ct == null) {
             return false;
         }
-        return ct.contains("application/json");
+        return ct.contains(CT_APPLICATION_JSON);
     }
 
     /**
@@ -53,7 +57,7 @@ public final class ContentTypeUtil {
         if (ct == null) {
             return false;
         }
-        return ct.contains("application/x-yaml");
+        return ct.contains(CT_APPLICATION_YAML);
     }
     
     public static final ContentHandle yamlToJson(ContentHandle yaml) {

--- a/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
+++ b/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
@@ -37,6 +37,7 @@ public abstract class AbstractResourceTestBase extends AbstractRegistryTestBase 
     protected static final String CT_JSON = "application/json";
     protected static final String CT_PROTO = "application/x-protobuf";
     protected static final String CT_YAML = "application/x-yaml";
+    protected static final String CT_XML = "application/xml";
 
     @Inject
     Instance<ServiceInitializer> initializers;

--- a/app/src/test/java/io/apicurio/registry/ArtifactsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/ArtifactsResourceTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hamcrest.CustomMatcher;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +35,8 @@ import io.apicurio.registry.rest.beans.Rule;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.RuleType;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.config.EncoderConfig;
+import io.restassured.config.RestAssuredConfig;
 import io.restassured.http.ContentType;
 
 /**
@@ -94,7 +97,6 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
                 .statusCode(200)
                 .body("id", equalTo("testCreateArtifact/EmptyAPI/detect"))
                 .body("type", equalTo(ArtifactType.OPENAPI.name()));
-
     }
 
     @Test
@@ -868,5 +870,70 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
             .then()
                 .statusCode(404);
 
+    }
+    
+    @Test
+    public void testYamlContentType() {
+        String artifactId = "testYamlContentType";
+        ArtifactType artifactType = ArtifactType.OPENAPI;
+        String artifactContent = resourceToString("openapi-empty.yaml");
+        
+        // Create OpenAPI artifact (from YAML)
+        given()
+            .config(RestAssuredConfig.config().encoderConfig(EncoderConfig.encoderConfig().encodeContentTypeAs(CT_YAML, ContentType.TEXT)))
+            .when()
+                .contentType(CT_YAML)
+                .header("X-Registry-ArtifactId", artifactId)
+                .header("X-Registry-ArtifactType", artifactType.name())
+                .body(artifactContent)
+                .post("/artifacts")
+            .then()
+                .statusCode(200)
+                .body("id", equalTo(artifactId))
+                .body("name", equalTo("Empty API"))
+                .body("description", equalTo("An example API design using OpenAPI."))
+                .body("type", equalTo(artifactType.name()));
+
+        // Get the artifact content (should be JSON)
+        given()
+            .when()
+                .pathParam("artifactId", "testYamlContentType")
+                .get("/artifacts/{artifactId}")
+            .then()
+                .statusCode(200)
+                .header("Content-Type", Matchers.containsString(CT_JSON))
+                .body("openapi", equalTo("3.0.2"))
+                .body("info.title", equalTo("Empty API"));
+    }
+    
+
+    @Test
+    public void testWsdlArtifact() {
+        String artifactId = "testWsdlArtifact";
+        ArtifactType artifactType = ArtifactType.WSDL;
+        String artifactContent = resourceToString("sample.wsdl");
+        
+        // Create OpenAPI artifact (from YAML)
+        given()
+            .config(RestAssuredConfig.config().encoderConfig(EncoderConfig.encoderConfig().encodeContentTypeAs(CT_XML, ContentType.TEXT)))
+            .when()
+                .contentType(CT_XML)
+                .header("X-Registry-ArtifactId", artifactId)
+                .header("X-Registry-ArtifactType", artifactType.name())
+                .body(artifactContent)
+                .post("/artifacts")
+            .then()
+                .statusCode(200)
+                .body("id", equalTo(artifactId))
+                .body("type", equalTo(artifactType.name()));
+
+        // Get the artifact content (should be XML)
+        given()
+            .when()
+                .pathParam("artifactId", "testWsdlArtifact")
+                .get("/artifacts/{artifactId}")
+            .then()
+                .statusCode(200)
+                .header("Content-Type", Matchers.containsString(CT_XML));
     }
 }

--- a/app/src/test/java/io/apicurio/registry/util/ContentTypeUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/util/ContentTypeUtilTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.content.ContentHandle;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+class ContentTypeUtilTest {
+    
+    private static final String YAML_CONTENT = "openapi: 3.0.2\r\n" + 
+            "info:\r\n" + 
+            "    title: Empty API\r\n" + 
+            "    version: 1.0.0\r\n" + 
+            "paths:\r\n" + 
+            "    /mice:\r\n" + 
+            "        get:\r\n" + 
+            "            responses:\r\n" + 
+            "                '200':\r\n" + 
+            "                    description: ...\r\n" + 
+            "components:\r\n" + 
+            "    schemas:\r\n" + 
+            "        Mouse:\r\n" + 
+            "            description: ''\r\n" + 
+            "            type: object\r\n" + 
+            "";
+    private static final String JSON_CONTENT = "{\r\n" + 
+            "  \"openapi\" : \"3.0.2\",\r\n" + 
+            "  \"info\" : {\r\n" + 
+            "    \"title\" : \"Empty API\",\r\n" + 
+            "    \"version\" : \"1.0.0\"\r\n" + 
+            "  },\r\n" + 
+            "  \"paths\" : {\r\n" + 
+            "    \"/mice\" : {\r\n" + 
+            "      \"get\" : {\r\n" + 
+            "        \"responses\" : {\r\n" + 
+            "          \"200\" : {\r\n" + 
+            "            \"description\" : \"...\"\r\n" + 
+            "          }\r\n" + 
+            "        }\r\n" + 
+            "      }\r\n" + 
+            "    }\r\n" + 
+            "  },\r\n" + 
+            "  \"components\" : {\r\n" + 
+            "    \"schemas\" : {\r\n" + 
+            "      \"Mouse\" : {\r\n" + 
+            "        \"description\" : \"\",\r\n" + 
+            "        \"type\" : \"object\"\r\n" + 
+            "      }\r\n" + 
+            "    }\r\n" + 
+            "  }\r\n" + 
+            "}";
+
+    /**
+     * Test method for {@link io.apicurio.registry.util.ContentTypeUtil#yamlToJson(io.apicurio.registry.content.ContentHandle)}.
+     */
+    @Test
+    void testYamlToJson() {
+        ContentHandle yaml = ContentHandle.create(YAML_CONTENT);
+        ContentHandle json = ContentTypeUtil.yamlToJson(yaml);
+        Assertions.assertEquals(JSON_CONTENT, json.content());
+
+    }
+
+}

--- a/app/src/test/java/io/apicurio/registry/util/ContentTypeUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/util/ContentTypeUtilTest.java
@@ -16,6 +16,9 @@
 
 package io.apicurio.registry.util;
 
+import java.io.BufferedReader;
+import java.io.StringReader;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -73,11 +76,22 @@ class ContentTypeUtilTest {
      * Test method for {@link io.apicurio.registry.util.ContentTypeUtil#yamlToJson(io.apicurio.registry.content.ContentHandle)}.
      */
     @Test
-    void testYamlToJson() {
+    void testYamlToJson() throws Exception {
         ContentHandle yaml = ContentHandle.create(YAML_CONTENT);
         ContentHandle json = ContentTypeUtil.yamlToJson(yaml);
-        Assertions.assertEquals(JSON_CONTENT, json.content());
-
+        Assertions.assertEquals(normalize(JSON_CONTENT), normalize(json.content()));
+    }
+    
+    private static final String normalize(String value) throws Exception {
+        StringBuilder builder = new StringBuilder();
+        BufferedReader reader = new BufferedReader(new StringReader(value));
+        String line = reader.readLine();
+        while (line != null) {
+            builder.append(line);
+            builder.append("\n");
+            line = reader.readLine();
+        }
+        return builder.toString();
     }
 
 }

--- a/app/src/test/resources/io/apicurio/registry/openapi-empty.yaml
+++ b/app/src/test/resources/io/apicurio/registry/openapi-empty.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.2
+info:
+    title: Empty API
+    version: 1.0.0
+    description: An example API design using OpenAPI.

--- a/app/src/test/resources/io/apicurio/registry/sample.wsdl
+++ b/app/src/test/resources/io/apicurio/registry/sample.wsdl
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<definitions name="StockQuote"
+
+targetNamespace="http://example.com/stockquote.wsdl"
+          xmlns:tns="http://example.com/stockquote.wsdl"
+          xmlns:xsd1="http://example.com/stockquote.xsd"
+          xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+          xmlns="http://schemas.xmlsoap.org/wsdl/">
+
+    <types>
+       <schema targetNamespace="http://example.com/stockquote.xsd"
+              xmlns="http://www.w3.org/2000/10/XMLSchema">
+           <element name="TradePriceRequest">
+              <complexType>
+                  <all>
+                      <element name="tickerSymbol" type="string"/>
+                  </all>
+              </complexType>
+           </element>
+           <element name="TradePrice">
+              <complexType>
+                  <all>
+                      <element name="price" type="float"/>
+                  </all>
+              </complexType>
+           </element>
+       </schema>
+    </types>
+
+    <message name="GetLastTradePriceInput">
+        <part name="body" element="xsd1:TradePriceRequest"/>
+    </message>
+
+    <message name="GetLastTradePriceOutput">
+        <part name="body" element="xsd1:TradePrice"/>
+    </message>
+
+    <portType name="StockQuotePortType">
+        <operation name="GetLastTradePrice">
+           <input message="tns:GetLastTradePriceInput"/>
+           <output message="tns:GetLastTradePriceOutput"/>
+        </operation>
+    </portType>
+
+    <binding name="StockQuoteSoapBinding" type="tns:StockQuotePortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="GetLastTradePrice">
+           <soap:operation soapAction="http://example.com/GetLastTradePrice"/>
+           <input>
+               <soap:body use="literal"/>
+           </input>
+           <output>
+               <soap:body use="literal"/>
+           </output>
+        </operation>
+    </binding>
+
+    <service name="StockQuoteService">
+        <documentation>My first service</documentation>
+        <port name="StockQuotePort" binding="tns:StockQuoteBinding">
+           <soap:address location="http://example.com/stockquote"/>
+        </port>
+    </service>
+
+</definitions>

--- a/common/src/main/java/io/apicurio/registry/rest/ArtifactsResource.java
+++ b/common/src/main/java/io/apicurio/registry/rest/ArtifactsResource.java
@@ -71,7 +71,7 @@ public interface ArtifactsResource {
    */
   @POST
   @Produces("application/json")
-  @Consumes({"application/json", "application/x-protobuf", "application/x-protobuffer"})
+  @Consumes({"application/json", "application/x-protobuf", "application/x-protobuffer", "application/x-yaml", "application/xml"})
   CompletionStage<ArtifactMetaData> createArtifact(
       @HeaderParam("X-Registry-ArtifactType") ArtifactType xRegistryArtifactType,
       @HeaderParam("X-Registry-ArtifactId") String xRegistryArtifactId, InputStream data);
@@ -89,7 +89,7 @@ public interface ArtifactsResource {
    */
   @Path("/{artifactId}")
   @GET
-  @Produces({"application/json", "application/x-protobuf", "application/x-protobuffer"})
+  @Produces({"application/json", "application/x-protobuf", "application/x-protobuffer", "application/xml"})
   Response getLatestArtifact(@PathParam("artifactId") String artifactId);
 
   /**
@@ -131,7 +131,7 @@ public interface ArtifactsResource {
   @Path("/{artifactId}")
   @PUT
   @Produces("application/json")
-  @Consumes({"application/json", "application/x-protobuf", "application/x-protobuffer"})
+  @Consumes({"application/json", "application/x-protobuf", "application/x-protobuffer", "application/x-yaml", "application/xml"})
   CompletionStage<ArtifactMetaData> updateArtifact(@PathParam("artifactId") String artifactId,
       @HeaderParam("X-Registry-ArtifactType") ArtifactType xRegistryArtifactType, InputStream data);
 
@@ -216,7 +216,7 @@ public interface ArtifactsResource {
   @Path("/{artifactId}/meta")
   @POST
   @Produces("application/json")
-  @Consumes({"application/json", "application/x-protobuf", "application/x-protobuffer"})
+  @Consumes({"application/json", "application/x-protobuf", "application/x-protobuffer", "application/x-yaml", "application/xml"})
   ArtifactMetaData getArtifactMetaDataByContent(@PathParam("artifactId") String artifactId,
       InputStream data);
 
@@ -276,7 +276,7 @@ public interface ArtifactsResource {
   @Path("/{artifactId}/versions")
   @POST
   @Produces("application/json")
-  @Consumes({"application/json", "application/x-protobuf", "application/x-protobuffer"})
+  @Consumes({"application/json", "application/x-protobuf", "application/x-protobuffer", "application/x-yaml", "application/xml"})
   CompletionStage<VersionMetaData> createArtifactVersion(@PathParam("artifactId") String artifactId,
       @HeaderParam("X-Registry-ArtifactType") ArtifactType xRegistryArtifactType, InputStream data);
 
@@ -295,7 +295,7 @@ public interface ArtifactsResource {
    */
   @Path("/{artifactId}/versions/{version}")
   @GET
-  @Produces({"application/json", "application/x-protobuf", "application/x-protobuffer"})
+  @Produces({"application/json", "application/x-protobuf", "application/x-protobuffer", "application/xml"})
   Response getArtifactVersion(@PathParam("version") Integer version,
       @PathParam("artifactId") String artifactId);
 
@@ -535,7 +535,7 @@ public interface ArtifactsResource {
    */
   @Path("/{artifactId}/test")
   @PUT
-  @Consumes({"application/json", "application/x-protobuf", "application/x-protobuffer"})
+  @Consumes({"application/json", "application/x-protobuf", "application/x-protobuffer", "application/x-yaml", "application/xml"})
   void testUpdateArtifact(@PathParam("artifactId") String artifactId,
       @HeaderParam("X-Registry-ArtifactType") ArtifactType xRegistryArtifactType, InputStream data);
 }

--- a/common/src/main/java/io/apicurio/registry/types/ArtifactMediaTypes.java
+++ b/common/src/main/java/io/apicurio/registry/types/ArtifactMediaTypes.java
@@ -24,6 +24,7 @@ import javax.ws.rs.core.MediaType;
 public final class ArtifactMediaTypes {
 
     public static final MediaType JSON = MediaType.APPLICATION_JSON_TYPE;
+    public static final MediaType XML = MediaType.APPLICATION_XML_TYPE;
     public static final MediaType YAML = new MediaType("application", "x-yaml");
     public static final MediaType PROTO = new MediaType("application", "x-protobuf");
     

--- a/ui/packages/models/src/artifactTypes.model.ts
+++ b/ui/packages/models/src/artifactTypes.model.ts
@@ -15,10 +15,18 @@
  * limitations under the License.
  */
 
-export * from "./artifactMetaData.model";
-export * from "./artifactTypes.model";
-export * from "./contentTypes.model";
-export * from "./rule.model";
-export * from "./searchedArtifact.model";
-export * from "./searchedVersion.model";
-export * from "./versionMetaData.model";
+// tslint:disable-next-line:interface-name
+export class ArtifactTypes {
+
+    public static AVRO: string = "AVRO";
+    public static PROTOBUF: string = "PROTOBUF";
+    public static JSON: string = "JSON";
+    public static OPENAPI: string = "OPENAPI";
+    public static ASYNCAPI: string = "ASYNCAPI";
+    public static GRAPHQL: string = "GRAPHQL";
+    public static KCONNECT: string = "KCONNECT";
+    public static WSDL: string = "WSDL";
+    public static XSD: string = "XSD";
+    public static XML: string = "XML";
+
+}

--- a/ui/packages/models/src/contentTypes.model.ts
+++ b/ui/packages/models/src/contentTypes.model.ts
@@ -15,10 +15,12 @@
  * limitations under the License.
  */
 
-export * from "./artifactMetaData.model";
-export * from "./artifactTypes.model";
-export * from "./contentTypes.model";
-export * from "./rule.model";
-export * from "./searchedArtifact.model";
-export * from "./searchedVersion.model";
-export * from "./versionMetaData.model";
+// tslint:disable-next-line:interface-name
+export class ContentTypes {
+
+    public static APPLICATION_JSON: string = "application/json";
+    public static APPLICATION_YAML: string = "application/x-yaml";
+    public static APPLICATION_XML: string = "application/xml";
+    public static APPLICATION_PROTOBUF: string = "application/x-protobuf";
+
+}

--- a/ui/packages/registry/src/app/components/common/artifactTypeIcon.tsx
+++ b/ui/packages/registry/src/app/components/common/artifactTypeIcon.tsx
@@ -17,6 +17,7 @@
 import React from "react";
 import "./artifactTypeIcon.css";
 import {PureComponent, PureComponentProps, PureComponentState} from "../baseComponent";
+import {ArtifactTypes} from "@apicurio/registry-models";
 
 /**
  * Properties
@@ -55,37 +56,34 @@ export class ArtifactTypeIcon extends PureComponent<ArtifactTypeIconProps, Artif
     private getTitle(): string {
         let title: string = this.props.type;
         switch (this.props.type) {
-            case "AVRO":
+            case ArtifactTypes.AVRO:
                 title = "Avro Schema";
                 break;
-            case "PROTOBUF":
+            case ArtifactTypes.PROTOBUF:
                 title = "Protobuf Schema";
                 break;
-            case "PROTOBUF_FD":
-                title = "Protobuf Schema";
-                break;
-            case "JSON":
+            case ArtifactTypes.JSON:
                 title = "JSON Schema";
                 break;
-            case "OPENAPI":
+            case ArtifactTypes.OPENAPI:
                 title = "OpenAPI Definition";
                 break;
-            case "ASYNCAPI":
+            case ArtifactTypes.ASYNCAPI:
                 title = "AsyncAPI Definition";
                 break;
-            case "GRAPHQL":
+            case ArtifactTypes.GRAPHQL:
                 title = "GraphQL Definition";
                 break;
-            case "KCONNECT":
+            case ArtifactTypes.KCONNECT:
                 title = "Kafka Connect Schema";
                 break;
-            case "WSDL":
+            case ArtifactTypes.WSDL:
                 title = "WSDL";
                 break;
-            case "XSD":
+            case ArtifactTypes.XSD:
                 title = "XML Schema";
                 break;
-            case "XML":
+            case ArtifactTypes.XML:
                 title = "XML";
                 break;
         }
@@ -95,37 +93,34 @@ export class ArtifactTypeIcon extends PureComponent<ArtifactTypeIconProps, Artif
     private getClassNames(): string {
         let classes: string = "artifact-type-icon";
         switch (this.props.type) {
-            case "AVRO":
+            case ArtifactTypes.AVRO:
                 classes += " avro-icon24";
                 break;
-            case "PROTOBUF":
+            case ArtifactTypes.PROTOBUF:
                 classes += " protobuf-icon24";
                 break;
-            case "PROTOBUF_FD":
-                classes += " protobuf-icon24";
-                break;
-            case "JSON":
+            case ArtifactTypes.JSON:
                 classes += " json-icon24";
                 break;
-            case "OPENAPI":
+            case ArtifactTypes.OPENAPI:
                 classes += " oai-icon24";
                 break;
-            case "ASYNCAPI":
+            case ArtifactTypes.ASYNCAPI:
                 classes += " aai-icon24";
                 break;
-            case "GRAPHQL":
+            case ArtifactTypes.GRAPHQL:
                 classes += " graphql-icon24";
                 break;
-            case "KCONNECT":
+            case ArtifactTypes.KCONNECT:
                 classes += " kconnect-icon24";
                 break;
-            case "WSDL":
+            case ArtifactTypes.WSDL:
                 classes += " xml-icon24";
                 break;
-            case "XSD":
+            case ArtifactTypes.XSD:
                 classes += " xml-icon24";
                 break;
-            case "XML":
+            case ArtifactTypes.XML:
                 classes += " xml-icon24";
                 break;
         }

--- a/ui/packages/registry/src/app/pages/artifactVersion/artifactVersion.tsx
+++ b/ui/packages/registry/src/app/pages/artifactVersion/artifactVersion.tsx
@@ -30,7 +30,7 @@ import {
     Tabs
 } from '@patternfly/react-core';
 import {PageComponent, PageProps, PageState} from "../basePage";
-import {ArtifactMetaData, Rule, VersionMetaData} from "@apicurio/registry-models";
+import {ArtifactMetaData, ArtifactTypes, ContentTypes, Rule, VersionMetaData} from "@apicurio/registry-models";
 import {ContentTabContent, DocumentationTabContent, InfoTabContent} from "./components/tabs";
 import {CreateVersionData, Services, EditableMetaData} from "@apicurio/registry-services";
 import {ArtifactVersionPageHeader} from "./components/pageheader";
@@ -264,13 +264,29 @@ export class ArtifactVersionPage extends PageComponent<ArtifactVersionPageProps,
     private doDownloadArtifact = (): void => {
         const content: string = this.state.artifactContent;
 
-        // TODO support all types here - graphql, etc.
-        let contentType: string = "application/json";
+        let contentType: string = ContentTypes.APPLICATION_JSON;
         let fext: string = "json";
-        if (this.state.artifact?.type === "PROTOBUF") {
-            contentType = "application/x-protobuf";
+        if (this.state.artifact?.type === ArtifactTypes.PROTOBUF) {
+            contentType = ContentTypes.APPLICATION_PROTOBUF;
             fext = "proto";
         }
+        if (this.state.artifact?.type === ArtifactTypes.WSDL) {
+            contentType = ContentTypes.APPLICATION_XML;
+            fext = "wsdl";
+        }
+        if (this.state.artifact?.type === ArtifactTypes.XSD) {
+            contentType = ContentTypes.APPLICATION_XML;
+            fext = "xsd";
+        }
+        if (this.state.artifact?.type === ArtifactTypes.XML) {
+            contentType = ContentTypes.APPLICATION_XML;
+            fext = "xml";
+        }
+        if (this.state.artifact?.type === ArtifactTypes.GRAPHQL) {
+            contentType = ContentTypes.APPLICATION_JSON;
+            fext = "graphql";
+        }
+
         const fname: string = this.artifactNameOrId() + "." + fext;
         Services.getDownloaderService().downloadToFS(content, contentType, fname);
     };

--- a/ui/packages/registry/src/app/pages/artifacts/components/uploadForm/uploadForm.tsx
+++ b/ui/packages/registry/src/app/pages/artifacts/components/uploadForm/uploadForm.tsx
@@ -30,18 +30,19 @@ import {
 } from "@patternfly/react-core";
 import {CaretDownIcon} from "@patternfly/react-icons";
 import {CreateArtifactData} from "@apicurio/registry-services";
+import {ArtifactTypes} from "@apicurio/registry-models";
 
 
 const artifactTypes: any[] = [
-    { id: "AVRO", label: "Avro Schema" },
-    { id: "PROTOBUF", label: "Protocol Buffer Schema" },
-    { id: "JSON", label: "JSON Schema" },
-    { id: "OPENAPI", label: "OpenAPI" },
-    { id: "ASYNCAPI", label: "AsyncAPI" },
-    { id: "GRAPHQL", label: "GraphQL" },
-    { id: "KCONNECT", label: "Kafka Connect Schema" },
-    { id: "WSDL", label: "WSDL" },
-    { id: "XSD", label: "XML Schema" },
+    { id: ArtifactTypes.AVRO, label: "Avro Schema" },
+    { id: ArtifactTypes.PROTOBUF, label: "Protocol Buffer Schema" },
+    { id: ArtifactTypes.JSON, label: "JSON Schema" },
+    { id: ArtifactTypes.OPENAPI, label: "OpenAPI" },
+    { id: ArtifactTypes.ASYNCAPI, label: "AsyncAPI" },
+    { id: ArtifactTypes.GRAPHQL, label: "GraphQL" },
+    { id: ArtifactTypes.KCONNECT, label: "Kafka Connect Schema" },
+    { id: ArtifactTypes.WSDL, label: "WSDL" },
+    { id: ArtifactTypes.XSD, label: "XML Schema" },
 ];
 
 /**

--- a/ui/packages/services/src/artifacts/artifacts.service.ts
+++ b/ui/packages/services/src/artifacts/artifacts.service.ts
@@ -15,7 +15,14 @@
  * limitations under the License.
  */
 
-import {SearchedArtifact, SearchedVersion, ArtifactMetaData, Rule, VersionMetaData} from "@apicurio/registry-models";
+import {
+    SearchedArtifact,
+    SearchedVersion,
+    ArtifactMetaData,
+    Rule,
+    VersionMetaData,
+    ContentTypes
+} from "@apicurio/registry-models";
 import {BaseService} from "../baseService";
 
 export interface CreateArtifactData {
@@ -200,21 +207,21 @@ export class ArtifactsService extends BaseService {
     private contentType(type: string, content: string): string {
         switch (type) {
             case "PROTOBUF":
-                return "application/x-protobuf";
+                return ContentTypes.APPLICATION_PROTOBUF;
             case "WSDL":
             case "XSD":
             case "XML":
-                return "application/xml";
+                return ContentTypes.APPLICATION_XML;
             case "GRAPHQL":
                 // TODO need a better content-type for GraphQL!
-                return "application/json";
+                return ContentTypes.APPLICATION_JSON;
         }
         if (this.isJson(content)) {
-            return "application/json";
+            return ContentTypes.APPLICATION_JSON;
         } else if (this.isXml(content)) {
-            return "application/xml";
+            return ContentTypes.APPLICATION_XML;
         } else {
-            return "application/x-yaml";
+            return ContentTypes.APPLICATION_YAML;
         }
     }
 

--- a/ui/packages/services/src/baseService.ts
+++ b/ui/packages/services/src/baseService.ts
@@ -19,6 +19,7 @@
 import {LoggerService} from "./logger";
 import {ConfigService} from "./config";
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import {ContentTypes} from "@apicurio/registry-models";
 
 /**
  * Interface implemented by all services.
@@ -98,7 +99,7 @@ export abstract class BaseService implements Service {
         this.logger.info("[BaseService] Making a GET request to: ", url);
 
         if (!options) {
-            options = this.options({ "Accept": "application/json" });
+            options = this.options({ "Accept": ContentTypes.APPLICATION_JSON });
         }
 
         const config: AxiosRequestConfig = this.axiosConfig("get", url, options);
@@ -126,7 +127,7 @@ export abstract class BaseService implements Service {
         this.logger.info("[BaseService] Making a POST request to: ", url);
 
         if (!options) {
-            options = this.options({ "Content-Type": "application/json" });
+            options = this.options({ "Content-Type": ContentTypes.APPLICATION_JSON });
         }
 
         const config: AxiosRequestConfig = this.axiosConfig("post", url, options, body);
@@ -153,7 +154,7 @@ export abstract class BaseService implements Service {
         this.logger.info("[BaseService] Making a POST request to: ", url);
 
         if (!options) {
-            options = this.options({ "Accept": "application/json", "Content-Type": "application/json" });
+            options = this.options({ "Accept": ContentTypes.APPLICATION_JSON, "Content-Type": ContentTypes.APPLICATION_JSON });
         }
 
         const config: AxiosRequestConfig = this.axiosConfig("post", url, options, body);
@@ -181,7 +182,7 @@ export abstract class BaseService implements Service {
         this.logger.info("[BaseService] Making a PUT request to: ", url);
 
         if (!options) {
-            options = this.options({ "Content-Type": "application/json" });
+            options = this.options({ "Content-Type": ContentTypes.APPLICATION_JSON });
         }
 
         const config: AxiosRequestConfig = this.axiosConfig("put", url, options, body);
@@ -208,7 +209,7 @@ export abstract class BaseService implements Service {
         this.logger.info("[BaseService] Making a PUT request to: ", url);
 
         if (!options) {
-            options = this.options({ "Accept": "application/json", "Content-Type": "application/json" });
+            options = this.options({ "Accept": ContentTypes.APPLICATION_JSON, "Content-Type": ContentTypes.APPLICATION_JSON });
         }
 
         const config: AxiosRequestConfig = this.axiosConfig("put", url, options, body);

--- a/ui/packages/services/src/downloader/downloader.service.ts
+++ b/ui/packages/services/src/downloader/downloader.service.ts
@@ -57,7 +57,7 @@ export class DownloaderService implements Service {
             window.navigator.msSaveBlob(blob, filename);
         } else {
             // Firefox version
-            const file: File = new File([content], filename, { type: 'application/force-download' });
+            const file: File = new File([content], filename, { type: "application/force-download" });
             window.open(URL.createObjectURL(file));
         }
         // Not async right now - so just resolve to true


### PR DESCRIPTION
We now accept content-type of YAML and XML when adding content to the registry.
YAML content can be sent for JSON-style artifacts (Avro, OpenAPI, AsyncAPI, etc).
The UI now sends the right content-type for whatever it's sending (XML, JSON, YAML, Protobuf).
YAML content is transformed to JSON immediately by the server, so will be stored as JSON even if sent as YAML.