### PR TITLE
ksql - generate globalId from kafka record

### DIFF
--- a/storage/ksql/src/main/java/io/apicurio/registry/storage/impl/ksql/KafkaSqlRegistryStorage.java
+++ b/storage/ksql/src/main/java/io/apicurio/registry/storage/impl/ksql/KafkaSqlRegistryStorage.java
@@ -30,7 +30,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
@@ -49,7 +48,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.Serdes;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -207,22 +205,8 @@ public class KafkaSqlRegistryStorage extends AbstractRegistryStorage {
                     if (records != null && !records.isEmpty()) {
                         log.debug("Consuming {} journal records.", records.count());
                         records.forEach(record -> {
-
-                            UUID req = Optional.ofNullable(record.headers().headers("req"))
-                                .map(Iterable::iterator)
-                                .map(it -> {
-                                    return it.hasNext() ? it.next() : null;
-                                })
-                                .map(Header::value)
-                                .map(String::new)
-                                .map(UUID::fromString)
-                                .orElse(null);
-
-                            String artifactId = record.key();
-                            Str.StorageValue storageAction = record.value();
-
                             // TODO instead of processing the journal record directly on the consumer thread, instead queue them and have *another* thread process the queue
-                            kafkaSqlSink.processStorageAction(req, artifactId, storageAction);
+                            kafkaSqlSink.processStorageAction(record);
                         });
                     }
                 }

--- a/storage/ksql/src/main/java/io/apicurio/registry/storage/impl/ksql/sql/SQLRegistryStorage.java
+++ b/storage/ksql/src/main/java/io/apicurio/registry/storage/impl/ksql/sql/SQLRegistryStorage.java
@@ -1,12 +1,24 @@
 package io.apicurio.registry.storage.impl.ksql.sql;
 
+import java.util.concurrent.CompletionStage;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
+import javax.transaction.Transactional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.storage.ArtifactAlreadyExistsException;
+import io.apicurio.registry.storage.ArtifactMetaDataDto;
+import io.apicurio.registry.storage.ArtifactNotFoundException;
+import io.apicurio.registry.storage.EditableArtifactMetaDataDto;
+import io.apicurio.registry.storage.RegistryStorageException;
 import io.apicurio.registry.storage.impl.sql.AbstractSqlRegistryStorage;
+import io.apicurio.registry.storage.impl.sql.GlobalIdGenerator;
+import io.apicurio.registry.types.ArtifactType;
 
 @ApplicationScoped
 @Named("SQLRegistryStorage")
@@ -18,5 +30,31 @@ public class SQLRegistryStorage extends AbstractSqlRegistryStorage{
     void onConstruct() {
         log.info("Using internal SQL storage.");
     }
+
+    @Override @Transactional
+    public CompletionStage<ArtifactMetaDataDto> createArtifact(String artifactId, ArtifactType artifactType, ContentHandle content, GlobalIdGenerator globalIdGenerator)
+            throws ArtifactAlreadyExistsException, RegistryStorageException {
+        return super.createArtifact(artifactId, artifactType, content, globalIdGenerator);
+    }
+
+    @Override @Transactional
+    public CompletionStage<ArtifactMetaDataDto> createArtifactWithMetadata(String artifactId, ArtifactType artifactType, ContentHandle content,
+            EditableArtifactMetaDataDto metaData, GlobalIdGenerator globalIdGenerator) throws ArtifactAlreadyExistsException, RegistryStorageException {
+        return super.createArtifactWithMetadata(artifactId, artifactType, content, metaData, globalIdGenerator);
+    }
+
+    @Override @Transactional
+    public CompletionStage<ArtifactMetaDataDto> updateArtifact(String artifactId, ArtifactType artifactType, ContentHandle content, GlobalIdGenerator globalIdGenerator)
+            throws ArtifactNotFoundException, RegistryStorageException {
+        return super.updateArtifact(artifactId, artifactType, content, globalIdGenerator);
+    }
+
+    @Override @Transactional
+    public CompletionStage<ArtifactMetaDataDto> updateArtifactWithMetadata(String artifactId, ArtifactType artifactType, ContentHandle content,
+            EditableArtifactMetaDataDto metaData, GlobalIdGenerator globalIdGenerator) throws ArtifactNotFoundException, RegistryStorageException {
+        return super.updateArtifactWithMetadata(artifactId, artifactType, content, metaData, globalIdGenerator);
+    }
+
+
 
 }

--- a/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -147,17 +147,20 @@ public abstract class CommonSqlStatements implements SqlStatements {
     public String updateArtifactLatestGlobalId() {
         return "UPDATE artifacts SET latest = (SELECT v.globalId FROM versions v WHERE v.artifactId = ? AND v.version = ?) WHERE artifactId = ?";
     }
-    
+
     /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#insertVersion()
      */
     @Override
-    public String insertVersion(boolean firstVersion) {
+    public String insertVersion(boolean firstVersion, String globalId) {
+        String query;
         if (firstVersion) {
-            return "INSERT INTO versions (artifactId, version, state, name, description, createdBy, createdOn, labels, properties, contentId) VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, ?)";
+            query = "INSERT INTO versions (globalId, artifactId, version, state, name, description, createdBy, createdOn, labels, properties, contentId) VALUES (%s, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)";
         } else {
-            return "INSERT INTO versions (artifactId, version, state, name, description, createdBy, createdOn, labels, properties, contentId) VALUES (?, (SELECT MAX(version) + 1 FROM versions WHERE artifactId = ?), ?, ?, ?, ?, ?, ?, ?, ?)";
+            query = "INSERT INTO versions (globalId, artifactId, version, state, name, description, createdBy, createdOn, labels, properties, contentId) VALUES (%s, ?, (SELECT MAX(version) + 1 FROM versions WHERE artifactId = ?), ?, ?, ?, ?, ?, ?, ?, ?)";
         }
+        query = String.format(query, globalId);
+        return query;
     }
 
     /**

--- a/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -152,14 +152,13 @@ public abstract class CommonSqlStatements implements SqlStatements {
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#insertVersion()
      */
     @Override
-    public String insertVersion(boolean firstVersion, String globalId) {
+    public String insertVersion(boolean firstVersion) {
         String query;
         if (firstVersion) {
-            query = "INSERT INTO versions (globalId, artifactId, version, state, name, description, createdBy, createdOn, labels, properties, contentId) VALUES (%s, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)";
+            query = "INSERT INTO versions (globalId, artifactId, version, state, name, description, createdBy, createdOn, labels, properties, contentId) VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)";
         } else {
-            query = "INSERT INTO versions (globalId, artifactId, version, state, name, description, createdBy, createdOn, labels, properties, contentId) VALUES (%s, ?, (SELECT MAX(version) + 1 FROM versions WHERE artifactId = ?), ?, ?, ?, ?, ?, ?, ?, ?)";
+            query = "INSERT INTO versions (globalId, artifactId, version, state, name, description, createdBy, createdOn, labels, properties, contentId) VALUES (?, ?, (SELECT MAX(version) + 1 FROM versions WHERE artifactId = ?), ?, ?, ?, ?, ?, ?, ?, ?)";
         }
-        query = String.format(query, globalId);
         return query;
     }
 

--- a/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/GlobalIdGenerator.java
+++ b/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/GlobalIdGenerator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.storage.impl.sql;
+
+/**
+ * @author Fabian Martinez
+ */
+public interface GlobalIdGenerator {
+
+    Object get();
+
+}

--- a/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/GlobalIdGenerator.java
+++ b/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/GlobalIdGenerator.java
@@ -20,6 +20,6 @@ package io.apicurio.registry.storage.impl.sql;
  */
 public interface GlobalIdGenerator {
 
-    Object get();
+    Long generate();
 
 }

--- a/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/SqlGlobalIdGenerator.java
+++ b/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/SqlGlobalIdGenerator.java
@@ -15,14 +15,19 @@
  */
 package io.apicurio.registry.storage.impl.sql;
 
+import org.jdbi.v3.core.Handle;
+
 /**
  * @author Fabian Martinez
  */
-public class SqlGlobalIdGenerator implements GlobalIdGenerator {
+public class SqlGlobalIdGenerator {
 
-    @Override
-    public Object get() {
-        return "nextval('globalidsequence')";
+    public static GlobalIdGenerator withHandle(Handle handle) {
+        return () -> {
+            return handle.createQuery("SELECT nextval('globalidsequence')")
+                    .mapTo(Long.class)
+                    .one();
+        };
     }
 
 }

--- a/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/SqlGlobalIdGenerator.java
+++ b/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/SqlGlobalIdGenerator.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.storage.impl.sql;
+
+/**
+ * @author Fabian Martinez
+ */
+public class SqlGlobalIdGenerator implements GlobalIdGenerator {
+
+    @Override
+    public Object get() {
+        return "nextval('globalidsequence')";
+    }
+
+}

--- a/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -113,7 +113,7 @@ public interface SqlStatements {
     /**
      * A statement used to insert a row in the versions table.
      */
-    public String insertVersion(boolean firstVersion);
+    public String insertVersion(boolean firstVersion, String globalId);
 
     /**
      * A statement used to select a single row in the versions table by globalId.

--- a/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/utils/sql/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -113,7 +113,7 @@ public interface SqlStatements {
     /**
      * A statement used to insert a row in the versions table.
      */
-    public String insertVersion(boolean firstVersion, String globalId);
+    public String insertVersion(boolean firstVersion);
 
     /**
      * A statement used to select a single row in the versions table by globalId.

--- a/utils/sql/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
+++ b/utils/sql/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
@@ -6,10 +6,10 @@ CREATE TABLE apicurio (prop_name VARCHAR(255) NOT NULL, prop_value VARCHAR(255))
 ALTER TABLE apicurio ADD PRIMARY KEY (prop_name);
 INSERT INTO apicurio (prop_name, prop_value) VALUES ('db_version', 1);
 
-CREATE TABLE globalrules (type VARCHAR(32) NOT NULL, configuration CLOB NOT NULL);
+CREATE TABLE globalrules (type VARCHAR(32) NOT NULL, configuration TEXT NOT NULL);
 ALTER TABLE globalrules ADD PRIMARY KEY (type);
 
-CREATE TABLE artifacts (artifactId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, createdBy VARCHAR(256), createdOn TIMESTAMP NOT NULL, latest BIGINT);
+CREATE TABLE artifacts (artifactId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, latest BIGINT);
 ALTER TABLE artifacts ADD PRIMARY KEY (artifactId);
 CREATE INDEX IDX_artifacts_0 ON artifacts(type);
 CREATE INDEX IDX_artifacts_1 ON artifacts(createdBy);

--- a/utils/sql/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
+++ b/utils/sql/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
@@ -25,7 +25,9 @@ ALTER TABLE content ADD CONSTRAINT UNQ_content_1 UNIQUE (contentHash);
 CREATE INDEX IDX_content_1 ON content(canonicalHash);
 CREATE INDEX IDX_content_2 ON content(contentHash);
 
-CREATE TABLE versions (globalId BIGINT AUTO_INCREMENT NOT NULL, artifactId VARCHAR(512) NOT NULL, version INT NOT NULL, state VARCHAR(64) NOT NULL, name VARCHAR(512), description VARCHAR(1024), createdBy VARCHAR(256), createdOn TIMESTAMP NOT NULL, labels CLOB, properties CLOB, contentId BIGINT NOT NULL);
+CREATE SEQUENCE globalidsequence;
+
+CREATE TABLE versions (globalId BIGINT NOT NULL, artifactId VARCHAR(512) NOT NULL, version INT NOT NULL, state VARCHAR(64) NOT NULL, name VARCHAR(512), description VARCHAR(1024), createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, labels TEXT, properties TEXT, contentId BIGINT NOT NULL);
 ALTER TABLE versions ADD PRIMARY KEY (globalId);
 ALTER TABLE versions ADD CONSTRAINT UQ_versions_1 UNIQUE (artifactId, version);
 ALTER TABLE versions ADD CONSTRAINT FK_versions_1 FOREIGN KEY (artifactId) REFERENCES artifacts(artifactId);

--- a/utils/sql/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
+++ b/utils/sql/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
@@ -25,7 +25,9 @@ ALTER TABLE content ADD CONSTRAINT UNQ_content_1 UNIQUE (contentHash);
 CREATE INDEX IDX_content_1 ON content(canonicalHash);
 CREATE INDEX IDX_content_2 ON content(contentHash);
 
-CREATE TABLE versions (globalId BIGSERIAL NOT NULL, artifactId VARCHAR(512) NOT NULL, version INT NOT NULL, state VARCHAR(64) NOT NULL, name VARCHAR(512), description VARCHAR(1024), createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, labels TEXT, properties TEXT, contentId BIGINT NOT NULL);
+CREATE SEQUENCE globalidsequence;
+
+CREATE TABLE versions (globalId BIGINT NOT NULL, artifactId VARCHAR(512) NOT NULL, version INT NOT NULL, state VARCHAR(64) NOT NULL, name VARCHAR(512), description VARCHAR(1024), createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, labels TEXT, properties TEXT, contentId BIGINT NOT NULL);
 ALTER TABLE versions ADD PRIMARY KEY (globalId);
 ALTER TABLE versions ADD CONSTRAINT UQ_versions_1 UNIQUE (artifactId, version);
 ALTER TABLE versions ADD CONSTRAINT FK_versions_1 FOREIGN KEY (artifactId) REFERENCES artifacts(artifactId);


### PR DESCRIPTION
Implements the abstraction in the SQL storage to provide the globalId in the ksql storage the globalId is generated from the kafka record partition + offset (similarly to the streams impl)