### PR TITLE
fix reset globalId and contentId sequence

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -2315,7 +2315,6 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
         });
     }
 
-    // TODO this can be improved using use ALTER SEQUENCE serial RESTART WITH 105;
     protected void resetGlobalId(Handle handle) {
         String sql = sqlStatements.selectMaxGlobalId();
         Optional<Long> maxGlobalId = handle.createQuery(sql)
@@ -2323,15 +2322,16 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                 .findOne();
 
         if (maxGlobalId.isPresent()) {
-            long id = maxGlobalId.get();
-
-            log.info("Resetting globalId sequence to {}", id);
-            while (nextGlobalId(handle) < id) {}
-            log.info("Successfully reset globalId to {}", nextGlobalId(handle));
+            log.info("Resetting globalId sequence");
+            long id = maxGlobalId.get() + 1;
+            //from alter sequence docs: the specified value will be returned by the next call of nextval
+            handle.createUpdate("ALTER SEQUENCE globalidsequence RESTART WITH ?")
+                .bind(0, id)
+                .execute();
+            log.info("Successfully reset globalId to {}", id);
         }
     }
 
-    // TODO this can be improved using use ALTER SEQUENCE serial RESTART WITH 105;
     protected void resetContentId(Handle handle) {
         String sql = sqlStatements.selectMaxContentId();
         Optional<Long> maxContentId = handle.createQuery(sql)
@@ -2339,11 +2339,13 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                 .findOne();
 
         if (maxContentId.isPresent()) {
+            log.info("Resetting contentId sequence");
             long id = maxContentId.get() + 1;
-
-            log.info("Resetting contentId sequence to {}", id);
-            while (nextContentId(handle) < id) {}
-            log.info("Successfully reset contentId to {}", nextContentId(handle));
+            //from alter sequence docs: the specified value will be returned by the next call of nextval
+            handle.createUpdate("ALTER SEQUENCE contentidsequence RESTART WITH ?")
+                .bind(0, id)
+                .execute();
+            log.info("Successfully reset contentId to {}", id);
         }
     }
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -2324,8 +2324,10 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
         if (maxGlobalId.isPresent()) {
             log.info("Resetting globalId sequence");
             long id = maxGlobalId.get() + 1;
-            //from alter sequence docs: the specified value will be returned by the next call of nextval
-            handle.createUpdate("ALTER SEQUENCE globalidsequence RESTART WITH ?")
+
+            sql = sqlStatements.resetSequence("globalidsequence");
+
+            handle.createUpdate(sql)
                 .bind(0, id)
                 .execute();
             log.info("Successfully reset globalId to {}", id);
@@ -2341,8 +2343,10 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
         if (maxContentId.isPresent()) {
             log.info("Resetting contentId sequence");
             long id = maxContentId.get() + 1;
-            //from alter sequence docs: the specified value will be returned by the next call of nextval
-            handle.createUpdate("ALTER SEQUENCE contentidsequence RESTART WITH ?")
+
+            sql = sqlStatements.resetSequence("contentidsequence");
+
+            handle.createUpdate(sql)
                 .bind(0, id)
                 .execute();
             log.info("Successfully reset contentId to {}", id);

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/H2SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/H2SqlStatements.java
@@ -78,4 +78,12 @@ public class H2SqlStatements extends CommonSqlStatements {
         return "MERGE INTO logconfiguration (logger, loglevel) KEY (logger) VALUES(?, ?)";
     }
 
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#resetSequence()
+     */
+    @Override
+    public String resetSequence(String sequence) {
+        return "ALTER SEQUENCE " + sequence + " RESTART WITH ?";
+    }
+
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
@@ -78,4 +78,12 @@ public class PostgreSQLSqlStatements extends CommonSqlStatements {
         return "INSERT INTO logconfiguration (logger, loglevel) VALUES (?, ?) ON CONFLICT (logger) DO UPDATE SET loglevel = ?";
     }
 
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#resetSequence()
+     */
+    @Override
+    public String resetSequence(String sequence) {
+        return "SELECT setval('" + sequence + "', ?, FALSE)";
+    }
+
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -442,6 +442,8 @@ public interface SqlStatements {
 
     public String selectMaxContentId();
 
+    public String resetSequence(String sequence);
+
     public String selectMaxGlobalId();
 
     public String selectContentExists();


### PR DESCRIPTION
This improves the reset of the db sequences we have, and should fix the errors when importing data from old registry reported in issue #1500 