### PR TITLE
fix connect-converters

### DIFF
--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/utils/Utils.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/utils/Utils.java
@@ -47,22 +47,11 @@ public class Utils {
                 //noinspection unchecked
                 setter.accept(instantiate((Class<V>) value));
             } else if (value instanceof String) {
-                Class<V> clazz = loadClass(type, (String) value);
+                Class<V> clazz = loadClass((String) value);
                 setter.accept(instantiate(clazz));
             } else {
                 throw new IllegalArgumentException(String.format("Cannot handle configuration [%s]: %s", type.getName(), value));
             }
-        }
-    }
-
-    //TODO make the instantiation mechanism configurable
-    @SuppressWarnings("unchecked")
-    private static <V> Class<V> loadClass(Class<V> type, String className) {
-        try {
-            //noinspection unchecked
-            return (Class<V>) type.getClassLoader().loadClass(className);
-        } catch (Exception e) {
-            throw new IllegalArgumentException(e);
         }
     }
 

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/AvroConverter.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/AvroConverter.java
@@ -22,6 +22,8 @@ import io.apicurio.registry.serde.avro.NonRecordContainer;
 import io.apicurio.registry.utils.converter.avro.AvroData;
 import io.apicurio.registry.utils.converter.avro.AvroDataConfig;
 import org.apache.avro.generic.GenericContainer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 
@@ -39,6 +41,22 @@ public class AvroConverter<T> extends SerdeBasedConverter<org.apache.avro.Schema
 
     public AvroConverter() {
         super();
+    }
+
+    /**
+     * @see io.apicurio.registry.utils.converter.SerdeBasedConverter#serializerClass()
+     */
+    @Override
+    protected Class<? extends Serializer> serializerClass() {
+        return AvroKafkaSerializer.class;
+    }
+
+    /**
+     * @see io.apicurio.registry.utils.converter.SerdeBasedConverter#deserializerClass()
+     */
+    @Override
+    protected Class<? extends Deserializer> deserializerClass() {
+        return AvroKafkaDeserializer.class;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})


### PR DESCRIPTION
attempt to fix 
```
java.lang.IllegalArgumentException: java.lang.ClassNotFoundException: io.apicurio.registry.serde.avro.AvroKafkaSerializer
	at io.apicurio.registry.serde.utils.Utils.loadClass(Utils.java:65)
	at io.apicurio.registry.serde.utils.Utils.instantiate(Utils.java:50)
	at io.apicurio.registry.utils.converter.SerdeBasedConverter.configure(SerdeBasedConverter.java:72)
	at io.apicurio.registry.utils.converter.AvroConverter.configure(AvroConverter.java:52)
	at org.apache.kafka.connect.runtime.isolation.Plugins.newConverter(Plugins.java:298)
	at org.apache.kafka.connect.runtime.Worker.startTask(Worker.java:530)
	at org.apache.kafka.connect.runtime.distributed.DistributedHerder.startTask(DistributedHerder.java:1258)
	at org.apache.kafka.connect.runtime.distributed.DistributedHerder.access$1700(DistributedHerder.java:127)
	at org.apache.kafka.connect.runtime.distributed.DistributedHerder$10.call(DistributedHerder.java:1273)
	at org.apache.kafka.connect.runtime.distributed.DistributedHerder$10.call(DistributedHerder.java:1269)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.ClassNotFoundException: io.apicurio.registry.serde.avro.AvroKafkaSerializer
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at io.apicurio.registry.serde.utils.Utils.loadClass(Utils.java:63)
	... 13 more
```