### PR TITLE
Store ibmcompat API metadata in properties field

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/Api.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/Api.java
@@ -16,6 +16,7 @@
  */
 package io.apicurio.registry.ibmcompat.api;
 
+import io.apicurio.registry.ibmcompat.api.impl.ApiUtil;
 import io.apicurio.registry.ibmcompat.model.NewSchema;
 import io.apicurio.registry.ibmcompat.model.NewSchemaVersion;
 import io.apicurio.registry.ibmcompat.model.Schema;
@@ -96,7 +97,7 @@ public class Api {
     @Produces({"application/json"})
     public Response apiSchemasSchemaidDelete(@PathParam("schemaid") String schemaid)
     throws ArtifactNotFoundException {
-        return service.apiSchemasSchemaidDelete(schemaid);
+        return service.apiSchemasSchemaidDelete(ApiUtil.normalizeSchemaID(schemaid));
     }
 
     @GET
@@ -104,7 +105,7 @@ public class Api {
     @Produces({"application/json"})
     public SchemaInfo apiSchemasSchemaidGet(@PathParam("schemaid") String schemaid)
     throws ArtifactNotFoundException {
-        return service.apiSchemasSchemaidGet(schemaid);
+        return service.apiSchemasSchemaidGet(ApiUtil.normalizeSchemaID(schemaid));
     }
 
     @PATCH
@@ -113,7 +114,7 @@ public class Api {
     @Produces({"application/json"})
     public Response apiSchemasSchemaidPatch(@PathParam("schemaid") String schemaid, @NotNull @Valid List<SchemaModificationPatch> schemaModificationPatches)
     throws ArtifactNotFoundException {
-        return service.apiSchemasSchemaidPatch(schemaid, schemaModificationPatches);
+        return service.apiSchemasSchemaidPatch(ApiUtil.normalizeSchemaID(schemaid), schemaModificationPatches);
     }
 
     @POST
@@ -127,7 +128,7 @@ public class Api {
         @DefaultValue("false") @QueryParam("verify") boolean verify
     )
     throws ArtifactNotFoundException, ArtifactAlreadyExistsException {
-        service.apiSchemasSchemaidVersionsPost(response, schemaid, schema, verify);
+        service.apiSchemasSchemaidVersionsPost(response, ApiUtil.normalizeSchemaID(schemaid), schema, verify);
     }
 
     @DELETE
@@ -135,7 +136,7 @@ public class Api {
     @Produces({"application/json"})
     public Response apiSchemasSchemaidVersionsVersionnumDelete(@PathParam("schemaid") String schemaid, @PathParam("versionnum") int versionnum)
     throws ArtifactNotFoundException {
-        return service.apiSchemasSchemaidVersionsVersionnumDelete(schemaid, versionnum);
+        return service.apiSchemasSchemaidVersionsVersionnumDelete(ApiUtil.normalizeSchemaID(schemaid), versionnum);
     }
 
     @GET
@@ -143,7 +144,7 @@ public class Api {
     @Produces({"application/json", "application/vnd.apache.avro+json"})
     public Schema apiSchemasSchemaidVersionsVersionnumGet(@PathParam("schemaid") String schemaid, @PathParam("versionnum") int versionnum)
     throws ArtifactNotFoundException {
-        return service.apiSchemasSchemaidVersionsVersionnumGet(schemaid, versionnum);
+        return service.apiSchemasSchemaidVersionsVersionnumGet(ApiUtil.normalizeSchemaID(schemaid), versionnum);
     }
 
     @PATCH
@@ -152,6 +153,6 @@ public class Api {
     @Produces({"application/json"})
     public Response apiSchemasSchemaidVersionsVersionnumPatch(@PathParam("schemaid") String schemaid, @PathParam("versionnum") int versionnum, @NotNull @Valid List<SchemaModificationPatch> schemaModificationPatches)
     throws ArtifactNotFoundException {
-        return service.apiSchemasSchemaidVersionsVersionnumPatch(schemaid, versionnum, schemaModificationPatches);
+        return service.apiSchemasSchemaidVersionsVersionnumPatch(ApiUtil.normalizeSchemaID(schemaid), versionnum, schemaModificationPatches);
     }
 }

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiServiceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiServiceImpl.java
@@ -52,7 +52,9 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -77,6 +79,9 @@ public class ApiServiceImpl implements ApiService {
     @Inject
     ArtifactIdGenerator idGenerator;
 
+    private static final String SCHEMA_NAME_ADDITIONAL_PROPERTY = "ibmcompat-schema-name";
+    private static final String SCHEMA_STATE_COMMENT_ADDITIONAL_PROPERTY = "ibmcompat-schema-state-comment";
+
     private List<SchemaVersion> getSchemaVersions(String schemaid) {
         return storage.getArtifactVersions(schemaid)
                       .stream()
@@ -93,7 +98,7 @@ public class ApiServiceImpl implements ApiService {
         SchemaVersion schemaVersion = null;
         try {
             ArtifactVersionMetaDataDto avmdd = storage.getArtifactVersionMetaData(schemaid, versionid);
-            schemaVersion = getSchemaVersion(avmdd.getVersion(), avmdd.getName(), avmdd.getCreatedOn(), avmdd.getState());
+            schemaVersion = getSchemaVersion(avmdd.getVersion(), avmdd.getName(), avmdd.getCreatedOn(), avmdd.getState(), avmdd.getDescription());
         } catch (ArtifactNotFoundException e) {
             // If artifact version does not exist (which may occur due to race conditions), swallow
             // the exception here and return a null result, to be filtered out
@@ -101,7 +106,7 @@ public class ApiServiceImpl implements ApiService {
         return schemaVersion;
     }
 
-    private SchemaVersion getSchemaVersion(int id, String name, long createdOn, ArtifactState state) {
+    private SchemaVersion getSchemaVersion(int id, String name, long createdOn, ArtifactState state, String description) {
         SchemaVersion schemaVersion = new SchemaVersion();
         schemaVersion.setId(id);
         schemaVersion.setDate(new Date(createdOn));
@@ -113,6 +118,9 @@ public class ApiServiceImpl implements ApiService {
         } else {
             versionState.setState(SchemaState.StateEnum.ACTIVE);
         }
+        if(description != null) {
+            versionState.setComment(description);
+        }
         schemaVersion.setState(versionState);
         return schemaVersion;
     }
@@ -121,9 +129,9 @@ public class ApiServiceImpl implements ApiService {
         List<ArtifactState> versionStates = storage.getArtifactVersions(schemaid).stream()
             .map(version -> storage.getArtifactVersionMetaData(schemaid, version).getState())
             .collect(Collectors.toList());
+        Map<String, String> properties = storage.getArtifactMetaData(schemaid).getProperties();
 
         schemaSummary.setId(schemaid);
-        schemaSummary.setName(schemaid); // TODO - add mechanism to store an artifact-level name
 
         // The schema is disabled if all versions are disabled
         boolean isSchemaDisabled = versionStates.stream().allMatch(versionState -> ArtifactState.DISABLED.equals(versionState));
@@ -138,17 +146,32 @@ public class ApiServiceImpl implements ApiService {
             schemaState.setState(SchemaState.StateEnum.ACTIVE);
         }
         schemaSummary.setState(schemaState);
+
+        if (properties != null) {
+            schemaSummary.setName(properties.getOrDefault(SCHEMA_NAME_ADDITIONAL_PROPERTY, schemaid));
+            schemaState.setComment(properties.get(SCHEMA_STATE_COMMENT_ADDITIONAL_PROPERTY));
+        } else {
+            schemaSummary.setName(schemaid);
+        }
+
     }
 
     private SchemaInfo getSchemaInfo(ArtifactMetaDataDto amdd) {
         SchemaInfo schemaInfo = new SchemaInfo();
         schemaInfo.setId(amdd.getId());
-        schemaInfo.setName(amdd.getId()); // TODO - add mechanism to store an artifact-level name
         schemaInfo.setEnabled(true);
 
         SchemaState schemaState = new SchemaState();
         schemaState.setState(SchemaState.StateEnum.ACTIVE);
         schemaInfo.setState(schemaState);
+
+        Map<String, String> properties = amdd.getProperties();
+        if (properties != null) {
+            schemaInfo.setName(properties.getOrDefault(SCHEMA_NAME_ADDITIONAL_PROPERTY, amdd.getId()));
+            schemaState.setComment(properties.get(SCHEMA_STATE_COMMENT_ADDITIONAL_PROPERTY));
+        } else {
+            schemaInfo.setName(amdd.getId());
+        }
 
         return schemaInfo;
     }
@@ -173,7 +196,7 @@ public class ApiServiceImpl implements ApiService {
             if (schemaVersions.isEmpty() || amdd.getVersion() != schemaVersions.get(schemaVersions.size() - 1).getId()) {
                 // Async storage types may not yet be ready to call storage.getArtifactVersionMetaData(),
                 // so add the new version to the response
-                schemaVersions.add(getSchemaVersion(amdd.getVersion(), amdd.getName(), amdd.getCreatedOn(), amdd.getState()));
+                schemaVersions.add(getSchemaVersion(amdd.getVersion(), amdd.getName(), amdd.getCreatedOn(), amdd.getState(), null));
             } else {
                 // Async storage types may not have updated the version metadata yet, so set the version name in the response
                 schemaVersions.get(schemaVersions.size() - 1).setName(amdd.getName());
@@ -181,7 +204,7 @@ public class ApiServiceImpl implements ApiService {
         } catch (ArtifactNotFoundException anfe) {
             // If this is a newly created schema, async storage types may not yet be ready to call
             // storage.getArtifactVersions(), so add the new version to the response
-            schemaVersions.add(getSchemaVersion(amdd.getVersion(), amdd.getName(), amdd.getCreatedOn(), amdd.getState()));
+            schemaVersions.add(getSchemaVersion(amdd.getVersion(), amdd.getName(), amdd.getCreatedOn(), amdd.getState(), null));
         } catch (Throwable throwable) {
             response.resume(t);
             return;
@@ -192,22 +215,39 @@ public class ApiServiceImpl implements ApiService {
     @Nullable
     private ArtifactState getPatchedArtifactState(List<SchemaModificationPatch> schemaModificationPatches) {
         ArtifactState artifactState = null;
+        boolean isEnabled = true;
+        boolean isDeprecated = false;
+
+        // Get the final enabled and deprecated states from the list of patches
         for (SchemaModificationPatch schemaModificationPatch : schemaModificationPatches) {
             if (schemaModificationPatch instanceof EnabledModification) {
-                if (((EnabledModification) schemaModificationPatch).getValue()) {
-                    artifactState = ArtifactState.ENABLED;
-                } else {
-                    artifactState = ArtifactState.DISABLED;
-                }
-            } else if (schemaModificationPatch instanceof StateModification) {
-                if (SchemaState.StateEnum.DEPRECATED.equals(((StateModification) schemaModificationPatch).getValue().getState())) {
-                    artifactState = ArtifactState.DEPRECATED;
-                } else {
-                    artifactState = ArtifactState.ENABLED;
-                }
+                isEnabled = ((EnabledModification) schemaModificationPatch).getValue();
+            } else if (schemaModificationPatch instanceof StateModification && !ArtifactState.DISABLED.equals(artifactState)) {
+                isDeprecated = SchemaState.StateEnum.DEPRECATED.equals(((StateModification) schemaModificationPatch).getValue().getState());
             }
         }
+
+        // Get the final artifact state - disabled overrides deprecated, which overrrides enabled.
+        if (!isEnabled) {
+            artifactState = ArtifactState.DISABLED;
+        } else if (isDeprecated) {
+            artifactState = ArtifactState.DEPRECATED;
+        } else {
+            artifactState = ArtifactState.ENABLED;
+        }
+
         return artifactState;
+    }
+
+    @Nullable
+    private String getPatchedArtifactStateComment(List<SchemaModificationPatch> schemaModificationPatches) {
+        String comment = null;
+        for (SchemaModificationPatch schemaModificationPatch : schemaModificationPatches) {
+            if (schemaModificationPatch instanceof StateModification) {
+                comment = ((StateModification) schemaModificationPatch).getValue().getComment();
+            }
+        }
+        return comment;
     }
 
     private void setSchemaVersionState(ArtifactState artifactState, SchemaVersion version) {
@@ -217,6 +257,14 @@ public class ApiServiceImpl implements ApiService {
             version.setEnabled(true);
         } else if(ArtifactState.DEPRECATED.equals(artifactState)) {
             version.getState().setState(SchemaState.StateEnum.DEPRECATED);
+        }
+    }
+
+    private void updateArtifactVersionState(String schemaid, int versionnum, ArtifactState artifactState) {
+        ArtifactVersionMetaDataDto avmdd = storage.getArtifactVersionMetaData(schemaid, versionnum);
+        if (artifactState != null && !artifactState.equals(avmdd.getState())) {
+            // Modify the artifact version state
+            storage.updateArtifactState(schemaid, artifactState, versionnum);
         }
     }
 
@@ -251,8 +299,9 @@ public class ApiServiceImpl implements ApiService {
         final String artifactId;
         if (schemaName == null) {
             artifactId = idGenerator.generate();
+            schemaName = artifactId;
         } else {
-            artifactId = schemaName.toLowerCase();
+            artifactId = ApiUtil.normalizeSchemaID(schemaName);
         }
         ContentHandle content = ContentHandle.create(schema.getDefinition());
         rulesService.applyRules(artifactId, ArtifactType.AVRO, content, RuleApplicationType.CREATE);
@@ -261,6 +310,10 @@ public class ApiServiceImpl implements ApiService {
         } else {
             EditableArtifactMetaDataDto dto = new EditableArtifactMetaDataDto();
             dto.setName(schema.getVersion());
+
+            Map<String, String> properties = new HashMap<>();
+            properties.put(SCHEMA_NAME_ADDITIONAL_PROPERTY, schemaName);
+            dto.setProperties(properties);
             storage.createArtifactWithMetadata(artifactId, ArtifactType.AVRO, content, dto)
                 .whenComplete((amdd, t) -> handleArtifactCreation(response, artifactId, amdd, t));
         }
@@ -290,8 +343,12 @@ public class ApiServiceImpl implements ApiService {
         if(artifactState != null) {
             // Modify all the artifact version states
             for (Long versionid : storage.getArtifactVersions(schemaid)) {
-                storage.updateArtifactState(schemaid, artifactState, versionid.intValue());
+                updateArtifactVersionState(schemaid, versionid.intValue(), artifactState);
             }
+        }
+        String schemaStateComment = getPatchedArtifactStateComment(schemaModificationPatches);
+        if (schemaStateComment != null) {
+            updateStateCommentInArtifactMetadata(schemaid, schemaStateComment);
         }
 
         // Return the updated schema info
@@ -306,6 +363,10 @@ public class ApiServiceImpl implements ApiService {
             info.setEnabled(true);
         } else if(ArtifactState.DEPRECATED.equals(artifactState)) {
             info.getState().setState(SchemaState.StateEnum.DEPRECATED);
+
+            if (schemaStateComment != null) {
+                info.getState().setComment(schemaStateComment);
+            }
             // Note: Can't be deprecated and disabled at the same time - Apicurio Registry has a single state for this.
             info.setEnabled(true);
         }
@@ -314,6 +375,22 @@ public class ApiServiceImpl implements ApiService {
         }
 
         return Response.ok().entity(info).build();
+    }
+
+    private void updateStateCommentInArtifactMetadata(String schemaid, String schemaStateComment) {
+        ArtifactMetaDataDto amdd = storage.getArtifactMetaData(schemaid);
+        Map<String, String> properties = amdd.getProperties();
+        if(properties == null) {
+            properties = new HashMap<>();
+        }
+        properties.put(SCHEMA_STATE_COMMENT_ADDITIONAL_PROPERTY, schemaStateComment);
+        EditableArtifactMetaDataDto dto = EditableArtifactMetaDataDto.builder()
+            .name(amdd.getName())
+            .description(amdd.getDescription())
+            .labels(amdd.getLabels())
+            .properties(properties)
+            .build();
+        storage.updateArtifactMetaData(schemaid, dto);
     }
 
     @Override
@@ -354,9 +431,16 @@ public class ApiServiceImpl implements ApiService {
     throws ArtifactNotFoundException {
 
         ArtifactState artifactState = getPatchedArtifactState(schemaModificationPatches);
-        if(artifactState != null) {
-            // Modify the artifact version state
-            storage.updateArtifactState(schemaid, artifactState, versionnum);
+        updateArtifactVersionState(schemaid, versionnum, artifactState);
+
+        String schemaVersionStateComment = getPatchedArtifactStateComment(schemaModificationPatches);
+        if (schemaVersionStateComment != null) {
+            ArtifactVersionMetaDataDto avmdd = storage.getArtifactVersionMetaData(schemaid, versionnum);
+            EditableArtifactMetaDataDto dto = EditableArtifactMetaDataDto.builder()
+                .name(avmdd.getName())
+                .description(schemaVersionStateComment)
+                .build();
+            storage.updateArtifactVersionMetaData(schemaid, versionnum, dto);
         }
 
         // Return the updated schema info

--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiUtil.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.ibmcompat.api.impl;
+
+public class ApiUtil {
+
+    /**
+     * Gets the unique ID for a schema with the provided name.
+     *
+     * The unique ID for a schema is defined as the client-provided
+     * name for the schema, after being transformed to lower-case.
+     *
+     * ibmcompat API clients are permitted use either the schema name
+     * or the schema ID in the endpoint path to refer to a schema.
+     */
+    public static String normalizeSchemaID(String schemaName) {
+        return schemaName.toLowerCase();
+    }
+
+}

--- a/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
+++ b/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
@@ -16,21 +16,20 @@
 
 package io.apicurio.registry;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.equalTo;
-
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-
-import org.hamcrest.CoreMatchers;
-import org.junit.jupiter.api.BeforeEach;
-
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.util.ServiceInitializer;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeEach;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Abstract base class for all tests that test via the jax-rs layer.
@@ -101,7 +100,26 @@ public abstract class AbstractResourceTestBase extends AbstractRegistryTestBase 
                     .statusCode(200);
         });
     }
-    
+
+    /**
+     * Wait for an artifact version to be created.
+     * @param artifactId
+     * @param version
+     * @throws Exception
+     */
+    protected void waitForVersion(String artifactId, int version) throws Exception {
+        TestUtils.retry(() -> {
+            given()
+                .when()
+                    .contentType(CT_JSON)
+                    .pathParam("artifactId", artifactId)
+                    .pathParam("version", version)
+                .get("/artifacts/{artifactId}/versions/{version}/meta")
+                .then()
+                    .statusCode(200);
+        });
+    }
+
     /**
      * Wait for an artifact version to be created.
      * @param globalId

--- a/app/src/test/java/io/apicurio/registry/ibmcompat/IBMCompatApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/ibmcompat/IBMCompatApiTest.java
@@ -39,7 +39,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public class IBMCompatApiTest extends AbstractResourceTestBase {
 
     @Test
-    public void testCreateSchema() {
+    public void testCreateSchema() throws Exception {
 
         // Convert the file contents to a JSON string value
         String schemaDefinition = resourceToString("avro.json")
@@ -47,6 +47,7 @@ public class IBMCompatApiTest extends AbstractResourceTestBase {
                 .replaceAll("\n", "\\\\n");
 
         String schemaName = "testCreateSchema_userInfo";
+        String schemaId = schemaName.toLowerCase();
         String versionName = "testversion_1.0.0";
 
         // Create Avro artifact via ibmcompat API
@@ -58,7 +59,7 @@ public class IBMCompatApiTest extends AbstractResourceTestBase {
             .then()
                 .statusCode(201)
                 .body("name", equalTo(schemaName))
-                .body("id", equalTo(schemaName.toLowerCase()))
+                .body("id", equalTo(schemaId))
                 .body("enabled", is(true))
                 .body("state.state", equalTo("active"))
                 .body("versions.size()", is(1))
@@ -67,6 +68,8 @@ public class IBMCompatApiTest extends AbstractResourceTestBase {
                 .body("versions[0].state.state", equalTo("active"))
                 .body("versions[0].enabled", is(true))
                 .body("versions[0].date", notNullValue());
+
+        waitForArtifact(schemaId);
 
         // Try to create the same Avro artifact via ibmcompat API
         given()
@@ -154,19 +157,19 @@ public class IBMCompatApiTest extends AbstractResourceTestBase {
         // schema ID in path can be the name or the id (which is the lower-cased name)
         given()
             .when()
-            .get("/ibmcompat/schemas/" + schemaId)
+                .get("/ibmcompat/schemas/" + schemaId)
             .then()
-            .statusCode(200)
-            .body("name", equalTo(schemaId))
-            .body("id", equalTo(schemaId))
-            .body("enabled", is(true))
-            .body("state.state", equalTo("active"))
-            .body("versions.size()", is(1))
-            .body("versions[0].name", equalTo("userInfo"))
-            .body("versions[0].id", is(1))
-            .body("versions[0].state.state", equalTo("active"))
-            .body("versions[0].enabled", is(true))
-            .body("versions[0].date", notNullValue());
+                .statusCode(200)
+                .body("name", equalTo(schemaId))
+                .body("id", equalTo(schemaId))
+                .body("enabled", is(true))
+                .body("state.state", equalTo("active"))
+                .body("versions.size()", is(1))
+                .body("versions[0].name", equalTo("userInfo"))
+                .body("versions[0].id", is(1))
+                .body("versions[0].state.state", equalTo("active"))
+                .body("versions[0].enabled", is(true))
+                .body("versions[0].date", notNullValue());
     }
 
     @Test
@@ -218,6 +221,8 @@ public class IBMCompatApiTest extends AbstractResourceTestBase {
             .then()
                 .statusCode(201)
                 .body("versions.size()", equalTo(2));
+
+        waitForVersion(schemaId, 2);
 
         // Patch the schema enabled state via ibmcompat API
         // TODO - this doesn't currently work due to getArtifactMetadata calls returning ArtifactNotFound
@@ -356,6 +361,8 @@ public class IBMCompatApiTest extends AbstractResourceTestBase {
                 .statusCode(201)
                 .body("versions.size()", equalTo(2));
 
+        waitForVersion(schemaId, 2);
+
         // Delete the artifact via ibmcompat API
         given()
             .when()
@@ -396,6 +403,8 @@ public class IBMCompatApiTest extends AbstractResourceTestBase {
             .then()
                 .statusCode(201)
                 .body("versions.size()", equalTo(2));
+
+        waitForVersion(schemaId, 2);
 
         // Patch the schema enabled state via ibmcompat API
         given()


### PR DESCRIPTION
- This commit updates the ibmcompat API so that metadata that does not
have an equivalent in the artifacts API is stored in and retrieved from
the `properties` metadata field.
- It also updates the API path handling to allow either the schema name
or schema ID (which is the lower-cased schema name) to be used to
address the artifact.

Signed-off-by: Andrew Borley <borley@uk.ibm.com>