### PR TITLE
Enhance ibmcompat API methods

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/Api.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/Api.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.apicurio.registry.ibmcompat.api;
 
 import static io.apicurio.registry.metrics.MetricIDs.REST_CONCURRENT_REQUEST_COUNT;
@@ -31,6 +47,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
+import io.apicurio.registry.storage.ArtifactAlreadyExistsException;
 import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
@@ -72,7 +89,7 @@ public class Api {
         @DefaultValue("false") @QueryParam("verify") boolean verify,
         @Context SecurityContext securityContext
     )
-    throws ArtifactNotFoundException {
+    throws ArtifactNotFoundException, ArtifactAlreadyExistsException {
         service.apiSchemasPost(response, schema, verify);
     }
 
@@ -111,7 +128,7 @@ public class Api {
         @NotNull @Valid NewSchemaVersion schema,
         @DefaultValue("false") @QueryParam("verify") boolean verify
     )
-    throws ArtifactNotFoundException {
+    throws ArtifactNotFoundException, ArtifactAlreadyExistsException {
         service.apiSchemasSchemaidVersionsPost(response, schemaid, schema, verify);
     }
 

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/Api.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/Api.java
@@ -16,16 +16,18 @@
  */
 package io.apicurio.registry.ibmcompat.api;
 
-import static io.apicurio.registry.metrics.MetricIDs.REST_CONCURRENT_REQUEST_COUNT;
-import static io.apicurio.registry.metrics.MetricIDs.REST_CONCURRENT_REQUEST_COUNT_DESC;
-import static io.apicurio.registry.metrics.MetricIDs.REST_GROUP_TAG;
-import static io.apicurio.registry.metrics.MetricIDs.REST_REQUEST_COUNT;
-import static io.apicurio.registry.metrics.MetricIDs.REST_REQUEST_COUNT_DESC;
-import static io.apicurio.registry.metrics.MetricIDs.REST_REQUEST_RESPONSE_TIME;
-import static io.apicurio.registry.metrics.MetricIDs.REST_REQUEST_RESPONSE_TIME_DESC;
-import static org.eclipse.microprofile.metrics.MetricUnits.MILLISECONDS;
-
-import java.util.List;
+import io.apicurio.registry.ibmcompat.model.NewSchema;
+import io.apicurio.registry.ibmcompat.model.NewSchemaVersion;
+import io.apicurio.registry.ibmcompat.model.Schema;
+import io.apicurio.registry.ibmcompat.model.SchemaInfo;
+import io.apicurio.registry.ibmcompat.model.SchemaListItem;
+import io.apicurio.registry.ibmcompat.model.SchemaModificationPatch;
+import io.apicurio.registry.metrics.RestMetricsApply;
+import io.apicurio.registry.storage.ArtifactAlreadyExistsException;
+import io.apicurio.registry.storage.ArtifactNotFoundException;
+import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Timed;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -46,20 +48,16 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
+import java.util.List;
 
-import io.apicurio.registry.storage.ArtifactAlreadyExistsException;
-import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Timed;
-
-import io.apicurio.registry.ibmcompat.model.AnyOfStateModificationEnabledModification;
-import io.apicurio.registry.ibmcompat.model.NewSchema;
-import io.apicurio.registry.ibmcompat.model.NewSchemaVersion;
-import io.apicurio.registry.ibmcompat.model.Schema;
-import io.apicurio.registry.ibmcompat.model.SchemaInfo;
-import io.apicurio.registry.ibmcompat.model.SchemaListItem;
-import io.apicurio.registry.metrics.RestMetricsApply;
-import io.apicurio.registry.storage.ArtifactNotFoundException;
+import static io.apicurio.registry.metrics.MetricIDs.REST_CONCURRENT_REQUEST_COUNT;
+import static io.apicurio.registry.metrics.MetricIDs.REST_CONCURRENT_REQUEST_COUNT_DESC;
+import static io.apicurio.registry.metrics.MetricIDs.REST_GROUP_TAG;
+import static io.apicurio.registry.metrics.MetricIDs.REST_REQUEST_COUNT;
+import static io.apicurio.registry.metrics.MetricIDs.REST_REQUEST_COUNT_DESC;
+import static io.apicurio.registry.metrics.MetricIDs.REST_REQUEST_RESPONSE_TIME;
+import static io.apicurio.registry.metrics.MetricIDs.REST_REQUEST_RESPONSE_TIME_DESC;
+import static org.eclipse.microprofile.metrics.MetricUnits.MILLISECONDS;
 
 @Path("/ibmcompat")
 @RestMetricsApply
@@ -113,9 +111,9 @@ public class Api {
     @Path("/schemas/{schemaid}")
     @Consumes({"application/json"})
     @Produces({"application/json"})
-    public Response apiSchemasSchemaidPatch(@PathParam("schemaid") String schemaid, @NotNull @Valid List<AnyOfStateModificationEnabledModification> anyOfStateModificationEnabledModification)
+    public Response apiSchemasSchemaidPatch(@PathParam("schemaid") String schemaid, @NotNull @Valid List<SchemaModificationPatch> schemaModificationPatches)
     throws ArtifactNotFoundException {
-        return service.apiSchemasSchemaidPatch(schemaid, anyOfStateModificationEnabledModification);
+        return service.apiSchemasSchemaidPatch(schemaid, schemaModificationPatches);
     }
 
     @POST
@@ -152,8 +150,8 @@ public class Api {
     @Path("/schemas/{schemaid}/versions/{versionnum}")
     @Consumes({"application/json"})
     @Produces({"application/json"})
-    public Response apiSchemasSchemaidVersionsVersionnumPatch(@PathParam("schemaid") String schemaid, @PathParam("versionnum") int versionnum, @NotNull @Valid List<AnyOfStateModificationEnabledModification> anyOfStateModificationEnabledModification)
+    public Response apiSchemasSchemaidVersionsVersionnumPatch(@PathParam("schemaid") String schemaid, @PathParam("versionnum") int versionnum, @NotNull @Valid List<SchemaModificationPatch> schemaModificationPatches)
     throws ArtifactNotFoundException {
-        return service.apiSchemasSchemaidVersionsVersionnumPatch(schemaid, versionnum, anyOfStateModificationEnabledModification);
+        return service.apiSchemasSchemaidVersionsVersionnumPatch(schemaid, versionnum, schemaModificationPatches);
     }
 }

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/ApiService.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/ApiService.java
@@ -16,18 +16,18 @@
  */
 package io.apicurio.registry.ibmcompat.api;
 
-import io.apicurio.registry.ibmcompat.model.AnyOfStateModificationEnabledModification;
 import io.apicurio.registry.ibmcompat.model.NewSchema;
 import io.apicurio.registry.ibmcompat.model.NewSchemaVersion;
 import io.apicurio.registry.ibmcompat.model.Schema;
 import io.apicurio.registry.ibmcompat.model.SchemaInfo;
 import io.apicurio.registry.ibmcompat.model.SchemaListItem;
+import io.apicurio.registry.ibmcompat.model.SchemaModificationPatch;
 import io.apicurio.registry.storage.ArtifactAlreadyExistsException;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
 
-import java.util.List;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
+import java.util.List;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
 public interface ApiService {
@@ -43,7 +43,7 @@ public interface ApiService {
     SchemaInfo apiSchemasSchemaidGet(String schemaid)
     throws ArtifactNotFoundException;
 
-    Response apiSchemasSchemaidPatch(String schemaid, List<AnyOfStateModificationEnabledModification> anyOfStateModificationEnabledModification)
+    Response apiSchemasSchemaidPatch(String schemaid, List<SchemaModificationPatch> schemaModificationPatches)
     throws ArtifactNotFoundException;
 
     void apiSchemasSchemaidVersionsPost(AsyncResponse response, String schemaid, NewSchemaVersion schema, boolean verify)
@@ -55,6 +55,6 @@ public interface ApiService {
     Schema apiSchemasSchemaidVersionsVersionnumGet(String schemaid, int versionnum)
     throws ArtifactNotFoundException;
 
-    Response apiSchemasSchemaidVersionsVersionnumPatch(String schemaid, int versionnum, List<AnyOfStateModificationEnabledModification> anyOfStateModificationEnabledModification)
+    Response apiSchemasSchemaidVersionsVersionnumPatch(String schemaid, int versionnum, List<SchemaModificationPatch> schemaModificationPatches)
     throws ArtifactNotFoundException;
 }

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/ApiService.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/ApiService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.apicurio.registry.ibmcompat.api;
 
 import io.apicurio.registry.ibmcompat.model.AnyOfStateModificationEnabledModification;
@@ -6,6 +22,7 @@ import io.apicurio.registry.ibmcompat.model.NewSchemaVersion;
 import io.apicurio.registry.ibmcompat.model.Schema;
 import io.apicurio.registry.ibmcompat.model.SchemaInfo;
 import io.apicurio.registry.ibmcompat.model.SchemaListItem;
+import io.apicurio.registry.storage.ArtifactAlreadyExistsException;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
 
 import java.util.List;
@@ -18,7 +35,7 @@ public interface ApiService {
     throws ArtifactNotFoundException;
 
     void apiSchemasPost(AsyncResponse response, NewSchema schema, boolean verify)
-    throws ArtifactNotFoundException;
+    throws ArtifactAlreadyExistsException;
 
     Response apiSchemasSchemaidDelete(String schemaid)
     throws ArtifactNotFoundException;
@@ -30,7 +47,7 @@ public interface ApiService {
     throws ArtifactNotFoundException;
 
     void apiSchemasSchemaidVersionsPost(AsyncResponse response, String schemaid, NewSchemaVersion schema, boolean verify)
-    throws ArtifactNotFoundException;
+    throws ArtifactNotFoundException, ArtifactAlreadyExistsException;
 
     Response apiSchemasSchemaidVersionsVersionnumDelete(String schemaid, int versionnum)
     throws ArtifactNotFoundException;

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiServiceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiServiceImpl.java
@@ -1,11 +1,32 @@
+/*
+ * Copyright 2020 Red Hat
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.apicurio.registry.ibmcompat.api.impl;
 
+import io.apicurio.registry.ibmcompat.model.SchemaState;
+import io.apicurio.registry.ibmcompat.model.SchemaSummary;
 import io.apicurio.registry.rules.RuleApplicationType;
 import io.apicurio.registry.rules.RulesService;
-import io.apicurio.registry.storage.ArtifactMetaDataDto;
+import io.apicurio.registry.storage.ArtifactAlreadyExistsException;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
+import io.apicurio.registry.storage.ArtifactVersionMetaDataDto;
+import io.apicurio.registry.storage.EditableArtifactMetaDataDto;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.StoredArtifact;
+import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.ibmcompat.api.ApiService;
@@ -20,11 +41,11 @@ import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.types.Current;
 import io.apicurio.registry.util.ArtifactIdGenerator;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -38,7 +59,6 @@ import javax.ws.rs.core.Response;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
 @Logged
 public class ApiServiceImpl implements ApiService {
-
     @Inject
     @Current
     RegistryStorage storage;
@@ -52,12 +72,113 @@ public class ApiServiceImpl implements ApiService {
     private List<SchemaVersion> getSchemaVersions(String schemaid) {
         return storage.getArtifactVersions(schemaid)
                       .stream()
-                      .map(l -> {
-                          SchemaVersion sv = new SchemaVersion();
-                          sv.setId(l.intValue());
-                          sv.setEnabled(true);
-                          return sv;
-                      }).collect(Collectors.toList());
+                      .map(versionid -> getSchemaVersion(schemaid, versionid))
+                      .filter(schemaVersion -> schemaVersion != null)
+                      .collect(Collectors.toList());
+    }
+
+    private SchemaVersion getLatestSchemaVersion(String schemaid) {
+        return getSchemaVersion(schemaid, storage.getArtifact(schemaid).getVersion());
+    }
+
+    private SchemaVersion getSchemaVersion(String schemaid, Long versionid) {
+        SchemaVersion schemaVersion = new SchemaVersion();
+        try {
+            ArtifactVersionMetaDataDto artifactMetaData = storage.getArtifactVersionMetaData(schemaid, versionid);
+            schemaVersion.setId(versionid.intValue()); // TODO not safe!
+            schemaVersion.setDate(new Date(artifactMetaData.getCreatedOn()));
+            schemaVersion.setName(artifactMetaData.getName());
+            schemaVersion.setEnabled(!ArtifactState.DISABLED.equals(artifactMetaData.getState()));
+            SchemaState versionState = new SchemaState();
+            if(ArtifactState.DEPRECATED.equals(artifactMetaData.getState())) {
+                versionState.setState(SchemaState.StateEnum.DEPRECATED);
+            } else {
+                versionState.setState(SchemaState.StateEnum.ACTIVE);
+            }
+            schemaVersion.setState(versionState);
+        } catch (ArtifactNotFoundException e) {
+            return null;
+        }
+        return schemaVersion;
+    }
+
+    private void populateSchemaSummary(String schemaid, SchemaSummary schemaSummary) {
+        List<ArtifactState> versionStates = storage.getArtifactVersions(schemaid).stream()
+            .map(version -> storage.getArtifactVersionMetaData(schemaid, version).getState())
+            .collect(Collectors.toList());
+
+        schemaSummary.setId(schemaid);
+        schemaSummary.setName(schemaid); // TODO - add mechanism to store an artifact-level name
+
+        // The schema is disabled if all versions are disabled
+        boolean isSchemaDisabled = versionStates.stream().allMatch(versionState -> ArtifactState.DISABLED.equals(versionState));
+        schemaSummary.setEnabled(!isSchemaDisabled);
+
+        // The schema is deprecated if all versions are deprecated
+        boolean isSchemaDeprecated = versionStates.stream().allMatch(versionState -> ArtifactState.DEPRECATED.equals(versionState));
+        SchemaState schemaState = new SchemaState();
+        if(isSchemaDeprecated) {
+            schemaState.setState(SchemaState.StateEnum.DEPRECATED);
+        } else {
+            schemaState.setState(SchemaState.StateEnum.ACTIVE);
+        }
+        schemaSummary.setState(schemaState);
+    }
+
+    private void handleArtifactCreation(AsyncResponse response, String artifactId, String versionName, Throwable t) {
+        if (t != null) {
+            response.resume(t);
+            return;
+        }
+
+        if (!doesArtifactExist(artifactId)) {
+            // Some storage (such as asyncmem) needs a wait before the artifact is available for updating
+            try {
+                waitForArtifactCreation(artifactId);
+            } catch (ArtifactNotFoundException e) {
+                response.resume(e);
+                return;
+            }
+        }
+
+        try {
+            // Set the artifact name from the version name
+            EditableArtifactMetaDataDto dto = new EditableArtifactMetaDataDto();
+            dto.setName(versionName);
+            // TODO: On Kafka topic storage, updateArtifactMetaData does not return. Help needed here.
+            // storage.updateArtifactMetaData(artifactId, dto);
+
+            // Prepare the response
+            SchemaInfo info = new SchemaInfo();
+            populateSchemaSummary(artifactId, info);
+            info.setVersions(getSchemaVersions(artifactId));
+
+            // updateArtifactMetaData call may be async, so also set the version name in the response
+            List<SchemaVersion> versions = info.getVersions();
+            versions.get(versions.size() - 1).setName(versionName);
+
+            response.resume(Response.status(Response.Status.CREATED).entity(info).build());
+        } catch (Throwable throwable) {
+            response.resume(throwable);
+        }
+    }
+
+    private void waitForArtifactCreation(String artifactId) throws ArtifactNotFoundException {
+        for (int i = 0; i < 5 && !doesArtifactExist(artifactId); i++) {
+            try {
+                Thread.sleep(200L);
+            } catch (InterruptedException e) {}
+        }
+        storage.getArtifact(artifactId);
+    }
+
+    private boolean doesArtifactExist(String artifactId) {
+        try {
+            storage.getArtifact(artifactId);
+            return true;
+        } catch (ArtifactNotFoundException ignored) {
+            return false;
+        }
     }
 
     public List<SchemaListItem> apiSchemasGet(int page, int perPage)
@@ -70,46 +191,34 @@ public class ApiServiceImpl implements ApiService {
                   .map(id -> {
                       SchemaListItem item = new SchemaListItem();
                       try {
-                          StoredArtifact artifact = storage.getArtifact(id);
-                          item.setId(id);
-                          item.setEnabled(true);
-                          SchemaVersion version = new SchemaVersion();
-                          version.setId(artifact.getVersion().intValue()); // TODO not safe!
-                          item.setLatest(version);
+                          populateSchemaSummary(id, item);
+                          item.setLatest(getLatestSchemaVersion(id));
                       } catch (ArtifactNotFoundException e) {
-                          // we can have deleted artifact ...
+                          return null;
                       }
                       return item;
                   })
-                  .filter(SchemaListItem::isEnabled)
+                  .filter(item -> item != null)
                   .collect(Collectors.toList());
     }
 
     public void apiSchemasPost(AsyncResponse response, NewSchema schema, boolean verify)
-    throws ArtifactNotFoundException {
-        String artifactId = schema.getName();
-        if (artifactId == null) {
+    throws ArtifactNotFoundException, ArtifactAlreadyExistsException {
+        String schemaName = schema.getName();
+        final String artifactId;
+        if (schemaName == null) {
             artifactId = idGenerator.generate();
+        } else {
+            artifactId = schemaName.toLowerCase();
         }
-
         ContentHandle content = ContentHandle.create(schema.getDefinition());
 
         if (verify) {
             rulesService.applyRules(artifactId, ArtifactType.AVRO, content, RuleApplicationType.CREATE);
             response.resume(Response.ok().entity(content).build());
         } else {
-            CompletionStage<ArtifactMetaDataDto> csArtifact = storage.createArtifact(artifactId, ArtifactType.AVRO, content);
-            csArtifact.whenComplete((amdd, t) -> {
-                if (t != null) {
-                    response.resume(t);
-                } else {
-                    SchemaInfo info = new SchemaInfo();
-                    info.setId(amdd.getId());
-                    info.setEnabled(true);
-                    info.setVersions(getSchemaVersions(amdd.getId()));
-                    response.resume(Response.status(Response.Status.CREATED).entity(info).build());
-                }
-            });
+            storage.createArtifact(artifactId, ArtifactType.AVRO, content)
+                    .whenComplete((amdd, t) -> handleArtifactCreation(response, artifactId, schema.getVersion(), t));
         }
     }
 
@@ -121,10 +230,8 @@ public class ApiServiceImpl implements ApiService {
 
     public SchemaInfo apiSchemasSchemaidGet(String schemaid)
     throws ArtifactNotFoundException {
-        storage.getArtifact(schemaid);
         SchemaInfo info = new SchemaInfo();
-        info.setId(schemaid);
-        info.setEnabled(true);
+        populateSchemaSummary(schemaid, info);
         info.setVersions(getSchemaVersions(schemaid));
         return info;
     }
@@ -135,25 +242,15 @@ public class ApiServiceImpl implements ApiService {
         return Response.ok().entity("OK").build();
     }
 
-    public void apiSchemasSchemaidVersionsPost(AsyncResponse response, String schemaid, NewSchemaVersion schema, boolean verify)
-    throws ArtifactNotFoundException {
-        ContentHandle body = ContentHandle.create(schema.getDefinition());
+    public void apiSchemasSchemaidVersionsPost(AsyncResponse response, String schemaid, NewSchemaVersion newSchemaVersion, boolean verify)
+    throws ArtifactNotFoundException, ArtifactAlreadyExistsException {
+        ContentHandle body = ContentHandle.create(newSchemaVersion.getDefinition());
         if (verify) {
             rulesService.applyRules(schemaid, ArtifactType.AVRO, body, RuleApplicationType.UPDATE);
             response.resume(Response.ok().entity(body).build());
         } else {
-            CompletionStage<ArtifactMetaDataDto> csArtifact = storage.updateArtifact(schemaid, ArtifactType.AVRO, body);
-            csArtifact.whenComplete((amdd, t) -> {
-                if (t != null) {
-                    response.resume(t);
-                } else {
-                    SchemaInfo info = new SchemaInfo();
-                    info.setId(amdd.getId());
-                    info.setEnabled(true);
-                    info.setVersions(getSchemaVersions(amdd.getId()));
-                    response.resume(Response.status(Response.Status.CREATED).entity(info).build());
-                }
-            });
+            storage.updateArtifact(schemaid, ArtifactType.AVRO, body)
+                .whenComplete((amdd, t) -> handleArtifactCreation(response, schemaid, newSchemaVersion.getVersion(), t));
         }
     }
 
@@ -165,14 +262,11 @@ public class ApiServiceImpl implements ApiService {
 
     public Schema apiSchemasSchemaidVersionsVersionnumGet(String schemaid, int versionnum)
     throws ArtifactNotFoundException {
-        StoredArtifact artifact = storage.getArtifactVersion(schemaid, versionnum);
         Schema schema = new Schema();
-        schema.setId(schemaid);
-        schema.setEnabled(true);
+        populateSchemaSummary(schemaid, schema);
+        StoredArtifact artifact = storage.getArtifactVersion(schemaid, versionnum);
         schema.setDefinition(artifact.getContent().content());
-        SchemaVersion version = new SchemaVersion();
-        version.setId(artifact.getVersion().intValue()); // TODO not safe!
-        schema.setVersion(version);
+        schema.setVersion(getSchemaVersion(schemaid, artifact.getVersion()));
         return schema;
     }
 

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiServiceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiServiceImpl.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
 /**
@@ -132,6 +133,9 @@ public class ApiServiceImpl implements ApiService {
 
     private void handleArtifactCreation(AsyncResponse response, String artifactId, String versionName, Throwable t) {
         if (t != null) {
+            if(t instanceof CompletionException) {
+                t = ((CompletionException) t).getCause();
+            }
             response.resume(t);
             return;
         }
@@ -233,6 +237,8 @@ public class ApiServiceImpl implements ApiService {
                           populateSchemaSummary(id, item);
                           item.setLatest(getLatestSchemaVersion(id));
                       } catch (ArtifactNotFoundException e) {
+                          // If artifact does not exist (which may occur due to race conditions), swallow
+                          // the exception here and filter the null result out below.
                           return null;
                       }
                       return item;

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/AnyOfStateModificationEnabledModification.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/AnyOfStateModificationEnabledModification.java
@@ -1,7 +1,0 @@
-package io.apicurio.registry.ibmcompat.model;
-
-/**
- * @author Ales Justin
- */
-public class AnyOfStateModificationEnabledModification {
-}

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/EnabledModification.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/EnabledModification.java
@@ -1,83 +1,29 @@
+/*
+ * Copyright 2020 Red Hat
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.util.Objects;
 import javax.validation.constraints.NotNull;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
-public class EnabledModification {
+public class EnabledModification extends SchemaModificationPatch {
 
-
-    /**
-     * Gets or Sets op
-     */
-    public enum OpEnum {
-        REPLACE("replace");
-        private String value;
-
-        OpEnum(String value) {
-            this.value = value;
-        }
-
-        @Override
-        @JsonValue
-        public String toString() {
-            return String.valueOf(value);
-        }
-    }
-
-    private OpEnum op;
-
-    /**
-     * Gets or Sets path
-     */
-    public enum PathEnum {
-        _ENABLED("/enabled");
-        private String value;
-
-        PathEnum(String value) {
-            this.value = value;
-        }
-
-        @Override
-        @JsonValue
-        public String toString() {
-            return String.valueOf(value);
-        }
-    }
-
-    private PathEnum path;
     private Boolean value;
-
-    /**
-     *
-     **/
-
-    @JsonProperty("op")
-    @NotNull
-    public OpEnum getOp() {
-        return op;
-    }
-
-    public void setOp(OpEnum op) {
-        this.op = op;
-    }
-
-    /**
-     *
-     **/
-
-    @JsonProperty("path")
-    @NotNull
-    public PathEnum getPath() {
-        return path;
-    }
-
-    public void setPath(PathEnum path) {
-        this.path = path;
-    }
 
     /**
      *
@@ -93,47 +39,5 @@ public class EnabledModification {
         this.value = value;
     }
 
-
-    @Override
-    public boolean equals(java.lang.Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        EnabledModification enabledModification = (EnabledModification) o;
-        return Objects.equals(op, enabledModification.op) &&
-               Objects.equals(path, enabledModification.path) &&
-               Objects.equals(value, enabledModification.value);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(op, path, value);
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class EnabledModification {\n");
-
-        sb.append("    op: ").append(toIndentedString(op)).append("\n");
-        sb.append("    path: ").append(toIndentedString(path)).append("\n");
-        sb.append("    value: ").append(toIndentedString(value)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
 }
 

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaInfo.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -6,73 +22,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
-public class SchemaInfo {
+public class SchemaInfo extends SchemaSummary {
 
-    private String id;
-    private String name;
-    private SchemaState state;
-    private Boolean enabled;
     private List<SchemaVersion> versions = new ArrayList<SchemaVersion>();
-
-    /**
-     * Lower-case URL-encoded version of the schema name.
-     **/
-
-    @JsonProperty("id")
-    @NotNull
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    /**
-     * User-provided name for a schema. Not necessarily unique.
-     **/
-
-    @JsonProperty("name")
-    @NotNull
-    @Size(min = 1, max = 100)
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    /**
-     *
-     **/
-
-    @JsonProperty("state")
-    @NotNull
-    public SchemaState getState() {
-        return state;
-    }
-
-    public void setState(SchemaState state) {
-        this.state = state;
-    }
-
-    /**
-     * Set to false if the schema is disabled. If the schema is disabled, all the schema versions are disabled.
-     **/
-
-    @JsonProperty("enabled")
-    @NotNull
-    public Boolean getEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(Boolean enabled) {
-        this.enabled = enabled;
-    }
 
     /**
      *
@@ -97,42 +51,24 @@ public class SchemaInfo {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        if (!super.equals(o)) return false;
         SchemaInfo schemaInfo = (SchemaInfo) o;
-        return Objects.equals(id, schemaInfo.id) &&
-               Objects.equals(name, schemaInfo.name) &&
-               Objects.equals(state, schemaInfo.state) &&
-               Objects.equals(enabled, schemaInfo.enabled) &&
-               Objects.equals(versions, schemaInfo.versions);
+        return Objects.equals(versions, schemaInfo.versions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, state, enabled, versions);
+        return Objects.hash(super.hashCode(), versions);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("class SchemaInfo {\n");
-
-        sb.append("    id: ").append(toIndentedString(id)).append("\n");
-        sb.append("    name: ").append(toIndentedString(name)).append("\n");
-        sb.append("    state: ").append(toIndentedString(state)).append("\n");
-        sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
+        sb.append(super.toString());
         sb.append("    versions: ").append(toIndentedString(versions)).append("\n");
         sb.append("}");
         return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
     }
 }
 

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaModificationPatch.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaModificationPatch.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.ibmcompat.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+/**
+ *
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "path")
+@JsonSubTypes({
+    @JsonSubTypes.Type(name = "/enabled", value = EnabledModification.class),
+    @JsonSubTypes.Type(name = "/state", value = StateModification.class)
+})
+public abstract class SchemaModificationPatch {
+
+    /**
+     * Gets or Sets op
+     */
+    public enum OpEnum {
+        REPLACE("replace");
+        private String value;
+
+        OpEnum(String value) {
+            this.value = value;
+        }
+
+        @Override
+        @JsonValue
+        public String toString() {
+            return value;
+        }
+    }
+
+    private OpEnum op;
+
+    /**
+     * Gets or Sets path
+     */
+    public enum PathEnum {
+        _ENABLED("/enabled"),
+        _STATE("/state");
+        private String value;
+
+        PathEnum(String value) {
+            this.value = value;
+        }
+
+        @Override
+        @JsonValue
+        public String toString() {
+            return value;
+        }
+    }
+
+    private PathEnum path;
+
+    /**
+     *
+     **/
+
+    @JsonProperty("op")
+    @NotNull
+    public OpEnum getOp() {
+        return op;
+    }
+
+    public void setOp(OpEnum op) {
+        this.op = op;
+    }
+
+    /**
+     *
+     **/
+
+    @JsonProperty("path")
+    @NotNull
+    public PathEnum getPath() {
+        return path;
+    }
+
+    public void setPath(PathEnum path) {
+        this.path = path;
+    }
+
+    @JsonProperty("value")
+    @NotNull
+    public abstract Object getValue();
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SchemaModificationPatch schemaModificationPatch = (SchemaModificationPatch) o;
+        return Objects.equals(op, schemaModificationPatch.op) &&
+            Objects.equals(path, schemaModificationPatch.path) &&
+            Objects.equals(getValue(), schemaModificationPatch.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(op, path, getValue());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SchemaModificationPatch {\n");
+
+        sb.append("    op: ").append(op.toString()).append("\n");
+        sb.append("    path: ").append(path.toString()).append("\n");
+        sb.append("    value: ").append(toIndentedString(getValue())).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaState.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaState.java
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2020 Red Hat
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.apicurio.registry.ibmcompat.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -54,6 +71,7 @@ public class SchemaState {
 
     @JsonProperty("comment")
     @Size(max = 300)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getComment() {
         return comment;
     }

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaVersion.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/SchemaVersion.java
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2020 Red Hat
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.apicurio.registry.ibmcompat.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Date;
@@ -53,6 +70,7 @@ public class SchemaVersion {
      **/
 
     @JsonProperty("date")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @NotNull
     public Date getDate() {
         return date;

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/model/StateModification.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/model/StateModification.java
@@ -1,83 +1,29 @@
+/*
+ * Copyright 2020 Red Hat
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.apicurio.registry.ibmcompat.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.util.Objects;
 import javax.validation.constraints.NotNull;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
-public class StateModification {
+public class StateModification extends SchemaModificationPatch {
 
-
-    /**
-     * Gets or Sets op
-     */
-    public enum OpEnum {
-        REPLACE("replace");
-        private String value;
-
-        OpEnum(String value) {
-            this.value = value;
-        }
-
-        @Override
-        @JsonValue
-        public String toString() {
-            return String.valueOf(value);
-        }
-    }
-
-    private OpEnum op;
-
-    /**
-     * Gets or Sets path
-     */
-    public enum PathEnum {
-        _STATE("/state");
-        private String value;
-
-        PathEnum(String value) {
-            this.value = value;
-        }
-
-        @Override
-        @JsonValue
-        public String toString() {
-            return String.valueOf(value);
-        }
-    }
-
-    private PathEnum path;
     private SchemaState value;
-
-    /**
-     *
-     **/
-
-    @JsonProperty("op")
-    @NotNull
-    public OpEnum getOp() {
-        return op;
-    }
-
-    public void setOp(OpEnum op) {
-        this.op = op;
-    }
-
-    /**
-     *
-     **/
-
-    @JsonProperty("path")
-    @NotNull
-    public PathEnum getPath() {
-        return path;
-    }
-
-    public void setPath(PathEnum path) {
-        this.path = path;
-    }
 
     /**
      *
@@ -91,49 +37,6 @@ public class StateModification {
 
     public void setValue(SchemaState value) {
         this.value = value;
-    }
-
-
-    @Override
-    public boolean equals(java.lang.Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        StateModification stateModification = (StateModification) o;
-        return Objects.equals(op, stateModification.op) &&
-               Objects.equals(path, stateModification.path) &&
-               Objects.equals(value, stateModification.value);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(op, path, value);
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class StateModification {\n");
-
-        sb.append("    op: ").append(toIndentedString(op)).append("\n");
-        sb.append("    path: ").append(toIndentedString(path)).append("\n");
-        sb.append("    value: ").append(toIndentedString(value)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
     }
 }
 

--- a/app/src/test/java/io/apicurio/registry/ibmcompat/IBMCompatApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/ibmcompat/IBMCompatApiTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.ibmcompat;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ibmcompat.model.SchemaListItem;
+import io.apicurio.registry.ibmcompat.model.SchemaState;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.common.mapper.TypeRef;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+
+
+@QuarkusTest
+public class IBMCompatApiTest extends AbstractResourceTestBase {
+
+    @Test
+    public void testCreateSchema() throws Exception {
+
+        // Convert the file contents to a JSON string value
+        String schemaDefinition = resourceToString("avro.json")
+            .replaceAll("\\\"", "\\\\\"")
+            .replaceAll("\\\n", "\\\\n");
+
+        String schemaName = "testCreateSchema_userInfo";
+        String versionName = "testversion_1.0.0";
+
+        // Create Avro artifact via ibmcompat API
+        given()
+            .when()
+                .contentType(CT_JSON)
+                .body("{\"name\":\"" + schemaName + "\",\"version\":\"" + versionName + "\",\"definition\":\"" + schemaDefinition + "\"}")
+                .post("/ibmcompat/schemas")
+            .then()
+                .statusCode(201)
+                .body("name", equalTo(schemaName.toLowerCase()))
+                .body("id", equalTo(schemaName.toLowerCase()))
+                .body("enabled", is(true))
+                .body("state.state", equalTo("active"))
+                .body("versions.size()", is(1))
+                .body("versions[0].name", equalTo(versionName))
+                .body("versions[0].id", is(1))
+                .body("versions[0].state.state", equalTo("active"))
+                .body("versions[0].enabled", is(true))
+                .body("versions[0].date", notNullValue());
+
+        // Try to create the same Avro artifact via ibmcompat API
+        given()
+            .when()
+                .contentType(CT_JSON)
+                .body("{\"name\":\"" + schemaName + "\",\"version\":\"" + versionName + "\",\"definition\":\"" + schemaDefinition + "\"}")
+                .post("/ibmcompat/schemas")
+            .then()
+                .statusCode(409);
+    }
+
+    @Test
+    public void testGetSchemas() throws Exception {
+
+        String artifactContent = resourceToString("avro.json");
+        String schemaName = "testGetSchemas_userInfo";
+
+        // Create Avro artifact via the artifact API
+        createArtifact(schemaName, ArtifactType.AVRO, artifactContent);
+
+        // Get the list of artifacts via ibmcompat API
+        List<SchemaListItem> schemas = given()
+            .when()
+                .get("/ibmcompat/schemas")
+            .then()
+                .statusCode(200)
+                .extract().body().as(new TypeRef<List<SchemaListItem>>(){});
+
+        // Find the schema that was just added
+        SchemaListItem schema = schemas.stream()
+            .filter(item -> schemaName.equals(item.getId()))
+            .findFirst()
+            .get();
+
+        Assertions.assertEquals(schemaName, schema.getName());
+        Assertions.assertEquals(true, schema.isEnabled());
+        Assertions.assertEquals(SchemaState.StateEnum.ACTIVE, schema.getState().getState());
+        Assertions.assertEquals(1, schema.getLatest().getId());
+        Assertions.assertEquals("userInfo", schema.getLatest().getName());
+        Assertions.assertEquals(true, schema.getLatest().getEnabled());
+        Assertions.assertEquals(SchemaState.StateEnum.ACTIVE, schema.getLatest().getState().getState());
+    }
+
+    @Test
+    public void testGetSchema() throws Exception {
+
+        String artifactContent = resourceToString("avro.json");
+        String schemaName = "testGetSchema_userInfo";
+
+        // Create Avro artifact via the artifact API
+        createArtifact(schemaName, ArtifactType.AVRO, artifactContent);
+
+        // Get the list of artifacts via ibmcompat API
+        given()
+            .when()
+                .get("/ibmcompat/schemas/" + schemaName)
+            .then()
+                .statusCode(200)
+                .body("name", equalTo(schemaName))
+                .body("id", equalTo(schemaName))
+                .body("enabled", is(true))
+                .body("state.state", equalTo("active"))
+                .body("versions.size()", is(1))
+                .body("versions[0].name", equalTo("userInfo"))
+                .body("versions[0].id", is(1))
+                .body("versions[0].state.state", equalTo("active"))
+                .body("versions[0].enabled", is(true))
+                .body("versions[0].date", notNullValue());
+    }
+
+    @Test
+    public void testDeleteSchema() throws Exception {
+
+        String artifactContent = resourceToString("avro.json");
+        String schemaName = "testDeleteSchema_userInfo";
+
+        // Create Avro artifact via the artifact API
+        createArtifact(schemaName, ArtifactType.AVRO, artifactContent);
+
+        // Delete the artifact via ibmcompat API
+        given()
+            .when()
+                .delete("/ibmcompat/schemas/" + schemaName)
+            .then()
+                .statusCode(204);
+
+        TestUtils.retry(() -> {
+            // Try to get the artifact via ibmcompat API
+            given()
+                .when()
+                    .get("/ibmcompat/schemas/" + schemaName)
+                .then()
+                    .statusCode(404);
+        });
+    }
+
+
+    @Test
+    public void testGetSchemaVersion() throws Exception {
+
+        String artifactContent = resourceToString("avro.json");
+        String schemaName = "testGetSchemaVersion_userInfo";
+
+        // Create Avro artifact via the artifact API
+        createArtifact(schemaName, ArtifactType.AVRO, artifactContent);
+
+        // Get the list of artifacts via ibmcompat API
+        given()
+            .when()
+                .get("/ibmcompat/schemas/" + schemaName + "/versions/1")
+            .then()
+                .statusCode(200)
+                .body("name", equalTo(schemaName))
+                .body("id", equalTo(schemaName))
+                .body("enabled", is(true))
+                .body("state.state", equalTo("active"))
+                .body("version.name", equalTo("userInfo"))
+                .body("version.id", is(1))
+                .body("version.state.state", equalTo("active"))
+                .body("version.enabled", is(true))
+                .body("version.date", notNullValue())
+                .body("definition", equalTo(artifactContent));
+    }
+
+    @Test
+    public void testCreateSchemaVersion() throws Exception {
+
+        String artifactContent = resourceToString("avro.json");
+        String newSchemaDefinition = artifactContent
+            .replaceAll("\\\"", "\\\\\"")
+            .replaceAll("\\\n", "\\\\n");
+
+        String schemaName = "testCreateSchemaVersion_userInfo";
+        String newVersionName = "testversion_2.0.0";
+
+        // Create Avro artifact via the artifact API
+        createArtifact(schemaName, ArtifactType.AVRO, artifactContent);
+
+        // Add the new version via ibmcompat API
+        given()
+            .when()
+                .contentType(CT_JSON)
+                .body("{\"version\":\"" + newVersionName + "\",\"definition\":\"" + newSchemaDefinition + "\"}")
+                .post("/ibmcompat/schemas/" + schemaName + "/versions")
+            .then()
+                .statusCode(201)
+                .body("name", equalTo(schemaName))
+                .body("id", equalTo(schemaName))
+                .body("enabled", equalTo(true))
+                .body("state.state", equalTo("active"))
+                .body("versions.size()", equalTo(2))
+                .body("versions[0].name", equalTo("userInfo"))
+                .body("versions[0].id", is(1))
+                .body("versions[1].name", equalTo(newVersionName))
+                .body("versions[1].id", is(2))
+                .body("versions[1].state.state", equalTo("active"))
+                .body("versions[1].enabled", equalTo(true))
+                .body("versions[1].date", notNullValue());
+    }
+
+    @Test
+    public void testDeleteSchemaVersion() throws Exception {
+
+        String artifactContent = resourceToString("avro.json");
+        String newSchemaDefinition = artifactContent
+            .replaceAll("\\\"", "\\\\\"")
+            .replaceAll("\\\n", "\\\\n");
+        String schemaName = "testDeleteSchemaVersion_userInfo";
+        String newVersionName = "testversion_2.0.0";
+
+        // Create Avro artifact via the artifact API
+        createArtifact(schemaName, ArtifactType.AVRO, artifactContent);
+        // Add the new version via ibmcompat API
+        given()
+            .when()
+                .contentType(CT_JSON)
+                .body("{\"version\":\"" + newVersionName + "\",\"definition\":\"" + newSchemaDefinition + "\"}")
+                .post("/ibmcompat/schemas/" + schemaName + "/versions")
+            .then()
+                .statusCode(201)
+                .body("versions.size()", equalTo(2));
+
+        // Delete the artifact via ibmcompat API
+        given()
+            .when()
+                .delete("/ibmcompat/schemas/" + schemaName+ "/versions/2")
+            .then()
+                .statusCode(204);
+
+        TestUtils.retry(() -> {
+            // Try to get the artifact via ibmcompat API
+            given()
+                .when()
+                    .get("/ibmcompat/schemas/" + schemaName + "/versions/2")
+                .then()
+                   .statusCode(404);
+        });
+    }
+}

--- a/app/src/test/resources/io/apicurio/registry/ibmcompat/avro.json
+++ b/app/src/test/resources/io/apicurio/registry/ibmcompat/avro.json
@@ -1,0 +1,6 @@
+{
+    "type" : "record",
+    "name" : "userInfo",
+    "namespace" : "my.example",
+    "fields" : [{"name" : "age", "type" : "int"}]
+} 


### PR DESCRIPTION
- This commit improves the data returned by the ibmcompat API GET
endpoints to include metadata already stored with the artifact.
- It also improves the ibmcompat API POST endpoints by returning
metadata stored with the artifact.
- It also adds a set of initial tests for the functionality that follow
the ccompat API and artifact API tests.
- It also improves the ibmcompat API PATCH endpoints by setting the
metadata stored with the artifact.

Signed-off-by: Andrew Borley <borley@uk.ibm.com>