### PR TITLE
fix streams clustered error - FAILED_PRECONDITION: org.apache.kafka.streams.errors.InvalidStateStoreException: The state store, storage-store, may have migrated to another instance

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -51,29 +51,33 @@ jobs:
         run: |
           echo "test_profile=all" >> $GITHUB_ENV
 
+      - name: Get maven wrapper
+        run: mvn -N io.takari:maven:wrapper -Dmaven=3.6.3
+
       - name: Build All Variants
-        run: mvn clean install -Pprod -Psql -Pstreams -Pkafkasql -Pmultitenancy -Pinfinispan -DskipTests
+        run: ./mvnw clean install -Pprod -Psql -Pstreams -Pkafkasql -Pmultitenancy -Pinfinispan -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
+
       - name: Build integration-tests-common
-        run: mvn install -Pintegration-tests -pl integration-tests/integration-tests-common
+        run: ./mvnw install -Pintegration-tests -pl integration-tests/integration-tests-common
       - name: Run UI tests - only PRs
         if: github.ref != 'refs/heads/master'
-        run: mvn verify -Pintegration-tests -Pui -Pinmemory -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
+        run: ./mvnw verify -Pintegration-tests -Pui -Pinmemory -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Integration Tests - streams
-        run: mvn verify -Pintegration-tests -P${{ env.test_profile }} -Pstreams -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Pstreams -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
       - name: Run Integration Tests - streams clustered
-        run: mvn verify -Pintegration-tests -Pclustered -Pstreams -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -Pclustered -Pstreams -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
       - name: Run Integration Tests - sql
-        run: mvn verify -Pintegration-tests -P${{ env.test_profile }} -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
       - name: Run Integration Tests - infinispan
-        run: mvn verify -Pintegration-tests -P${{ env.test_profile }} -Pinfinispan -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Pinfinispan -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
       - name: Run Integration Tests - kafkasql
-        run: mvn verify -Pintegration-tests -P${{ env.test_profile }} -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
       - name: Run Integration Tests - multitenancy
-        run: mvn verify -Pintegration-tests -Pmultitenancy -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
+        run: ./mvnw verify -Pintegration-tests -Pmultitenancy -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Legacy Tests - streams
-        run: mvn verify -Pintegration-tests -P${{ env.test_profile }} -Pstreams -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Pstreams -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress
       - name: Run Legacy Tests - sql
-        run: mvn verify -Pintegration-tests -P${{ env.test_profile }} -Psql -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Psql -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress
       - name: Collect logs
         if: failure()
         run: ./.github/scripts/collect_logs.sh

--- a/.github/workflows/kubernetes-tests.yaml
+++ b/.github/workflows/kubernetes-tests.yaml
@@ -32,8 +32,11 @@ jobs:
           version: '11'
           architecture: x64
 
+      - name: Get maven wrapper
+        run: mvn -N io.takari:maven:wrapper -Dmaven=3.6.3
+
       - name: Build All Variants
-        run: mvn clean install -Pprod -Psql -Pinfinispan -Pstreams -Pmultitenancy -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw clean install -Pprod -Psql -Pinfinispan -Pstreams -Pmultitenancy -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 
       - name: Build The Tagged Docker Images
         run: |

--- a/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
+++ b/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
@@ -123,6 +123,8 @@ public class RegistryFacade {
         }
         LOGGER.info("Deploying registry using storage {}, test profile {}", RegistryUtils.REGISTRY_STORAGE.name(), RegistryUtils.TEST_PROFILE);
         Map<String, String> appEnv = new HashMap<>();
+        appEnv.put("LOG_LEVEL", "DEBUG");
+        appEnv.put("REGISTRY_LOG_LEVEL", "DEBUG");
         switch (RegistryUtils.REGISTRY_STORAGE) {
             case inmemory:
             case infinispan:
@@ -213,8 +215,6 @@ public class RegistryFacade {
                 cmd.addAll(Arrays.asList(
                         // "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005",
                         "-Dquarkus.http.port=" + httpPort,
-                        "-Dquarkus.log.console.level=DEBUG",
-                        "-Dquarkus.log.category.\"io\".level=DEBUG",
                         "-jar", path));
                 int timeout = executor.execute(cmd, appEnv);
                 return timeout == 0;
@@ -435,8 +435,6 @@ public class RegistryFacade {
                 cmd.addAll(Arrays.asList(
                         // "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005",
                         "-Dquarkus.http.port=8081",
-                        "-Dquarkus.log.console.level=DEBUG",
-                        "-Dquarkus.log.category.\"io\".level=DEBUG",
                         "-jar", path));
                 int timeout = executor.execute(cmd, appEnv);
                 return timeout == 0;

--- a/integration-tests/legacy-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
+++ b/integration-tests/legacy-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
@@ -213,11 +213,9 @@ public class SchemasConfluentIT extends ConfluentBaseIT {
         String name = "schemaname";
         String subjectName = TestUtils.generateArtifactId();
         ParsedSchema schema = new AvroSchema("{\"type\":\"record\",\"name\":\"" + name + "\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}");
-        int globalId = createArtifactViaConfluentClient(schema, subjectName);
+        createArtifactViaConfluentClient(schema, subjectName);
 
         assertThat(1, is(confluentService.getAllSubjects().size()));
-
-        TestUtils.retry(() -> registryClient.getArtifactMetaDataByGlobalId(globalId));
 
         TestUtils.waitFor("artifact created", Constants.POLL_INTERVAL, Constants.TIMEOUT_GLOBAL, () -> {
             try {

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/ApicurioV2BaseIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/ApicurioV2BaseIT.java
@@ -67,11 +67,9 @@ public class ApicurioV2BaseIT extends ApicurioRegistryBaseIT {
     protected RegistryClient createRegistryClient() {
         if (!TestUtils.isExternalRegistry() && RegistryUtils.TEST_PROFILE.contains(Constants.CLUSTERED)) {
 
-            RegistryClient c1 = RegistryClientFactory.create("http://localhost:" + TestUtils.getRegistryPort() + "/apis/registry/v2");
             int c2port = TestUtils.getRegistryPort() + 1;
-            RegistryClient c2 = RegistryClientFactory.create("http://localhost:" + c2port + "/apis/registry/v2");
 
-            return new LoadBalanceRegistryClient(Arrays.asList(c1, c2));
+            return new LoadBalanceRegistryClient(Arrays.asList("http://localhost:" + TestUtils.getRegistryPort(), "http://localhost:" + c2port));
         } else {
             return RegistryClientFactory.create(TestUtils.getRegistryV2ApiUrl());
         }

--- a/utils/streams/src/main/java/io/apicurio/registry/utils/streams/diservice/DistributedService.java
+++ b/utils/streams/src/main/java/io/apicurio/registry/utils/streams/diservice/DistributedService.java
@@ -134,8 +134,8 @@ public abstract class DistributedService<K, S> implements AutoCloseable {
         }
         ArrayList<S> services = new ArrayList<>(smetas.size());
         for (StreamsMetadata smeta : smetas) {
-            // only use stores that have some active partitions
-            if (smeta.topicPartitions().size() > 0) {
+            // only use stores that have some active partitions and have the store active
+            if (smeta.topicPartitions().size() > 0 && smeta.stateStoreNames().contains(storeName)) {
                 services.add(serviceForHostInfo(smeta.hostInfo(), null));
             }
         }


### PR DESCRIPTION
The important change is in `DistributedService` https://github.com/Apicurio/apicurio-registry/compare/master...famartinrh:fix-streams-clustered?expand=1#diff-72b94b74a845b17f8872b30371c5fcaa20a60a325f424be08f0e5cc341d30c2b

The new clustered tests deploy one kafka (so topics only have one partition) and two apicurio-registry nodes. So one kafka streams store (one topic) gets assigned to **only one** apicurio-registry node (becase only one partition per topic). 
Then the tests where making search requests to both nodes. A search request queries all nodes with `allServicesForStore` to perform the search in the store.
Because in this scenario the store is in **only one** apicurio-registry node, the grpc request to the node that does not have the store locally fails (with an error like `FAILED_PRECONDITION: org.apache.kafka.streams.errors.InvalidStateStoreException: The state store, storage-store, may have migrated to another instance`), that error means the store is not located in that node , which makes sense!!

This never happened before because this scenario (1 kafka , 2 registries) was never applied, this configuration is not realistic and we always deploy 3 nodes kafka clusters and 3 nodes registries cluster so all stores were balanced to all nodes...

Altough this is not a realistic scenario I think it's still a bug :)

Other changes in the PR are improvements to tests that were failing
