### PR TITLE
cli - import export commands

### DIFF
--- a/.github/workflows/cli-release-macos.yaml
+++ b/.github/workflows/cli-release-macos.yaml
@@ -1,0 +1,43 @@
+name: release-build-native-macos
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install graalvm
+      uses: DeLaGuardo/setup-graalvm@4.0
+      with:
+        # GraalVM version, no pattern syntax available atm
+        graalvm: '21.0.0.2'
+        # Java version, optional, defaults to 'java8'. Available options are 'java8' and 'java11'.
+        java: 'java11'
+        # Architecture flag, optional, defaults to 'amd64'. Available options are 'amd64' and 'aarch64'. Later is available only for linux runners.
+        arch: 'amd64'
+    - name: Install native-image
+      run: gu install native-image
+    - name: Get maven wrapper
+      run: mvn -N io.takari:maven:wrapper -Dmaven=3.6.3
+    - name: Set version
+      run: ./mvnw versions:set -DnewVersion="${{ github.event.release.tag_name }}"
+    - name: Build jvm jar
+      run: ./mvnw -pl cli -am install
+    - name: Build native executable
+      run: ./mvnw -pl cli package -Dnative
+    - name: Upload native executable
+      id: upload-native-executable
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./cli/target/apicurio-registry-cli-${{ github.event.release.tag_name }}-runner
+        asset_name: apicurio-registry-cli-${{ github.event.release.tag_name }}-macos
+        asset_label: macos
+        asset_content_type: application/octet-stream

--- a/.github/workflows/cli-release-macos.yaml
+++ b/.github/workflows/cli-release-macos.yaml
@@ -1,4 +1,4 @@
-name: release-build-native-macos
+name: cli-release-build-native-macos
 
 on:
   release:

--- a/.github/workflows/cli-release-win64.yaml
+++ b/.github/workflows/cli-release-win64.yaml
@@ -1,0 +1,52 @@
+name: cli-release-build-native-win64
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install graalvm
+      uses: DeLaGuardo/setup-graalvm@4.0
+      with:
+        # GraalVM version, no pattern syntax available atm
+        graalvm: '21.0.0.2'
+        # Java version, optional, defaults to 'java8'. Available options are 'java8' and 'java11'.
+        java: 'java11'
+        # Architecture flag, optional, defaults to 'amd64'. Available options are 'amd64' and 'aarch64'. Later is available only for linux runners.
+        arch: 'amd64'
+    - name: Install native-image
+      run: |
+        %JAVA_HOME%/bin/gu.cmd install native-image
+      shell: cmd
+    - name: Configure Pagefile
+      # Increased the page-file size due to memory-consumption of native-image command
+      # For details see https://github.com/actions/virtual-environments/issues/785
+      uses: al-cheb/configure-pagefile-action@v1.2
+    - name: Set version
+      run: mvn versions:set -DnewVersion="${{ github.event.release.tag_name }}"
+      shell: cmd
+    - name: Build jvm jar
+      run: mvn -pl cli -am install
+    - name: Build native executable
+      # Invoke the native-image build with the necessary Visual Studio tooling/environment intialized
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+        mvn -pl cli package -Dnative
+      shell: cmd
+    - name: Upload native executable
+      id: upload-native-executable
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: cli/target/apicurio-registry-cli-${{ github.event.release.tag_name }}-runner.exe
+        asset_name: apicurio-registry-cli-${{ github.event.release.tag_name }}-win64.exe
+        asset_label: win64
+        asset_content_type: application/octet-stream

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -1,4 +1,4 @@
-name: release-build
+name: cli-release-build
 
 on:
   release:

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -1,0 +1,52 @@
+name: release-build
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install graalvm
+      uses: DeLaGuardo/setup-graalvm@4.0
+      with:
+        # GraalVM version, no pattern syntax available atm
+        graalvm: '21.0.0.2'
+        # Java version, optional, defaults to 'java8'. Available options are 'java8' and 'java11'.
+        java: 'java11'
+        # Architecture flag, optional, defaults to 'amd64'. Available options are 'amd64' and 'aarch64'. Later is available only for linux runners.
+        arch: 'amd64'
+    - name: Install native-image
+      run: gu install native-image
+    - name: Get maven wrapper
+      run: mvn -N io.takari:maven:wrapper -Dmaven=3.6.3
+    - name: Set version
+      run: ./mvnw versions:set -DnewVersion="${{ github.event.release.tag_name }}"
+    - name: Build jvm jar
+      run: ./mvnw -pl cli -am install
+    - name: Upload jvm
+      id: upload-jar
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./cli/target/apicurio-registry-cli-${{ github.event.release.tag_name }}-runner.jar
+        asset_name: apicurio-registry-cli-${{ github.event.release.tag_name }}.jar
+        asset_content_type: application/octet-stream
+    - name: Build native executable
+      run: ./mvnw -pl cli package -Dnative
+    - name: Upload native executable
+      id: upload-native-executable
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./cli/target/apicurio-registry-cli-${{ github.event.release.tag_name }}-runner
+        asset_name: apicurio-registry-cli-${{ github.event.release.tag_name }}-linux
+        asset_content_type: application/octet-stream

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -61,3 +61,36 @@ jobs:
             name: ${{ github.workflow }}
             url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
             status: ${{ job.status }}
+
+  cli-linux-native-build:
+    name: CLI linux build
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Apicurio' && github.ref == 'refs/heads/master'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install graalvm
+      uses: DeLaGuardo/setup-graalvm@4.0
+      with:
+        # GraalVM version, no pattern syntax available atm
+        graalvm: '21.0.0.2'
+        # Java version, optional, defaults to 'java8'. Available options are 'java8' and 'java11'.
+        java: 'java11'
+        # Architecture flag, optional, defaults to 'amd64'. Available options are 'amd64' and 'aarch64'. Later is available only for linux runners.
+        arch: 'amd64'
+    - name: Install native-image
+      run: gu install native-image
+    - name: Get maven wrapper
+      run: mvn -N io.takari:maven:wrapper -Dmaven=3.6.3
+    - name: Set version
+      run: ./mvnw versions:set -DnewVersion="${{ github.event.release.tag_name }}"
+    - name: Build jvm jar
+      run: ./mvnw -pl cli -am install
+    - name: Build native executable
+      run: ./mvnw -pl cli package -Dnative
+    - name: Google Chat Notification
+      if: ${{ failure() }}
+      uses: Co-qn/google-chat-notification@releases/v1
+      with:
+        name: ${{ github.workflow }}
+        url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+        status: ${{ job.status }}

--- a/cli/README.md
+++ b/cli/README.md
@@ -24,8 +24,8 @@ mvn package -Pnative
 ```
 
 ### To ease the usage we suggest adding aliases:
-* if compiled to a jar: `alias rscli='java -jar <PATH_TO_REGISTRY_PROJECT>/cli/target/apicurio-registry-cli-2.0.0-SNAPSHOT-runner.jar'`
-* if compiled to a native executable: `alias rscli=<PATH_TO_REGISTRY_PROJECT>/cli/target/apicurio-registry-cli-2.0.0-SNAPSHOT-runner`
+* if compiled to a jar: `alias rscli='java -jar <PATH_TO_REGISTRY_PROJECT>/cli/target/apicurio-registry-cli-*-runner.jar'`
+* if compiled to a native executable: `alias rscli=<PATH_TO_REGISTRY_PROJECT>/cli/target/apicurio-registry-cli-*-runner`
 
 During the build you can also find completion script in target/ directory: `rscli_completion.sh`.
 You can `source` this script and get tab completion ootb.

--- a/cli/src/main/java/io/apicurio/registry/cli/EntryCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/EntryCommand.java
@@ -20,6 +20,8 @@ import picocli.CommandLine;
 
 import java.util.logging.Level;
 
+import io.apicurio.registry.cli.admin.ExportCommand;
+import io.apicurio.registry.cli.admin.ImportCommand;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
 
@@ -45,7 +47,9 @@ import io.quarkus.runtime.annotations.QuarkusMain;
                 DeleteCommand.class,
                 UpdateStateCommand.class,
                 UpdateMetadataCommand.class,
-                ListRulesCommand.class
+                ListRulesCommand.class,
+                ExportCommand.class,
+                ImportCommand.class
         }
 )
 public class EntryCommand implements Runnable, QuarkusApplication {

--- a/cli/src/main/java/io/apicurio/registry/cli/admin/ExportCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/admin/ExportCommand.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.cli.admin;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+import io.apicurio.registry.cli.AbstractCommand;
+import io.apicurio.registry.utils.IoUtil;
+import picocli.CommandLine;
+
+/**
+ * @author Fabian Martinez
+ */
+@CommandLine.Command(name = "export", description = "Export registry data into a zip file")
+public class ExportCommand extends AbstractCommand {
+
+    @CommandLine.Option(names = {"-f", "--file"}, description = "file to write the registry exported data ", defaultValue = "registry-export.zip")
+    File file;
+
+    /**
+     * @see java.lang.Runnable#run()
+     */
+    @Override
+    public void run() {
+
+        File output = file;
+        try (FileOutputStream fos = new FileOutputStream(output)) {
+
+            println("Exporting registry data to " + output.getName());
+
+            InputStream export = getClient().exportData();
+
+            IoUtil.copy(export, fos);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+    }
+
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/admin/ImportCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/admin/ImportCommand.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.cli.admin;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import io.apicurio.registry.cli.AbstractCommand;
+import picocli.CommandLine;
+
+/**
+ * @author Fabian Martinez
+ */
+@CommandLine.Command(name = "import", description = "Import registry data from a zip file")
+public class ImportCommand extends AbstractCommand {
+
+    @CommandLine.Option(names = {"-f", "--file"}, description = "file to read the registry exported data ", defaultValue = "registry-export.zip")
+    File file;
+
+    /**
+     * @see java.lang.Runnable#run()
+     */
+    @Override
+    public void run() {
+
+        File input = file;
+        try (FileInputStream fis = new FileInputStream(input)) {
+
+            println("Importing registry data from " + input.getName());
+
+            getClient().importData(fis);
+
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+    }
+}

--- a/cli/src/main/resources/application.properties
+++ b/cli/src/main/resources/application.properties
@@ -3,3 +3,4 @@ quarkus.log.level=SEVERE
 quarkus.banner.enabled=false
 # required for native image
 quarkus.ssl.native=true
+quarkus.package.type=legacy-jar


### PR DESCRIPTION
This PR adds the import and export features to the CLI tool.

This PR also adds two new workflows for building the native executables of the CLI for linux, windows and macOS platforms.

The new workflows are triggered when a new release is created and they add the executables as assets of the release.
