### PR TITLE
Allow users to define Kafka Streams topic names

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -13,6 +13,7 @@ quarkus.index-dependency.jaxrs.artifact-id=jboss-jaxrs-api_2.1_spec
 %dev.quarkus.hibernate-orm.log.sql=true
 %dev.quarkus.hibernate-orm.log.jdbc-warnings=true
 %dev.quarkus.hibernate-orm.statistics=true
+
 # Kafka -- when used
 %dev.registry.kafka.common.bootstrap.servers=${bootstrap.servers:localhost:9092}
 # Kafka - Registry producer
@@ -34,6 +35,8 @@ quarkus.index-dependency.jaxrs.artifact-id=jboss-jaxrs-api_2.1_spec
 %dev.registry.streams.topology.num.standby.replicas=1
 %dev.registry.streams.topology.processing.guarantee=exactly_once
 %dev.registry.streams.topology.replication.factor=1
+%dev.registry.streams.topology.global.id.topic=global-id-topic
+%dev.registry.streams.topology.storage.topic=storage-topic
 %dev.registry.streams.storage-producer.enable.idempotence=true
 #%dev.registry.streams.storage-producer.max.in.flight.requests.per.connection=5
 %dev.registry.streams.storage-producer.retries=3
@@ -83,6 +86,8 @@ quarkus.index-dependency.jaxrs.artifact-id=jboss-jaxrs-api_2.1_spec
 %prod.registry.streams.topology.num.standby.replicas=1
 %prod.registry.streams.topology.processing.guarantee=exactly_once
 %prod.registry.streams.topology.replication.factor=1
+%prod.registry.streams.topology.global.id.topic=global-id-topic
+%prod.registry.streams.topology.storage.topic=storage-topic
 %prod.registry.streams.storage-producer.enable.idempotence=true
 #%prod.registry.streams.storage-producer.max.in.flight.requests.per.connection=5
 %prod.registry.streams.storage-producer.retries=3


### PR DESCRIPTION
Fixes #768 

The following env variables can be used now for overriding topic names
- REGISTRY_STREAMS_TOPOLOGY_STORAGE_TOPIC
- REGISTRY_STREAMS_TOPOLOGY_GLOBAL_ID_TOPIC