### PR TITLE
Support for multi-tenant aware logging

### DIFF
--- a/app/src/main/java/io/apicurio/registry/RegistryQuarkusMain.java
+++ b/app/src/main/java/io/apicurio/registry/RegistryQuarkusMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,17 @@
  * limitations under the License.
  */
 
-package io.apicurio.registry.ccompat.rest.impl;
+package io.apicurio.registry;
 
-import javax.inject.Inject;
-
-import org.slf4j.Logger;
-
-import io.apicurio.registry.ccompat.store.RegistryStorageFacade;
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
 
 /**
- * @author Ales Justin
- * @author Jakub Senko 'jsenko@redhat.com'
+ * @author eric.wittmann@gmail.com
  */
-public abstract class AbstractResource {
-
-    @Inject
-    RegistryStorageFacade facade;
-
-    @Inject
-    Logger log;
-
+@QuarkusMain
+public class RegistryQuarkusMain {
+    public static void main(String... args) {
+        Quarkus.run(args);
+    }
 }

--- a/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.auth;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
@@ -24,8 +25,6 @@ import javax.interceptor.InvocationContext;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.apicurio.registry.storage.NotFoundException;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
@@ -38,10 +37,12 @@ import io.quarkus.security.identity.SecurityIdentity;
  * @author eric.wittmann@gmail.com
  */
 @Interceptor
+@Priority(Interceptor.Priority.APPLICATION)
 @Authorized
 public class AuthorizedInterceptor {
 
-    private static final Logger log = LoggerFactory.getLogger(AuthorizedInterceptor.class);
+    @Inject
+    Logger log;
 
     @Inject
     SecurityIdentity securityIdentity;

--- a/app/src/main/java/io/apicurio/registry/content/extract/AvroContentExtractor.java
+++ b/app/src/main/java/io/apicurio/registry/content/extract/AvroContentExtractor.java
@@ -18,8 +18,10 @@ package io.apicurio.registry.content.extract;
 
 import java.io.IOException;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,21 +32,23 @@ import io.apicurio.registry.content.ContentHandle;
  * Performs meta-data extraction for Avro content.
  * @author Ales Justin
  */
+@ApplicationScoped
 public class AvroContentExtractor implements ContentExtractor {
-    private static final Logger log = LoggerFactory.getLogger(AvroContentExtractor.class);
 
-    public static final ContentExtractor INSTANCE = new AvroContentExtractor();
+    @Inject
+    Logger log;
 
     private ObjectMapper mapper = new ObjectMapper();
 
     private AvroContentExtractor() {
     }
 
+    @Override
     public ExtractedMetaData extract(ContentHandle content) {
         try {
             JsonNode avroSchema = mapper.readTree(content.bytes());
             JsonNode name = avroSchema.get("name");
-            
+
             ExtractedMetaData metaData = null;
             if (name != null && !name.isNull()) {
                 metaData = new ExtractedMetaData();

--- a/app/src/main/java/io/apicurio/registry/content/extract/JsonContentExtractor.java
+++ b/app/src/main/java/io/apicurio/registry/content/extract/JsonContentExtractor.java
@@ -18,9 +18,10 @@ package io.apicurio.registry.content.extract;
 
 import java.io.IOException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
+import org.slf4j.Logger;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -30,22 +31,24 @@ import io.apicurio.registry.content.ContentHandle;
  * Performs meta-data extraction for JSON Schema content.
  * @author Ales Justin
  */
+@ApplicationScoped
 public class JsonContentExtractor implements ContentExtractor {
-    private static final Logger log = LoggerFactory.getLogger(JsonContentExtractor.class);
 
-    public static final ContentExtractor INSTANCE = new JsonContentExtractor();
+    @Inject
+    Logger log;
 
     private ObjectMapper mapper = new ObjectMapper();
 
     private JsonContentExtractor() {
     }
 
+    @Override
     public ExtractedMetaData extract(ContentHandle content) {
         try {
             JsonNode jsonSchema = mapper.readTree(content.bytes());
             JsonNode title = jsonSchema.get("title");
             JsonNode desc = jsonSchema.get("description");
-            
+
             ExtractedMetaData metaData = null;
             if (title != null && !title.isNull()) {
                 metaData = new ExtractedMetaData();

--- a/app/src/main/java/io/apicurio/registry/content/extract/OpenApiOrAsyncApiContentExtractor.java
+++ b/app/src/main/java/io/apicurio/registry/content/extract/OpenApiOrAsyncApiContentExtractor.java
@@ -16,8 +16,10 @@
 
 package io.apicurio.registry.content.extract;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.combined.visitors.CombinedVisitorAdapter;
@@ -30,20 +32,22 @@ import io.apicurio.registry.content.ContentHandle;
  * Performs meta-data extraction for OpenAPI content.
  * @author eric.wittmann@gmail.com
  */
+@ApplicationScoped
 public class OpenApiOrAsyncApiContentExtractor implements ContentExtractor {
-    private static final Logger log = LoggerFactory.getLogger(OpenApiOrAsyncApiContentExtractor.class);
 
-    public static final ContentExtractor INSTANCE = new OpenApiOrAsyncApiContentExtractor();
+    @Inject
+    Logger log;
 
     private OpenApiOrAsyncApiContentExtractor() {
     }
 
+    @Override
     public ExtractedMetaData extract(ContentHandle content) {
         try {
             Document openApi = Library.readDocumentFromJSONString(content.content());
             MetaDataVisitor viz = new MetaDataVisitor();
             Library.visitTree(openApi, viz, TraverserDirection.down);
-            
+
             ExtractedMetaData metaData = null;
             if (viz.name != null || viz.description != null) {
                 metaData = new ExtractedMetaData();
@@ -60,12 +64,12 @@ public class OpenApiOrAsyncApiContentExtractor implements ContentExtractor {
             return null;
         }
     }
-    
+
     private static class MetaDataVisitor extends CombinedVisitorAdapter {
-        
+
         String name;
         String description;
-        
+
         /**
          * @see io.apicurio.datamodels.combined.visitors.CombinedVisitorAdapter#visitInfo(io.apicurio.datamodels.core.models.common.Info)
          */
@@ -74,6 +78,6 @@ public class OpenApiOrAsyncApiContentExtractor implements ContentExtractor {
             name = node.title;
             description = node.description;
         }
-        
+
     }
 }

--- a/app/src/main/java/io/apicurio/registry/content/extract/WsdlOrXsdContentExtractor.java
+++ b/app/src/main/java/io/apicurio/registry/content/extract/WsdlOrXsdContentExtractor.java
@@ -18,8 +18,10 @@ package io.apicurio.registry.content.extract;
 
 import java.io.InputStream;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 
 import io.apicurio.registry.content.ContentHandle;
@@ -29,20 +31,19 @@ import io.apicurio.registry.util.DocumentBuilderAccessor;
  * Performs meta-data extraction for WSDL or XSD content.
  * @author eric.wittmann@gmail.com
  */
+@ApplicationScoped
 public class WsdlOrXsdContentExtractor implements ContentExtractor {
-    private static final Logger log = LoggerFactory.getLogger(WsdlOrXsdContentExtractor.class);
 
-    public static final ContentExtractor INSTANCE = new WsdlOrXsdContentExtractor();
+    @Inject
+    Logger log;
 
-    private WsdlOrXsdContentExtractor() {
-    }
-
+    @Override
     public ExtractedMetaData extract(ContentHandle content) {
         try (InputStream contentIS = content.stream()) {
             Document document = DocumentBuilderAccessor.getDocumentBuilder().parse(contentIS);
             String name = document.getDocumentElement().getAttribute("name");
             String targetNS = document.getDocumentElement().getAttribute("targetNamespace");
-            
+
             ExtractedMetaData metaData = null;
             if (name != null && !name.equals("")) {
                 metaData = new ExtractedMetaData();

--- a/app/src/main/java/io/apicurio/registry/events/EventsServiceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/events/EventsServiceImpl.java
@@ -26,8 +26,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.apicurio.registry.events.dto.RegistryEventType;
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.Vertx;
@@ -41,12 +39,13 @@ import io.vertx.core.eventbus.EventBus;
 @ApplicationScoped
 public class EventsServiceImpl implements EventsService {
 
-    private static final Logger log = LoggerFactory.getLogger(EventsServiceImpl.class);
-
     private static final String INTERNAL_EVENTS_ADDRESS = "registry-events";
 
     private ObjectMapper mapper;
     private boolean configuredSinks = false;
+
+    @Inject
+    Logger log;
 
     @Inject
     Vertx vertx;

--- a/app/src/main/java/io/apicurio/registry/events/http/HttpEventSink.java
+++ b/app/src/main/java/io/apicurio/registry/events/http/HttpEventSink.java
@@ -21,8 +21,6 @@ import javax.inject.Inject;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.apicurio.registry.events.EventSink;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -36,9 +34,10 @@ import io.vertx.core.http.HttpClientOptions;
 @ApplicationScoped
 public class HttpEventSink implements EventSink {
 
-    private static final Logger log = LoggerFactory.getLogger(HttpEventSink.class);
-
     private HttpClient httpClient;
+
+    @Inject
+    Logger log;
 
     @Inject
     HttpSinksConfiguration sinksConfiguration;

--- a/app/src/main/java/io/apicurio/registry/events/kafka/KafkaEventSink.java
+++ b/app/src/main/java/io/apicurio/registry/events/kafka/KafkaEventSink.java
@@ -30,8 +30,6 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serdes;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.apicurio.registry.events.EventSink;
 import io.apicurio.registry.utils.RegistryProperties;
 import io.apicurio.registry.utils.kafka.AsyncProducer;
@@ -45,7 +43,8 @@ import io.vertx.core.eventbus.Message;
 @ApplicationScoped
 public class KafkaEventSink implements EventSink {
 
-    private static final Logger log = LoggerFactory.getLogger(KafkaEventSink.class);
+    @Inject
+    Logger log;
 
     @Inject
     @RegistryProperties(

--- a/app/src/main/java/io/apicurio/registry/logging/LoggerProducer.java
+++ b/app/src/main/java/io/apicurio/registry/logging/LoggerProducer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.logging;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+@ApplicationScoped
+public class LoggerProducer {
+
+    private final Map<Class<?>, Logger> loggers = new HashMap<>();
+
+    /**
+     * @param targetClass
+     */
+    public Logger getLogger(Class<?> targetClass) {
+        Logger logger = loggers.computeIfAbsent(targetClass, k -> {
+            return LoggerFactory.getLogger(targetClass);
+        });
+        return logger;
+    }
+
+    /**
+     * Produces a logger for injection.
+     * @param injectionPoint
+     */
+    @Produces
+    public Logger produceLogger(InjectionPoint injectionPoint) {
+        Class<?> targetClass = injectionPoint.getBean().getBeanClass();
+        return getLogger(targetClass);
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/logging/LoggingInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/logging/LoggingInterceptor.java
@@ -16,15 +16,13 @@
 
 package io.apicurio.registry.logging;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import javax.annotation.Priority;
+import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.apicurio.registry.rest.RegistryApplication;
 
@@ -32,10 +30,12 @@ import io.apicurio.registry.rest.RegistryApplication;
  * @author eric.wittmann@gmail.com
  */
 @Interceptor
+@Priority(Interceptor.Priority.APPLICATION)
 @Logged
 public class LoggingInterceptor {
 
-    private static final Map<Class<?>, Logger> loggers = new HashMap<>();
+    @Inject
+    LoggerProducer loggerProducer;
 
     @AroundInvoke
     public Object logMethodEntry(InvocationContext context) throws Exception {
@@ -47,7 +47,7 @@ public class LoggingInterceptor {
                 targetClass = target.getClass();
             }
 
-            logger = getLogger(targetClass);
+            logger = loggerProducer.getLogger(targetClass);
         } catch (Throwable t) {
         }
 
@@ -67,16 +67,6 @@ public class LoggingInterceptor {
         if (context != null && context.getMethod() != null && context.getMethod().getName() != null && context.getParameters() != null && logger != null) {
             logger.trace("LEAVING method [{}]", context.getMethod().getName());
         }
-    }
-
-    /**
-     * Gets a logger for the given target class.
-     * @param targetClass
-     */
-    private Logger getLogger(Class<?> targetClass) {
-        return loggers.computeIfAbsent(targetClass, k -> {
-            return LoggerFactory.getLogger(targetClass);
-        });
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/metrics/LivenessUtil.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/LivenessUtil.java
@@ -25,7 +25,6 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.apicurio.registry.rest.RegistryExceptionMapper;
 
@@ -35,7 +34,8 @@ import io.apicurio.registry.rest.RegistryExceptionMapper;
 @ApplicationScoped
 public class LivenessUtil {
 
-    private static final Logger log = LoggerFactory.getLogger(PersistenceExceptionLivenessInterceptor.class);
+    @Inject
+    Logger log;
 
     @Inject
     @ConfigProperty(name = "registry.liveness.errors.ignored")

--- a/app/src/main/java/io/apicurio/registry/metrics/PersistenceExceptionLivenessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/PersistenceExceptionLivenessCheck.java
@@ -3,13 +3,13 @@ package io.apicurio.registry.metrics;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
+import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Fail liveness check if the number of exceptions thrown by artifactStore is too high.
@@ -21,7 +21,8 @@ import org.slf4j.LoggerFactory;
 @Default
 public class PersistenceExceptionLivenessCheck extends AbstractErrorCounterHealthCheck implements HealthCheck, LivenessCheck {
 
-    private static final Logger log = LoggerFactory.getLogger(PersistenceExceptionLivenessCheck.class);
+    @Inject
+    Logger log;
 
     /**
      * Maximum number of exceptions raised by artifactStore implementation,

--- a/app/src/main/java/io/apicurio/registry/metrics/PersistenceExceptionLivenessInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/PersistenceExceptionLivenessInterceptor.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.metrics;
 
+import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
@@ -11,9 +12,10 @@ import javax.interceptor.InvocationContext;
  * @author Jakub Senko 'jsenko@redhat.com'
  */
 @Interceptor
+@Priority(Interceptor.Priority.APPLICATION)
 @PersistenceExceptionLivenessApply
 public class PersistenceExceptionLivenessInterceptor {
-    
+
     @Inject
     PersistenceExceptionLivenessCheck check;
     @Inject

--- a/app/src/main/java/io/apicurio/registry/metrics/PersistenceSimpleReadinessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/PersistenceSimpleReadinessCheck.java
@@ -1,14 +1,16 @@
 package io.apicurio.registry.metrics;
 
-import io.apicurio.registry.storage.RegistryStorage;
-import io.apicurio.registry.types.Current;
-import org.eclipse.microprofile.health.HealthCheck;
-import org.eclipse.microprofile.health.HealthCheckResponse;
-import org.eclipse.microprofile.health.Readiness;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+import org.slf4j.Logger;
+
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.types.Current;
 
 /**
  * @author Jakub Senko 'jsenko@redhat.com'
@@ -18,7 +20,8 @@ import javax.inject.Inject;
 @Default
 public class PersistenceSimpleReadinessCheck implements HealthCheck {
 
-//    private static final Logger log = LoggerFactory.getLogger(PersistenceSimpleReadinessCheck.class);
+    @Inject
+    Logger log;
 
     @Inject
     @Current

--- a/app/src/main/java/io/apicurio/registry/metrics/PersistenceTimeoutReadinessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/PersistenceTimeoutReadinessCheck.java
@@ -5,11 +5,13 @@ import java.time.Duration;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
+import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
+import org.slf4j.Logger;
 
 /**
  * Fail readiness check if the duration of processing a artifactStore operation is too high.
@@ -21,7 +23,8 @@ import org.eclipse.microprofile.health.Liveness;
 @Default
 public class PersistenceTimeoutReadinessCheck extends AbstractErrorCounterHealthCheck implements HealthCheck {
 
-//    private static final Logger log = LoggerFactory.getLogger(PersistenceTimeoutReadinessCheck.class);
+    @Inject
+    Logger log;
 
     /**
      * Maximum number of timeouts as captured by this interceptor,

--- a/app/src/main/java/io/apicurio/registry/metrics/PersistenceTimeoutReadinessInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/PersistenceTimeoutReadinessInterceptor.java
@@ -2,10 +2,13 @@ package io.apicurio.registry.metrics;
 
 import java.time.Instant;
 
+import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
+
+import org.slf4j.Logger;
 
 /**
  * Fail readiness check if the duration of processing a artifactStore operation is too high.
@@ -13,10 +16,12 @@ import javax.interceptor.InvocationContext;
  * @author Jakub Senko 'jsenko@redhat.com'
  */
 @Interceptor
+@Priority(Interceptor.Priority.APPLICATION)
 @PersistenceTimeoutReadinessApply
 public class PersistenceTimeoutReadinessInterceptor {
 
-//    private static final Logger log = LoggerFactory.getLogger(PersistenceTimeoutReadinessInterceptor.class);
+    @Inject
+    Logger log;
 
     @Inject
     PersistenceTimeoutReadinessCheck check;

--- a/app/src/main/java/io/apicurio/registry/metrics/ResponseErrorLivenessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/ResponseErrorLivenessCheck.java
@@ -3,13 +3,13 @@ package io.apicurio.registry.metrics;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
+import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Jakub Senko 'jsenko@redhat.com'
@@ -19,7 +19,8 @@ import org.slf4j.LoggerFactory;
 @Default
 public class ResponseErrorLivenessCheck extends AbstractErrorCounterHealthCheck implements HealthCheck, LivenessCheck {
 
-    private static final Logger log = LoggerFactory.getLogger(ResponseErrorLivenessCheck.class);
+    @Inject
+    Logger log;
 
     /**
      * Maximum number of HTTP 5xx errors returned to the user

--- a/app/src/main/java/io/apicurio/registry/metrics/ResponseTimeoutReadinessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/ResponseTimeoutReadinessCheck.java
@@ -5,8 +5,6 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
@@ -14,6 +12,7 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -30,9 +29,10 @@ import javax.ws.rs.ext.Provider;
 public class ResponseTimeoutReadinessCheck extends AbstractErrorCounterHealthCheck
         implements HealthCheck, ContainerRequestFilter, ContainerResponseFilter {
 
-    private static final Logger log = LoggerFactory.getLogger(ResponseTimeoutReadinessCheck.class);
-
     private static final String HEADER_NAME = "X-Apicurio-Registry-ResponseTimeoutReadinessCheck-RequestStart";
+
+    @Inject
+    Logger log;
 
     /**
      * Maximum number of requests taking more than {@link ResponseTimeoutReadinessCheck#configTimeoutSec} seconds,

--- a/app/src/main/java/io/apicurio/registry/metrics/RestMetricsInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/RestMetricsInterceptor.java
@@ -8,6 +8,7 @@ import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
 
+import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
@@ -24,6 +25,7 @@ import static org.eclipse.microprofile.metrics.MetricUnits.MILLISECONDS;
  * @author Jakub Senko 'jsenko@redhat.com'
  */
 @Interceptor
+@Priority(Interceptor.Priority.APPLICATION)
 @RestMetricsApply
 public class RestMetricsInterceptor {
 

--- a/app/src/main/java/io/apicurio/registry/mt/TenantContextImpl.java
+++ b/app/src/main/java/io/apicurio/registry/mt/TenantContextImpl.java
@@ -26,6 +26,7 @@ import org.jboss.logging.MDC;
 @ApplicationScoped
 public class TenantContextImpl implements TenantContext {
 
+    private static final String TENANT_ID_KEY = "tenantId";
     private static final String DEFAULT_TENANT_ID = "_";
     private static ThreadLocal<String> tid = ThreadLocal.withInitial(() -> DEFAULT_TENANT_ID);
 
@@ -43,7 +44,7 @@ public class TenantContextImpl implements TenantContext {
     @Override
     public void tenantId(String tenantId) {
         tid.set(tenantId);
-        MDC.put("tenantId", tenantId);
+        MDC.put(TENANT_ID_KEY, tenantId);
     }
 
     /**
@@ -52,7 +53,7 @@ public class TenantContextImpl implements TenantContext {
     @Override
     public void clearTenantId() {
         this.tenantId(DEFAULT_TENANT_ID);
-        MDC.remove("tenantId");
+        MDC.remove(TENANT_ID_KEY);
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/mt/TenantContextImpl.java
+++ b/app/src/main/java/io/apicurio/registry/mt/TenantContextImpl.java
@@ -18,6 +18,8 @@ package io.apicurio.registry.mt;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import org.jboss.logging.MDC;
+
 /**
  * @author eric.wittmann@gmail.com
  */
@@ -41,14 +43,16 @@ public class TenantContextImpl implements TenantContext {
     @Override
     public void tenantId(String tenantId) {
         tid.set(tenantId);
+        MDC.put("tenantId", tenantId);
     }
-    
+
     /**
      * @see io.apicurio.registry.mt.TenantContext#clearTenantId()
      */
     @Override
     public void clearTenantId() {
         this.tenantId(DEFAULT_TENANT_ID);
+        MDC.remove("tenantId");
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/mt/TenantIdResolver.java
+++ b/app/src/main/java/io/apicurio/registry/mt/TenantIdResolver.java
@@ -22,8 +22,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.apicurio.registry.rest.Headers;
 import io.apicurio.registry.rest.RegistryApplicationServletFilter;
 import io.quarkus.runtime.StartupEvent;
@@ -41,11 +39,12 @@ import io.vertx.ext.web.RoutingContext;
 @ApplicationScoped
 public class TenantIdResolver {
 
-    protected final Logger log = LoggerFactory.getLogger(getClass());
-
     private static final int TENANT_ID_POSITION = 2;
 
     String multitenancyBasePath;
+
+    @Inject
+    Logger log;
 
     @Inject
     MultitenancyProperties mtProperties;

--- a/app/src/main/java/io/apicurio/registry/rest/CompatibilityV1ApiRequestFilter.java
+++ b/app/src/main/java/io/apicurio/registry/rest/CompatibilityV1ApiRequestFilter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 
 import javax.annotation.Priority;
+import javax.inject.Inject;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -28,7 +29,6 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.ext.Provider;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Request filter that rewrites requests from the path the API had for the 1.X releases to it's new location under "/apis/registry/v1"
@@ -46,7 +46,8 @@ import org.slf4j.LoggerFactory;
 @Provider
 public class CompatibilityV1ApiRequestFilter implements ContainerRequestFilter {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    @Inject
+    Logger log;
 
     public static final String V1_API_OLD_PATH = "/api/";
 

--- a/app/src/main/java/io/apicurio/registry/rest/RegistryExceptionMapper.java
+++ b/app/src/main/java/io/apicurio/registry/rest/RegistryExceptionMapper.java
@@ -42,8 +42,6 @@ import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.apicurio.registry.ccompat.rest.error.ConflictException;
 import io.apicurio.registry.ccompat.rest.error.UnprocessableEntityException;
 import io.apicurio.registry.metrics.LivenessUtil;
@@ -81,14 +79,16 @@ import io.apicurio.registry.storage.VersionNotFoundException;
 @Provider
 public class RegistryExceptionMapper implements ExceptionMapper<Throwable> {
 
-    private static final Logger log = LoggerFactory.getLogger(RegistryExceptionMapper.class);
-
     private static final int HTTP_UNPROCESSABLE_ENTITY = 422;
 
     private static final Map<Class<? extends Exception>, Integer> CODE_MAP;
 
     @Inject
+    Logger log;
+
+    @Inject
     ResponseErrorLivenessCheck liveness;
+
     @Inject
     LivenessUtil livenessUtil;
 

--- a/app/src/main/java/io/apicurio/registry/rest/v2/AdminResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/AdminResourceImpl.java
@@ -46,8 +46,7 @@ import javax.ws.rs.core.StreamingOutput;
 import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
-import org.slf4j.LoggerFactory;
-
+import org.slf4j.Logger;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.metrics.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.ResponseTimeoutReadinessCheck;
@@ -82,6 +81,9 @@ import io.apicurio.registry.utils.impexp.EntityWriter;
 @Timed(name = REST_REQUEST_RESPONSE_TIME, description = REST_REQUEST_RESPONSE_TIME_DESC, tags = {"group=" + REST_GROUP_TAG, "metric=" + REST_REQUEST_RESPONSE_TIME}, unit = MILLISECONDS)
 @Logged
 public class AdminResourceImpl implements AdminResource {
+
+    @Inject
+    Logger log;
 
     @Inject
     @Current
@@ -235,7 +237,7 @@ public class AdminResourceImpl implements AdminResource {
                 try {
                     return reader.readEntity();
                 } catch (Exception e) {
-                    LoggerFactory.getLogger(AdminResourceImpl.class).error("Error reading data from import ZIP file.", e);
+                    log.error("Error reading data from import ZIP file.", e);
                     return null;
                 }
             }

--- a/app/src/main/java/io/apicurio/registry/rest/v2/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/SearchResourceImpl.java
@@ -42,8 +42,6 @@ import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
 import io.apicurio.registry.logging.Logged;
@@ -82,7 +80,9 @@ public class SearchResourceImpl implements SearchResource {
 
     private static final String EMPTY_CONTENT_ERROR_MESSAGE = "Empty content is not allowed.";
     private static final String CANONICAL_QUERY_PARAM_ERROR_MESSAGE = "When setting 'canonical' to 'true', the 'artifactType' query parameter is also required.";
-    private static final Logger log = LoggerFactory.getLogger(SearchResourceImpl.class);
+
+    @Inject
+    Logger log;
 
     @Inject
     @Current

--- a/app/src/main/java/io/apicurio/registry/services/DisabledApisMatcherService.java
+++ b/app/src/main/java/io/apicurio/registry/services/DisabledApisMatcherService.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.apicurio.registry.mt.MultitenancyProperties;
 
@@ -38,7 +37,8 @@ import io.apicurio.registry.mt.MultitenancyProperties;
 @ApplicationScoped
 public class DisabledApisMatcherService {
 
-    protected final Logger log = LoggerFactory.getLogger(getClass());
+    @Inject
+    Logger log;
 
     private static final String UI_PATTERN = "/ui/.*";
 

--- a/app/src/main/java/io/apicurio/registry/services/LogConfigurationService.java
+++ b/app/src/main/java/io/apicurio/registry/services/LogConfigurationService.java
@@ -42,7 +42,8 @@ import io.quarkus.scheduler.Scheduled.ConcurrentExecution;
 @ApplicationScoped
 public class LogConfigurationService {
 
-    private static final Logger LOGGER = Logger.getLogger(LogConfigurationService.class.getName());
+    @Inject
+    org.slf4j.Logger LOGGER;
 
     @Inject
     @Current
@@ -56,7 +57,7 @@ public class LogConfigurationService {
         if (!storage.isAlive() || !storage.isReady()) {
             return;
         }
-        LOGGER.finest("Running periodic log configuration process");
+        LOGGER.trace("Running periodic log configuration process");
         for (LogConfigurationDto logConfig : storage.listLogConfigurations()) {
             Logger logger = Logger.getLogger(logConfig.getLogger());
             Level expectedLevel = Level.parse(logConfig.getLogLevel().value());

--- a/app/src/main/java/io/apicurio/registry/services/tenant/CustomTenantConfigResolver.java
+++ b/app/src/main/java/io/apicurio/registry/services/tenant/CustomTenantConfigResolver.java
@@ -32,7 +32,6 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class provides the logic to configure the authentication layer with the tenant configuration
@@ -46,7 +45,8 @@ import org.slf4j.LoggerFactory;
 @ApplicationScoped
 public class CustomTenantConfigResolver implements TenantConfigResolver {
 
-    protected final Logger log = LoggerFactory.getLogger(getClass());
+    @Inject
+    Logger log;
 
     @Inject
     TenantMetadataService tenantMetadataService;

--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorageProducer.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorageProducer.java
@@ -25,8 +25,6 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.apicurio.registry.events.EventSourcedRegistryStorage;
 import io.apicurio.registry.events.EventsService;
 import io.apicurio.registry.storage.impl.sql.InMemoryRegistryStorage;
@@ -37,7 +35,9 @@ import io.apicurio.registry.types.Current;
  */
 @ApplicationScoped
 public class RegistryStorageProducer {
-    private static Logger log = LoggerFactory.getLogger(RegistryStorageProducer.class);
+
+    @Inject
+    Logger log;
 
     @Inject
     Instance<RegistryStorage> storages;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -48,8 +48,6 @@ import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.Update;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.agroal.api.AgroalDataSource;
 import io.apicurio.registry.System;
 import io.apicurio.registry.content.ContentHandle;
@@ -121,9 +119,11 @@ import io.quarkus.security.identity.SecurityIdentity;
  */
 public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage {
 
-    private static final Logger log = LoggerFactory.getLogger(AbstractSqlRegistryStorage.class);
     private static int DB_VERSION = 1;
     private static final Object dbMutex = new Object();
+
+    @Inject
+    Logger log;
 
     @Inject
     TenantContext tenantContext;
@@ -145,6 +145,9 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
 
     @Inject
     SecurityIdentity securityIdentity;
+
+    @Inject
+    ArtifactStateExt artifactStateEx;
 
     protected SqlStatements sqlStatements() {
         return sqlStatements;
@@ -399,7 +402,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
             long globalId = dto.getGlobalId();
             ArtifactState oldState = dto.getState();
             ArtifactState newState = state;
-            ArtifactStateExt.applyState(s -> {
+            artifactStateEx.applyState(s -> {
                 String sql = sqlStatements.updateArtifactVersionState();
                 int rowCount = handle.createUpdate(sql)
                         .bind(0, s.name())
@@ -427,7 +430,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
             ArtifactState oldState = dto.getState();
             ArtifactState newState = state;
             if (oldState != newState) {
-                ArtifactStateExt.applyState(s -> {
+                artifactStateEx.applyState(s -> {
                     String sql = sqlStatements.updateArtifactVersionState();
                     int rowCount = handle.createUpdate(sql)
                             .bind(0, s.name())

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/InMemoryRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/InMemoryRegistryStorage.java
@@ -31,8 +31,6 @@ import javax.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
-import org.slf4j.LoggerFactory;
-
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.metrics.PersistenceExceptionLivenessApply;
 import io.apicurio.registry.metrics.PersistenceTimeoutReadinessApply;
@@ -53,7 +51,7 @@ public class InMemoryRegistryStorage extends AbstractSqlRegistryStorage {
 
     @PostConstruct
     void onConstruct() {
-        LoggerFactory.getLogger(InMemoryRegistryStorage.class).info("Using In Memory (H2) SQL storage.");
+        log.info("Using In Memory (H2) SQL storage.");
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatementsProducer.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatementsProducer.java
@@ -18,27 +18,29 @@ package io.apicurio.registry.storage.impl.sql;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author eric.wittmann@gmail.com
  */
 @ApplicationScoped
 public class SqlStatementsProducer {
-    private static Logger logger = LoggerFactory.getLogger(SqlStatementsProducer.class);
+
+    @Inject
+    Logger log;
 
     @ConfigProperty(name = "quarkus.datasource.db-kind", defaultValue = "postgresql")
     String databaseType;
-    
+
     /**
      * Produces an {@link SqlStatements} instance for injection.
      */
     @Produces @ApplicationScoped
     public SqlStatements createSqlStatements() {
-        logger.debug("Creating an instance of ISqlStatements for DB: " + databaseType);
+        log.debug("Creating an instance of ISqlStatements for DB: " + databaseType);
         if ("h2".equals(databaseType)) {
             return new H2SqlStatements();
         }

--- a/app/src/main/java/io/apicurio/registry/types/provider/AsyncApiArtifactTypeUtilProvider.java
+++ b/app/src/main/java/io/apicurio/registry/types/provider/AsyncApiArtifactTypeUtilProvider.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.types.provider;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
 import io.apicurio.registry.content.canon.JsonContentCanonicalizer;
@@ -35,6 +36,10 @@ import io.apicurio.registry.types.ArtifactType;
 @ApplicationScoped
 @Logged
 public class AsyncApiArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvider {
+
+    @Inject
+    OpenApiOrAsyncApiContentExtractor extractor;
+
     @Override
     public ArtifactType getArtifactType() {
         return ArtifactType.ASYNCAPI;
@@ -57,6 +62,6 @@ public class AsyncApiArtifactTypeUtilProvider extends AbstractArtifactTypeUtilPr
 
     @Override
     protected ContentExtractor createContentExtractor() {
-        return OpenApiOrAsyncApiContentExtractor.INSTANCE;
+        return extractor;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/types/provider/AvroArtifactTypeUtilProvider.java
+++ b/app/src/main/java/io/apicurio/registry/types/provider/AvroArtifactTypeUtilProvider.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.types.provider;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import io.apicurio.registry.content.canon.AvroContentCanonicalizer;
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
@@ -35,6 +36,10 @@ import io.apicurio.registry.types.ArtifactType;
 @ApplicationScoped
 @Logged
 public class AvroArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvider {
+
+    @Inject
+    AvroContentExtractor extractor;
+
     @Override
     public ArtifactType getArtifactType() {
         return ArtifactType.AVRO;
@@ -57,7 +62,7 @@ public class AvroArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvid
 
     @Override
     protected ContentExtractor createContentExtractor() {
-        return AvroContentExtractor.INSTANCE;
+        return extractor;
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/types/provider/JsonArtifactTypeUtilProvider.java
+++ b/app/src/main/java/io/apicurio/registry/types/provider/JsonArtifactTypeUtilProvider.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.types.provider;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
 import io.apicurio.registry.content.canon.JsonContentCanonicalizer;
@@ -35,6 +36,10 @@ import io.apicurio.registry.types.ArtifactType;
 @ApplicationScoped
 @Logged
 public class JsonArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvider {
+
+    @Inject
+    JsonContentExtractor extractor;
+
     @Override
     public ArtifactType getArtifactType() {
         return ArtifactType.JSON;
@@ -57,6 +62,6 @@ public class JsonArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvid
 
     @Override
     protected ContentExtractor createContentExtractor() {
-        return JsonContentExtractor.INSTANCE;
+        return extractor;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/types/provider/OpenApiArtifactTypeUtilProvider.java
+++ b/app/src/main/java/io/apicurio/registry/types/provider/OpenApiArtifactTypeUtilProvider.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.types.provider;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
 import io.apicurio.registry.content.canon.JsonContentCanonicalizer;
@@ -35,6 +36,10 @@ import io.apicurio.registry.types.ArtifactType;
 @ApplicationScoped
 @Logged
 public class OpenApiArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvider {
+
+    @Inject
+    OpenApiOrAsyncApiContentExtractor extractor;
+
     @Override
     public ArtifactType getArtifactType() {
         return ArtifactType.OPENAPI;
@@ -57,6 +62,6 @@ public class OpenApiArtifactTypeUtilProvider extends AbstractArtifactTypeUtilPro
 
     @Override
     protected ContentExtractor createContentExtractor() {
-        return OpenApiOrAsyncApiContentExtractor.INSTANCE;
+        return extractor;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/types/provider/WsdlArtifactTypeUtilProvider.java
+++ b/app/src/main/java/io/apicurio/registry/types/provider/WsdlArtifactTypeUtilProvider.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.types.provider;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
 import io.apicurio.registry.content.canon.XmlContentCanonicalizer;
@@ -35,6 +36,9 @@ import io.apicurio.registry.types.ArtifactType;
 @ApplicationScoped
 @Logged
 public class WsdlArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvider {
+
+    @Inject
+    WsdlOrXsdContentExtractor extractor;
 
     /**
      * @see io.apicurio.registry.types.provider.ArtifactTypeUtilProvider#getArtifactType()
@@ -73,7 +77,7 @@ public class WsdlArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvid
      */
     @Override
     protected ContentExtractor createContentExtractor() {
-        return WsdlOrXsdContentExtractor.INSTANCE;
+        return extractor;
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/types/provider/XsdArtifactTypeUtilProvider.java
+++ b/app/src/main/java/io/apicurio/registry/types/provider/XsdArtifactTypeUtilProvider.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.types.provider;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
 import io.apicurio.registry.content.canon.XmlContentCanonicalizer;
@@ -35,6 +36,9 @@ import io.apicurio.registry.types.ArtifactType;
 @ApplicationScoped
 @Logged
 public class XsdArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvider {
+
+    @Inject
+    WsdlOrXsdContentExtractor extractor;
 
     /**
      * @see io.apicurio.registry.types.provider.ArtifactTypeUtilProvider#getArtifactType()
@@ -73,7 +77,7 @@ public class XsdArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvide
      */
     @Override
     protected ContentExtractor createContentExtractor() {
-        return WsdlOrXsdContentExtractor.INSTANCE;
+        return extractor;
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
+++ b/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
@@ -28,7 +28,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.apicurio.registry.utils.RegistryProperties;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Holds/accesses all configuration settings for the UI.
@@ -37,8 +36,9 @@ import org.slf4j.LoggerFactory;
 @ApplicationScoped
 public class UiConfigProperties {
 
-    private static final Logger logger = LoggerFactory.getLogger(UiConfigProperties.class);
-    
+    @Inject
+    Logger log;
+
     @Inject
     @ConfigProperty(name = "registry.ui.features.readOnly", defaultValue = "false")
     boolean featureReadOnly;
@@ -56,7 +56,7 @@ public class UiConfigProperties {
     boolean tenantEnabled;
 
     private final Map<String, Object> keycloakConfig;
-    
+
     /**
      * Constructor.
      * @param kcProperties
@@ -65,32 +65,32 @@ public class UiConfigProperties {
         this.keycloakConfig = new HashMap<>();
         kcProperties.stringPropertyNames().forEach(key -> keycloakConfig.put(key, kcProperties.get(key)));
     }
-    
+
     @PostConstruct
     void onConstruct() {
-        logger.debug("============> kcProperties  " + keycloakConfig);
-        logger.debug("============> tenantEnabled  " + tenantEnabled);
-        logger.debug("============> featureReadOnly  " + featureReadOnly);
-        logger.debug("============> uiUrl  " + uiUrl);
-        logger.debug("============> apiUrl  " + apiUrl);
+        log.debug("============> kcProperties  " + keycloakConfig);
+        log.debug("============> tenantEnabled  " + tenantEnabled);
+        log.debug("============> featureReadOnly  " + featureReadOnly);
+        log.debug("============> uiUrl  " + uiUrl);
+        log.debug("============> apiUrl  " + apiUrl);
     }
 
     public Map<String, Object> getKeycloakProperties() {
         return keycloakConfig;
     }
-    
+
     public boolean isFeatureReadOnly() {
         return featureReadOnly;
     }
-    
+
     public String getUiUrl() {
         return uiUrl;
     }
-    
+
     public String getApiUrl() {
         return apiUrl;
     }
-    
+
     public boolean isKeycloakAuthEnabled() {
         return tenantEnabled;
     }

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -9,6 +9,8 @@ registry.description=High performance, runtime registry for schemas and API desi
 registry.version=${project.version}
 registry.date=${timestamp}
 
+# Basic logging
+quarkus.log.console.format=%d{YYYY-MM-DD HH:mm:ss} %p <%X{tenantId}> [%C] (%t) %m%n
 
 # === Dev profile - see README
 %dev.quarkus.http.port=${HTTP_PORT:8080}

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlSink.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlSink.java
@@ -10,7 +10,6 @@ import javax.inject.Inject;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.mt.TenantContext;
@@ -58,7 +57,8 @@ import io.apicurio.registry.utils.impexp.GroupEntity;
 @Logged
 public class KafkaSqlSink {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass().getName());
+    @Inject
+    Logger log;
 
     @Inject
     KafkaSqlCoordinator coordinator;

--- a/storage/sql/pom.xml
+++ b/storage/sql/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${test-containers.version}</version>
+            <version>${test-containers.version}</version><!--$NO-MVN-MAN-VER$-->
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/storage/sql/src/main/java/io/apicurio/registry/storage/impl/sql/SqlRegistryStorage.java
+++ b/storage/sql/src/main/java/io/apicurio/registry/storage/impl/sql/SqlRegistryStorage.java
@@ -31,9 +31,6 @@ import javax.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.metrics.PersistenceExceptionLivenessApply;
 import io.apicurio.registry.metrics.PersistenceTimeoutReadinessApply;
@@ -52,8 +49,6 @@ import io.apicurio.registry.storage.RegistryStorage;
 @Timed(name = STORAGE_OPERATION_TIME, description = STORAGE_OPERATION_TIME_DESC, tags = {"group=" + STORAGE_GROUP_TAG, "metric=" + STORAGE_OPERATION_TIME}, unit = MILLISECONDS)
 @Logged
 public class SqlRegistryStorage extends AbstractSqlRegistryStorage {
-
-    private static final Logger log = LoggerFactory.getLogger(SqlRegistryStorage.class);
 
     @PostConstruct
     void onConstruct() {


### PR DESCRIPTION
There is a fair bit of noise in this PR, for which I apologize.  I started out thinking I would need to wrap the Logger in a custom class so that I could add the tenantId to each message.  Then I realized I could just use [Mapped Diagnostic Contexts](https://www.baeldung.com/mdc-in-log4j-2-logback) and didn't need to wrap the Logger.  However, the CDI changes needed to wrap the Logger I think ended up looking rather good (you can now just `@Inject` a `Logger` into your CDI class).  So I'm keeping all those changes.  :)

Anyway, the relevant changes for adding `tenantId` to the log output can be found in `TenantContextImpl` and `application.properties`.  The former is where I use `MDC.put()` and `MDC.remove()` to add the tenantId to the logging context.  And the latter is where I'm customizing the logging output to include the `tenantId` MDC property.

Oh, and I am also now calling `clearTenantId()` in the filter to reset it after each request.  Without that, the tenantId information can leak to other non-request related code (e.g. the scheduled job that watches the DB for LogLevel changes).
