### PR TITLE
StartupEvent observer to run the import

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
+++ b/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
@@ -6,6 +6,7 @@ import io.apicurio.registry.types.Current;
 import io.apicurio.registry.utils.impexp.Entity;
 import io.apicurio.registry.utils.impexp.EntityReader;
 import io.quarkus.runtime.StartupEvent;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -15,6 +16,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.zip.ZipInputStream;
 
 @ApplicationScoped
@@ -27,10 +29,12 @@ public class ImportLifecycleBean {
     @Current
     RegistryStorage storage;
 
+    @ConfigProperty(name = "registry.import")
+    Optional<String> registryImportZipPath;
+
     void onStart(@Observes StartupEvent ev) {
-        final String registryImportZipPath = java.lang.System.getenv("REGISTRY_IMPORT");
-        if (registryImportZipPath != null && !registryImportZipPath.isEmpty()) {
-            try (final InputStream registryImportZip = new FileInputStream(registryImportZipPath)) {
+        if (registryImportZipPath.isPresent()) {
+            try (final InputStream registryImportZip = new FileInputStream(registryImportZipPath.get())) {
                 final ZipInputStream zip = new ZipInputStream(registryImportZip, StandardCharsets.UTF_8);
                 final EntityReader reader = new EntityReader(zip);
                 try (EntityInputStream stream = new EntityInputStream() {

--- a/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
+++ b/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
@@ -30,11 +30,12 @@ public class ImportLifecycleBean {
     RegistryStorage storage;
 
     @ConfigProperty(name = "registry.import")
-    Optional<String> registryImportZipPath;
+    Optional<String> registryImport;
 
     void onStart(@Observes StartupEvent ev) {
-        if (registryImportZipPath.isPresent()) {
-            try (final InputStream registryImportZip = new FileInputStream(registryImportZipPath.get())) {
+        if (registryImport.isPresent()) {
+            final String registryImportZipPath = registryImport.get();
+            try (final InputStream registryImportZip = new FileInputStream(registryImportZipPath)) {
                 final ZipInputStream zip = new ZipInputStream(registryImportZip, StandardCharsets.UTF_8);
                 final EntityReader reader = new EntityReader(zip);
                 try (EntityInputStream stream = new EntityInputStream() {

--- a/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
+++ b/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
@@ -1,0 +1,61 @@
+package io.apicurio.registry;
+
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.impexp.EntityInputStream;
+import io.apicurio.registry.types.Current;
+import io.apicurio.registry.utils.impexp.Entity;
+import io.apicurio.registry.utils.impexp.EntityReader;
+import io.quarkus.runtime.StartupEvent;
+import org.slf4j.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipInputStream;
+
+@ApplicationScoped
+public class ImportLifecycleBean {
+
+    @Inject
+    Logger log;
+
+    @Inject
+    @Current
+    RegistryStorage storage;
+
+    void onStart(@Observes StartupEvent ev) {
+        final String registryImportZipPath = java.lang.System.getenv("REGISTRY_IMPORT");
+        if (registryImportZipPath != null && !registryImportZipPath.isEmpty()) {
+            try (final InputStream registryImportZip = new FileInputStream(registryImportZipPath)) {
+                final ZipInputStream zip = new ZipInputStream(registryImportZip, StandardCharsets.UTF_8);
+                final EntityReader reader = new EntityReader(zip);
+                try (EntityInputStream stream = new EntityInputStream() {
+                    @Override
+                    public Entity nextEntity() {
+                        try {
+                            return reader.readEntity();
+                        } catch (Exception e) {
+                            log.error("Error reading data from import ZIP file {}.", registryImportZipPath, e);
+                            return null;
+                        }
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        zip.close();
+                    }
+                }) {
+                    storage.importData(stream);
+                    log.info("Registry successfully imported from {}", registryImportZipPath);
+                }
+            } catch (IOException ioe) {
+                log.warn("Registry import from {} failed", registryImportZipPath, ioe);
+            }
+        }
+    }
+
+}

--- a/app/src/test/java/io/apicurio/registry/ImportLifecycleBeanTest.java
+++ b/app/src/test/java/io/apicurio/registry/ImportLifecycleBeanTest.java
@@ -28,7 +28,6 @@ public class ImportLifecycleBeanTest extends AbstractResourceTestBase {
                 .get("/registry/v2/admin/rules")
                 .then()
                 .statusCode(200)
-                .log().all()
                 .body("[0]", equalTo("COMPATIBILITY"))
                 .body("[1]", nullValue());
     }

--- a/app/src/test/java/io/apicurio/registry/ImportLifecycleBeanTest.java
+++ b/app/src/test/java/io/apicurio/registry/ImportLifecycleBeanTest.java
@@ -1,0 +1,61 @@
+package io.apicurio.registry;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+@TestProfile(ImportLifecycleBeanTestProfile.class)
+public class ImportLifecycleBeanTest extends AbstractResourceTestBase {
+
+    @BeforeEach
+    protected void beforeEach() throws Exception {
+        prepareServiceInitializers();
+    }
+
+    @Test
+    public void testStartupImportGlobalRules() {
+        given()
+                .when()
+                .accept(CT_JSON)
+                .get("/registry/v2/admin/rules")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("[0]", equalTo("COMPATIBILITY"))
+                .body("[1]", nullValue());
+    }
+
+    @Test
+    public void testStartupImportArtifacts() {
+        given()
+                .when()
+                .accept(CT_JSON)
+                .get("/registry/v2/search/artifacts")
+                .then()
+                .statusCode(200)
+                .body("count", is(3))
+                .body("artifacts.id", containsInAnyOrder("Artifact-3", "Artifact-2", "Artifact-1"));
+    }
+
+    @Test
+    public void testStartupImportArtifactsVersions() {
+        given()
+                .when()
+                .accept(CT_JSON)
+                .get("/registry/v2/groups/ImportTest/artifacts/Artifact-1/versions")
+                .then()
+                .statusCode(200)
+                .body("versions.size()", is(3))
+                .body("versions[0].version", equalTo("1.0.1"))
+                .body("versions[1].version", equalTo("1.0.2"))
+                .body("versions[2].version", equalTo("1.0.3"));
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/ImportLifecycleBeanTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/ImportLifecycleBeanTestProfile.java
@@ -1,0 +1,15 @@
+package io.apicurio.registry;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class ImportLifecycleBeanTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Collections.singletonMap("registry.import","src/test/resources-unfiltered/io/apicurio/registry/rest/v2/export.zip");
+    }
+
+}

--- a/app/src/test/java/io/apicurio/registry/ImportLifecycleBeanTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/ImportLifecycleBeanTestProfile.java
@@ -9,7 +9,7 @@ public class ImportLifecycleBeanTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Collections.singletonMap("registry.import","src/test/resources-unfiltered/io/apicurio/registry/rest/v2/export.zip");
+        return Collections.singletonMap("registry.import.url", getClass().getResource("rest/v2/export.zip").toExternalForm());
     }
 
 }


### PR DESCRIPTION
resolve #1502 

This introduces the env variable `REGISTRY_IMPORT_URL` to provide the URL to a ZIP file containing the export of a registry.
In an OCP instance, it could be used both:

- "dinamically" using an init container to download the ZIP file and adding the env variable value to the Deployment
- "statically" creating a container image with a bundled ZIP file (sample Dockerfile in [1])

~The PR is missing the tests and I suppose the package and the name of the class should be discussed as well but I would like to share something working to explore with you such a solution.~ fixed


[1]
```
FROM apicurio/apicurio-registry-mem:latest-snapshot

ADD export.zip /tmp/registry/
ENV REGISTRY_IMPORT=/tmp/registry/export.zip
```