### PR TITLE
fix testLoggersCRUD test

### DIFF
--- a/app/src/test/java/io/apicurio/registry/RegistryClientV2Test.java
+++ b/app/src/test/java/io/apicurio/registry/RegistryClientV2Test.java
@@ -768,6 +768,7 @@ public class RegistryClientV2Test extends AbstractResourceTestBase {
         final NamedLogConfiguration logConfiguration = clientV2.getLogConfiguration(logger);
         assertEquals(LogLevel.DEBUG, logConfiguration.getLevel());
         assertEquals(logger, logConfiguration.getName());
+        clientV2.removeLogConfiguration(logger);
     }
 
     private ArtifactMetaData createArtifact(String groupId, String artifactId) {

--- a/app/src/test/java/io/apicurio/registry/rest/v2/AdminResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/rest/v2/AdminResourceTest.java
@@ -36,6 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import io.apicurio.registry.AbstractResourceTestBase;
@@ -60,10 +61,13 @@ public class AdminResourceTest extends AbstractResourceTestBase {
 
     private static final String TEST_LOGGER_NAME = "org.acme.test";
 
+    @ConfigProperty(name = "quarkus.log.level")
+    String defaultLogLevel;
+
     @BeforeEach
     public void setUp() {
         Logger logger = Logger.getLogger(TEST_LOGGER_NAME);
-        logger.setLevel(Level.INFO);
+        logger.setLevel(Level.parse(defaultLogLevel));
     }
 
     @Test


### PR DESCRIPTION
AdminResourceTest#testLoggersCRUD was failing because of a conflict with RegistryClientV2Test. Now it should be fixed