### PR TITLE
Revert "Bump json-schema-validator from 1.0.51 to 1.0.52"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 
         <!-- Schema types -->
         <avro.version>1.10.2</avro.version>
-        <json-schema-validator.version>1.0.52</json-schema-validator.version>
+        <json-schema-validator.version>1.0.51</json-schema-validator.version>
         <wire-schema.version>3.2.2</wire-schema.version>
         <protobuf.version>3.15.8</protobuf.version>
         <xmlsec.version>2.1.5</xmlsec.version>


### PR DESCRIPTION
Reverts Apicurio/apicurio-registry#1427

This is just to verify if this change actually is an issue