### PR TITLE
Allow transition from Deprecated state to Enabled or Disabled states

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/ArtifactStateExt.java
+++ b/app/src/main/java/io/apicurio/registry/storage/ArtifactStateExt.java
@@ -20,12 +20,12 @@ import io.apicurio.registry.types.ArtifactState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.apicurio.registry.storage.MetaDataKeys.STATE;
-
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+
+import static io.apicurio.registry.storage.MetaDataKeys.STATE;
 
 /**
  * @author Ales Justin
@@ -39,7 +39,7 @@ public class ArtifactStateExt {
         transitions = new HashMap<>();
         transitions.put(ArtifactState.ENABLED, EnumSet.of(ArtifactState.DISABLED, ArtifactState.DEPRECATED, ArtifactState.DELETED));
         transitions.put(ArtifactState.DISABLED, EnumSet.of(ArtifactState.ENABLED, ArtifactState.DEPRECATED, ArtifactState.DELETED));
-        transitions.put(ArtifactState.DEPRECATED, EnumSet.of(ArtifactState.DELETED));
+        transitions.put(ArtifactState.DEPRECATED, EnumSet.of(ArtifactState.ENABLED, ArtifactState.DISABLED, ArtifactState.DELETED));
         transitions.put(ArtifactState.DELETED, EnumSet.noneOf(ArtifactState.class));
     }
 

--- a/storage/asyncmem/src/main/java/io/apicurio/registry/asyncmem/AsyncInMemoryRegistryStorage.java
+++ b/storage/asyncmem/src/main/java/io/apicurio/registry/asyncmem/AsyncInMemoryRegistryStorage.java
@@ -226,9 +226,6 @@ public class AsyncInMemoryRegistryStorage extends SimpleMapRegistryStorage {
      */
     @Override
     public void updateArtifactState(String artifactId, ArtifactState state, Integer version) {
-        if (state == ArtifactState.ENABLED && this.isDeprecated(artifactId, version)) {
-            throw new InvalidArtifactStateException(ArtifactState.DEPRECATED, state);
-        }
         this.executor.execute(() -> {
             preUpdateSleep();
             runWithErrorSuppression(() -> {
@@ -516,36 +513,6 @@ public class AsyncInMemoryRegistryStorage extends SimpleMapRegistryStorage {
             return true;
         } catch (RuleNotFoundException e) {
             return false;
-        }
-    }
-
-    private boolean isArtifactDeprecated(String artifactId) {
-        try {
-            ArtifactMetaDataDto metaData = this.getArtifactMetaData(artifactId);
-            if (metaData.getState() == ArtifactState.DEPRECATED) {
-                return true;
-            }
-        } catch (ArtifactNotFoundException | RegistryStorageException e) {
-        }
-        return false;
-    }
-
-    private boolean isVersionDeprecated(String artifactId, Integer version) {
-        try {
-            ArtifactVersionMetaDataDto metaData = this.getArtifactVersionMetaData(artifactId, version.longValue());
-            if (metaData.getState() == ArtifactState.DEPRECATED) {
-                return true;
-            }
-        } catch (ArtifactNotFoundException | RegistryStorageException e) {
-        }
-        return false;
-    }
-
-    private boolean isDeprecated(String artifactId, Integer version) {
-        if (version == null) {
-            return this.isArtifactDeprecated(artifactId);
-        } else {
-            return this.isVersionDeprecated(artifactId, version);
         }
     }
 


### PR DESCRIPTION
- This commit allows an artifact to transition from the `Deprecated`
state to either the `Enabled` or `Disabled` states. This allows users
who have accidentally deprecated a schema to re-enable it, or it allows
a deprecated schema to become disabled so that clients can no longer use
it.

See initial discussion in issue #722

Signed-off-by: Andrew Borley <borley@uk.ibm.com>