### PR TITLE
Added some additional improvements to the new RuleViolationException with causes

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiServiceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ibmcompat/api/impl/ApiServiceImpl.java
@@ -16,8 +16,28 @@
  */
 package io.apicurio.registry.ibmcompat.api.impl;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.Response;
+
+import org.jetbrains.annotations.Nullable;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.ibmcompat.api.ApiService;
 import io.apicurio.registry.ibmcompat.model.EnabledModification;
@@ -34,7 +54,6 @@ import io.apicurio.registry.ibmcompat.model.StateModification;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.rules.RuleApplicationType;
 import io.apicurio.registry.rules.RulesService;
-import io.apicurio.registry.rules.validity.InvalidContentException;
 import io.apicurio.registry.storage.ArtifactAlreadyExistsException;
 import io.apicurio.registry.storage.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
@@ -47,22 +66,6 @@ import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.Current;
 import io.apicurio.registry.util.ArtifactIdGenerator;
-import org.jetbrains.annotations.Nullable;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
 
 /**
  * @author Ales Justin
@@ -281,7 +284,7 @@ public class ApiServiceImpl implements ApiService {
         try {
             verifiedContent = new ObjectMapper().writeValueAsString(content.content());
         } catch (JsonProcessingException e) {
-            throw new InvalidContentException(e);
+            throw new BadRequestException(e);
         }
         response.resume(Response.ok().entity(verifiedContent).build());
     }

--- a/app/src/main/java/io/apicurio/registry/rules/RuleViolationException.java
+++ b/app/src/main/java/io/apicurio/registry/rules/RuleViolationException.java
@@ -16,13 +16,14 @@
 
 package io.apicurio.registry.rules;
 
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
 import io.apicurio.registry.rest.beans.RuleViolationCause;
 import io.apicurio.registry.types.RegistryException;
 import io.apicurio.registry.types.RuleType;
 import lombok.Getter;
-
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * Exception thrown when a configured rule is violated, rejecting an artifact content
@@ -44,10 +45,26 @@ public class RuleViolationException extends RegistryException {
 
     /**
      * Constructor.
-     * @param ruleConfiguration is optional, can be null
+     * @param message
+     * @param ruleType
+     * @param ruleConfiguration
+     * @param cause
      */
-    public RuleViolationException(String message, RuleType ruleType, String ruleConfiguration,
-                                  Set<RuleViolationCause> causes) {
+    public RuleViolationException(String message, RuleType ruleType, String ruleConfiguration, Throwable cause) {
+        super(message, cause);
+        this.ruleType = ruleType;
+        this.ruleConfiguration = Optional.ofNullable(ruleConfiguration);
+        this.causes = new HashSet<>();
+    }
+
+    /**
+     * Constructor.
+     * @param message
+     * @param ruleType
+     * @param ruleConfiguration
+     * @param causes
+     */
+    public RuleViolationException(String message, RuleType ruleType, String ruleConfiguration, Set<RuleViolationCause> causes) {
         super(message);
         this.ruleType = ruleType;
         this.ruleConfiguration = Optional.ofNullable(ruleConfiguration);
@@ -56,10 +73,14 @@ public class RuleViolationException extends RegistryException {
 
     /**
      * Constructor.
-     * @param ruleConfiguration is optional, can be null
+     * @param message
+     * @param ruleType
+     * @param ruleConfiguration
+     * @param causes
+     * @param cause
      */
     public RuleViolationException(String message, RuleType ruleType, String ruleConfiguration,
-                                  Set<RuleViolationCause> causes, Throwable cause) {
+            Set<RuleViolationCause> causes, Throwable cause) {
         super(message, cause);
         this.ruleType = ruleType;
         this.ruleConfiguration = Optional.ofNullable(ruleConfiguration);

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/AvroCompatibilityChecker.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/AvroCompatibilityChecker.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static io.apicurio.registry.rules.compatibility.CompatibilityExecutionResult.empty;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -46,7 +45,7 @@ public class AvroCompatibilityChecker implements CompatibilityChecker {
         SchemaValidator schemaValidator = validatorFor(compatibilityLevel);
 
         if (schemaValidator == null) {
-            return empty(true);
+            return CompatibilityExecutionResult.compatible();
         }
 
         List<Schema> existingSchemas = existingSchemaStrings.stream().map(s -> new Schema.Parser().parse(s)).collect(Collectors.toList());
@@ -55,9 +54,9 @@ public class AvroCompatibilityChecker implements CompatibilityChecker {
 
         try {
             schemaValidator.validate(toValidate, existingSchemas);
-            return empty(true);
+            return CompatibilityExecutionResult.compatible();
         } catch (SchemaValidationException e) {
-            return empty(false);
+            return CompatibilityExecutionResult.incompatible(e);
         }
     }
 

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityDifference.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityDifference.java
@@ -14,28 +14,21 @@
  * limitations under the License.
  */
 
-package io.apicurio.registry.rules.validity;
+package io.apicurio.registry.rules.compatibility;
 
-import io.apicurio.registry.types.RegistryException;
+import io.apicurio.registry.rest.beans.RuleViolationCause;
 
 /**
- * Indicates that the artifact content was invalid.
+ * Represents a single compatibility difference.  These are generated when doing compatibility checking 
+ * between two versions of an artifact.  A non-zero collection of these indicates a compatibility violation.
+ * 
  * @author eric.wittmann@gmail.com
  */
-public class InvalidContentException extends RegistryException {
+public interface CompatibilityDifference {
 
-    private static final long serialVersionUID = 2546589404804650539L;
-
-    public InvalidContentException(String message) {
-        super(message);
-    }
-
-    public InvalidContentException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public InvalidContentException(Throwable cause) {
-        super(cause);
-    }
-
+    /**
+     * Converts the difference into a rule violation cause.
+     */
+    public RuleViolationCause asRuleViolationCause();
+    
 }

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityExecutionResult.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityExecutionResult.java
@@ -1,7 +1,5 @@
 package io.apicurio.registry.rules.compatibility;
 
-import io.apicurio.registry.rules.compatibility.jsonschema.diff.Difference;
-
 import java.util.Collections;
 import java.util.Set;
 
@@ -9,37 +7,54 @@ import java.util.Set;
  * Created by aohana
  *
  * Holds the result for a compatibility check
- * isCompatible - whether the compatibility check is successful or not
  * incompatibleDifferences - will contain values in case the schema type has difference type information in case the
  * new schema is not compatible (only JSON schema as of now)
  */
 public class CompatibilityExecutionResult {
 
-    private boolean isCompatible;
-    private Set<Difference> incompatibleDifferences;
+    private final Set<CompatibilityDifference> incompatibleDifferences;
 
-    public CompatibilityExecutionResult(boolean isCompatible, Set<Difference> incompatibleDifferences) {
-        this.isCompatible = isCompatible;
+    private CompatibilityExecutionResult(Set<CompatibilityDifference> incompatibleDifferences) {
         this.incompatibleDifferences = incompatibleDifferences;
     }
 
     public boolean isCompatible() {
-        return isCompatible;
+        return incompatibleDifferences == null || incompatibleDifferences.isEmpty();
     }
 
-    public void setCompatible(boolean compatible) {
-        isCompatible = compatible;
-    }
-
-    public Set<Difference> getIncompatibleDifferences() {
+    public Set<CompatibilityDifference> getIncompatibleDifferences() {
         return incompatibleDifferences;
     }
 
-    public void setIncompatibleDifferences(Set<Difference> incompatibleDifferences) {
-        this.incompatibleDifferences = incompatibleDifferences;
+    public static CompatibilityExecutionResult compatible() {
+        return new CompatibilityExecutionResult(Collections.emptySet());
+    }
+    
+    /**
+     * Creates an instance of {@link CompatibilityExecutionResult} that represents "incompatible" results.  This
+     * variant takes the set of {@link CompatibilityDifference}s as the basis of the result.  A non-zero number
+     * of differences indicates incompatibility.
+     */
+    public static CompatibilityExecutionResult incompatible(Set<CompatibilityDifference> incompatibleDifferences) {
+        return new CompatibilityExecutionResult(incompatibleDifferences);
     }
 
-    public static CompatibilityExecutionResult empty(boolean isCompatible) {
-        return new CompatibilityExecutionResult(isCompatible, Collections.emptySet());
+    /**
+     * Creates an instance of {@link CompatibilityExecutionResult} that represents "incompatible" results.  This
+     * variant takes an Exception and converts that into a set of differences.  Ideally this would never be used,
+     * but some artifact types do not have the level of granularity to report individual differences.
+     */
+    public static CompatibilityExecutionResult incompatible(Exception e) {
+        CompatibilityDifference diff = new GenericCompatibilityDifference(e);
+        return new CompatibilityExecutionResult(Collections.singleton(diff));
+    }
+
+    /**
+     * Creates an instance of {@link CompatibilityExecutionResult} that represents "incompatible" results.  This
+     * variant takes a message.
+     */
+    public static CompatibilityExecutionResult incompatible(String message) {
+        CompatibilityDifference diff = new GenericCompatibilityDifference(message);
+        return new CompatibilityExecutionResult(Collections.singleton(diff));
     }
 }

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityRuleExecutor.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityRuleExecutor.java
@@ -16,26 +16,26 @@
 
 package io.apicurio.registry.rules.compatibility;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.rest.beans.RuleViolationCause;
 import io.apicurio.registry.rules.RuleContext;
 import io.apicurio.registry.rules.RuleExecutor;
 import io.apicurio.registry.rules.RuleViolationException;
-import io.apicurio.registry.rules.compatibility.jsonschema.diff.Difference;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 
 /**
  * Rule executor for the "Compatibility" rule.  The Compatibility Rule is responsible
@@ -74,15 +74,17 @@ public class CompatibilityRuleExecutor implements RuleExecutor {
         }
     }
 
-    private Set<RuleViolationCause> transformCompatibilityDiffs(Set<Difference> incompatibleDifferences) {
-
-        if(!incompatibleDifferences.isEmpty()) {
+    /**
+     * Convert the set of compatibility differences into a collection of rule violation causes
+     * for return to the user.
+     * @param differences
+     */
+    private Set<RuleViolationCause> transformCompatibilityDiffs(Set<CompatibilityDifference> differences) {
+        if (!differences.isEmpty()) {
             Set<RuleViolationCause> res = new HashSet<>();
-
-            for (Difference diff : incompatibleDifferences) {
-                res.add(new RuleViolationCause(diff.getDiffType().getDescription(), diff.getPathUpdated()));
+            for (CompatibilityDifference diff : differences) {
+                res.add(diff.asRuleViolationCause());
             }
-
             return res;
         } else {
             return Collections.emptySet();

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/GenericCompatibilityDifference.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/GenericCompatibilityDifference.java
@@ -14,45 +14,42 @@
  * limitations under the License.
  */
 
-package io.apicurio.registry.rules.compatibility.jsonschema.diff;
+package io.apicurio.registry.rules.compatibility;
 
 import io.apicurio.registry.rest.beans.RuleViolationCause;
-import io.apicurio.registry.rules.compatibility.CompatibilityDifference;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.ToString;
 
 /**
- * @author Jakub Senko <jsenko@redhat.com>
+ * @author eric.wittmann@gmail.com
  */
-@Builder
-@Getter
-@EqualsAndHashCode
-@ToString
-public class Difference implements CompatibilityDifference {
+public class GenericCompatibilityDifference implements CompatibilityDifference {
 
-    @NonNull
-    private final DiffType diffType;
+    private final String message;
+    
+    /**
+     * Constructor.
+     * @param e
+     */
+    public GenericCompatibilityDifference(Exception e) {
+        this.message = e.getMessage();
+    }
 
-    @NonNull
-    private final String pathOriginal;
-
-    @NonNull
-    private final String pathUpdated;
-
-    @NonNull
-    private final String subSchemaOriginal;
-
-    @NonNull
-    private final String subSchemaUpdated;
-
+    /**
+     * Constructor.
+     * @param message
+     */
+    public GenericCompatibilityDifference(String message) {
+        this.message = message;
+    }
+    
     /**
      * @see io.apicurio.registry.rules.compatibility.CompatibilityDifference#asRuleViolationCause()
      */
     @Override
     public RuleViolationCause asRuleViolationCause() {
-        return new RuleViolationCause(getDiffType().getDescription(), getPathUpdated());
+        RuleViolationCause cause = new RuleViolationCause();
+        cause.setDescription(message);
+        cause.setContext("/");
+        return cause;
     }
+
 }

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/JsonSchemaCompatibilityChecker.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/JsonSchemaCompatibilityChecker.java
@@ -16,23 +16,24 @@
 
 package io.apicurio.registry.rules.compatibility;
 
-import com.google.common.collect.ImmutableSet;
-import io.apicurio.registry.rules.compatibility.jsonschema.JsonSchemaDiffLibrary;
-import io.apicurio.registry.rules.compatibility.jsonschema.diff.Difference;
+import static java.util.Objects.requireNonNull;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import static java.util.Objects.requireNonNull;
+import com.google.common.collect.ImmutableSet;
+
+import io.apicurio.registry.rules.compatibility.jsonschema.JsonSchemaDiffLibrary;
+import io.apicurio.registry.rules.compatibility.jsonschema.diff.Difference;
 
 /**
  * @author Ales Justin
  * @author Jonathan Halliday
  * @author Jakub Senko <jsenko@redhat.com>
  */
-public class JsonCompatibilityChecker implements CompatibilityChecker { // TODO rename to JsonSchemaCompatibilityChecker
+public class JsonSchemaCompatibilityChecker implements CompatibilityChecker {
 
     /**
      * @see CompatibilityChecker#isCompatibleWith(io.apicurio.registry.rules.compatibility.CompatibilityLevel, java.util.List, java.lang.String)
@@ -44,34 +45,35 @@ public class JsonCompatibilityChecker implements CompatibilityChecker { // TODO 
         requireNonNull(proposedSchema, "proposedSchema MUST NOT be null");
 
         if (existingSchemas.isEmpty()) {
-            return new CompatibilityExecutionResult(true, Collections.emptySet());
+            return CompatibilityExecutionResult.compatible();
         }
         // TODO There is more information available on which differences are causing an issue. Make it visible to users.
-        Set<Difference> incompatibleDiffs;
+        Set<Difference> incompatibleDiffs = new HashSet<Difference>();
         switch (compatibilityLevel) {
             case BACKWARD:
                 incompatibleDiffs = JsonSchemaDiffLibrary.getIncompatibleDifferences(existingSchemas.get(existingSchemas.size() - 1), proposedSchema);
-                return new CompatibilityExecutionResult(incompatibleDiffs.isEmpty(), incompatibleDiffs);
-            case BACKWARD_TRANSITIVE: {
+                break;
+            case BACKWARD_TRANSITIVE:
                 incompatibleDiffs = transitively(existingSchemas, proposedSchema);
-                return new CompatibilityExecutionResult(incompatibleDiffs.isEmpty(), incompatibleDiffs);
-            }
+                break;
             case FORWARD:
                 incompatibleDiffs = JsonSchemaDiffLibrary.getIncompatibleDifferences(proposedSchema, existingSchemas.get(existingSchemas.size() - 1));
-                return new CompatibilityExecutionResult(incompatibleDiffs.isEmpty(), incompatibleDiffs);
+                break;
             case FORWARD_TRANSITIVE:
                 incompatibleDiffs = transitively(existingSchemas, proposedSchema);
-                return new CompatibilityExecutionResult(incompatibleDiffs.isEmpty(), incompatibleDiffs);
+                break;
             case FULL:
                 incompatibleDiffs = ImmutableSet.<Difference>builder().addAll(JsonSchemaDiffLibrary.getIncompatibleDifferences(existingSchemas.get(existingSchemas.size() - 1), proposedSchema)).addAll(
                         JsonSchemaDiffLibrary.getIncompatibleDifferences(proposedSchema, existingSchemas.get(existingSchemas.size() - 1))).build();
-                return new CompatibilityExecutionResult(incompatibleDiffs.isEmpty(), incompatibleDiffs);
+                break;
             case FULL_TRANSITIVE:
                 incompatibleDiffs = ImmutableSet.<Difference>builder().addAll(transitively(existingSchemas, proposedSchema)).addAll(transitively(existingSchemas, proposedSchema)).build();
-                return new CompatibilityExecutionResult(incompatibleDiffs.isEmpty(), incompatibleDiffs);
-            default:
-                return new CompatibilityExecutionResult(true, Collections.emptySet());
+                break;
+            case NONE:
+                break;
         }
+        Set<CompatibilityDifference> diffs = incompatibleDiffs.stream().map(diff -> (CompatibilityDifference) diff).collect(Collectors.toSet());
+        return CompatibilityExecutionResult.incompatible(diffs);
     }
 
     private Set<Difference> transitively(List<String> existingSchemas, String proposedSchema) {

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/NoopCompatibilityChecker.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/NoopCompatibilityChecker.java
@@ -18,7 +18,6 @@ package io.apicurio.registry.rules.compatibility;
 
 import java.util.List;
 
-import static io.apicurio.registry.rules.compatibility.CompatibilityExecutionResult.empty;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -35,6 +34,6 @@ public class NoopCompatibilityChecker implements CompatibilityChecker {
         requireNonNull(compatibilityLevel, "compatibilityLevel MUST NOT be null");
         requireNonNull(existingSchemas, "existingSchemas MUST NOT be null");
         requireNonNull(proposedSchema, "proposedSchema MUST NOT be null");
-        return empty(true);
+        return CompatibilityExecutionResult.compatible();
     }
 }

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/ProtobufCompatibilityChecker.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/ProtobufCompatibilityChecker.java
@@ -16,10 +16,9 @@
 
 package io.apicurio.registry.rules.compatibility;
 
-import java.util.List;
-
-import static io.apicurio.registry.rules.compatibility.CompatibilityExecutionResult.empty;
 import static java.util.Objects.requireNonNull;
+
+import java.util.List;
 
 /**
  * @author Ales Justin
@@ -36,30 +35,38 @@ public class ProtobufCompatibilityChecker implements CompatibilityChecker {
         requireNonNull(proposedSchema, "proposedSchema MUST NOT be null");
 
         if (existingSchemas.isEmpty()) {
-            return empty(true);
+            return CompatibilityExecutionResult.compatible();
         }
         switch (compatibilityLevel) {
             case BACKWARD: {
                 ProtobufFile fileBefore = new ProtobufFile(existingSchemas.get(existingSchemas.size() - 1));
                 ProtobufFile fileAfter = new ProtobufFile(proposedSchema);
                 ProtobufCompatibilityCheckerImpl checker = new ProtobufCompatibilityCheckerImpl(fileBefore, fileAfter);
-                return empty(checker.validate());
+                if (checker.validate()) {
+                    return CompatibilityExecutionResult.compatible();
+                } else {
+                    return CompatibilityExecutionResult.incompatible("The new version of the protobuf artifact is not backward compatible.");
+                }
             }
             case BACKWARD_TRANSITIVE:
                 ProtobufFile fileAfter = new ProtobufFile(proposedSchema);
                 for (String existing : existingSchemas) {
                     ProtobufFile fileBefore = new ProtobufFile(existing);
                     ProtobufCompatibilityCheckerImpl checker = new ProtobufCompatibilityCheckerImpl(fileBefore, fileAfter);
-                    return empty(!checker.validate());
+                    if (checker.validate()) {
+                        return CompatibilityExecutionResult.compatible();
+                    } else {
+                        return CompatibilityExecutionResult.incompatible("The new version of the protobuf artifact is not backward compatible.");
+                    }
                 }
-                return empty(true);
+                return CompatibilityExecutionResult.compatible();
             case FORWARD:
             case FORWARD_TRANSITIVE:
             case FULL:
             case FULL_TRANSITIVE:
                 throw new IllegalStateException("Compatibility level " + compatibilityLevel + " not supported for Protobuf schemas");
             default:
-                return empty(true);
+                return CompatibilityExecutionResult.compatible();
         }
     }
 }

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/ProtobufFdCompatibilityChecker.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/ProtobufFdCompatibilityChecker.java
@@ -21,7 +21,6 @@ import io.apicurio.registry.content.ContentHandle;
 
 import java.util.List;
 
-import static io.apicurio.registry.rules.compatibility.CompatibilityExecutionResult.empty;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -35,10 +34,10 @@ public class ProtobufFdCompatibilityChecker implements CompatibilityChecker {
         requireNonNull(proposedArtifact, "proposedSchema MUST NOT be null");
         try {
             Serde.Schema.parseFrom(proposedArtifact.bytes());
-            return empty(true);
-        } catch (Exception ignore) {
+            return CompatibilityExecutionResult.compatible();
+        } catch (Exception error) {
+            return CompatibilityExecutionResult.incompatible(error);
         }
-        return empty(false);
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonSchemaDiffLibrary.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonSchemaDiffLibrary.java
@@ -16,18 +16,20 @@
 
 package io.apicurio.registry.rules.compatibility.jsonschema;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import io.apicurio.registry.rules.compatibility.jsonschema.diff.DiffContext;
-import io.apicurio.registry.rules.compatibility.jsonschema.diff.Difference;
-import io.apicurio.registry.rules.compatibility.jsonschema.diff.SchemaDiffVisitor;
+import static io.apicurio.registry.rules.compatibility.jsonschema.JsonUtil.MAPPER;
+import static io.apicurio.registry.rules.compatibility.jsonschema.wrapper.WrapUtil.wrap;
+
+import java.util.Set;
+
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 
-import java.util.Set;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
-import static io.apicurio.registry.rules.compatibility.jsonschema.JsonUtil.MAPPER;
-import static io.apicurio.registry.rules.compatibility.jsonschema.wrapper.WrapUtil.wrap;
+import io.apicurio.registry.rules.compatibility.jsonschema.diff.DiffContext;
+import io.apicurio.registry.rules.compatibility.jsonschema.diff.Difference;
+import io.apicurio.registry.rules.compatibility.jsonschema.diff.SchemaDiffVisitor;
 
 /**
  * @author Jakub Senko <jsenko@redhat.com>

--- a/app/src/main/java/io/apicurio/registry/rules/validity/AvroContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/AvroContentValidator.java
@@ -16,10 +16,13 @@
 
 package io.apicurio.registry.rules.validity;
 
-import io.apicurio.registry.content.ContentHandle;
+import javax.enterprise.context.ApplicationScoped;
+
 import org.apache.avro.Schema;
 
-import javax.enterprise.context.ApplicationScoped;
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
+import io.apicurio.registry.types.RuleType;
 
 /**
  * A content validator implementation for the Avro content type.
@@ -38,13 +41,13 @@ public class AvroContentValidator implements ContentValidator {
      * @see io.apicurio.registry.rules.validity.ContentValidator#validate(io.apicurio.registry.rules.validity.ValidityLevel, ContentHandle)
      */
     @Override
-    public void validate(ValidityLevel level, ContentHandle artifactContent) throws InvalidContentException {
+    public void validate(ValidityLevel level, ContentHandle artifactContent) throws RuleViolationException {
         if (level == ValidityLevel.SYNTAX_ONLY || level == ValidityLevel.FULL) {
             try {
                 Schema.Parser parser = new Schema.Parser();
                 parser.parse(artifactContent.content());
             } catch (Exception e) {
-                throw new InvalidContentException("Syntax violation for Avro artifact.", e);
+                throw new RuleViolationException("Syntax violation for Avro artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
     }

--- a/app/src/main/java/io/apicurio/registry/rules/validity/ContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/ContentValidator.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.rules.validity;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
 
 /**
  * Validates content.  Syntax and semantic validations are possible based on configuration.  An
@@ -31,8 +32,8 @@ public interface ContentValidator {
      *
      * @param level           the level
      * @param artifactContent the content
-     * @throws InvalidContentException for any invalid content
+     * @throws RuleViolationException for any invalid content
      */
-    void validate(ValidityLevel level, ContentHandle artifactContent) throws InvalidContentException;
+    public void validate(ValidityLevel level, ContentHandle artifactContent) throws RuleViolationException;
 
 }

--- a/app/src/main/java/io/apicurio/registry/rules/validity/GraphQLContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/GraphQLContentValidator.java
@@ -20,6 +20,8 @@ import javax.enterprise.context.ApplicationScoped;
 
 import graphql.schema.idl.SchemaParser;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
+import io.apicurio.registry.types.RuleType;
 
 /**
  * A content validator implementation for the GraphQL content type.
@@ -38,12 +40,12 @@ public class GraphQLContentValidator implements ContentValidator {
      * @see io.apicurio.registry.rules.validity.ContentValidator#validate(io.apicurio.registry.rules.validity.ValidityLevel, ContentHandle)
      */
     @Override
-    public void validate(ValidityLevel level, ContentHandle content) throws InvalidContentException {
+    public void validate(ValidityLevel level, ContentHandle content) throws RuleViolationException {
         if (level == ValidityLevel.SYNTAX_ONLY || level == ValidityLevel.FULL) {
             try {
                 new SchemaParser().parse(content.content());
             } catch (Exception e) {
-                throw new InvalidContentException("Syntax violation for GraphQL artifact.", e);
+                throw new RuleViolationException("Syntax violation for GraphQL artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
     }

--- a/app/src/main/java/io/apicurio/registry/rules/validity/JsonSchemaContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/JsonSchemaContentValidator.java
@@ -24,6 +24,8 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
+import io.apicurio.registry.types.RuleType;
 
 /**
  * A content validator implementation for the JsonSchema content type.
@@ -44,7 +46,7 @@ public class JsonSchemaContentValidator implements ContentValidator {
      * @see io.apicurio.registry.rules.validity.ContentValidator#validate(io.apicurio.registry.rules.validity.ValidityLevel, ContentHandle)
      */
     @Override
-    public void validate(ValidityLevel level, ContentHandle artifactContent) throws InvalidContentException {
+    public void validate(ValidityLevel level, ContentHandle artifactContent) throws RuleViolationException {
         if (level == ValidityLevel.SYNTAX_ONLY || level == ValidityLevel.FULL) {
             try {
                 JsonNode node = objectMapper.readTree(artifactContent.bytes());
@@ -53,7 +55,7 @@ public class JsonSchemaContentValidator implements ContentValidator {
                     factory.getSchema(node);
                 }
             } catch (Exception e) {
-                throw new InvalidContentException("Syntax violation for JSON Schema artifact.", e);
+                throw new RuleViolationException("Syntax violation for JSON Schema artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
     }

--- a/app/src/main/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidator.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
+import io.apicurio.registry.types.RuleType;
 
 /**
  * A content validator implementation for the Kafka Connect schema content type.
@@ -57,13 +59,13 @@ public class KafkaConnectContentValidator implements ContentValidator {
      * @see io.apicurio.registry.rules.validity.ContentValidator#validate(io.apicurio.registry.rules.validity.ValidityLevel, io.apicurio.registry.content.ContentHandle)
      */
     @Override
-    public void validate(ValidityLevel level, ContentHandle artifactContent) throws InvalidContentException {
+    public void validate(ValidityLevel level, ContentHandle artifactContent) throws RuleViolationException {
         if (level == ValidityLevel.SYNTAX_ONLY || level == ValidityLevel.FULL) {
             try {
                 JsonNode jsonNode = mapper.readTree(artifactContent.content());
                 jsonConverter.asConnectSchema(jsonNode);
             } catch (Exception e) {
-                throw new InvalidContentException("Syntax violation for Kafka Connect Schema artifact.", e);
+                throw new RuleViolationException("Syntax violation for Kafka Connect Schema artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
     }

--- a/app/src/main/java/io/apicurio/registry/rules/validity/ProtobufContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/ProtobufContentValidator.java
@@ -16,10 +16,12 @@
 
 package io.apicurio.registry.rules.validity;
 
-import io.apicurio.registry.content.ContentHandle;
-import io.apicurio.registry.rules.compatibility.ProtobufFile;
-
 import javax.enterprise.context.ApplicationScoped;
+
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
+import io.apicurio.registry.rules.compatibility.ProtobufFile;
+import io.apicurio.registry.types.RuleType;
 
 /**
  * A content validator implementation for the Protobuf content type.
@@ -38,12 +40,12 @@ public class ProtobufContentValidator implements ContentValidator {
      * @see io.apicurio.registry.rules.validity.ContentValidator#validate(io.apicurio.registry.rules.validity.ValidityLevel, ContentHandle)
      */
     @Override
-    public void validate(ValidityLevel level, ContentHandle artifactContent) throws InvalidContentException {
+    public void validate(ValidityLevel level, ContentHandle artifactContent) throws RuleViolationException {
         if (level == ValidityLevel.SYNTAX_ONLY || level == ValidityLevel.FULL) {
             try {
                 ProtobufFile.toProtoFileElement(artifactContent.content());
             } catch (Exception e) {
-                throw new InvalidContentException("Syntax violation for Protobuf artifact.", e);
+                throw new RuleViolationException("Syntax violation for Protobuf artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
     }

--- a/app/src/main/java/io/apicurio/registry/rules/validity/ProtobufFdContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/ProtobufFdContentValidator.java
@@ -16,10 +16,12 @@
 
 package io.apicurio.registry.rules.validity;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import io.apicurio.registry.common.proto.Serde;
 import io.apicurio.registry.content.ContentHandle;
-
-import javax.enterprise.context.ApplicationScoped;
+import io.apicurio.registry.rules.RuleViolationException;
+import io.apicurio.registry.types.RuleType;
 
 /**
  * A content validator implementation for the Protobuf FD content type.
@@ -38,12 +40,12 @@ public class ProtobufFdContentValidator implements ContentValidator {
      * @see ContentValidator#validate(ValidityLevel, ContentHandle)
      */
     @Override
-    public void validate(ValidityLevel level, ContentHandle artifactContent) throws InvalidContentException {
+    public void validate(ValidityLevel level, ContentHandle artifactContent) throws RuleViolationException {
         if (level == ValidityLevel.FULL) {
             try {
                 Serde.Schema.parseFrom(artifactContent.bytes());
             } catch (Exception e) {
-                throw new InvalidContentException("Content violation for ProtobufFD artifact.", e);
+                throw new RuleViolationException("Syntax violation for ProtobufFD artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
     }

--- a/app/src/main/java/io/apicurio/registry/rules/validity/ValidityRuleExecutor.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/ValidityRuleExecutor.java
@@ -16,18 +16,15 @@
 
 package io.apicurio.registry.rules.validity;
 
-import com.google.common.collect.ImmutableSet;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import io.apicurio.registry.logging.Logged;
-import io.apicurio.registry.rest.beans.RuleViolationCause;
 import io.apicurio.registry.rules.RuleContext;
 import io.apicurio.registry.rules.RuleExecutor;
 import io.apicurio.registry.rules.RuleViolationException;
-import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -44,15 +41,10 @@ public class ValidityRuleExecutor implements RuleExecutor {
      */
     @Override
     public void execute(RuleContext context) throws RuleViolationException {
-        try {
-            ValidityLevel level = ValidityLevel.valueOf(context.getConfiguration());
-            ArtifactTypeUtilProvider provider = factory.getArtifactTypeProvider(context.getArtifactType());
-            ContentValidator validator = provider.getContentValidator();
-            validator.validate(level, context.getUpdatedContent());
-        } catch (InvalidContentException e) {
-            throw new RuleViolationException(e.getMessage(), RuleType.VALIDITY, context.getConfiguration(),
-                    ImmutableSet.of(new RuleViolationCause(e.getMessage(), context.getConfiguration())), e);
-        }
+        ValidityLevel level = ValidityLevel.valueOf(context.getConfiguration());
+        ArtifactTypeUtilProvider provider = factory.getArtifactTypeProvider(context.getArtifactType());
+        ContentValidator validator = provider.getContentValidator();
+        validator.validate(level, context.getUpdatedContent());
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/rules/validity/WsdlContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/WsdlContentValidator.java
@@ -23,6 +23,8 @@ import javax.enterprise.context.ApplicationScoped;
 import org.w3c.dom.Document;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
+import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.util.DocumentBuilderAccessor;
 import io.apicurio.registry.util.WSDLReaderAccessor;
 
@@ -43,7 +45,7 @@ public class WsdlContentValidator extends XmlContentValidator {
      *      io.apicurio.registry.content.ContentHandle)
      */
     @Override
-    public void validate(ValidityLevel level, ContentHandle artifactContent) throws InvalidContentException {
+    public void validate(ValidityLevel level, ContentHandle artifactContent) throws RuleViolationException {
         if (level == ValidityLevel.SYNTAX_ONLY || level == ValidityLevel.FULL) {
             try (InputStream stream = artifactContent.stream()) {
                 Document wsdlDoc = DocumentBuilderAccessor.getDocumentBuilder().parse(stream);
@@ -52,7 +54,7 @@ public class WsdlContentValidator extends XmlContentValidator {
                     WSDLReaderAccessor.getWSDLReader().readWSDL(null, wsdlDoc);
                 }
             } catch (Exception e) {
-                throw new InvalidContentException("Syntax violation for WSDL Schema artifact.", e);
+                throw new RuleViolationException("Syntax violation for WSDL Schema artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
     }

--- a/app/src/main/java/io/apicurio/registry/rules/validity/XmlContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/XmlContentValidator.java
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import javax.enterprise.context.ApplicationScoped;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
+import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.util.DocumentBuilderAccessor;
 
 /**
@@ -40,12 +42,12 @@ public class XmlContentValidator implements ContentValidator {
      *      io.apicurio.registry.content.ContentHandle)
      */
     @Override
-    public void validate(ValidityLevel level, ContentHandle artifactContent) throws InvalidContentException {
+    public void validate(ValidityLevel level, ContentHandle artifactContent) throws RuleViolationException {
         if (level == ValidityLevel.SYNTAX_ONLY || level == ValidityLevel.FULL) {
             try (InputStream stream = artifactContent.stream()) {
                 DocumentBuilderAccessor.getDocumentBuilder().parse(stream);
             } catch (Exception e) {
-                throw new InvalidContentException("Syntax violation for XML Schema artifact.", e);
+                throw new RuleViolationException("Syntax violation for XML artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
     }

--- a/app/src/main/java/io/apicurio/registry/rules/validity/XsdContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/rules/validity/XsdContentValidator.java
@@ -23,6 +23,8 @@ import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
+import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.util.SchemaFactoryAccessor;
 
 /**
@@ -41,7 +43,7 @@ public class XsdContentValidator extends XmlContentValidator {
      *      io.apicurio.registry.content.ContentHandle)
      */
     @Override
-    public void validate(ValidityLevel level, ContentHandle artifactContent) throws InvalidContentException {
+    public void validate(ValidityLevel level, ContentHandle artifactContent) throws RuleViolationException {
         super.validate(level, artifactContent);
 
         if (level == ValidityLevel.FULL) {
@@ -50,7 +52,7 @@ public class XsdContentValidator extends XmlContentValidator {
                 Source source = new StreamSource(semanticStream);
                 SchemaFactoryAccessor.getSchemaFactory().newSchema(source);
             } catch (Exception e) {
-                throw new InvalidContentException("Syntax violation for XSD Schema artifact.", e);
+                throw new RuleViolationException("Syntax violation for XSD Schema artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
     }

--- a/app/src/main/java/io/apicurio/registry/types/provider/JsonArtifactTypeUtilProvider.java
+++ b/app/src/main/java/io/apicurio/registry/types/provider/JsonArtifactTypeUtilProvider.java
@@ -24,7 +24,7 @@ import io.apicurio.registry.content.extract.ContentExtractor;
 import io.apicurio.registry.content.extract.JsonContentExtractor;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
-import io.apicurio.registry.rules.compatibility.JsonCompatibilityChecker;
+import io.apicurio.registry.rules.compatibility.JsonSchemaCompatibilityChecker;
 import io.apicurio.registry.rules.validity.ContentValidator;
 import io.apicurio.registry.rules.validity.JsonSchemaContentValidator;
 import io.apicurio.registry.types.ArtifactType;
@@ -42,7 +42,7 @@ public class JsonArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvid
 
     @Override
     protected CompatibilityChecker createCompatibilityChecker() {
-        return new JsonCompatibilityChecker();
+        return new JsonSchemaCompatibilityChecker();
     }
 
     @Override

--- a/app/src/test/java/io/apicurio/registry/ArtifactsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/ArtifactsResourceTest.java
@@ -156,9 +156,7 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(409)
                 .body("error_code", equalTo(409))
-                .body("message", equalTo("Syntax violation for OpenAPI artifact."))
-                .body("causes[0].description", equalTo("Syntax violation for OpenAPI artifact."))
-                .body("causes[0].context", equalTo("FULL"));
+                .body("message", equalTo("Syntax violation for OpenAPI artifact."));
     }
 
     @Test
@@ -445,10 +443,7 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(409)
                 .body("error_code", equalTo(409))
-                .body("message", equalTo("Syntax violation for JSON Schema artifact."))
-                .body("causes[0].description", equalTo("Syntax violation for JSON Schema artifact."))
-                .body("causes[0].context", equalTo("FULL"));
-
+                .body("message", equalTo("Syntax violation for JSON Schema artifact."));
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/rules/validity/AsyncApiContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/AsyncApiContentValidatorTest.java
@@ -18,6 +18,8 @@ package io.apicurio.registry.rules.validity;
 
 import io.apicurio.registry.AbstractRegistryTestBase;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +47,7 @@ public class AsyncApiContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidSyntax() throws Exception {
         ContentHandle content = resourceToContentHandle("asyncapi-invalid-syntax.json");
         AsyncApiContentValidator validator = new AsyncApiContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.SYNTAX_ONLY, content);
         });
     }
@@ -54,7 +56,7 @@ public class AsyncApiContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidSemantics() throws Exception {
         ContentHandle content = resourceToContentHandle("asyncapi-invalid-semantics.json");
         AsyncApiContentValidator validator = new AsyncApiContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.FULL, content);
         });
     }

--- a/app/src/test/java/io/apicurio/registry/rules/validity/AvroContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/AvroContentValidatorTest.java
@@ -18,6 +18,8 @@ package io.apicurio.registry.rules.validity;
 
 import io.apicurio.registry.AbstractRegistryTestBase;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +40,7 @@ public class AvroContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidAvroSchema() throws Exception {
         ContentHandle content = resourceToContentHandle("avro-invalid.json");
         AvroContentValidator validator = new AvroContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.SYNTAX_ONLY, content);
         });
     }

--- a/app/src/test/java/io/apicurio/registry/rules/validity/GraphQLContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/GraphQLContentValidatorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import io.apicurio.registry.AbstractRegistryTestBase;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
 
 /**
  * Tests the GraphQL content validator.
@@ -39,7 +40,7 @@ public class GraphQLContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidSyntax() throws Exception {
         ContentHandle content = resourceToContentHandle("graphql-invalid.graphql");
         GraphQLContentValidator validator = new GraphQLContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.SYNTAX_ONLY, content);
         });
     }

--- a/app/src/test/java/io/apicurio/registry/rules/validity/JsonSchemaContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/JsonSchemaContentValidatorTest.java
@@ -16,10 +16,12 @@
 
 package io.apicurio.registry.rules.validity;
 
-import io.apicurio.registry.AbstractRegistryTestBase;
-import io.apicurio.registry.content.ContentHandle;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.AbstractRegistryTestBase;
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
 
 /**
  * Tests the JSON Schema content validator.
@@ -38,7 +40,7 @@ public class JsonSchemaContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidJsonSchema() throws Exception {
         ContentHandle content = resourceToContentHandle("jsonschema-invalid.json");
         JsonSchemaContentValidator validator = new JsonSchemaContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.SYNTAX_ONLY, content);
         });
     }

--- a/app/src/test/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidatorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import io.apicurio.registry.AbstractRegistryTestBase;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
 
 /**
  * Tests the Kafka Connect content validator.
@@ -39,7 +40,7 @@ public class KafkaConnectContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidSyntax() throws Exception {
         ContentHandle content = resourceToContentHandle("kconnect-invalid.json");
         KafkaConnectContentValidator validator = new KafkaConnectContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.SYNTAX_ONLY, content);
         });
     }

--- a/app/src/test/java/io/apicurio/registry/rules/validity/OpenApiContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/OpenApiContentValidatorTest.java
@@ -16,10 +16,12 @@
 
 package io.apicurio.registry.rules.validity;
 
-import io.apicurio.registry.AbstractRegistryTestBase;
-import io.apicurio.registry.content.ContentHandle;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.AbstractRegistryTestBase;
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
 
 /**
  * Tests the OpenAPI content validator.
@@ -45,7 +47,7 @@ public class OpenApiContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidSyntax() throws Exception {
         ContentHandle content = resourceToContentHandle("openapi-invalid-syntax.json");
         OpenApiContentValidator validator = new OpenApiContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.SYNTAX_ONLY, content);
         });
     }
@@ -54,7 +56,7 @@ public class OpenApiContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidSemantics() throws Exception {
         ContentHandle content = resourceToContentHandle("openapi-invalid-semantics.json");
         OpenApiContentValidator validator = new OpenApiContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.FULL, content);
         });
     }

--- a/app/src/test/java/io/apicurio/registry/rules/validity/ProtobufContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/ProtobufContentValidatorTest.java
@@ -16,10 +16,12 @@
 
 package io.apicurio.registry.rules.validity;
 
-import io.apicurio.registry.AbstractRegistryTestBase;
-import io.apicurio.registry.content.ContentHandle;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.AbstractRegistryTestBase;
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
 
 /**
  * Tests the Protobuf content validator.
@@ -38,7 +40,7 @@ public class ProtobufContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidProtobufSchema() throws Exception {
         ContentHandle content = resourceToContentHandle("protobuf-invalid.proto");
         ProtobufContentValidator validator = new ProtobufContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.SYNTAX_ONLY, content);
         });
     }

--- a/app/src/test/java/io/apicurio/registry/rules/validity/ProtobufFdContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/ProtobufFdContentValidatorTest.java
@@ -16,13 +16,16 @@
 
 package io.apicurio.registry.rules.validity;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import com.google.protobuf.Descriptors;
+
 import io.apicurio.registry.AbstractRegistryTestBase;
 import io.apicurio.registry.common.proto.Serde;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
 import io.apicurio.registry.support.TestCmmn;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 /**
  * Tests the Protobuf FD content validator.
@@ -54,7 +57,7 @@ public class ProtobufFdContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidProtobufFdContent() {
         ContentHandle content = ContentHandle.create("qwerty");
         ProtobufFdContentValidator validator = new ProtobufFdContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.FULL, content);
         });
     }

--- a/app/src/test/java/io/apicurio/registry/rules/validity/WsdlContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/WsdlContentValidatorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import io.apicurio.registry.AbstractRegistryTestBase;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
 
 /**
  * @author cfoskin@redhat.com
@@ -39,7 +40,7 @@ public class WsdlContentValidatorTest extends AbstractRegistryTestBase {
     public void testinValidSyntax() throws Exception {
         ContentHandle content = resourceToContentHandle("wsdl-invalid-syntax.wsdl");
         WsdlContentValidator validator = new WsdlContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.SYNTAX_ONLY, content);
         });
     }
@@ -55,7 +56,7 @@ public class WsdlContentValidatorTest extends AbstractRegistryTestBase {
     public void testinValidSemantics() throws Exception {
         ContentHandle content = resourceToContentHandle("wsdl-invalid-semantics.wsdl");
         WsdlContentValidator validator = new WsdlContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             //WSDLException faultCode=INVALID_WSDL: Encountered illegal extension element '{http://schemas.xmlsoap.org/wsdl/}element' in the context of a 'javax.wsdl.Types'. Extension elements must be in a namespace other than WSDL's
             validator.validate(ValidityLevel.FULL, content);
         });

--- a/app/src/test/java/io/apicurio/registry/rules/validity/XmlContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/XmlContentValidatorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import io.apicurio.registry.AbstractRegistryTestBase;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
 
 /**
  * @author cfoskin@redhat.com
@@ -37,7 +38,7 @@ public class XmlContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidSyntax() throws Exception {
         ContentHandle content = resourceToContentHandle("xml-invalid-syntax.xml");
         XsdContentValidator validator = new XsdContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.SYNTAX_ONLY, content);
         });
     }

--- a/app/src/test/java/io/apicurio/registry/rules/validity/XsdContentValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/rules/validity/XsdContentValidatorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import io.apicurio.registry.AbstractRegistryTestBase;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rules.RuleViolationException;
 
 /**
  * @author cfoskin@redhat.com
@@ -39,7 +40,7 @@ public class XsdContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidSyntax() throws Exception {
         ContentHandle content = resourceToContentHandle("xml-schema-invalid-syntax.xsd");
         XsdContentValidator validator = new XsdContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.SYNTAX_ONLY, content);
         });
     }
@@ -55,7 +56,7 @@ public class XsdContentValidatorTest extends AbstractRegistryTestBase {
     public void testInvalidSemantics() throws Exception {
         ContentHandle content = resourceToContentHandle("xml-schema-invalid-semantics.xsd");
         XsdContentValidator validator = new XsdContentValidator();
-        Assertions.assertThrows(InvalidContentException.class, () -> {
+        Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.FULL, content);
         });
     }

--- a/app/src/test/resources/io/apicurio/registry/rules/validity/openapi-invalid-singleerror.json
+++ b/app/src/test/resources/io/apicurio/registry/rules/validity/openapi-invalid-singleerror.json
@@ -1,0 +1,56 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Empty API",
+        "version": "1.0.0",
+        "description": "An example API design using OpenAPI."
+    },
+    "paths": {
+        "/widgets": {
+            "summary": "Path used to manage the list of widgets.",
+            "description": "The REST endpoint/path used to list and create zero or more `Widget` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.",
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Widget"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Successful response - returns an array of `Widget` entities."
+                    }
+                },
+                "operationId": "getwidgets",
+                "summary": "List All widgets",
+                "description": "Gets a list of all `Widget` entities."
+            },
+            "post": {
+                "requestBody": {
+                    "description": "A new `Widget` to be created.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful response."
+                    }
+                },
+                "operationId": "createWidget",
+                "summary": "Create a Widget",
+                "description": "Creates a new instance of a `Widget`."
+            }
+        }
+    },
+    "components": {}
+}


### PR DESCRIPTION
* No longer expose the "Difference" class too broadly.  
* Updated the Validity rule to allow returning causes (only supported by OpenApi and AsyncApi validators)

The `Difference` class is JSON Schema compatibility specific.  So I introduced a new `CompatibilityDifference` interface that we can use if we ever have support for fine-grained compatibility reporting for other artifact types.

Also now that we have "causes" available for rule violations, we can capture and return the semantic validation errors returned by the OpenAPI and AsyncAPI validators.

Hoping for some feedback from @jsenko and @ronsher and @adiohana on this. :)