### PR TITLE
fix: do not append assembly Id

### DIFF
--- a/distro/connect-converter/pom.xml
+++ b/distro/connect-converter/pom.xml
@@ -60,6 +60,7 @@
                         </goals>
                         <configuration>
                             <finalName>apicurio-kafka-connect-converter-${project.version}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
                             <attach>true</attach>  <!-- we want attach & deploy these to Maven -->
                             <descriptors>
                                 <descriptor>src/assembly/${assembly.descriptor}.xml</descriptor>


### PR DESCRIPTION
types other than jar was not getting resolved by maven since the id specified in the descriptor was getting appended