### PR TITLE
disable apis flag - list of regexps

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/DisableApisFilter.java
+++ b/app/src/main/java/io/apicurio/registry/rest/DisableApisFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.rest;
+
+import java.io.IOException;
+import java.net.URI;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.Provider;
+
+import io.apicurio.registry.services.DisabledApisMatcherService;
+
+/**
+ * @author Fabian Martinez
+ */
+@PreMatching
+@Priority(1)
+@Provider
+public class DisableApisFilter implements ContainerRequestFilter {
+
+    @Inject
+    DisabledApisMatcherService disabledApisMatcherService;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+
+        URI reqUri = requestContext.getUriInfo().getRequestUri();
+        String path = reqUri.getPath();
+
+        boolean disabled = disabledApisMatcherService.isDisabled(path);
+
+        if (disabled) {
+            Response response = Response.status(Status.NOT_FOUND).build();
+            requestContext.abortWith(response);
+        }
+
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/services/DisabledApisMatcherService.java
+++ b/app/src/main/java/io/apicurio/registry/services/DisabledApisMatcherService.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -50,15 +51,19 @@ public class DisabledApisMatcherService {
             return;
         }
         for (String regexp : disableRegexps.get()) {
-            Pattern p = Pattern.compile(regexp);
-            disabledPatternsList.add(p);
+            try {
+                Pattern p = Pattern.compile(regexp);
+                disabledPatternsList.add(p);
+            } catch (PatternSyntaxException e) {
+                log.error("An error occurred parsing a regexp for disabling APIs: " + regexp, e);
+            }
         }
     }
 
     public boolean isDisabled(String requestPath) {
         for (Pattern pattern : disabledPatternsList) {
             if (pattern.matcher(requestPath).matches()) {
-                log.debug("Request {} is rejected because it's disabled by pattern {}", requestPath, pattern.pattern());
+                log.warn("Request {} is rejected because it's disabled by pattern {}", requestPath, pattern.pattern());
                 return true;
             }
         }

--- a/app/src/main/java/io/apicurio/registry/services/DisabledApisMatcherService.java
+++ b/app/src/main/java/io/apicurio/registry/services/DisabledApisMatcherService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.services;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Fabian Martinez
+ */
+@ApplicationScoped
+public class DisabledApisMatcherService {
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    private List<Pattern> disabledPatternsList;
+
+    @Inject
+    @ConfigProperty(name = "apicurio.registry.disable.apis")
+    Optional<List<String>> disableRegexps;
+
+    @PostConstruct
+    public void init() {
+        disabledPatternsList = new ArrayList<>();
+        if (disableRegexps.isEmpty()) {
+            return;
+        }
+        for (String regexp : disableRegexps.get()) {
+            Pattern p = Pattern.compile(regexp);
+            disabledPatternsList.add(p);
+        }
+    }
+
+    public boolean isDisabled(String requestPath) {
+        for (Pattern pattern : disabledPatternsList) {
+            if (pattern.matcher(requestPath).matches()) {
+                log.debug("Request {} is rejected because it's disabled by pattern {}", requestPath, pattern.pattern());
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/services/tenant/CustomTenantConfigResolver.java
+++ b/app/src/main/java/io/apicurio/registry/services/tenant/CustomTenantConfigResolver.java
@@ -63,8 +63,16 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
     @Inject
     TenantIdResolver tenantIdResolver;
 
+    @Inject
+    @ConfigProperty(name = "registry.auth.enabled")
+    boolean authEnabled;
+
     @Override
     public OidcTenantConfig resolve(RoutingContext context) {
+
+        if (!authEnabled) {
+            return null;
+        }
 
         if (!tenantIdResolver.resolveTenantId(context)) {
             log.debug("Tenant config is not loaded, fallback to default tenant");

--- a/app/src/test/java/io/apicurio/registry/ccompat/rest/ConfluentCompatApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/ccompat/rest/ConfluentCompatApiTest.java
@@ -50,7 +50,7 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
 
     private static final String SCHEMA_SIMPLE = "{\"type\": \"string\"}";
 
-    private static final String SCHEMA_SIMPLE_WRAPPED = "{\"schema\":\"{\\\"type\\\": \\\"string\\\"}\"}";
+    public static final String SCHEMA_SIMPLE_WRAPPED = "{\"schema\":\"{\\\"type\\\": \\\"string\\\"}\"}";
 
     private static final String SCHEMA_SIMPLE_WRAPPED_WITH_TYPE = "{\"schema\":\"{\\\"type\\\": \\\"string\\\"}\","
             + "\"schemaType\": \"AVRO\"}";

--- a/app/src/test/java/io/apicurio/registry/mt/MultitenancyNoAuthTest.java
+++ b/app/src/test/java/io/apicurio/registry/mt/MultitenancyNoAuthTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.mt;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.UUID;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.RegistryClientFactory;
+import io.apicurio.registry.rest.client.exception.ArtifactNotFoundException;
+import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.v2.beans.Rule;
+import io.apicurio.registry.rest.v2.beans.SearchedArtifact;
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.RuleType;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * @author Fabian Martinez
+ */
+@QuarkusTest
+@TestProfile(MultitenancyNoAuthTestProfile.class)
+public class MultitenancyNoAuthTest extends AbstractResourceTestBase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MultitenancyNoAuthTest.class);
+
+    @Inject
+    RegistryStorage storage;
+
+    @Test
+    public void testSecuredMultitenantRegistry() throws Exception {
+
+        try {
+            storage.getTenantMetadata("foo");
+        } catch (Exception e) {
+            if (e instanceof UnsupportedOperationException) {
+                throw new TestAbortedException("Multitenancy not supported - aborting test", e);
+            }
+        }
+
+        RegistryClient clientTenant1 = RegistryClientFactory.create("http://localhost:8081/t/" + UUID.randomUUID().toString() + "/apis/registry/v2" );
+        RegistryClient clientTenant2 = RegistryClientFactory.create("http://localhost:8081/t/" + UUID.randomUUID().toString() + "/apis/registry/v2" );
+
+        try {
+            tenantOperations(clientTenant1);
+            try {
+                tenantOperations(clientTenant2);
+            } finally {
+                cleanTenantArtifacts(clientTenant2);
+            }
+        } finally {
+            cleanTenantArtifacts(clientTenant1);
+        }
+
+    }
+
+    private void tenantOperations(RegistryClient client) throws Exception {
+        assertTrue(client.listArtifactsInGroup(null).getCount().intValue() == 0);
+
+        String artifactId = TestUtils.generateArtifactId();
+        ArtifactMetaData meta = client.createArtifact(null, artifactId, ArtifactType.JSON, new ByteArrayInputStream("{}".getBytes()));
+        TestUtils.retry(() -> client.getContentByGlobalId(meta.getGlobalId()));
+
+        assertNotNull(client.getLatestArtifact(meta.getGroupId(), meta.getId()));
+
+        assertTrue(client.listArtifactsInGroup(null).getCount().intValue() == 1);
+
+        Rule ruleConfig = new Rule();
+        ruleConfig.setType(RuleType.VALIDITY);
+        ruleConfig.setConfig("NONE");
+        client.createArtifactRule(meta.getGroupId(), meta.getId(), ruleConfig);
+
+        client.createGlobalRule(ruleConfig);
+    }
+
+    private void cleanTenantArtifacts(RegistryClient client) throws Exception {
+        List<SearchedArtifact> artifacts = client.listArtifactsInGroup(null).getArtifacts();
+        for (SearchedArtifact artifact : artifacts) {
+            try {
+                client.deleteArtifact(artifact.getGroupId(), artifact.getId());
+            } catch (ArtifactNotFoundException e) {
+                //because of async storage artifact may be already deleted but listed anyway
+                LOGGER.info(e.getMessage());
+            } catch (Exception e) {
+                LOGGER.error("", e);
+            }
+        }
+        TestUtils.retry(() -> assertTrue(client.listArtifactsInGroup(null).getCount().intValue() == 0));
+    }
+
+
+}

--- a/app/src/test/java/io/apicurio/registry/mt/MultitenancyNoAuthTest.java
+++ b/app/src/test/java/io/apicurio/registry/mt/MultitenancyNoAuthTest.java
@@ -39,6 +39,7 @@ import io.apicurio.registry.rest.v2.beans.Rule;
 import io.apicurio.registry.rest.v2.beans.SearchedArtifact;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.Current;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
@@ -54,6 +55,7 @@ public class MultitenancyNoAuthTest extends AbstractResourceTestBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(MultitenancyNoAuthTest.class);
 
     @Inject
+    @Current
     RegistryStorage storage;
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/mt/MultitenancyNoAuthTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/mt/MultitenancyNoAuthTestProfile.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.mt;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+/**
+ * @author Fabian Martinez
+ */
+public class MultitenancyNoAuthTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> props = new HashMap<>();
+        props.put("registry.enable.multitenancy", "true");
+        return props;
+    }
+
+}

--- a/app/src/test/java/io/apicurio/registry/rest/DisableApisFlagsTest.java
+++ b/app/src/test/java/io/apicurio/registry/rest/DisableApisFlagsTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.rest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.anything;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ccompat.rest.ConfluentCompatApiTest;
+import io.apicurio.registry.ccompat.rest.ContentTypes;
+import io.apicurio.registry.services.DisabledApisMatcherService;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * @author Fabian Martinez
+ */
+@QuarkusTest
+@TestProfile(DisableApisTestProfile.class)
+public class DisableApisFlagsTest extends AbstractResourceTestBase {
+
+//    apicurio.registry.disable.apis
+
+    @Inject
+    DisabledApisMatcherService matcherService;
+
+    @Test
+    public void testRegexp() {
+
+        assertTrue(matcherService.isDisabled("/apis/ibmcompat/v1/schemas"));
+
+        assertTrue(matcherService.isDisabled("/apis/ccompat/v6/subjects/abcfoo/versions"));
+
+        assertFalse(matcherService.isDisabled("/apis/ccompat/v6/subjects"));
+
+    }
+
+    @Test
+    public void testRestApi() throws Exception {
+        doTestDisabledApis();
+    }
+
+    public static void doTestDisabledApis() throws Exception {
+        doTestDisabledSubPathRegexp();
+
+        doTestDisabledPathExactMatch();
+
+        doTestDisabledChildPathByParentPath();
+    }
+
+    private static void doTestDisabledSubPathRegexp() {
+        //this should return http 404, it's disabled
+        given()
+            .when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(ConfluentCompatApiTest.SCHEMA_SIMPLE_WRAPPED)
+                .post("/ccompat/v6/subjects/{subject}/versions", UUID.randomUUID().toString())
+            .then()
+                .statusCode(404);
+
+        //this should return http 200, it's not disabled
+        given()
+            .when().contentType(CT_JSON).get("/ccompat/v6/subjects")
+            .then()
+            .statusCode(200)
+            .body(anything());
+    }
+
+    private static void doTestDisabledPathExactMatch() {
+        String schemaDefinition = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}";
+        String schemaName = "testVerifySchema_userInfo";
+        String versionName = "testversion_1.0.0";
+
+        //the entire ibmcompat api is disabled
+        given()
+            .when()
+                .queryParam("verify", "true")
+                .contentType(CT_JSON)
+                .body("{\"name\":\"" + schemaName + "\",\"version\":\"" + versionName + "\",\"definition\":\"" + schemaDefinition + "\"}")
+                .post("/ibmcompat/v1/schemas")
+            .then()
+                .statusCode(404);
+    }
+
+    private static void doTestDisabledChildPathByParentPath() throws Exception {
+        String artifactContent = "{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}";
+        String schemaId = TestUtils.generateArtifactId();
+
+        given()
+            .when()
+                .contentType(CT_JSON + "; artifactType=AVRO")
+                .pathParam("groupId", "default")
+                .header("X-Registry-ArtifactId", schemaId)
+                .body(artifactContent)
+                .post("/registry/v2/groups/{groupId}/artifacts")
+            .then()
+                .statusCode(200);
+
+
+        //the entire ibmcompat api is disabled
+        given()
+            .when()
+                .get("/ibmcompat/v1/schemas/" + schemaId)
+            .then()
+                .statusCode(404);
+    }
+
+
+}

--- a/app/src/test/java/io/apicurio/registry/rest/DisableApisTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/rest/DisableApisTestProfile.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.rest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+/**
+ * @author Fabian Martinez
+ */
+public class DisableApisTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> props = new HashMap<>();
+        props.put("apicurio.registry.disable.apis", "/apis/ibmcompat/.*,/apis/ccompat/v6/subjects/[^/]+/versions.*");
+        return props;
+    }
+
+}
+

--- a/app/src/test/java/io/apicurio/registry/rest/MultipleRequestFiltersTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/rest/MultipleRequestFiltersTestProfile.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.rest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+/**
+ * @author Fabian Martinez
+ */
+public class MultipleRequestFiltersTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> props = new HashMap<>();
+        props.put("registry.enable.multitenancy", "true");
+        props.put("apicurio.registry.disable.apis", "/apis/ibmcompat/.*,/apis/ccompat/v6/subjects/[^/]+/versions.*");
+        return props;
+    }
+
+}

--- a/app/src/test/java/io/apicurio/registry/rest/MultitenancyAndDisabledApisTest.java
+++ b/app/src/test/java/io/apicurio/registry/rest/MultitenancyAndDisabledApisTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.rest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.anything;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ccompat.rest.ConfluentCompatApiTest;
+import io.apicurio.registry.ccompat.rest.ContentTypes;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * @author Fabian Martinez
+ */
+@QuarkusTest
+@TestProfile(MultipleRequestFiltersTestProfile.class)
+public class MultitenancyAndDisabledApisTest extends AbstractResourceTestBase {
+
+    @Test
+    public void testRestApi() throws Exception {
+        DisableApisFlagsTest.doTestDisabledApis();
+
+        //this should return http 404, it's disabled
+        given()
+            .baseUri("http://localhost:8081")
+            .when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(ConfluentCompatApiTest.SCHEMA_SIMPLE_WRAPPED)
+                .post("/t/abc/apis/ccompat/v6/subjects/{subject}/versions", UUID.randomUUID().toString())
+            .then()
+                .statusCode(404);
+
+        //this should return http 200, it's not disabled
+        given()
+            .baseUri("http://localhost:8081")
+            .when().contentType(CT_JSON).get("/t/abc/apis/ccompat/v6/subjects")
+            .then()
+            .statusCode(200)
+            .body(anything());
+    }
+
+}


### PR DESCRIPTION
Implements #1236 and adds a few tests to verify the new functionality and the interation of several `ContainerRequestFilters` (multitenancy filter and disabled apis filter)