### PR TITLE
special characters handling - % and non ASCII characters are now forbidden

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/ArtifactsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ArtifactsResourceImpl.java
@@ -71,6 +71,7 @@ import io.apicurio.registry.storage.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
 import io.apicurio.registry.storage.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.EditableArtifactMetaDataDto;
+import io.apicurio.registry.storage.InvalidArtifactIdException;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.RuleConfigurationDto;
 import io.apicurio.registry.storage.StoredArtifact;
@@ -84,6 +85,7 @@ import io.apicurio.registry.util.ArtifactIdGenerator;
 import io.apicurio.registry.util.ArtifactTypeUtil;
 import io.apicurio.registry.util.ContentTypeUtil;
 import io.apicurio.registry.util.DtoUtil;
+import io.apicurio.registry.utils.ArtifactIdValidator;
 import io.apicurio.registry.utils.ProtoUtil;
 
 /**
@@ -318,6 +320,8 @@ public class ArtifactsResourceImpl implements ArtifactsResource, Headers {
 
             if (artifactId == null || artifactId.trim().isEmpty()) {
                 artifactId = idGenerator.generate();
+            } else if (!ArtifactIdValidator.isArtifactIdAllowed(artifactId)) {
+                throw new InvalidArtifactIdException(ArtifactIdValidator.ARTIFACT_ID_ERROR_MESSAGE);
             }
             if (ContentTypeUtil.isApplicationYaml(ct)) {
                 content = ContentTypeUtil.yamlToJson(content);

--- a/app/src/main/java/io/apicurio/registry/rest/RegistryExceptionMapper.java
+++ b/app/src/main/java/io/apicurio/registry/rest/RegistryExceptionMapper.java
@@ -27,6 +27,7 @@ import io.apicurio.registry.rules.RuleViolationException;
 import io.apicurio.registry.storage.AlreadyExistsException;
 import io.apicurio.registry.storage.ArtifactAlreadyExistsException;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
+import io.apicurio.registry.storage.InvalidArtifactIdException;
 import io.apicurio.registry.storage.InvalidArtifactStateException;
 import io.apicurio.registry.storage.InvalidArtifactTypeException;
 import io.apicurio.registry.storage.NotFoundException;
@@ -97,6 +98,7 @@ public class RegistryExceptionMapper implements ExceptionMapper<Throwable> {
         map.put(ConflictException.class, HTTP_CONFLICT);
         map.put(UnprocessableEntityException.class, HTTP_UNPROCESSABLE_ENTITY);
         map.put(InvalidArtifactTypeException.class, HTTP_BAD_REQUEST);
+        map.put(InvalidArtifactIdException.class, HTTP_BAD_REQUEST);
         CODE_MAP = Collections.unmodifiableMap(map);
     }
 

--- a/app/src/main/java/io/apicurio/registry/storage/InvalidArtifactIdException.java
+++ b/app/src/main/java/io/apicurio/registry/storage/InvalidArtifactIdException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.storage;
+
+import io.apicurio.registry.types.RegistryException;
+
+/**
+ * @author Fabian Martinez
+ */
+public class InvalidArtifactIdException extends RegistryException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidArtifactIdException(String message) {
+        super(message);
+    }
+
+}

--- a/common/src/main/java/io/apicurio/registry/utils/ArtifactIdValidator.java
+++ b/common/src/main/java/io/apicurio/registry/utils/ArtifactIdValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.utils;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Fabian Martinez
+ */
+public class ArtifactIdValidator {
+
+    public static final String ARTIFACT_ID_ERROR_MESSAGE = "Character % and non ASCII characters are not allowed";
+
+    private ArtifactIdValidator() {
+        //utility class
+    }
+
+    public static boolean isArtifactIdAllowed(String artifactId) {
+        return Charset.forName(StandardCharsets.US_ASCII.name()).newEncoder().canEncode(artifactId)
+                && !artifactId.contains("%");
+    }
+
+}

--- a/common/src/main/java/io/apicurio/registry/utils/ArtifactIdValidator.java
+++ b/common/src/main/java/io/apicurio/registry/utils/ArtifactIdValidator.java
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class ArtifactIdValidator {
 
-    public static final String ARTIFACT_ID_ERROR_MESSAGE = "Character % and non ASCII characters are not allowed";
+    public static final String ARTIFACT_ID_ERROR_MESSAGE = "Character % and non ASCII characters are not allowed in artifact IDs.";
 
     private ArtifactIdValidator() {
         //utility class

--- a/rest-client/src/main/java/io/apicurio/registry/client/RegistryRestClientImpl.java
+++ b/rest-client/src/main/java/io/apicurio/registry/client/RegistryRestClientImpl.java
@@ -17,6 +17,7 @@
 
 package io.apicurio.registry.client;
 
+import io.apicurio.registry.client.exception.InvalidArtifactIdException;
 import io.apicurio.registry.client.request.HeadersInterceptor;
 import io.apicurio.registry.client.request.RequestExecutor;
 import io.apicurio.registry.client.service.ArtifactsService;
@@ -35,6 +36,7 @@ import io.apicurio.registry.rest.beans.VersionMetaData;
 import io.apicurio.registry.rest.beans.VersionSearchResults;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.RuleType;
+import io.apicurio.registry.utils.ArtifactIdValidator;
 import io.apicurio.registry.utils.IoUtil;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
@@ -54,6 +56,10 @@ import javax.net.ssl.X509TrustManager;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -231,6 +237,9 @@ public class RegistryRestClientImpl implements RegistryRestClient {
     @Override
     public ArtifactMetaData createArtifact(String artifactId, ArtifactType artifactType, InputStream data,
                                            IfExistsType ifExists, Boolean canonical) {
+        if (artifactId != null && !ArtifactIdValidator.isArtifactIdAllowed(artifactId)) {
+            throw new InvalidArtifactIdException();
+        }
         return requestExecutor.execute(artifactsService.createArtifact(requestHeaders.get(), artifactType, artifactId, ifExists, canonical,
                 RequestBody.create(MediaType.parse("*/*"), IoUtil.toBytes(data))));
     }
@@ -238,126 +247,126 @@ public class RegistryRestClientImpl implements RegistryRestClient {
     @Override
     public InputStream getLatestArtifact(String artifactId) {
 
-        return requestExecutor.execute(artifactsService.getLatestArtifact(requestHeaders.get(), artifactId)).byteStream();
+        return requestExecutor.execute(artifactsService.getLatestArtifact(requestHeaders.get(), encodeURIComponent(artifactId))).byteStream();
     }
 
     @Override
     public ArtifactMetaData updateArtifact(String artifactId, ArtifactType artifactType, InputStream data) {
 
-        return requestExecutor.execute(artifactsService.updateArtifact(requestHeaders.get(), artifactId, artifactType, RequestBody.create(MediaType.parse("*/*"), IoUtil.toBytes(data))));
+        return requestExecutor.execute(artifactsService.updateArtifact(requestHeaders.get(), encodeURIComponent(artifactId), artifactType, RequestBody.create(MediaType.parse("*/*"), IoUtil.toBytes(data))));
     }
 
     @Override
     public void deleteArtifact(String artifactId) {
 
-        requestExecutor.execute(artifactsService.deleteArtifact(requestHeaders.get(), artifactId));
+        requestExecutor.execute(artifactsService.deleteArtifact(requestHeaders.get(), encodeURIComponent(artifactId)));
     }
 
     @Override
     public void updateArtifactState(String artifactId, UpdateState data) {
 
-        requestExecutor.execute(artifactsService.updateArtifactState(requestHeaders.get(), artifactId, data));
+        requestExecutor.execute(artifactsService.updateArtifactState(requestHeaders.get(), encodeURIComponent(artifactId), data));
     }
 
     @Override
     public ArtifactMetaData getArtifactMetaData(String artifactId) {
 
-        return requestExecutor.execute(artifactsService.getArtifactMetaData(requestHeaders.get(), artifactId));
+        return requestExecutor.execute(artifactsService.getArtifactMetaData(requestHeaders.get(), encodeURIComponent(artifactId)));
     }
 
     @Override
     public void updateArtifactMetaData(String artifactId, EditableMetaData data) {
 
-        requestExecutor.execute(artifactsService.updateArtifactMetaData(requestHeaders.get(), artifactId, data));
+        requestExecutor.execute(artifactsService.updateArtifactMetaData(requestHeaders.get(), encodeURIComponent(artifactId), data));
     }
 
     @Override
     public ArtifactMetaData getArtifactMetaDataByContent(String artifactId, Boolean canonical, InputStream data) {
-        return requestExecutor.execute(artifactsService.getArtifactMetaDataByContent(requestHeaders.get(), artifactId, canonical, RequestBody.create(MediaType.parse("*/*"), IoUtil.toBytes(data))));
+        return requestExecutor.execute(artifactsService.getArtifactMetaDataByContent(requestHeaders.get(), encodeURIComponent(artifactId), canonical, RequestBody.create(MediaType.parse("*/*"), IoUtil.toBytes(data))));
     }
 
     @Override
     public List<Long> listArtifactVersions(String artifactId) {
 
-        return requestExecutor.execute(artifactsService.listArtifactVersions(requestHeaders.get(), artifactId));
+        return requestExecutor.execute(artifactsService.listArtifactVersions(requestHeaders.get(), encodeURIComponent(artifactId)));
     }
 
     @Override
     public VersionMetaData createArtifactVersion(String artifactId, ArtifactType artifactType, InputStream data) {
 
-        return requestExecutor.execute(artifactsService.createArtifactVersion(requestHeaders.get(), artifactId, artifactType, RequestBody.create(MediaType.parse("*/*"), IoUtil.toBytes(data))));
+        return requestExecutor.execute(artifactsService.createArtifactVersion(requestHeaders.get(), encodeURIComponent(artifactId), artifactType, RequestBody.create(MediaType.parse("*/*"), IoUtil.toBytes(data))));
     }
 
     @Override
     public InputStream getArtifactVersion(String artifactId, Integer version) {
 
-        return requestExecutor.execute(artifactsService.getArtifactVersion(requestHeaders.get(), version, artifactId)).byteStream();
+        return requestExecutor.execute(artifactsService.getArtifactVersion(requestHeaders.get(), version, encodeURIComponent(artifactId))).byteStream();
     }
 
     @Override
     public void updateArtifactVersionState(String artifactId, Integer version, UpdateState data) {
 
-        requestExecutor.execute(artifactsService.updateArtifactVersionState(requestHeaders.get(), version, artifactId, data));
+        requestExecutor.execute(artifactsService.updateArtifactVersionState(requestHeaders.get(), version, encodeURIComponent(artifactId), data));
     }
 
     @Override
     public VersionMetaData getArtifactVersionMetaData(String artifactId, Integer version) {
 
-        return requestExecutor.execute(artifactsService.getArtifactVersionMetaData(requestHeaders.get(), version, artifactId));
+        return requestExecutor.execute(artifactsService.getArtifactVersionMetaData(requestHeaders.get(), version, encodeURIComponent(artifactId)));
     }
 
     @Override
     public void updateArtifactVersionMetaData(String artifactId, Integer version, EditableMetaData data) {
 
-        requestExecutor.execute(artifactsService.updateArtifactVersionMetaData(requestHeaders.get(), version, artifactId, data));
+        requestExecutor.execute(artifactsService.updateArtifactVersionMetaData(requestHeaders.get(), version, encodeURIComponent(artifactId), data));
     }
 
     @Override
     public void deleteArtifactVersionMetaData(String artifactId, Integer version) {
 
-        requestExecutor.execute(artifactsService.deleteArtifactVersionMetaData(requestHeaders.get(), version, artifactId));
+        requestExecutor.execute(artifactsService.deleteArtifactVersionMetaData(requestHeaders.get(), version, encodeURIComponent(artifactId)));
     }
 
     @Override
     public List<RuleType> listArtifactRules(String artifactId) {
 
-        return requestExecutor.execute(artifactsService.listArtifactRules(requestHeaders.get(), artifactId));
+        return requestExecutor.execute(artifactsService.listArtifactRules(requestHeaders.get(), encodeURIComponent(artifactId)));
     }
 
     @Override
     public void createArtifactRule(String artifactId, Rule data) {
 
-        requestExecutor.execute(artifactsService.createArtifactRule(requestHeaders.get(), artifactId, data));
+        requestExecutor.execute(artifactsService.createArtifactRule(requestHeaders.get(), encodeURIComponent(artifactId), data));
     }
 
     @Override
     public void deleteArtifactRules(String artifactId) {
 
-        requestExecutor.execute(artifactsService.deleteArtifactRules(requestHeaders.get(), artifactId));
+        requestExecutor.execute(artifactsService.deleteArtifactRules(requestHeaders.get(), encodeURIComponent(artifactId)));
     }
 
     @Override
     public Rule getArtifactRuleConfig(String artifactId, RuleType rule) {
 
-        return requestExecutor.execute(artifactsService.getArtifactRuleConfig(requestHeaders.get(), rule, artifactId));
+        return requestExecutor.execute(artifactsService.getArtifactRuleConfig(requestHeaders.get(), rule, encodeURIComponent(artifactId)));
     }
 
     @Override
     public Rule updateArtifactRuleConfig(String artifactId, RuleType rule, Rule data) {
 
-        return requestExecutor.execute(artifactsService.updateArtifactRuleConfig(requestHeaders.get(), rule, artifactId, data));
+        return requestExecutor.execute(artifactsService.updateArtifactRuleConfig(requestHeaders.get(), rule, encodeURIComponent(artifactId), data));
     }
 
     @Override
     public void deleteArtifactRule(String artifactId, RuleType rule) {
 
-        requestExecutor.execute(artifactsService.deleteArtifactRule(requestHeaders.get(), rule, artifactId));
+        requestExecutor.execute(artifactsService.deleteArtifactRule(requestHeaders.get(), rule, encodeURIComponent(artifactId)));
     }
 
     @Override
     public void testUpdateArtifact(String artifactId, ArtifactType artifactType, InputStream data) {
 
-        requestExecutor.execute(artifactsService.testUpdateArtifact(requestHeaders.get(), artifactId, artifactType, RequestBody.create(MediaType.parse("*/*"), IoUtil.toBytes(data))));
+        requestExecutor.execute(artifactsService.testUpdateArtifact(requestHeaders.get(), encodeURIComponent(artifactId), artifactType, RequestBody.create(MediaType.parse("*/*"), IoUtil.toBytes(data))));
     }
 
     @Override
@@ -381,7 +390,7 @@ public class RegistryRestClientImpl implements RegistryRestClient {
     @Override
     public VersionSearchResults searchVersions(String artifactId, Integer offset, Integer limit) {
 
-        return requestExecutor.execute(searchService.searchVersions(requestHeaders.get(), artifactId, offset, limit));
+        return requestExecutor.execute(searchService.searchVersions(requestHeaders.get(), encodeURIComponent(artifactId), offset, limit));
     }
 
     @Override
@@ -437,5 +446,14 @@ public class RegistryRestClientImpl implements RegistryRestClient {
     @Override
     public Map<String, String> getHeaders() {
         return requestHeaders.get();
+    }
+
+    private String encodeURIComponent(String value) {
+        try {
+            //TODO what to use here ASCII or UTF_8 ??
+            return URLEncoder.encode(value, StandardCharsets.US_ASCII.name());
+        } catch ( UnsupportedEncodingException e ) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/rest-client/src/main/java/io/apicurio/registry/client/RegistryRestClientImpl.java
+++ b/rest-client/src/main/java/io/apicurio/registry/client/RegistryRestClientImpl.java
@@ -450,8 +450,7 @@ public class RegistryRestClientImpl implements RegistryRestClient {
 
     private String encodeURIComponent(String value) {
         try {
-            //TODO what to use here ASCII or UTF_8 ??
-            return URLEncoder.encode(value, StandardCharsets.US_ASCII.name());
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
         } catch ( UnsupportedEncodingException e ) {
             throw new UncheckedIOException(e);
         }

--- a/rest-client/src/main/java/io/apicurio/registry/client/exception/InvalidArtifactIdException.java
+++ b/rest-client/src/main/java/io/apicurio/registry/client/exception/InvalidArtifactIdException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.client.exception;
+
+import io.apicurio.registry.utils.ArtifactIdValidator;
+
+public class InvalidArtifactIdException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidArtifactIdException() {
+        super(ArtifactIdValidator.ARTIFACT_ID_ERROR_MESSAGE);
+    }
+}

--- a/rest-client/src/main/java/io/apicurio/registry/client/service/ArtifactsService.java
+++ b/rest-client/src/main/java/io/apicurio/registry/client/service/ArtifactsService.java
@@ -25,6 +25,7 @@ import retrofit2.Call;
 import retrofit2.http.*;
 
 import java.util.Map;
+
 import java.util.List;
 
 /**
@@ -43,64 +44,64 @@ public interface ArtifactsService {
                                           @Body RequestBody data);
 
     @GET("artifacts/{artifactId}")
-    Call<ResponseBody> getLatestArtifact(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId);
+    Call<ResponseBody> getLatestArtifact(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId);
 
     @PUT("artifacts/{artifactId}")
-    Call<ArtifactMetaData> updateArtifact(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId,
+    Call<ArtifactMetaData> updateArtifact(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId,
                                           @Header("X-Registry-ArtifactType") ArtifactType xRegistryArtifactType, @Body RequestBody data);
 
     @DELETE("artifacts/{artifactId}")
-    Call<Void> deleteArtifact(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId);
+    Call<Void> deleteArtifact(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId);
 
     @PUT("artifacts/{artifactId}/state")
-    Call<Void> updateArtifactState(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId, @Body UpdateState data);
+    Call<Void> updateArtifactState(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId, @Body UpdateState data);
 
     @GET("artifacts/{artifactId}/meta")
-    Call<ArtifactMetaData> getArtifactMetaData(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId);
+    Call<ArtifactMetaData> getArtifactMetaData(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId);
 
     @PUT("artifacts/{artifactId}/meta")
     Call<Void> updateArtifactMetaData(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId, @Body EditableMetaData data);
 
     @POST("artifacts/{artifactId}/meta")
-    Call<ArtifactMetaData> getArtifactMetaDataByContent(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId,
+    Call<ArtifactMetaData> getArtifactMetaDataByContent(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId,
                                                         @Query("canonical") Boolean canonical,
                                                         @Body RequestBody data);
 
     @GET("artifacts/{artifactId}/versions")
-    Call<List<Long>> listArtifactVersions(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId);
+    Call<List<Long>> listArtifactVersions(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId);
 
     @POST("artifacts/{artifactId}/versions")
-    Call<VersionMetaData> createArtifactVersion(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId,
+    Call<VersionMetaData> createArtifactVersion(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId,
                                                 @Header("X-Registry-ArtifactType") ArtifactType xRegistryArtifactType, @Body RequestBody data);
 
     @GET("artifacts/{artifactId}/versions/{version}")
     Call<ResponseBody> getArtifactVersion(@HeaderMap Map<String, String> headers, @Path("version") Integer version,
-                                          @Path("artifactId") String artifactId);
+                                                @Path(value = "artifactId", encoded = true) String artifactId);
 
     @PUT("artifacts/{artifactId}/versions/{version}/state")
     Call<Void> updateArtifactVersionState(@HeaderMap Map<String, String> headers, @Path("version") Integer version,
-                                          @Path("artifactId") String artifactId, @Body UpdateState data);
+                                                @Path(value = "artifactId", encoded = true) String artifactId, @Body UpdateState data);
 
     @GET("artifacts/{artifactId}/versions/{version}/meta")
     Call<VersionMetaData> getArtifactVersionMetaData(@HeaderMap Map<String, String> headers, @Path("version") Integer version,
-                                                     @Path("artifactId") String artifactId);
+                                                    @Path(value = "artifactId", encoded = true) String artifactId);
 
     @PUT("artifacts/{artifactId}/versions/{version}/meta")
     Call<Void> updateArtifactVersionMetaData(@HeaderMap Map<String, String> headers, @Path("version") Integer version,
-                                             @Path("artifactId") String artifactId, @Body EditableMetaData data);
+                                            @Path(value = "artifactId", encoded = true) String artifactId, @Body EditableMetaData data);
 
     @DELETE("artifacts/{artifactId}/versions/{version}/meta")
     Call<Void> deleteArtifactVersionMetaData(@HeaderMap Map<String, String> headers, @Path("version") Integer version,
-                                             @Path("artifactId") String artifactId);
+                                            @Path(value = "artifactId", encoded = true) String artifactId);
 
     @GET("artifacts/{artifactId}/rules")
-    Call<List<RuleType>> listArtifactRules(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId);
+    Call<List<RuleType>> listArtifactRules(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId);
 
     @POST("artifacts/{artifactId}/rules")
-    Call<Void> createArtifactRule(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId, @Body Rule data);
+    Call<Void> createArtifactRule(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId, @Body Rule data);
 
     @DELETE("artifacts/{artifactId}/rules")
-    Call<Void> deleteArtifactRules(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId);
+    Call<Void> deleteArtifactRules(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId);
 
     @GET("artifacts/{artifactId}/rules/{rule}")
     Call<Rule> getArtifactRuleConfig(@HeaderMap Map<String, String> headers, @Path("rule") RuleType rule,
@@ -115,6 +116,6 @@ public interface ArtifactsService {
                                   @Path("artifactId") String artifactId);
 
     @PUT("artifacts/{artifactId}/test")
-    Call<Void> testUpdateArtifact(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId,
+    Call<Void> testUpdateArtifact(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId,
                                   @Header("X-Registry-ArtifactType") ArtifactType xRegistryArtifactType, @Body RequestBody data);
 }

--- a/rest-client/src/main/java/io/apicurio/registry/client/service/SearchService.java
+++ b/rest-client/src/main/java/io/apicurio/registry/client/service/SearchService.java
@@ -39,7 +39,7 @@ public interface SearchService {
                                                 @Query("over") SearchOver over, @Query("order") SortOrder order);
 
     @GET("search/artifacts/{artifactId}/versions")
-    Call<VersionSearchResults> searchVersions(@HeaderMap Map<String, String> headers, @Path("artifactId") String artifactId,
+    Call<VersionSearchResults> searchVersions(@HeaderMap Map<String, String> headers, @Path(value = "artifactId", encoded = true) String artifactId,
                                         @Query("offset") Integer offset, @Query("limit") Integer limit);
 
 }

--- a/tests/src/main/java/io/apicurio/tests/RegistryDeploymentManager.java
+++ b/tests/src/main/java/io/apicurio/tests/RegistryDeploymentManager.java
@@ -73,6 +73,7 @@ public class RegistryDeploymentManager implements BeforeEachCallback, AfterEachC
         RestAssured.baseURI = TestUtils.getRegistryApiUrl();
         LOGGER.info("Registry app is running on {}", RestAssured.baseURI);
         RestAssured.defaultParser = Parser.JSON;
+        RestAssured.urlEncodingEnabled = false;
     }
 
     @Override

--- a/tests/src/main/java/io/apicurio/tests/utils/BaseHttpUtils.java
+++ b/tests/src/main/java/io/apicurio/tests/utils/BaseHttpUtils.java
@@ -114,4 +114,17 @@ public class BaseHttpUtils {
                 .response();
     }
 
+    public static Response artifactPostRequest(String artifactId, String contentType, String body, String endpoint, int returnCode) {
+        return given()
+            .when()
+                .header("X-Registry-Artifactid", artifactId)
+                .contentType(contentType)
+                .body(body)
+                .post(endpoint)
+            .then()
+                .statusCode(returnCode)
+                .extract()
+                .response();
+    }
+
 }

--- a/tests/src/main/java/io/apicurio/tests/utils/subUtils/ArtifactUtils.java
+++ b/tests/src/main/java/io/apicurio/tests/utils/subUtils/ArtifactUtils.java
@@ -25,6 +25,10 @@ import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
 
 import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import static io.apicurio.tests.utils.BaseHttpUtils.getRequest;
@@ -42,7 +46,7 @@ public class ArtifactUtils {
 
     public static Response getArtifact(String artifactId, String version, int returnCode) {
         return
-            BaseHttpUtils.getRequest(RestConstants.JSON, "/artifacts/" + artifactId + "/" + version, returnCode);
+            BaseHttpUtils.getRequest(RestConstants.JSON, "/artifacts/" + encodeURIComponent(artifactId) + "/" + version, returnCode);
     }
 
     public static Response getArtifactSpecificVersion(String artifactId, String version) {
@@ -62,7 +66,7 @@ public class ArtifactUtils {
     }
 
     public static Response listArtifactVersions(String artifactId, int returnCode) {
-        return BaseHttpUtils.getRequest(RestConstants.JSON, "/artifacts/" + artifactId + "/versions", returnCode);
+        return BaseHttpUtils.getRequest(RestConstants.JSON, "/artifacts/" + encodeURIComponent(artifactId) + "/versions", returnCode);
     }
 
     public static Response createArtifact(String artifact) {
@@ -73,12 +77,16 @@ public class ArtifactUtils {
         return  BaseHttpUtils.postRequest(RestConstants.JSON, artifact, "/artifacts", returnCode);
     }
 
+    public static Response createArtifact(String artifactId, String artifact, int returnCode) {
+        return  BaseHttpUtils.artifactPostRequest(artifactId, RestConstants.JSON, artifact, "/artifacts", returnCode);
+    }
+
     public static ArtifactMetaData createArtifact(RegistryRestClient client, ArtifactType atype, String artifactId, InputStream artifactData) {
         return client.createArtifact(artifactId, atype, artifactData);
     }
 
     public static Response createArtifactNewVersion(String artifactId, String artifact, int returnCode) {
-        return BaseHttpUtils.postRequest(RestConstants.JSON, artifact, "/artifacts/" + artifactId + "/versions", returnCode);
+        return BaseHttpUtils.postRequest(RestConstants.JSON, artifact, "/artifacts/" + encodeURIComponent(artifactId) + "/versions", returnCode);
     }
 
     public static Response updateArtifact(String artifactId, String artifact) {
@@ -86,19 +94,19 @@ public class ArtifactUtils {
     }
 
     public static Response updateArtifact(String artifactId, String artifact, int returnCode) {
-        return BaseHttpUtils.putRequest(RestConstants.JSON, artifact, "/artifacts/" + artifactId, returnCode);
+        return BaseHttpUtils.putRequest(RestConstants.JSON, artifact, "/artifacts/" + encodeURIComponent(artifactId), returnCode);
     }
 
     public static ArtifactMetaData updateArtifact(RegistryRestClient client, ArtifactType atype, String artifactId, InputStream artifactData) {
         return client.updateArtifact(artifactId, atype, artifactData);
     }
 
-    public static Response deleteArtifact(String artifactId) {
+    public static Response deleteArtifact(String artifactId) throws Exception {
         return deleteArtifact(artifactId, 204);
     }
 
-    public static Response deleteArtifact(String artifactId, int returnCode) {
-        return BaseHttpUtils.deleteRequest(RestConstants.JSON, "/artifacts/" + artifactId, returnCode);
+    public static Response deleteArtifact(String artifactId, int returnCode) throws Exception {
+        return BaseHttpUtils.deleteRequest(RestConstants.JSON, "/artifacts/" + encodeURIComponent(artifactId), returnCode);
     }
 
     public static Response deleteArtifactVersion(String artifactId, String version) {
@@ -106,7 +114,7 @@ public class ArtifactUtils {
     }
 
     public static Response deleteArtifactVersion(String artifactId, String version, int returnCode) {
-        return BaseHttpUtils.deleteRequest(RestConstants.JSON, "/artifacts/" + artifactId + "/versions/" + version, returnCode);
+        return BaseHttpUtils.deleteRequest(RestConstants.JSON, "/artifacts/" + encodeURIComponent(artifactId) + "/versions/" + version, returnCode);
     }
 
     public static Response createArtifactRule(String artifactId, String rule) {
@@ -114,7 +122,7 @@ public class ArtifactUtils {
     }
 
     public static Response createArtifactRule(String artifactId, String rule, int returnCode) {
-        return BaseHttpUtils.rulesPostRequest(RestConstants.JSON, rule, "/artifacts/" + artifactId + "/rules", returnCode);
+        return BaseHttpUtils.rulesPostRequest(RestConstants.JSON, rule, "/artifacts/" + encodeURIComponent(artifactId) + "/rules", returnCode);
     }
 
     public static Response getArtifactRule(String artifactId, RuleType ruleType) {
@@ -122,7 +130,7 @@ public class ArtifactUtils {
     }
 
     public static Response getArtifactRule(String artifactId, RuleType ruleType, int returnCode) {
-        return BaseHttpUtils.rulesGetRequest(RestConstants.JSON, "/artifacts/" + artifactId + "/rules/" + ruleType, returnCode);
+        return BaseHttpUtils.rulesGetRequest(RestConstants.JSON, "/artifacts/" + encodeURIComponent(artifactId) + "/rules/" + ruleType, returnCode);
     }
 
     public static Response updateArtifactRule(String artifactId, RuleType ruleType, String rule) {
@@ -130,7 +138,7 @@ public class ArtifactUtils {
     }
 
     public static Response updateArtifactRule(String artifactId, RuleType ruleType, String rule, int returnCode) {
-        return BaseHttpUtils.rulesPutRequest(RestConstants.JSON, rule, "/artifacts/" + artifactId + "/rules/" + ruleType, returnCode);
+        return BaseHttpUtils.rulesPutRequest(RestConstants.JSON, rule, "/artifacts/" + encodeURIComponent(artifactId) + "/rules/" + ruleType, returnCode);
     }
 
     public static Response deleteArtifactString(String artifactId, RuleType ruleType) {
@@ -138,11 +146,11 @@ public class ArtifactUtils {
     }
 
     public static Response deleteArtifactRule(String artifactId, RuleType ruleType, int returnCode) {
-        return BaseHttpUtils.rulesDeleteRequest(RestConstants.JSON, "/artifacts/" + artifactId + "/rules/" + ruleType, returnCode);
+        return BaseHttpUtils.rulesDeleteRequest(RestConstants.JSON, "/artifacts/" + encodeURIComponent(artifactId) + "/rules/" + ruleType, returnCode);
     }
 
     public static Response listArtifactRules(String artifactId) {
-        return getRequest(RestConstants.JSON, "/artifacts/" + artifactId + "/rules", 200);
+        return getRequest(RestConstants.JSON, "/artifacts/" + encodeURIComponent(artifactId) + "/rules", 200);
     }
 
     public static Response getArtifactMetadata(String artifactId) {
@@ -150,7 +158,7 @@ public class ArtifactUtils {
     }
 
     public static Response getArtifactMetadata(String artifactId, int returnCode) {
-        return getRequest(RestConstants.JSON, "/artifacts/" + artifactId + "/meta", returnCode);
+        return getRequest(RestConstants.JSON, "/artifacts/" + encodeURIComponent(artifactId) + "/meta", returnCode);
     }
 
     public static Response getArtifactVersionMetadata(String artifactId, String version) {
@@ -158,7 +166,7 @@ public class ArtifactUtils {
     }
 
     public static Response getArtifactVersionMetadata(String artifactId, String version, int returnCode) {
-        return getRequest(RestConstants.JSON, "/artifacts/" + artifactId + "/versions/" + version + "/meta", returnCode);
+        return getRequest(RestConstants.JSON, "/artifacts/" + encodeURIComponent(artifactId) + "/versions/" + version + "/meta", returnCode);
     }
 
     public static Response updateArtifactMetadata(String artifactId, String metadata) {
@@ -166,7 +174,7 @@ public class ArtifactUtils {
     }
 
     public static Response updateArtifactMetadata(String artifactId, String metadata, int returnCode) {
-        return putRequest(RestConstants.JSON, metadata, "/artifacts/" + artifactId + "/meta", returnCode);
+        return putRequest(RestConstants.JSON, metadata, "/artifacts/" + encodeURIComponent(artifactId) + "/meta", returnCode);
     }
 
     public static Response updateArtifactVersionMetadata(String artifactId, String version, String metadata) {
@@ -174,7 +182,7 @@ public class ArtifactUtils {
     }
 
     public static Response updateArtifactVersionMetadata(String artifactId, String version, String metadata, int returnCode) {
-        return putRequest(RestConstants.JSON, metadata, "/artifacts/" + artifactId + "/versions/" + version + "/meta", returnCode);
+        return putRequest(RestConstants.JSON, metadata, "/artifacts/" + encodeURIComponent(artifactId) + "/versions/" + version + "/meta", returnCode);
     }
 
     public static Response deleteArtifactVersionMetadata(String artifactId, String version) {
@@ -182,7 +190,7 @@ public class ArtifactUtils {
     }
 
     public static Response deleteArtifactVersionMetadata(String artifactId, String version, int returnCode) {
-        return BaseHttpUtils.deleteRequest(RestConstants.JSON, "/artifacts/" + artifactId + "/versions/" + version + "/meta", returnCode);
+        return BaseHttpUtils.deleteRequest(RestConstants.JSON, "/artifacts/" + encodeURIComponent(artifactId) + "/versions/" + version + "/meta", returnCode);
     }
 
     public static HashMap<String, String> getFieldsFromResponse(JsonPath jsonPath) {
@@ -205,5 +213,14 @@ public class ArtifactUtils {
 
     public static Response updateSchemaMetadata(String schemaName, String metadata, int returnCode) {
         return putRequest(RestConstants.JSON, metadata, "/ccompat/subjects/" + schemaName + "/meta", returnCode);
+    }
+
+    private static String encodeURIComponent(String value) {
+        try {
+            //TODO what to use here ASCII or UTF_8 ??
+            return URLEncoder.encode(value, StandardCharsets.US_ASCII.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/tests/src/main/java/io/apicurio/tests/utils/subUtils/ArtifactUtils.java
+++ b/tests/src/main/java/io/apicurio/tests/utils/subUtils/ArtifactUtils.java
@@ -217,8 +217,7 @@ public class ArtifactUtils {
 
     private static String encodeURIComponent(String value) {
         try {
-            //TODO what to use here ASCII or UTF_8 ??
-            return URLEncoder.encode(value, StandardCharsets.US_ASCII.name());
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             throw new UncheckedIOException(e);
         }

--- a/tests/src/test/java/io/apicurio/tests/selenium/resources/ArtifactListItem.java
+++ b/tests/src/test/java/io/apicurio/tests/selenium/resources/ArtifactListItem.java
@@ -17,6 +17,10 @@ package io.apicurio.tests.selenium.resources;
 
 import static io.apicurio.tests.ui.pages.BasePage.byDataTestId;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -26,12 +30,13 @@ public class ArtifactListItem extends WebItem {
     private String description;
     private WebElement viewArtifactButton;
 
-    public ArtifactListItem(int index, WebElement webItem) {
+    public ArtifactListItem(int index, WebElement webItem) throws UnsupportedEncodingException {
         super(webItem);
 
         viewArtifactButton = webItem.findElement(byDataTestId("artifacts-lnk-view-" + index));
         String[] slices = viewArtifactButton.getAttribute("href").split("/");
-        artifactId = slices[slices.length - 1];
+
+        artifactId = URLDecoder.decode(slices[slices.length - 1], StandardCharsets.UTF_8.name());
 
         description = webItem.findElement(By.className("artifact-description")).getText();
     }

--- a/tests/src/test/java/io/apicurio/tests/ui/DeleteArtifactIT.java
+++ b/tests/src/test/java/io/apicurio/tests/ui/DeleteArtifactIT.java
@@ -43,7 +43,7 @@ public class DeleteArtifactIT extends BaseIT {
     SeleniumProvider selenium = SeleniumProvider.getInstance();
 
     @AfterEach
-    void cleanArtifacts(ExtensionContext ctx) {
+    void logIfError(ExtensionContext ctx) {
         if (ctx.getExecutionException().isPresent()) {
             LOGGER.error("", ctx.getExecutionException().get());
         }

--- a/tests/src/test/java/io/apicurio/tests/ui/pages/ArtifactDetailsPage.java
+++ b/tests/src/test/java/io/apicurio/tests/ui/pages/ArtifactDetailsPage.java
@@ -15,7 +15,12 @@
  */
 package io.apicurio.tests.ui.pages;
 
+import static org.junit.Assert.assertNotNull;
+
+import java.time.Duration;
+
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import io.apicurio.tests.selenium.SeleniumProvider;
 
@@ -31,6 +36,12 @@ public class ArtifactDetailsPage extends BasePage {
 
     public WebElement getDeleteButtonDeleteDialog() {
         return selenium.getDriver().findElement(byDataTestId("modal-btn-delete"));
+    }
+
+    public void verifyIsOpen() throws Exception {
+        selenium.getDriverWait().withTimeout(Duration.ofSeconds(30)).until(ExpectedConditions.and(
+                ExpectedConditions.urlContains("/versions/")));
+        assertNotNull(selenium.getWebElement(() -> getDeleteButton()));
     }
 
 }

--- a/tests/src/test/java/io/apicurio/tests/ui/pages/ArtifactsListPage.java
+++ b/tests/src/test/java/io/apicurio/tests/ui/pages/ArtifactsListPage.java
@@ -36,12 +36,10 @@ public class ArtifactsListPage extends BasePage {
     protected static final Logger LOGGER = LoggerFactory.getLogger(ArtifactsListPage.class);
 
     private UploadArtifactDialog uploadArtifactDialog;
-    private ArtifactDetailsPage artifactDetailsPage;
 
     public ArtifactsListPage(SeleniumProvider selenium) {
         super(selenium);
         this.uploadArtifactDialog = new UploadArtifactDialog(selenium);
-        this.artifactDetailsPage = new ArtifactDetailsPage(selenium);
     }
 
     public void verifyIsOpen() throws Exception {
@@ -83,7 +81,7 @@ public class ArtifactsListPage extends BasePage {
         return items;
     }
 
-    public WebElement getViewArtifactButton(String artifactId) throws Exception {
+    private WebElement getViewArtifactButton(String artifactId) throws Exception {
         return getArtifactListItems()
                 .stream()
                 .filter(item -> item.getArtifactId().equals(artifactId))
@@ -98,8 +96,9 @@ public class ArtifactsListPage extends BasePage {
         return this.uploadArtifactDialog;
     }
 
-    public ArtifactDetailsPage getArtifactDetailsPage() {
-        return this.artifactDetailsPage;
+    public ArtifactDetailsPage openArtifactDetailsPage(String artifactId) throws Exception {
+        selenium.clickOnItem(this.getViewArtifactButton(artifactId));
+        return new ArtifactDetailsPage(selenium);
     }
 
 }

--- a/tests/src/test/java/io/apicurio/tests/ui/pages/UploadArtifactDialog.java
+++ b/tests/src/test/java/io/apicurio/tests/ui/pages/UploadArtifactDialog.java
@@ -63,4 +63,8 @@ public class UploadArtifactDialog extends BasePage {
         return selenium.getDriver().findElement(byDataTestId("breadcrumb-lnk-artifacts"));
     }
 
+    public void fillArtifactId(String artifactId) {
+        selenium.fillInputItem(this.getArtifactIdInput(), artifactId);
+    }
+
 }


### PR DESCRIPTION
This PR implements the handling of special characters in artifactId in the UI, rest client and api backend.

After some investigation around react-router (used in the UI) and okhttp and retrofit (used in the rest client) I concluded to no longer allow non ASCII characters and the percentage simbol `&`  to be part of an artifactId 

The api now validates when creating an artifact if it's allowed, otherwise the backend returns http status 400

In the UI , react-router produced URI encoding issues that caused crashes in the web when the artifactId contained the character `%` , I have not been able to solve this by updating the router dependency so I decided to forbid the problematic character

The rest client had several issues handling special characters. 
`okhttp` does not allow to have non-ascii characters in the http headers (and we put the artifactId in a header when creating a new artifact), the solution I found was to forbid non ASCII characters in the whole project. 
The other issue was with `retrofit` and the encoding of special characters in the URI , after some testing I noticed the encoding performed by `retrofit` is not compatible with the decoding that happens in the quarkus side (the registry backend). The solution I found was to implement the encoding of the artifactId in the rest client side.


This PR also includes new integration tests to verify all the changes made to the UI, the API and the rest-client