### PR TITLE
Implement HTTP Response status code metrics reporting for REST API

### DIFF
--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
@@ -3,12 +3,15 @@ package io.apicurio.registry.metrics;
 import static io.apicurio.registry.metrics.MetricIDs.REST_GROUP_TAG;
 import static org.eclipse.microprofile.metrics.MetricRegistry.Type.APPLICATION;
 import static org.eclipse.microprofile.metrics.MetricType.COUNTER;
+import static org.eclipse.microprofile.metrics.MetricType.TIMER;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 import javax.ws.rs.Path;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.ResourceInfo;
@@ -19,13 +22,16 @@ import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.smallrye.metrics.app.Clock;
+
 @Provider
 @RestMetricsResponseFilteredNameBinding
-public class RestMetricsResponseFilter implements ContainerResponseFilter {
+public class RestMetricsResponseFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
 	@Inject
 	@RegistryType(type = APPLICATION)
@@ -36,8 +42,21 @@ public class RestMetricsResponseFilter implements ContainerResponseFilter {
 	String REST_HTTP_REQUESTS_TOTAL = "rest_http_requests_total";
 	String REST_HTTP_REQUESTS_TOTAL_DESC = "Total number of REST HTTP Requests";
 
+	String REST_HTTP_REQUESTS_TIME = "rest_http_request_duration";
+	String REST_HTTP_REQUESTS_TIME_DESC = "Execution time of REST HTTP Requests in seconds";
+
+	private Clock clock = Clock.defaultClock();
+
+	public static final String REQUEST_START_TIME_CONTEXT_PROPERTY_NAME = "request-start-time";
+
 	@Context
 	private ResourceInfo resourceInfo;
+
+	@Override
+	public void filter(ContainerRequestContext requestContext) throws IOException {
+		long sample = clock.getTick();
+		requestContext.setProperty(REQUEST_START_TIME_CONTEXT_PROPERTY_NAME, sample);
+	}
 
 	@Override
 	public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
@@ -67,6 +86,23 @@ public class RestMetricsResponseFilter implements ContainerResponseFilter {
 				new Tag("endpoint", this.getUri()), new Tag("method", requestContext.getMethod()), };
 		Counter statusFamilyCounter = metricRegistry.counter(metadata, counterTags);
 		statusFamilyCounter.inc();
+
+		long startTimeSample = (long) requestContext.getProperty(REQUEST_START_TIME_CONTEXT_PROPERTY_NAME);
+		long endTimeSample = clock.getTick();
+		long elapsed = endTimeSample - startTimeSample;
+
+		final Metadata timerMetadata = Metadata.builder().withName(REST_HTTP_REQUESTS_TIME)
+				.withDescription(REST_HTTP_REQUESTS_TIME_DESC).withType(TIMER).build();
+		Tag[] timerTags = { new Tag("group", REST_GROUP_TAG), new Tag("metric", REST_HTTP_REQUESTS_TIME),
+				new Tag("status", String.format("%dxx", statusFamilyCode)),
+				// TODO this information those not include base path (/api). Should we include
+				// it as part
+				// of the endpoint tag? or being in the rest_http_requests_total context it's
+				// assumed that user
+				// knows the path? maybe another tag named basePath?
+				new Tag("endpoint", this.getUri()), new Tag("method", requestContext.getMethod()), };
+		Timer timer = metricRegistry.timer(timerMetadata, timerTags);
+		timer.update(elapsed, TimeUnit.NANOSECONDS);
 	}
 
 	private String getUri() {

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
@@ -42,6 +42,13 @@ import org.eclipse.microprofile.metrics.annotation.RegistryType;
 
 import io.smallrye.metrics.app.Clock;
 
+/**
+ * Filter class that filters REST API requests and responses to report metrics
+ * about them. Binding of the methods being filtered is performed through the
+ * {@link io.apicurio.registry.metrics.RestMetricsResponseFilteredNameBinding}
+ * annotation added in the {@link io.apicurio.registry.rest.RegistryApplication}
+ * JAX-RS Application class
+ */
 @Provider
 @RestMetricsResponseFilteredNameBinding
 public class RestMetricsResponseFilter implements ContainerRequestFilter, ContainerResponseFilter {

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
@@ -86,8 +86,8 @@ public class RestMetricsResponseFilter implements ContainerRequestFilter, Contai
 		final Metadata metadata = Metadata.builder().withName(REST_HTTP_REQUESTS_TOTAL)
 				.withDescription(REST_HTTP_REQUESTS_TOTAL_DESC).withType(COUNTER).build();
 		Tag[] counterTags = { new Tag("group", REST_GROUP_TAG), new Tag("metric", REST_HTTP_REQUESTS_TOTAL),
-				new Tag("status", String.format("%dxx", statusFamilyCode)),
-				new Tag("endpoint", this.getUri()), new Tag("method", requestContext.getMethod()), };
+				new Tag("status", String.format("%dxx", statusFamilyCode)), new Tag("endpoint", this.getUri()),
+				new Tag("method", requestContext.getMethod()), };
 		Counter statusFamilyCounter = metricRegistry.counter(metadata, counterTags);
 		statusFamilyCounter.inc();
 
@@ -98,8 +98,8 @@ public class RestMetricsResponseFilter implements ContainerRequestFilter, Contai
 		final Metadata timerMetadata = Metadata.builder().withName(REST_HTTP_REQUESTS_TIME)
 				.withDescription(REST_HTTP_REQUESTS_TIME_DESC).withType(TIMER).build();
 		Tag[] timerTags = { new Tag("group", REST_GROUP_TAG), new Tag("metric", REST_HTTP_REQUESTS_TIME),
-				new Tag("status", String.format("%dxx", statusFamilyCode)),
-				new Tag("endpoint", this.getUri()), new Tag("method", requestContext.getMethod()), };
+				new Tag("status", String.format("%dxx", statusFamilyCode)), new Tag("endpoint", this.getUri()),
+				new Tag("method", requestContext.getMethod()), };
 		Timer timer = metricRegistry.timer(timerMetadata, timerTags);
 		timer.update(elapsed, TimeUnit.NANOSECONDS);
 	}

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
@@ -91,11 +91,6 @@ public class RestMetricsResponseFilter implements ContainerRequestFilter, Contai
 				.withDescription(REST_HTTP_REQUESTS_TOTAL_DESC).withType(COUNTER).build();
 		Tag[] counterTags = { new Tag("group", REST_GROUP_TAG), new Tag("metric", REST_HTTP_REQUESTS_TOTAL),
 				new Tag("status", String.format("%dxx", statusFamilyCode)),
-				// TODO this information those not include base path (/api). Should we include
-				// it as part
-				// of the endpoint tag? or being in the rest_http_requests_total context it's
-				// assumed that user
-				// knows the path? maybe another tag named basePath?
 				new Tag("endpoint", this.getUri()), new Tag("method", requestContext.getMethod()), };
 		Counter statusFamilyCounter = metricRegistry.counter(metadata, counterTags);
 		statusFamilyCounter.inc();
@@ -108,11 +103,6 @@ public class RestMetricsResponseFilter implements ContainerRequestFilter, Contai
 				.withDescription(REST_HTTP_REQUESTS_TIME_DESC).withType(TIMER).build();
 		Tag[] timerTags = { new Tag("group", REST_GROUP_TAG), new Tag("metric", REST_HTTP_REQUESTS_TIME),
 				new Tag("status", String.format("%dxx", statusFamilyCode)),
-				// TODO this information those not include base path (/api). Should we include
-				// it as part
-				// of the endpoint tag? or being in the rest_http_requests_total context it's
-				// assumed that user
-				// knows the path? maybe another tag named basePath?
 				new Tag("endpoint", this.getUri()), new Tag("method", requestContext.getMethod()), };
 		Timer timer = metricRegistry.timer(timerMetadata, timerTags);
 		timer.update(elapsed, TimeUnit.NANOSECONDS);

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
@@ -76,8 +76,6 @@ public class RestMetricsResponseFilter implements ContainerRequestFilter, Contai
 	@Override
 	public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
 			throws IOException {
-		log.info("'{} {}'", requestContext.getMethod(), requestContext.getUriInfo().getRequestUri().toString());
-		log.info("Response code: '{}'", responseContext.getStatus());
 		// Don't do anything when response code has not been set or when
 		// response code is not between 1XX and 5XX
 		int statusCode = responseContext.getStatus();

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
@@ -1,0 +1,61 @@
+package io.apicurio.registry.metrics;
+
+import static io.apicurio.registry.metrics.MetricIDs.*;
+
+import static org.eclipse.microprofile.metrics.MetricRegistry.Type.APPLICATION;
+import static org.eclipse.microprofile.metrics.MetricType.COUNTER;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+@RestMetricsResponseFilteredNameBinding
+public class RestMetricsResponseFilter implements ContainerResponseFilter {
+
+	@Inject
+	@RegistryType(type = APPLICATION)
+	MetricRegistry metricRegistry;
+
+	private static final Logger log = LoggerFactory.getLogger(RestMetricsResponseFilter.class);
+
+	String REST_RESPONSE_STATUS_CODE_COUNT = "rest_response_status_code";
+	String REST_RESPONSE_STATUS_CODE_COUNT_DESC = "Total number of REST HTTP Response Codes across all endpoints.";
+
+	@Override
+	public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+			throws IOException {
+		log.info("'{} {}'", requestContext.getMethod(), requestContext.getUriInfo().getRequestUri().toString());
+		log.info("Response code: '{}'", responseContext.getStatus());
+		
+		// Don't do anything when response code has not been set or when
+		// response code is not between 1XX and 5XX
+		int statusCode = responseContext.getStatus();
+		if (statusCode == -1) {
+			return;
+		}
+		if (statusCode < 100 || statusCode >= 600) {
+			return;
+		}
+
+		final Metadata metadata = Metadata.builder().withName(REST_RESPONSE_STATUS_CODE_COUNT)
+				.withDescription(REST_RESPONSE_STATUS_CODE_COUNT_DESC).withType(COUNTER).build();
+		int statusFamilyCode = statusCode / 100;
+		Tag[] counterTags = { new Tag("group", REST_GROUP_TAG), new Tag("metric", REST_RESPONSE_STATUS_CODE_COUNT),
+				new Tag("code", String.format("%dxx", statusFamilyCode)), };
+		Counter statusFamilyCounter = metricRegistry.counter(metadata, counterTags);
+		statusFamilyCounter.inc();
+	}
+}

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
@@ -39,8 +39,6 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.smallrye.metrics.app.Clock;
 
@@ -51,8 +49,6 @@ public class RestMetricsResponseFilter implements ContainerRequestFilter, Contai
 	@Inject
 	@RegistryType(type = APPLICATION)
 	MetricRegistry metricRegistry;
-
-	private static final Logger log = LoggerFactory.getLogger(RestMetricsResponseFilter.class);
 
 	String REST_HTTP_REQUESTS_TOTAL = "rest_http_requests_total";
 	String REST_HTTP_REQUESTS_TOTAL_DESC = "Total number of REST HTTP Requests";

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
@@ -31,8 +31,8 @@ public class RestMetricsResponseFilter implements ContainerResponseFilter {
 
 	private static final Logger log = LoggerFactory.getLogger(RestMetricsResponseFilter.class);
 
-	String REST_RESPONSE_STATUS_CODE_COUNT = "rest_response_status_code";
-	String REST_RESPONSE_STATUS_CODE_COUNT_DESC = "Total number of REST HTTP Response Codes across all endpoints.";
+	String REST_HTTP_REQUESTS_TOTAL = "rest_http_requests_total";
+	String REST_HTTP_REQUESTS_TOTAL_DESC = "Total number of REST HTTP Requests";
 
 	@Override
 	public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
@@ -50,10 +50,10 @@ public class RestMetricsResponseFilter implements ContainerResponseFilter {
 			return;
 		}
 
-		final Metadata metadata = Metadata.builder().withName(REST_RESPONSE_STATUS_CODE_COUNT)
-				.withDescription(REST_RESPONSE_STATUS_CODE_COUNT_DESC).withType(COUNTER).build();
+		final Metadata metadata = Metadata.builder().withName(REST_HTTP_REQUESTS_TOTAL)
+				.withDescription(REST_HTTP_REQUESTS_TOTAL_DESC).withType(COUNTER).build();
 		int statusFamilyCode = statusCode / 100;
-		Tag[] counterTags = { new Tag("group", REST_GROUP_TAG), new Tag("metric", REST_RESPONSE_STATUS_CODE_COUNT),
+		Tag[] counterTags = { new Tag("group", REST_GROUP_TAG), new Tag("metric", REST_HTTP_REQUESTS_TOTAL),
 				new Tag("code", String.format("%dxx", statusFamilyCode)), };
 		Counter statusFamilyCounter = metricRegistry.counter(metadata, counterTags);
 		statusFamilyCounter.inc();

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.apicurio.registry.metrics;
 
 import static io.apicurio.registry.metrics.MetricIDs.REST_GROUP_TAG;

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilter.java
@@ -1,16 +1,18 @@
 package io.apicurio.registry.metrics;
 
-import static io.apicurio.registry.metrics.MetricIDs.*;
-
+import static io.apicurio.registry.metrics.MetricIDs.REST_GROUP_TAG;
 import static org.eclipse.microprofile.metrics.MetricRegistry.Type.APPLICATION;
 import static org.eclipse.microprofile.metrics.MetricType.COUNTER;
 
 import java.io.IOException;
 
 import javax.inject.Inject;
+import javax.ws.rs.Path;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.ext.Provider;
 
 import org.eclipse.microprofile.metrics.Counter;
@@ -34,12 +36,14 @@ public class RestMetricsResponseFilter implements ContainerResponseFilter {
 	String REST_HTTP_REQUESTS_TOTAL = "rest_http_requests_total";
 	String REST_HTTP_REQUESTS_TOTAL_DESC = "Total number of REST HTTP Requests";
 
+	@Context
+	private ResourceInfo resourceInfo;
+
 	@Override
 	public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
 			throws IOException {
 		log.info("'{} {}'", requestContext.getMethod(), requestContext.getUriInfo().getRequestUri().toString());
 		log.info("Response code: '{}'", responseContext.getStatus());
-		
 		// Don't do anything when response code has not been set or when
 		// response code is not between 1XX and 5XX
 		int statusCode = responseContext.getStatus();
@@ -49,13 +53,34 @@ public class RestMetricsResponseFilter implements ContainerResponseFilter {
 		if (statusCode < 100 || statusCode >= 600) {
 			return;
 		}
+		int statusFamilyCode = statusCode / 100;
 
 		final Metadata metadata = Metadata.builder().withName(REST_HTTP_REQUESTS_TOTAL)
 				.withDescription(REST_HTTP_REQUESTS_TOTAL_DESC).withType(COUNTER).build();
-		int statusFamilyCode = statusCode / 100;
 		Tag[] counterTags = { new Tag("group", REST_GROUP_TAG), new Tag("metric", REST_HTTP_REQUESTS_TOTAL),
-				new Tag("code", String.format("%dxx", statusFamilyCode)), };
+				new Tag("status", String.format("%dxx", statusFamilyCode)),
+				// TODO this information those not include base path (/api). Should we include
+				// it as part
+				// of the endpoint tag? or being in the rest_http_requests_total context it's
+				// assumed that user
+				// knows the path? maybe another tag named basePath?
+				new Tag("endpoint", this.getUri()), new Tag("method", requestContext.getMethod()), };
 		Counter statusFamilyCounter = metricRegistry.counter(metadata, counterTags);
 		statusFamilyCounter.inc();
 	}
+
+	private String getUri() {
+		return getResourceClassPath() + getResourceMethodPath();
+	}
+
+	private String getResourceClassPath() {
+		Path classPath = resourceInfo.getResourceClass().getAnnotation(Path.class);
+		return classPath != null ? classPath.value() : "";
+	}
+
+	private String getResourceMethodPath() {
+		Path methodPath = resourceInfo.getResourceMethod().getAnnotation(Path.class);
+		return methodPath != null ? methodPath.value() : "";
+	}
+
 }

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilteredNameBinding.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilteredNameBinding.java
@@ -1,0 +1,14 @@
+package io.apicurio.registry.metrics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.NameBinding;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(value = RetentionPolicy.RUNTIME)
+@NameBinding
+public @interface RestMetricsResponseFilteredNameBinding {
+}

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilteredNameBinding.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilteredNameBinding.java
@@ -22,6 +22,10 @@ import java.lang.annotation.Target;
 
 import javax.ws.rs.NameBinding;
 
+/**
+ * Meta-Annotation used to perform name-binding between REST API methods and
+ * {@link io.apicurio.registry.metrics.RestMetricsResponseFilter} filter
+ */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(value = RetentionPolicy.RUNTIME)
 @NameBinding

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilteredNameBinding.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsResponseFilteredNameBinding.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.apicurio.registry.metrics;
 
 import java.lang.annotation.ElementType;

--- a/app/src/main/java/io/apicurio/registry/rest/RegistryApplication.java
+++ b/app/src/main/java/io/apicurio/registry/rest/RegistryApplication.java
@@ -19,10 +19,13 @@ package io.apicurio.registry.rest;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
+import io.apicurio.registry.metrics.RestMetricsResponseFilteredNameBinding;
+
 /**
  * @author eric.wittmann@gmail.com
  */
 @ApplicationPath("/api")
+@RestMetricsResponseFilteredNameBinding
 public class RegistryApplication extends Application {
 
 }


### PR DESCRIPTION
Hi,

As part of https://issues.redhat.com/browse/IPT-109, https://issues.redhat.com/browse/IPT-155 I'm trying to come up with a solution on reporting metrics with the response codes status and durations (latencies) in the REST API.

I've taken a look at the codebase to see how API rest is exposed and this is how I think it works:

It seems that metrics in service-registry are reported/exposed using the `Microprofile` (https://projects.eclipse.org/projects/technology.microprofile) Java library. Metrics are exposed on the `/metrics` endpoint.
The REST Web Services API is exposed using `JAX-RS` (https://docs.oracle.com/javaee/7/api/javax/ws/rs/package-summary.html) . The REST API is exposed in the `/api` endpoint.

Based on this I explored the following approaches:
* Trying to use some possible existing construct in `Microprofile` that reports HTTP metrics. I haven't found any construct to do that. Keep in mind I have never used `Microprofile` before. Maybe there is something but if there is I haven't found it.
*  It seems using a standard Java interceptor like the one we have for rest metrics `RestMetricsInterceptor` cannot be used as standard interceptors do not receive detail about HTTP responses

After digging a little bit on what could be done a solution that I think might be feasible to implement is making use of `ContainerResponseFilter` in JAX-RS (https://docs.oracle.com/javaee/7/api/javax/ws/rs/container/ContainerResponseFilter.html)  that seems allows us to filter HTTP Responses.

This PR implements reporting 1xx, 2xx, 3xx, 4xx, 5xx response codes counts on requests performed to the REST API. It performs a NameBinding of the ContainerResponseFilter with the `RegistryApplication` class that I understand contains the entrypoint of the REST API. This means for example that a request to /anotherurl would not be processed by this filter.

There are some specificities of the implemented behavior that we should evaluate whether they are in our interest or not:

I've done a few tests to see when the filter is executed with the current implementation:
* When a 200 status code is returned the response filter is executed
* When a 503 status code is returned the response filter is executed
* When a 406 status code is returned (forced for example by sending '-H "Accept: text/xmsdfdsfl') the response filter is NOT executed. This behavior surprised me
* When a 400 status code is returned (forced for example by sending invalid data like -d 'invaliddata') the response filter is executed
* When a 404 status code is returned due to a non-existing endpoint has been requested the response filter is NOT executed. I think this behavior is expected as
  we are only filtering on the existing api rest endpoints. In any case, is this what we want?
  endpoints
* When executing a request against /metrics for example, or to /nonexistentpath (which are not inside the api rest code) the response filter is
  NOT executed. I think this behavior is expected as they are not prat of the REST api code. In any case, is this what we want?

I've not tried with other kind of status codes, but it seems that there's some case/s where a request to an existing endpoint is not
evaluated by the filter for some reason.

The implemented metrics format look like this:
```
msoriano@localhost:~/eclipse-workspace/github.com/Apicurio/apicurio-registry (add-rest-api-metrics-response-filter)$ curl localhost:8080/metrics 2>/dev/null| grep -i xx
application_rest_response_status_code_total{code="4xx",group="REST",metric="rest_response_status_code"} 2.0
application_rest_response_status_code_total{code="5xx",group="REST",metric="rest_response_status_code"} 3.0
```

The corresponding metric is created the first time a new status code family type is returned.

We could add more tags/labels to the metric or organize different metrics for it. Just keep in mind that depending on what we process and the defined metrics
the cardinality of the metrics could increase expontentially so we have to be careful with it, specially if we add a label/metric that might have unbounded values.

What do you think about this implementation approach and the current behavior? let's iterate on this.

Thank you.