### PR TITLE
fix update metadata bug

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/ArtifactsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ArtifactsResourceImpl.java
@@ -592,6 +592,8 @@ public class ArtifactsResourceImpl implements ArtifactsResource, Headers {
         EditableArtifactMetaDataDto dto = new EditableArtifactMetaDataDto();
         dto.setName(data.getName());
         dto.setDescription(data.getDescription());
+        dto.setLabels(data.getLabels());
+        dto.setProperties(data.getProperties());
         storage.updateArtifactVersionMetaData(artifactId, version.longValue(), dto);
     }
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/AbstractMapRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/AbstractMapRegistryStorage.java
@@ -725,6 +725,16 @@ public abstract class AbstractMapRegistryStorage extends AbstractRegistryStorage
         if (metaData.getDescription() != null) {
             storage.put(artifactId, version, MetaDataKeys.DESCRIPTION, metaData.getDescription());
         }
+        if (metaData.getLabels() != null && !metaData.getLabels().isEmpty()) {
+            storage.put(artifactId, version, MetaDataKeys.LABELS, String.join(",", metaData.getLabels()));
+        }
+        if (metaData.getProperties() != null && !metaData.getProperties().isEmpty()) {
+            try {
+                storage.put(artifactId, version, MetaDataKeys.PROPERTIES, new ObjectMapper().writeValueAsString(metaData.getProperties()));
+            } catch (JsonProcessingException e) {
+                throw new InvalidPropertiesException(MetaDataKeys.PROPERTIES + " could not be processed for storage.", e);
+            }
+        }
     }
 
     /**
@@ -734,6 +744,8 @@ public abstract class AbstractMapRegistryStorage extends AbstractRegistryStorage
     public void deleteArtifactVersionMetaData(String artifactId, long version) throws ArtifactNotFoundException, VersionNotFoundException, RegistryStorageException {
         storage.remove(artifactId, version, MetaDataKeys.NAME);
         storage.remove(artifactId, version, MetaDataKeys.DESCRIPTION);
+        storage.remove(artifactId, version, MetaDataKeys.LABELS);
+        storage.remove(artifactId, version, MetaDataKeys.PROPERTIES);
     }
 
     /**


### PR DESCRIPTION
I noticed the `updateVersionMetaData` was not updating the labels and properties.
I also refactored a bit the method to handle the metadata update in the sql storage because I saw a possibility to remove some duplicated code