### PR TITLE
serdes - fallback artifact reference provider

### DIFF
--- a/integration-tests/legacy-tests/src/test/java/io/apicurio/tests/serdes/apicurio/BasicApicurioSerDesIT.java
+++ b/integration-tests/legacy-tests/src/test/java/io/apicurio/tests/serdes/apicurio/BasicApicurioSerDesIT.java
@@ -24,7 +24,6 @@ import io.apicurio.registry.utils.IoUtil;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.BaseIT;
 import io.apicurio.tests.common.Constants;
-import io.apicurio.tests.common.serdes.proto.MsgTypes;
 import io.apicurio.tests.serdes.KafkaClients;
 import io.apicurio.tests.utils.subUtils.ArtifactUtils;
 import org.apache.avro.Schema;
@@ -200,30 +199,6 @@ public class BasicApicurioSerDesIT extends BaseIT {
             b.addImport(toSchemaProto(d));
         }
         return b.build();
-    }
-
-    @Test
-    void testProtobufSerDes() throws InterruptedException, ExecutionException, TimeoutException {
-        Serde.Schema protobufSchema = toSchemaProto(MsgTypes.Msg.newBuilder().build().getDescriptorForType().getFile());
-        String artifactId = TestUtils.generateArtifactId();
-
-        String subjectName = TestUtils.generateSubject();
-        kafkaCluster.createTopic(artifactId, 1, 1);
-        LOGGER.debug("++++++++++++++++++ Created topic: {}", artifactId);
-
-        ArtifactMetaData artifact = ArtifactUtils.createArtifact(registryClient, ArtifactType.PROTOBUF_FD,
-                                                                 artifactId, IoUtil.toStream(protobufSchema.toByteArray()));
-        LOGGER.debug("++++++++++++++++++ Artifact created: {}", artifact.getGlobalId());
-
-        TestUtils.waitFor(
-            "Artifact not registered",
-            Constants.POLL_INTERVAL,
-            Constants.TIMEOUT_GLOBAL,
-            () -> registryClient.getArtifactMetaDataByGlobalId(artifact.getGlobalId()) != null
-        );
-
-        KafkaClients.produceProtobufMessages(artifactId, subjectName, 100).get(5, TimeUnit.SECONDS);
-        KafkaClients.consumeProtobufMessages(artifactId, 100).get(5, TimeUnit.SECONDS);
     }
 
     @BeforeAll

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/serdes/apicurio/JsonSchemaMsgFactory.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/serdes/apicurio/JsonSchemaMsgFactory.java
@@ -20,6 +20,9 @@ import java.io.InputStream;
 import java.util.Date;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.apicurio.registry.utils.IoUtil;
 import io.apicurio.tests.common.serdes.json.Msg;
 import io.apicurio.tests.common.serdes.json.ValidMessage;
@@ -54,6 +57,13 @@ public class JsonSchemaMsgFactory {
         msg.setMessage("Hello " + count);
         msg.setTime(new Date().getTime());
         return msg;
+    }
+
+    public JsonNode generateMessageJsonNode(int count) {
+        ValidMessage msg = new ValidMessage();
+        msg.setMessage("Hello " + count);
+        msg.setTime(new Date().getTime());
+        return new ObjectMapper().valueToTree(msg);
     }
 
     public boolean validateAsMap(Map<String, Object> map) {

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/AbstractKafkaDeserializer.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/AbstractKafkaDeserializer.java
@@ -22,13 +22,20 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
 
 import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.serde.config.BaseKafkaDeserializerConfig;
+import io.apicurio.registry.serde.config.BaseKafkaSerDeConfig;
+import io.apicurio.registry.serde.fallback.DefaultFallbackArtifactProvider;
+import io.apicurio.registry.serde.fallback.FallbackArtifactProvider;
 import io.apicurio.registry.serde.strategy.ArtifactReference;
+import io.apicurio.registry.serde.utils.Utils;
 
 /**
  * @author Ales Justin
  * @author Fabian Martinez
  */
 public abstract class AbstractKafkaDeserializer<T, U> extends AbstractKafkaSerDe<T, U> implements Deserializer<U> {
+
+    protected FallbackArtifactProvider fallbackArtifactProvider;
 
     public AbstractKafkaDeserializer() {
         super();
@@ -46,6 +53,35 @@ public abstract class AbstractKafkaDeserializer<T, U> extends AbstractKafkaSerDe
         super(client, schemaResolver);
     }
 
+    /**
+     * @see io.apicurio.registry.serde.AbstractKafkaSerDe#configure(io.apicurio.registry.serde.config.BaseKafkaSerDeConfig, boolean)
+     */
+    @Override
+    protected void configure(BaseKafkaSerDeConfig config, boolean isKey) {
+        super.configure(config, isKey);
+
+        BaseKafkaDeserializerConfig deserializerConfig = new BaseKafkaDeserializerConfig(config.originals());
+
+        Object fallbackProvider = deserializerConfig.getFallbackArtifactProvider();
+        Utils.instantiate(FallbackArtifactProvider.class, fallbackProvider, this::setFallbackArtifactProvider);
+        fallbackArtifactProvider.configure(config.originals(), isKey);
+
+        if (fallbackArtifactProvider instanceof DefaultFallbackArtifactProvider) {
+            if (!((DefaultFallbackArtifactProvider) fallbackArtifactProvider).isConfigured()) {
+                //it's not configured, just remove it so it's not executed
+                fallbackArtifactProvider = null;
+            }
+        }
+
+    }
+
+    /**
+     * @param fallbackArtifactProvider the fallbackArtifactProvider to set
+     */
+    public void setFallbackArtifactProvider(FallbackArtifactProvider fallbackArtifactProvider) {
+        this.fallbackArtifactProvider = fallbackArtifactProvider;
+    }
+
     protected abstract U readData(ParsedSchema<T> schema, ByteBuffer buffer, int start, int length);
 
     protected abstract U readData(Headers headers, ParsedSchema<T> schema, ByteBuffer buffer, int start, int length);
@@ -59,7 +95,7 @@ public abstract class AbstractKafkaDeserializer<T, U> extends AbstractKafkaSerDe
         ByteBuffer buffer = getByteBuffer(data);
         ArtifactReference artifactReference = getIdHandler().readId(buffer);
 
-        SchemaLookupResult<T> schema = getSchemaResolver().resolveSchemaByArtifactReference(artifactReference);
+        SchemaLookupResult<T> schema = resolve(topic, null, data, artifactReference);
 
         int length = buffer.limit() - 1 - getIdHandler().idSize();
         int start = buffer.position() + buffer.arrayOffset();
@@ -83,7 +119,8 @@ public abstract class AbstractKafkaDeserializer<T, U> extends AbstractKafkaSerDe
             throw new IllegalStateException("Headers cannot be null");
         } else {
             ArtifactReference artifactReference = headersHandler.readHeaders(headers);
-            SchemaLookupResult<T> schema = getSchemaResolver().resolveSchemaByArtifactReference(artifactReference);
+
+            SchemaLookupResult<T> schema = resolve(topic, headers, data, artifactReference);
 
             ByteBuffer buffer = ByteBuffer.wrap(data);
             int length = buffer.limit();
@@ -94,6 +131,24 @@ public abstract class AbstractKafkaDeserializer<T, U> extends AbstractKafkaSerDe
                     .setParsedSchema(schema.getSchema());
 
             return readData(headers, parsedSchema, buffer, start, length);
+        }
+    }
+
+    private SchemaLookupResult<T> resolve(String topic, Headers headers, byte[] data, ArtifactReference artifactReference) {
+        try {
+            return getSchemaResolver().resolveSchemaByArtifactReference(artifactReference);
+        } catch (RuntimeException e) {
+            if (fallbackArtifactProvider == null) {
+                throw e;
+            } else {
+                try {
+                    ArtifactReference fallbackReference = fallbackArtifactProvider.get(topic, headers, data);
+                    return getSchemaResolver().resolveSchemaByArtifactReference(fallbackReference);
+                } catch (RuntimeException fe) {
+                    fe.addSuppressed(e);
+                    throw fe;
+                }
+            }
         }
     }
 

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/DefaultIdHandler.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/DefaultIdHandler.java
@@ -35,7 +35,6 @@ public class DefaultIdHandler implements IdHandler {
     public void writeId(ArtifactReference reference, OutputStream out) throws IOException {
         long id;
         if (idOption == IdOption.contentId) {
-            //TODO leave this exception or fallback to other options? if the latter it's recommended to remove a similar exception from DefaultSchemaResolver
             if (reference.getContentId() == null) {
                 throw new SerializationException("Missing contentId. IdOption is contentId but there is no contentId in the ArtifactReference");
             }
@@ -53,7 +52,6 @@ public class DefaultIdHandler implements IdHandler {
     public void writeId(ArtifactReference reference, ByteBuffer buffer) {
         long id;
         if (idOption == IdOption.contentId) {
-            //TODO leave this exception or fallback to other options? if the latter it's recommended to remove a similar exception from DefaultSchemaResolver
             if (reference.getContentId() == null) {
                 throw new SerializationException("Missing contentId. IdOption is contentId but there is no contentId in the ArtifactReference");
             }

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/DefaultSchemaResolver.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/DefaultSchemaResolver.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
 
 import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
@@ -111,10 +110,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T>{
     @Override
     public SchemaLookupResult<S> resolveSchemaByArtifactReference(ArtifactReference reference) {
         //TODO add here more conditions whenever we support referencing by contentHash or some other thing
-        if (idOption == IdOption.contentId) {
-            if (reference.getContentId() == null) {
-                throw new SerializationException("Missing contentId. IdOption is contentId but there is no contentId in the ArtifactReference");
-            }
+        if (idOption == IdOption.contentId && reference.getContentId() != null) {
             return resolveSchemaByContentId(reference.getContentId());
         }
         if (reference.getGlobalId() == null) {

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/Legacy4ByteIdHandler.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/Legacy4ByteIdHandler.java
@@ -37,7 +37,6 @@ public class Legacy4ByteIdHandler implements IdHandler {
     public void writeId(ArtifactReference reference, OutputStream out) throws IOException {
         long id;
         if (idOption == IdOption.contentId) {
-            //TODO leave this exception or fallback to other options? if the latter it's recommended to remove a similar exception from DefaultSchemaResolver
             if (reference.getContentId() == null) {
                 throw new SerializationException("Missing contentId. IdOption is contentId but there is no contentId in the ArtifactReference");
             }
@@ -55,7 +54,6 @@ public class Legacy4ByteIdHandler implements IdHandler {
     public void writeId(ArtifactReference reference, ByteBuffer buffer) {
         long id;
         if (idOption == IdOption.contentId) {
-            //TODO leave this exception or fallback to other options? if the latter it's recommended to remove a similar exception from DefaultSchemaResolver
             if (reference.getContentId() == null) {
                 throw new SerializationException("Missing contentId. IdOption is contentId but there is no contentId in the ArtifactReference");
             }

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/SerdeConfig.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/SerdeConfig.java
@@ -21,6 +21,8 @@ import java.util.Properties;
 import io.apicurio.registry.rest.client.config.ClientConfig;
 import io.apicurio.registry.rest.v2.beans.IfExists;
 import io.apicurio.registry.serde.config.IdOption;
+import io.apicurio.registry.serde.fallback.DefaultFallbackArtifactProvider;
+import io.apicurio.registry.serde.fallback.FallbackArtifactProvider;
 import io.apicurio.registry.serde.headers.DefaultHeadersHandler;
 import io.apicurio.registry.serde.headers.HeadersHandler;
 import io.apicurio.registry.serde.strategy.ArtifactResolverStrategy;
@@ -73,18 +75,21 @@ public class SerdeConfig {
     public static final boolean FIND_LATEST_ARTIFACT_DEFAULT = false;
 
     /**
+     * Only applicable for serializers
      * Optional, set explicitly the groupId used for querying/creating an artifact.
      * Overrides the groupId returned by the {@link ArtifactResolverStrategy}
      */
     public static final String EXPLICIT_ARTIFACT_GROUP_ID = "apicurio.registry.artifact.group-id";
 
     /**
+     * Only applicable for serializers
      * Optional, set explicitly the artifactId used for querying/creating an artifact.
      * Overrides the artifactId returned by the {@link ArtifactResolverStrategy}
      */
     public static final String EXPLICIT_ARTIFACT_ID = "apicurio.registry.artifact.artifact-id";
 
     /**
+     * Only applicable for serializers
      * Optional, set explicitly the version used for querying/creating an artifact.
      * Overrides the version returned by the {@link ArtifactResolverStrategy}
      */
@@ -201,6 +206,32 @@ public class SerdeConfig {
      */
     public static final String VALIDATION_ENABLED = "apicurio.registry.serde.validation-enabled";
     public static final boolean VALIDATION_ENABLED_DEFAULT = true;
+
+    /**
+     * Only applicable for deserializers
+     * Optional, set explicitly the groupId used as fallback for resolving the artifact used for deserialization.
+     */
+    public static final String FALLBACK_ARTIFACT_GROUP_ID = "apicurio.registry.fallback.group-id";
+
+    /**
+     * Only applicable for deserializers
+     * Optional, set explicitly the artifactId used as fallback for resolving the artifact used for deserialization.
+     */
+    public static final String FALLBACK_ARTIFACT_ID = "apicurio.registry.fallback.artifact-id";
+
+    /**
+     * Only applicable for deserializers
+     * Optional, set explicitly the version used as fallback for resolving the artifact used for deserialization.
+     */
+    public static final String FALLBACK_ARTIFACT_VERSION = "apicurio.registry.fallback.version";
+
+    /**
+     * Only applicable for deserializers
+     * Optional, allows to set a custom implementation of {@link FallbackArtifactProvider} , for resolving the artifact used for deserialization.
+     */
+    public static final String FALLBACK_ARTIFACT_PROVIDER = "apicurio.registry.fallback.provider";
+    public static final String FALLBACK_ARTIFACT_PROVIDER_DEFAULT = DefaultFallbackArtifactProvider.class.getName();
+
 
     /**
      * Fully qualified Java classname of a class that will be used as the return type for the deserializer. Aplicable for keys deserialization.

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/config/BaseKafkaDeserializerConfig.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/config/BaseKafkaDeserializerConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.serde.config;
+
+import static io.apicurio.registry.serde.SerdeConfig.FALLBACK_ARTIFACT_PROVIDER;
+import static io.apicurio.registry.serde.SerdeConfig.FALLBACK_ARTIFACT_PROVIDER_DEFAULT;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+
+/**
+ * @author Fabian Martinez
+ */
+public class BaseKafkaDeserializerConfig extends BaseKafkaSerDeConfig {
+
+    public static ConfigDef configDef() {
+        ConfigDef configDef = new ConfigDef()
+                .define(FALLBACK_ARTIFACT_PROVIDER, Type.CLASS, FALLBACK_ARTIFACT_PROVIDER_DEFAULT, Importance.HIGH, "TODO docs");
+
+        return configDef;
+      }
+
+    public BaseKafkaDeserializerConfig(Map<?, ?> originals) {
+        super(configDef(), originals);
+    }
+
+    public Object getFallbackArtifactProvider() {
+        return this.get(FALLBACK_ARTIFACT_PROVIDER);
+    }
+
+}

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/fallback/DefaultFallbackArtifactProvider.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/fallback/DefaultFallbackArtifactProvider.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.serde.fallback;
+
+import java.util.Map;
+
+import org.apache.kafka.common.header.Headers;
+
+import io.apicurio.registry.serde.SerdeConfig;
+import io.apicurio.registry.serde.strategy.ArtifactReference;
+
+/**
+ * Default implementation of FallbackArtifactProvider that simply uses config properties
+ * @author Fabian Martinez
+ */
+public class DefaultFallbackArtifactProvider implements FallbackArtifactProvider {
+
+    private ArtifactReference fallbackArtifactReference;
+
+    /**
+     * @see io.apicurio.registry.serde.FallbackArtifactProvider#configure(java.util.Map, boolean)
+     */
+    @Override
+    public void configure(Map<String, Object> configs, boolean isKey) {
+
+        String groupIdConfigKey = SerdeConfig.FALLBACK_ARTIFACT_GROUP_ID;
+        if (isKey) {
+            groupIdConfigKey += ".key";
+        }
+        String fallbackGroupId = (String) configs.get(groupIdConfigKey);
+
+        String artifactIdConfigKey = SerdeConfig.FALLBACK_ARTIFACT_ID;
+        if (isKey) {
+            artifactIdConfigKey += ".key";
+        }
+        String fallbackArtifactId = (String) configs.get(artifactIdConfigKey);
+
+        String versionConfigKey = SerdeConfig.FALLBACK_ARTIFACT_VERSION;
+        if (isKey) {
+            versionConfigKey += ".key";
+        }
+        String fallbackVersion = (String) configs.get(versionConfigKey);
+
+        if (fallbackArtifactId != null) {
+            fallbackArtifactReference = ArtifactReference.builder()
+                    .groupId(fallbackGroupId)
+                    .artifactId(fallbackArtifactId)
+                    .version(fallbackVersion)
+                    .build();
+        }
+
+    }
+
+    /**
+     * @see io.apicurio.registry.serde.fallback.FallbackArtifactProvider#get(java.lang.String, org.apache.kafka.common.header.Headers, byte[])
+     */
+    @Override
+    public ArtifactReference get(String topic, Headers headers, byte[] data) {
+        return fallbackArtifactReference;
+    }
+
+    public boolean isConfigured() {
+        return fallbackArtifactReference != null;
+    }
+
+}

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/fallback/FallbackArtifactProvider.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/fallback/FallbackArtifactProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.serde.fallback;
+
+import java.util.Map;
+
+import org.apache.kafka.common.header.Headers;
+
+import io.apicurio.registry.serde.strategy.ArtifactReference;
+
+/**
+ * Interface for providing a fallback ArtifactReference when the SchemaResolver is not able to find an ArtifactReference in the kafka message
+ *
+ * @author Fabian Martinez
+ */
+public interface FallbackArtifactProvider {
+
+    default void configure(Map<String, Object> configs, boolean isKey) {
+    }
+
+    /**
+     * Returns an ArtifactReference that will be used as the fallback
+     * to search in the registry for the artifact that will be used to deserialize the kafka message
+     * @param topic
+     * @param headers , can be null
+     * @param data
+     * @return
+     */
+    public ArtifactReference get(String topic, Headers headers, byte[] data);
+
+}

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/headers/DefaultHeadersHandler.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/headers/DefaultHeadersHandler.java
@@ -67,7 +67,6 @@ public class DefaultHeadersHandler implements HeadersHandler {
     @Override
     public void writeHeaders(Headers headers, ArtifactReference reference) {
         if (idOption == IdOption.contentId) {
-            //TODO leave this exception or fallback to other options? if the latter it's recommended to remove a similar exception from DefaultSchemaResolver
             if (reference.getContentId() == null) {
                 throw new SerializationException("Missing contentId. IdOption is contentId but there is no contentId in the ArtifactReference");
             }


### PR DESCRIPTION
This PR adds a new functionality to our serdes, specifically the deserializers. There is a new interface `FallbackArtifactProvider` that allows to implement custom strategies to try to lookup for a schema in the case the `SchemaResolver` fail to find an artifact. 

Wether it's because no globalId can be found in the kafka message or because the `SchemaResolver` failed to find an artifact in the registry for that globalId...

There is a DefaultFallbackArtifactProvider that uses hardcoded config properties.