### PR TITLE
fix streams storage default group handling and fix ui tests

### DIFF
--- a/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
+++ b/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
@@ -195,7 +195,7 @@ public abstract class AbstractResourceTestBase extends AbstractRegistryTestBase 
             given()
                 .when()
                     .contentType(CT_JSON)
-                    .pathParam("groupId", groupId)
+                    .pathParam("groupId", groupId == null ? "default" : groupId)
                     .pathParam("artifactId", artifactId)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
                 .then()

--- a/app/src/test/java/io/apicurio/registry/RegistryClientTest.java
+++ b/app/src/test/java/io/apicurio/registry/RegistryClientTest.java
@@ -861,6 +861,8 @@ public class RegistryClientTest extends AbstractResourceTestBase {
         assertNull(vmeta.getGroupId());
 
         clientV2.listArtifactsInGroup(null).getArtifacts()
+            .stream()
+            .filter(s -> s.getId().equals(artifactId))
             .forEach(s -> assertNull(s.getGroupId()));
 
     }

--- a/app/src/test/java/io/apicurio/registry/RegistryClientTest.java
+++ b/app/src/test/java/io/apicurio/registry/RegistryClientTest.java
@@ -59,6 +59,7 @@ import static io.apicurio.registry.utils.tests.TestUtils.retry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -808,13 +809,73 @@ public class RegistryClientTest extends AbstractResourceTestBase {
         clientV2.removeLogConfiguration(logger);
     }
 
+    @Test
+    public void testDefaultGroup() throws Exception {
+        String nullDefaultGroup = null;
+        String artifactId1 = "test1";
+        createArtifact(nullDefaultGroup, artifactId1);
+        verifyGroupNullInMetadata(artifactId1, IoUtil.toStream(ARTIFACT_CONTENT.getBytes(StandardCharsets.UTF_8)));
+
+        String defaultDefaultGroup = "default";
+        String artifactId2 = "test2";
+        createArtifact(defaultDefaultGroup, artifactId2);
+        verifyGroupNullInMetadata(artifactId2, IoUtil.toStream(ARTIFACT_CONTENT.getBytes(StandardCharsets.UTF_8)));
+
+        String dummyGroup = "dummy";
+        String artifactId3 = "test3";
+        createArtifact(dummyGroup, artifactId3);
+
+        ArtifactSearchResults result = clientV2.searchArtifacts(null, null, null, null, null, null, null, null, null);
+
+        SearchedArtifact artifact1 = result.getArtifacts().stream()
+            .filter(s -> s.getId().equals(artifactId1))
+            .findFirst()
+            .orElseThrow();
+
+        assertNull(artifact1.getGroupId());
+
+        SearchedArtifact artifact2 = result.getArtifacts().stream()
+                .filter(s -> s.getId().equals(artifactId2))
+                .findFirst()
+                .orElseThrow();
+
+        assertNull(artifact2.getGroupId());
+
+        SearchedArtifact artifact3 = result.getArtifacts().stream()
+                .filter(s -> s.getId().equals(artifactId3))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(dummyGroup, artifact3.getGroupId());
+
+    }
+
+    private void verifyGroupNullInMetadata(String artifactId, InputStream content) {
+        ArtifactMetaData meta = clientV2.getArtifactMetaData(null, artifactId);
+        assertNull(meta.getGroupId());
+
+        VersionMetaData vmeta = clientV2.getArtifactVersionMetaData(null, artifactId, Long.toString(meta.getVersion()));
+        assertNull(vmeta.getGroupId());
+
+        vmeta = clientV2.getArtifactVersionMetaDataByContent(null, artifactId, content);
+        assertNull(vmeta.getGroupId());
+
+        clientV2.listArtifactsInGroup(null).getArtifacts()
+            .forEach(s -> assertNull(s.getGroupId()));
+
+    }
+
     private ArtifactMetaData createArtifact(String groupId, String artifactId) throws Exception {
         final InputStream stream = IoUtil.toStream(ARTIFACT_CONTENT.getBytes(StandardCharsets.UTF_8));
         final ArtifactMetaData created = clientV2.createArtifact(groupId, artifactId, null, ArtifactType.JSON, IfExists.FAIL, false, stream);
         waitForArtifact(groupId, artifactId);
 
         assertNotNull(created);
-        assertEquals(groupId, created.getGroupId());
+        if (groupId == null || groupId.equals("default")) {
+            assertNull(created.getGroupId());
+        } else {
+            assertEquals(groupId, created.getGroupId());
+        }
         assertEquals(artifactId, created.getId());
 
         return created;

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/selenium/resources/ArtifactListItem.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/selenium/resources/ArtifactListItem.java
@@ -67,9 +67,13 @@ public class ArtifactListItem extends WebItem {
         return viewArtifactLink;
     }
 
+    /**
+     * @see java.lang.Object#toString()
+     */
     @Override
     public String toString() {
-        return "ArtifactListItem [artifactId=" + artifactId + ", description=" + description + "]";
+        return "ArtifactListItem [groupId=" + groupId + ", artifactId=" + artifactId + ", description="
+                + description + "]";
     }
 
     public boolean matches(String groupId, String artifactId) {

--- a/storage/streams/src/main/java/io/apicurio/registry/streams/StreamsRegistryStorage.java
+++ b/storage/streams/src/main/java/io/apicurio/registry/streams/StreamsRegistryStorage.java
@@ -1225,7 +1225,7 @@ public class StreamsRegistryStorage extends AbstractRegistryStorage {
         private Str.Data data;
     }
 
-    public static ArtifactMetaDataDto toArtifactMetaData(Map<String, String> content) {
+    private static ArtifactMetaDataDto toArtifactMetaData(Map<String, String> content) {
         ArtifactMetaDataDto dto = MetaDataKeys.toArtifactMetaData(content);
         if (dto.getGroupId().equals(LEGACY_GROUP_ID)) {
             dto.setGroupId(null);

--- a/storage/streams/src/main/java/io/apicurio/registry/streams/StreamsRegistryStorage.java
+++ b/storage/streams/src/main/java/io/apicurio/registry/streams/StreamsRegistryStorage.java
@@ -463,7 +463,7 @@ public class StreamsRegistryStorage extends AbstractRegistryStorage {
                                 // somebody beat us to it ...
                                 throw new ArtifactAlreadyExistsException(groupId, artifactId);
                             }
-                            final ArtifactMetaDataDto artifactMetaDataDto = MetaDataKeys.toArtifactMetaData(first.getMetadataMap());
+                            final ArtifactMetaDataDto artifactMetaDataDto = toArtifactMetaData(first.getMetadataMap());
                             artifactMetaDataDto.setContentId(first.getContentId());
                             return artifactMetaDataDto;
                         }
@@ -628,7 +628,7 @@ public class StreamsRegistryStorage extends AbstractRegistryStorage {
                     for (int i = d.getArtifactsCount() - 1; i >= 0; i--) {
                         Str.ArtifactValue value = d.getArtifacts(i);
                         if (value.getId() == globalId) {
-                            ArtifactMetaDataDto artifactMetaDataDto = MetaDataKeys.toArtifactMetaData(value.getMetadataMap());
+                            ArtifactMetaDataDto artifactMetaDataDto = toArtifactMetaData(value.getMetadataMap());
 
                             if (artifactMetaDataDto.getVersion() != ARTIFACT_FIRST_VERSION) {
                                 ArtifactVersionMetaDataDto firstVersionContent = getArtifactVersionMetaData(groupId, artifactId, ARTIFACT_FIRST_VERSION);
@@ -763,7 +763,7 @@ public class StreamsRegistryStorage extends AbstractRegistryStorage {
         final Str.ArtifactValue artifactValue = getLastArtifact(groupId, artifactId);
         final Map<String, String> content = getLastArtifact(groupId, artifactId).getMetadataMap();
 
-        final ArtifactMetaDataDto artifactMetaDataDto = MetaDataKeys.toArtifactMetaData(content);
+        final ArtifactMetaDataDto artifactMetaDataDto = toArtifactMetaData(content);
 
         artifactMetaDataDto.setContentId(artifactValue.getContentId());
 
@@ -843,7 +843,7 @@ public class StreamsRegistryStorage extends AbstractRegistryStorage {
             throw new ArtifactNotFoundException("GlobalId: " + id);
         }
         return handleVersion(tuple.getKey(), tuple.getVersion(), null, value -> {
-                    final ArtifactMetaDataDto artifactMetaDataDto = MetaDataKeys.toArtifactMetaData(value.getMetadataMap());
+                    final ArtifactMetaDataDto artifactMetaDataDto = toArtifactMetaData(value.getMetadataMap());
                     artifactMetaDataDto.setContentId(value.getContentId());
                     return artifactMetaDataDto;
                 }
@@ -1224,4 +1224,13 @@ public class StreamsRegistryStorage extends AbstractRegistryStorage {
         private RecordMetadata rmd;
         private Str.Data data;
     }
+
+    public static ArtifactMetaDataDto toArtifactMetaData(Map<String, String> content) {
+        ArtifactMetaDataDto dto = MetaDataKeys.toArtifactMetaData(content);
+        if (dto.getGroupId().equals(LEGACY_GROUP_ID)) {
+            dto.setGroupId(null);
+        }
+        return dto;
+    }
+
 }


### PR DESCRIPTION
The streams storage was handling the default group ("default" or null) incorrectly. It was returning a string "null" instead of null. I noticed this error in the UI tests.

This PR adds a test to verify all storages handle the default group the same way, plus some improvements in the UI tests that were failing.
