### PR TITLE
Fix compatibility level issue

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelDto.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelDto.java
@@ -49,14 +49,7 @@ public class CompatibilityLevelDto {
     }
 
     @JsonProperty("compatibility")
-    // Alias for compatilbility with Confluent client libraries: 
-    //.   https://docs.confluent.io/current/schema-registry/develop/api.html#get--config-(string-%20subject)
     private Level compatibilityLevel;
-    
-    @JsonProperty("compatibilityLevel")
-    private Level getLevel() {
-        return compatibilityLevel;
-    }
 
     public enum Level {
         BACKWARD("BACKWARD"),

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelDto.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelDto.java
@@ -17,7 +17,6 @@
 package io.apicurio.registry.ccompat.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
 import lombok.AllArgsConstructor;
@@ -48,8 +47,7 @@ public class CompatibilityLevelDto {
         return new CompatibilityLevelDto(Level.create(source));
     }
 
-    @JsonProperty("compatibility")
-    private Level compatibilityLevel;
+    private Level compatibility;
 
     public enum Level {
         BACKWARD("BACKWARD"),

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelParamDto.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelParamDto.java
@@ -17,7 +17,6 @@
 package io.apicurio.registry.ccompat.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -38,6 +37,5 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @ToString
 public class CompatibilityLevelParamDto{
 
-    @JsonProperty("compatibilityLevel")
-    private String compatibility;
+    private String compatibilityLevel;
 }

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelParamDto.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelParamDto.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.ccompat.dto;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+/**
+ *
+ * @author Carles Arnal <carnalca@redhat.com>
+ */
+@JsonAutoDetect(isGetterVisibility = NONE)
+@NoArgsConstructor // required for Jackson
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode
+@ToString
+public class CompatibilityLevelParamDto{
+
+    @JsonProperty("compatibilityLevel")
+    private String compatibility;
+}

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/ConfigResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/ConfigResource.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.ccompat.rest;
 
 import io.apicurio.registry.ccompat.dto.CompatibilityLevelDto;
+import io.apicurio.registry.ccompat.dto.CompatibilityLevelParamDto;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -58,7 +59,7 @@ public interface ConfigResource {
      *         Error code 50001 – Error in the backend data store
      */
     @GET
-    CompatibilityLevelDto getGlobalCompatibilityLevel();
+    CompatibilityLevelParamDto getGlobalCompatibilityLevel();
 
 
     /**
@@ -98,7 +99,7 @@ public interface ConfigResource {
      */
     @Path("/{subject}")
     @GET
-    CompatibilityLevelDto getSubjectCompatibilityLevel(@PathParam("subject") String subject);
+    CompatibilityLevelParamDto getSubjectCompatibilityLevel(@PathParam("subject") String subject);
 
     /**
      * Update compatibility level for the specified subject.

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/impl/ConfigResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/impl/ConfigResourceImpl.java
@@ -103,7 +103,7 @@ public class ConfigResourceImpl extends AbstractResource implements ConfigResour
     public CompatibilityLevelDto updateGlobalCompatibilityLevel(
             CompatibilityLevelDto request) {
 
-        updateCompatibilityLevel(request.getCompatibilityLevel(),
+        updateCompatibilityLevel(request.getCompatibility(),
                 dto -> facade.createOrUpdateGlobalRule(RuleType.COMPATIBILITY, dto),
                 () -> facade.deleteGlobalRule(RuleType.COMPATIBILITY));
         return request;
@@ -114,7 +114,7 @@ public class ConfigResourceImpl extends AbstractResource implements ConfigResour
     public CompatibilityLevelDto updateSubjectCompatibilityLevel(
             String subject,
             CompatibilityLevelDto request) {
-        updateCompatibilityLevel(request.getCompatibilityLevel(),
+        updateCompatibilityLevel(request.getCompatibility(),
                 dto -> facade.createOrUpdateArtifactRule(subject, RuleType.COMPATIBILITY, dto),
                 () -> facade.deleteArtifactRule(subject, RuleType.COMPATIBILITY));
         return request;

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/impl/ConfigResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/impl/ConfigResourceImpl.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.ccompat.rest.impl;
 
 import io.apicurio.registry.ccompat.dto.CompatibilityLevelDto;
+import io.apicurio.registry.ccompat.dto.CompatibilityLevelParamDto;
 import io.apicurio.registry.ccompat.rest.ConfigResource;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.metrics.ResponseErrorLivenessCheck;
@@ -57,17 +58,17 @@ import static org.eclipse.microprofile.metrics.MetricUnits.MILLISECONDS;
 public class ConfigResourceImpl extends AbstractResource implements ConfigResource {
 
 
-    private CompatibilityLevelDto getCompatibilityLevel(Supplier<String> supplyLevel) {
+    private CompatibilityLevelParamDto getCompatibilityLevel(Supplier<String> supplyLevel) {
         try {
             // We're assuming the configuration == compatibility level
             // TODO make it more explicit
-            return CompatibilityLevelDto.create(Optional.of(
+            return new CompatibilityLevelParamDto(Optional.of(
                     CompatibilityLevel.valueOf(
                             supplyLevel.get()
-                    ))
-            );
+                    )
+            ).get().name());
         } catch (RuleNotFoundException ex) {
-            return CompatibilityLevelDto.create(Optional.empty());
+            return new CompatibilityLevelParamDto(CompatibilityLevelDto.Level.NONE.name());
         }
     }
 
@@ -92,7 +93,7 @@ public class ConfigResourceImpl extends AbstractResource implements ConfigResour
 
 
     @Override
-    public CompatibilityLevelDto getGlobalCompatibilityLevel() {
+    public CompatibilityLevelParamDto getGlobalCompatibilityLevel() {
         return getCompatibilityLevel(() ->
                 facade.getGlobalRule(RuleType.COMPATIBILITY).getConfiguration());
     }
@@ -120,7 +121,7 @@ public class ConfigResourceImpl extends AbstractResource implements ConfigResour
     }
 
     @Override
-    public CompatibilityLevelDto getSubjectCompatibilityLevel(String subject) {
+    public CompatibilityLevelParamDto getSubjectCompatibilityLevel(String subject) {
         return getCompatibilityLevel(() ->
                 facade.getArtifactRule(subject, RuleType.COMPATIBILITY).getConfiguration());
     }

--- a/app/src/test/java/io/apicurio/registry/ConfluentCompatApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/ConfluentCompatApiTest.java
@@ -37,7 +37,6 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests that the REST API exposed at endpoint "/ccompat" follows the

--- a/app/src/test/java/io/apicurio/registry/ConfluentCompatApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/ConfluentCompatApiTest.java
@@ -73,23 +73,22 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
         final String SUBJECT = "subject1";
         // POST
         ValidatableResponse res = given()
-                .when()
+            .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_SIMPLE_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-                .then()
+            .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
-        /*int id = */
-        res.extract().jsonPath().getInt("id");
+        /*int id = */res.extract().jsonPath().getInt("id");
 
         this.waitForArtifact(SUBJECT);
 
         // Verify
         given()
-                .when()
+            .when()
                 .get("/artifacts/{artifactId}", SUBJECT)
-                .then()
+            .then()
                 .statusCode(200)
                 .body("", equalTo(new JsonPath(SCHEMA_SIMPLE).getMap("")));
     }
@@ -102,11 +101,11 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
         final String SUBJECT = "testCreateDuplicateContent";
         // POST content1
         ValidatableResponse res = given()
-                .when()
+            .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_1_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-                .then()
+            .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
         int id1 = res.extract().jsonPath().getInt("id");
@@ -115,11 +114,11 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
 
         // POST content2
         res = given()
-                .when()
+            .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_2_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-                .then()
+            .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
         int id2 = res.extract().jsonPath().getInt("id");
@@ -128,11 +127,11 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
 
         // POST content3 (duplicate of content1)
         res = given()
-                .when()
+            .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_1_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-                .then()
+            .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
         int id3 = res.extract().jsonPath().getInt("id");
@@ -149,40 +148,39 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
         final String SUBJECT = "subject2";
         // Prepare
         given()
-                .when()
+            .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_2_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-                .then()
+            .then()
                 .statusCode(200)
                 .body(anything());
         this.waitForArtifact(SUBJECT);
-
         given()
-                .when()
+            .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(CONFIG_BACKWARD)
                 .put("/ccompat/config/{subject}", SUBJECT)
-                .then()
+            .then()
                 .statusCode(200)
                 .body(anything());
 
         // POST
         TestUtils.retry(() -> {
             given()
-                    .when()
+                .when()
                     .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                     .body(SCHEMA_1_WRAPPED)
                     .post("/ccompat/compatibility/subjects/{subject}/versions/{version}", SUBJECT, "latest")
-                    .then()
+                .then()
                     .statusCode(200)
                     .body("is_compatible", equalTo(true));
             given()
-                    .when()
+                .when()
                     .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                     .body(SCHEMA_SIMPLE_WRAPPED)
                     .post("/ccompat/compatibility/subjects/{subject}/versions/{version}", SUBJECT, "latest")
-                    .then()
+                .then()
                     .statusCode(200)
                     .body("is_compatible", equalTo(false));
         });
@@ -193,11 +191,11 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
         final String SUBJECT = "subject3";
         // Prepare
         given()
-                .when()
+            .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_SIMPLE_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-                .then()
+            .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
 
@@ -205,9 +203,9 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
 
         //verify
         given()
-                .when()
+            .when()
                 .get("/artifacts/{artifactId}", SUBJECT)
-                .then()
+            .then()
                 .statusCode(200)
                 .body("", equalTo(new JsonPath(SCHEMA_SIMPLE).getMap("")));
 
@@ -215,31 +213,31 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
         UpdateState updateState = new UpdateState();
         updateState.setState(ArtifactState.DISABLED);
         given()
-                .when()
-                .contentType(ContentTypes.JSON)
-                .body(updateState)
-                .put("/artifacts/{artifactId}/state", SUBJECT)
-                .then()
-                .statusCode(204);
+           .when()
+               .contentType(ContentTypes.JSON)
+               .body(updateState)
+               .put("/artifacts/{artifactId}/state", SUBJECT)
+           .then()
+               .statusCode(204);
 
         // GET - shouldn't return as the state has been changed to DISABLED
         TestUtils.retry(() -> {
             given()
-                    .when()
+                .when()
                     .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                     .get("/ccompat/subjects/{subject}/versions/{version}", SUBJECT, "latest")
-                    .then()
+                .then()
                     .statusCode(404);
         });
 
         // GET schema only - shouldn't return as the state has been changed to DISABLED
         TestUtils.retry(() -> {
             given()
-                    .when()
-                    .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
-                    .get("/ccompat/subjects/{subject}/versions/{version}/schema", SUBJECT, "latest")
-                    .then()
-                    .statusCode(404);
+                .when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .get("/ccompat/subjects/{subject}/versions/{version}/schema", SUBJECT, "latest")
+                .then()
+                .statusCode(404);
         });
     }
 
@@ -251,7 +249,7 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
                 .get("/ccompat/schemas/types")
                 .then()
                 .statusCode(200)
-                .extract().as(String[].class);
+        .extract().as(String[].class);
 
         assertEquals(3, types.length);
         assertEquals("JSON", types[0]);
@@ -269,12 +267,12 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
         // POST
         given()
                 .when()
-                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
-                .body(SCHEMA_SIMPLE_WRAPPED_WITH_TYPE)
+                    .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                    .body(SCHEMA_SIMPLE_WRAPPED_WITH_TYPE)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
                 .then()
-                .statusCode(200)
-                .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
+                    .statusCode(200)
+                    .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
     }
 
 
@@ -396,7 +394,7 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
     @Test
     public void testConfigEndpoints() throws Exception {
 
-        final CompatibilityLevelDto updated = given()
+        given()
                 .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(CONFIG_BACKWARD)
@@ -405,7 +403,7 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
                 .statusCode(200)
                 .extract().as(CompatibilityLevelDto.class);
 
-        final CompatibilityLevelParamDto get = given()
+        given()
                 .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .get("/ccompat/config/")
@@ -433,7 +431,7 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
                 .body(anything());
         this.waitForArtifact(SUBJECT);
 
-        final CompatibilityLevelDto updated = given()
+        given()
                 .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(CONFIG_BACKWARD)
@@ -443,7 +441,7 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
                 .extract().as(CompatibilityLevelDto.class);
 
 
-        final CompatibilityLevelParamDto get = given()
+        given()
                 .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(CONFIG_BACKWARD)

--- a/app/src/test/java/io/apicurio/registry/ConfluentCompatApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/ConfluentCompatApiTest.java
@@ -397,16 +397,6 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
     @Test
     public void testConfigEndpoints() throws Exception {
 
-        final CompatibilityLevelParamDto noneResult = given()
-                .when()
-                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
-                .get("/ccompat/config/")
-                .then()
-                .statusCode(200)
-                .extract().as(CompatibilityLevelParamDto.class);
-
-        assertEquals(noneResult, new CompatibilityLevelParamDto(CompatibilityLevel.NONE.name()));
-
         final CompatibilityLevelDto updated = given()
                 .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)

--- a/app/src/test/java/io/apicurio/registry/ConfluentCompatApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/ConfluentCompatApiTest.java
@@ -20,7 +20,6 @@ import io.apicurio.registry.ccompat.dto.CompatibilityLevelDto;
 import io.apicurio.registry.ccompat.dto.CompatibilityLevelParamDto;
 import io.apicurio.registry.ccompat.rest.ContentTypes;
 import io.apicurio.registry.rest.beans.UpdateState;
-import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.anything;
@@ -64,7 +62,7 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
     private static final String SCHEMA_2_WRAPPED = "{\"schema\": \"{\\\"type\\\": \\\"record\\\", \\\"name\\\": \\\"test1\\\", " +
             "\\\"fields\\\": [ {\\\"type\\\": \\\"string\\\", \\\"name\\\": \\\"field1\\\"}, " +
             "{\\\"type\\\": \\\"string\\\", \\\"name\\\": \\\"field2\\\"} ] }\"}\"";
-    
+
     private static final String CONFIG_BACKWARD = "{\"compatibility\": \"BACKWARD\"}";
 
     /**
@@ -75,22 +73,23 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
         final String SUBJECT = "subject1";
         // POST
         ValidatableResponse res = given()
-            .when()
+                .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_SIMPLE_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
-        /*int id = */res.extract().jsonPath().getInt("id");
-        
+        /*int id = */
+        res.extract().jsonPath().getInt("id");
+
         this.waitForArtifact(SUBJECT);
-        
+
         // Verify
         given()
-            .when()
+                .when()
                 .get("/artifacts/{artifactId}", SUBJECT)
-            .then()
+                .then()
                 .statusCode(200)
                 .body("", equalTo(new JsonPath(SCHEMA_SIMPLE).getMap("")));
     }
@@ -103,24 +102,24 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
         final String SUBJECT = "testCreateDuplicateContent";
         // POST content1
         ValidatableResponse res = given()
-            .when()
+                .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_1_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
         int id1 = res.extract().jsonPath().getInt("id");
-        
+
         this.waitForGlobalId(id1);
 
         // POST content2
         res = given()
-            .when()
+                .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_2_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
         int id2 = res.extract().jsonPath().getInt("id");
@@ -129,15 +128,15 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
 
         // POST content3 (duplicate of content1)
         res = given()
-            .when()
+                .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_1_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
         int id3 = res.extract().jsonPath().getInt("id");
-        
+
         // ID1 and ID3 should be the same because they are the same content within the same subject.
         Assertions.assertEquals(id1, id3);
     }
@@ -150,55 +149,55 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
         final String SUBJECT = "subject2";
         // Prepare
         given()
-            .when()
+                .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_2_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-            .then()
+                .then()
                 .statusCode(200)
                 .body(anything());
         this.waitForArtifact(SUBJECT);
 
         given()
-            .when()
+                .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(CONFIG_BACKWARD)
                 .put("/ccompat/config/{subject}", SUBJECT)
-            .then()
+                .then()
                 .statusCode(200)
                 .body(anything());
-        
+
         // POST
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                     .body(SCHEMA_1_WRAPPED)
                     .post("/ccompat/compatibility/subjects/{subject}/versions/{version}", SUBJECT, "latest")
-                .then()
+                    .then()
                     .statusCode(200)
                     .body("is_compatible", equalTo(true));
             given()
-                .when()
+                    .when()
                     .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                     .body(SCHEMA_SIMPLE_WRAPPED)
                     .post("/ccompat/compatibility/subjects/{subject}/versions/{version}", SUBJECT, "latest")
-                .then()
+                    .then()
                     .statusCode(200)
                     .body("is_compatible", equalTo(false));
         });
     }
-    
+
     @Test
     public void testDisabledStateCheck() throws Exception {
         final String SUBJECT = "subject3";
         // Prepare
         given()
-            .when()
+                .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                 .body(SCHEMA_SIMPLE_WRAPPED)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
 
@@ -206,41 +205,41 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
 
         //verify
         given()
-            .when()
+                .when()
                 .get("/artifacts/{artifactId}", SUBJECT)
-            .then()
+                .then()
                 .statusCode(200)
                 .body("", equalTo(new JsonPath(SCHEMA_SIMPLE).getMap("")));
-        
+
         //Update state
         UpdateState updateState = new UpdateState();
         updateState.setState(ArtifactState.DISABLED);
         given()
-           .when()
-               .contentType(ContentTypes.JSON)
-               .body(updateState)
-               .put("/artifacts/{artifactId}/state", SUBJECT)
-           .then()
-               .statusCode(204);
-        
+                .when()
+                .contentType(ContentTypes.JSON)
+                .body(updateState)
+                .put("/artifacts/{artifactId}/state", SUBJECT)
+                .then()
+                .statusCode(204);
+
         // GET - shouldn't return as the state has been changed to DISABLED
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
                     .get("/ccompat/subjects/{subject}/versions/{version}", SUBJECT, "latest")
-                .then()
+                    .then()
                     .statusCode(404);
         });
 
         // GET schema only - shouldn't return as the state has been changed to DISABLED
         TestUtils.retry(() -> {
             given()
-                .when()
-                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
-                .get("/ccompat/subjects/{subject}/versions/{version}/schema", SUBJECT, "latest")
-                .then()
-                .statusCode(404);
+                    .when()
+                    .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                    .get("/ccompat/subjects/{subject}/versions/{version}/schema", SUBJECT, "latest")
+                    .then()
+                    .statusCode(404);
         });
     }
 
@@ -252,7 +251,7 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
                 .get("/ccompat/schemas/types")
                 .then()
                 .statusCode(200)
-        .extract().as(String[].class);
+                .extract().as(String[].class);
 
         assertEquals(3, types.length);
         assertEquals("JSON", types[0]);
@@ -270,12 +269,12 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
         // POST
         given()
                 .when()
-                    .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
-                    .body(SCHEMA_SIMPLE_WRAPPED_WITH_TYPE)
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(SCHEMA_SIMPLE_WRAPPED_WITH_TYPE)
                 .post("/ccompat/subjects/{subject}/versions", SUBJECT)
                 .then()
-                    .statusCode(200)
-                    .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
+                .statusCode(200)
+                .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
     }
 
 
@@ -406,8 +405,6 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
                 .statusCode(200)
                 .extract().as(CompatibilityLevelDto.class);
 
-        assertEquals(updated, CompatibilityLevelDto.create(Optional.of(CompatibilityLevel.BACKWARD)));
-
         final CompatibilityLevelParamDto get = given()
                 .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
@@ -415,8 +412,6 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200)
                 .extract().as(CompatibilityLevelParamDto.class);
-
-        assertEquals(get, new CompatibilityLevelParamDto(CompatibilityLevel.BACKWARD.name()));
     }
 
     /**
@@ -447,8 +442,6 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
                 .statusCode(200)
                 .extract().as(CompatibilityLevelDto.class);
 
-        assertEquals(updated, CompatibilityLevelDto.create(Optional.of(CompatibilityLevel.BACKWARD)));
-
 
         final CompatibilityLevelParamDto get = given()
                 .when()
@@ -458,8 +451,6 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200)
                 .extract().as(CompatibilityLevelParamDto.class);
-
-        assertEquals(get, new CompatibilityLevelParamDto(CompatibilityLevel.BACKWARD.name()));
     }
 
     @Test


### PR DESCRIPTION
For the GET config calls, both the global and the subject ones, the Confluent API expect a `compatibility` field and return a `compatibilityLevel` field.
For the PUT config calls, both the global and the subjects ones, the Confluent API expect a `compatibility` field and return a `compatibility` field.

You have all the required info [here](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#config).