### PR TITLE
 Several improvements to confluent compatibility tests

### DIFF
--- a/tests/src/main/java/io/apicurio/tests/Constants.java
+++ b/tests/src/main/java/io/apicurio/tests/Constants.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 public interface Constants {
     long POLL_INTERVAL = Duration.ofSeconds(1).toMillis();
     long TIMEOUT_FOR_REGISTRY_START_UP = Duration.ofSeconds(15).toMillis();
+    long TIMEOUT_FOR_REGISTRY_READY = Duration.ofSeconds(25).toMillis();
     long TIMEOUT_GLOBAL = Duration.ofSeconds(30).toMillis();
 
     /**

--- a/tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
+++ b/tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.tests;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInfo;
+
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+
+public abstract class ConfluentBaseIT extends BaseIT {
+
+    protected static SchemaRegistryClient confluentService;
+
+    @BeforeAll
+    static void confluentBeforeAll(TestInfo info) throws Exception {
+        confluentService = new CachedSchemaRegistryClient(TestUtils.getRegistryUrl() + "/ccompat", 3);
+        clearAllConfluentSubjects();
+    }
+
+    @AfterEach
+    void clear() throws IOException, RestClientException {
+        clearAllConfluentSubjects();
+    }
+
+    public int createArtifactViaConfluentClient(Schema schema, String artifactName) throws IOException, RestClientException, TimeoutException {
+        int idOfSchema = confluentService.register(artifactName, schema);
+        confluentService.reset(); // clear cache
+        TestUtils.waitFor("Wait until artifact globalID mapping is finished", Constants.POLL_INTERVAL, Constants.TIMEOUT_GLOBAL,
+            () -> {
+                try {
+                    Schema newSchema = confluentService.getBySubjectAndId(artifactName, idOfSchema);
+                    LOGGER.info("Checking that created schema is equal to the get schema");
+                    assertThat(schema.toString(), is(newSchema.toString()));
+                    assertThat(confluentService.getVersion(artifactName, schema), is(confluentService.getVersion(artifactName, newSchema)));
+                    LOGGER.info("Created schema with id:{} and name:{}", idOfSchema, newSchema.getFullName());
+                    return true;
+                } catch (IOException | RestClientException e) {
+                    e.printStackTrace();
+                    return false;
+                }
+            });
+        return idOfSchema;
+    }
+
+    protected static void clearAllConfluentSubjects() throws IOException, RestClientException {
+        for (String confluentSubject : confluentService.getAllSubjects()) {
+            LOGGER.info("Deleting confluent schema {}", confluentSubject);
+            confluentService.deleteSubject(confluentSubject);
+        }
+    }
+
+}

--- a/tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
+++ b/tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
@@ -19,7 +19,7 @@ package io.apicurio.tests.serdes.confluent;
 import io.apicurio.registry.client.RegistryService;
 import io.apicurio.registry.utils.tests.RegistryServiceTest;
 import io.apicurio.registry.utils.tests.TestUtils;
-import io.apicurio.tests.BaseIT;
+import io.apicurio.tests.ConfluentBaseIT;
 import io.apicurio.tests.serdes.KafkaClients;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.apache.avro.Schema;
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 @Tag(CLUSTER)
-public class BasicConfluentSerDesIT extends BaseIT {
+public class BasicConfluentSerDesIT extends ConfluentBaseIT {
 
     @Test
     void testAvroConfluentSerDes() throws IOException, RestClientException, InterruptedException, ExecutionException, TimeoutException {

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AllArtifactTypesIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AllArtifactTypesIT.java
@@ -131,5 +131,8 @@ class AllArtifactTypesIT extends BaseIT {
     @AfterEach
     void deleteRules(RegistryService service) {
         service.deleteAllGlobalRules();
+        service.listArtifacts().forEach(artifactId -> {
+            service.deleteArtifact(artifactId);
+        });
     }
 }

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/MetadataConfluentIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/MetadataConfluentIT.java
@@ -17,7 +17,7 @@
 package io.apicurio.tests.smokeTests.confluent;
 
 import io.apicurio.registry.utils.tests.TestUtils;
-import io.apicurio.tests.BaseIT;
+import io.apicurio.tests.ConfluentBaseIT;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.apache.avro.Schema;
@@ -34,7 +34,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 @Tag(SMOKE)
-public class MetadataConfluentIT extends BaseIT {
+public class MetadataConfluentIT extends ConfluentBaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetadataConfluentIT.class);
 

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/RulesResourceConfluentIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/RulesResourceConfluentIT.java
@@ -17,7 +17,7 @@
 package io.apicurio.tests.smokeTests.confluent;
 
 import io.apicurio.registry.utils.tests.TestUtils;
-import io.apicurio.tests.BaseIT;
+import io.apicurio.tests.ConfluentBaseIT;
 import io.apicurio.tests.utils.subUtils.GlobalRuleUtils;
 import org.apache.avro.Schema;
 import org.junit.jupiter.api.AfterAll;
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import static io.apicurio.tests.Constants.SMOKE;
 
 @Tag(SMOKE)
-public class RulesResourceConfluentIT extends BaseIT {
+public class RulesResourceConfluentIT extends ConfluentBaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetadataConfluentIT.class);
 

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
@@ -201,9 +201,6 @@ public class SchemasConfluentIT extends ConfluentBaseIT {
 
         assertThat(1, is(confluentService.getAllSubjects().size()));
 
-        Response ar = ArtifactUtils.getArtifact(subjectName);
-        LOGGER.info(ar.asString());
-
         TestUtils.retry(() -> service.getArtifactMetaDataByGlobalId(globalId));
 
         TestUtils.waitFor("artifact created", Constants.POLL_INTERVAL, Constants.TIMEOUT_GLOBAL, () -> {
@@ -227,12 +224,9 @@ public class SchemasConfluentIT extends ConfluentBaseIT {
             }
         });
 
-        TestUtils.waitFor("artifact deletion", Constants.POLL_INTERVAL, Constants.TIMEOUT_GLOBAL, () -> {
-            return service.getLatestArtifact(subjectName) == null;
-        });
-
-        rules = service.listArtifactRules(subjectName);
-        assertThat(0, is(rules.size()));
+        TestUtils.assertWebError(404, () -> service.getLatestArtifact(subjectName), true);
+        TestUtils.assertWebError(404, () -> service.listArtifactRules(subjectName), true);
+        TestUtils.assertWebError(404, () -> service.getArtifactRuleConfig(rules.get(0), subjectName), true);
 
         //if rule was actually deleted creating same artifact again shouldn't fail
         createArtifactViaConfluentClient(schema, subjectName);

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
@@ -16,8 +16,11 @@
 
 package io.apicurio.tests.smokeTests.confluent;
 
+import io.apicurio.registry.client.RegistryService;
+import io.apicurio.registry.types.RuleType;
+import io.apicurio.registry.utils.tests.RegistryServiceTest;
 import io.apicurio.registry.utils.tests.TestUtils;
-import io.apicurio.tests.BaseIT;
+import io.apicurio.tests.ConfluentBaseIT;
 import io.apicurio.tests.Constants;
 import io.apicurio.tests.utils.subUtils.ArtifactUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -35,14 +38,17 @@ import static io.apicurio.tests.Constants.SMOKE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
+import javax.ws.rs.WebApplicationException;
+
 @Tag(SMOKE)
-public class SchemasConfluentIT extends BaseIT {
+public class SchemasConfluentIT extends ConfluentBaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SchemasConfluentIT.class);
 
@@ -160,6 +166,77 @@ public class SchemasConfluentIT extends BaseIT {
     @Test
     void deleteNonexistingSchema() {
         assertThrows(RestClientException.class, () -> confluentService.deleteSubject("non-existing"));
+    }
+
+    @RegistryServiceTest(localOnly = false)
+    void createConfluentQueryApicurio(RegistryService service) throws IOException, RestClientException, TimeoutException {
+        String name = "schemaname";
+        String subjectName = TestUtils.generateArtifactId();
+        String rawSchema = "{\"type\":\"record\",\"name\":\"" + name + "\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
+        Schema schema = new Schema.Parser().parse(rawSchema);
+        createArtifactViaConfluentClient(schema, subjectName);
+
+        assertThat(1, is(confluentService.getAllSubjects().size()));
+
+        Response ar = ArtifactUtils.getArtifact(subjectName);
+        assertEquals(rawSchema, ar.asString());
+        LOGGER.info(ar.asString());
+
+        TestUtils.waitFor("artifact created", Constants.POLL_INTERVAL, Constants.TIMEOUT_GLOBAL, () -> {
+            try {
+                return service.getLatestArtifact(subjectName) != null;
+            } catch (WebApplicationException e) {
+                return false;
+            }
+        });
+    }
+
+    @RegistryServiceTest(localOnly = false)
+    void testCreateDeleteSchemaRuleIsDeleted(RegistryService service) throws Exception {
+
+        String name = "schemaname";
+        String subjectName = TestUtils.generateArtifactId();
+        Schema schema = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"" + name + "\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}");
+        int globalId = createArtifactViaConfluentClient(schema, subjectName);
+
+        assertThat(1, is(confluentService.getAllSubjects().size()));
+
+        Response ar = ArtifactUtils.getArtifact(subjectName);
+        LOGGER.info(ar.asString());
+
+        TestUtils.retry(() -> service.getArtifactMetaDataByGlobalId(globalId));
+
+        TestUtils.waitFor("artifact created", Constants.POLL_INTERVAL, Constants.TIMEOUT_GLOBAL, () -> {
+            try {
+                return service.getLatestArtifact(subjectName) != null;
+            } catch (WebApplicationException e) {
+                return false;
+            }
+        });
+
+        List<RuleType> rules = service.listArtifactRules(subjectName);
+        assertThat(1, is(rules.size()));
+
+        confluentService.deleteSubject(subjectName);
+
+        TestUtils.waitFor("schema deletion", Constants.POLL_INTERVAL, Constants.TIMEOUT_GLOBAL, () -> {
+            try {
+                return confluentService.getAllSubjects().size() == 0;
+            } catch (IOException | RestClientException e) {
+                return false;
+            }
+        });
+
+        TestUtils.waitFor("artifact deletion", Constants.POLL_INTERVAL, Constants.TIMEOUT_GLOBAL, () -> {
+            return service.getLatestArtifact(subjectName) == null;
+        });
+
+        rules = service.listArtifactRules(subjectName);
+        assertThat(0, is(rules.size()));
+
+        //if rule was actually deleted creating same artifact again shouldn't fail
+        createArtifactViaConfluentClient(schema, subjectName);
+        assertThat(1, is(confluentService.getAllSubjects().size()));
     }
 
     @AfterEach

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
@@ -19,6 +19,12 @@ package io.apicurio.registry.utils.tests;
 
 import io.apicurio.registry.client.RegistryService;
 import io.apicurio.registry.rest.beans.ArtifactMetaData;
+import io.apicurio.registry.utils.IoUtil;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,6 +100,28 @@ public class TestUtils {
         } catch (IOException ex) {
             log.warn("Cannot connect to Registry instance: {}", ex.getMessage());
             return false; // Either timeout or unreachable or failed DNS lookup.
+        }
+    }
+
+    /**
+     * Checks the readniess endpoint of the registry
+     *
+     * @return true if registry readiness endpoint replies sucessfully
+     */
+    public static boolean isReady(boolean logResponse) {
+        try {
+            CloseableHttpResponse res = HttpClients.createMinimal().execute(new HttpGet(getRegistryUrl().replace("/api", "/health/ready")));
+            boolean ok = res.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
+            if (ok) {
+                log.info("Service registry is ready");
+            }
+            if (logResponse) {
+                log.info(IoUtil.toString(res.getEntity().getContent()));
+            }
+            return ok;
+        } catch (IOException e) {
+            log.warn("Service registry is not ready {}", e.getMessage());
+            return false;
         }
     }
 


### PR DESCRIPTION
* create confluent base class so cleaning methods are only called when confluence tests are executed
* check health endpoint to way for registry to be ready before starting testsuite
* added tests to verify rules are deleted when artifact is deleted

Test `SchemasConfluentIT#testCreateDeleteSchemaRuleIsDeleted` is showing a bug in the rules deletion when an artifact is deleted.