### PR TITLE
fix streams unstable tests

### DIFF
--- a/tests/src/test/java/io/apicurio/tests/BaseIT.java
+++ b/tests/src/test/java/io/apicurio/tests/BaseIT.java
@@ -56,7 +56,11 @@ public abstract class BaseIT implements TestSeparator, Constants {
     protected static final Logger LOGGER = LoggerFactory.getLogger(BaseIT.class);
     protected static KafkaFacade kafkaCluster = KafkaFacade.getInstance();
 
-    protected final RegistryRestClient registryClient = RegistryRestClientFactory.create(TestUtils.getRegistryApiUrl());
+    protected final RegistryRestClient registryClient = createRegistryClient();
+
+    protected RegistryRestClient createRegistryClient() {
+        return RegistryRestClientFactory.create(TestUtils.getRegistryApiUrl());
+    }
 
     protected final String resourceToString(String resourceName) {
         try (InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {

--- a/tests/src/test/java/io/apicurio/tests/BaseIT.java
+++ b/tests/src/test/java/io/apicurio/tests/BaseIT.java
@@ -18,13 +18,13 @@ package io.apicurio.tests;
 
 import io.apicurio.registry.client.RegistryRestClient;
 import io.apicurio.registry.client.RegistryRestClientFactory;
+import io.apicurio.registry.client.exception.ArtifactNotFoundException;
 import io.apicurio.registry.rest.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.beans.EditableMetaData;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.tests.SimpleDisplayName;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.interfaces.TestSeparator;
-import io.apicurio.tests.utils.subUtils.ArtifactUtils;
 import org.apache.avro.Schema;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -40,12 +40,14 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayNameGeneration(SimpleDisplayName.class)
 @ExtendWith(RegistryDeploymentManager.class)
@@ -68,17 +70,18 @@ public abstract class BaseIT implements TestSeparator, Constants {
     @AfterEach
     void cleanArtifacts() throws Exception {
         LOGGER.info("Removing all artifacts");
-        String[] artifacts = ArtifactUtils.listArtifacts().getBody().as(String[].class);
+        List<String> artifacts = registryClient.listArtifacts();
         for (String artifactId : artifacts) {
             try {
-                ArtifactUtils.deleteArtifact(artifactId);
-            } catch (AssertionError e) {
+                registryClient.deleteArtifact(artifactId);
+            } catch (ArtifactNotFoundException e) {
                 //because of async storage artifact may be already deleted but listed anyway
                 LOGGER.info(e.getMessage());
             } catch (Exception e) {
                 LOGGER.error("", e);
             }
         }
+        TestUtils.retry(() -> assertTrue(registryClient.listArtifacts().isEmpty()));
     }
 
     protected Map<String, String> createMultipleArtifacts(RegistryRestClient apicurioService, int count) throws Exception {

--- a/tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
+++ b/tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
@@ -136,8 +136,8 @@ public class RegistryConverterIT extends BaseIT {
 
     @Test
     public void testAvro() throws Exception {
-        try (AvroKafkaSerializer<GenericData.Record> serializer = new AvroKafkaSerializer<GenericData.Record>(registryClient);
-             AvroKafkaDeserializer<GenericData.Record> deserializer = new AvroKafkaDeserializer<>(registryClient)) {
+        try (AvroKafkaSerializer<GenericData.Record> serializer = new AvroKafkaSerializer<GenericData.Record>(createRegistryClient());
+             AvroKafkaDeserializer<GenericData.Record> deserializer = new AvroKafkaDeserializer<>(createRegistryClient())) {
 
             serializer.setGlobalIdStrategy(new AutoRegisterIdStrategy<>());
             AvroData avroData = new AvroData(new AvroDataConfig(Collections.emptyMap()));
@@ -165,7 +165,7 @@ public class RegistryConverterIT extends BaseIT {
     @Test
     public void testPrettyJson() throws Exception {
         testJson(
-            registryClient,
+            createRegistryClient(),
             new PrettyFormatStrategy(),
             input -> {
                 try {
@@ -182,7 +182,7 @@ public class RegistryConverterIT extends BaseIT {
     @Test
     public void testCompactJson() throws Exception {
         testJson(
-            registryClient,
+            createRegistryClient(),
             new CompactFormatStrategy(),
             input -> {
                 ByteBuffer buffer = AbstractKafkaSerDe.getByteBuffer(input);

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
@@ -237,7 +237,7 @@ public class TestUtils {
     }
 
     public static <T> T retry(Callable<T> callable) throws Exception {
-        return retry(callable, "Action #" + System.currentTimeMillis(), 15);
+        return retry(callable, "Action #" + System.currentTimeMillis(), 20);
     }
 
     public static void retry(RunnableExc runnable, String name, int maxRetries) throws Exception {

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
@@ -161,7 +161,7 @@ public class TestUtils {
             boolean result;
             try {
                 result = ready.getAsBoolean();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 result = false;
             }
             long timeLeft = deadline - System.currentTimeMillis();
@@ -237,7 +237,7 @@ public class TestUtils {
     }
 
     public static <T> T retry(Callable<T> callable) throws Exception {
-        return retry(callable, "Action #" + System.currentTimeMillis(), 20);
+        return retry(callable, "Action #" + System.currentTimeMillis(), 15);
     }
 
     public static void retry(RunnableExc runnable, String name, int maxRetries) throws Exception {


### PR DESCRIPTION
There are several integration tests that have been failing in master for a while now, but always for the streams storage variant.
That indicates there are issues because of the asynchronous storage.

One issue was with `BasicApicurioSerDesIT.testEvolveAvroApicurio` , the problem was in `TestUtils.waitFor` that leaked an AssertionError

The other issue was with `ArtifactsIT.testAllowedSpecialCharactersCreateViaApi` that reported an http error with code 409, that lead to the process of artifacts cleanup after each test. This PR improves the cleanup process to ensure all artifacts are 100% removed after each test.
