### PR TITLE
upgrade kafka-connect to 2.4.1 in compile-time dependency while ensur…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <h2.version>1.4.199</h2.version>
 
         <!-- Search -->
-        <connect.version>2.2.1</connect.version>
+        <connect.version>2.4.1</connect.version>
         <infinispan.version>10.0.1.Final</infinispan.version>
         
         <!-- Specifications -->

--- a/search/connector/src/main/java/io/apicurio/registry/connector/Compatibility.java
+++ b/search/connector/src/main/java/io/apicurio/registry/connector/Compatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat
+ * Copyright 2020 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/search/connector/src/main/java/io/apicurio/registry/connector/Compatibility.java
+++ b/search/connector/src/main/java/io/apicurio/registry/connector/Compatibility.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.connector;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.runtime.Worker;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
+import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
+import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.storage.ConfigBackingStore;
+import org.apache.kafka.connect.storage.OffsetBackingStore;
+import org.apache.kafka.connect.storage.StatusBackingStore;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * Compatibility utilities.
+ * It is assumed that the code is compiled with kafka-connect 2.4 and its resulting jar may be used
+ * not only with kafka-connect 2.4 but also with kafka-connect 2.2, 2.3 which are not binary compatible
+ * with kafka-connect 2.4 in some classes.
+ */
+class Compatibility {
+    private static Class<?> CLS_CONNECTOR_CLIENT_CONFIG_OVERRIDE_POLICY;
+    private static Constructor<?> CTR_WORKER_22;
+    private static Constructor<?> CTR_DISTRIBUTED_HERDER_22;
+
+    static {
+        try {
+            // for 2.3, 2.4 - ConnectorClientConfigOverridePolicy is available
+            CLS_CONNECTOR_CLIENT_CONFIG_OVERRIDE_POLICY = Class.forName("org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy", true, Compatibility.class.getClassLoader());
+        } catch (Throwable t) {
+            // for 2.2 - not available
+            CLS_CONNECTOR_CLIENT_CONFIG_OVERRIDE_POLICY = null;
+        }
+        try {
+            // for 2.2, 2.3 - get the consturctor from the old Worker
+            CTR_WORKER_22 = Worker.class.getConstructor(String.class, Time.class, Plugins.class, WorkerConfig.class, OffsetBackingStore.class);
+        } catch (Throwable t) {
+            // for 2.4 - use the current constructor
+            CTR_WORKER_22 = null;
+        }
+        try {
+            // for 2.2, 2.3 - get the constructor from the old DistributedHerder
+            CTR_DISTRIBUTED_HERDER_22 = DistributedHerder.class.getConstructor(DistributedConfig.class, Time.class, Worker.class, String.class, StatusBackingStore.class, ConfigBackingStore.class, String.class);
+        } catch (Throwable t) {
+            // for 2.4 - use the current constructor
+            CTR_DISTRIBUTED_HERDER_22 = null;
+        }
+    }
+
+    static Object createConnectorClientConfigOverridePolicy(Plugins plugins, AbstractConfig config) throws ConnectException {
+        if (CLS_CONNECTOR_CLIENT_CONFIG_OVERRIDE_POLICY != null) {
+            return plugins.newPlugin(
+                    config.getString(WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG),
+                    config, CLS_CONNECTOR_CLIENT_CONFIG_OVERRIDE_POLICY);
+        }
+        return null;
+    }
+
+    static Worker createWorker(String workerId,
+                               Time time,
+                               Plugins plugins,
+                               WorkerConfig config,
+                               OffsetBackingStore offsetBackingStore,
+                               Object connectorClientConfigOverridePolicy) throws ConnectException {
+
+        if (CTR_WORKER_22 == null) {
+            return new Worker(workerId, time, plugins, config, offsetBackingStore, (ConnectorClientConfigOverridePolicy)connectorClientConfigOverridePolicy);
+        }
+        try {
+            return (Worker)CTR_WORKER_22.newInstance(workerId, time, plugins, config, offsetBackingStore);
+        } catch (Throwable t) {
+            throw new ConnectException(t);
+        }
+    }
+
+    static DistributedHerder createDistributedHerder(DistributedConfig config,
+                                                     Time time,
+                                                     Worker worker,
+                                                     String kafkaClusterId,
+                                                     StatusBackingStore statusBackingStore,
+                                                     ConfigBackingStore configBackingStore,
+                                                     String restUrl,
+                                                     Object connectorClientConfigOverridePolicy) throws ConnectException {
+
+        if (CTR_DISTRIBUTED_HERDER_22 == null) {
+            return new DistributedHerder(config, time, worker, kafkaClusterId, statusBackingStore, configBackingStore, restUrl, (ConnectorClientConfigOverridePolicy)connectorClientConfigOverridePolicy);
+        }
+        try {
+            return (DistributedHerder)CTR_DISTRIBUTED_HERDER_22.newInstance(config, time, worker, kafkaClusterId, statusBackingStore, configBackingStore, restUrl);
+        } catch (Throwable t) {
+            throw new ConnectException(t);
+        }
+    }
+}

--- a/search/connector/src/main/java/io/apicurio/registry/connector/ConnectorApplication.java
+++ b/search/connector/src/main/java/io/apicurio/registry/connector/ConnectorApplication.java
@@ -87,8 +87,9 @@ public class ConnectorApplication {
 
         KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore();
         offsetBackingStore.configure(config);
+        Object connectorClientConfigOverridePolicy = Compatibility.createConnectorClientConfigOverridePolicy(plugins, config);
 
-        Worker worker = new Worker(workerId, time, plugins, config, offsetBackingStore);
+        Worker worker = Compatibility.createWorker(workerId, time, plugins, config, offsetBackingStore, connectorClientConfigOverridePolicy);
         WorkerConfigTransformer configTransformer = worker.configTransformer();
 
         Converter internalValueConverter = worker.getInternalValueConverter();
@@ -100,9 +101,9 @@ public class ConnectorApplication {
             config,
             configTransformer);
 
-        DistributedHerder herder = new DistributedHerder(config, time, worker,
+        DistributedHerder herder = Compatibility.createDistributedHerder(config, time, worker,
                                                          kafkaClusterId, statusBackingStore, configBackingStore,
-                                                         advertisedUrl.toString());
+                                                         advertisedUrl.toString(), connectorClientConfigOverridePolicy);
 
         final Connect connect = new Connect(herder, rest);
         log.info("Kafka Connect distributed worker initialization took {}ms", time.hiResClockMs() - initStart);

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -122,6 +122,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-json</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
             <version>${vertx.version}</version>
@@ -188,6 +198,17 @@
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-utils-converter</artifactId>
             <scope>compile</scope>
+            <exclusions>
+                <!-- exclude these so that the project can decide which version to use -->
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>connect-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>connect-json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>


### PR DESCRIPTION
…ing runtime compatibility with kafka-connect 2.2.x, 2.3.x

Resulted from this question.
 https://github.com/Apicurio/apicurio-registry/issues/557
