### PR TITLE
tests - fix tests name in test reporting

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -29,6 +29,7 @@
         <slf4j-log4j.version>2.13.3</slf4j-log4j.version>
         <hamcrest.version>2.2</hamcrest.version>
         <commons-logging.version>1.2</commons-logging.version>
+        <version.surefire.plugin>3.0.0-M4</version.surefire.plugin>
     </properties>
 
     <repositories>
@@ -278,6 +279,14 @@
                             <environmentVariables>
                                 <REGISTRY_JAR_PATH>../app/target/apicurio-registry-app-${project.version}-runner.jar</REGISTRY_JAR_PATH>
                             </environmentVariables>
+                            <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                                <disable>false</disable>
+                                <version>3.0</version>
+                                <usePhrasedFileName>false</usePhrasedFileName>
+                                <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+                                <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+                                <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                            </statelessTestsetReporter>
                         </configuration>
                     </execution>
                 </executions>

--- a/tests/src/test/java/io/apicurio/tests/BaseIT.java
+++ b/tests/src/test/java/io/apicurio/tests/BaseIT.java
@@ -21,6 +21,7 @@ import io.apicurio.registry.rest.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.beans.EditableMetaData;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.ConcurrentUtil;
+import io.apicurio.registry.utils.tests.SimpleDisplayName;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.interfaces.TestSeparator;
 import io.apicurio.tests.utils.subUtils.ArtifactUtils;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +56,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+@DisplayNameGeneration(SimpleDisplayName.class)
 public abstract class BaseIT implements TestSeparator, Constants {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(BaseIT.class);

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RegistryServiceExtension.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RegistryServiceExtension.java
@@ -104,7 +104,7 @@ public class RegistryServiceExtension implements TestTemplateInvocationContextPr
                     k -> new RegistryServiceWrapper(k, REGISTRY_CLIENT_CREATE, registryUrl),
                     RegistryServiceWrapper.class
                 );
-            invocationCtxts.add(new RegistryServiceTestTemplateInvocationContext(plain));
+            invocationCtxts.add(new RegistryServiceTestTemplateInvocationContext(plain, context.getRequiredTestMethod()));
         }
 
         if (testRegistryClient(REGISTRY_CLIENT_CACHED)) {
@@ -113,7 +113,7 @@ public class RegistryServiceExtension implements TestTemplateInvocationContextPr
                     k -> new RegistryServiceWrapper(k, REGISTRY_CLIENT_CACHED, registryUrl),
                     RegistryServiceWrapper.class
                 );
-            invocationCtxts.add(new RegistryServiceTestTemplateInvocationContext(cached));
+            invocationCtxts.add(new RegistryServiceTestTemplateInvocationContext(cached, context.getRequiredTestMethod()));
         }
 
         return invocationCtxts.stream();
@@ -123,6 +123,11 @@ public class RegistryServiceExtension implements TestTemplateInvocationContextPr
         String testRegistryClients = TestUtils.getTestRegistryClients();
         return testRegistryClients == null || testRegistryClients.equalsIgnoreCase(REGISTRY_CLIENT_ALL)
                 || testRegistryClients.equalsIgnoreCase(clientType);
+    }
+
+    private static boolean isTestAllClientTypes() {
+        String testRegistryClients = TestUtils.getTestRegistryClients();
+        return testRegistryClients == null || testRegistryClients.equalsIgnoreCase(REGISTRY_CLIENT_ALL);
     }
 
     private static class RegistryServiceWrapper implements ExtensionContext.Store.CloseableResource {
@@ -145,14 +150,20 @@ public class RegistryServiceExtension implements TestTemplateInvocationContextPr
 
     private static class RegistryServiceTestTemplateInvocationContext implements TestTemplateInvocationContext, ParameterResolver {
         private RegistryServiceWrapper wrapper;
+        private Method testMethod;
 
-        public RegistryServiceTestTemplateInvocationContext(RegistryServiceWrapper wrapper) {
+        public RegistryServiceTestTemplateInvocationContext(RegistryServiceWrapper wrapper, Method testMethod) {
             this.wrapper = wrapper;
+            this.testMethod = testMethod;
         }
 
         @Override
         public String getDisplayName(int invocationIndex) {
-            return String.format("%s [%s]", wrapper.key, invocationIndex);
+            if (isTestAllClientTypes()) {
+                return String.format("%s (%s) [%s]", testMethod.getName(), wrapper.key, invocationIndex);
+            } else {
+                return testMethod.getName();
+            }
         }
 
         @Override

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/SimpleDisplayName.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/SimpleDisplayName.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.utils.tests;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+public class SimpleDisplayName extends DisplayNameGenerator.ReplaceUnderscores {
+
+    @Override
+    public String generateDisplayNameForClass(Class<?> testClass) {
+        return super.generateDisplayNameForClass(testClass);
+    }
+
+    @Override
+    public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
+        return super.generateDisplayNameForNestedClass(nestedClass) + "...";
+    }
+
+    @Override
+    public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+        return testMethod.getName();
+    }
+
+}


### PR DESCRIPTION
This changes simplify the name of testcases in xunit reports and are needed for QE to easily be able to do test reporting.