### PR TITLE
Refactoring to support more easily adding tombstone messages on failures

### DIFF
--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
@@ -16,22 +16,20 @@
 
 package io.apicurio.registry.storage.impl.kafkasql;
 
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-
-import io.apicurio.registry.storage.impl.kafkasql.keys.MessageKey;
-import io.apicurio.registry.storage.impl.kafkasql.values.MessageValue;
+import java.util.Properties;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface MessageSender {
+public interface KafkaSqlConfiguration {
 
-    /**
-     * Called to send/publish a message to Kafka.
-     * @param key
-     * @param value
-     */
-    public CompletableFuture<UUID> send(MessageKey key, MessageValue value);
-
+    public String bootstrapServers();
+    public String topic();
+    public Integer startupLag();
+    public Integer pollTimeout();
+    public Integer baseOffset();
+    public Integer responseTimeout();
+    public Properties producerProperties();
+    public Properties consumerProperties();
+    
 }

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlCoordinator.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlCoordinator.java
@@ -25,9 +25,6 @@ import java.util.concurrent.TimeUnit;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.types.RegistryException;
 
 /**
@@ -38,16 +35,14 @@ import io.apicurio.registry.types.RegistryException;
  * @author eric.wittmann@gmail.com
  */
 @ApplicationScoped
-@Logged
 public class KafkaSqlCoordinator {
+
+    @Inject
+    KafkaSqlConfiguration configuration;
 
     private static final Object NULL = new Object();
     private Map<UUID, CountDownLatch> latches = new ConcurrentHashMap<>();
     private Map<UUID, Object> returnValues = new ConcurrentHashMap<>();
-
-    @Inject
-    @ConfigProperty(name = "registry.kafkasql.coordinator.response-timeout", defaultValue = "30000")
-    Integer responseTimeout;
 
     /**
      * Creates a UUID for a single operation.
@@ -68,7 +63,7 @@ public class KafkaSqlCoordinator {
      */
     public Object waitForResponse(UUID uuid) {
         try {
-            latches.get(uuid).await(responseTimeout, TimeUnit.MILLISECONDS);
+            latches.get(uuid).await(configuration.responseTimeout(), TimeUnit.MILLISECONDS);
 
             Object rval = returnValues.remove(uuid);
             if (rval == NULL) {

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlFactory.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlFactory.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage.impl.kafkasql;
+
+import java.util.Properties;
+import java.util.UUID;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.apicurio.registry.storage.impl.kafkasql.keys.MessageKey;
+import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlKeyDeserializer;
+import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlKeySerializer;
+import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlPartitioner;
+import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlValueDeserializer;
+import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlValueSerializer;
+import io.apicurio.registry.storage.impl.kafkasql.values.MessageValue;
+import io.apicurio.registry.utils.RegistryProperties;
+import io.apicurio.registry.utils.kafka.AsyncProducer;
+import io.apicurio.registry.utils.kafka.ProducerActions;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+@ApplicationScoped
+public class KafkaSqlFactory {
+
+    @Inject
+    @ConfigProperty(name = "registry.kafkasql.bootstrap.servers")
+    String bootstrapServers;
+
+    @Inject
+    @ConfigProperty(name = "registry.kafkasql.topic", defaultValue = "kafkasql-journal")
+    String topic;
+
+    @Inject
+    @ConfigProperty(name = "registry.kafkasql.consumer.startupLag", defaultValue = "1000")
+    Integer startupLag;
+
+    @Inject
+    @ConfigProperty(name = "registry.kafkasql.consumer.poll.timeout", defaultValue = "1000")
+    Integer pollTimeout;
+
+    @Inject
+    @ConfigProperty(name = "registry.kafkasql.global-id.base-offset", defaultValue = "1")
+    Integer baseOffset;
+
+    @Inject
+    @ConfigProperty(name = "registry.kafkasql.coordinator.response-timeout", defaultValue = "30000")
+    Integer responseTimeout;
+
+    @Inject
+    @RegistryProperties(
+            value = {"registry.kafka.common", "registry.kafkasql.producer"},
+            empties = {"ssl.endpoint.identification.algorithm="}
+    )
+    Properties producerProperties;
+
+    @Inject
+    @RegistryProperties(
+            value = {"registry.kafka.common", "registry.kafkasql.consumer"},
+            empties = {"ssl.endpoint.identification.algorithm="}
+    )
+    Properties consumerProperties;
+
+    @ApplicationScoped
+    @Produces
+    public KafkaSqlConfiguration createConfiguration() {
+        KafkaSqlConfiguration config = new KafkaSqlConfiguration() {
+            @Override
+            public String bootstrapServers() {
+                return bootstrapServers;
+            }
+            @Override
+            public String topic() {
+                return topic;
+            }
+            @Override
+            public Integer startupLag() {
+                return startupLag;
+            }
+            @Override
+            public Integer pollTimeout() {
+                return pollTimeout;
+            }
+            @Override
+            public Integer baseOffset() {
+                return baseOffset;
+            }
+            @Override
+            public Integer responseTimeout() {
+                return responseTimeout;
+            }
+            @Override
+            public Properties producerProperties() {
+                return producerProperties;
+            }
+            @Override
+            public Properties consumerProperties() {
+                return consumerProperties;
+            }
+            
+        };
+        return config;
+    }
+
+    /**
+     * Creates the Kafka producer.
+     */
+    @ApplicationScoped
+    @Produces
+    public ProducerActions<MessageKey, MessageValue> createKafkaProducer() {
+        Properties props = (Properties) producerProperties.clone();
+
+        // Configure kafka settings
+        props.putIfAbsent(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.putIfAbsent(ProducerConfig.CLIENT_ID_CONFIG, "Producer-" + topic);
+        props.putIfAbsent(ProducerConfig.ACKS_CONFIG, "all");
+        props.putIfAbsent(ProducerConfig.LINGER_MS_CONFIG, 10);
+        props.putIfAbsent(ProducerConfig.PARTITIONER_CLASS_CONFIG, KafkaSqlPartitioner.class);
+
+        // Create the Kafka producer
+        KafkaSqlKeySerializer keySerializer = new KafkaSqlKeySerializer();
+        KafkaSqlValueSerializer valueSerializer = new KafkaSqlValueSerializer();
+        return new AsyncProducer<MessageKey, MessageValue>(props, keySerializer, valueSerializer);
+    }
+
+    /**
+     * Creates the Kafka consumer.
+     */
+    @ApplicationScoped
+    @Produces
+    public KafkaConsumer<MessageKey, MessageValue> createKafkaConsumer() {
+        Properties props = (Properties) consumerProperties.clone();
+
+        props.putIfAbsent(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        props.putIfAbsent(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        props.putIfAbsent(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
+        props.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        // Create the Kafka Consumer
+        KafkaSqlKeyDeserializer keyDeserializer = new KafkaSqlKeyDeserializer();
+        KafkaSqlValueDeserializer valueDeserializer = new KafkaSqlValueDeserializer();
+        KafkaConsumer<MessageKey, MessageValue> consumer = new KafkaConsumer<>(props, keyDeserializer, valueDeserializer);
+        return consumer;
+    }
+    
+}

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
@@ -45,13 +44,8 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.header.internals.RecordHeader;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
@@ -82,11 +76,6 @@ import io.apicurio.registry.storage.StoredArtifact;
 import io.apicurio.registry.storage.VersionNotFoundException;
 import io.apicurio.registry.storage.impl.AbstractRegistryStorage;
 import io.apicurio.registry.storage.impl.kafkasql.keys.MessageKey;
-import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlKeyDeserializer;
-import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlKeySerializer;
-import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlPartitioner;
-import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlValueDeserializer;
-import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlValueSerializer;
 import io.apicurio.registry.storage.impl.kafkasql.sql.KafkaSqlSink;
 import io.apicurio.registry.storage.impl.kafkasql.sql.KafkaSqlStore;
 import io.apicurio.registry.storage.impl.kafkasql.values.ActionType;
@@ -97,9 +86,6 @@ import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
 import io.apicurio.registry.utils.ConcurrentUtil;
-import io.apicurio.registry.utils.RegistryProperties;
-import io.apicurio.registry.utils.kafka.AsyncProducer;
-import io.apicurio.registry.utils.kafka.ProducerActions;
 import io.quarkus.runtime.StartupEvent;
 
 /**
@@ -117,9 +103,12 @@ import io.quarkus.runtime.StartupEvent;
 @Timed(name = STORAGE_OPERATION_TIME, description = STORAGE_OPERATION_TIME_DESC, tags = {"group=" + STORAGE_GROUP_TAG, "metric=" + STORAGE_OPERATION_TIME}, unit = MILLISECONDS)
 @Logged
 @SuppressWarnings("unchecked")
-public class KafkaSqlRegistryStorage extends AbstractRegistryStorage implements MessageSender {
+public class KafkaSqlRegistryStorage extends AbstractRegistryStorage {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaSqlRegistryStorage.class);
+    
+    @Inject
+    KafkaSqlConfiguration configuration;
 
     @Inject
     KafkaSqlCoordinator coordinator;
@@ -131,67 +120,25 @@ public class KafkaSqlRegistryStorage extends AbstractRegistryStorage implements 
     KafkaSqlStore sqlStore;
 
     @Inject
-    @ConfigProperty(name = "registry.kafkasql.bootstrap.servers")
-    String bootstrapServers;
-
-    @Inject
-    @RegistryProperties(
-            value = {"registry.kafka.common", "registry.kafkasql.producer"},
-            empties = {"ssl.endpoint.identification.algorithm="}
-    )
-    Properties producerProperties;
-
-    @Inject
-    @RegistryProperties(
-            value = {"registry.kafka.common", "registry.kafkasql.consumer"},
-            empties = {"ssl.endpoint.identification.algorithm="}
-    )
-    Properties consumerProperties;
-
-    @Inject
-    @ConfigProperty(name = "registry.kafkasql.topic", defaultValue = "kafkasql-journal")
-    String topic;
-
-    @Inject
-    @ConfigProperty(name = "registry.kafkasql.consumer.startupLag", defaultValue = "1000")
-    Integer startupLag;
-
-    @Inject
-    @ConfigProperty(name = "registry.kafkasql.consumer.poll.timeout", defaultValue = "1000")
-    Integer pollTimeout;
+    ArtifactTypeUtilProviderFactory factory;
     
     @Inject
-    ArtifactTypeUtilProviderFactory factory;
+    KafkaConsumer<MessageKey, MessageValue> consumer;
+    
+    @Inject
+    KafkaSqlSubmitter submitter;
 
     private boolean stopped = true;
-    private ProducerActions<MessageKey, MessageValue> producer;
-    private KafkaConsumer<MessageKey, MessageValue> consumer;
-    private KafkaSqlSubmitter submitter;
 
     void onConstruct(@Observes StartupEvent ev) {
         log.info("Using Kafka-SQL storage.");
         // Start the Kafka Consumer thread
-        consumer = createKafkaConsumer();
         startConsumerThread(consumer);
-
-        producer = createKafkaProducer();
-        submitter = new KafkaSqlSubmitter(this);
     }
 
     @PreDestroy
     void onDestroy() {
         stopped = true;
-    }
-
-    /**
-     * @see io.apicurio.registry.storage.impl.kafkasql.MessageSender#send(io.apicurio.registry.storage.impl.kafkasql.keys.MessageKey, io.apicurio.registry.storage.impl.kafkasql.values.MessageValue)
-     */
-    @Override
-    public CompletableFuture<UUID> send(MessageKey key, MessageValue value) {
-        UUID requestId = coordinator.createUUID();
-        RecordHeader header = new RecordHeader("req", requestId.toString().getBytes());
-        ProducerRecord<MessageKey, MessageValue> record = new ProducerRecord<>(topic, 0, key, value, Collections.singletonList(header));
-        return producer.apply(record).thenApply(rm -> requestId);
     }
 
     /**
@@ -201,24 +148,24 @@ public class KafkaSqlRegistryStorage extends AbstractRegistryStorage implements 
      * @param consumer
      */
     private void startConsumerThread(final KafkaConsumer<MessageKey, MessageValue> consumer) {
-        log.info("Starting KSQL consumer thread on topic: {}", topic);
-        log.info("Bootstrap servers: " + bootstrapServers);
+        log.info("Starting KSQL consumer thread on topic: {}", configuration.topic());
+        log.info("Bootstrap servers: " + configuration.bootstrapServers());
         Runnable runner = () -> {
-            log.info("KSQL consumer thread startup lag: {}", startupLag);
+            log.info("KSQL consumer thread startup lag: {}", configuration.startupLag());
 
             try {
                 // Startup lag
-                try { Thread.sleep(startupLag); } catch (InterruptedException e) { }
+                try { Thread.sleep(configuration.startupLag()); } catch (InterruptedException e) { }
 
-                log.info("Subscribing to {}", topic);
+                log.info("Subscribing to {}", configuration.topic());
 
                 // Subscribe to the journal topic
-                Collection<String> topics = Collections.singleton(topic);
+                Collection<String> topics = Collections.singleton(configuration.topic());
                 consumer.subscribe(topics);
 
                 // Main consumer loop
                 while (!stopped) {
-                    final ConsumerRecords<MessageKey, MessageValue> records = consumer.poll(Duration.ofMillis(pollTimeout));
+                    final ConsumerRecords<MessageKey, MessageValue> records = consumer.poll(Duration.ofMillis(configuration.pollTimeout()));
                     if (records != null && !records.isEmpty()) {
                         log.debug("Consuming {} journal records.", records.count());
                         records.forEach(record -> {
@@ -236,44 +183,6 @@ public class KafkaSqlRegistryStorage extends AbstractRegistryStorage implements 
         thread.setDaemon(true);
         thread.setName("KSQL Kafka Consumer Thread");
         thread.start();
-    }
-
-    /**
-     * Creates the Kafka producer.
-     */
-    private ProducerActions<MessageKey, MessageValue> createKafkaProducer() {
-        Properties props = (Properties) producerProperties.clone();
-
-        // Configure kafka settings
-        props.putIfAbsent(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.putIfAbsent(ProducerConfig.CLIENT_ID_CONFIG, "Producer-" + topic);
-        props.putIfAbsent(ProducerConfig.ACKS_CONFIG, "all");
-        props.putIfAbsent(ProducerConfig.LINGER_MS_CONFIG, 10);
-        props.putIfAbsent(ProducerConfig.PARTITIONER_CLASS_CONFIG, KafkaSqlPartitioner.class);
-
-        // Create the Kafka producer
-        KafkaSqlKeySerializer keySerializer = new KafkaSqlKeySerializer();
-        KafkaSqlValueSerializer valueSerializer = new KafkaSqlValueSerializer();
-        return new AsyncProducer<MessageKey, MessageValue>(props, keySerializer, valueSerializer);
-    }
-
-    /**
-     * Creates the Kafka consumer.
-     */
-    private KafkaConsumer<MessageKey, MessageValue> createKafkaConsumer() {
-        Properties props = (Properties) consumerProperties.clone();
-
-        props.putIfAbsent(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
-        props.putIfAbsent(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
-        props.putIfAbsent(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
-        props.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-
-        // Create the Kafka Consumer
-        KafkaSqlKeyDeserializer keyDeserializer = new KafkaSqlKeyDeserializer();
-        KafkaSqlValueDeserializer valueDeserializer = new KafkaSqlValueDeserializer();
-        KafkaConsumer<MessageKey, MessageValue> consumer = new KafkaConsumer<>(props, keyDeserializer, valueDeserializer);
-        return consumer;
     }
 
     /**

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlStorageProvider.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlStorageProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.apicurio.registry.storage.impl.kafkasql;
 
 import javax.enterprise.context.ApplicationScoped;


### PR DESCRIPTION
I had to restructure some things in order to make the Kafka message submitter injectable so that it could easily be used by the Sink, where it was needed in this use-case.

When reviewing this PR, the actual functional change is here:

https://github.com/Apicurio/apicurio-registry/pull/1108/files#diff-47a512339688aeb4390b3269d8c92a87ce49ed56916e0a88e0cde27717f4bdaf

There is a new try/catch block in the `processArtifactMessage` method - that is where the tombstone message is being sent on failure.  The rest of the changes are so that I could inject the message submitter into `KafkaSqlSink`.  :)