### PR TITLE
tests - add env var to be able to manage tests invocation

### DIFF
--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RegistryServiceExtension.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RegistryServiceExtension.java
@@ -33,6 +33,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -41,6 +42,9 @@ import java.util.stream.Stream;
  * @author Ales Justin
  */
 public class RegistryServiceExtension implements TestTemplateInvocationContextProvider {
+
+    private static final String REGISTRY_CLIENT_CREATE = "create";
+    private static final String REGISTRY_CLIENT_CACHED = "cached";
 
     private enum ParameterType {
         REGISTRY_SERVICE,
@@ -89,21 +93,34 @@ public class RegistryServiceExtension implements TestTemplateInvocationContextPr
         String registryUrl = TestUtils.getRegistryUrl(rst);
 
         ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.GLOBAL);
-        RegistryServiceWrapper plain = store.getOrComputeIfAbsent(
-            "plain_client",
-            k -> new RegistryServiceWrapper(k, "create", registryUrl),
-            RegistryServiceWrapper.class
-        );
-        RegistryServiceWrapper cached = store.getOrComputeIfAbsent(
-            "cached_client",
-            k -> new RegistryServiceWrapper(k, "cached", registryUrl),
-            RegistryServiceWrapper.class
-        );
 
-        return Stream.of(
-            new RegistryServiceTestTemplateInvocationContext(plain),
-            new RegistryServiceTestTemplateInvocationContext(cached)
-        );
+        List<TestTemplateInvocationContext> invocationCtxts = new ArrayList<>();
+
+        if (testRegistryClient(REGISTRY_CLIENT_CREATE)) {
+            RegistryServiceWrapper plain = store.getOrComputeIfAbsent(
+                    "plain_client",
+                    k -> new RegistryServiceWrapper(k, REGISTRY_CLIENT_CREATE, registryUrl),
+                    RegistryServiceWrapper.class
+                );
+            invocationCtxts.add(new RegistryServiceTestTemplateInvocationContext(plain));
+        }
+
+        if (testRegistryClient(REGISTRY_CLIENT_CACHED)) {
+            RegistryServiceWrapper cached = store.getOrComputeIfAbsent(
+                    "cached_client",
+                    k -> new RegistryServiceWrapper(k, REGISTRY_CLIENT_CACHED, registryUrl),
+                    RegistryServiceWrapper.class
+                );
+            invocationCtxts.add(new RegistryServiceTestTemplateInvocationContext(cached));
+        }
+
+        return invocationCtxts.stream();
+    }
+
+    private boolean testRegistryClient(String clientType) {
+        String testRegistryClients = TestUtils.getTestRegistryClients();
+        return testRegistryClients == null || testRegistryClients.equalsIgnoreCase("all")
+                || testRegistryClients.equalsIgnoreCase(clientType);
     }
 
     private static class RegistryServiceWrapper implements ExtensionContext.Store.CloseableResource {
@@ -181,9 +198,9 @@ public class RegistryServiceExtension implements TestTemplateInvocationContextPr
 
         private RegistryService createRegistryService() {
             switch (wrapper.method) {
-                case "create":
+                case REGISTRY_CLIENT_CREATE:
                     return RegistryClient.create(wrapper.registryUrl);
-                case "cached":
+                case REGISTRY_CLIENT_CACHED:
                     return RegistryClient.cached(wrapper.registryUrl);
                 default:
                     throw new IllegalArgumentException("Unsupported registry client method: " + wrapper.method);

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RegistryServiceExtension.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RegistryServiceExtension.java
@@ -45,6 +45,7 @@ public class RegistryServiceExtension implements TestTemplateInvocationContextPr
 
     private static final String REGISTRY_CLIENT_CREATE = "create";
     private static final String REGISTRY_CLIENT_CACHED = "cached";
+    private static final String REGISTRY_CLIENT_ALL = "all";
 
     private enum ParameterType {
         REGISTRY_SERVICE,
@@ -119,7 +120,7 @@ public class RegistryServiceExtension implements TestTemplateInvocationContextPr
 
     private boolean testRegistryClient(String clientType) {
         String testRegistryClients = TestUtils.getTestRegistryClients();
-        return testRegistryClients == null || testRegistryClients.equalsIgnoreCase("all")
+        return testRegistryClients == null || testRegistryClients.equalsIgnoreCase(REGISTRY_CLIENT_ALL)
                 || testRegistryClients.equalsIgnoreCase(clientType);
     }
 

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
@@ -56,6 +56,7 @@ public class TestUtils {
     private static final String REGISTRY_HOST = System.getenv().getOrDefault("REGISTRY_HOST", DEFAULT_REGISTRY_HOST);
     private static final int REGISTRY_PORT = Integer.parseInt(System.getenv().getOrDefault("REGISTRY_PORT", String.valueOf(DEFAULT_REGISTRY_PORT)));
     private static final String EXTERNAL_REGISTRY = System.getenv().getOrDefault("EXTERNAL_REGISTRY", "false");
+    private static final String TEST_REGISTRY_CLIENT = System.getenv("TEST_REGISTRY_CLIENT");
 
     private TestUtils() {
         // All static methods
@@ -82,6 +83,10 @@ public class TestUtils {
         } else {
             return String.format("http://%s:%s/api", REGISTRY_HOST, REGISTRY_PORT);
         }
+    }
+
+    public static String getTestRegistryClients() {
+        return TEST_REGISTRY_CLIENT;
     }
 
     /**


### PR DESCRIPTION
This is needed for QE CI so tests metadata reporting will work properly, currently every test is run twice because is run with two variants of the registry client. I added a new env var to be able to control this so tests in QE CI are not executed twice