### PR TITLE
integration-tests - more realistic clustered tests

### DIFF
--- a/app/src/test/java/io/apicurio/registry/events/KafkaEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/events/KafkaEventsTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.rnorth.ducttape.unreliables.Unreliables;
 
 import io.apicurio.registry.AbstractResourceTestBase;
@@ -54,6 +55,7 @@ import io.quarkus.test.junit.TestProfile;
  */
 @QuarkusTest
 @TestProfile(KafkaEventsProfile.class)
+@DisabledIfSystemProperty(named = "kafka.storage", matches = "true")
 public class KafkaEventsTest extends AbstractResourceTestBase {
 
     @Test

--- a/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
+++ b/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
@@ -146,6 +146,12 @@ public class RegistryFacade {
         }
     }
 
+    public List<String> getClusteredRegistryNodes() {
+        int c2port = TestUtils.getRegistryPort() + 1;
+        int c3port = c2port + 1;
+        return Arrays.asList("http://localhost:" + TestUtils.getRegistryPort(), "http://localhost:" + c2port, "http://localhost:" + c3port);
+    }
+
     public boolean isRunning() {
         return !processes.isEmpty();
     }
@@ -192,8 +198,15 @@ public class RegistryFacade {
                 Map<String, String> node1Env = new HashMap<>(appEnv);
                 runRegistryNode(path, node1Env, String.valueOf(TestUtils.getRegistryPort()));
 
+                int c2port = TestUtils.getRegistryPort() + 1;
+
                 Map<String, String> node2Env = new HashMap<>(appEnv);
-                runRegistryNode(path, node2Env, String.valueOf(TestUtils.getRegistryPort() + 1));
+                runRegistryNode(path, node2Env, String.valueOf(c2port));
+
+                int c3port = c2port + 1;
+
+                Map<String, String> node3Env = new HashMap<>(appEnv);
+                runRegistryNode(path, node3Env, String.valueOf(c3port));
 
             } else {
                 if (Constants.MULTITENANCY.equals(RegistryUtils.TEST_PROFILE)) {
@@ -239,7 +252,10 @@ public class RegistryFacade {
 
             try {
                 nodeIsReady.accept(TestUtils.getRegistryPort());
-                nodeIsReady.accept(TestUtils.getRegistryPort() + 1);
+                int c2port = TestUtils.getRegistryPort() + 1;
+                nodeIsReady.accept(c2port);
+                int c3port = c2port + 1;
+                nodeIsReady.accept(c3port);
             } catch (Throwable e) {
                 throw new Exception(e);
             }

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/ApicurioV2BaseIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/ApicurioV2BaseIT.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -49,6 +48,7 @@ import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.common.ApicurioRegistryBaseIT;
 import io.apicurio.tests.common.Constants;
+import io.apicurio.tests.common.RegistryFacade;
 import io.apicurio.tests.common.utils.RegistryUtils;
 import io.restassured.RestAssured;
 import io.restassured.parsing.Parser;
@@ -66,10 +66,7 @@ public class ApicurioV2BaseIT extends ApicurioRegistryBaseIT {
 
     protected RegistryClient createRegistryClient() {
         if (!TestUtils.isExternalRegistry() && RegistryUtils.TEST_PROFILE.contains(Constants.CLUSTERED)) {
-
-            int c2port = TestUtils.getRegistryPort() + 1;
-
-            return new LoadBalanceRegistryClient(Arrays.asList("http://localhost:" + TestUtils.getRegistryPort(), "http://localhost:" + c2port));
+            return new LoadBalanceRegistryClient(RegistryFacade.getInstance().getClusteredRegistryNodes());
         } else {
             return RegistryClientFactory.create(TestUtils.getRegistryBaseUrl());
         }

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/LoadBalanceRegistryClient.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/LoadBalanceRegistryClient.java
@@ -20,6 +20,8 @@ import java.io.InputStream;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
 import io.apicurio.registry.rest.client.RegistryClient;
 import io.apicurio.registry.rest.client.RegistryClientFactory;
 import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
@@ -68,8 +70,8 @@ public class LoadBalanceRegistryClient implements RegistryClient {
     }
 
     private synchronized RegistryClient getTarget() {
-        RegistryClientHolder t = this.targets.poll();
-        this.targets.addLast(t);
+        int randomElementIndex = ThreadLocalRandom.current().nextInt(this.targets.size());
+        RegistryClientHolder t = this.targets.get(randomElementIndex);
         System.out.println("Request to " + t.host);
         return t.client;
     }

--- a/storage/kafkasql/pom.xml
+++ b/storage/kafkasql/pom.xml
@@ -176,6 +176,7 @@
                 <configuration>
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <kafka.storage>true</kafka.storage>
                     </systemProperties>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This PR disables the kafka-events QuarkusTest when running kafkasql unit-tests, because of issues in GH actions due to running two kafka instances in containers.

This PR also improves the integration-tests, now it deploys 3 registry nodes locally and the load balancer client does a random load balancing. This is expected to provide a more realistic scenario...