### PR TITLE
Map the version property into the DTO exposed to the frontend for SearchedVersion

### DIFF
--- a/storage/sql/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedVersionMapper.java
+++ b/storage/sql/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedVersionMapper.java
@@ -52,6 +52,7 @@ public class SearchedVersionMapper implements RowMapper<SearchedVersion> {
         dto.setCreatedOn(rs.getTimestamp("createdOn").getTime());
         dto.setName(rs.getString("name"));
         dto.setDescription(rs.getString("description"));
+        dto.setVersion(rs.getInt("version"));
         dto.setLabels(SqlUtil.deserializeLabels(rs.getString("labels")));
         //dto.setProperties(SqlUtil.deserializeProperties(rs.getString("properties")));
         dto.setType(ArtifactType.valueOf(rs.getString("type")));


### PR DESCRIPTION
When using SQL storage, the "version" property wasn't mapped from the ResultSet, causing the UI to not receive it, and listing empty version names in the UI dropdown. 
This also broke the navigation to different artifact versions using the dropdown since the URL ended up including "undefined" in the path.

Fix for issue https://github.com/Apicurio/apicurio-registry/issues/1015