### PR TITLE
fix: Use PAT for creating release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,7 +142,7 @@ jobs:
       - name: Create GitHub Release
         run: |
           cd registry
-          ./.github/scripts/create-github-release.sh ${{ github.event.inputs.release-version}} ${{ github.event.inputs.branch}} $GITHUB_REPOSITORY ${{ secrets.GITHUB_TOKEN }}
+          ./.github/scripts/create-github-release.sh ${{ github.event.inputs.release-version}} ${{ github.event.inputs.branch}} $GITHUB_REPOSITORY ${{ secrets.ACCESS_TOKEN }}
 
       - name: Generate Release Notes
         run: |


### PR DESCRIPTION
events triggered by the GITHUB_TOKEN will not create a new workflow run. Hence, the cli-release workflows were not getting triggered on the release event.