### PR TITLE
fix infinispan global rules cleanup bug

### DIFF
--- a/common/src/main/java/io/apicurio/registry/utils/ConcurrentUtil.java
+++ b/common/src/main/java/io/apicurio/registry/utils/ConcurrentUtil.java
@@ -40,7 +40,7 @@ public class ConcurrentUtil {
                     if (t instanceof RuntimeException)
                         throw (RuntimeException) t;
                     if (t instanceof Error) throw (Error) t;
-                    throw new RuntimeException(t);
+                    throw new RuntimeException(e);
                 }
             }
         } finally {

--- a/storage/infinispan/src/main/java/io/apicurio/registry/infinispan/InfinispanRegistryStorage.java
+++ b/storage/infinispan/src/main/java/io/apicurio/registry/infinispan/InfinispanRegistryStorage.java
@@ -19,10 +19,13 @@ package io.apicurio.registry.infinispan;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.metrics.PersistenceExceptionLivenessApply;
 import io.apicurio.registry.metrics.PersistenceTimeoutReadinessApply;
+import io.apicurio.registry.storage.RegistryStorageException;
 import io.apicurio.registry.storage.impl.AbstractMapRegistryStorage;
 import io.apicurio.registry.storage.impl.MultiMap;
 import io.apicurio.registry.storage.impl.StorageMap;
 import io.apicurio.registry.storage.impl.TupleId;
+import io.apicurio.registry.utils.ConcurrentUtil;
+
 import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
@@ -154,4 +157,10 @@ public class InfinispanRegistryStorage extends AbstractMapRegistryStorage {
         ClusterHealth health = manager.getHealth().getClusterHealth();
         return (health.getHealthStatus() != HealthStatus.DEGRADED);
     }
+
+    @Override
+    public void deleteGlobalRules() throws RegistryStorageException {
+        ConcurrentUtil.get(manager.getCache(GLOBAL_RULES_CACHE, true).clearAsync());
+    }
+
 }

--- a/tests/src/main/java/io/apicurio/tests/RegistryFacade.java
+++ b/tests/src/main/java/io/apicurio/tests/RegistryFacade.java
@@ -292,7 +292,9 @@ public class RegistryFacade {
                 }
             }
             if (logsPath != null) {
-                TestUtils.writeFile(logsPath.resolve(currentDate + "-" + p.getName() + "-" + "stdout.log"), p.getStdOut());
+                Path filePath = logsPath.resolve(currentDate + "-" + p.getName() + "-" + "stdout.log");
+                LOGGER.info("Storing registry logs to " + filePath.toString());
+                TestUtils.writeFile(filePath, p.getStdOut());
                 String stdErr = p.getStdErr();
                 if (stdErr != null && !stdErr.isEmpty()) {
                     TestUtils.writeFile(logsPath.resolve(currentDate + "-" + p.getName() + "-" + "stderr.log"), stdErr);

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
@@ -27,9 +27,11 @@ import io.apicurio.tests.BaseIT;
 import io.apicurio.tests.utils.subUtils.ArtifactUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.apicurio.tests.Constants.ACCEPTANCE;
 import static io.apicurio.tests.Constants.SMOKE;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,6 +48,7 @@ class RulesResourceIT extends BaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RulesResourceIT.class);
 
+    @Test
     void createAndDeleteGlobalRules(RegistryRestClient service) throws Exception {
         // Create a global rule
         Rule rule = new Rule();
@@ -78,6 +81,7 @@ class RulesResourceIT extends BaseIT {
     }
 
     @Tag(ACCEPTANCE)
+    @Test
     void createAndValidateGlobalRules(RegistryRestClient service) throws Exception {
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
@@ -112,6 +116,7 @@ class RulesResourceIT extends BaseIT {
     }
 
     @Tag(ACCEPTANCE)
+    @Test
     void createAndValidateArtifactRule(RegistryRestClient service) throws Exception {
         String artifactId1 = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
@@ -167,6 +172,7 @@ class RulesResourceIT extends BaseIT {
         });
     }
 
+    @Test
     void testRulesDeletedWithArtifact(RegistryRestClient service) throws Exception {
         String artifactId1 = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
@@ -16,18 +16,18 @@
 
 package io.apicurio.tests.smokeTests.apicurio;
 
-import io.apicurio.registry.client.RegistryRestClient;
+import io.apicurio.registry.client.RegistryService;
 import io.apicurio.registry.rest.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.beans.Rule;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.utils.IoUtil;
+import io.apicurio.registry.utils.tests.RegistryServiceTest;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.BaseIT;
 import io.apicurio.tests.utils.subUtils.ArtifactUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,8 +48,8 @@ class RulesResourceIT extends BaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RulesResourceIT.class);
 
-    @Test
-    void createAndDeleteGlobalRules(RegistryRestClient service) throws Exception {
+    @RegistryServiceTest
+    void createAndDeleteGlobalRules(RegistryService service) throws Exception {
         // Create a global rule
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
@@ -80,9 +80,9 @@ class RulesResourceIT extends BaseIT {
         TestUtils.assertWebError(404, () -> service.getGlobalRuleConfig(RuleType.VALIDITY));
     }
 
+    @RegistryServiceTest
     @Tag(ACCEPTANCE)
-    @Test
-    void createAndValidateGlobalRules(RegistryRestClient service) throws Exception {
+    void createAndValidateGlobalRules(RegistryService service) throws Exception {
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
         rule.setConfig("SYNTAX_ONLY");
@@ -115,9 +115,9 @@ class RulesResourceIT extends BaseIT {
         });
     }
 
+    @RegistryServiceTest
     @Tag(ACCEPTANCE)
-    @Test
-    void createAndValidateArtifactRule(RegistryRestClient service) throws Exception {
+    void createAndValidateArtifactRule(RegistryService service) throws Exception {
         String artifactId1 = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
 
@@ -172,8 +172,8 @@ class RulesResourceIT extends BaseIT {
         });
     }
 
-    @Test
-    void testRulesDeletedWithArtifact(RegistryRestClient service) throws Exception {
+    @RegistryServiceTest
+    void testRulesDeletedWithArtifact(RegistryService service) throws Exception {
         String artifactId1 = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
 
@@ -196,11 +196,11 @@ class RulesResourceIT extends BaseIT {
         assertThat(0, is(service.listArtifacts().size()));
 
         TestUtils.assertWebError(404, () -> service.listArtifactRules(artifactId1));
-        TestUtils.assertWebError(404, () -> service.getArtifactRuleConfig(artifactId1, RuleType.VALIDITY));
+        TestUtils.assertWebError(404, () -> service.getArtifactRuleConfig(RuleType.VALIDITY, artifactId1));
     }
 
     @AfterEach
-    void clearRules(RegistryRestClient service) throws Exception {
+    void clearRules(RegistryService service) throws Exception {
         LOGGER.info("Removing all global rules");
         service.deleteAllGlobalRules();
         TestUtils.retry(() -> {

--- a/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
+++ b/tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
@@ -16,13 +16,12 @@
 
 package io.apicurio.tests.smokeTests.apicurio;
 
-import io.apicurio.registry.client.RegistryService;
+import io.apicurio.registry.client.RegistryRestClient;
 import io.apicurio.registry.rest.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.beans.Rule;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.utils.IoUtil;
-import io.apicurio.registry.utils.tests.RegistryServiceTest;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.BaseIT;
 import io.apicurio.tests.utils.subUtils.ArtifactUtils;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.apicurio.tests.Constants.ACCEPTANCE;
 import static io.apicurio.tests.Constants.SMOKE;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,8 +46,7 @@ class RulesResourceIT extends BaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RulesResourceIT.class);
 
-    @RegistryServiceTest
-    void createAndDeleteGlobalRules(RegistryService service) throws Exception {
+    void createAndDeleteGlobalRules(RegistryRestClient service) throws Exception {
         // Create a global rule
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
@@ -80,9 +77,8 @@ class RulesResourceIT extends BaseIT {
         TestUtils.assertWebError(404, () -> service.getGlobalRuleConfig(RuleType.VALIDITY));
     }
 
-    @RegistryServiceTest
     @Tag(ACCEPTANCE)
-    void createAndValidateGlobalRules(RegistryService service) throws Exception {
+    void createAndValidateGlobalRules(RegistryRestClient service) throws Exception {
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
         rule.setConfig("SYNTAX_ONLY");
@@ -115,9 +111,8 @@ class RulesResourceIT extends BaseIT {
         });
     }
 
-    @RegistryServiceTest
     @Tag(ACCEPTANCE)
-    void createAndValidateArtifactRule(RegistryService service) throws Exception {
+    void createAndValidateArtifactRule(RegistryRestClient service) throws Exception {
         String artifactId1 = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
 
@@ -172,8 +167,7 @@ class RulesResourceIT extends BaseIT {
         });
     }
 
-    @RegistryServiceTest
-    void testRulesDeletedWithArtifact(RegistryService service) throws Exception {
+    void testRulesDeletedWithArtifact(RegistryRestClient service) throws Exception {
         String artifactId1 = TestUtils.generateArtifactId();
         String artifactDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}";
 
@@ -196,11 +190,12 @@ class RulesResourceIT extends BaseIT {
         assertThat(0, is(service.listArtifacts().size()));
 
         TestUtils.assertWebError(404, () -> service.listArtifactRules(artifactId1));
-        TestUtils.assertWebError(404, () -> service.getArtifactRuleConfig(RuleType.VALIDITY, artifactId1));
+        TestUtils.assertWebError(404, () -> service.getArtifactRuleConfig(artifactId1, RuleType.VALIDITY));
     }
 
     @AfterEach
-    void clearRules(RegistryService service) throws Exception {
+    void clearRules(RegistryRestClient service) throws Exception {
+        LOGGER.info("Removing all global rules");
         service.deleteAllGlobalRules();
         TestUtils.retry(() -> {
             List<RuleType> rules = service.listGlobalRules();


### PR DESCRIPTION
fixes "deleteGlobalRules" for infinispan storage, it was using the default "clear" method which indicates to not be used in production, actually it produced a race sometimes in tests making RulesResourceIT to fail.

This PR also changes RulesResourceIT tests to use the new rest client