### PR TITLE
tests - add new profile and disable LoadIT test

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -363,6 +363,14 @@
         </profile>
 
         <profile>
+            <id>acceptance</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>acceptance</groups>
+            </properties>
+        </profile>
+
+        <profile>
             <id>enableConverterTest</id>
             <properties>
                 <exclude.integration.tests>**/NothingToExclude.java</exclude.integration.tests>

--- a/tests/src/main/java/io/apicurio/tests/Constants.java
+++ b/tests/src/main/java/io/apicurio/tests/Constants.java
@@ -41,5 +41,10 @@ public interface Constants {
      */
     String UI = "ui";
 
+    /**
+     * Tag for acceptance tests, less tests than smoke testing
+     */
+    String ACCEPTANCE = "acceptance";
+
     Path LOGS_DIR = Paths.get("target/logs/");
 }

--- a/tests/src/test/java/io/apicurio/tests/BaseIT.java
+++ b/tests/src/test/java/io/apicurio/tests/BaseIT.java
@@ -72,7 +72,7 @@ public abstract class BaseIT implements TestSeparator, Constants {
             try {
                 ArtifactUtils.deleteArtifact(artifactId);
             } catch (AssertionError e) {
-                //because of async storage artifact may be already deleted but because listed anyway
+                //because of async storage artifact may be already deleted but listed anyway
                 LOGGER.info(e.getMessage());
             } catch (Exception e) {
                 LOGGER.error("", e);

--- a/tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
+++ b/tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
@@ -70,7 +70,15 @@ public abstract class ConfluentBaseIT extends BaseIT {
     protected static void clearAllConfluentSubjects() throws IOException, RestClientException {
         for (String confluentSubject : confluentService.getAllSubjects()) {
             LOGGER.info("Deleting confluent schema {}", confluentSubject);
-            confluentService.deleteSubject(confluentSubject);
+            try {
+                confluentService.deleteSubject(confluentSubject);
+            } catch (RestClientException e) {
+                if (e.getStatus() == 404) {
+                    //subjects may be already deleted
+                    continue;
+                }
+                throw e;
+            }
         }
     }
 

--- a/tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
+++ b/tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
@@ -20,6 +20,7 @@ import static io.apicurio.registry.utils.tests.TestUtils.retry;
 import static io.apicurio.registry.utils.tests.TestUtils.waitForSchema;
 import static io.apicurio.registry.utils.tests.TestUtils.waitForSchemaCustom;
 import static io.apicurio.tests.Constants.CLUSTER;
+import static io.apicurio.tests.Constants.ACCEPTANCE;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -71,6 +72,7 @@ import io.apicurio.tests.BaseIT;
  * @author Ales Justin
  */
 @Tag(CLUSTER)
+@Tag(ACCEPTANCE)
 public class RegistryConverterIT extends BaseIT {
 
     @RegistryServiceTest

--- a/tests/src/test/java/io/apicurio/tests/serdes/apicurio/BasicApicurioSerDesIT.java
+++ b/tests/src/test/java/io/apicurio/tests/serdes/apicurio/BasicApicurioSerDesIT.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
+import static io.apicurio.tests.Constants.ACCEPTANCE;
 import static io.apicurio.tests.Constants.CLUSTER;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -45,6 +46,7 @@ import java.util.concurrent.TimeoutException;
 public class BasicApicurioSerDesIT extends BaseIT {
 
     @RegistryServiceTest
+    @Tag(ACCEPTANCE)
     void testAvroApicurioSerDes(RegistryService service) throws InterruptedException, ExecutionException, TimeoutException {
         String topicName = TestUtils.generateTopic();
         String subjectName = topicName + "-value";

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AllArtifactTypesIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AllArtifactTypesIT.java
@@ -28,6 +28,7 @@ import io.apicurio.tests.utils.subUtils.ArtifactUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 
+import static io.apicurio.tests.Constants.ACCEPTANCE;
 import static io.apicurio.tests.Constants.SMOKE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -95,16 +96,19 @@ class AllArtifactTypesIT extends BaseIT {
     }
 
     @RegistryServiceTest
+    @Tag(ACCEPTANCE)
     void testAvro(RegistryService service) {
         doTest(service, "avro/multi-field_v1.json", "avro/multi-field_v2.json", ArtifactType.AVRO);
     }
 
     @RegistryServiceTest
+    @Tag(ACCEPTANCE)
     void testProtobuf(RegistryService service) {
         doTest(service, "protobuf/tutorial_v1.proto", "protobuf/tutorial_v2.proto", ArtifactType.PROTOBUF);
     }
 
     @RegistryServiceTest
+    @Tag(ACCEPTANCE)
     void testJsonSchema(RegistryService service) {
         doTest(service, "jsonSchema/person_v1.json", "jsonSchema/person_v2.json", ArtifactType.JSON);
     }

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
@@ -15,6 +15,7 @@
  */
 package io.apicurio.tests.smokeTests.apicurio;
 
+import static io.apicurio.tests.Constants.ACCEPTANCE;
 import static io.apicurio.tests.Constants.SMOKE;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -54,6 +55,7 @@ class ArtifactsIT extends BaseIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactsIT.class);
 
     @RegistryServiceTest
+    @Tag(ACCEPTANCE)
     void createAndUpdateArtifact(RegistryService service) throws Exception {
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
@@ -123,6 +125,7 @@ class ArtifactsIT extends BaseIT {
     }
 
     @RegistryServiceTest
+    @Tag(ACCEPTANCE)
     void createNonAvroArtifact(RegistryService service) throws Exception {
         ByteArrayInputStream artifactData = new ByteArrayInputStream("{\"type\":\"INVALID\",\"config\":\"invalid\"}".getBytes(StandardCharsets.UTF_8));
         String artifactId = TestUtils.generateArtifactId();
@@ -165,6 +168,7 @@ class ArtifactsIT extends BaseIT {
     }
 
     @RegistryServiceTest
+    @Tag(ACCEPTANCE)
     void testDuplicatedArtifact(RegistryService service) throws Exception {
         ByteArrayInputStream artifactData = new ByteArrayInputStream("{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}".getBytes(StandardCharsets.UTF_8));
         String artifactId = TestUtils.generateArtifactId();

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/LoadIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/LoadIT.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +46,15 @@ import io.apicurio.registry.utils.tests.RegistryServiceTest;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.BaseIT;
 
+/**
+ * Disabled because this is too flaky and it needs to be redesigned to align better
+ * with common usage of the registry, which is frequent reads sporadic writes.
+ *
+ * @author Fabian Martinez
+ *
+ */
 @Tag(SMOKE)
+@Disabled
 public class LoadIT extends BaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoadIT.class);

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/MetadataIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/MetadataIT.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.apicurio.tests.Constants.ACCEPTANCE;
 import static io.apicurio.tests.Constants.SMOKE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -45,6 +46,7 @@ class MetadataIT extends BaseIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(MetadataIT.class);
 
     @RegistryServiceTest
+    @Tag(ACCEPTANCE)
     void getAndUpdateMetadataOfArtifact(RegistryService service) throws Exception {
         String artifactId = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.apicurio.tests.Constants.ACCEPTANCE;
 import static io.apicurio.tests.Constants.SMOKE;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -80,6 +81,7 @@ class RulesResourceIT extends BaseIT {
     }
 
     @RegistryServiceTest
+    @Tag(ACCEPTANCE)
     void createAndValidateGlobalRules(RegistryService service) throws Exception {
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
@@ -114,6 +116,7 @@ class RulesResourceIT extends BaseIT {
     }
 
     @RegistryServiceTest
+    @Tag(ACCEPTANCE)
     void createAndValidateArtifactRule(RegistryService service) throws Exception {
         String artifactId1 = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/MetadataConfluentIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/MetadataConfluentIT.java
@@ -16,6 +16,7 @@
 
 package io.apicurio.tests.smokeTests.confluent;
 
+import static io.apicurio.tests.Constants.ACCEPTANCE;
 import static io.apicurio.tests.Constants.SMOKE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -41,6 +42,7 @@ public class MetadataConfluentIT extends ConfluentBaseIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(MetadataConfluentIT.class);
 
     @Test
+    @Tag(ACCEPTANCE)
     void getAndUpdateMetadataOfSchema() throws IOException, RestClientException, TimeoutException {
         ParsedSchema schema = new AvroSchema("{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}");
         String schemaSubject = TestUtils.generateArtifactId();

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/RulesResourceConfluentIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/RulesResourceConfluentIT.java
@@ -36,6 +36,7 @@ public class RulesResourceConfluentIT extends ConfluentBaseIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(MetadataConfluentIT.class);
 
     @Test
+    @Tag(ACCEPTANCE)
     void compatibilityGlobalRules() throws Exception {
         GlobalRuleUtils.createGlobalCompatibilityConfig("FULL");
 

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
@@ -16,6 +16,7 @@
 
 package io.apicurio.tests.smokeTests.confluent;
 
+import static io.apicurio.tests.Constants.ACCEPTANCE;
 import static io.apicurio.tests.Constants.SMOKE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
@@ -54,6 +55,7 @@ public class SchemasConfluentIT extends ConfluentBaseIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(SchemasConfluentIT.class);
 
     @Test
+    @Tag(ACCEPTANCE)
     void createAndUpdateSchema() throws Exception {
         String artifactId = TestUtils.generateArtifactId();
 

--- a/tests/src/test/java/io/apicurio/tests/ui/UploadArtifactsIT.java
+++ b/tests/src/test/java/io/apicurio/tests/ui/UploadArtifactsIT.java
@@ -37,6 +37,7 @@ import io.apicurio.tests.selenium.SeleniumChrome;
 import io.apicurio.tests.selenium.SeleniumProvider;
 import io.apicurio.tests.selenium.resources.ArtifactListItem;
 
+import static io.apicurio.tests.Constants.ACCEPTANCE;
 import static io.apicurio.tests.Constants.UI;
 
 @Tag(UI)
@@ -77,6 +78,7 @@ public class UploadArtifactsIT extends BaseIT {
 //    }
 
     @RegistryServiceTest
+    @Tag(ACCEPTANCE)
     void testProtobuf(RegistryService service) throws Exception {
         doTest(service, "protobuf/tutorial_v1.proto", ArtifactType.PROTOBUF, null, false);
     }


### PR DESCRIPTION
Adds a new test profile used in QE pipelines for quickly testing main functionalities.
Fix a minor issue in confluent api tests cleanup and disables LoadIT test because it is flaky and should be reworked