### PR TITLE
Add Kafka Serde implementations for Kafka Streams applications

### DIFF
--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/AbstractSerde.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/AbstractSerde.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.utils.serde;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+public abstract class AbstractSerde<T> implements Serde<T> {
+    final private Serializer<T> serializer;
+    final private Deserializer<T> deserializer;
+
+    AbstractSerde(Serializer<T> serializer, Deserializer<T> deserializer) {
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        serializer.configure(configs, isKey);
+        deserializer.configure(configs, isKey);
+    }
+
+    @Override
+    public void close() {
+        serializer.close();
+        deserializer.close();
+    }
+
+    @Override
+    public Serializer<T> serializer() {
+        return serializer;
+    }
+
+    @Override
+    public Deserializer<T> deserializer() {
+        return deserializer;
+    }
+}

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/AvroKafkaDeserializer.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/AvroKafkaDeserializer.java
@@ -18,6 +18,7 @@
 package io.apicurio.registry.utils.serde;
 
 import io.apicurio.registry.client.RegistryService;
+import io.apicurio.registry.utils.IoUtil;
 import io.apicurio.registry.utils.serde.avro.AvroDatumProvider;
 import io.apicurio.registry.utils.serde.avro.AvroSchemaUtils;
 import io.apicurio.registry.utils.serde.avro.DefaultAvroDatumProvider;
@@ -30,6 +31,7 @@ import org.apache.kafka.common.header.Headers;
 import javax.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -77,7 +79,12 @@ public class AvroKafkaDeserializer<U> extends AbstractKafkaDeserializer<Schema, 
 
     @Override
     protected Schema toSchema(Response response) {
-        return AvroSchemaUtils.parse(response.readEntity(String.class));
+        Object responseEntity = response.getEntity();
+        if (responseEntity instanceof InputStream) {
+            return AvroSchemaUtils.parse(IoUtil.toString((InputStream) responseEntity));
+        } else {
+            return AvroSchemaUtils.parse(response.readEntity(String.class));
+        }
     }
 
     @Override

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/AvroSerde.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/AvroSerde.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.utils.serde;
+
+/**
+ * Wraps the AvroKafkaSerializer and AvroKafkaDeserializer.
+ */
+public class AvroSerde<T> extends AbstractSerde<T> {
+    public AvroSerde() {
+        super(new AvroKafkaSerializer<>(), new AvroKafkaDeserializer<>());
+    }
+}

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/JsonSchemaSerde.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/JsonSchemaSerde.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.utils.serde;
+
+/**
+ * Wraps the JsonSchemaKafkaSerializer and JsonSchemaKafkaDeserializer.
+ */
+public class JsonSchemaSerde<T> extends AbstractSerde<T> {
+    public JsonSchemaSerde() {
+        super(new JsonSchemaKafkaSerializer<>(), new JsonSchemaKafkaDeserializer<>());
+    }
+}

--- a/utils/serde/src/main/java/io/apicurio/registry/utils/serde/ProtobufSerde.java
+++ b/utils/serde/src/main/java/io/apicurio/registry/utils/serde/ProtobufSerde.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.utils.serde;
+
+import com.google.protobuf.Message;
+import org.apache.kafka.common.serialization.Deserializer;
+
+/****
+ * Wraps the ProtobufKafkaSerializer and ProtobufKafkaDeserializer.
+ */
+public class ProtobufSerde<T extends Message> extends AbstractSerde<T> {
+    public ProtobufSerde() {
+        super(new ProtobufKafkaSerializer<T>(), (Deserializer<T>) new ProtobufKafkaDeserializer());
+    }
+}
+


### PR DESCRIPTION
 - This commit adds three implementations of Kafka's Serde interface
which provides a wrapper for a Serializer and Deserializer. The
three implementations wrap the AvroKafkaSerializer/Deserializer, the
JsonSchemaKafkaSerializer/Deserializer and the
ProtobufKafkaSerializer/Deserializer. See issue #641 for more info.
 - It also adds a workaround for the issue where Kafka Deserializers
throw a `java.lang.IllegalStateException: Method not supported on an
outbound message` error (see #702 and #808) due to the use of
JAX-RS classes in the CompatibleClient class.

Signed-off-by: Andrew Borley <borley@uk.ibm.com>