### PR TITLE
Disable UI when multitenancy is enabled

### DIFF
--- a/app/src/main/java/io/apicurio/registry/mt/MultitenancyProperties.java
+++ b/app/src/main/java/io/apicurio/registry/mt/MultitenancyProperties.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.mt;
+
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * @author Fabian Martinez
+ */
+@ApplicationScoped
+public class MultitenancyProperties {
+
+    @Inject
+    @ConfigProperty(name = "registry.enable.multitenancy")
+    boolean multitenancyEnabled;
+
+    @Inject
+    @ConfigProperty(name = "registry.multitenancy.base.path")
+    String nameMultitenancyBasePath;
+
+    @Inject
+    @ConfigProperty(name = "registry.tenant.manager.url")
+    Optional<String> tenantManagerUrl;
+
+    /**
+     * @return the multitenancyEnabled
+     */
+    public boolean isMultitenancyEnabled() {
+        return multitenancyEnabled;
+    }
+
+    /**
+     * @return the nameMultitenancyBasePath
+     */
+    public String getNameMultitenancyBasePath() {
+        return nameMultitenancyBasePath;
+    }
+
+    /**
+     * @return the tenantManagerUrl
+     */
+    public Optional<String> getTenantManagerUrl() {
+        return tenantManagerUrl;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/mt/TenantIdResolver.java
+++ b/app/src/main/java/io/apicurio/registry/mt/TenantIdResolver.java
@@ -21,7 +21,6 @@ import java.util.function.Supplier;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,24 +45,19 @@ public class TenantIdResolver {
 
     private static final int TENANT_ID_POSITION = 2;
 
-    @Inject
-    @ConfigProperty(name = "registry.multitenancy.base.path")
-    String nameMultitenancyBasePath;
-
     String multitenancyBasePath;
 
     @Inject
-    @ConfigProperty(name = "registry.enable.multitenancy")
-    boolean multitenancyEnabled;
+    MultitenancyProperties mtProperties;
 
     @Inject
     TenantContext tenantContext;
 
     void init(@Observes StartupEvent ev) {
-        if (multitenancyEnabled) {
+        if (mtProperties.isMultitenancyEnabled()) {
             log.info("Registry running with multitenancy enabled");
         }
-        multitenancyBasePath = "/" + nameMultitenancyBasePath + "/";
+        multitenancyBasePath = "/" + mtProperties.getNameMultitenancyBasePath() + "/";
     }
 
     public boolean resolveTenantId(RoutingContext ctx) {
@@ -71,7 +65,7 @@ public class TenantIdResolver {
     }
 
     public boolean resolveTenantId(String uri, Supplier<String> tenantIdHeaderProvider, Consumer<String> afterSuccessfullUrlResolution) {
-        if (multitenancyEnabled) {
+        if (mtProperties.isMultitenancyEnabled()) {
             log.debug("Resolving tenantId for request {}", uri);
 
             if (uri.startsWith(multitenancyBasePath)) {

--- a/app/src/main/java/io/apicurio/registry/rest/RegistryApplicationServletFilter.java
+++ b/app/src/main/java/io/apicurio/registry/rest/RegistryApplicationServletFilter.java
@@ -17,8 +17,6 @@
 package io.apicurio.registry.rest;
 
 import java.io.IOException;
-import java.util.regex.Pattern;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.Filter;
@@ -53,8 +51,6 @@ import io.apicurio.registry.services.DisabledApisMatcherService;
 public class RegistryApplicationServletFilter implements Filter {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
-
-    private Pattern uiPattern = Pattern.compile("/ui/.*");
 
     @Inject
     TenantIdResolver tenantIdResolver;
@@ -98,12 +94,6 @@ public class RegistryApplicationServletFilter implements Filter {
             }
 
             boolean disabled = disabledApisMatcherService.isDisabled(evaluatedURI);
-
-            //UI is disabled multitenancy is enabled
-            if (mtProperties.isMultitenancyEnabled() && uiPattern.matcher(evaluatedURI).matches()) {
-                log.debug("Disabling request, direct access to UI is disabled in multitenancy deployments");
-                disabled = true;
-            }
 
             if (disabled) {
                 HttpServletResponse httpResponse = (HttpServletResponse) response;


### PR DESCRIPTION
This PR implements a check in `RegistryApplicationServletFilter` that disables the UI when the registry is deployed with multitenancy enabled.

If we want the UI to be used with multitenancy enableb (and with authentication working) the easiest way I can think of is to provide a UI server that will use some version of the `/ui/config.js` servlet to provide the specific tenantAuth info... so for this the issue #1313 will be kept open.