### PR TITLE
tests - fix getRegistryUrl

### DIFF
--- a/tests/src/main/java/io/apicurio/tests/serdes/KafkaClients.java
+++ b/tests/src/main/java/io/apicurio/tests/serdes/KafkaClients.java
@@ -94,11 +94,11 @@ public class KafkaClients {
         props.putIfAbsent(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer);
         // Schema Registry location.
         if (valueSerializer.contains("confluent")) {
-            props.putIfAbsent(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, TestUtils.getRegistryUrl() + "/ccompat");
+            props.putIfAbsent(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, TestUtils.getRegistryApiUrl() + "/ccompat");
             props.putIfAbsent(AbstractKafkaAvroSerDeConfig.AUTO_REGISTER_SCHEMAS, "false");
             props.putIfAbsent(KafkaAvroSerializerConfig.VALUE_SUBJECT_NAME_STRATEGY, artifactIdStrategy);
         } else {
-            props.putIfAbsent(AbstractKafkaSerDe.REGISTRY_URL_CONFIG_PARAM, TestUtils.getRegistryUrl());
+            props.putIfAbsent(AbstractKafkaSerDe.REGISTRY_URL_CONFIG_PARAM, TestUtils.getRegistryApiUrl());
             props.putIfAbsent(AbstractKafkaSerializer.REGISTRY_ARTIFACT_ID_STRATEGY_CONFIG_PARAM, artifactIdStrategy);
         }
 
@@ -121,9 +121,9 @@ public class KafkaClients {
         props.putIfAbsent(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer);
         //Schema registry location.
         if (valueDeserializer.contains("confluent")) {
-            props.putIfAbsent(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, TestUtils.getRegistryUrl() + "/ccompat");
+            props.putIfAbsent(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, TestUtils.getRegistryApiUrl() + "/ccompat");
         } else {
-            props.putIfAbsent(AbstractKafkaSerDe.REGISTRY_URL_CONFIG_PARAM, TestUtils.getRegistryUrl());
+            props.putIfAbsent(AbstractKafkaSerDe.REGISTRY_URL_CONFIG_PARAM, TestUtils.getRegistryApiUrl());
         }
         return new KafkaConsumer<>(props);
     }

--- a/tests/src/test/java/io/apicurio/tests/BaseIT.java
+++ b/tests/src/test/java/io/apicurio/tests/BaseIT.java
@@ -77,13 +77,13 @@ public abstract class BaseIT implements TestSeparator, Constants {
         if (!TestUtils.isExternalRegistry()) {
             registry.start();
         } else {
-            LOGGER.info("Going to use already running registries on {}", TestUtils.getRegistryUrl());
+            LOGGER.info("Going to use already running registries on {}", TestUtils.getRegistryApiUrl());
         }
-        TestUtils.waitFor("Cannot connect to registries on " + TestUtils.getRegistryUrl() + " in timeout!",
+        TestUtils.waitFor("Cannot connect to registries on " + TestUtils.getRegistryApiUrl() + " in timeout!",
                           Constants.POLL_INTERVAL, Constants.TIMEOUT_FOR_REGISTRY_START_UP, TestUtils::isReachable);
         TestUtils.waitFor("Registry reports is ready",
                 Constants.POLL_INTERVAL, Constants.TIMEOUT_FOR_REGISTRY_READY, () -> TestUtils.isReady(false), () -> TestUtils.isReady(true));
-        RestAssured.baseURI = TestUtils.getRegistryUrl();
+        RestAssured.baseURI = TestUtils.getRegistryApiUrl();
         LOGGER.info("Registry app is running on {}", RestAssured.baseURI);
         RestAssured.defaultParser = Parser.JSON;
     }

--- a/tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
+++ b/tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
@@ -38,7 +38,7 @@ public abstract class ConfluentBaseIT extends BaseIT {
 
     @BeforeAll
     static void confluentBeforeAll(TestInfo info) throws Exception {
-        confluentService = new CachedSchemaRegistryClient(TestUtils.getRegistryUrl() + "/ccompat", 3);
+        confluentService = new CachedSchemaRegistryClient(TestUtils.getRegistryApiUrl() + "/ccompat", 3);
         clearAllConfluentSubjects();
     }
 

--- a/tests/src/test/java/io/apicurio/tests/converters/KafkaConnectConverterIT.java
+++ b/tests/src/test/java/io/apicurio/tests/converters/KafkaConnectConverterIT.java
@@ -134,7 +134,7 @@ public class KafkaConnectConverterIT extends BaseIT {
 
     private ConnectorConfiguration getConfiguration(int id, String converter, String... options) {
         final String apicurioUrl = TestUtils.isExternalRegistry() ?
-                TestUtils.getRegistryUrl()
+                TestUtils.getRegistryApiUrl()
                 :
                 "http://host.testcontainers.internal:8081/api/";
 

--- a/tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
+++ b/tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
@@ -73,7 +73,7 @@ import io.apicurio.tests.BaseIT;
 @Tag(CLUSTER)
 public class RegistryConverterIT extends BaseIT {
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     public void testConfiguration(Supplier<RegistryService> supplier) throws Exception {
         Schema schema = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"myrecord4\",\"fields\":[{\"name\":\"bar\",\"type\":\"string\"}]}");
 
@@ -84,7 +84,7 @@ public class RegistryConverterIT extends BaseIT {
         CompletionStage<ArtifactMetaData> csa = service.createArtifact(
             ArtifactType.AVRO,
             artifactId + "-myrecord4",
-            null, 
+            null,
             new ByteArrayInputStream(schema.toString().getBytes(StandardCharsets.UTF_8))
         );
         ArtifactMetaData amd = ConcurrentUtil.result(csa);
@@ -142,7 +142,7 @@ public class RegistryConverterIT extends BaseIT {
         }
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     public void testAvro(Supplier<RegistryService> supplier) throws Exception {
         RegistryService service = supplier.get();
         try (AvroKafkaSerializer<GenericData.Record> serializer = new AvroKafkaSerializer<GenericData.Record>(service);
@@ -151,27 +151,27 @@ public class RegistryConverterIT extends BaseIT {
             serializer.setGlobalIdStrategy(new AutoRegisterIdStrategy<>());
             AvroData avroData = new AvroData(new AvroDataConfig(Collections.emptyMap()));
             try (AvroConverter converter = new AvroConverter<>(serializer, deserializer, avroData)) {
-    
+
                 org.apache.kafka.connect.data.Schema sc = SchemaBuilder.struct()
                                                                        .field("bar", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
                                                                        .build();
                 Struct struct = new Struct(sc);
                 struct.put("bar", "somebar");
-    
+
                 String subject = generateArtifactId();
-    
+
                 byte[] bytes = converter.fromConnectData(subject, sc, struct);
-    
+
                 // some impl details ...
                 waitForSchema(service, bytes);
-    
+
                 Struct ir = (Struct) converter.toConnectData(subject, bytes).value();
                 Assertions.assertEquals("somebar", ir.get("bar").toString());
             }
         }
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     public void testPrettyJson(Supplier<RegistryService> supplier) throws Exception {
         testJson(
             supplier.get(),
@@ -188,7 +188,7 @@ public class RegistryConverterIT extends BaseIT {
         );
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     public void testCompactJson(Supplier<RegistryService> supplier) throws Exception {
         testJson(
             supplier.get(),

--- a/tests/src/test/java/io/apicurio/tests/serdes/apicurio/BasicApicurioSerDesIT.java
+++ b/tests/src/test/java/io/apicurio/tests/serdes/apicurio/BasicApicurioSerDesIT.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeoutException;
 @Tag(CLUSTER)
 public class BasicApicurioSerDesIT extends BaseIT {
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testAvroApicurioSerDes(RegistryService service) throws InterruptedException, ExecutionException, TimeoutException {
         String topicName = TestUtils.generateTopic();
         String subjectName = topicName + "-value";
@@ -58,7 +58,7 @@ public class BasicApicurioSerDesIT extends BaseIT {
         KafkaClients.consumeAvroApicurioMessages(topicName, 10).get(5, TimeUnit.SECONDS);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testAvroApicurioSerDesFail(RegistryService service) throws TimeoutException {
         String topicName = TestUtils.generateTopic();
         String subjectName = TestUtils.generateSubject();
@@ -71,7 +71,7 @@ public class BasicApicurioSerDesIT extends BaseIT {
         assertThrows(ExecutionException.class, () -> KafkaClients.produceAvroApicurioMessagesRecordStrategy(topicName, subjectName, schema, 10, "wrong-key").get(5, TimeUnit.SECONDS));
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testAvroApicurioSerDesWrongStrategyTopic(RegistryService service) throws TimeoutException {
         String topicName = TestUtils.generateTopic();
         String subjectName = TestUtils.generateSubject();
@@ -84,7 +84,7 @@ public class BasicApicurioSerDesIT extends BaseIT {
         assertThrows(ExecutionException.class, () -> KafkaClients.produceAvroApicurioMessagesTopicStrategy(topicName, subjectName, schema, 10, "wrong-key").get(5, TimeUnit.SECONDS));
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testAvroApicurioSerDesWrongStrategyRecord(RegistryService service) throws TimeoutException {
         String topicName = TestUtils.generateTopic();
         String subjectName = topicName + "-value";
@@ -97,7 +97,7 @@ public class BasicApicurioSerDesIT extends BaseIT {
         assertThrows(ExecutionException.class, () -> KafkaClients.produceAvroApicurioMessagesRecordStrategy(topicName, subjectName, schema, 10, "wrong-key").get(5, TimeUnit.SECONDS));
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testEvolveAvroApicurio(RegistryService service) throws InterruptedException, ExecutionException, TimeoutException {
         String topicName = TestUtils.generateTopic();
         String recordName = TestUtils.generateSubject();
@@ -129,7 +129,7 @@ public class BasicApicurioSerDesIT extends BaseIT {
         KafkaClients.consumeAvroApicurioMessages(topicName, 30).get(5, TimeUnit.SECONDS);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testAvroApicurioForMultipleTopics(RegistryService service) throws InterruptedException, ExecutionException, TimeoutException {
         String topicName1 = TestUtils.generateTopic();
         String topicName2 = TestUtils.generateTopic();
@@ -152,7 +152,7 @@ public class BasicApicurioSerDesIT extends BaseIT {
         KafkaClients.consumeAvroApicurioMessages(topicName3, 10).get(5, TimeUnit.SECONDS);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testJsonSchemaApicurioSerDes(RegistryService service) throws InterruptedException, ExecutionException, TimeoutException {
         String jsonSchema = "{" +
                             "    \"$id\": \"https://example.com/message.schema.json\"," +
@@ -164,14 +164,14 @@ public class BasicApicurioSerDesIT extends BaseIT {
                             "    \"type\": \"object\"," +
                             "    \"properties\": {" +
                             "        \"message\": {" +
-                "            \"description\": \"\"," + 
-                "            \"type\": \"string\"" + 
-                "        }," + 
-                "        \"time\": {" + 
-                "            \"description\": \"\"," + 
-                "            \"type\": \"number\"" + 
-                "        }" + 
-                "    }" + 
+                "            \"description\": \"\"," +
+                "            \"type\": \"string\"" +
+                "        }," +
+                "        \"time\": {" +
+                "            \"description\": \"\"," +
+                "            \"type\": \"number\"" +
+                "        }" +
+                "    }" +
                 "}";
         String artifactId = TestUtils.generateArtifactId();
         String subjectName = TestUtils.generateSubject();
@@ -202,7 +202,7 @@ public class BasicApicurioSerDesIT extends BaseIT {
         return b.build();
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testProtobufSerDes(RegistryService service) throws InterruptedException, ExecutionException, TimeoutException {
         Serde.Schema protobufSchema = toSchemaProto(MsgTypes.Msg.newBuilder().build().getDescriptorForType().getFile());
         String artifactId = TestUtils.generateArtifactId();
@@ -226,7 +226,7 @@ public class BasicApicurioSerDesIT extends BaseIT {
         KafkaClients.produceProtobufMessages(artifactId, subjectName, 100).get(5, TimeUnit.SECONDS);
         KafkaClients.consumeProtobufMessages(artifactId, 100).get(5, TimeUnit.SECONDS);
     }
-    
+
     @BeforeAll
     static void setupEnvironment() {
         kafkaCluster.start();

--- a/tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
+++ b/tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
@@ -92,7 +92,7 @@ public class BasicConfluentSerDesIT extends ConfluentBaseIT {
         assertThrows(ExecutionException.class, () -> KafkaClients.produceAvroConfluentMessagesRecordStrategy(topicName, subjectName, schema, 10, "wrong-key").get(5, TimeUnit.SECONDS));
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testEvolveAvroConfluent(RegistryService service) throws InterruptedException, ExecutionException, TimeoutException, IOException, RestClientException {
         String topicName = TestUtils.generateTopic();
         String recordName = "myrecordconfluent5";

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AllArtifactTypesIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AllArtifactTypesIT.java
@@ -94,37 +94,37 @@ class AllArtifactTypesIT extends BaseIT {
         }
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testAvro(RegistryService service) {
         doTest(service, "avro/multi-field_v1.json", "avro/multi-field_v2.json", ArtifactType.AVRO);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testProtobuf(RegistryService service) {
         doTest(service, "protobuf/tutorial_v1.proto", "protobuf/tutorial_v2.proto", ArtifactType.PROTOBUF);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testJsonSchema(RegistryService service) {
         doTest(service, "jsonSchema/person_v1.json", "jsonSchema/person_v2.json", ArtifactType.JSON);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testKafkaConnect(RegistryService service) {
         doTest(service, "kafkaConnect/simple_v1.json", "kafkaConnect/simple_v2.json", ArtifactType.KCONNECT);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testOpenApi30(RegistryService service) {
         doTest(service, "openapi/3.0-petstore_v1.json", "openapi/3.0-petstore_v2.json", ArtifactType.OPENAPI);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testAsyncApi(RegistryService service) {
         doTest(service, "asyncapi/2.0-streetlights_v1.json", "asyncapi/2.0-streetlights_v2.json", ArtifactType.ASYNCAPI);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testGraphQL(RegistryService service) {
         doTest(service, "graphql/swars_v1.graphql", "graphql/swars_v2.graphql", ArtifactType.GRAPHQL);
     }

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
@@ -53,7 +53,7 @@ class ArtifactsIT extends BaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactsIT.class);
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void createAndUpdateArtifact(RegistryService service) throws Exception {
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
@@ -109,7 +109,7 @@ class ArtifactsIT extends BaseIT {
         assertThat(response.getJsonArray("fields").getJsonObject(0).getString("name"), is("foo"));
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void createAndDeleteMultipleArtifacts(RegistryService service) throws Exception {
         LOGGER.info("Creating some artifacts...");
         Map<String, String> idMap = createMultipleArtifacts(service, 10);
@@ -122,7 +122,7 @@ class ArtifactsIT extends BaseIT {
         }
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void createNonAvroArtifact(RegistryService service) throws Exception {
         ByteArrayInputStream artifactData = new ByteArrayInputStream("{\"type\":\"INVALID\",\"config\":\"invalid\"}".getBytes(StandardCharsets.UTF_8));
         String artifactId = TestUtils.generateArtifactId();
@@ -141,7 +141,7 @@ class ArtifactsIT extends BaseIT {
         assertThat(response.getString("config"), is("invalid"));
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void createArtifactSpecificVersion(RegistryService service) throws Exception {
         ByteArrayInputStream artifactData = new ByteArrayInputStream("{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}".getBytes(StandardCharsets.UTF_8));
         String artifactId = TestUtils.generateArtifactId();
@@ -164,7 +164,7 @@ class ArtifactsIT extends BaseIT {
         assertThat(artifactVersions, hasItems(1L, 2L));
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testDuplicatedArtifact(RegistryService service) throws Exception {
         ByteArrayInputStream artifactData = new ByteArrayInputStream("{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}".getBytes(StandardCharsets.UTF_8));
         String artifactId = TestUtils.generateArtifactId();
@@ -175,7 +175,7 @@ class ArtifactsIT extends BaseIT {
         TestUtils.assertWebError(409, () -> ArtifactUtils.createArtifact(service, ArtifactType.AVRO, artifactId, iad), true);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testDisableEnableArtifact(RegistryService service) throws Exception {
         String artifactId = TestUtils.generateArtifactId();
         String artifactData = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
@@ -209,7 +209,7 @@ class ArtifactsIT extends BaseIT {
         });
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testDisableEnableArtifactVersion(RegistryService service) throws Exception {
         String artifactId = TestUtils.generateArtifactId();
         String artifactData = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
@@ -273,7 +273,7 @@ class ArtifactsIT extends BaseIT {
         });
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testDeprecateArtifact(RegistryService service) throws Exception {
         String artifactId = TestUtils.generateArtifactId();
         String artifactData = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
@@ -302,7 +302,7 @@ class ArtifactsIT extends BaseIT {
         });
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testDeprecateArtifactVersion(RegistryService service) throws Exception {
         String artifactId = TestUtils.generateArtifactId();
         String artifactData = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
@@ -344,7 +344,7 @@ class ArtifactsIT extends BaseIT {
         });
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void deleteNonexistingSchema(RegistryService service) {
         TestUtils.assertWebError(404, () -> service.deleteArtifact("non-existing"));
     }

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/LoadIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/LoadIT.java
@@ -52,7 +52,7 @@ public class LoadIT extends BaseIT {
 
     private String base = TestUtils.generateArtifactId();
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void concurrentLoadTest(RegistryService apicurioService) throws Exception {
 
         Queue<String> artifactsQueue = new ConcurrentLinkedQueue<>();

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/MetadataIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/MetadataIT.java
@@ -44,7 +44,7 @@ class MetadataIT extends BaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetadataIT.class);
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void getAndUpdateMetadataOfArtifact(RegistryService service) throws Exception {
         String artifactId = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
@@ -82,7 +82,7 @@ class MetadataIT extends BaseIT {
         });
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void getAndUpdateMetadataOfArtifactSpecificVersion(RegistryService service) throws Exception {
         String artifactId = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
@@ -47,7 +47,7 @@ class RulesResourceIT extends BaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RulesResourceIT.class);
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void createAndDeleteGlobalRules(RegistryService service) throws Exception {
         // Create a global rule
         Rule rule = new Rule();
@@ -79,7 +79,7 @@ class RulesResourceIT extends BaseIT {
         TestUtils.assertWebError(404, () -> service.getGlobalRuleConfig(RuleType.VALIDITY));
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void createAndValidateGlobalRules(RegistryService service) throws Exception {
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
@@ -113,7 +113,7 @@ class RulesResourceIT extends BaseIT {
         });
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void createAndValidateArtifactRule(RegistryService service) throws Exception {
         String artifactId1 = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
@@ -169,7 +169,7 @@ class RulesResourceIT extends BaseIT {
         });
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testRulesDeletedWithArtifact(RegistryService service) throws Exception {
         String artifactId1 = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
@@ -170,7 +170,7 @@ public class SchemasConfluentIT extends ConfluentBaseIT {
         assertThrows(RestClientException.class, () -> confluentService.deleteSubject("non-existing"));
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void createConfluentQueryApicurio(RegistryService service) throws IOException, RestClientException, TimeoutException {
         String name = "schemaname";
         String subjectName = TestUtils.generateArtifactId();
@@ -193,7 +193,7 @@ public class SchemasConfluentIT extends ConfluentBaseIT {
         });
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testCreateDeleteSchemaRuleIsDeleted(RegistryService service) throws Exception {
 
         String name = "schemaname";

--- a/tests/src/test/java/io/apicurio/tests/ui/DeleteArtifactIT.java
+++ b/tests/src/test/java/io/apicurio/tests/ui/DeleteArtifactIT.java
@@ -48,7 +48,7 @@ public class DeleteArtifactIT extends BaseIT {
         }
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testDeleteArtifacts(RegistryService service) throws Exception {
         RegistryUITester page = new RegistryUITester(selenium);
         page.openWebPage();
@@ -96,7 +96,7 @@ public class DeleteArtifactIT extends BaseIT {
         });
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testDeleteViaApi(RegistryService service) throws Exception {
         RegistryUITester page = new RegistryUITester(selenium);
         page.openWebPage();

--- a/tests/src/test/java/io/apicurio/tests/ui/UploadArtifactsIT.java
+++ b/tests/src/test/java/io/apicurio/tests/ui/UploadArtifactsIT.java
@@ -76,32 +76,32 @@ public class UploadArtifactsIT extends BaseIT {
 //        doTest(service, "avro/multi-field_v1.json", ArtifactType.AVRO, null, false);
 //    }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testProtobuf(RegistryService service) throws Exception {
         doTest(service, "protobuf/tutorial_v1.proto", ArtifactType.PROTOBUF, null, false);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testJsonSchema(RegistryService service) throws Exception {
         doTest(service, "jsonSchema/person_v1.json", ArtifactType.JSON, null, false);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testKafkaConnect(RegistryService service) throws Exception {
         doTest(service, "kafkaConnect/simple_v1.json", ArtifactType.KCONNECT, null, false);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testOpenApi30(RegistryService service) throws Exception {
         doTest(service, "openapi/3.0-petstore_v1.json", ArtifactType.OPENAPI, null, false);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testAsyncApi(RegistryService service) throws Exception {
         doTest(service, "asyncapi/2.0-streetlights_v1.json", ArtifactType.ASYNCAPI, null, false);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testGraphQL(RegistryService service) throws Exception {
         doTest(service, "graphql/swars_v1.graphql", ArtifactType.GRAPHQL, null, false);
     }
@@ -113,44 +113,44 @@ public class UploadArtifactsIT extends BaseIT {
 //        doTest(service, "avro/multi-field_v1.json", null, null);
 //    }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testProtobufAutoDetect(RegistryService service) throws Exception {
         doTest(service, "protobuf/tutorial_v1.proto", ArtifactType.PROTOBUF, null, true);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testJsonSchemaAutoDetect(RegistryService service) throws Exception {
         doTest(service, "jsonSchema/person_v1.json", ArtifactType.JSON, null, true);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testOpenApi30AutoDetect(RegistryService service) throws Exception {
         doTest(service, "openapi/3.0-petstore_v1.json", ArtifactType.OPENAPI, null, true);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testAsyncApiAutoDetect(RegistryService service) throws Exception {
         doTest(service, "asyncapi/2.0-streetlights_v1.json", ArtifactType.ASYNCAPI, null, true);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testGraphQLAutoDetect(RegistryService service) throws Exception {
         doTest(service, "graphql/swars_v1.graphql", ArtifactType.GRAPHQL, null, true);
     }
 
     //provide artifact id
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testSetArtifactId(RegistryService service) throws Exception {
         doTest(service, "openapi/3.0-petstore_v1.json", ArtifactType.OPENAPI, "testArtifactIdOpenApi", false);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testSetArtifactIdAndAutodetect(RegistryService service) throws Exception {
         doTest(service, "openapi/3.0-petstore_v1.json", ArtifactType.OPENAPI, "testArtifactIdOpenApi", true);
     }
 
-    @RegistryServiceTest(localOnly = false)
+    @RegistryServiceTest
     void testCreateViaApi(RegistryService service) throws Exception {
 
         RegistryUITester page = new RegistryUITester(selenium);

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RegistryServiceExtension.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RegistryServiceExtension.java
@@ -80,10 +80,10 @@ public class RegistryServiceExtension implements TestTemplateInvocationContextPr
 
     @Override
     public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
-        RegistryServiceTest rst = AnnotationUtils.findAnnotation(context.getRequiredTestMethod(), RegistryServiceTest.class)
+        AnnotationUtils.findAnnotation(context.getRequiredTestMethod(), RegistryServiceTest.class)
                                                  .orElseThrow(IllegalStateException::new); // should be there
 
-        String registryUrl = TestUtils.getRegistryUrl(rst);
+        String registryUrl = TestUtils.getRegistryApiUrl();
 
         ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.GLOBAL);
 

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RegistryServiceTest.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RegistryServiceTest.java
@@ -34,17 +34,5 @@ import java.lang.annotation.Target;
 @TestTemplate
 @ExtendWith(RegistryServiceExtension.class)
 public @interface RegistryServiceTest {
-    /**
-     * Provide the RegistryService url.
-     *
-     * @return the url
-     */
-    String value() default "http://localhost:8081/api";
 
-    /**
-     * Limit the registry to local app.
-     *
-     * @return false to allow external lookup, true otherwise
-     */
-    boolean localOnly() default true;
 }

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
@@ -76,25 +76,18 @@ public class TestUtils {
     }
 
     public static String getRegistryUIUrl() {
-        return getRegistryUrl().replace("/api", "/ui");
+        return getRegistryUrl().concat("/ui");
     }
 
-    public static String getRegistryUrl() {
-        return getRegistryUrl(
-            String.format("http://%s:%s/api", REGISTRY_HOST, REGISTRY_PORT),
-            false
-        );
+    public static String getRegistryApiUrl() {
+        return getRegistryUrl().concat("/api");
     }
 
-    public static String getRegistryUrl(RegistryServiceTest rst) {
-        return getRegistryUrl(rst.value(), rst.localOnly());
-    }
-
-    public static String getRegistryUrl(String fallbackUrl, boolean localOnly) {
-        if (localOnly || !isExternalRegistry()) {
-            return fallbackUrl;
+    private static String getRegistryUrl() {
+        if (isExternalRegistry()) {
+            return String.format("http://%s:%s", REGISTRY_HOST, REGISTRY_PORT);
         } else {
-            return String.format("http://%s:%s/api", REGISTRY_HOST, REGISTRY_PORT);
+            return String.format("http://%s:%s", DEFAULT_REGISTRY_HOST, DEFAULT_REGISTRY_PORT);
         }
     }
 
@@ -128,7 +121,7 @@ public class TestUtils {
      */
     public static boolean isReady(boolean logResponse) {
         try {
-            CloseableHttpResponse res = HttpClients.createMinimal().execute(new HttpGet(getRegistryUrl().replace("/api", "/health/ready")));
+            CloseableHttpResponse res = HttpClients.createMinimal().execute(new HttpGet(getRegistryUrl().concat("/health/ready")));
             boolean ok = res.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
             if (ok) {
                 log.info("Service registry is ready");
@@ -307,5 +300,4 @@ public class TestUtils {
         ArtifactMetaData amd = retry(() -> service.getArtifactMetaDataByGlobalId(id));
         Assertions.assertNotNull(amd); // wait for global id to populate
     }
-    
 }


### PR DESCRIPTION
Changes `TestUtils.getRegistryUrl` to `TestUtils.getRegistryApiUrl` to fix an issue with `getRegistryUIUrl` where the replacement done (from /api to /ui) produced issues in cases where the registry host started with `http://apicurio...` (which is pretty common :) )

This PR also removes the fields from `RegistryServiceTest` annotation because they were not being used and from my POV they weren't useful