### PR TITLE
Refactor to decouple JsonSchemaDiffLibrary from rest service objects.

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/JsonSchemaCompatibilityChecker.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/JsonSchemaCompatibilityChecker.java
@@ -72,7 +72,11 @@ public class JsonSchemaCompatibilityChecker implements CompatibilityChecker {
             case NONE:
                 break;
         }
-        Set<CompatibilityDifference> diffs = incompatibleDiffs.stream().map(diff -> (CompatibilityDifference) diff).collect(Collectors.toSet());
+        Set<CompatibilityDifference> diffs =
+            incompatibleDiffs
+                .stream()
+                .map(JsonSchemaCompatibilityDifference::new)
+                .collect(Collectors.toSet());
         return CompatibilityExecutionResult.incompatible(diffs);
     }
 

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/JsonSchemaCompatibilityDifference.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/JsonSchemaCompatibilityDifference.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.rules.compatibility;
+
+import io.apicurio.registry.rest.beans.RuleViolationCause;
+import io.apicurio.registry.rules.compatibility.jsonschema.diff.Difference;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * Translation object for Difference into CompatibilityDifference.
+ * @author Ravindranath Kakarla <rnath@amazon.com>
+ */
+@Builder
+@Getter
+@EqualsAndHashCode
+public class JsonSchemaCompatibilityDifference implements CompatibilityDifference {
+    @NonNull
+    private final Difference difference;
+
+    /**
+     * @see io.apicurio.registry.rules.compatibility.CompatibilityDifference#asRuleViolationCause()
+     */
+    @Override
+    public RuleViolationCause asRuleViolationCause() {
+        return new RuleViolationCause(difference.getDiffType().getDescription(), difference.getPathUpdated());
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/jsonschema/diff/Difference.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/jsonschema/diff/Difference.java
@@ -16,8 +16,6 @@
 
 package io.apicurio.registry.rules.compatibility.jsonschema.diff;
 
-import io.apicurio.registry.rest.beans.RuleViolationCause;
-import io.apicurio.registry.rules.compatibility.CompatibilityDifference;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -31,7 +29,7 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode
 @ToString
-public class Difference implements CompatibilityDifference {
+public class Difference {
 
     @NonNull
     private final DiffType diffType;
@@ -47,12 +45,4 @@ public class Difference implements CompatibilityDifference {
 
     @NonNull
     private final String subSchemaUpdated;
-
-    /**
-     * @see io.apicurio.registry.rules.compatibility.CompatibilityDifference#asRuleViolationCause()
-     */
-    @Override
-    public RuleViolationCause asRuleViolationCause() {
-        return new RuleViolationCause(getDiffType().getDescription(), getPathUpdated());
-    }
 }

--- a/app/src/test/java/io/apicurio/registry/ArtifactTypeTest.java
+++ b/app/src/test/java/io/apicurio/registry/ArtifactTypeTest.java
@@ -30,6 +30,7 @@ import io.apicurio.registry.rules.compatibility.CompatibilityExecutionResult;
 import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
 import io.apicurio.registry.rules.compatibility.jsonschema.diff.DiffType;
 import io.apicurio.registry.rules.compatibility.jsonschema.diff.Difference;
+import io.apicurio.registry.rules.compatibility.JsonSchemaCompatibilityDifference;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
@@ -85,7 +86,8 @@ public class ArtifactTypeTest extends AbstractRegistryTestBase {
 
     private Difference findDiffByPathUpdated(Set<CompatibilityDifference> incompatibleDifferences, String path) {
         for(CompatibilityDifference cd : incompatibleDifferences) {
-            Difference diff = (Difference) cd;
+            JsonSchemaCompatibilityDifference jsonSchemaCompatibilityDifference = (JsonSchemaCompatibilityDifference) cd;
+            Difference diff = jsonSchemaCompatibilityDifference.getDifference();
             if(diff.getPathUpdated().equals(path)) {
                 return diff;
             }


### PR DESCRIPTION
This is related to [Issue](https://github.com/Apicurio/apicurio-registry/issues/1214)

During refactoring I realized that `Difference` class in `JsonSchemaDiffLibrary` uses `RuleViolationCause`. `RuleViolationCause` seems to be a rest service specific bean. This change will decouple it.

I will submitting subsequent PR to move the files to different location.

