### PR TITLE
Export only tenant content

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -2153,6 +2153,7 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
             this.jdbi.withHandle(handle -> {
                 String sql = sqlStatements.exportContent();
                 Stream<ContentEntity> stream = handle.createQuery(sql)
+                        .bind(0, tenantContext().tenantId())
                         .setFetchSize(50)
                         .map(ContentEntityMapper.instance)
                         .stream();

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -661,7 +661,9 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String exportContent() {
-        return "SELECT * FROM content c";
+        return "SELECT * FROM content c "
+                + "JOIN versions v ON v.contentId = c.contentId "
+                + "WHERE v.tenantId = ?";
     }
 
     /**


### PR DESCRIPTION
Improvement to the export API to export only the rows from the content table that belong to the current tenant.