### PR TITLE
integration-tests - only wait when registry deployed locally

### DIFF
--- a/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryDeploymentManager.java
+++ b/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryDeploymentManager.java
@@ -50,18 +50,18 @@ public class RegistryDeploymentManager implements BeforeEachCallback, AfterEachC
         } else {
             LOGGER.info("Going to use already running registries on {}", TestUtils.getRegistryV1ApiUrl());
         }
-        try {
-            registry.waitForRegistryReady();
-        } catch (Exception e) {
-            if (!TestUtils.isExternalRegistry()) {
+        if (!TestUtils.isExternalRegistry()) {
+            try {
+                registry.waitForRegistryReady();
+            } catch (Exception e) {
                 try {
                     Path logsPath = RegistryUtils.getLogsPath(context.getRequiredTestClass(), context.getDisplayName());
                     registry.stopAndCollectLogs(logsPath);
                 } catch (IOException e1) {
                     e.addSuppressed(e1);
                 }
+                throw new IllegalStateException(e);
             }
-            throw new IllegalStateException(e);
         }
     }
 

--- a/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
+++ b/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
@@ -206,7 +206,7 @@ public class RegistryFacade {
 
     public void waitForRegistryReady() throws Exception {
 
-        if (!TestUtils.isExternalRegistry() && RegistryUtils.TEST_PROFILE.contains(Constants.CLUSTERED)) {
+        if (RegistryUtils.TEST_PROFILE.contains(Constants.CLUSTERED)) {
 
             ThrowingConsumer<Integer> nodeIsReady = (port) -> {
                 TestUtils.waitFor("Cannot connect to registries on node :" + port + " in timeout!",
@@ -231,7 +231,7 @@ public class RegistryFacade {
             TestUtils.waitFor("Registry reports is ready",
                     Constants.POLL_INTERVAL, Constants.TIMEOUT_FOR_REGISTRY_READY, () -> TestUtils.isReady(false), () -> TestUtils.isReady(true));
 
-            if (!TestUtils.isExternalRegistry() && Constants.MULTITENANCY.equals(RegistryUtils.TEST_PROFILE)) {
+            if (Constants.MULTITENANCY.equals(RegistryUtils.TEST_PROFILE)) {
                 TestUtils.waitFor("Cannot connect to Tenant Manager on " + this.tenantManagerUrl + " in timeout!",
                         Constants.POLL_INTERVAL, Constants.TIMEOUT_FOR_REGISTRY_START_UP, () -> TestUtils.isReachable("localhost", 8585, "Tenant Manager"));
 

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
@@ -407,7 +407,7 @@ class ArtifactsIT extends ApicurioV2BaseIT {
 
         registryClient.getArtifactMetaData(groupId, artifactId);
 
-        registryClient.getArtifactVersionMetaDataByContent(groupId, artifactId, false, new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+        TestUtils.retry(() -> registryClient.getArtifactVersionMetaDataByContent(groupId, artifactId, false, new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))));
 
         registryClient.listArtifactVersions(groupId, artifactId, 0, 10);
 
@@ -433,7 +433,7 @@ class ArtifactsIT extends ApicurioV2BaseIT {
 
         registryClient.getArtifactMetaData(groupId, artifactId);
 
-        registryClient.getArtifactVersionMetaDataByContent(groupId, artifactId, false, new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+        TestUtils.retry(() -> registryClient.getArtifactVersionMetaDataByContent(groupId, artifactId, false, new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))));
 
         registryClient.listArtifactVersions(groupId, artifactId, 0, 100);
 


### PR DESCRIPTION
This is a change needed for the kubernetes testsuite