### PR TITLE
tests - remove unnecessary dependencies

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -29,7 +29,6 @@
         <slf4j-log4j.version>2.13.3</slf4j-log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <commons-logging.version>1.2</commons-logging.version>
-        <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
     </properties>
 
     <repositories>
@@ -67,32 +66,11 @@
             <version>${commons-logging.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>${javax-annotation-api.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Test Only -->
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-protobuf-serializer</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-json-schema-serializer</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -113,11 +91,6 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Dependency `kafka-protobuf-serializer` includes `com.github.everit-org.json-schema:org.everit.json.schema:jar:1.12.1` which fails to be pulled in internal CI, I would love to fix the issue I have in internal CI but I figured out there is no need to include `kafka-protobuf-serializer` in tests pom, so I removed it and some others that are not needed