### PR TITLE
Crud strategies, if not found, create artifact or update schema (#687)

### DIFF
--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/strategy/AbstractCrudIdStrategy.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/strategy/AbstractCrudIdStrategy.java
@@ -18,6 +18,7 @@ package io.apicurio.registry.utils.serde.strategy;
 
 import io.apicurio.registry.client.RegistryService;
 import io.apicurio.registry.rest.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.beans.IfExistsType;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.ConcurrentUtil;
 
@@ -50,7 +51,7 @@ public abstract class AbstractCrudIdStrategy<T> implements GlobalIdStrategy<T> {
             return initialLookup(service, artifactId, artifactType, schema);
         } catch (WebApplicationException e) {
             if (isNotFound(e.getResponse())) {
-                CompletionStage<ArtifactMetaData> cs = service.createArtifact(artifactType, artifactId, null, toStream(schema));
+                CompletionStage<ArtifactMetaData> cs = service.createArtifact(artifactType, artifactId, IfExistsType.RETURN_OR_UPDATE, toStream(schema));
                 ArtifactMetaData amd = unwrap(cs);
                 afterCreateArtifact(schema, amd);
                 return amd.getGlobalId();


### PR DESCRIPTION
Related to issue #687  not about cache request, but after review with partner @antonmry, this simple change made possible update the artifact when the schema is different.
Three strategies extends `AbstractCrudIdStrategy`:
- `AutoRegisterIdStrategy`: always run update, no affectation by this changed
- `GetOrCreateIdStrategy`: if artifact-id exists, get the last global-id (don't check if schema is equals), otherwise create artifact with the schema. No affectation by this change: if artifact not found, create it (no possible update)
- `CachedSchemaIdStrategy`: If artifact-id exists but schema isn't equals gets a 404 response, try to create artifact and fails (the artifact exists). **The change affects only this case**: try to create artifact, really add a new version of schema, and gets the global-id.
