### PR TITLE
apicurio registry events - first version

### DIFF
--- a/app/src/main/java/io/apicurio/registry/events/EventsService.java
+++ b/app/src/main/java/io/apicurio/registry/events/EventsService.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.events;
+
+import java.util.UUID;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.core.MediaType;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+
+/**
+ * @author Fabian Martinez
+ */
+@ApplicationScoped
+public class EventsService {
+
+    private static final Logger log = LoggerFactory.getLogger(EventsService.class);
+
+    private ObjectMapper mapper;
+    private HttpClient httpClient;
+
+    @Inject
+    SinksConfiguration sinksConfiguration;
+
+    @Inject
+    Vertx vertx;
+
+    @SuppressWarnings("deprecated")
+    public void triggerEvent(RegistryEventType type, Object data) {
+
+        if (data == null) {
+            return;
+        }
+
+        if (sinksConfiguration.httpSinks().isEmpty()) {
+            return;
+        }
+
+        log.info("Firing event " + type.name());
+
+        Buffer buffer;
+        try {
+            buffer = Buffer.buffer(getMapper().writeValueAsBytes(data));
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing event data", e);
+            return;
+        }
+
+        for (HttpSinkConfiguration httpSink : sinksConfiguration.httpSinks()) {
+            sendEventHttp(type, httpSink, buffer);
+        }
+
+    }
+
+    private void sendEventHttp(RegistryEventType type, HttpSinkConfiguration httpSink, Buffer data) {
+        try {
+            log.debug("Sending event to sink "+httpSink.getName());
+            getHttpClient()
+                .postAbs(httpSink.getEndpoint())
+                .putHeader("ce-id", UUID.randomUUID().toString())
+                .putHeader("ce-specversion", "1.0")
+                .putHeader("ce-source", "apicurio-registry")
+                .putHeader("ce-type", type.cloudEventType())
+                .putHeader("content-type", MediaType.APPLICATION_JSON)
+                .exceptionHandler(ex -> {
+                    log.error("Error sending event to " + httpSink.getEndpoint(), ex);
+                })
+                .handler(res -> {
+                    //do nothing
+                })
+                .end(data);
+        } catch (Exception e) {
+            log.error("Error sending http event", e);
+        }
+    }
+
+    private synchronized HttpClient getHttpClient() {
+        if (httpClient == null) {
+            httpClient = vertx.createHttpClient(new HttpClientOptions()
+                .setConnectTimeout(15 * 1000));
+        }
+        return httpClient;
+    }
+
+    private synchronized ObjectMapper getMapper() {
+        if (mapper == null) {
+            mapper = new ObjectMapper();
+            mapper.setSerializationInclusion(Include.NON_NULL);
+        }
+        return mapper;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/events/EventsServiceConfiguration.java
+++ b/app/src/main/java/io/apicurio/registry/events/EventsServiceConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.events;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.apicurio.registry.utils.RegistryProperties;
+
+/**
+ * @author Fabian Martinez
+ */
+@ApplicationScoped
+public class EventsServiceConfiguration {
+
+    @ConfigProperty(name = "registry.events.ksink")
+    Optional<String> ksink;
+
+    @Produces
+    public SinksConfiguration sinkConfig(@RegistryProperties(value = {"registry.events.sink"}) Properties properties) {
+        List<HttpSinkConfiguration> httpSinks = properties.stringPropertyNames().stream()
+            .map(key -> new HttpSinkConfiguration(key, properties.getProperty(key)))
+            .collect(Collectors.toList());
+        if (ksink.isPresent()) {
+            httpSinks.add(new HttpSinkConfiguration("k_sink", ksink.get()));
+        }
+        return new SinksConfiguration(httpSinks);
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/events/HttpSinkConfiguration.java
+++ b/app/src/main/java/io/apicurio/registry/events/HttpSinkConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.events;
+
+/**
+ * @author Fabian Martinez
+ */
+public class HttpSinkConfiguration {
+    
+    private String name;
+    private String endpoint;
+
+    public HttpSinkConfiguration(String name, String endpoint) {
+        this.name = name;
+        this.endpoint = endpoint;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/events/RegistryEventType.java
+++ b/app/src/main/java/io/apicurio/registry/events/RegistryEventType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.events;
+
+/**
+ * @author Fabian Martinez
+ */
+public enum RegistryEventType {
+
+    ARTIFACT_CREATED,
+    ARTIFACT_VERSION_CREATED,
+    ARTIFACT_UPDATED;
+
+    private String cloudEventType;
+
+    private RegistryEventType() {
+        this.cloudEventType = "io.apicurio.registry."+this.name().toLowerCase().replace("_", "-");
+    }
+
+    public String cloudEventType() {
+        return this.cloudEventType;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/events/SinksConfiguration.java
+++ b/app/src/main/java/io/apicurio/registry/events/SinksConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.events;
+
+import java.util.List;
+
+/**
+ * @author Fabian Martinez
+ */
+public class SinksConfiguration {
+
+    private List<HttpSinkConfiguration> httpSinks;
+
+    public SinksConfiguration(List<HttpSinkConfiguration> httpSinks) {
+        this.httpSinks = httpSinks;
+    }
+
+    public List<HttpSinkConfiguration> httpSinks() {
+        return this.httpSinks;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/rest/ArtifactsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ArtifactsResourceImpl.java
@@ -52,6 +52,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.events.EventsService;
+import io.apicurio.registry.events.RegistryEventType;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.metrics.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.ResponseTimeoutReadinessCheck;
@@ -120,6 +122,9 @@ public class ArtifactsResourceImpl implements ArtifactsResource, Headers {
     @Inject
     @Current
     SearchClient searchClient;
+
+    @Inject
+    EventsService eventsService;
 
     private static final int GET_ARTIFACT_IDS_LIMIT = 10000;
 
@@ -339,7 +344,8 @@ public class ArtifactsResourceImpl implements ArtifactsResource, Headers {
                             handleIfExists(xRegistryArtifactType, xRegistryArtifactId, ifExists, finalContent, ct) :
                             CompletableFuture.completedFuture(DtoUtil.dtoToMetaData(finalArtifactId, artifactType, amd))
                     )
-                    .thenCompose(amdd -> indexArtifact(finalArtifactId, finalContent, amdd));
+                    .thenCompose(amdd -> indexArtifact(finalArtifactId, finalContent, amdd))
+                    .whenComplete((meta, e) -> eventsService.triggerEvent(RegistryEventType.ARTIFACT_CREATED, meta));
         } catch (ArtifactAlreadyExistsException ex) {
             return handleIfExists(xRegistryArtifactType, xRegistryArtifactId, ifExists, content, ct)
                     .thenCompose(amdd -> indexArtifact(xRegistryArtifactId, finalContent, amdd));
@@ -386,7 +392,9 @@ public class ArtifactsResourceImpl implements ArtifactsResource, Headers {
 
         ArtifactType artifactType = determineArtifactType(content, xRegistryArtifactType, ct);
         rulesService.applyRules(artifactId, artifactType, content, RuleApplicationType.UPDATE);
-        return storage.updateArtifact(artifactId, artifactType, content).thenApply(dto -> DtoUtil.dtoToMetaData(artifactId, artifactType, dto));
+        return storage.updateArtifact(artifactId, artifactType, content)
+            .thenApply(dto -> DtoUtil.dtoToMetaData(artifactId, artifactType, dto))
+            .whenComplete((meta, e) -> eventsService.triggerEvent(RegistryEventType.ARTIFACT_UPDATED, meta));
     }
 
     /**
@@ -439,7 +447,8 @@ public class ArtifactsResourceImpl implements ArtifactsResource, Headers {
         final ContentHandle finalContent = content;
         return storage.updateArtifact(artifactId, artifactType, content)
                 .thenCompose(amdd -> indexArtifact(artifactId, finalContent, DtoUtil.dtoToMetaData(artifactId, artifactType, amdd)))
-                .thenApply(amd -> DtoUtil.dtoToVersionMetaData(artifactId, artifactType, amd));
+                .thenApply(amd -> DtoUtil.dtoToVersionMetaData(artifactId, artifactType, amd))
+                .whenComplete((meta, e) -> eventsService.triggerEvent(RegistryEventType.ARTIFACT_VERSION_CREATED, meta));
     }
 
     /**

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -143,3 +143,10 @@ mp.openapi.servers=/api
 %prod.registry.metrics.ResponseTimeoutReadinessCheck.counterResetWindowDurationSec=${READINESS_COUNTER_RESET:30}
 %prod.registry.metrics.ResponseTimeoutReadinessCheck.statusResetWindowDurationSec=${READINESS_STATUS_RESET:60}
 %prod.registry.metrics.ResponseTimeoutReadinessCheck.timeoutSec=${READINESS_TIMEOUT:20}
+
+# Events
+# example
+# %dev.registry.events.sink.eventdisplay=http://localhost:8888/
+# compatibility with knative sink binding
+%dev.registry.events.ksink=${K_SINK:}
+%prod.registry.events.ksink=${K_SINK:}


### PR DESCRIPTION
Implementation of registry events, it allows to configure a set of HTTP endpoints in which apicurio registry will post it's internal events following CloudEvents spec.
I tried to make it as simple as possible and avoided to include new dependencies