### PR TITLE
Add TLS auth support to rest client calls

### DIFF
--- a/rest-client/src/main/java/io/apicurio/registry/client/CompatibleClient.java
+++ b/rest-client/src/main/java/io/apicurio/registry/client/CompatibleClient.java
@@ -16,7 +16,16 @@
  */
 package io.apicurio.registry.client;
 
-import io.apicurio.registry.rest.beans.*;
+import io.apicurio.registry.rest.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.beans.ArtifactSearchResults;
+import io.apicurio.registry.rest.beans.EditableMetaData;
+import io.apicurio.registry.rest.beans.IfExistsType;
+import io.apicurio.registry.rest.beans.Rule;
+import io.apicurio.registry.rest.beans.SearchOver;
+import io.apicurio.registry.rest.beans.SortOrder;
+import io.apicurio.registry.rest.beans.UpdateState;
+import io.apicurio.registry.rest.beans.VersionMetaData;
+import io.apicurio.registry.rest.beans.VersionSearchResults;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.RuleType;
 
@@ -48,16 +57,16 @@ public class CompatibleClient implements RegistryService {
         this.delegate = RegistryRestClientFactory.create(baseUrl);
     }
 
-    private CompatibleClient(String baseUrl, Map<String, String> requestHeaders) {
-        this.delegate = RegistryRestClientFactory.create(baseUrl, requestHeaders);
+    private CompatibleClient(String baseUrl, Map<String, Object> configs) {
+        this.delegate = RegistryRestClientFactory.create(baseUrl, configs);
     }
 
     public static RegistryService createCompatible(String baseUrl) {
         return new CompatibleClient(baseUrl);
     }
 
-    public static RegistryService createCompatible(String baseUrl, Map<String, String> requestHeaders) {
-        return new CompatibleClient(baseUrl, requestHeaders);
+    public static RegistryService createCompatible(String baseUrl, Map<String, Object> configs) {
+        return new CompatibleClient(baseUrl, configs);
     }
 
     @Override

--- a/rest-client/src/main/java/io/apicurio/registry/client/RegistryRestClientFactory.java
+++ b/rest-client/src/main/java/io/apicurio/registry/client/RegistryRestClientFactory.java
@@ -17,41 +17,28 @@
 
 package io.apicurio.registry.client;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import okhttp3.Credentials;
-import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+
+import java.util.Map;
 
 /**
  * @author eric.wittmann@gmail.com
  */
 public class RegistryRestClientFactory {
 
-    public static RegistryRestClient create(String baseUrl) {
-        // Check if url includes user/password
-        // and add auth header if it does
-        HttpUrl url = HttpUrl.parse(baseUrl);
-        String user = url.encodedUsername();
-        String pwd = url.encodedPassword();
-        if (user != null) {
-            String credentials = Credentials.basic(user, pwd);
-            Map<String, String> headers = new HashMap<>();
-            headers.put("Authorization", credentials);
-            return new RegistryRestClientImpl(baseUrl, headers);
-        } else {
-            return new RegistryRestClientImpl(baseUrl);
-        }
 
+
+
+    public static RegistryRestClient create(String baseUrl) {
+        return new RegistryRestClientImpl(baseUrl);
     }
 
     public static RegistryRestClient create(String baseUrl, OkHttpClient okHttpClient) {
         return new RegistryRestClientImpl(baseUrl, okHttpClient);
     }
 
-    public static RegistryRestClient create(String baseUrl, Map<String, String> headers) {
-        return new RegistryRestClientImpl(baseUrl, headers);
+    public static RegistryRestClient create(String baseUrl, Map<String, Object> configs) {
+        return new RegistryRestClientImpl(baseUrl, configs);
     }
 
 }

--- a/rest-client/src/main/java/io/apicurio/registry/client/RegistryRestClientImpl.java
+++ b/rest-client/src/main/java/io/apicurio/registry/client/RegistryRestClientImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Red Hat
+ * Copyright 2020 IBM
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +17,27 @@
 
 package io.apicurio.registry.client;
 
-import io.apicurio.registry.rest.beans.*;
-import io.apicurio.registry.types.ArtifactType;
-import io.apicurio.registry.types.RuleType;
-import io.apicurio.registry.utils.IoUtil;
 import io.apicurio.registry.client.request.HeadersInterceptor;
 import io.apicurio.registry.client.request.RequestHandler;
 import io.apicurio.registry.client.service.ArtifactsService;
 import io.apicurio.registry.client.service.IdsService;
 import io.apicurio.registry.client.service.RulesService;
 import io.apicurio.registry.client.service.SearchService;
+import io.apicurio.registry.rest.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.beans.ArtifactSearchResults;
+import io.apicurio.registry.rest.beans.EditableMetaData;
+import io.apicurio.registry.rest.beans.IfExistsType;
+import io.apicurio.registry.rest.beans.Rule;
+import io.apicurio.registry.rest.beans.SearchOver;
+import io.apicurio.registry.rest.beans.SortOrder;
+import io.apicurio.registry.rest.beans.UpdateState;
+import io.apicurio.registry.rest.beans.VersionMetaData;
+import io.apicurio.registry.rest.beans.VersionSearchResults;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.RuleType;
+import io.apicurio.registry.utils.IoUtil;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -33,9 +45,36 @@ import okhttp3.RequestBody;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.apicurio.registry.client.request.Config.REGISTRY_REQUEST_HEADERS_PREFIX;
+import static io.apicurio.registry.client.request.Config.REGISTRY_REQUEST_KEYSTORE_LOCATION;
+import static io.apicurio.registry.client.request.Config.REGISTRY_REQUEST_KEYSTORE_PASSWORD;
+import static io.apicurio.registry.client.request.Config.REGISTRY_REQUEST_KEYSTORE_TYPE;
+import static io.apicurio.registry.client.request.Config.REGISTRY_REQUEST_KEY_PASSWORD;
+import static io.apicurio.registry.client.request.Config.REGISTRY_REQUEST_TRUSTSTORE_LOCATION;
+import static io.apicurio.registry.client.request.Config.REGISTRY_REQUEST_TRUSTSTORE_PASSWORD;
+import static io.apicurio.registry.client.request.Config.REGISTRY_REQUEST_TRUSTSTORE_TYPE;
 
 /**
  * @author Carles Arnal <carnalca@redhat.com>
@@ -51,17 +90,11 @@ public class RegistryRestClientImpl implements RegistryRestClient {
     private IdsService idsService;
 
     RegistryRestClientImpl(String baseUrl) {
-        if (!baseUrl.endsWith("/")) {
-            baseUrl += "/";
-        }
-        this.retrofit = new Retrofit.Builder()
-                .baseUrl(baseUrl)
-                .addConverterFactory(JacksonConverterFactory.create())
-                .build();
+        this(baseUrl, Collections.emptyMap());
+    }
 
-        this.requestHandler = new RequestHandler();
-
-        initServices(retrofit);
+    RegistryRestClientImpl(String baseUrl, Map<String, Object> config) {
+        this(baseUrl, createHttpClientWithConfig(baseUrl, config));
     }
 
     RegistryRestClientImpl(String baseUrl, OkHttpClient okHttpClient) {
@@ -79,31 +112,84 @@ public class RegistryRestClientImpl implements RegistryRestClient {
         initServices(retrofit);
     }
 
-    RegistryRestClientImpl(String baseUrl, Map<String, String> headers) {
-        if (!baseUrl.endsWith("/")) {
-            baseUrl += "/";
-        }
-
-        final OkHttpClient okHttpClient = createWithHeaders(headers);
-
-        this.retrofit = new Retrofit.Builder()
-                .client(okHttpClient)
-                .addConverterFactory(JacksonConverterFactory.create())
-                .baseUrl(baseUrl)
-                .build();
-
-        this.requestHandler = new RequestHandler();
-
-        initServices(retrofit);
+    private static OkHttpClient createHttpClientWithConfig(String baseUrl, Map<String, Object> configs) {
+        OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder();
+        okHttpClientBuilder = addHeaders(okHttpClientBuilder, baseUrl, configs);
+        okHttpClientBuilder = addSSL(okHttpClientBuilder, configs);
+        return okHttpClientBuilder.build();
     }
 
-    private static OkHttpClient createWithHeaders(Map<String, String> headers) {
+    private static OkHttpClient.Builder addHeaders(OkHttpClient.Builder okHttpClientBuilder, String baseUrl, Map<String, Object> configs) {
 
-        final Interceptor headersInterceptor = new HeadersInterceptor(headers);
+        Map<String, String> requestHeaders = configs.entrySet().stream()
+            .filter(map -> map.getKey().startsWith(REGISTRY_REQUEST_HEADERS_PREFIX))
+            .collect(Collectors.toMap(map -> map.getKey()
+                .replace(REGISTRY_REQUEST_HEADERS_PREFIX, ""), map -> map.getValue().toString()));
 
-        return new OkHttpClient.Builder()
-                .addInterceptor(headersInterceptor)
-                .build();
+        if(!requestHeaders.containsKey("Authorization")) {
+            // Check if url includes user/password
+            // and add auth header if it does
+            HttpUrl url = HttpUrl.parse(baseUrl);
+            String user = url.encodedUsername();
+            String pwd = url.encodedPassword();
+            if (user != null && !user.isEmpty()) {
+                String credentials = Credentials.basic(user, pwd);
+                requestHeaders.put("Authorization", credentials);
+            }
+        }
+
+        if(!requestHeaders.isEmpty()) {
+            final Interceptor headersInterceptor = new HeadersInterceptor(requestHeaders);
+            return okHttpClientBuilder.addInterceptor(headersInterceptor);
+        } else {
+            return okHttpClientBuilder;
+        }
+    }
+
+    private static OkHttpClient.Builder addSSL(OkHttpClient.Builder okHttpClientBuilder, Map<String, Object> configs) {
+
+        try {
+            KeyManager[] keyManagers = null;
+            TrustManager[] trustManagers = null;
+
+            if (configs.containsKey(REGISTRY_REQUEST_KEYSTORE_LOCATION)) {
+                String keystoreType = (String) configs.getOrDefault(REGISTRY_REQUEST_KEYSTORE_TYPE, "JKS");
+                KeyStore keystore = KeyStore.getInstance(keystoreType);
+                String keyStorePwd = (String) configs.getOrDefault(REGISTRY_REQUEST_KEYSTORE_PASSWORD, "");
+                keystore.load(new FileInputStream((String) configs.get(REGISTRY_REQUEST_KEYSTORE_LOCATION)), keyStorePwd.toCharArray());
+
+                KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                // If no key password provided, try using the keystore password
+                String keyPwd = (String) configs.getOrDefault(REGISTRY_REQUEST_KEY_PASSWORD, keyStorePwd);
+                keyManagerFactory.init(keystore, keyPwd.toCharArray());
+                keyManagers = keyManagerFactory.getKeyManagers();
+            }
+
+            if (configs.containsKey(REGISTRY_REQUEST_TRUSTSTORE_LOCATION)) {
+                String truststoreType = (String) configs.getOrDefault(REGISTRY_REQUEST_TRUSTSTORE_TYPE, "JKS");
+                KeyStore truststore = KeyStore.getInstance(truststoreType);
+                String truststorePwd = (String) configs.getOrDefault(REGISTRY_REQUEST_TRUSTSTORE_PASSWORD, "");
+                truststore.load(new FileInputStream((String) configs.get(REGISTRY_REQUEST_TRUSTSTORE_LOCATION)), truststorePwd.toCharArray());
+                TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                trustManagerFactory.init(truststore);
+
+                trustManagers = trustManagerFactory.getTrustManagers();
+                if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
+                    throw new IllegalStateException("Unexpected default trust managers:" + Arrays.toString(trustManagers));
+                }
+            }
+
+            if (keyManagers != null || trustManagers != null) {
+                SSLContext sslContext = SSLContext.getInstance("SSL");
+                sslContext.init(keyManagers, trustManagers, new SecureRandom());
+                return okHttpClientBuilder.sslSocketFactory(sslContext.getSocketFactory(), (X509TrustManager) trustManagers[0]);
+            } else {
+                return okHttpClientBuilder;
+            }
+        }
+        catch(IOException | UnrecoverableKeyException | NoSuchAlgorithmException | KeyStoreException | CertificateException | KeyManagementException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     private void initServices(Retrofit retrofit) {

--- a/rest-client/src/main/java/io/apicurio/registry/client/request/Config.java
+++ b/rest-client/src/main/java/io/apicurio/registry/client/request/Config.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.client.request;
+
+public class Config {
+    public static final String REGISTRY_REQUEST_HEADERS_PREFIX = "apicurio.registry.request.headers.";
+    public static final String REGISTRY_REQUEST_TRUSTSTORE_PREFIX = "apicurio.registry.request.ssl.truststore";
+    public static final String REGISTRY_REQUEST_TRUSTSTORE_LOCATION = REGISTRY_REQUEST_TRUSTSTORE_PREFIX + ".location";
+    public static final String REGISTRY_REQUEST_TRUSTSTORE_TYPE = REGISTRY_REQUEST_TRUSTSTORE_PREFIX + ".type";
+    public static final String REGISTRY_REQUEST_TRUSTSTORE_PASSWORD = REGISTRY_REQUEST_TRUSTSTORE_PREFIX + ".password";
+    public static final String REGISTRY_REQUEST_KEYSTORE_PREFIX = "apicurio.registry.request.ssl.keystore";
+    public static final String REGISTRY_REQUEST_KEYSTORE_LOCATION = REGISTRY_REQUEST_KEYSTORE_PREFIX + ".location";
+    public static final String REGISTRY_REQUEST_KEYSTORE_TYPE = REGISTRY_REQUEST_KEYSTORE_PREFIX + ".type";
+    public static final String REGISTRY_REQUEST_KEYSTORE_PASSWORD = REGISTRY_REQUEST_KEYSTORE_PREFIX + ".password";
+    public static final String REGISTRY_REQUEST_KEY_PASSWORD = "apicurio.registry.request.ssl.key.password";
+}


### PR DESCRIPTION
 - This commit adds support for HTTPS calls to apicurio-registry with or
without TLS client auth. Supported configuration keys are:
   - `apicurio.registry.request.ssl.truststore.location`
   - `apicurio.registry.request.ssl.truststore.password`
   - `apicurio.registry.request.ssl.truststore.type`
   - `apicurio.registry.request.ssl.keystore.location`
   - `apicurio.registry.request.ssl.keystore.password`
   - `apicurio.registry.request.ssl.keystore.type`
   - `apicurio.registry.request.ssl.key.password`
 - It also refactors the request header handling code to move it out of
the serdes code and into the RegistryRestClient, so all clients can use
it. This includes the basic auth handling for when the username and
password are encoded in the URL.

Signed-off-by: Andrew Borley <borley@uk.ibm.com>