### PR TITLE
ui tests - fix selenium tests when run in k8s testsuite

### DIFF
--- a/tests/src/test/java/io/apicurio/tests/selenium/SeleniumChromeExtension.java
+++ b/tests/src/test/java/io/apicurio/tests/selenium/SeleniumChromeExtension.java
@@ -15,12 +15,19 @@
  */
 package io.apicurio.tests.selenium;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.Testcontainers;
@@ -67,23 +74,78 @@ public class SeleniumChromeExtension implements BeforeTestExecutionCallback, Aft
         }
     }
 
-    private void deployChrome() {
+    private void deployChrome() throws Exception {
         LOGGER.info("Deploying chrome browser");
-        if (!TestUtils.isExternalRegistry()) {
+        String uiUrl;
+        WebDriver driver;
+        if (TestUtils.isExternalRegistry()) {
+            // we are supposing that if registry is deployed externally selenium will be as well
+            driver = getRemoteChromeDriver();
+            String registrySeleniumHost =  System.getenv().getOrDefault("REGISTRY_SELENIUM_HOST", TestUtils.getRegistryHost());
+            String registrySeleniumPort = System.getenv().getOrDefault("REGISTRY_SELENIUM_PORT", Integer.toString(TestUtils.getRegistryPort()));
+            uiUrl = String.format("http://%s:%s/ui", registrySeleniumHost, registrySeleniumPort);
+        } else {
             Testcontainers.exposeHostPorts(TestUtils.getRegistryPort());
-        }
-        chrome = new BrowserWebDriverContainer()
+            uiUrl = TestUtils.getRegistryUIUrl().replace("localhost", "host.testcontainers.internal");
+            chrome = new BrowserWebDriverContainer()
                 .withCapabilities(new ChromeOptions());
-        chrome.start();
-        SeleniumProvider.getInstance().setupDriver(chrome.getWebDriver());
-        SeleniumProvider.getInstance().setUiUrl(TestUtils.getRegistryUIUrl().replace("localhost", "host.testcontainers.internal"));
+            chrome.start();
+            driver = chrome.getWebDriver();
+        }
+        SeleniumProvider.getInstance().setupDriver(driver);
+        SeleniumProvider.getInstance().setUiUrl(uiUrl);
         deployed = true;
     }
 
     private void deleteChrome() {
         SeleniumProvider.getInstance().tearDownDrivers();
         LOGGER.info("Stopping chrome browser");
-        chrome.stop();
+        if (!TestUtils.isExternalRegistry()) {
+            chrome.stop();
+        }
         deployed = false;
+    }
+
+    public static RemoteWebDriver getRemoteChromeDriver() throws Exception {
+        String seleniumHost =  System.getenv().getOrDefault("SELENIUM_HOST", "localhost");
+        String seleniumPort = System.getenv().getOrDefault("SELENIUM_PORT", "80");
+        ChromeOptions options = new ChromeOptions();
+        options.setAcceptInsecureCerts(true);
+        options.addArguments("test-type", "--headless", "--no-sandbox", "--disable-dev-shm-usage", "--disable-extensions");
+        return getRemoteDriver(seleniumHost, seleniumPort, options);
+    }
+
+    private static RemoteWebDriver getRemoteDriver(String host, String port, Capabilities options) throws Exception {
+        int attempts = 60;
+        URL hubUrl = new URL(String.format("http://%s:%s/wd/hub", host, port));
+        LOGGER.info("Using remote selenium " + hubUrl);
+        for (int i = 0; i < attempts; i++) {
+            try {
+                testReachable(hubUrl);
+                return new RemoteWebDriver(hubUrl, options);
+            } catch (IOException e) {
+                if (i == attempts - 1) {
+                    LOGGER.warn("Cannot connect to hub", e);
+                } else {
+                    LOGGER.warn("Cannot connect to hub: {}", e.getMessage());
+                }
+            }
+            Thread.sleep(2000);
+        }
+        throw new IllegalStateException("Selenium webdriver cannot connect to selenium container");
+    }
+
+    private static void testReachable(URL url) throws IOException {
+        LOGGER.info("Trying to connect to {}", url.toString());
+        HttpURLConnection urlConnection = null;
+        try {
+            urlConnection = (HttpURLConnection) url.openConnection();
+            urlConnection.getContent();
+            LOGGER.info("Client is able to connect to the selenium hub");
+        } finally {
+            if (urlConnection != null) {
+                urlConnection.disconnect();
+            }
+        }
     }
 }


### PR DESCRIPTION
UI tests were failing when executed from the kubernetes test suite, that was because selenium was deployed in a container that cannot access the kubernetes cluster deployed for k8s testsuite (accessible through localhost)...

With this changes new tests assume that if env var "EXTERNAL_REGISTRY" is true it means registry is deployed by someone else and selenium (required only for ui tests) is deployed by someone else as well. Selenium connection details are in env vars "SELENIUM_HOST" and "SELENIUM_PORT"

Because for k8s testsuite selenium is deployed inside kubernetes cluster in order to be able to access an apicurio-registry deployed inside same kubernetes cluster I had to add env vars "REGISTRY_SELENIUM_HOST" and "REGISTRY_SELENIUM_PORT" to be able to specify a reachable url to selenium