### PR TITLE
Support disabled artifacts in the UI listing/details

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/ArtifactsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ArtifactsResourceImpl.java
@@ -40,6 +40,7 @@ import io.apicurio.registry.storage.EditableArtifactMetaDataDto;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.RuleConfigurationDto;
 import io.apicurio.registry.storage.StoredArtifact;
+import io.apicurio.registry.storage.VersionNotFoundException;
 import io.apicurio.registry.types.ArtifactMediaTypes;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
@@ -339,7 +340,7 @@ public class ArtifactsResourceImpl implements ArtifactsResource, Headers {
     @Override
     public Response getLatestArtifact(String artifactId) {
         ArtifactMetaDataDto metaData = storage.getArtifactMetaData(artifactId);
-        if(ArtifactState.DISABLED.equals(metaData.getState())) {
+        if (ArtifactState.DISABLED.equals(metaData.getState())) {
             throw new ArtifactNotFoundException(artifactId);
         }
         StoredArtifact artifact = storage.getArtifact(artifactId);
@@ -428,9 +429,9 @@ public class ArtifactsResourceImpl implements ArtifactsResource, Headers {
      */
     @Override
     public Response getArtifactVersion(Integer version, String artifactId) {
-        ArtifactMetaDataDto metaData = storage.getArtifactMetaData(artifactId);
-        if(ArtifactState.DISABLED.equals(metaData.getState())) {
-            throw new ArtifactNotFoundException(artifactId);
+        ArtifactVersionMetaDataDto metaData = storage.getArtifactVersionMetaData(artifactId, version);
+        if (ArtifactState.DISABLED.equals(metaData.getState())) {
+            throw new VersionNotFoundException(artifactId, version);
         }
         StoredArtifact artifact = storage.getArtifactVersion(artifactId, version);
 

--- a/ui/packages/registry/src/app/pages/artifacts/components/artifactList/artifactList.css
+++ b/ui/packages/registry/src/app/pages/artifacts/components/artifactList/artifactList.css
@@ -35,6 +35,10 @@
     content: ')';
 }
 
+.artifact-list .artifact-list-item .content-cell .artifact-title .status-badge {
+    margin-left: 10px;
+    border: 1px solid #ccc;
+}
 
 .artifact-list .artifact-list-item .content-cell .artifact-description {
     font-size: 13px;

--- a/ui/packages/registry/src/app/pages/artifacts/components/artifactList/artifactList.tsx
+++ b/ui/packages/registry/src/app/pages/artifacts/components/artifactList/artifactList.tsx
@@ -22,12 +22,12 @@ import {
     DataListAction,
     DataListCell,
     DataListItemCells,
-    DataListItemRow
+    DataListItemRow,
+    Label
 } from '@patternfly/react-core';
 import {SearchedArtifact} from "@apicurio/registry-models";
 import {Link} from "react-router-dom";
 import {ArtifactTypeIcon, PureComponent, PureComponentProps, PureComponentState} from "../../../../components";
-import {Services} from "@apicurio/registry-services";
 import {ArtifactName} from "./artifactName";
 
 /**
@@ -68,6 +68,11 @@ export class ArtifactList extends PureComponent<ArtifactListProps, ArtifactListS
                                         <DataListCell key="main content" className="content-cell">
                                             <div className="artifact-title">
                                                 <ArtifactName id={artifact.id} name={artifact.name} />
+                                                {
+                                                    this.statuses(artifact).map( status =>
+                                                        <Badge className="status-badge" key={status} isRead={true}>{status}</Badge>
+                                                    )
+                                                }
                                             </div>
                                             <div className="artifact-description">{this.description(artifact)}</div>
                                             <div className="artifact-tags">
@@ -100,6 +105,17 @@ export class ArtifactList extends PureComponent<ArtifactListProps, ArtifactListS
 
     private labels(artifact: SearchedArtifact): string[] {
         return artifact.labels ? artifact.labels : [];
+    }
+
+    private statuses(artifact: SearchedArtifact): string[] {
+        const rval: string[] = [];
+        if (artifact.state === "DISABLED") {
+            rval.push("Disabled");
+        }
+        if (artifact.state === "DEPRECATED") {
+            rval.push("Deprecated");
+        }
+        return rval;
     }
 
     private artifactLink(artifact: SearchedArtifact): string {


### PR DESCRIPTION
Updated the UI to no longer break when encountering disabled artifacts.

I have not yet added actual support for enabling/disabling (or deprecating/undeprecating) via the UI yet.  But at least the UI won't break when it sees disabled content.

I did add a label/badge to the artifact listing that will display when an artifact is disabled or deprecated.