### PR TITLE
Adding support for auth for the registry client

### DIFF
--- a/.github/scripts/docker-prune.sh
+++ b/.github/scripts/docker-prune.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+# pruning is only run when inside CI to avoid accidentally removing stuff
+# GITHUB_ACTIONS is always set to true inside Github Actions
+# https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
+if [ "${GITHUB_ACTIONS}" == true ] ; then
+  docker container prune -f
+  docker image prune -f
+  docker network prune -f
+  docker volume prune -f
+fi

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -359,5 +359,93 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>docker-keycloak</id>
+            <activation>
+                <property>
+                    <name>docker</name>
+                </property>
+            </activation>
+            <properties>
+                <keycloak.url>http://localhost:8280/auth</keycloak.url>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>quay.io/keycloak/keycloak:11.0.0</name>
+                                    <alias>registry-test-keycloak</alias>
+                                    <run>
+                                        <ports>
+                                            <port>8280:8080</port>
+                                        </ports>
+                                        <env>
+                                            <KEYCLOAK_USER>admin</KEYCLOAK_USER>
+                                            <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
+                                            <JAVA_OPTS>
+                                                -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m                                                      -Djava.net.preferIPv4Stack=true
+                                                -Djava.awt.headless=true
+                                                -Dkeycloak.profile.feature.upload_scripts=enabled
+                                            </JAVA_OPTS>
+                                        </env>
+                                        <log>
+                                            <prefix>Keycloak:</prefix>
+                                            <date>default</date>
+                                            <color>cyan</color>
+                                        </log>
+                                        <wait>
+                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <http>
+                                                <url>http://localhost:8280</url>
+                                            </http>
+                                            <time>100000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                            <allContainers>true</allContainers>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>docker-start</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>docker-stop</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>docker-prune</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${basedir}/../.github/scripts/docker-prune.sh</executable>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 </project>

--- a/app/src/test/java/io/apicurio/registry/RegistryClientTest.java
+++ b/app/src/test/java/io/apicurio/registry/RegistryClientTest.java
@@ -27,6 +27,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
+import io.apicurio.registry.auth.KeycloakResourceManager;
+import io.quarkus.test.common.QuarkusTestResource;
 import org.junit.jupiter.api.Assertions;
 
 import io.apicurio.registry.client.RegistryService;
@@ -46,6 +48,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * @author Ales Justin
  */
 @QuarkusTest
+@QuarkusTestResource(KeycloakResourceManager.class)
 public class RegistryClientTest extends AbstractResourceTestBase {
 
     @RegistryServiceTest

--- a/app/src/test/java/io/apicurio/registry/auth/KeycloakResourceManager.java
+++ b/app/src/test/java/io/apicurio/registry/auth/KeycloakResourceManager.java
@@ -1,0 +1,114 @@
+package io.apicurio.registry.auth;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.restassured.RestAssured;
+import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.idm.*;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+import java.util.*;
+
+public class KeycloakResourceManager implements QuarkusTestResourceLifecycleManager {
+	private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8280/auth");
+	private static final String KEYCLOAK_REALM = "registry";
+	public static final String REGISTRY_APP = "registry-app";
+
+	static {
+		RestAssured.useRelaxedHTTPSValidation();
+	}
+
+	@Override
+	public Map<String, String> start() {
+		RealmRepresentation realm = createRealm(KEYCLOAK_REALM);
+
+		realm.getClients().add(createClient(REGISTRY_APP));
+		realm.getUsers().add(createUser("alice", "user"));
+		realm.getUsers().add(createUser("admin", "user", "admin"));
+		try {
+			RestAssured
+					.given()
+					.auth().oauth2(getAdminToken())
+					.contentType("application/json")
+					.body(JsonSerialization.writeValueAsBytes(realm))
+					.when()
+					.post(KEYCLOAK_SERVER_URL + "/admin/realms").then()
+					.statusCode(201);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+		return Collections.emptyMap();
+	}
+
+	private static String getAdminToken() {
+		return RestAssured
+				.given()
+				.param("grant_type", "password")
+				.param("username", "admin")
+				.param("password", "admin")
+				.param("client_id", "admin-cli")
+				.when()
+				.post(KEYCLOAK_SERVER_URL + "/realms/master/protocol/openid-connect/token")
+				.as(AccessTokenResponse.class).getToken();
+	}
+
+	private static RealmRepresentation createRealm(String name) {
+		RealmRepresentation realm = new RealmRepresentation();
+
+		realm.setRealm(name);
+		realm.setEnabled(true);
+		realm.setUsers(new ArrayList<>());
+		realm.setClients(new ArrayList<>());
+		realm.setAccessTokenLifespan(3);
+
+		RolesRepresentation roles = new RolesRepresentation();
+		List<RoleRepresentation> realmRoles = new ArrayList<>();
+
+		roles.setRealm(realmRoles);
+		realm.setRoles(roles);
+
+		realm.getRoles().getRealm().add(new RoleRepresentation("user", null, false));
+		realm.getRoles().getRealm().add(new RoleRepresentation("admin", null, false));
+
+		return realm;
+	}
+
+	private static ClientRepresentation createClient(String clientId) {
+		ClientRepresentation client = new ClientRepresentation();
+		client.setClientId(clientId);
+		client.setPublicClient(false);
+		client.setSecret("secret");
+		client.setDirectAccessGrantsEnabled(true);
+		client.setEnabled(true);
+		return client;
+	}
+
+	private static UserRepresentation createUser(String username, String... realmRoles) {
+		UserRepresentation user = new UserRepresentation();
+
+		user.setUsername(username);
+		user.setEnabled(true);
+		user.setCredentials(new ArrayList<>());
+		user.setRealmRoles(Arrays.asList(realmRoles));
+		user.setEmail(username + "@redhat.com");
+
+		CredentialRepresentation credential = new CredentialRepresentation();
+		credential.setType(CredentialRepresentation.PASSWORD);
+		credential.setValue(username);
+		credential.setTemporary(false);
+
+		user.getCredentials().add(credential);
+
+		return user;
+	}
+
+	@Override
+	public void stop() {
+		RestAssured
+				.given()
+				.auth().oauth2(getAdminToken())
+				.when()
+				.delete(KEYCLOAK_SERVER_URL + "/admin/realms/" + KEYCLOAK_REALM).then().statusCode(204);
+
+	}
+}

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -26,6 +26,31 @@
             <artifactId>resteasy-client-microprofile</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client</artifactId>
+            <version>10.0.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-multipart-provider</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jackson2-provider</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jaxb-provider</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
         <!-- Only real usage in server-side -->
 
         <dependency>

--- a/client/src/main/java/io/apicurio/registry/client/GenericClient.java
+++ b/client/src/main/java/io/apicurio/registry/client/GenericClient.java
@@ -192,6 +192,7 @@ public class GenericClient {
                     targetClass,
                     tc -> RestClientBuilder.newBuilder()
                                            .baseUri(baseUri)
+                                           .register(HeaderDecorator.class)
                                            .executorService(executor)
                                            .build(tc)
                 );

--- a/client/src/main/java/io/apicurio/registry/client/HeaderDecorator.java
+++ b/client/src/main/java/io/apicurio/registry/client/HeaderDecorator.java
@@ -1,0 +1,16 @@
+package io.apicurio.registry.client;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import java.io.IOException;
+
+public class HeaderDecorator implements ClientRequestFilter {
+
+    public static final String AUTHORIZATION = "Authorization";
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        requestContext.getHeaders().add(AUTHORIZATION, RegistryClient.getToken());
+    }
+
+}

--- a/client/src/main/java/io/apicurio/registry/client/RegistryClient.java
+++ b/client/src/main/java/io/apicurio/registry/client/RegistryClient.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.Response;
  */
 public class RegistryClient {
     private static final Logger log = Logger.getLogger(RegistryClient.class.getName());
+    private static String token;
 
     private RegistryClient() {
     }
@@ -79,5 +80,13 @@ public class RegistryClient {
         if (stateSupplier.get() == ArtifactState.DEPRECATED) {
             log.warning(String.format("Artifact %s [%s] is deprecated", artifactId, version));
         }
+    }
+
+    public static void setToken(String authToken){
+        token = authToken;
+    }
+
+    public static String getToken(){
+        return token;
     }
 }

--- a/client/src/main/java/io/apicurio/registry/client/RegistryClient.java
+++ b/client/src/main/java/io/apicurio/registry/client/RegistryClient.java
@@ -16,6 +16,7 @@
 
 package io.apicurio.registry.client;
 
+import io.apicurio.registry.client.auth.AuthConfig;
 import io.apicurio.registry.rest.Headers;
 import io.apicurio.registry.rest.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.beans.VersionMetaData;
@@ -31,7 +32,6 @@ import javax.ws.rs.core.Response;
  */
 public class RegistryClient {
     private static final Logger log = Logger.getLogger(RegistryClient.class.getName());
-    private static String token;
 
     private RegistryClient() {
     }
@@ -43,8 +43,21 @@ public class RegistryClient {
                                                                  .build();
     }
 
+
+    public static RegistryService create(String baseUrl, AuthConfig authConfig) {
+        return new GenericClient.Builder<>(RegistryService.class).setBaseUrl(baseUrl)
+                .setCustomMethods(RegistryClient::handleReset)
+                .setAuth(authConfig)
+                .setResultConsumer(RegistryClient::handleResult)
+                .build();
+    }
+
     public static RegistryService cached(String baseUrl) {
         return cached(create(baseUrl));
+    }
+
+    public static RegistryService cached(String baseUrl, AuthConfig authConfig) {
+        return cached(create(baseUrl,authConfig));
     }
 
     public static RegistryService cached(RegistryService delegate) {
@@ -82,11 +95,4 @@ public class RegistryClient {
         }
     }
 
-    public static void setToken(String authToken){
-        token = authToken;
-    }
-
-    public static String getToken(){
-        return token;
-    }
 }

--- a/client/src/main/java/io/apicurio/registry/client/auth/Auth.java
+++ b/client/src/main/java/io/apicurio/registry/client/auth/Auth.java
@@ -1,0 +1,18 @@
+package io.apicurio.registry.client.auth;
+
+
+public class Auth {
+   private AuthConfig config;
+
+   public Auth(AuthConfig config) {
+      this.config = config;
+   }
+
+   public AuthStrategy getAuthStrategy() {
+      switch(this.config.getProvider()) {
+         case KEYCLOAK: return new KeycloakAuth(config);
+      }
+      return null;
+   }
+
+}

--- a/client/src/main/java/io/apicurio/registry/client/auth/AuthConfig.java
+++ b/client/src/main/java/io/apicurio/registry/client/auth/AuthConfig.java
@@ -1,0 +1,78 @@
+package io.apicurio.registry.client.auth;
+
+import org.keycloak.admin.client.Config;
+
+public class AuthConfig extends Config {
+    private AuthProvider provider;
+
+    public AuthProvider getProvider() {
+        return provider;
+    }
+
+    public void setProvider(AuthProvider provider) {
+        this.provider = provider;
+    }
+
+    public AuthConfig(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, AuthProvider provider) {
+        super(serverUrl, realm, username, password, clientId, clientSecret);
+        this.provider = provider;
+    }
+
+    public AuthConfig(String serverUrl, String realm, String username, String password, String clientId, String clientSecret) {
+        super(serverUrl, realm, username, password, clientId, clientSecret);
+    }
+
+    public AuthConfig(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, String grantType) {
+        super(serverUrl, realm, username, password, clientId, clientSecret, grantType);
+    }
+
+    public static class Builder {
+        private String serverUrl;
+        private String realm;
+        private String username;
+        private String password;
+        private String clientId;
+        private String clientSecret;
+        private AuthConfig config;
+        private AuthProvider provider;
+
+        public Builder(AuthProvider provider) {
+            this.provider = provider;
+        }
+
+        public Builder setRealm(String realm) {
+            this.realm = realm;
+            return this;
+        }
+
+        public Builder setUsername(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder setPassword(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder setClientId(String clientId) {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public Builder setClientSecret(String clientSecret) {
+            this.clientSecret = clientSecret;
+            return this;
+        }
+
+        public Builder setServerUrl(String serverUrl) {
+            this.serverUrl = serverUrl;
+            return this;
+        }
+
+        public AuthConfig Build(){
+            return this.config = new AuthConfig(this.serverUrl, this.realm, this.username, this.password, this.clientId, this.clientSecret, this.provider);
+        }
+    }
+
+}

--- a/client/src/main/java/io/apicurio/registry/client/auth/AuthProvider.java
+++ b/client/src/main/java/io/apicurio/registry/client/auth/AuthProvider.java
@@ -1,0 +1,5 @@
+package io.apicurio.registry.client.auth;
+
+public enum AuthProvider {
+    KEYCLOAK
+}

--- a/client/src/main/java/io/apicurio/registry/client/auth/AuthStrategy.java
+++ b/client/src/main/java/io/apicurio/registry/client/auth/AuthStrategy.java
@@ -1,0 +1,5 @@
+package io.apicurio.registry.client.auth;
+
+public interface AuthStrategy {
+    public String getToken();
+}

--- a/client/src/main/java/io/apicurio/registry/client/auth/HeaderDecorator.java
+++ b/client/src/main/java/io/apicurio/registry/client/auth/HeaderDecorator.java
@@ -1,4 +1,4 @@
-package io.apicurio.registry.client;
+package io.apicurio.registry.client.auth;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
@@ -7,10 +7,18 @@ import java.io.IOException;
 public class HeaderDecorator implements ClientRequestFilter {
 
     public static final String AUTHORIZATION = "Authorization";
+    private static String token;
+
+    public static String getToken() {
+        return token;
+    }
+
+    public static void setToken(String token) {
+        HeaderDecorator.token = token;
+    }
 
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
-        requestContext.getHeaders().add(AUTHORIZATION, RegistryClient.getToken());
+        requestContext.getHeaders().add(AUTHORIZATION, getToken());
     }
-
 }

--- a/client/src/main/java/io/apicurio/registry/client/auth/KeycloakAuth.java
+++ b/client/src/main/java/io/apicurio/registry/client/auth/KeycloakAuth.java
@@ -1,0 +1,23 @@
+package io.apicurio.registry.client.auth;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+
+public class KeycloakAuth implements AuthStrategy {
+
+    private Keycloak keycloak;
+
+    public KeycloakAuth(AuthConfig config) {
+        this.keycloak = KeycloakBuilder.builder()
+                .serverUrl(config.getServerUrl())
+                .username(config.getUsername())
+                .password(config.getPassword())
+                .realm(config.getRealm())
+                .clientId(config.getClientId())
+                .build();
+    }
+
+    @Override
+    public String getToken() {
+        return this.keycloak.tokenManager().getAccessToken().getToken();
+    }
+}

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
@@ -32,6 +32,8 @@ import java.util.function.Function;
 
 import javax.ws.rs.WebApplicationException;
 
+import io.apicurio.registry.client.auth.AuthConfig;
+import io.apicurio.registry.client.auth.AuthProvider;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -58,6 +60,7 @@ public class TestUtils {
     private static final int REGISTRY_PORT = Integer.parseInt(System.getenv().getOrDefault("REGISTRY_PORT", String.valueOf(DEFAULT_REGISTRY_PORT)));
     private static final String EXTERNAL_REGISTRY = System.getenv().getOrDefault("EXTERNAL_REGISTRY", "false");
     private static final String TEST_REGISTRY_CLIENT = System.getenv("TEST_REGISTRY_CLIENT");
+    public static final String REGISTRY = "registry";
 
     private TestUtils() {
         // All static methods
@@ -77,6 +80,17 @@ public class TestUtils {
 
     public static String getRegistryUIUrl() {
         return getRegistryUrl().concat("/ui");
+    }
+
+    public static AuthConfig getAuthConfig(AuthProvider authProvider){
+        AuthConfig config = new AuthConfig.Builder(authProvider)
+                .setServerUrl("http://localhost:8280/auth")
+                .setClientId("admin-cli")
+                .setRealm(REGISTRY)
+                .setUsername("admin")
+                .setPassword("admin")
+                .Build();
+        return config;
     }
 
     public static String getRegistryApiUrl() {


### PR DESCRIPTION
Authentication/authorization proof of concept: https://github.com/Apicurio/apicurio-registry/issues/674
Poc with keycloak:
https://github.com/carlesarnal/apicurio-registry/tree/auth-poc-674

Update Registry Client to support a client method with a configurable authentication mechanism. Config is provided as a parameter in the create/cached method. Currently, it only supports keycloak auth strategy, but it can be extended to support other mechanisms. 

Example:
```
String registryUrl = "http://0.0.0.0:8080/api";
AuthConfig config = new AuthConfig.Builder(AuthProvider.KEYCLOAK)
				.setServerUrl("http://127.0.0.1:8081/auth")
				.setClientId("admin-cli")
				.setRealm("master")
				.setUsername("admin")
				.setPassword("admin")
				.Build();

RegistryService service = RegistryClient.cached(registryUrl, config);

```
