### PR TITLE
kafkasql now uses the DB to obtain global Ids

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -34,6 +34,14 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     /**
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#selectNextGlobalId()
+     */
+    @Override
+    public String selectNextGlobalId() {
+        return "SELECT nextval('globalidsequence')";
+    }
+
+    /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements.core.storage.jdbc.ISqlStatements#databaseInitialization()
      */
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -396,5 +396,10 @@ public interface SqlStatements {
      */
     public String selectGroupByGroupId();
 
+    /**
+     * As statement used to get the next generated/sequenced globalId.
+     */
+    public String selectNextGlobalId();
+
 
 }

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
@@ -25,7 +25,7 @@ ALTER TABLE content ADD CONSTRAINT UNQ_content_1 UNIQUE (contentHash);
 CREATE HASH INDEX IDX_content_1 ON content(canonicalHash);
 CREATE HASH INDEX IDX_content_2 ON content(contentHash);
 
-CREATE SEQUENCE globalidsequence;
+CREATE SEQUENCE globalidsequence INCREMENT BY 1 NO MINVALUE CACHE 100;
 
 CREATE TABLE versions (globalId BIGINT NOT NULL, tenantId VARCHAR(128) NOT NULL, groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, version VARCHAR(256), versionId INT NOT NULL, state VARCHAR(64) NOT NULL, name VARCHAR(512), description VARCHAR(1024), createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, labels TEXT, properties TEXT, contentId BIGINT NOT NULL);
 ALTER TABLE versions ADD PRIMARY KEY (globalId);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
@@ -25,7 +25,7 @@ ALTER TABLE content ADD CONSTRAINT UNQ_content_1 UNIQUE (contentHash);
 CREATE INDEX IDX_content_1 ON content USING HASH (canonicalHash);
 CREATE INDEX IDX_content_2 ON content USING HASH (contentHash);
 
-CREATE SEQUENCE globalidsequence;
+CREATE SEQUENCE globalidsequence INCREMENT BY 1 NO MINVALUE CACHE 100;
 
 CREATE TABLE versions (globalId BIGINT NOT NULL, tenantId VARCHAR(128) NOT NULL, groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, version VARCHAR(256), versionId INT NOT NULL, state VARCHAR(64) NOT NULL, name VARCHAR(512), description VARCHAR(1024), createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, labels TEXT, properties TEXT, contentId BIGINT NOT NULL);
 ALTER TABLE versions ADD PRIMARY KEY (globalId);

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlFactory.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlFactory.java
@@ -70,10 +70,6 @@ public class KafkaSqlFactory {
     Integer pollTimeout;
 
     @Inject
-    @ConfigProperty(name = "registry.kafkasql.global-id.base-offset", defaultValue = "1")
-    Integer baseOffset;
-
-    @Inject
     @ConfigProperty(name = "registry.kafkasql.coordinator.response-timeout", defaultValue = "30000")
     Integer responseTimeout;
 
@@ -125,10 +121,6 @@ public class KafkaSqlFactory {
             @Override
             public Integer pollTimeout() {
                 return pollTimeout;
-            }
-            @Override
-            public Integer baseOffset() {
-                return baseOffset;
             }
             @Override
             public Integer responseTimeout() {

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
@@ -38,6 +38,7 @@ import io.apicurio.registry.storage.impl.kafkasql.keys.ArtifactRuleKey;
 import io.apicurio.registry.storage.impl.kafkasql.keys.ArtifactVersionKey;
 import io.apicurio.registry.storage.impl.kafkasql.keys.BootstrapKey;
 import io.apicurio.registry.storage.impl.kafkasql.keys.ContentKey;
+import io.apicurio.registry.storage.impl.kafkasql.keys.GlobalIdKey;
 import io.apicurio.registry.storage.impl.kafkasql.keys.GlobalRuleKey;
 import io.apicurio.registry.storage.impl.kafkasql.keys.GroupKey;
 import io.apicurio.registry.storage.impl.kafkasql.keys.LogConfigKey;
@@ -47,6 +48,7 @@ import io.apicurio.registry.storage.impl.kafkasql.values.ArtifactRuleValue;
 import io.apicurio.registry.storage.impl.kafkasql.values.ArtifactValue;
 import io.apicurio.registry.storage.impl.kafkasql.values.ArtifactVersionValue;
 import io.apicurio.registry.storage.impl.kafkasql.values.ContentValue;
+import io.apicurio.registry.storage.impl.kafkasql.values.GlobalIdValue;
 import io.apicurio.registry.storage.impl.kafkasql.values.GlobalRuleValue;
 import io.apicurio.registry.storage.impl.kafkasql.values.GroupValue;
 import io.apicurio.registry.storage.impl.kafkasql.values.LogConfigValue;
@@ -120,14 +122,14 @@ public class KafkaSqlSubmitter {
      * Artifact
      * ****************************************************************************************** */
     public CompletableFuture<UUID> submitArtifact(String tenantId, String groupId, String artifactId, String version, ActionType action,
-            ArtifactType artifactType, String contentHash, String createdBy, Date createdOn,
+            Long globalId, ArtifactType artifactType, String contentHash, String createdBy, Date createdOn,
             EditableArtifactMetaDataDto metaData) {
         ArtifactKey key = ArtifactKey.create(tenantId, groupId, artifactId);
-        ArtifactValue value = ArtifactValue.create(action, version, artifactType, contentHash, createdBy, createdOn, metaData);
+        ArtifactValue value = ArtifactValue.create(action, globalId, version, artifactType, contentHash, createdBy, createdOn, metaData);
         return send(key, value);
     }
     public CompletableFuture<UUID> submitArtifact(String tenantId, String groupId, String artifactId, ActionType action) {
-        return this.submitArtifact(tenantId, groupId, artifactId, null, action, null, null, null, null, null);
+        return this.submitArtifact(tenantId, groupId, artifactId, null, action, null, null, null, null, null, null);
     }
 
 
@@ -184,6 +186,15 @@ public class KafkaSqlSubmitter {
         return submitLogConfig(tenantId, action, null);
     }
 
+
+    /* ******************************************************************************************
+     * Global ID
+     * ****************************************************************************************** */
+    public CompletableFuture<UUID> submitGlobalId(ActionType action) {
+        GlobalIdKey key = GlobalIdKey.create();
+        GlobalIdValue value = GlobalIdValue.create(action);
+        return send(key, value);
+    }
 
 
     /* ******************************************************************************************

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/MessageType.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/MessageType.java
@@ -24,7 +24,7 @@ import java.util.Map;
  */
 public enum MessageType {
 
-    Bootstrap(0), GlobalRule(1), Content(2), Artifact(3), ArtifactRule(4), ArtifactVersion(5), Group(6), LogConfig(7);
+    Bootstrap(0), GlobalRule(1), Content(2), Artifact(3), ArtifactRule(4), ArtifactVersion(5), Group(6), LogConfig(7), GlobalId(8);
 
     private final byte ord;
 

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalIdKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalIdKey.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage.impl.kafkasql.keys;
+
+import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public class GlobalIdKey extends AbstractMessageKey {
+
+    private static final String GLOBAL_ID_PARTITION_KEY = "__apicurio_registry_global_id__";
+
+    /**
+     * Creator method.
+     * @param tenantId
+     * @param ruleType
+     */
+    public static final GlobalIdKey create() {
+        GlobalIdKey key = new GlobalIdKey();
+        return key;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.kafkasql.keys.MessageKey#getType()
+     */
+    @Override
+    public MessageType getType() {
+        return MessageType.GlobalId;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.kafkasql.keys.MessageKey#getPartitionKey()
+     */
+    @Override
+    public String getPartitionKey() {
+        return getTenantId() + GLOBAL_ID_PARTITION_KEY;
+    }
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "GlobalIdKey []";
+    }
+
+}

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/MessageTypeToKeyClass.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/MessageTypeToKeyClass.java
@@ -56,6 +56,9 @@ public class MessageTypeToKeyClass {
                 case ArtifactVersion:
                     index.put(type, ArtifactVersionKey.class);
                     break;
+                case GlobalId:
+                    index.put(type, GlobalIdKey.class);
+                    break;
                 default:
                     throw new RuntimeException("[MessageTypeToKeyClass] Type not mapped: " + type);
             }

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlStore.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlStore.java
@@ -36,6 +36,16 @@ import io.apicurio.registry.types.RuleType;
 @Logged
 public class KafkaSqlStore extends AbstractSqlRegistryStorage {
 
+    @Transactional
+    public long nextGlobalId() {
+        return withHandle( handle -> {
+            String sql = sqlStatements().selectNextGlobalId();
+            return handle.createQuery(sql)
+                    .mapTo(Long.class)
+                    .one();
+        });
+    }
+
     public boolean isContentExists(String contentHash) throws RegistryStorageException {
         return withHandle( handle -> {
             String sql = sqlStatements().selectContentCountByHash();

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactValue.java
@@ -27,6 +27,7 @@ import io.apicurio.registry.types.ArtifactType;
  */
 public class ArtifactValue extends ArtifactVersionValue {
 
+    private Long globalId;
     private String version;
     private ArtifactType artifactType;
     private String contentHash;
@@ -36,10 +37,11 @@ public class ArtifactValue extends ArtifactVersionValue {
     /**
      * Creator method.
      */
-    public static final ArtifactValue create(ActionType action, String version, ArtifactType artifactType, String contentHash, String createdBy,
+    public static final ArtifactValue create(ActionType action, Long globalId, String version, ArtifactType artifactType, String contentHash, String createdBy,
             Date createdOn, EditableArtifactMetaDataDto metaData) {
         ArtifactValue value = new ArtifactValue();
         value.setAction(action);
+        value.setGlobalId(globalId);
         value.setVersion(version);
         value.setArtifactType(artifactType);
         value.setContentHash(contentHash);
@@ -125,6 +127,20 @@ public class ArtifactValue extends ArtifactVersionValue {
      */
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    /**
+     * @return the globalId
+     */
+    public Long getGlobalId() {
+        return globalId;
+    }
+
+    /**
+     * @param globalId the globalId to set
+     */
+    public void setGlobalId(Long globalId) {
+        this.globalId = globalId;
     }
 
 }

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/GlobalIdValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/GlobalIdValue.java
@@ -14,24 +14,31 @@
  * limitations under the License.
  */
 
-package io.apicurio.registry.storage.impl.kafkasql;
+package io.apicurio.registry.storage.impl.kafkasql.values;
 
-import java.util.Properties;
+import io.apicurio.registry.storage.impl.kafkasql.MessageType;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface KafkaSqlConfiguration {
+public class GlobalIdValue extends AbstractMessageValue {
 
-    public String bootstrapServers();
-    public String topic();
-    public Properties topicProperties();
-    public boolean isTopicAutoCreate();
-    public Integer startupLag();
-    public Integer pollTimeout();
-    public Integer responseTimeout();
-    public Properties producerProperties();
-    public Properties consumerProperties();
-    public Properties adminProperties();
+    /**
+     * Creator method.
+     * @param action
+     */
+    public static final GlobalIdValue create(ActionType action) {
+        GlobalIdValue value = new GlobalIdValue();
+        value.setAction(action);
+        return value;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.kafkasql.values.MessageValue#getType()
+     */
+    @Override
+    public MessageType getType() {
+        return MessageType.GlobalId;
+    }
 
 }

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/MessageTypeToValueClass.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/MessageTypeToValueClass.java
@@ -55,6 +55,9 @@ public class MessageTypeToValueClass {
                 case ArtifactVersion:
                     index.put(type, ArtifactVersionValue.class);
                     break;
+                case GlobalId:
+                    index.put(type, GlobalIdValue.class);
+                    break;
                 default:
                     throw new RuntimeException("[MessageTypeToValueClass] Type not mapped: " + type);
             }


### PR DESCRIPTION
OK this is a simple change to use the Kafka topic and the SQL database to generate global Ids in the KafkaSQL storage impl.  Next I will need to work on a simple import/export API to see how that works with this.