### PR TITLE
tenant urls mapping

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -66,6 +66,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc</artifactId>
         </dependency>
 

--- a/app/src/main/java/io/apicurio/registry/mt/TenantContext.java
+++ b/app/src/main/java/io/apicurio/registry/mt/TenantContext.java
@@ -20,11 +20,11 @@ package io.apicurio.registry.mt;
  * @author eric.wittmann@gmail.com
  */
 public interface TenantContext {
-    
+
     public String tenantId();
-    
+
     public void tenantId(String tenantId);
-    
-    public void clearTenantId();
+
+    public boolean isLoaded();
 
 }

--- a/app/src/main/java/io/apicurio/registry/mt/TenantContextImpl.java
+++ b/app/src/main/java/io/apicurio/registry/mt/TenantContextImpl.java
@@ -16,39 +16,43 @@
 
 package io.apicurio.registry.mt;
 
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-@ApplicationScoped
+@RequestScoped
 public class TenantContextImpl implements TenantContext {
 
-    private static final String DEFAULT_TENANT_ID = "_";
-    private static ThreadLocal<String> tid = ThreadLocal.withInitial(() -> DEFAULT_TENANT_ID);
+    protected static final String DEFAULT_TENANT_ID = "_";
+
+    protected String tenantId = DEFAULT_TENANT_ID;
 
     /**
      * @see io.apicurio.registry.mt.TenantContext#tenantId()
      */
     @Override
     public String tenantId() {
-        return tid.get();
+        return this.tenantId;
     }
 
     /**
-     * @see io.apicurio.registry.mt.TenantContext#tenantId(java.lang.String)
+     * Sets the tenantId to this context, this operation can only happen once per context instance.
      */
     @Override
     public void tenantId(String tenantId) {
-        tid.set(tenantId);
+        if (!this.tenantId.equals(DEFAULT_TENANT_ID)) {
+            throw new IllegalAccessError("Tenant context can only be initialized once");
+        }
+        this.tenantId = tenantId;
     }
-    
+
     /**
-     * @see io.apicurio.registry.mt.TenantContext#clearTenantId()
+     * @see io.apicurio.registry.mt.TenantContext#isLoaded()
      */
     @Override
-    public void clearTenantId() {
-        this.tenantId(DEFAULT_TENANT_ID);
+    public boolean isLoaded() {
+        return !this.tenantId.equals(DEFAULT_TENANT_ID);
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/mt/TenantRequestFilter.java
+++ b/app/src/main/java/io/apicurio/registry/mt/TenantRequestFilter.java
@@ -70,6 +70,9 @@ public class TenantRequestFilter {
                 tenantContext.tenantId(tenantId);
 
                 String actualUri = uri.substring(tenantPrefixLength(tenantId));
+                if (actualUri.length() == 0) {
+                    actualUri = "/";
+                }
 
                 log.debug("Rerouting request {} to {} tenantId {}", uri, actualUri, tenantContext.tenantId());
 

--- a/app/src/main/java/io/apicurio/registry/mt/TenantRequestFilter.java
+++ b/app/src/main/java/io/apicurio/registry/mt/TenantRequestFilter.java
@@ -17,34 +17,80 @@
 package io.apicurio.registry.mt;
 
 import io.apicurio.registry.rest.Headers;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.vertx.web.RouteFilter;
+import io.vertx.ext.web.RoutingContext;
 
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-@Provider
-public class TenantRequestFilter implements ContainerRequestFilter {
+public class TenantRequestFilter {
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static final String MULTITENANT_BASE_PATH = "/t/";
+
+    @ConfigProperty(name = "registry.enable.multitenancy")
+    boolean multitenancyEnabled;
 
     @Inject
     TenantContext tenantContext;
 
-    /**
-     * @see javax.ws.rs.container.ContainerRequestFilter#filter(javax.ws.rs.container.ContainerRequestContext)
-     */
-    @Override
-    public void filter(ContainerRequestContext requestContext) throws IOException {
-        String tenantId = requestContext.getHeaderString(Headers.TENANT_ID);
-        if (tenantId != null) {
-
-            tenantContext.tenantId(tenantId);
-        } else {
-            tenantContext.clearTenantId();
+    void init(@Observes StartupEvent ev) {
+        if (multitenancyEnabled) {
+            log.info("Registry running with multitenancy enabled");
         }
+    }
+
+    @RouteFilter(value = RouteFilter.DEFAULT_PRIORITY + 1000)
+    public void tenantRedirectFilter(RoutingContext ctx) throws IOException {
+
+        if (multitenancyEnabled) {
+
+            String uri = ctx.request().uri();
+
+            log.debug("Filtering request {} current tenantId {}", uri, tenantContext.tenantId());
+
+            if (uri.startsWith(MULTITENANT_BASE_PATH)) {
+                String[] tokens = uri.split("/");
+                String tenantId = tokens[2];
+                tenantContext.tenantId(tenantId);
+
+                String actualUri = uri.substring(tenantPrefixLength(tenantId));
+
+                log.debug("Rerouting request {} to {} tenantId {}", uri, actualUri, tenantContext.tenantId());
+
+                ctx.reroute(actualUri);
+                //very important to return
+                return;
+            }
+
+            String tenantId = ctx.request().getHeader(Headers.TENANT_ID);
+            if (tenantId != null) {
+                tenantContext.tenantId(tenantId);
+            }
+
+            if (tenantContext.isLoaded()) {
+                ctx.response().putHeader(Headers.TENANT_ID, tenantContext.tenantId());
+            }
+
+        }
+
+        ctx.next();
+
+    }
+
+    private int tenantPrefixLength(String tenantId) {
+        return (MULTITENANT_BASE_PATH + tenantId).length();
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/mt/TenantRequestFilter.java
+++ b/app/src/main/java/io/apicurio/registry/mt/TenantRequestFilter.java
@@ -37,7 +37,10 @@ public class TenantRequestFilter {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
-    private static final String MULTITENANT_BASE_PATH = "/t/";
+    @ConfigProperty(name = "registry.multitenancy.base.path")
+    String nameMultitenancyBasePath;
+
+    String multitenancyBasePath;
 
     @ConfigProperty(name = "registry.enable.multitenancy")
     boolean multitenancyEnabled;
@@ -49,6 +52,7 @@ public class TenantRequestFilter {
         if (multitenancyEnabled) {
             log.info("Registry running with multitenancy enabled");
         }
+        multitenancyBasePath = "/" + nameMultitenancyBasePath + "/";
     }
 
     @RouteFilter(value = RouteFilter.DEFAULT_PRIORITY + 1000)
@@ -60,7 +64,7 @@ public class TenantRequestFilter {
 
             log.debug("Filtering request {} current tenantId {}", uri, tenantContext.tenantId());
 
-            if (uri.startsWith(MULTITENANT_BASE_PATH)) {
+            if (uri.startsWith(multitenancyBasePath)) {
                 String[] tokens = uri.split("/");
                 String tenantId = tokens[2];
                 tenantContext.tenantId(tenantId);
@@ -90,7 +94,7 @@ public class TenantRequestFilter {
     }
 
     private int tenantPrefixLength(String tenantId) {
-        return (MULTITENANT_BASE_PATH + tenantId).length();
+        return (multitenancyBasePath + tenantId).length();
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/services/tenant/CustomTenantConfigResolver.java
+++ b/app/src/main/java/io/apicurio/registry/services/tenant/CustomTenantConfigResolver.java
@@ -31,9 +31,13 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ApplicationScoped
 public class CustomTenantConfigResolver implements TenantConfigResolver {
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
 
     @Inject
     @Current
@@ -50,9 +54,12 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
     public OidcTenantConfig resolve(RoutingContext context) {
 
         if (!tenantContext.isLoaded()) {
+            log.debug("Tenant config is not loaded, fallback to default tenant");
             // resolve to default tenant configuration
             return null;
         }
+
+        log.debug("Resolving tenant {}", tenantContext.tenantId());
 
         final TenantMetadataDto registryTenant = registryStorage.getTenantMetadata(tenantContext.tenantId());
         final OidcTenantConfig config = new OidcTenantConfig();

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -79,6 +79,10 @@ mp.openapi.servers=/api
 %prod.registry.events.kafka.config.retries=3
 %prod.registry.events.kafka.config.acks=all
 
+%test.registry.enable.multitenancy=false
+%dev.registry.enable.multitenancy=false
+%prod.registry.enable.multitenancy=false
+
 #Auth - disabled by default
 
 registry.auth.enabled=${AUTH_ENABLED:false}

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -83,6 +83,8 @@ mp.openapi.servers=/api
 %dev.registry.enable.multitenancy=false
 %prod.registry.enable.multitenancy=false
 
+registry.multitenancy.base.path=t
+
 #Auth - disabled by default
 
 registry.auth.enabled=${AUTH_ENABLED:false}

--- a/app/src/test/java/io/apicurio/registry/storage/AbstractRegistryStorageTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/AbstractRegistryStorageTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 
 import io.apicurio.registry.AbstractResourceTestBase;
 import io.apicurio.registry.content.ContentHandle;
-import io.apicurio.registry.mt.TenantContext;
 import io.apicurio.registry.rest.beans.ArtifactSearchResults;
 import io.apicurio.registry.rest.beans.SearchOver;
 import io.apicurio.registry.rest.beans.SortOrder;
@@ -47,35 +46,35 @@ import io.apicurio.registry.utils.tests.TestUtils;
  * @author eric.wittmann@gmail.com
  */
 public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBase {
-    
-    protected static final String OPENAPI_CONTENT = "{" + 
-            "    \"openapi\": \"3.0.2\"," + 
-            "    \"info\": {" + 
-            "        \"title\": \"Empty API\"," + 
-            "        \"version\": \"1.0.0\"," + 
-            "        \"description\": \"An example API design using OpenAPI.\"" + 
-            "    }" + 
+
+    protected static final String OPENAPI_CONTENT = "{" +
+            "    \"openapi\": \"3.0.2\"," +
+            "    \"info\": {" +
+            "        \"title\": \"Empty API\"," +
+            "        \"version\": \"1.0.0\"," +
+            "        \"description\": \"An example API design using OpenAPI.\"" +
+            "    }" +
             "}";
-    protected static final String OPENAPI_CONTENT_V2 = "{" + 
-            "    \"openapi\": \"3.0.2\"," + 
-            "    \"info\": {" + 
-            "        \"title\": \"Empty API 2\"," + 
-            "        \"version\": \"1.0.1\"," + 
-            "        \"description\": \"An example API design using OpenAPI.\"" + 
-            "    }" + 
+    protected static final String OPENAPI_CONTENT_V2 = "{" +
+            "    \"openapi\": \"3.0.2\"," +
+            "    \"info\": {" +
+            "        \"title\": \"Empty API 2\"," +
+            "        \"version\": \"1.0.1\"," +
+            "        \"description\": \"An example API design using OpenAPI.\"" +
+            "    }" +
             "}";
-    protected static final String OPENAPI_CONTENT_TEMPLATE = "{" + 
-            "    \"openapi\": \"3.0.2\"," + 
-            "    \"info\": {" + 
-            "        \"title\": \"Empty API 2\"," + 
-            "        \"version\": \"VERSION\"," + 
-            "        \"description\": \"An example API design using OpenAPI.\"" + 
-            "    }" + 
+    protected static final String OPENAPI_CONTENT_TEMPLATE = "{" +
+            "    \"openapi\": \"3.0.2\"," +
+            "    \"info\": {" +
+            "        \"title\": \"Empty API 2\"," +
+            "        \"version\": \"VERSION\"," +
+            "        \"description\": \"An example API design using OpenAPI.\"" +
+            "    }" +
             "}";
 
     @Inject
-    TenantContext tenantCtx;
-    
+    MockTenantContext tenantCtx;
+
     String tenantId1;
     String tenantId2;
 
@@ -84,7 +83,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         tenantId1 = UUID.randomUUID().toString();
         tenantId2 = UUID.randomUUID().toString();
     }
-    
+
     @AfterEach
     protected void resetTenant() throws Exception {
         tenantCtx.clearTenantId();
@@ -94,7 +93,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
      * Gets the storage to use.  Subclasses must provide this.
      */
     protected abstract RegistryStorage storage();
-    
+
     @Test
     public void testGetArtifactIds() throws Exception {
         String artifactIdPrefix = "testGetArtifactIds-";
@@ -105,12 +104,12 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
             Assertions.assertNotNull(dto);
             Assertions.assertEquals(artifactId, dto.getId());
         }
-        
+
         Set<String> ids = storage().getArtifactIds(10);
         Assertions.assertNotNull(ids);
         Assertions.assertEquals(10, ids.size());
     }
-    
+
     @Test
     public void testCreateArtifact() throws Exception {
         String artifactId = "testCreateArtifact-1";
@@ -124,13 +123,13 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertNull(dto.getProperties());
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
         Assertions.assertEquals(1, dto.getVersion());
-        
+
         StoredArtifact storedArtifact = storage().getArtifact(artifactId);
         Assertions.assertNotNull(storedArtifact);
         Assertions.assertEquals(OPENAPI_CONTENT, storedArtifact.getContent().content());
         Assertions.assertEquals(dto.getGlobalId(), storedArtifact.getGlobalId());
         Assertions.assertEquals(dto.getVersion(), storedArtifact.getVersion());
-        
+
         ArtifactMetaDataDto amdDto = storage().getArtifactMetaData(artifactId);
         Assertions.assertNotNull(amdDto);
         Assertions.assertEquals(dto.getGlobalId(), amdDto.getGlobalId());
@@ -140,7 +139,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals(1, amdDto.getVersion());
         Assertions.assertNull(amdDto.getLabels());
         Assertions.assertNull(amdDto.getProperties());
-        
+
         ArtifactVersionMetaDataDto versionMetaDataDto = storage().getArtifactVersionMetaData(artifactId, 1);
         Assertions.assertNotNull(versionMetaDataDto);
         Assertions.assertEquals(dto.getGlobalId(), versionMetaDataDto.getGlobalId());
@@ -148,19 +147,19 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals("An example API design using OpenAPI.", versionMetaDataDto.getDescription());
         Assertions.assertEquals(ArtifactState.ENABLED, versionMetaDataDto.getState());
         Assertions.assertEquals(1, versionMetaDataDto.getVersion());
-        
+
         StoredArtifact storedVersion = storage().getArtifactVersion(dto.getGlobalId());
         Assertions.assertNotNull(storedVersion);
         Assertions.assertEquals(OPENAPI_CONTENT, storedVersion.getContent().content());
         Assertions.assertEquals(dto.getGlobalId(), storedVersion.getGlobalId());
         Assertions.assertEquals(dto.getVersion(), storedVersion.getVersion());
-        
+
         storedVersion = storage().getArtifactVersion(artifactId, 1);
         Assertions.assertNotNull(storedVersion);
         Assertions.assertEquals(OPENAPI_CONTENT, storedVersion.getContent().content());
         Assertions.assertEquals(dto.getGlobalId(), storedVersion.getGlobalId());
         Assertions.assertEquals(dto.getVersion(), storedVersion.getVersion());
-        
+
         SortedSet<Long> versions = storage().getArtifactVersions(artifactId);
         Assertions.assertNotNull(versions);
         Assertions.assertEquals(1, versions.iterator().next());
@@ -184,13 +183,13 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals(metaData.getProperties(), dto.getProperties());
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
         Assertions.assertEquals(1, dto.getVersion());
-        
+
         StoredArtifact storedArtifact = storage().getArtifact(artifactId);
         Assertions.assertNotNull(storedArtifact);
         Assertions.assertEquals(OPENAPI_CONTENT, storedArtifact.getContent().content());
         Assertions.assertEquals(dto.getGlobalId(), storedArtifact.getGlobalId());
         Assertions.assertEquals(dto.getVersion(), storedArtifact.getVersion());
-        
+
         ArtifactMetaDataDto amdDto = storage().getArtifactMetaData(artifactId);
         Assertions.assertNotNull(amdDto);
         Assertions.assertEquals(dto.getGlobalId(), amdDto.getGlobalId());
@@ -208,7 +207,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         ContentHandle content = ContentHandle.create(OPENAPI_CONTENT);
         ArtifactMetaDataDto dto = storage().createArtifact(artifactId, ArtifactType.OPENAPI, content).toCompletableFuture().get();
         Assertions.assertNotNull(dto);
-        
+
         // Should throw error for duplicate artifact.
         Assertions.assertThrows(ArtifactAlreadyExistsException.class, () -> {
             storage().createArtifact(artifactId, ArtifactType.OPENAPI, content).toCompletableFuture().get();
@@ -243,12 +242,12 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         ArtifactMetaDataDto dto = storage().createArtifact(artifactId, ArtifactType.OPENAPI, content).toCompletableFuture().get();
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(artifactId, dto.getId());
-        
+
         SortedSet<Long> versions = storage().getArtifactVersions(artifactId);
         Assertions.assertNotNull(versions);
         Assertions.assertFalse(versions.isEmpty());
         Assertions.assertEquals(1, versions.size());
-        
+
         ContentHandle contentv2 = ContentHandle.create(OPENAPI_CONTENT_V2);
         ArtifactMetaDataDto dtov2 = storage().updateArtifact(artifactId, ArtifactType.OPENAPI, contentv2).toCompletableFuture().get();
         Assertions.assertNotNull(dtov2);
@@ -347,12 +346,12 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         ArtifactMetaDataDto dto = storage().createArtifact(artifactId, ArtifactType.OPENAPI, content).toCompletableFuture().get();
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(artifactId, dto.getId());
-        
+
         SortedSet<Long> versions = storage().getArtifactVersions(artifactId);
         Assertions.assertNotNull(versions);
         Assertions.assertFalse(versions.isEmpty());
         Assertions.assertEquals(1, versions.size());
-        
+
         ContentHandle contentv2 = ContentHandle.create(OPENAPI_CONTENT_V2);
         EditableArtifactMetaDataDto metaData = new EditableArtifactMetaDataDto("NAME", "DESC", Collections.singletonList("LBL"), Collections.singletonMap("K", "V"));
         ArtifactMetaDataDto dtov2 = storage().updateArtifactWithMetadata(artifactId, ArtifactType.OPENAPI, contentv2, metaData).toCompletableFuture().get();
@@ -389,9 +388,9 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertNull(dto.getProperties());
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
         Assertions.assertEquals(1, dto.getVersion());
-        
+
         long globalId = dto.getGlobalId();
-        
+
         dto = storage().getArtifactMetaData(globalId);
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(artifactId, dto.getId());
@@ -402,7 +401,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
         Assertions.assertEquals(1, dto.getVersion());
     }
-    
+
     @Test
     public void testUpdateArtifactMetaData() throws Exception {
         String artifactId = "testUpdateArtifactMetaData-1";
@@ -416,7 +415,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertNull(dto.getProperties());
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
         Assertions.assertEquals(1, dto.getVersion());
-        
+
         String newName = "Updated Name";
         String newDescription = "Updated description.";
         List<String> newLabels = Collections.singletonList("foo");
@@ -425,7 +424,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         newProperties.put("ting", "bin");
         EditableArtifactMetaDataDto emd = new EditableArtifactMetaDataDto(newName, newDescription, newLabels, newProperties);
         storage().updateArtifactMetaData(artifactId, emd);
-        
+
         ArtifactMetaDataDto metaData = storage().getArtifactMetaData(artifactId);
         Assertions.assertNotNull(metaData);
         Assertions.assertEquals(newName, metaData.getName());
@@ -441,9 +440,9 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         ArtifactMetaDataDto dto = storage().createArtifact(artifactId, ArtifactType.OPENAPI, content).toCompletableFuture().get();
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
-        
+
         storage().updateArtifactState(artifactId, ArtifactState.DEPRECATED);
-        
+
         ArtifactMetaDataDto metaData = storage().getArtifactMetaData(artifactId);
         Assertions.assertNotNull(metaData);
         Assertions.assertEquals(ArtifactState.DEPRECATED, metaData.getState());
@@ -463,10 +462,10 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals(artifactId, dtov2.getId());
         Assertions.assertEquals(2, dtov2.getVersion());
         Assertions.assertEquals(ArtifactState.ENABLED, dtov2.getState());
-        
+
         storage().updateArtifactState(artifactId, ArtifactState.DISABLED, 1);
         storage().updateArtifactState(artifactId, ArtifactState.DEPRECATED, 2);
-        
+
         ArtifactVersionMetaDataDto v1 = storage().getArtifactVersionMetaData(artifactId, 1);
         ArtifactVersionMetaDataDto v2 = storage().getArtifactVersionMetaData(artifactId, 2);
         Assertions.assertNotNull(v1);
@@ -488,7 +487,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertNull(dto.getProperties());
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
         Assertions.assertEquals(1, dto.getVersion());
-        
+
         String newName = "Updated Name";
         String newDescription = "Updated description.";
         List<String> newLabels = Collections.singletonList("foo");
@@ -497,7 +496,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         newProperties.put("ting", "bin");
         EditableArtifactMetaDataDto emd = new EditableArtifactMetaDataDto(newName, newDescription, newLabels, newProperties);
         storage().updateArtifactVersionMetaData(artifactId, 1, emd);
-        
+
         ArtifactVersionMetaDataDto metaData = storage().getArtifactVersionMetaData(artifactId, 1);
         Assertions.assertNotNull(metaData);
         Assertions.assertEquals(newName, metaData.getName());
@@ -517,11 +516,11 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertNull(dto.getProperties());
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
         Assertions.assertEquals(1, dto.getVersion());
-        
+
         storage().getArtifact(artifactId);
-        
+
         storage().deleteArtifact(artifactId);
-        
+
         Assertions.assertThrows(ArtifactNotFoundException.class, () -> {
             storage().getArtifact(artifactId);
         });
@@ -546,7 +545,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
         Assertions.assertEquals(1, dto.getVersion());
-        
+
         storage().deleteArtifactVersion(artifactId, 1);
 
         final String aid1 = artifactId;
@@ -562,7 +561,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertThrows(ArtifactNotFoundException.class, () -> {
             storage().getArtifactVersionMetaData(aid1, 1);
         });
-        
+
         // Delete one of multiple versions
         artifactId = "testDeleteArtifactVersion-2";
         content = ContentHandle.create(OPENAPI_CONTENT);
@@ -575,11 +574,11 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         ArtifactMetaDataDto dtov2 = storage().updateArtifact(artifactId, ArtifactType.OPENAPI, contentv2).toCompletableFuture().get();
         Assertions.assertNotNull(dtov2);
         Assertions.assertEquals(2, dtov2.getVersion());
-        
+
         storage().deleteArtifactVersion(artifactId, 1);
-        
+
         final String aid2 = artifactId;
-        
+
         storage().getArtifact(aid2);
         storage().getArtifactMetaData(aid2);
         Assertions.assertThrows(ArtifactNotFoundException.class, () -> {
@@ -588,7 +587,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertThrows(ArtifactNotFoundException.class, () -> {
             storage().getArtifactVersionMetaData(aid2, 1);
         });
-        
+
         // Delete the latest version
         artifactId = "testDeleteArtifactVersion-3";
         content = ContentHandle.create(OPENAPI_CONTENT);
@@ -600,7 +599,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         contentv2 = ContentHandle.create(OPENAPI_CONTENT_V2);
         dtov2 = storage().updateArtifact(artifactId, ArtifactType.OPENAPI, contentv2).toCompletableFuture().get();
         Assertions.assertNotNull(dtov2);
-        
+
         final String aid3 = artifactId;
         storage().deleteArtifactVersion(aid3, 2);
         SortedSet<Long> versions = storage().getArtifactVersions(aid3);
@@ -608,17 +607,17 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertFalse(versions.isEmpty());
         Assertions.assertEquals(1, versions.size());
         Assertions.assertEquals(1, versions.first());
-        
+
         VersionSearchResults result = storage().searchVersions(aid3, 0, 10);
         Assertions.assertNotNull(result);
         Assertions.assertEquals(1, result.getCount());
         Assertions.assertEquals(1, result.getVersions().iterator().next().getVersion());
-        
+
         ArtifactMetaDataDto artifactMetaData = storage().getArtifactMetaData(aid3);
         Assertions.assertNotNull(artifactMetaData);
         Assertions.assertEquals(1, artifactMetaData.getVersion());
         Assertions.assertEquals(aid3, artifactMetaData.getId());
-        
+
         storage().getArtifact(aid3);
         ArtifactMetaDataDto metaData = storage().getArtifactMetaData(aid3);
         Assertions.assertNotNull(metaData);
@@ -644,9 +643,9 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertNull(dto.getProperties());
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
         Assertions.assertEquals(1, dto.getVersion());
-        
+
         storage().deleteArtifactVersionMetaData(artifactId, 1);
-        
+
         ArtifactVersionMetaDataDto metaData = storage().getArtifactVersionMetaData(artifactId, 1);
         Assertions.assertNotNull(metaData);
         Assertions.assertNull(metaData.getName());
@@ -654,7 +653,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals(ArtifactState.ENABLED, metaData.getState());
         Assertions.assertEquals(1, metaData.getVersion());
     }
-    
+
     @Test
     public void testCreateArtifactRule() throws Exception {
         String artifactId = "testCreateArtifactRule-1";
@@ -691,7 +690,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         RuleConfigurationDto rule = storage().getArtifactRule(artifactId, RuleType.VALIDITY);
         Assertions.assertNotNull(rule);
         Assertions.assertEquals("FULL", rule.getConfiguration());
-        
+
         RuleConfigurationDto updatedConfig = new RuleConfigurationDto("NONE");
         storage().updateArtifactRule(artifactId, RuleType.VALIDITY, updatedConfig);
 
@@ -714,7 +713,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         RuleConfigurationDto rule = storage().getArtifactRule(artifactId, RuleType.VALIDITY);
         Assertions.assertNotNull(rule);
         Assertions.assertEquals("FULL", rule.getConfiguration());
-        
+
         storage().deleteArtifactRule(artifactId, RuleType.VALIDITY);
 
         Assertions.assertThrows(RuleNotFoundException.class, () -> {
@@ -736,7 +735,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
 
         List<RuleType> rules = storage().getArtifactRules(artifactId);
         Assertions.assertEquals(2, rules.size());
-        
+
         storage().deleteArtifactRules(artifactId);
 
         Assertions.assertThrows(RuleNotFoundException.class, () -> {
@@ -746,40 +745,40 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
             storage().getArtifactRule(artifactId, RuleType.COMPATIBILITY);
         });
     }
-    
+
     @Test
     public void testGlobalRules() {
         List<RuleType> globalRules = storage().getGlobalRules();
         Assertions.assertNotNull(globalRules);
         Assertions.assertTrue(globalRules.isEmpty());
-        
+
         RuleConfigurationDto config = new RuleConfigurationDto();
         config.setConfiguration("FULL");
         storage().createGlobalRule(RuleType.COMPATIBILITY, config);
-        
+
         RuleConfigurationDto rule = storage().getGlobalRule(RuleType.COMPATIBILITY);
         Assertions.assertEquals(rule.getConfiguration(), config.getConfiguration());
-        
+
         globalRules = storage().getGlobalRules();
         Assertions.assertNotNull(globalRules);
         Assertions.assertFalse(globalRules.isEmpty());
         Assertions.assertEquals(globalRules.size(), 1);
         Assertions.assertEquals(globalRules.get(0), RuleType.COMPATIBILITY);
-        
+
         Assertions.assertThrows(RuleAlreadyExistsException.class, () -> {
             storage().createGlobalRule(RuleType.COMPATIBILITY, config);
         });
-        
+
         RuleConfigurationDto updatedConfig = new RuleConfigurationDto("FORWARD");
         storage().updateGlobalRule(RuleType.COMPATIBILITY, updatedConfig);
-        
+
         rule = storage().getGlobalRule(RuleType.COMPATIBILITY);
         Assertions.assertEquals(rule.getConfiguration(), updatedConfig.getConfiguration());
-        
+
         Assertions.assertThrows(RuleNotFoundException.class, () -> {
             storage().updateGlobalRule(RuleType.VALIDITY, config);
         });
-        
+
         storage().deleteGlobalRules();
         globalRules = storage().getGlobalRules();
         Assertions.assertNotNull(globalRules);
@@ -807,34 +806,34 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
                     properties);
             storage().createArtifactWithMetadata(artifactId, ArtifactType.OPENAPI, content, metaData).toCompletableFuture().get();
         }
-        
+
         long start = System.currentTimeMillis();
-        
+
         ArtifactSearchResults results = storage().searchArtifacts("testSearchArtifacts", 0, 10, SearchOver.name, SortOrder.asc);
         Assertions.assertNotNull(results);
         Assertions.assertEquals(50, results.getCount());
         Assertions.assertNotNull(results.getArtifacts());
         Assertions.assertEquals(10, results.getArtifacts().size());
-        
+
         results = storage().searchArtifacts("testSearchArtifacts-19-name", 0, 10, SearchOver.name, SortOrder.asc);
         Assertions.assertNotNull(results);
         Assertions.assertEquals(1, results.getCount());
         Assertions.assertNotNull(results.getArtifacts());
         Assertions.assertEquals(1, results.getArtifacts().size());
         Assertions.assertEquals("testSearchArtifacts-19-name", results.getArtifacts().get(0).getName());
-        
+
         results = storage().searchArtifacts("testSearchArtifacts-33-description", 0, 10, SearchOver.description, SortOrder.asc);
         Assertions.assertNotNull(results);
         Assertions.assertEquals(1, results.getCount());
         Assertions.assertNotNull(results.getArtifacts());
         Assertions.assertEquals(1, results.getArtifacts().size());
         Assertions.assertEquals("testSearchArtifacts-33-name", results.getArtifacts().get(0).getName());
-        
+
         results = storage().searchArtifacts(null, 0, 11, SearchOver.everything, SortOrder.asc);
         Assertions.assertNotNull(results);
         Assertions.assertNotNull(results.getArtifacts());
         Assertions.assertEquals(11, results.getArtifacts().size());
-        
+
         results = storage().searchArtifacts("testSearchArtifacts", 0, 1000, SearchOver.everything, SortOrder.asc);
         Assertions.assertNotNull(results);
         Assertions.assertEquals(50, results.getCount());
@@ -868,7 +867,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         ArtifactMetaDataDto dto = storage().createArtifact(artifactId, ArtifactType.OPENAPI, content).toCompletableFuture().get();
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(artifactId, dto.getId());
-        
+
         // Add more versions
         for (int idx = 2; idx <= 50; idx++) {
             content = ContentHandle.create(OPENAPI_CONTENT_TEMPLATE.replaceAll("VERSION", "1.0." + idx));
@@ -885,7 +884,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
             Assertions.assertNotNull(results);
             Assertions.assertEquals(50, results.getCount());
             Assertions.assertEquals(10, results.getVersions().size());
-    
+
             results = storage().searchVersions(artifactId, 0, 1000);
             Assertions.assertNotNull(results);
             Assertions.assertEquals(50, results.getCount());
@@ -909,13 +908,13 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertNull(dto.getProperties());
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
         Assertions.assertEquals(1, dto.getVersion());
-        
+
         StoredArtifact storedArtifact = storage().getArtifact(artifactId);
         Assertions.assertNotNull(storedArtifact);
         Assertions.assertEquals(OPENAPI_CONTENT, storedArtifact.getContent().content());
         Assertions.assertEquals(dto.getGlobalId(), storedArtifact.getGlobalId());
         Assertions.assertEquals(dto.getVersion(), storedArtifact.getVersion());
-        
+
         ArtifactMetaDataDto amdDto = storage().getArtifactMetaData(artifactId);
         Assertions.assertNotNull(amdDto);
         Assertions.assertEquals(dto.getGlobalId(), amdDto.getGlobalId());
@@ -925,7 +924,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals(1, amdDto.getVersion());
         Assertions.assertNull(amdDto.getLabels());
         Assertions.assertNull(amdDto.getProperties());
-        
+
         // Switch to tenantId 2 and make sure the GET operations no longer work
         tenantCtx.tenantId(tenantId2);
         try {
@@ -951,7 +950,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertNull(dto.getProperties());
         Assertions.assertEquals(ArtifactState.ENABLED, dto.getState());
         Assertions.assertEquals(1, dto.getVersion());
-        
+
         // Switch to tenantId 2 and create the same artifact
         tenantCtx.tenantId(tenantId2);
         content = ContentHandle.create(OPENAPI_CONTENT);
@@ -983,14 +982,14 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
                     properties);
             storage().createArtifactWithMetadata(artifactId, ArtifactType.OPENAPI, content, metaData).toCompletableFuture().get();
         }
-        
+
         // Search for the artifacts using Tenant 2 (0 results expected)
         tenantCtx.tenantId(tenantId2);
         ArtifactSearchResults searchResults = storage().searchArtifacts("testMultiTenant_Search", 0, 100, SearchOver.labels, SortOrder.asc);
         Assertions.assertNotNull(searchResults);
         Assertions.assertEquals(0, searchResults.getCount());
         Assertions.assertTrue(searchResults.getArtifacts().isEmpty());
-        
+
         // Search for the artifacts using Tenant 1 (10 results expected)
         tenantCtx.tenantId(tenantId1);
         searchResults = storage().searchArtifacts("testMultiTenant_Search", 0, 100, SearchOver.labels, SortOrder.asc);
@@ -1006,7 +1005,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         List<RuleType> globalRules = storage().getGlobalRules();
         Assertions.assertNotNull(globalRules);
         Assertions.assertTrue(globalRules.isEmpty());
-        
+
         RuleConfigurationDto config = new RuleConfigurationDto();
         config.setConfiguration("FULL");
         storage().createGlobalRule(RuleType.COMPATIBILITY, config);
@@ -1016,25 +1015,25 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         } catch (RuleAlreadyExistsException e) {
             // this is expected
         }
-        
+
         RuleConfigurationDto rule = storage().getGlobalRule(RuleType.COMPATIBILITY);
         Assertions.assertEquals(rule.getConfiguration(), config.getConfiguration());
-        
+
         globalRules = storage().getGlobalRules();
         Assertions.assertNotNull(globalRules);
         Assertions.assertFalse(globalRules.isEmpty());
         Assertions.assertEquals(globalRules.size(), 1);
         Assertions.assertEquals(globalRules.get(0), RuleType.COMPATIBILITY);
-        
+
         ///////////////////////////////////////////////////
         // Now switch to tenant #2 and do the same stuff
         ///////////////////////////////////////////////////
-        
+
         tenantCtx.tenantId(tenantId2);
         globalRules = storage().getGlobalRules();
         Assertions.assertNotNull(globalRules);
         Assertions.assertTrue(globalRules.isEmpty());
-        
+
         config = new RuleConfigurationDto();
         config.setConfiguration("FULL");
         storage().createGlobalRule(RuleType.COMPATIBILITY, config);
@@ -1044,17 +1043,17 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         } catch (RuleAlreadyExistsException e) {
             // this is expected
         }
-        
+
         rule = storage().getGlobalRule(RuleType.COMPATIBILITY);
         Assertions.assertEquals(rule.getConfiguration(), config.getConfiguration());
-        
+
         globalRules = storage().getGlobalRules();
         Assertions.assertNotNull(globalRules);
         Assertions.assertFalse(globalRules.isEmpty());
         Assertions.assertEquals(globalRules.size(), 1);
         Assertions.assertEquals(globalRules.get(0), RuleType.COMPATIBILITY);
     }
-    
+
     @Test
     public void testMultiTenant_ArtifactNotFound() throws Exception {
         tenantCtx.tenantId(tenantId1);
@@ -1062,7 +1061,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         tenantCtx.tenantId(tenantId2);
         this.testArtifactNotFound();
     }
-    
+
     @Test
     public void testMultiTenant_CreateArtifactRule() throws Exception {
         tenantCtx.tenantId(tenantId1);
@@ -1070,7 +1069,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         tenantCtx.tenantId(tenantId2);
         this.testCreateArtifactRule();
     }
-    
+
     @Test
     public void testMultiTenant_CreateArtifactVersionWithMetaData() throws Exception {
         tenantCtx.tenantId(tenantId1);
@@ -1078,7 +1077,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         tenantCtx.tenantId(tenantId2);
         this.testCreateArtifactVersionWithMetaData();
     }
-    
+
     @Test
     public void testMultiTenant_CreateDuplicateArtifact() throws Exception {
         tenantCtx.tenantId(tenantId1);
@@ -1086,7 +1085,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         tenantCtx.tenantId(tenantId2);
         this.testCreateDuplicateArtifact();
     }
-    
+
     @Test
     public void testMultiTenant_UpdateArtifactMetaData() throws Exception {
         tenantCtx.tenantId(tenantId1);
@@ -1094,7 +1093,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         tenantCtx.tenantId(tenantId2);
         this.testUpdateArtifactMetaData();
     }
-    
+
     @Test
     public void testMultiTenant_UpdateArtifactRule() throws Exception {
         tenantCtx.tenantId(tenantId1);
@@ -1102,7 +1101,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         tenantCtx.tenantId(tenantId2);
         this.testUpdateArtifactRule();
     }
-    
+
     @Test
     public void testMultiTenant_UpdateArtifactState() throws Exception {
         tenantCtx.tenantId(tenantId1);
@@ -1110,7 +1109,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         tenantCtx.tenantId(tenantId2);
         this.testUpdateArtifactState();
     }
-    
+
     @Test
     public void testMultiTenant_UpdateArtifactVersionMetaData() throws Exception {
         tenantCtx.tenantId(tenantId1);
@@ -1118,7 +1117,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         tenantCtx.tenantId(tenantId2);
         this.testUpdateArtifactVersionMetaData();
     }
-    
+
     @Test
     public void testMultiTenant_UpdateArtifactVersionState() throws Exception {
         tenantCtx.tenantId(tenantId1);

--- a/app/src/test/java/io/apicurio/registry/storage/MockTenantContext.java
+++ b/app/src/test/java/io/apicurio/registry/storage/MockTenantContext.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.storage;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Alternative;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.apicurio.registry.mt.TenantContextImpl;
+import io.quarkus.runtime.StartupEvent;
+
+/**
+ * @author Fabian Martinez
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class MockTenantContext extends TenantContextImpl {
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    void init(@Observes StartupEvent ev) {
+        log.info("Using Mock TenantContext");
+    }
+
+    @Override
+    public void tenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public void clearTenantId() {
+        this.tenantId = DEFAULT_TENANT_ID;
+    }
+
+}

--- a/app/src/test/java/io/apicurio/registry/storage/MultitenantRegistryProfile.java
+++ b/app/src/test/java/io/apicurio/registry/storage/MultitenantRegistryProfile.java
@@ -13,29 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.apicurio.registry.storage;
 
-package io.apicurio.registry.mt;
+import java.util.Collections;
+import java.util.Map;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
-
-import io.apicurio.registry.types.Current;
+import io.quarkus.test.junit.QuarkusTestProfile;
 
 /**
- * @author eric.wittmann@gmail.com
+ * @author Fabian Martinez
  */
-@ApplicationScoped
-public class TenantContextProvider {
-    
-    @Inject
-    TenantContextImpl impl;
+public class MultitenantRegistryProfile implements QuarkusTestProfile {
 
-    @Produces
-    @ApplicationScoped
-    @Current
-    public TenantContext tenant() {
-        return impl;
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Collections.singletonMap("registry.enable.multitenancy", "true");
     }
 
 }

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/api/RegistryTenantResource.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/api/RegistryTenantResource.java
@@ -17,7 +17,6 @@ package io.apicurio.multitenant.api;
 
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -62,12 +61,13 @@ public class RegistryTenantResource {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response createTenant(NewRegistryTenantRequest tenantRequest) {
 
+        required(tenantRequest.getTenantId(), "TenantId is mandatory");
         required(tenantRequest.getOrganizationId(), "OrganizationId is mandatory");
         required(tenantRequest.getClientId(), "ClientId is mandatory");
 
         RegistryTenantDto tenant = new RegistryTenantDto();
 
-        tenant.setTenantId(UUID.randomUUID().toString());
+        tenant.setTenantId(tenantRequest.getTenantId());
 
         tenant.setOrganizationId(tenantRequest.getOrganizationId());
         tenant.setAuthClientId(tenantRequest.getClientId());

--- a/multitenancy/tenant-manager-api/src/test/java/io/apicurio/multitenant/RegistryTenantResourceTest.java
+++ b/multitenancy/tenant-manager-api/src/test/java/io/apicurio/multitenant/RegistryTenantResourceTest.java
@@ -24,6 +24,8 @@ import io.restassured.response.Response;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -50,6 +52,7 @@ public class RegistryTenantResourceTest {
     @Test
     public void testCRUD() {
         NewRegistryTenantRequest req = new NewRegistryTenantRequest();
+        req.setTenantId(UUID.randomUUID().toString());
         req.setOrganizationId("aaa");
         req.setDeploymentFlavor("small");
         req.setClientId("aaaaa");

--- a/multitenancy/tenant-manager-api/src/test/java/io/apicurio/multitenant/TenantManagerClientTest.java
+++ b/multitenancy/tenant-manager-api/src/test/java/io/apicurio/multitenant/TenantManagerClientTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,7 @@ public class TenantManagerClientTest {
     @Test
     public void testCRUD() {
         NewRegistryTenantRequest req = new NewRegistryTenantRequest();
+        req.setTenantId(UUID.randomUUID().toString());
         req.setOrganizationId("aaa");
         req.setDeploymentFlavor("small");
         req.setClientId("aaaaa");

--- a/multitenancy/tenant-manager-datamodel/src/main/java/io/apicurio/multitenant/datamodel/NewRegistryTenantRequest.java
+++ b/multitenancy/tenant-manager-datamodel/src/main/java/io/apicurio/multitenant/datamodel/NewRegistryTenantRequest.java
@@ -27,6 +27,8 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 @JsonInclude(Include.NON_NULL)
 public class NewRegistryTenantRequest {
 
+    private String tenantId;
+
     private String deploymentFlavor;
 
     private String organizationId;
@@ -35,6 +37,14 @@ public class NewRegistryTenantRequest {
 
     public NewRegistryTenantRequest() {
         // empty
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     public String getOrganizationId() {

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlSink.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlSink.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.control.ActivateRequestContext;
 import javax.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -53,7 +54,7 @@ public class KafkaSqlSink {
 
     @Inject
     KafkaSqlConfiguration configuration;
-    
+
     @Inject
     KafkaSqlSubmitter submitter;
 
@@ -64,13 +65,14 @@ public class KafkaSqlSink {
      * Called by the {@link KafkaSqlRegistryStorage} main Kafka consumer loop to process a single
      * message in the topic.  Each message represents some attempt to modify the registry data.  So
      * each message much be consumed and applied to the in-memory SQL data store.
-     * 
+     *
      * This method extracts the UUID from the message headers, delegates the message processing
      * to <code>doProcessMessage()</code>, and handles any exceptions that might occur. Finally
      * it will report the result to any local threads that may be waiting (via the coordinator).
-     * 
+     *
      * @param record
      */
+    @ActivateRequestContext
     public void processMessage(ConsumerRecord<MessageKey, MessageValue> record) {
         // If the key is null, we couldn't deserialize the message
         if (record.key() == null) {
@@ -132,28 +134,24 @@ public class KafkaSqlSink {
             Long globalId = toGlobalId(offset, partition);
             return globalId;
         };
-        
+
         String tenantId = key.getTenantId();
         tenantContext.tenantId(tenantId);
-        try {
-            MessageType messageType = key.getType();
-            switch (messageType) {
-                case Artifact:
-                    return processArtifactMessage((ArtifactKey) key, (ArtifactValue) value, globalIdGenerator);
-                case ArtifactRule:
-                    return processArtifactRuleMessage((ArtifactRuleKey) key, (ArtifactRuleValue) value);
-                case ArtifactVersion:
-                    return processArtifactVersion((ArtifactVersionKey) key, (ArtifactVersionValue) value);
-                case Content:
-                    return processContent((ContentKey) key, (ContentValue) value);
-                case GlobalRule:
-                    return processGlobalRuleVersion((GlobalRuleKey) key, (GlobalRuleValue) value);
-                default:
-                    log.warn("Unrecognized message type: %s", record.key());
-                    throw new RegistryStorageException("Unexpected message type: " + messageType.name());
-            }
-        } finally {
-            tenantContext.clearTenantId();
+        MessageType messageType = key.getType();
+        switch (messageType) {
+            case Artifact:
+                return processArtifactMessage((ArtifactKey) key, (ArtifactValue) value, globalIdGenerator);
+            case ArtifactRule:
+                return processArtifactRuleMessage((ArtifactRuleKey) key, (ArtifactRuleValue) value);
+            case ArtifactVersion:
+                return processArtifactVersion((ArtifactVersionKey) key, (ArtifactVersionValue) value);
+            case Content:
+                return processContent((ContentKey) key, (ContentValue) value);
+            case GlobalRule:
+                return processGlobalRuleVersion((GlobalRuleKey) key, (GlobalRuleValue) value);
+            default:
+                log.warn("Unrecognized message type: %s", record.key());
+                throw new RegistryStorageException("Unexpected message type: " + messageType.name());
         }
     }
 

--- a/storage/kafkasql/src/test/java/io/apicurio/registry/storage/impl/sql/KafkaSqlRegistryStorageTest.java
+++ b/storage/kafkasql/src/test/java/io/apicurio/registry/storage/impl/sql/KafkaSqlRegistryStorageTest.java
@@ -19,19 +19,22 @@ package io.apicurio.registry.storage.impl.sql;
 import javax.inject.Inject;
 
 import io.apicurio.registry.storage.AbstractRegistryStorageTest;
+import io.apicurio.registry.storage.MultitenantRegistryProfile;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.impl.kafkasql.KafkaSqlRegistryStorage;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 
 /**
  * @author eric.wittmann@gmail.com
  */
 @QuarkusTest
+@TestProfile(MultitenantRegistryProfile.class)
 public class KafkaSqlRegistryStorageTest extends AbstractRegistryStorageTest {
-    
+
     @Inject
     KafkaSqlRegistryStorage storage;
-    
+
     /**
      * @see io.apicurio.registry.storage.AbstractRegistryStorageTest#storage()
      */
@@ -39,5 +42,5 @@ public class KafkaSqlRegistryStorageTest extends AbstractRegistryStorageTest {
     protected RegistryStorage storage() {
         return storage;
     }
-    
+
 }

--- a/storage/sql/src/test/java/io/apicurio/registry/storage/impl/sql/SqlRegistryStorageTest.java
+++ b/storage/sql/src/test/java/io/apicurio/registry/storage/impl/sql/SqlRegistryStorageTest.java
@@ -19,18 +19,21 @@ package io.apicurio.registry.storage.impl.sql;
 import javax.inject.Inject;
 
 import io.apicurio.registry.storage.AbstractRegistryStorageTest;
+import io.apicurio.registry.storage.MultitenantRegistryProfile;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 
 /**
  * @author eric.wittmann@gmail.com
  */
 @QuarkusTest
+@TestProfile(MultitenantRegistryProfile.class)
 class SqlRegistryStorageTest extends AbstractRegistryStorageTest {
-    
+
     @Inject
     SqlRegistryStorage storage;
-    
+
     /**
      * @see io.apicurio.registry.storage.AbstractRegistryStorageTest#storage()
      */


### PR DESCRIPTION
This PR adds a vertx filter that allows the registry to accept requests at 

`/t/{tenantId}/api/...`

The registry still accepts requests at `/api/...` or '/health/...` ...

it also adds the property `registry.enable.multitenancy` to enable and disable this feature