### PR TITLE
Some work to remove JDBI to make a native Quarkus build possible

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -96,17 +96,11 @@
             <artifactId>quarkus-agroal</artifactId>
         </dependency>
 
-        <!-- JDBI -->
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-core</artifactId>
-        </dependency>
+        <!-- Third Party Libraries -->
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
-
-        <!-- Third Party Libraries -->
         <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-data-models</artifactId>

--- a/app/src/main/java/io/apicurio/registry/content/extract/AvroContentExtractor.java
+++ b/app/src/main/java/io/apicurio/registry/content/extract/AvroContentExtractor.java
@@ -40,7 +40,7 @@ public class AvroContentExtractor implements ContentExtractor {
 
     private ObjectMapper mapper = new ObjectMapper();
 
-    private AvroContentExtractor() {
+    AvroContentExtractor() {
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/content/extract/JsonContentExtractor.java
+++ b/app/src/main/java/io/apicurio/registry/content/extract/JsonContentExtractor.java
@@ -39,7 +39,7 @@ public class JsonContentExtractor implements ContentExtractor {
 
     private ObjectMapper mapper = new ObjectMapper();
 
-    private JsonContentExtractor() {
+    JsonContentExtractor() {
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/content/extract/OpenApiOrAsyncApiContentExtractor.java
+++ b/app/src/main/java/io/apicurio/registry/content/extract/OpenApiOrAsyncApiContentExtractor.java
@@ -38,7 +38,7 @@ public class OpenApiOrAsyncApiContentExtractor implements ContentExtractor {
     @Inject
     Logger log;
 
-    private OpenApiOrAsyncApiContentExtractor() {
+    OpenApiOrAsyncApiContentExtractor() {
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -319,11 +319,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                     .bind(1, contentId)
                     .map(ContentMapper.instance)
                     .findFirst();
-            if (res.isEmpty()) {
-                throw new ContentNotFoundException("contentId-" + contentId);
-            } else {
-                return res.get();
-            }
+            return res.orElseThrow(() -> new ContentNotFoundException("contentId-" + contentId));
         });
     }
 
@@ -339,11 +335,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                     .bind(1, contentHash)
                     .map(ContentMapper.instance)
                     .findFirst();
-            if (res.isEmpty()) {
-                throw new ContentNotFoundException("contentHash-" + contentHash);
-            } else {
-                return res.get();
-            }
+            return res.orElseThrow(() -> new ContentNotFoundException("contentHash-" + contentHash));
         });
     }
 
@@ -361,9 +353,8 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                     .list();
             if (dtos.isEmpty()) {
                 throw new ContentNotFoundException("contentId-" + contentId);
-            } else {
-                return dtos;
             }
+            return dtos;
         });
     }
 
@@ -831,11 +822,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         .bind(2, artifactId)
                         .map(StoredArtifactMapper.instance)
                         .findOne();
-                if (res.isEmpty()) {
-                    throw new ArtifactNotFoundException(groupId, artifactId);
-                } else {
-                    return res.get();
-                }
+                return res.orElseThrow(() -> new ArtifactNotFoundException(groupId, artifactId));
             });
         } catch (ArtifactNotFoundException e) {
             throw e;
@@ -1132,11 +1119,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         .bind(2, artifactId)
                         .map(ArtifactMetaDataDtoMapper.instance)
                         .findOne();
-                if (res.isEmpty()) {
-                    throw new ArtifactNotFoundException(groupId, artifactId);
-                } else {
-                    return res.get();
-                }
+                return res.orElseThrow(() -> new ArtifactNotFoundException(groupId, artifactId));
             });
         } catch (ArtifactNotFoundException e) {
             throw e;
@@ -1173,11 +1156,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         .bind(3, hash)
                         .map(ArtifactVersionMetaDataDtoMapper.instance)
                         .findOne();
-                if (res.isEmpty()) {
-                    throw new ArtifactNotFoundException(groupId, artifactId);
-                } else {
-                    return res.get();
-                }
+                return res.orElseThrow(() -> new ArtifactNotFoundException(groupId, artifactId));
             });
         } catch (ArtifactNotFoundException e) {
             throw e;
@@ -1201,11 +1180,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         .bind(1, globalId)
                         .map(ArtifactMetaDataDtoMapper.instance)
                         .findOne();
-                if (res.isEmpty()) {
-                    throw new ArtifactNotFoundException(null, String.valueOf(globalId));
-                } else {
-                    return res.get();
-                }
+                return res.orElseThrow(() -> new ArtifactNotFoundException(null, String.valueOf(globalId)));
             });
         } catch (ArtifactNotFoundException e) {
             throw e;
@@ -1340,14 +1315,12 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         .bind(3, rule.name())
                         .map(RuleConfigurationDtoMapper.instance)
                         .findOne();
-                if (res.isEmpty()) {
+                return res.orElseThrow(() -> {
                     if (!isArtifactExists(groupId, artifactId)) {
-                        throw new ArtifactNotFoundException(groupId, artifactId);
+                        return new ArtifactNotFoundException(groupId, artifactId);
                     }
-                    throw new RuleNotFoundException(rule);
-                } else {
-                    return res.get();
-                }
+                    return new RuleNotFoundException(rule);
+                });
             });
         } catch (ArtifactNotFoundException e) {
             throw e;
@@ -1501,11 +1474,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         .bind(1, globalId)
                         .map(StoredArtifactMapper.instance)
                         .findOne();
-                if (res.isEmpty()) {
-                    throw new ArtifactNotFoundException(null, "gid-" + globalId);
-                } else {
-                    return res.get();
-                }
+                return res.orElseThrow(() -> new ArtifactNotFoundException(null, "gid-" + globalId));
             });
         } catch (ArtifactNotFoundException e) {
             throw e;
@@ -1531,11 +1500,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         .bind(3, version)
                         .map(StoredArtifactMapper.instance)
                         .findOne();
-                if (res.isEmpty()) {
-                    throw new ArtifactNotFoundException(groupId, artifactId);
-                } else {
-                    return res.get();
-                }
+                return res.orElseThrow(() -> new ArtifactNotFoundException(groupId, artifactId));
             });
         } catch (ArtifactNotFoundException e) {
             throw e;
@@ -1662,11 +1627,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         .bind(3, version)
                         .map(ArtifactVersionMetaDataDtoMapper.instance)
                         .findOne();
-                if (res.isEmpty()) {
-                    throw new VersionNotFoundException(groupId, artifactId, version);
-                } else {
-                    return res.get();
-                }
+                return res.orElseThrow(() -> new VersionNotFoundException(groupId, artifactId, version));
             });
         } catch (VersionNotFoundException e) {
             throw e;
@@ -1888,11 +1849,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         .bind(1, rule.name())
                         .map(RuleConfigurationDtoMapper.instance)
                         .findOne();
-                if (res.isEmpty()) {
-                    throw new RuleNotFoundException(rule);
-                } else {
-                    return res.get();
-                }
+                return res.orElseThrow(() -> new RuleNotFoundException(rule));
             });
         } catch (RuleNotFoundException e) {
             throw e;
@@ -1966,11 +1923,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         .bind(0, logger)
                         .map(LogConfigurationMapper.instance)
                         .findOne();
-                if (res.isEmpty()) {
-                    throw new LogConfigurationNotFoundException(logger);
-                } else {
-                    return res.get();
-                }
+                return res.orElseThrow(() -> new LogConfigurationNotFoundException(logger));
             });
         } catch (LogConfigurationNotFoundException e) {
             throw e;
@@ -2137,11 +2090,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         .bind(0, groupId)
                         .map(GroupMetaDataDtoMapper.instance)
                         .findOne();
-                if (res.isEmpty()) {
-                    throw new GroupNotFoundException(groupId);
-                } else {
-                    return res.get();
-                }
+                return res.orElseThrow(() -> new GroupNotFoundException(groupId));
             });
         } catch (GroupNotFoundException e) {
             throw e;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -42,7 +42,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     /**
-     * @see io.apicurio.registry.storage.impl.sql.SqlStatements.core.storage.jdbc.ISqlStatements#databaseInitialization()
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#databaseInitialization()
      */
     @Override
     public List<String> databaseInitialization() {
@@ -58,7 +58,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     /**
-     * @see io.apicurio.registry.storage.impl.sql.SqlStatements.core.storage.jdbc.ISqlStatements#databaseUpgrade(int, int)
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#databaseUpgrade(int, int)
      */
     @Override
     public List<String> databaseUpgrade(int fromVersion, int toVersion) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/Handle.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/Handle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,23 @@
 
 package io.apicurio.registry.storage.impl.sql;
 
+import java.io.Closeable;
+
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface IDbUpgrader {
+public interface Handle extends Closeable {
 
     /**
-     * Called by the {@link AbstractSqlRegistryStorage} class when upgrading the database.
-     * @param dbHandle
+     * Create a new Query from the given SQL.
+     * @param sql
      */
-    public void upgrade(Handle dbHandle) throws Exception;
+    Query createQuery(String sql);
+
+    /**
+     * Create a new Update statement from the given SQL.
+     * @param sql
+     */
+    Update createUpdate(String sql);
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/HandleCallback.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/HandleCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,16 @@ package io.apicurio.registry.storage.impl.sql;
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface IDbUpgrader {
+@FunctionalInterface
+public interface HandleCallback<T, X extends Exception> {
 
     /**
-     * Called by the {@link AbstractSqlRegistryStorage} class when upgrading the database.
-     * @param dbHandle
+     * Will be invoked with an open Handle. The handle may be closed when this callback returns.
+     *
+     * @param handle Handle to be used only within scope of this callback
+     * @return The return value of the callback
+     * @throws X optional exception thrown by the callback
      */
-    public void upgrade(Handle dbHandle) throws Exception;
+    T withHandle(Handle handle) throws X;
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/HandleFactory.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/HandleFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage.impl.sql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.agroal.api.AgroalDataSource;
+import io.apicurio.registry.storage.RegistryStorageException;
+import io.apicurio.registry.types.RegistryException;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+@ApplicationScoped
+public class HandleFactory {
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    public <R, X extends Exception> R withHandle(HandleCallback<R, X> callback) throws X {
+        try (Connection connection = dataSource.getConnection()) {
+            Handle handleImpl = new HandleImpl(connection);
+            return callback.withHandle(handleImpl);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public <R, X extends Exception> R withHandleNoException(HandleCallback<R, X> callback)  throws RegistryStorageException {
+        try {
+            return withHandle(callback);
+        } catch (RegistryException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RegistryStorageException(e);
+        }
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/HandleImpl.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/HandleImpl.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage.impl.sql;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public class HandleImpl implements Handle {
+
+    private final Connection connection;
+
+    /**
+     * Constructor.
+     * @param connection
+     */
+    public HandleImpl(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * @see java.io.Closeable#close()
+     */
+    @Override
+    public void close() throws IOException {
+        try {
+            this.connection.close();
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.Handle#createQuery(java.lang.String)
+     */
+    @Override
+    public Query createQuery(String sql) {
+        QueryImpl query = new QueryImpl(connection, sql);
+        return query;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.Handle#createUpdate(java.lang.String)
+     */
+    @Override
+    public Update createUpdate(String sql) {
+        UpdateImpl update = new UpdateImpl(connection, sql);
+        return update;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/MappedQuery.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/MappedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,25 @@
 
 package io.apicurio.registry.storage.impl.sql;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface IDbUpgrader {
+public interface MappedQuery<R> {
 
-    /**
-     * Called by the {@link AbstractSqlRegistryStorage} class when upgrading the database.
-     * @param dbHandle
-     */
-    public void upgrade(Handle dbHandle) throws Exception;
+    public R one();
+
+    public R first();
+
+    public Optional<R> findOne();
+
+    public Optional<R> findFirst();
+
+    public List<R> list();
+
+    public Stream<R> stream();
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/MappedQueryImpl.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/MappedQueryImpl.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage.impl.sql;
+
+import java.io.Closeable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public class MappedQueryImpl<T> implements MappedQuery<T>, Closeable {
+
+    final PreparedStatement statement;
+    final RowMapper<T> mapper;
+    final ResultSet resultSet;
+
+    /**
+     * Constructor.
+     * @param statement
+     * @param mapper
+     * @throws SQLException
+     */
+    public MappedQueryImpl(PreparedStatement statement, RowMapper<T> mapper) throws SQLException {
+        this.statement = statement;
+        this.mapper = mapper;
+        this.resultSet = statement.executeQuery();
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.MappedQuery#one()
+     */
+    @Override
+    public T one() {
+        T rval = null;
+        try {
+            if (this.resultSet.next()) {
+                rval = this.mapper.map(resultSet);
+                if (this.resultSet.next()) {
+                    throw new RuntimeSqlException("SQL error: Expected only one result but got multiple.");
+                }
+            } else {
+                throw new RuntimeSqlException("SQL error: Expected only one result row but got none.");
+            }
+        } catch (SQLException e) {
+            throw new RuntimeSqlException(e);
+        } finally {
+            close();
+        }
+        return rval;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.MappedQuery#first()
+     */
+    @Override
+    public T first() {
+        T rval = null;
+        try {
+            if (this.resultSet.next()) {
+                rval = this.mapper.map(resultSet);
+            } else {
+                throw new RuntimeSqlException("SQL error: Expected AT LEAST one result row but got none.");
+            }
+        } catch (SQLException e) {
+            throw new RuntimeSqlException(e);
+        } finally {
+            close();
+        }
+        return rval;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.MappedQuery#findOne()
+     */
+    @Override
+    public Optional<T> findOne() {
+        Optional<T> rval;
+        try {
+            if (this.resultSet.next()) {
+                rval = Optional.of(this.mapper.map(resultSet));
+                if (this.resultSet.next()) {
+                    throw new RuntimeSqlException("SQL error: Expected only one result but got multiple.");
+                }
+            } else {
+                rval = Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeSqlException(e);
+        } finally {
+            close();
+        }
+        return rval;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.MappedQuery#findFirst()
+     */
+    @Override
+    public Optional<T> findFirst() {
+        Optional<T> rval = null;
+        try {
+            if (this.resultSet.next()) {
+                rval = Optional.of(this.mapper.map(resultSet));
+            } else {
+                rval = Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeSqlException(e);
+        } finally {
+            close();
+        }
+        return rval;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.MappedQuery#list()
+     */
+    @Override
+    public List<T> list() {
+        List<T> rval = new LinkedList<>();
+        try {
+            while (this.resultSet.next()) {
+                T t = this.mapper.map(resultSet);
+                rval.add(t);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeSqlException(e);
+        } finally {
+            close();
+        }
+        return rval;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.MappedQuery#stream()
+     */
+    @Override
+    public Stream<T> stream() {
+        return StreamSupport.stream(new Spliterators.AbstractSpliterator<T>(Long.MAX_VALUE, Spliterator.IMMUTABLE | Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.NONNULL) {
+            @Override
+            public boolean tryAdvance(Consumer<? super T> action) {
+                try {
+                    if (!resultSet.next()) {
+                        return false;
+                    }
+                    T t = mapper.map(resultSet);
+                    action.accept(t);
+                    return true;
+                } catch (SQLException e) {
+                    throw new RuntimeSqlException(e);
+                }
+            }
+
+        }, false).onClose(this::close);
+    }
+
+    /**
+     * @see java.io.Closeable#close()
+     */
+    @Override
+    public void close() {
+        try {
+            this.statement.close();
+        } catch (SQLException e) {
+            throw new RuntimeSqlException(e);
+        }
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
@@ -59,7 +59,7 @@ public class PostgreSQLSqlStatements extends CommonSqlStatements {
      */
     @Override
     public String isDatabaseInitialized() {
-        return "SELECT count(*) AS count FROM information_schema.tables WHERE table_name = 'artifacts' LIMIT 1";
+        return "SELECT count(*) AS count FROM information_schema.tables WHERE table_name = 'artifacts'";
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/Query.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ package io.apicurio.registry.storage.impl.sql;
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface IDbUpgrader {
+public interface Query extends Sql<Query> {
 
-    /**
-     * Called by the {@link AbstractSqlRegistryStorage} class when upgrading the database.
-     * @param dbHandle
-     */
-    public void upgrade(Handle dbHandle) throws Exception;
+    public Query setFetchSize(int size);
+
+    public <T> MappedQuery<T> map(RowMapper<T> mapper);
+
+    public <T> MappedQuery<T> mapTo(Class<T> someClass);
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/QueryImpl.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/QueryImpl.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage.impl.sql;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import io.apicurio.registry.storage.impl.sql.mappers.IntegerMapper;
+import io.apicurio.registry.storage.impl.sql.mappers.LongMapper;
+import io.apicurio.registry.storage.impl.sql.mappers.StringMapper;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public class QueryImpl extends SqlImpl<Query> implements Query {
+
+    private int fetchSize = -1;
+
+    /**
+     * Constructor.
+     * @param connection
+     * @param sql
+     */
+    public QueryImpl(Connection connection, String sql) {
+        super(connection, sql);
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.Query#setFetchSize(int)
+     */
+    @Override
+    public Query setFetchSize(int size) {
+        this.fetchSize = size;
+        return this;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.Query#map(io.apicurio.registry.storage.impl.sql.RowMapper)
+     */
+    @Override
+    public <T> MappedQuery<T> map(RowMapper<T> mapper) {
+        try {
+            PreparedStatement statement = this.connection.prepareStatement(sql);
+            this.bindParametersTo(statement);
+            if (this.fetchSize != -1) {
+                statement.setFetchSize(fetchSize);
+            }
+            return new MappedQueryImpl<T>(statement, mapper);
+        } catch (SQLException e) {
+            throw new RuntimeSqlException(e);
+        }
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.Query#mapTo(java.lang.Class)
+     */
+    @Override
+    public <T> MappedQuery<T> mapTo(Class<T> someClass) {
+        RowMapper<T> mapper = this.createMapper(someClass);
+        return this.map(mapper);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> RowMapper<T> createMapper(Class<T> someClass) {
+        if (someClass == Long.class) {
+            return (RowMapper<T>) LongMapper.instance;
+        } else if (someClass == Integer.class) {
+            return (RowMapper<T>) IntegerMapper.instance;
+        } else if (someClass == String.class) {
+            return (RowMapper<T>) StringMapper.instance;
+        } else {
+            throw new RuntimeSqlException("Row mapper not implemented for class: " + someClass);
+        }
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/ResultIterable.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/ResultIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,6 @@ package io.apicurio.registry.storage.impl.sql;
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface IDbUpgrader {
-
-    /**
-     * Called by the {@link AbstractSqlRegistryStorage} class when upgrading the database.
-     * @param dbHandle
-     */
-    public void upgrade(Handle dbHandle) throws Exception;
+public interface ResultIterable<T> {
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/RowMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/RowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,14 @@
 
 package io.apicurio.registry.storage.impl.sql;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface IDbUpgrader {
+public interface RowMapper<T> {
 
-    /**
-     * Called by the {@link AbstractSqlRegistryStorage} class when upgrading the database.
-     * @param dbHandle
-     */
-    public void upgrade(Handle dbHandle) throws Exception;
+    public T map(ResultSet rs) throws SQLException;
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/RuntimeSqlException.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/RuntimeSqlException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,29 @@
 
 package io.apicurio.registry.storage.impl.sql;
 
+import java.sql.SQLException;
+
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface IDbUpgrader {
+public class RuntimeSqlException extends RuntimeException {
 
-    /**
-     * Called by the {@link AbstractSqlRegistryStorage} class when upgrading the database.
-     * @param dbHandle
-     */
-    public void upgrade(Handle dbHandle) throws Exception;
+    private static final long serialVersionUID = 2262442842283175353L;
+
+    public RuntimeSqlException() {
+        super();
+    }
+
+    public RuntimeSqlException(String message) {
+        super(message);
+    }
+
+    public RuntimeSqlException(String message, SQLException cause) {
+        super(message, cause);
+    }
+
+    public RuntimeSqlException(SQLException cause) {
+        super(cause);
+    }
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/Sql.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/Sql.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,24 @@
 
 package io.apicurio.registry.storage.impl.sql;
 
+import java.util.Date;
+
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface IDbUpgrader {
+public interface Sql<Q> {
 
-    /**
-     * Called by the {@link AbstractSqlRegistryStorage} class when upgrading the database.
-     * @param dbHandle
-     */
-    public void upgrade(Handle dbHandle) throws Exception;
+    public Q bind(int position, String value);
+
+    public Q bind(int position, Long value);
+
+    public Q bind(int position, Integer value);
+
+    public Q bind(int position, Enum<?> value);
+
+    public Q bind(int position, Date value);
+
+    public Q bind(int position, byte[] value);
+
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlImpl.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlImpl.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage.impl.sql;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+@SuppressWarnings("unchecked")
+public abstract class SqlImpl<Q> implements Sql<Q> {
+
+    protected final Connection connection;
+    protected final String sql;
+    protected final List<SqlParam> parameters;
+
+    /**
+     * @param connection
+     * @param sql
+     */
+    public SqlImpl(Connection connection, String sql) {
+        this.connection = connection;
+        this.sql = sql;
+        this.parameters = new LinkedList<>();
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.Sql#bind(int, java.lang.String)
+     */
+    @Override
+    public Q bind(int position, String value) {
+        this.parameters.add(new SqlParam(position, value, SqlParamType.STRING));
+        return (Q) this;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.Sql#bind(int, java.lang.Long)
+     */
+    @Override
+    public Q bind(int position, Long value) {
+        this.parameters.add(new SqlParam(position, value, SqlParamType.LONG));
+        return (Q) this;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.Sql#bind(int, java.lang.Integer)
+     */
+    @Override
+    public Q bind(int position, Integer value) {
+        this.parameters.add(new SqlParam(position, value, SqlParamType.INTEGER));
+        return (Q) this;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.Sql#bind(int, java.lang.Enum)
+     */
+    @Override
+    public Q bind(int position, Enum<?> value) {
+        this.parameters.add(new SqlParam(position, value, SqlParamType.ENUM));
+        return (Q) this;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.Sql#bind(int, java.util.Date)
+     */
+    @Override
+    public Q bind(int position, Date value) {
+        this.parameters.add(new SqlParam(position, value, SqlParamType.DATE));
+        return (Q) this;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.Sql#bind(int, byte[])
+     */
+    @Override
+    public Q bind(int position, byte[] value) {
+        this.parameters.add(new SqlParam(position, value, SqlParamType.BYTES));
+        return (Q) this;
+    }
+
+    protected void bindParametersTo(PreparedStatement statement) {
+        this.parameters.forEach(param -> {
+            param.bindTo(statement);
+        });
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlParam.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlParam.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage.impl.sql;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.Date;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public class SqlParam {
+
+    private final int position;
+    private final Object value;
+    private final SqlParamType type;
+
+    /**
+     * Constructor.
+     * @param position
+     * @param value
+     * @param type
+     */
+    public SqlParam(int position, Object value, SqlParamType type) {
+        this.position = position;
+        this.value = value;
+        this.type = type;
+    }
+
+    /**
+     * Binds this SQL parameter to the given statement.
+     * @param statement
+     */
+    public void bindTo(PreparedStatement statement) {
+        int position = this.position + 1; // convert from sensible position (starts at 0) to JDBC position index (starts at 1)
+        try {
+            switch (type) {
+                case BYTES:
+                    statement.setBytes(position, (byte[]) value);
+                    break;
+                case DATE:
+                    if (value == null) {
+                        statement.setNull(position, Types.TIMESTAMP);
+                    } else {
+                        Timestamp ts = new Timestamp(((Date) value).getTime());
+                        statement.setTimestamp(position, ts);
+                    }
+                    break;
+                case ENUM:
+                    if (value == null) {
+                        statement.setNull(position, Types.VARCHAR);
+                    } else {
+                        statement.setString(position, ((Enum<?>) value).name());
+                    }
+                    break;
+                case INTEGER:
+                    if (value == null) {
+                        statement.setNull(position, Types.INTEGER);
+                    } else {
+                        statement.setInt(position, (Integer) value);
+                    }
+                    break;
+                case LONG:
+                    if (value == null) {
+                        statement.setNull(position, Types.INTEGER);
+                    } else {
+                        statement.setLong(position, (Long) value);
+                    }
+                    break;
+                case STRING:
+                    statement.setString(position, (String) value);
+                    break;
+                default:
+                    throw new RuntimeSqlException("bindTo not supported for SqlParamType: " + type);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeSqlException(e);
+        }
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlParamType.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlParamType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,8 @@ package io.apicurio.registry.storage.impl.sql;
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface IDbUpgrader {
+public enum SqlParamType {
 
-    /**
-     * Called by the {@link AbstractSqlRegistryStorage} class when upgrading the database.
-     * @param dbHandle
-     */
-    public void upgrade(Handle dbHandle) throws Exception;
+    STRING, INTEGER, LONG, DATE, BYTES, ENUM
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatementVariableBinder.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatementVariableBinder.java
@@ -16,8 +16,6 @@
 
 package io.apicurio.registry.storage.impl.sql;
 
-import org.jdbi.v3.core.statement.Query;
-
 /**
  * @author eric.wittmann@gmail.com
  */
@@ -25,5 +23,5 @@ import org.jdbi.v3.core.statement.Query;
 public interface SqlStatementVariableBinder {
 
     void bind(Query query, int idx);
-    
+
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/Update.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/Update.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,8 @@ package io.apicurio.registry.storage.impl.sql;
 /**
  * @author eric.wittmann@gmail.com
  */
-public interface IDbUpgrader {
+public interface Update extends Sql<Update> {
 
-    /**
-     * Called by the {@link AbstractSqlRegistryStorage} class when upgrading the database.
-     * @param dbHandle
-     */
-    public void upgrade(Handle dbHandle) throws Exception;
+    public int execute();
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/UpdateImpl.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/UpdateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,35 +14,37 @@
  * limitations under the License.
  */
 
-package io.apicurio.registry.storage.impl.sql.mappers;
+package io.apicurio.registry.storage.impl.sql;
 
-import java.sql.ResultSet;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
-
-import io.apicurio.registry.content.ContentHandle;
-import io.apicurio.registry.storage.impl.sql.RowMapper;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class ContentMapper implements RowMapper<ContentHandle> {
-
-    public static final ContentMapper instance = new ContentMapper();
+public class UpdateImpl extends SqlImpl<Update> implements Update {
 
     /**
      * Constructor.
+     * @param connection
+     * @param sql
      */
-    private ContentMapper() {
+    public UpdateImpl(Connection connection, String sql) {
+        super(connection, sql);
     }
 
     /**
-     * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
+     * @see io.apicurio.registry.storage.impl.sql.Update#execute()
      */
     @Override
-    public ContentHandle map(ResultSet rs) throws SQLException {
-        byte[] contentBytes = rs.getBytes("content");
-        ContentHandle content = ContentHandle.create(contentBytes);
-        return content;
+    public int execute() {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            bindParametersTo(statement);
+            return statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeSqlException(e);
+        }
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactMetaDataDtoMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactMetaDataDtoMapper.java
@@ -19,10 +19,8 @@ package io.apicurio.registry.storage.impl.sql.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
+import io.apicurio.registry.storage.impl.sql.RowMapper;
 import io.apicurio.registry.storage.impl.sql.SqlUtil;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
@@ -44,7 +42,7 @@ public class ArtifactMetaDataDtoMapper implements RowMapper<ArtifactMetaDataDto>
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public ArtifactMetaDataDto map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public ArtifactMetaDataDto map(ResultSet rs) throws SQLException {
         ArtifactMetaDataDto dto = new ArtifactMetaDataDto();
         dto.setGroupId(SqlUtil.denormalizeGroupId(rs.getString("groupId")));
         dto.setId(rs.getString("artifactId"));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactRuleEntityMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactRuleEntityMapper.java
@@ -19,9 +19,7 @@ package io.apicurio.registry.storage.impl.sql.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
+import io.apicurio.registry.storage.impl.sql.RowMapper;
 import io.apicurio.registry.storage.impl.sql.SqlUtil;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.utils.impexp.ArtifactRuleEntity;
@@ -43,7 +41,7 @@ public class ArtifactRuleEntityMapper implements RowMapper<ArtifactRuleEntity> {
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public ArtifactRuleEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public ArtifactRuleEntity map(ResultSet rs) throws SQLException {
         ArtifactRuleEntity entity = new ArtifactRuleEntity();
         entity.groupId = SqlUtil.denormalizeGroupId(rs.getString("groupId"));
         entity.artifactId = rs.getString("artifactId");

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactVersionEntityMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactVersionEntityMapper.java
@@ -19,9 +19,7 @@ package io.apicurio.registry.storage.impl.sql.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
+import io.apicurio.registry.storage.impl.sql.RowMapper;
 import io.apicurio.registry.storage.impl.sql.SqlUtil;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
@@ -44,7 +42,7 @@ public class ArtifactVersionEntityMapper implements RowMapper<ArtifactVersionEnt
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public ArtifactVersionEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public ArtifactVersionEntity map(ResultSet rs) throws SQLException {
         ArtifactVersionEntity entity = new ArtifactVersionEntity();
         entity.globalId = rs.getLong("globalId");
         entity.groupId = SqlUtil.denormalizeGroupId(rs.getString("groupId"));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactVersionMetaDataDtoMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactVersionMetaDataDtoMapper.java
@@ -19,10 +19,8 @@ package io.apicurio.registry.storage.impl.sql.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
+import io.apicurio.registry.storage.impl.sql.RowMapper;
 import io.apicurio.registry.storage.impl.sql.SqlUtil;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
@@ -45,7 +43,7 @@ public class ArtifactVersionMetaDataDtoMapper implements RowMapper<ArtifactVersi
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public ArtifactVersionMetaDataDto map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public ArtifactVersionMetaDataDto map(ResultSet rs) throws SQLException {
         ArtifactVersionMetaDataDto dto = new ArtifactVersionMetaDataDto();
         dto.setGlobalId(rs.getLong("globalId"));
         dto.setContentId(rs.getLong("contentId"));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ContentEntityMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ContentEntityMapper.java
@@ -19,9 +19,7 @@ package io.apicurio.registry.storage.impl.sql.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
+import io.apicurio.registry.storage.impl.sql.RowMapper;
 import io.apicurio.registry.utils.impexp.ContentEntity;
 
 /**
@@ -41,7 +39,7 @@ public class ContentEntityMapper implements RowMapper<ContentEntity> {
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public ContentEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public ContentEntity map(ResultSet rs) throws SQLException {
         ContentEntity entity = new ContentEntity();
         entity.contentId = rs.getLong("contentId");
         entity.canonicalHash = rs.getString("canonicalHash");

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/GroupEntityMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/GroupEntityMapper.java
@@ -19,9 +19,7 @@ package io.apicurio.registry.storage.impl.sql.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
+import io.apicurio.registry.storage.impl.sql.RowMapper;
 import io.apicurio.registry.storage.impl.sql.SqlUtil;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.impexp.GroupEntity;
@@ -43,7 +41,7 @@ public class GroupEntityMapper implements RowMapper<GroupEntity> {
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public GroupEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public GroupEntity map(ResultSet rs) throws SQLException {
         GroupEntity entity = new GroupEntity();
         entity.groupId = SqlUtil.denormalizeGroupId(rs.getString("groupId"));
         entity.description = rs.getString("description");

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/GroupMetaDataDtoMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/GroupMetaDataDtoMapper.java
@@ -19,10 +19,8 @@ package io.apicurio.registry.storage.impl.sql.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
 import io.apicurio.registry.storage.dto.GroupMetaDataDto;
+import io.apicurio.registry.storage.impl.sql.RowMapper;
 import io.apicurio.registry.storage.impl.sql.SqlUtil;
 import io.apicurio.registry.types.ArtifactType;
 
@@ -43,7 +41,7 @@ public class GroupMetaDataDtoMapper implements RowMapper<GroupMetaDataDto> {
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public GroupMetaDataDto map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public GroupMetaDataDto map(ResultSet rs) throws SQLException {
         GroupMetaDataDto dto = new GroupMetaDataDto();
         dto.setGroupId(SqlUtil.denormalizeGroupId(rs.getString("groupId")));
         dto.setDescription(rs.getString("description"));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/IntegerMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/IntegerMapper.java
@@ -20,31 +20,26 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import io.apicurio.registry.storage.impl.sql.RowMapper;
-import io.apicurio.registry.types.RuleType;
-import io.apicurio.registry.utils.impexp.GlobalRuleEntity;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class GlobalRuleEntityMapper implements RowMapper<GlobalRuleEntity> {
+public class IntegerMapper implements RowMapper<Integer> {
 
-    public static final GlobalRuleEntityMapper instance = new GlobalRuleEntityMapper();
+    public static final IntegerMapper instance = new IntegerMapper();
 
     /**
      * Constructor.
      */
-    private GlobalRuleEntityMapper() {
+    private IntegerMapper() {
     }
 
     /**
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public GlobalRuleEntity map(ResultSet rs) throws SQLException {
-        GlobalRuleEntity entity = new GlobalRuleEntity();
-        entity.ruleType = RuleType.fromValue(rs.getString("type"));
-        entity.configuration = rs.getString("configuration");
-        return entity;
+    public Integer map(ResultSet rs) throws SQLException {
+        return rs.getInt(1);
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/LogConfigurationMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/LogConfigurationMapper.java
@@ -19,10 +19,8 @@ package io.apicurio.registry.storage.impl.sql.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
 import io.apicurio.registry.storage.dto.LogConfigurationDto;
+import io.apicurio.registry.storage.impl.sql.RowMapper;
 import io.apicurio.registry.types.LogLevel;
 
 /**
@@ -39,7 +37,7 @@ public class LogConfigurationMapper implements RowMapper<LogConfigurationDto> {
     }
 
     @Override
-    public LogConfigurationDto map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public LogConfigurationDto map(ResultSet rs) throws SQLException {
         LogConfigurationDto dto = new LogConfigurationDto();
         dto.setLogger(rs.getString("logger"));
         dto.setLogLevel(LogLevel.fromValue(rs.getString("loglevel")));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/LongMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/LongMapper.java
@@ -20,31 +20,26 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import io.apicurio.registry.storage.impl.sql.RowMapper;
-import io.apicurio.registry.types.RuleType;
-import io.apicurio.registry.utils.impexp.GlobalRuleEntity;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class GlobalRuleEntityMapper implements RowMapper<GlobalRuleEntity> {
+public class LongMapper implements RowMapper<Long> {
 
-    public static final GlobalRuleEntityMapper instance = new GlobalRuleEntityMapper();
+    public static final LongMapper instance = new LongMapper();
 
     /**
      * Constructor.
      */
-    private GlobalRuleEntityMapper() {
+    private LongMapper() {
     }
 
     /**
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public GlobalRuleEntity map(ResultSet rs) throws SQLException {
-        GlobalRuleEntity entity = new GlobalRuleEntity();
-        entity.ruleType = RuleType.fromValue(rs.getString("type"));
-        entity.configuration = rs.getString("configuration");
-        return entity;
+    public Long map(ResultSet rs) throws SQLException {
+        return rs.getLong(1);
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/RuleConfigurationDtoMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/RuleConfigurationDtoMapper.java
@@ -19,32 +19,30 @@ package io.apicurio.registry.storage.impl.sql.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import io.apicurio.registry.storage.dto.RuleConfigurationDto;
 import io.apicurio.registry.storage.impl.sql.RowMapper;
-import io.apicurio.registry.types.RuleType;
-import io.apicurio.registry.utils.impexp.GlobalRuleEntity;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class GlobalRuleEntityMapper implements RowMapper<GlobalRuleEntity> {
+public class RuleConfigurationDtoMapper implements RowMapper<RuleConfigurationDto> {
 
-    public static final GlobalRuleEntityMapper instance = new GlobalRuleEntityMapper();
+    public static final RuleConfigurationDtoMapper instance = new RuleConfigurationDtoMapper();
 
     /**
      * Constructor.
      */
-    private GlobalRuleEntityMapper() {
+    private RuleConfigurationDtoMapper() {
     }
 
     /**
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public GlobalRuleEntity map(ResultSet rs) throws SQLException {
-        GlobalRuleEntity entity = new GlobalRuleEntity();
-        entity.ruleType = RuleType.fromValue(rs.getString("type"));
-        entity.configuration = rs.getString("configuration");
-        return entity;
+    public RuleConfigurationDto map(ResultSet rs) throws SQLException {
+        RuleConfigurationDto dto = new RuleConfigurationDto();
+        dto.setConfiguration(rs.getString("configuration"));
+        return dto;
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedArtifactMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedArtifactMapper.java
@@ -16,15 +16,14 @@
 
 package io.apicurio.registry.storage.impl.sql.mappers;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
 import io.apicurio.registry.storage.dto.SearchedArtifactDto;
+import io.apicurio.registry.storage.impl.sql.RowMapper;
 import io.apicurio.registry.storage.impl.sql.SqlUtil;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -43,7 +42,7 @@ public class SearchedArtifactMapper implements RowMapper<SearchedArtifactDto> {
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public SearchedArtifactDto map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public SearchedArtifactDto map(ResultSet rs) throws SQLException {
         SearchedArtifactDto dto = new SearchedArtifactDto();
         dto.setGroupId(SqlUtil.denormalizeGroupId(rs.getString("groupId")));
         dto.setId(rs.getString("artifactId"));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedVersionMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedVersionMapper.java
@@ -16,15 +16,14 @@
 
 package io.apicurio.registry.storage.impl.sql.mappers;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
 import io.apicurio.registry.storage.dto.SearchedVersionDto;
+import io.apicurio.registry.storage.impl.sql.RowMapper;
 import io.apicurio.registry.storage.impl.sql.SqlUtil;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -43,7 +42,7 @@ public class SearchedVersionMapper implements RowMapper<SearchedVersionDto> {
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public SearchedVersionDto map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public SearchedVersionDto map(ResultSet rs) throws SQLException {
         SearchedVersionDto dto = new SearchedVersionDto();
         dto.setGlobalId(rs.getLong("globalId"));
         dto.setVersion(rs.getString("version"));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/StoredArtifactMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/StoredArtifactMapper.java
@@ -19,11 +19,9 @@ package io.apicurio.registry.storage.impl.sql.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.dto.StoredArtifactDto;
+import io.apicurio.registry.storage.impl.sql.RowMapper;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -42,7 +40,7 @@ public class StoredArtifactMapper implements RowMapper<StoredArtifactDto> {
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public StoredArtifactDto map(ResultSet rs, StatementContext ctx) throws SQLException {
+    public StoredArtifactDto map(ResultSet rs) throws SQLException {
         long globalId = rs.getLong("globalId");
         String version = rs.getString("version");
         int versionId = rs.getInt("versionId");

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/StringMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/StringMapper.java
@@ -20,31 +20,26 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import io.apicurio.registry.storage.impl.sql.RowMapper;
-import io.apicurio.registry.types.RuleType;
-import io.apicurio.registry.utils.impexp.GlobalRuleEntity;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class GlobalRuleEntityMapper implements RowMapper<GlobalRuleEntity> {
+public class StringMapper implements RowMapper<String> {
 
-    public static final GlobalRuleEntityMapper instance = new GlobalRuleEntityMapper();
+    public static final StringMapper instance = new StringMapper();
 
     /**
      * Constructor.
      */
-    private GlobalRuleEntityMapper() {
+    private StringMapper() {
     }
 
     /**
      * @see org.jdbi.v3.core.mapper.RowMapper#map(java.sql.ResultSet, org.jdbi.v3.core.statement.StatementContext)
      */
     @Override
-    public GlobalRuleEntity map(ResultSet rs) throws SQLException {
-        GlobalRuleEntity entity = new GlobalRuleEntity();
-        entity.ruleType = RuleType.fromValue(rs.getString("type"));
-        entity.configuration = rs.getString("configuration");
-        return entity;
+    public String map(ResultSet rs) throws SQLException {
+        return rs.getString(1);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,6 @@
         <lombok.version>1.18.20</lombok.version>
         <h2.version>1.4.199</h2.version>
         <retrofit.version>2.9.0</retrofit.version>
-        <jdbi.version>3.20.0</jdbi.version>
         <commons-codec.version>1.15</commons-codec.version>
         <jboss-slf4j.version>1.2.1.Final</jboss-slf4j.version>
         <keycloak.version>11.0.3</keycloak.version>
@@ -402,13 +401,6 @@
                 <groupId>wsdl4j</groupId>
                 <artifactId>wsdl4j</artifactId>
                 <version>${wsdl4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-bom</artifactId>
-                <version>${jdbi.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlStore.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlStore.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.concurrent.CompletionStage;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.transaction.Transactional;
 
@@ -17,6 +18,7 @@ import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
 import io.apicurio.registry.storage.impl.sql.AbstractSqlRegistryStorage;
 import io.apicurio.registry.storage.impl.sql.GlobalIdGenerator;
+import io.apicurio.registry.storage.impl.sql.HandleFactory;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.RuleType;
@@ -41,22 +43,25 @@ import io.apicurio.registry.utils.impexp.GroupEntity;
 @Logged
 public class KafkaSqlStore extends AbstractSqlRegistryStorage {
 
+    @Inject
+    HandleFactory handles;
+
     @Transactional
     public long nextGlobalId() {
-        return withHandle( handle -> {
+        return handles.withHandleNoException( handle -> {
             return nextGlobalId(handle);
         });
     }
 
     @Transactional
     public long nextContentId() {
-        return withHandle( handle -> {
+        return handles.withHandleNoException( handle -> {
             return nextContentId(handle);
         });
     }
 
     public boolean isContentExists(String contentHash) throws RegistryStorageException {
-        return withHandle( handle -> {
+        return handles.withHandleNoException( handle -> {
             String sql = sqlStatements().selectContentCountByHash();
             return handle.createQuery(sql)
                     .bind(0, contentHash)
@@ -66,7 +71,7 @@ public class KafkaSqlStore extends AbstractSqlRegistryStorage {
     }
 
     public boolean isArtifactRuleExists(String groupId, String artifactId, RuleType rule) throws RegistryStorageException {
-        return withHandle( handle -> {
+        return handles.withHandleNoException( handle -> {
             String sql = sqlStatements().selectArtifactRuleCountByType();
             return handle.createQuery(sql)
                     .bind(0, tenantContext().tenantId())
@@ -79,7 +84,7 @@ public class KafkaSqlStore extends AbstractSqlRegistryStorage {
     }
 
     public boolean isGlobalRuleExists(RuleType rule) throws RegistryStorageException {
-        return withHandle( handle -> {
+        return handles.withHandleNoException( handle -> {
             String sql = sqlStatements().selectGlobalRuleCountByType();
             return handle.createQuery(sql)
                     .bind(0, tenantContext().tenantId())
@@ -91,7 +96,7 @@ public class KafkaSqlStore extends AbstractSqlRegistryStorage {
 
     @Transactional
     public void storeContent(long contentId, String contentHash, String canonicalHash, ContentHandle content) throws RegistryStorageException {
-        withHandle( handle -> {
+        handles.withHandleNoException( handle -> {
             if (!isContentExists(contentId)) {
                 byte [] contentBytes = content.bytes();
                 String sql = sqlStatements().importContent();
@@ -144,7 +149,7 @@ public class KafkaSqlStore extends AbstractSqlRegistryStorage {
     }
 
     private long contentIdFromHash(String contentHash) {
-        return withHandle( handle -> {
+        return handles.withHandleNoException( handle -> {
             String sql = sqlStatements().selectContentIdByHash();
             return handle.createQuery(sql)
                     .bind(0, contentHash)
@@ -155,7 +160,7 @@ public class KafkaSqlStore extends AbstractSqlRegistryStorage {
 
     @Transactional
     public void importArtifactRule(ArtifactRuleEntity entity) {
-        withHandle(handle -> {
+        handles.withHandleNoException(handle -> {
             super.importArtifactRule(handle, entity);
             return null;
         });
@@ -163,7 +168,7 @@ public class KafkaSqlStore extends AbstractSqlRegistryStorage {
 
     @Transactional
     public void importArtifactVersion(ArtifactVersionEntity entity) {
-        withHandle(handle -> {
+        handles.withHandleNoException(handle -> {
             super.importArtifactVersion(handle, entity);
             return null;
         });
@@ -171,7 +176,7 @@ public class KafkaSqlStore extends AbstractSqlRegistryStorage {
 
     @Transactional
     public void importContent(ContentEntity entity) {
-        withHandle(handle -> {
+        handles.withHandleNoException(handle -> {
             super.importContent(handle, entity);
             return null;
         });
@@ -179,7 +184,7 @@ public class KafkaSqlStore extends AbstractSqlRegistryStorage {
 
     @Transactional
     public void importGlobalRule(GlobalRuleEntity entity) {
-        withHandle(handle -> {
+        handles.withHandleNoException(handle -> {
             super.importGlobalRule(handle, entity);
             return null;
         });
@@ -187,7 +192,7 @@ public class KafkaSqlStore extends AbstractSqlRegistryStorage {
 
     @Transactional
     public void importGroup(GroupEntity entity) {
-        withHandle(handle -> {
+        handles.withHandleNoException(handle -> {
             super.importGroup(handle, entity);
             return null;
         });
@@ -195,7 +200,7 @@ public class KafkaSqlStore extends AbstractSqlRegistryStorage {
 
     @Transactional
     public void resetContentId() {
-        withHandle(handle -> {
+        handles.withHandleNoException(handle -> {
             super.resetContentId(handle);
             return null;
         });
@@ -203,7 +208,7 @@ public class KafkaSqlStore extends AbstractSqlRegistryStorage {
 
     @Transactional
     public void resetGlobalId() {
-        withHandle(handle -> {
+        handles.withHandleNoException(handle -> {
             super.resetGlobalId(handle);
             return null;
         });


### PR DESCRIPTION
The strategy here was to replicate the same patterns used by JDBI, but with custom interfaces/classes.  As I suspected, the surface area wasn't really that large.

I also found some interesting improvements, especially using `findOne()` and checking for empty (to detect 404 errors) rather than using `find()` and catching an `IllegalStateException`.  Give this a look and let me know what you think!