### PR TITLE
tests - new kubernetes workflow

### DIFF
--- a/.github/scripts/deploy_operator.sh
+++ b/.github/scripts/deploy_operator.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+TEST_NAMESPACE=apicurio-registry-test
+
+kubectl create namespace $TEST_NAMESPACE
+
+function waitForPodByLabel() {
+    LABEL_SEARCH=$1
+    while [[ $(kubectl get pods -n $TEST_NAMESPACE -l $LABEL_SEARCH -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "waiting for pod $LABEL_SEARCH" && sleep 5; done
+}
+
+curl -sSL https://raw.githubusercontent.com/apicurio/apicurio-registry-operator/master/docs/resources/install.yaml | sed "s/{NAMESPACE}/$TEST_NAMESPACE/g" | kubectl apply -n $TEST_NAMESPACE -f -
+waitForPodByLabel "name=apicurio-registry-operator"
+
+curl -sSL https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.18.0/strimzi-cluster-operator-0.18.0.yaml | sed "s/namespace: .*/namespace: $TEST_NAMESPACE/g" | kubectl apply -n $TEST_NAMESPACE -f -
+waitForPodByLabel "name=strimzi-cluster-operator"
+
+kubectl apply -n $TEST_NAMESPACE -f .github/scripts/kubefiles/kafka
+sleep 30
+kubectl get pod -n $TEST_NAMESPACE
+
+kubectl apply -n $TEST_NAMESPACE -f .github/scripts/kubefiles/apicurio/apicurio-registry-streams.yaml
+sleep 5
+kubectl get pod -n $TEST_NAMESPACE
+waitForPodByLabel "app=apicurio-registry-streams"
+kubectl wait deployment -l app=apicurio-registry-streams --for condition=available --timeout=180s
+kubectl get ingress -n $TEST_NAMESPACE
+
+# set -a
+# REGISTRY_HOST=localhost
+# REGISTRY_PORT=80

--- a/.github/scripts/deploy_operator.sh
+++ b/.github/scripts/deploy_operator.sh
@@ -23,7 +23,7 @@ kubectl apply -n $TEST_NAMESPACE -f .github/scripts/kubefiles/apicurio/apicurio-
 sleep 5
 kubectl get pod -n $TEST_NAMESPACE
 waitForPodByLabel "app=apicurio-registry-streams"
-kubectl wait deployment -l app=apicurio-registry-streams --for condition=available --timeout=180s
+kubectl get pod -n $TEST_NAMESPACE
 kubectl get ingress -n $TEST_NAMESPACE
 
 # set -a

--- a/.github/scripts/kubefiles/apicurio/apicurio-registry-streams.yaml
+++ b/.github/scripts/kubefiles/apicurio/apicurio-registry-streams.yaml
@@ -1,0 +1,12 @@
+apiVersion: apicur.io/v1alpha1
+kind: ApicurioRegistry
+metadata:
+  name: apicurio-registry-streams
+spec:
+  deployment:
+    host: "localhost"
+  configuration:
+    persistence: streams
+    streams:
+      applicationId: registry-application
+      bootstrapServers: my-cluster-kafka-bootstrap:9092

--- a/.github/scripts/kubefiles/kafka/kafka-cluster.yaml
+++ b/.github/scripts/kubefiles/kafka/kafka-cluster.yaml
@@ -1,0 +1,29 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    version: 2.4.0
+    replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      log.message.format.version: "2.4"
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: true
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: true
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/.github/scripts/kubefiles/kafka/registry-topics.yaml
+++ b/.github/scripts/kubefiles/kafka/registry-topics.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: storage-topic
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 3
+  replicas: 3
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+
+---
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: global-id-topic
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 3
+  replicas: 3
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824

--- a/.github/scripts/setup_kind.sh
+++ b/.github/scripts/setup_kind.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.8.1/kind-$(uname)-amd64"
+chmod +x ./kind
+
+cat <<EOF | ./kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+EOF
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
+kubectl patch deployment ingress-nginx-controller -n ingress-nginx --type=json -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--enable-ssl-passthrough"}]'

--- a/.github/workflows/k8s_e2e.yaml
+++ b/.github/workflows/k8s_e2e.yaml
@@ -7,16 +7,12 @@ env:
 on:
   # push:
   #   paths-ignore:
-  #     # - '.github/**'
+  #     # - '.github/project.yaml'
+        # - 'docs/**'
   #     - '.gitignore'
   #     - 'LICENSE'
   #     - 'README*'
-  #   branches: ['*']
     # branches: [master]
-#TODO choose to fire up with cron or on push to master
-# on:
-#   schedule:
-#     - cron:  '0 */2 * * *'
 
 #This trigger is only for testing
   pull_request:

--- a/.github/workflows/k8s_e2e.yaml
+++ b/.github/workflows/k8s_e2e.yaml
@@ -56,7 +56,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Run Integration Tests
-        run: mvn verify -am -Pall -pl tests -Dmaven.javadoc.skip=true
+        run: mvn verify -am -Psmoke -Pcluster -pl tests -Dmaven.javadoc.skip=true
       - name: Collect logs
         if: failure()
         run: ./.github/scripts/collect_logs.sh

--- a/.github/workflows/k8s_e2e.yaml
+++ b/.github/workflows/k8s_e2e.yaml
@@ -1,0 +1,69 @@
+name: Kubernetes e2e testing
+
+env:
+  EXTERNAL_REGISTRY: true
+  REGISTRY_PORT: 80
+
+on:
+  # push:
+  #   paths-ignore:
+  #     # - '.github/**'
+  #     - '.gitignore'
+  #     - 'LICENSE'
+  #     - 'README*'
+  #   branches: ['*']
+    # branches: [master]
+#TODO choose to fire up with cron or on push to master
+# on:
+#   schedule:
+#     - cron:  '0 */2 * * *'
+
+#This trigger is only for testing
+  pull_request:
+    paths-ignore:
+      - '.github/project.yaml'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'README*'
+    branches: [master]
+
+
+jobs:
+  integration-tests-on-k8s:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    #TODO uncomment, only for testing
+    # if: github.repository_owner == 'Apicurio' && github.actor != 'dependabot-preview[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Kind
+        run: ./.github/scripts/setup_kind.sh
+
+      - name: Install operator and deploy registry
+        run: ./.github/scripts/deploy_operator.sh
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache Dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Run Integration Tests
+        run: mvn verify -am -Pall -pl tests -Dmaven.javadoc.skip=true
+      - name: Collect logs
+        if: failure()
+        run: ./.github/scripts/collect_logs.sh
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs
+          path: artifacts
+          

--- a/.github/workflows/k8s_e2e.yaml
+++ b/.github/workflows/k8s_e2e.yaml
@@ -52,7 +52,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Run Integration Tests
-        run: mvn verify -am -Psmoke -Pcluster -pl tests -Dmaven.javadoc.skip=true
+        run: mvn verify -am -Psmoke -Pcluster -Pstreams -pl tests -Dmaven.javadoc.skip=true -DtrimStackTrace=false
       - name: Collect logs
         if: failure()
         run: ./.github/scripts/collect_logs.sh

--- a/tests/src/main/java/io/apicurio/tests/utils/RegistryUtils.java
+++ b/tests/src/main/java/io/apicurio/tests/utils/RegistryUtils.java
@@ -26,8 +26,11 @@ import io.apicurio.tests.RegistryStorageType;
 
 public class RegistryUtils {
 
-    public static final RegistryStorageType REGISTRY_STORAGE =
-            RegistryStorageType.valueOf(Optional.ofNullable(System.getProperty("test.storage")).orElse(RegistryStorageType.inmemory.name()));
+    public static final RegistryStorageType REGISTRY_STORAGE = RegistryStorageType.valueOf(
+                Optional.ofNullable(System.getProperty("test.storage", RegistryStorageType.inmemory.name()))
+                    .map(s -> s.isEmpty() ? null : s)
+                    .orElse(RegistryStorageType.inmemory.name())
+            );
 
     private RegistryUtils() {
         //utils class


### PR DESCRIPTION
Adds a new workflow to GH actions to run the integration tests against the registry deployed on kubernetes using the operator and kafka streams as a storage.

An important technicall detail is, because the operator is used the version deployed by the registry is whatever is pinned in the [operator yaml's used](https://raw.githubusercontent.com/apicurio/apicurio-registry-operator/master/docs/resources/install.yaml) , I think the most desirable would be to use a snapshot version of the operator that deploys the latest-snapshot images of the registry

The scripts used are verified and the workflow works, now it's the time to choose how and when do we want to trigger this workflow. My idea is to trigger it after a push to master branch or periodically on master branch.