### PR TITLE
Fix configurable quarkus http port

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.index-dependency.jaxrs.group-id=org.jboss.spec.javax.ws.rs
 quarkus.index-dependency.jaxrs.artifact-id=jboss-jaxrs-api_2.1_spec
 
 # === Dev profile - see README
-@dev.quarkus.http.port=${HTTP_PORT:8080}
+%dev.quarkus.http.port=${HTTP_PORT:8080}
 %dev.quarkus.log.level=DEBUG
 %dev.quarkus.log.console.enable=true
 %dev.quarkus.datasource.url=jdbc:h2:tcp://localhost:9123/mem:registry;DB_CLOSE_DELAY=-1;IFEXISTS=FALSE;
@@ -48,7 +48,7 @@ quarkus.index-dependency.jaxrs.artifact-id=jboss-jaxrs-api_2.1_spec
 
 # === Prod profile - see README
 # HTTP Port
-@prod.quarkus.http.port=${HTTP_PORT:8080}
+%prod.quarkus.http.port=${HTTP_PORT:8080}
 
 # Log
 %prod.quarkus.log.level=${LOG_LEVEL:INFO}


### PR DESCRIPTION
When doing local tests, I wasn't able to change the http port for quarkus.
I tried to run quarkus:dev goal setting the HTTP_PORT environment variable but it didn't change the port
when running.

Looking at quarkus configuration guide https://quarkus.io/guides/config#create-the-configuration I see that
profile properties start with '%'.

However, '@' was being used for the quarkus.http.port which was a typo and prevented the http port
for quarkus being configurable.

I think this might be a typo, unless I'm missing some way to configure the port when the property starts with '@'.

What do you think?