### PR TITLE
Fix various issues

### DIFF
--- a/storage/streams/src/main/java/io/apicurio/registry/streams/StreamsRegistryStorage.java
+++ b/storage/streams/src/main/java/io/apicurio/registry/streams/StreamsRegistryStorage.java
@@ -315,6 +315,9 @@ public class StreamsRegistryStorage implements RegistryStorage {
                 throw new ArtifactNotFoundException(artifactId);
             }
 
+            // Delete any rules configured for the artifact.
+            this.deleteArtifactRulesInternal(artifactId);
+
             ConcurrentUtil.get(submitter.submitArtifact(Str.ActionType.DELETE, artifactId, -1, null, null));
 
             SortedSet<Long> result = new TreeSet<>();
@@ -325,8 +328,6 @@ public class StreamsRegistryStorage implements RegistryStorage {
                 }
             }
 
-            // Also delete any rules configured for the artifact.
-            this.deleteArtifactRulesInternal(artifactId);
             return result;
         } else {
             throw new ArtifactNotFoundException(artifactId);

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/LoadIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/LoadIT.java
@@ -46,9 +46,9 @@ import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.BaseIT;
 
 @Tag(SMOKE)
-public class LoadTest extends BaseIT {
+public class LoadIT extends BaseIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoadTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoadIT.class);
 
     private String base = TestUtils.generateArtifactId();
 
@@ -83,7 +83,7 @@ public class LoadTest extends BaseIT {
         }, runnable -> new Thread(runnable).start());
 
         try {
-            List<CompletionStage<Void>> createResults = IntStream.range(0, 1000).mapToObj(i -> {
+            List<CompletionStage<Void>> createResults = IntStream.range(0, 250).mapToObj(i -> {
                 return createArtifactAsync(apicurioService, i)
                         .thenAccept(m ->
                             artifactsQueue.offer(m.getId())
@@ -101,7 +101,7 @@ public class LoadTest extends BaseIT {
         }
 
         try {
-            Throwable result = deleteingResult.get(60, TimeUnit.SECONDS);
+            Throwable result = deleteingResult.get(120, TimeUnit.SECONDS);
             if (result != null) {
                 deleteLoopFlag.set(false);
                 throw new IllegalStateException("Error deleteing artifacts", result);


### PR DESCRIPTION
 * rename LoadTest, increase timeout and reduce number of artifacts created
 * fix bug in streams storage where artifact rules weren't when artifact is deleted
increase timeout, this bug was reproducible in tests module running against streams storage in test `RulesResourceIT.testRulesDeletedWithArtifact`