### PR TITLE
Prepare for building native images for all storages and tenant-manager

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -105,40 +105,26 @@ jobs:
 
       - name: Build Native executables
         run: |
-          make build-sql-native build-kafkasql-native build-tenant-manager-native
+          make build-sql-native build-kafkasql-native build-tenant-manager
 
       - name: Build Native Images
+        env:
+          IMAGE_REPO: quay.io
+          IMAGE_TAG: latest-snapshot
         run: |
-          make SQL_DOCKERFILE=Dockerfile.native IMAGE_TAG=latest-native DOCKER_BUILD_WORKSPACE=storage/sql build-sql-image
-          make KAFKASQL_DOCKERFILE=Dockerfile.native IMAGE_TAG=latest-native DOCKER_BUILD_WORKSPACE=storage/kafkasql build-kafkasql-image
-          make build-tenant-manager-image-native
-
-      - name: Login to DockerHub Registry
-        if: github.event_name == 'push'
-        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-
-      - name: Build The Images for Docker.io
-        if: github.event_name == 'push'
-        run: ./.github/scripts/build-images.sh ${GITHUB_REF#refs/heads/} docker.io snapshot
-
-      - name: List All The Images
-        run: docker images
-
-      - name: Push The Images To Docker.io
-        if: github.event_name == 'push'
-        run: ./.github/scripts/push-images.sh ${GITHUB_REF#refs/heads/} docker.io snapshot
+          make build-sql-native-image build-kafkasql-native-image build-tenant-manager-image
 
       - name: Login to Quay.io Registry
         if: github.event_name == 'push'
         run: docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
 
-      - name: Build The Images for Quay.io
+      - name: Push Native Images
+        env:
+          IMAGE_REPO: quay.io
+          IMAGE_TAG: latest-snapshot
         if: github.event_name == 'push'
-        run: ./.github/scripts/build-images.sh ${GITHUB_REF#refs/heads/} quay.io snapshot
+        run: |
+          make push-sql-native-image push-kafkasql-native-image push-tenant-manager-image
 
       - name: List All The Images
         run: docker images
-
-      - name: Push The Images To Quay.io
-        if: github.event_name == 'push'
-        run: ./.github/scripts/push-images.sh ${GITHUB_REF#refs/heads/} quay.io snapshot

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -104,8 +104,25 @@ jobs:
         run: make SKIP_TESTS=true BUILD_FLAGS='-Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5' build-all
 
       - name: Build Native executables
+        env:
+          SKIP_TESTS: "true"
         run: |
           make build-sql-native build-kafkasql-native build-tenant-manager
+
+      - name: Run Integration Tests - sql
+        run: ./mvnw verify -Pintegration-tests -Pacceptance -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
+      - name: Run Integration Tests - kafkasql
+        run: ./mvnw verify -Pintegration-tests -Pacceptance -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
+      - name: Run Integration Tests - multitenancy
+        run: ./mvnw verify -Pintegration-tests -Pmultitenancy -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false -DtestNative=true
+      - name: Run Integration Tests - sql migration
+        run: ./mvnw verify -Pintegration-tests -Pmigration -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
+      - name: Run Integration Tests - kafkasql migration
+        run: ./mvnw verify -Pintegration-tests -Pmigration -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
+      - name: Run Integration Tests - sql auth
+        run: ./mvnw verify -Pintegration-tests -Pauth -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
+      - name: Run Integration Tests - kafkasql auth
+        run: ./mvnw verify -Pintegration-tests -Pauth -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
 
       - name: Build Native Images
         env:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -107,31 +107,29 @@ jobs:
         env:
           SKIP_TESTS: "true"
         run: |
-          make build-sql-native build-kafkasql-native build-tenant-manager
+          make build-sql-native build-tenant-manager
 
       - name: Build integration-tests-common
         run: ./mvnw install -Pintegration-tests -pl integration-tests/integration-tests-common
       - name: Run Integration Tests - sql
         run: ./mvnw verify -Pintegration-tests -Pacceptance -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
-      - name: Run Integration Tests - kafkasql
-        run: ./mvnw verify -Pintegration-tests -Pacceptance -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
       - name: Run Integration Tests - multitenancy
         run: ./mvnw verify -Pintegration-tests -Pmultitenancy -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false -DtestNative=true
       - name: Run Integration Tests - sql migration
         run: ./mvnw verify -Pintegration-tests -Pmigration -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
-      - name: Run Integration Tests - kafkasql migration
-        run: ./mvnw verify -Pintegration-tests -Pmigration -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
       - name: Run Integration Tests - sql auth
         run: ./mvnw verify -Pintegration-tests -Pauth -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
-      - name: Run Integration Tests - kafkasql auth
-        run: ./mvnw verify -Pintegration-tests -Pauth -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
+      - name: Run UI tests - only PRs
+        run: ./mvnw verify -Pintegration-tests -Pui -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false -DtestNative=true
+      - name: Run Legacy Tests - sql
+        run: ./mvnw verify -Pintegration-tests -Pacceptance -Psql -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
 
       - name: Build Native Images
         env:
           IMAGE_REPO: quay.io
           IMAGE_TAG: latest-snapshot
         run: |
-          make build-sql-native-image build-kafkasql-native-image build-tenant-manager-image
+          make build-sql-native-image build-tenant-manager-image
 
       - name: Login to Quay.io Registry
         if: github.event_name == 'push'
@@ -143,7 +141,7 @@ jobs:
           IMAGE_TAG: latest-snapshot
         if: github.event_name == 'push'
         run: |
-          make push-sql-native-image push-kafkasql-native-image push-tenant-manager-image
+          make push-sql-native-image push-tenant-manager-image
 
       - name: List All The Images
         run: docker images

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -75,83 +75,83 @@ jobs:
       - name: Push The Images To Quay.io
         if: github.event_name == 'push'
         run: ./.github/scripts/push-images.sh ${GITHUB_REF#refs/heads/} quay.io snapshot
-  build-native-images:
-    name: Build native images
-    runs-on: ubuntu-18.04
-    if: github.repository_owner == 'Apicurio'
-    steps:
-      - name: Checkout Code with Ref '${{ github.ref }}'
-        uses: actions/checkout@v2
+  # build-native-images:
+  #   name: Build native images
+  #   runs-on: ubuntu-18.04
+  #   if: github.repository_owner == 'Apicurio'
+  #   steps:
+  #     - name: Checkout Code with Ref '${{ github.ref }}'
+  #       uses: actions/checkout@v2
 
-      - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
-        with:
-          version: '11'
-          architecture: x64
+  #     - name: Set up JDK 11
+  #       uses: AdoptOpenJDK/install-jdk@v1
+  #       with:
+  #         version: '11'
+  #         architecture: x64
 
-      - name: Cache Dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-verify-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-verify-
+  #     - name: Cache Dependencies
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: ~/.m2/repository
+  #         key: ${{ runner.os }}-verify-${{ hashFiles('**/pom.xml') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-verify-
 
-      - name: Get maven wrapper
-        run: mvn -N io.takari:maven:wrapper -Dmaven=3.6.3
+  #     - name: Get maven wrapper
+  #       run: mvn -N io.takari:maven:wrapper -Dmaven=3.6.3
 
-      - name: Build All Variants
-        run: make SKIP_TESTS=true BUILD_FLAGS='-Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5' build-all
+  #     - name: Build All Variants
+  #       run: make SKIP_TESTS=true BUILD_FLAGS='-Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5' build-all
 
-      - name: Build Native executables
-        env:
-          SKIP_TESTS: "true"
-        run: |
-          make build-sql-native build-tenant-manager
+  #     - name: Build Native executables
+  #       env:
+  #         SKIP_TESTS: "true"
+  #       run: |
+  #         make build-sql-native build-tenant-manager
 
-      - name: Build integration-tests-common
-        run: ./mvnw install -Pintegration-tests -pl integration-tests/integration-tests-common
-      - name: Run Integration Tests - sql
-        run: ./mvnw verify -Pintegration-tests -Pacceptance -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
-      - name: Run Integration Tests - multitenancy
-        run: ./mvnw verify -Pintegration-tests -Pmultitenancy -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false -DtestNative=true
-      - name: Run Integration Tests - sql migration
-        run: ./mvnw verify -Pintegration-tests -Pmigration -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
-      - name: Run Integration Tests - sql auth
-        run: ./mvnw verify -Pintegration-tests -Pauth -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
-      - name: Run UI tests - only PRs
-        run: ./mvnw verify -Pintegration-tests -Pui -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false -DtestNative=true
-      - name: Run Legacy Tests - sql
-        run: ./mvnw verify -Pintegration-tests -Pacceptance -Psql -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
+  #     - name: Build integration-tests-common
+  #       run: ./mvnw install -Pintegration-tests -pl integration-tests/integration-tests-common
+  #     - name: Run Integration Tests - sql
+  #       run: ./mvnw verify -Pintegration-tests -Pacceptance -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
+  #     - name: Run Integration Tests - multitenancy
+  #       run: ./mvnw verify -Pintegration-tests -Pmultitenancy -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false -DtestNative=true
+  #     - name: Run Integration Tests - sql migration
+  #       run: ./mvnw verify -Pintegration-tests -Pmigration -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
+  #     - name: Run Integration Tests - sql auth
+  #       run: ./mvnw verify -Pintegration-tests -Pauth -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
+  #     - name: Run UI tests - only PRs
+  #       run: ./mvnw verify -Pintegration-tests -Pui -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false -DtestNative=true
+  #     - name: Run Legacy Tests - sql
+  #       run: ./mvnw verify -Pintegration-tests -Pacceptance -Psql -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
 
-      - name: Collect logs
-        if: failure()
-        run: ./.github/scripts/collect_logs.sh
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v1.0.0
-        with:
-          name: tests-logs
-          path: artifacts
+  #     - name: Collect logs
+  #       if: failure()
+  #       run: ./.github/scripts/collect_logs.sh
+  #     - name: Upload tests logs artifacts
+  #       if: failure()
+  #       uses: actions/upload-artifact@v1.0.0
+  #       with:
+  #         name: tests-logs
+  #         path: artifacts
 
-      - name: Build Native Images
-        env:
-          IMAGE_REPO: quay.io
-          IMAGE_TAG: latest-snapshot
-        run: |
-          make build-sql-native-image build-tenant-manager-image
+  #     - name: Build Native Images
+  #       env:
+  #         IMAGE_REPO: quay.io
+  #         IMAGE_TAG: latest-snapshot
+  #       run: |
+  #         make build-sql-native-image build-tenant-manager-image
 
-      - name: Login to Quay.io Registry
-        if: github.event_name == 'push'
-        run: docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+  #     - name: Login to Quay.io Registry
+  #       if: github.event_name == 'push'
+  #       run: docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
 
-      - name: Push Native Images
-        env:
-          IMAGE_REPO: quay.io
-          IMAGE_TAG: latest-snapshot
-        if: github.event_name == 'push'
-        run: |
-          make push-sql-native-image push-tenant-manager-image
+  #     - name: Push Native Images
+  #       env:
+  #         IMAGE_REPO: quay.io
+  #         IMAGE_TAG: latest-snapshot
+  #       if: github.event_name == 'push'
+  #       run: |
+  #         make push-sql-native-image push-tenant-manager-image
 
-      - name: List All The Images
-        run: docker images
+  #     - name: List All The Images
+  #       run: docker images

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -124,6 +124,16 @@ jobs:
       - name: Run Legacy Tests - sql
         run: ./mvnw verify -Pintegration-tests -Pacceptance -Psql -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
 
+      - name: Collect logs
+        if: failure()
+        run: ./.github/scripts/collect_logs.sh
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs
+          path: artifacts
+
       - name: Build Native Images
         env:
           IMAGE_REPO: quay.io

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -75,3 +75,70 @@ jobs:
       - name: Push The Images To Quay.io
         if: github.event_name == 'push'
         run: ./.github/scripts/push-images.sh ${GITHUB_REF#refs/heads/} quay.io snapshot
+  build-native-images:
+    name: Build native images
+    runs-on: ubuntu-18.04
+    if: github.repository_owner == 'Apicurio' && github.event_name == 'push'
+    steps:
+      - name: Checkout Code with Ref '${{ github.ref }}'
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: AdoptOpenJDK/install-jdk@v1
+        with:
+          version: '11'
+          architecture: x64
+
+      - name: Cache Dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-verify-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-verify-
+
+      - name: Get maven wrapper
+        run: mvn -N io.takari:maven:wrapper -Dmaven=3.6.3
+
+      - name: Build All Variants
+        run: make SKIP_TESTS=true BUILD_FLAGS='-Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5' build-all
+
+      - name: Build Native executables
+        run: |
+          make build-sql-native build-kafkasql-native build-tenant-manager-native
+
+      - name: Build Native Images
+        run: |
+          make SQL_DOCKERFILE=Dockerfile.native IMAGE_TAG=latest-native DOCKER_BUILD_WORKSPACE=storage/sql build-sql-image
+          make KAFKASQL_DOCKERFILE=Dockerfile.native IMAGE_TAG=latest-native DOCKER_BUILD_WORKSPACE=storage/kafkasql build-kafkasql-image
+          make build-tenant-manager-image-native
+
+      - name: Login to DockerHub Registry
+        if: github.event_name == 'push'
+        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+
+      - name: Build The Images for Docker.io
+        if: github.event_name == 'push'
+        run: ./.github/scripts/build-images.sh ${GITHUB_REF#refs/heads/} docker.io snapshot
+
+      - name: List All The Images
+        run: docker images
+
+      - name: Push The Images To Docker.io
+        if: github.event_name == 'push'
+        run: ./.github/scripts/push-images.sh ${GITHUB_REF#refs/heads/} docker.io snapshot
+
+      - name: Login to Quay.io Registry
+        if: github.event_name == 'push'
+        run: docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+
+      - name: Build The Images for Quay.io
+        if: github.event_name == 'push'
+        run: ./.github/scripts/build-images.sh ${GITHUB_REF#refs/heads/} quay.io snapshot
+
+      - name: List All The Images
+        run: docker images
+
+      - name: Push The Images To Quay.io
+        if: github.event_name == 'push'
+        run: ./.github/scripts/push-images.sh ${GITHUB_REF#refs/heads/} quay.io snapshot

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -78,7 +78,7 @@ jobs:
   build-native-images:
     name: Build native images
     runs-on: ubuntu-18.04
-    if: github.repository_owner == 'Apicurio' && github.event_name == 'push'
+    if: github.repository_owner == 'Apicurio'
     steps:
       - name: Checkout Code with Ref '${{ github.ref }}'
         uses: actions/checkout@v2

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -109,6 +109,8 @@ jobs:
         run: |
           make build-sql-native build-kafkasql-native build-tenant-manager
 
+      - name: Build integration-tests-common
+        run: ./mvnw install -Pintegration-tests -pl integration-tests/integration-tests-common
       - name: Run Integration Tests - sql
         run: ./mvnw verify -Pintegration-tests -Pacceptance -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtestNative=true
       - name: Run Integration Tests - kafkasql

--- a/Makefile
+++ b/Makefile
@@ -40,29 +40,20 @@ build-all:
 	@echo "----------------------------------------------------------------------"
 	./mvnw clean install -Pprod -Psql -Pkafkasql -Pmultitenancy -DskipTests=$(SKIP_TESTS) $(BUILD_FLAGS)
 
-.PHONY: build-sql-native ## Builds sql storage variant native executable. Variables available for override [BUILD_FLAGS]
+.PHONY: build-sql-native ## Builds sql storage variant native executable. Variables available for override [SKIP_TESTS, BUILD_FLAGS]
 build-sql-native:
-	./mvnw package -Pnative -Dquarkus.native.container-build=true -Pprod -Psql -pl storage/sql -DskipTests $(BUILD_FLAGS)
+	./mvnw package -Pnative -Dquarkus.native.container-build=true -Pprod -Psql -pl storage/sql -Dskiptests=$(SKIP_TESTS) $(BUILD_FLAGS)
 
-.PHONY: build-kafkasql-native ## Builds kafkasql storage variant native executable. Variables available for override [BUILD_FLAGS]
+.PHONY: build-kafkasql-native ## Builds kafkasql storage variant native executable. Variables available for override [SKIP_TESTS, BUILD_FLAGS]
 build-kafkasql-native:
-	./mvnw package -Pnative -Dquarkus.native.container-build=true -Pprod -Pkafkasql -pl storage/kafkasql -DskipTests $(BUILD_FLAGS)
+	./mvnw package -Pnative -Dquarkus.native.container-build=true -Pprod -Pkafkasql -pl storage/kafkasql -Dskiptests=$(SKIP_TESTS) $(BUILD_FLAGS)
 
-.PHONY: build-tenant-manager ## Builds tenant-manager-api. Variables available for override [SKIP_TESTS, BUILD_FLAGS]
+.PHONY: build-tenant-manager ## Builds tenant manager natively [SKIP_TESTS, BUILD_FLAGS]
 build-tenant-manager:
 	@echo "----------------------------------------------------------------------"
-	@echo "                     Building Tenant Manager                          "
+	@echo "                 Building Tenant Manager                              "
 	@echo "----------------------------------------------------------------------"
-	./mvnw clean install -am -Pprod -Pmultitenancy -pl 'multitenancy/tenant-manager-api' -Dskiptests=$(SKIP_TESTS) $(BUILD_FLAGS)
-
-
-
-.PHONY: build-tenant-manager-native ## Builds tenant manager natively
-build-tenant-manager-native:
-	@echo "----------------------------------------------------------------------"
-	@echo "                 Building Tenant Manager Natively                     "
-	@echo "----------------------------------------------------------------------"
-	./mvnw clean install -am -Pprod -Pmultitenancy -pl 'multitenancy/tenant-manager-api' -Pnative -Dquarkus.native.container-build=true
+	./mvnw package -Pnative -Dquarkus.native.container-build=true -Pprod -Pmultitenancy -pl 'multitenancy/tenant-manager-api' -Dskiptests=$(SKIP_TESTS) $(BUILD_FLAGS)
 
 
 
@@ -105,7 +96,23 @@ push-sql-image:
 	@echo "------------------------------------------------------------------------"
 	docker push $(IMAGE_REPO)/apicurio/apicurio-registry-sql:$(IMAGE_TAG)
 
+.PHONY: build-sql-native-image ## Builds docker image for 'sql' storage variant. Variables available for override [IMAGE_REPO, IMAGE_TAG]
+build-sql-native-image:
+	@echo "------------------------------------------------------------------------"
+	@echo " Building Image For SQL Storage Variant (using Native Executable)"
+	@echo " Repository: $(IMAGE_REPO)"
+	@echo " Tag: $(IMAGE_TAG)"
+	@echo "------------------------------------------------------------------------"
+	docker build -f $(DISTRO_DOCKER_WORKSPACE)/Dockerfile.native -t $(IMAGE_REPO)/apicurio/apicurio-registry-sql-native:$(IMAGE_TAG) storage/sql
 
+.PHONY: push-sql-native-image ## Pushes docker image for 'sql' storage variant. Variables available for override [IMAGE_REPO, IMAGE_TAG]
+push-sql-native-image:
+	@echo "------------------------------------------------------------------------"
+	@echo " Pushing Image For SQL Storage Variant (using Native Executable)"
+	@echo " Repository: $(IMAGE_REPO)"
+	@echo " Tag: $(IMAGE_TAG)"
+	@echo "------------------------------------------------------------------------"
+	docker push $(IMAGE_REPO)/apicurio/apicurio-registry-sql-native:$(IMAGE_TAG)
 
 .PHONY: build-kafkasql-image ## Builds docker image for kafkasql storage variant. Variables available for override [KAFKASQL_DOCKERFILE, IMAGE_REPO, IMAGE_TAG, DOCKER_BUILD_WORKSPACE]
 build-kafkasql-image:
@@ -126,16 +133,33 @@ push-kafkasql-image:
 	@echo "------------------------------------------------------------------------"
 	docker push $(IMAGE_REPO)/apicurio/apicurio-registry-kafkasql:$(IMAGE_TAG)
 
-
-
-.PHONY: build-tenant-manager-image ## Builds docker image for tenant-manager-api. Variables available for override [IMAGE_REPO, IMAGE_TAG]
-build-tenant-manager-image:
+.PHONY: build-kafkasql-native-image ## Builds docker image for kafkasql storage variant. Variables available for override [IMAGE_REPO, IMAGE_TAG]
+build-kafkasql-native-image:
 	@echo "------------------------------------------------------------------------"
-	@echo " Building Image For Tenant Manager API"
+	@echo " Building Image For Kafkasql Storage Variant (using Native Executable)"
 	@echo " Repository: $(IMAGE_REPO)"
 	@echo " Tag: $(IMAGE_TAG)"
 	@echo "------------------------------------------------------------------------"
-	docker build -f multitenancy/tenant-manager-api/src/main/docker/Dockerfile.jvm -t $(IMAGE_REPO)/apicurio/apicurio-registry-tenant-manager-api:$(IMAGE_TAG) ./multitenancy/tenant-manager-api/
+	docker build -f $(DISTRO_DOCKER_WORKSPACE)/Dockerfile.native -t $(IMAGE_REPO)/apicurio/apicurio-registry-kafkasql-native:$(IMAGE_TAG) storage/kafkasql
+
+
+.PHONY: push-kafkasql-native-image ## Pushes docker image for 'kafkasql' storage variant. Variables available for override [IMAGE_REPO, IMAGE_TAG]
+push-kafkasql-native-image:
+	@echo "------------------------------------------------------------------------"
+	@echo " Pushing Image For Kafkasql Storage Variant (using Native Executable)"
+	@echo " Repository: $(IMAGE_REPO)"
+	@echo " Tag: $(IMAGE_TAG)"
+	@echo "------------------------------------------------------------------------"
+	docker push $(IMAGE_REPO)/apicurio/apicurio-registry-kafkasql-native:$(IMAGE_TAG)
+
+.PHONY: build-tenant-manager-image ## Builds native docker image for tenant manager. Variables available for override [IMAGE_REPO, IMAGE_TAG]
+build-tenant-manager-image:
+	@echo "------------------------------------------------------------------------"
+	@echo " Building Native Image For Tenant Manager"
+	@echo " Repository: $(IMAGE_REPO)"
+	@echo " Tag: $(IMAGE_TAG)-native"
+	@echo "------------------------------------------------------------------------"
+	docker build -f multitenancy/tenant-manager-api/src/main/docker/Dockerfile.native -t $(IMAGE_REPO)/apicurio/apicurio-registry-tenant-manager-api:$(IMAGE_TAG) ./multitenancy/tenant-manager-api/
 
 
 .PHONY: push-tenant-manager-image ## Pushes docker image for tenant-manager-api. Variables available for override [IMAGE_REPO, IMAGE_TAG]
@@ -147,25 +171,11 @@ push-tenant-manager-image:
 	@echo "------------------------------------------------------------------------"
 	docker push $(IMAGE_REPO)/apicurio/apicurio-registry-tenant-manager-api:$(IMAGE_TAG)
 
-
-
-.PHONY: build-tenant-manager-image-native ## Builds native docker image for tenant manager. Variables available for override [IMAGE_REPO, IMAGE_TAG]
-build-tenant-manager-image-native:
-	@echo "------------------------------------------------------------------------"
-	@echo " Building Native Image For Tenant Manager"
-	@echo " Repository: $(IMAGE_REPO)"
-	@echo " Tag: $(IMAGE_TAG)-native"
-	@echo "------------------------------------------------------------------------"
-	docker build -f multitenancy/tenant-manager-api/src/main/docker/Dockerfile.native -t $(IMAGE_REPO)/apicurio/apicurio-registry-tenant-manager-api:$(IMAGE_TAG)-native ./multitenancy/tenant-manager-api/
-
-
 .PHONY: build-all-images ## Builds all the Images. Variables available for override [IMAGE_REPO, IMAGE_TAG]
-build-all-images: build-mem-image build-sql-image build-kafkasql-image build-tenant-manager-image
-
-
+build-all-images: build-mem-image build-sql-image build-kafkasql-image
 
 .PHONY: push-all-images ## Pushes all the Images. Variables available for override [IMAGE_REPO, IMAGE_TAG]
-push-all-images: push-mem-image push-sql-image push-kafkasql-image push-tenant-manager-image
+push-all-images: push-mem-image push-sql-image push-kafkasql-image
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -42,18 +42,18 @@ build-all:
 
 .PHONY: build-sql-native ## Builds sql storage variant native executable. Variables available for override [SKIP_TESTS, BUILD_FLAGS]
 build-sql-native:
-	./mvnw package -Pnative -Dquarkus.native.container-build=true -Pprod -Psql -pl storage/sql -Dskiptests=$(SKIP_TESTS) $(BUILD_FLAGS)
+	./mvnw package -Pnative -Dquarkus.native.container-build=true -Pprod -Psql -pl storage/sql -DskipTests=$(SKIP_TESTS) $(BUILD_FLAGS)
 
 .PHONY: build-kafkasql-native ## Builds kafkasql storage variant native executable. Variables available for override [SKIP_TESTS, BUILD_FLAGS]
 build-kafkasql-native:
-	./mvnw package -Pnative -Dquarkus.native.container-build=true -Pprod -Pkafkasql -pl storage/kafkasql -Dskiptests=$(SKIP_TESTS) $(BUILD_FLAGS)
+	./mvnw package -Pnative -Dquarkus.native.container-build=true -Pprod -Pkafkasql -pl storage/kafkasql -DskipTests=$(SKIP_TESTS) $(BUILD_FLAGS)
 
 .PHONY: build-tenant-manager ## Builds tenant manager natively [SKIP_TESTS, BUILD_FLAGS]
 build-tenant-manager:
 	@echo "----------------------------------------------------------------------"
 	@echo "                 Building Tenant Manager                              "
 	@echo "----------------------------------------------------------------------"
-	./mvnw package -Pnative -Dquarkus.native.container-build=true -Pprod -Pmultitenancy -pl 'multitenancy/tenant-manager-api' -Dskiptests=$(SKIP_TESTS) $(BUILD_FLAGS)
+	./mvnw package -Pnative -Dquarkus.native.container-build=true -Pprod -Pmultitenancy -pl 'multitenancy/tenant-manager-api' -DskipTests=$(SKIP_TESTS) $(BUILD_FLAGS)
 
 
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -149,8 +149,8 @@
 
         <!-- Kafka Connect -->
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>connect-api</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kafka-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -256,6 +256,12 @@
             <artifactId>keycloak-admin-client</artifactId>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+        </dependency>
+        
     </dependencies>
 
     <build>
@@ -396,50 +402,6 @@
             </properties>
         </profile>
         <profile>
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-maven-plugin</artifactId>
-                        <version>${quarkus.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>native-image</goal>
-                                </goals>
-                                <configuration>
-                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                                <configuration>
-                                    <systemProperties>
-                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                                    </systemProperties>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>sub</id>
             <activation>
                 <property>
@@ -463,5 +425,40 @@
                 </plugins>
             </build>
         </profile>
+        
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+        </profile>
+        
     </profiles>
 </project>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -256,12 +256,6 @@
             <artifactId>keycloak-admin-client</artifactId>
             <scope>test</scope>
         </dependency>
-        
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-        </dependency>
-        
     </dependencies>
 
     <build>

--- a/app/src/main/java/io/apicurio/registry/URLRegisterForReflection.java
+++ b/app/src/main/java/io/apicurio/registry/URLRegisterForReflection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-package io.apicurio.registry.ui.beans;
+package io.apicurio.registry;
+
+import java.net.URL;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
- * @author eric.wittmann@gmail.com
+ * @author Fabian Martinez
  */
-@RegisterForReflection
-public class ConfigJsArtifacts {
-
-    public String type = "rest";
-    public String url;
+@RegisterForReflection(targets = URL.class)
+public class URLRegisterForReflection {
 
 }

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityCheckResponse.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityCheckResponse.java
@@ -18,6 +18,8 @@ package io.apicurio.registry.ccompat.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -38,6 +40,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @Getter
 @EqualsAndHashCode
 @ToString
+@RegisterForReflection
 public class CompatibilityCheckResponse {
 
     public static final CompatibilityCheckResponse IS_COMPATIBLE = new CompatibilityCheckResponse(true);

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelDto.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelDto.java
@@ -19,6 +19,7 @@ package io.apicurio.registry.ccompat.dto;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -41,6 +42,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @Getter
 @EqualsAndHashCode
 @ToString
+@RegisterForReflection
 public class CompatibilityLevelDto {
 
     public static CompatibilityLevelDto create(Optional<CompatibilityLevel> source) {

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelParamDto.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/CompatibilityLevelParamDto.java
@@ -17,6 +17,8 @@
 package io.apicurio.registry.ccompat.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -35,6 +37,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @Getter
 @EqualsAndHashCode
 @ToString
+@RegisterForReflection
 public class CompatibilityLevelParamDto{
 
     private String compatibilityLevel;

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/ModeDto.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/ModeDto.java
@@ -18,6 +18,8 @@ package io.apicurio.registry.ccompat.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -36,6 +38,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @Getter
 @EqualsAndHashCode
 @ToString
+@RegisterForReflection
 public class ModeDto {
 
     @JsonProperty("mode")

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/Schema.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/Schema.java
@@ -18,6 +18,8 @@ package io.apicurio.registry.ccompat.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -35,6 +37,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @Getter
 @EqualsAndHashCode
 @ToString
+@RegisterForReflection
 public class Schema {
 
     @JsonProperty("id")

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/SchemaContent.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/SchemaContent.java
@@ -18,6 +18,8 @@ package io.apicurio.registry.ccompat.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.*;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -32,6 +34,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @EqualsAndHashCode
 @ToString
 @Builder
+@RegisterForReflection
 public class SchemaContent {
 
     @JsonProperty("schema")

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/SchemaId.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/SchemaId.java
@@ -18,6 +18,8 @@ package io.apicurio.registry.ccompat.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -35,6 +37,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @Getter
 @EqualsAndHashCode
 @ToString
+@RegisterForReflection
 public class SchemaId {
 
     @JsonProperty("id")

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/SchemaInfo.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/SchemaInfo.java
@@ -18,6 +18,8 @@ package io.apicurio.registry.ccompat.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.*;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -32,6 +34,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @EqualsAndHashCode
 @ToString
 @Builder
+@RegisterForReflection
 public class SchemaInfo {
 
     @JsonProperty("schema")

--- a/app/src/main/java/io/apicurio/registry/ccompat/dto/SubjectVersion.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/dto/SubjectVersion.java
@@ -18,6 +18,8 @@ package io.apicurio.registry.ccompat.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.*;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -32,6 +34,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @EqualsAndHashCode
 @ToString
 @Builder
+@RegisterForReflection
 public class SubjectVersion {
 
     @JsonProperty("subject")

--- a/app/src/main/java/io/apicurio/registry/storage/dto/EditableArtifactMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/EditableArtifactMetaDataDto.java
@@ -25,6 +25,8 @@ import lombok.ToString;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author eric.wittmann@gmail.com
  */
@@ -32,6 +34,7 @@ import java.util.Map;
 @Builder
 @EqualsAndHashCode
 @ToString
+@RegisterForReflection
 public class EditableArtifactMetaDataDto {
 
     private String name;

--- a/app/src/main/java/io/apicurio/registry/storage/dto/LogConfigurationDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/LogConfigurationDto.java
@@ -16,6 +16,7 @@
 package io.apicurio.registry.storage.dto;
 
 import io.apicurio.registry.types.LogLevel;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -24,6 +25,7 @@ import lombok.ToString;
  */
 @EqualsAndHashCode
 @ToString
+@RegisterForReflection
 public class LogConfigurationDto {
 
     private String logger;

--- a/app/src/main/java/io/apicurio/registry/storage/dto/RuleConfigurationDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/RuleConfigurationDto.java
@@ -16,6 +16,7 @@
 
 package io.apicurio.registry.storage.dto;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -28,10 +29,11 @@ import lombok.ToString;
 @Builder
 @EqualsAndHashCode
 @ToString
+@RegisterForReflection
 public class RuleConfigurationDto {
 
     private String configuration; // TODO why not a map?
-    
+
     /**
      * Constructor.
      */

--- a/app/src/main/java/io/apicurio/registry/ui/beans/ConfigJs.java
+++ b/app/src/main/java/io/apicurio/registry/ui/beans/ConfigJs.java
@@ -16,11 +16,14 @@
 
 package io.apicurio.registry.ui.beans;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ConfigJs {
-    
+
     public String mode;
     public ConfigJsArtifacts artifacts = new ConfigJsArtifacts();
     public ConfigJsUi ui = new ConfigJsUi();

--- a/app/src/main/java/io/apicurio/registry/ui/beans/ConfigJsAuth.java
+++ b/app/src/main/java/io/apicurio/registry/ui/beans/ConfigJsAuth.java
@@ -18,14 +18,17 @@ package io.apicurio.registry.ui.beans;
 
 import java.util.Map;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ConfigJsAuth {
-    
+
     public String type;
     public Map<String, Object> options;
-    
+
     /**
      * Constructor.
      */

--- a/app/src/main/java/io/apicurio/registry/ui/beans/ConfigJsFeatures.java
+++ b/app/src/main/java/io/apicurio/registry/ui/beans/ConfigJsFeatures.java
@@ -16,11 +16,14 @@
 
 package io.apicurio.registry.ui.beans;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ConfigJsFeatures {
-    
+
     public boolean readOnly;
 
 }

--- a/app/src/main/java/io/apicurio/registry/ui/beans/ConfigJsUi.java
+++ b/app/src/main/java/io/apicurio/registry/ui/beans/ConfigJsUi.java
@@ -16,14 +16,17 @@
 
 package io.apicurio.registry.ui.beans;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ConfigJsUi {
-    
+
     public String url;
     public String contextPath;
-    
+
     /**
      * Constructor.
      */

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,8 +1,6 @@
+quarkus.native.resources.includes=io/apicurio/registry/storage/impl/sql/h2.ddl
+
 # Additional index dependencies
-
-quarkus.ssl.native=false
-quarkus.native.report-errors-at-runtime=true
-
 quarkus.index-dependency.jaxrs.group-id=org.jboss.spec.javax.ws.rs
 quarkus.index-dependency.jaxrs.artifact-id=jboss-jaxrs-api_2.1_spec
 

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,5 +1,8 @@
 # Additional index dependencies
 
+quarkus.ssl.native=false
+quarkus.native.report-errors-at-runtime=true
+
 quarkus.index-dependency.jaxrs.group-id=org.jboss.spec.javax.ws.rs
 quarkus.index-dependency.jaxrs.artifact-id=jboss-jaxrs-api_2.1_spec
 

--- a/common/src/main/java/io/apicurio/registry/events/dto/ArtifactId.java
+++ b/common/src/main/java/io/apicurio/registry/events/dto/ArtifactId.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 
 /**
  * Root Type for ArtifactId
@@ -32,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "artifactId",
     "version"
 })
+@RegisterForReflection
 public class ArtifactId {
 
     @JsonProperty("groupId")

--- a/common/src/main/java/io/apicurio/registry/events/dto/ArtifactRuleChange.java
+++ b/common/src/main/java/io/apicurio/registry/events/dto/ArtifactRuleChange.java
@@ -19,9 +19,12 @@ package io.apicurio.registry.events.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author Fabian Martinez
  */
+@RegisterForReflection
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ArtifactRuleChange extends ArtifactId {
 

--- a/common/src/main/java/io/apicurio/registry/events/dto/ArtifactStateChange.java
+++ b/common/src/main/java/io/apicurio/registry/events/dto/ArtifactStateChange.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 
 /**
  * Root Type for ArtifactStateChange
@@ -33,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "state",
     "version"
 })
+@RegisterForReflection
 public class ArtifactStateChange {
 
     @JsonProperty("groupId")

--- a/common/src/main/java/io/apicurio/registry/events/dto/RegistryEventType.java
+++ b/common/src/main/java/io/apicurio/registry/events/dto/RegistryEventType.java
@@ -15,9 +15,12 @@
  */
 package io.apicurio.registry.events.dto;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author Fabian Martinez
  */
+@RegisterForReflection
 public enum RegistryEventType {
 
     GROUP_CREATED,

--- a/distro/docker/src/main/docker/Dockerfile.native
+++ b/distro/docker/src/main/docker/Dockerfile.native
@@ -1,13 +1,14 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
-
-ENV APP_URL=app/target/apicurio-registry-app-*-runner
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 WORKDIR /work/
 
-ADD ${APP_URL} /work/application
-
-RUN chmod 775 /work
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+    
+COPY --chown=1001:root target/apicurio-registry-*-runner /work/application
 
 EXPOSE 8080
+USER 1001
 
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
+++ b/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
@@ -617,14 +617,12 @@ public class RegistryFacade {
         if (targetDir.isDirectory()) {
             File[] files = targetDir.listFiles();
             for (File file : files) {
-                if (file.getName().contains("-runner")) {
-                    if (extension != null) {
-                        if (file.getName().endsWith("." + extension)) {
-                            return file.getAbsolutePath();
-                        }
-                    } else {
+                if (extension != null) {
+                    if (file.getName().contains("-runner") && file.getName().endsWith("." + extension)) {
                         return file.getAbsolutePath();
                     }
+                } else if (file.getName().endsWith("-runner")) {
+                    return file.getAbsolutePath();
                 }
             }
         }

--- a/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
+++ b/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.TimeZone;
 import java.util.concurrent.CompletableFuture;
@@ -172,11 +173,6 @@ public class RegistryFacade {
             throw new IllegalStateException("Only sql storage allowed for multitenancy tests");
         }
 
-        String path = getJarPath();
-        if (path == null) {
-            throw new IllegalStateException("Could not determine where to find the executable jar for the server. " +
-                "This may happen if you are using an IDE to debug.");
-        }
         LOGGER.info("Deploying registry using storage {}, test profile {}", RegistryUtils.REGISTRY_STORAGE.name(), RegistryUtils.TEST_PROFILE);
         Map<String, String> appEnv = new HashMap<>();
         appEnv.put("LOG_LEVEL", "DEBUG");
@@ -185,10 +181,10 @@ public class RegistryFacade {
         if (RegistryUtils.TEST_PROFILE.contains(Constants.MIGRATION)) {
             Map<String, String> registry1Env = new HashMap<>(appEnv);
             deployStorage(registry1Env);
-            runRegistryNode(path, registry1Env, String.valueOf(TestUtils.getRegistryPort()));
+            runRegistry(registry1Env, "node-1", String.valueOf(TestUtils.getRegistryPort()));
             Map<String, String> registry2Env = new HashMap<>(appEnv);
             deployStorage(registry2Env);
-            runRegistryNode(path, registry2Env, String.valueOf(TestUtils.getRegistryPort() + 1));
+            runRegistry(registry2Env, "node-2", String.valueOf(TestUtils.getRegistryPort() + 1));
         } else {
 
             deployStorage(appEnv);
@@ -196,17 +192,17 @@ public class RegistryFacade {
             if (RegistryUtils.TEST_PROFILE.contains(Constants.CLUSTERED)) {
 
                 Map<String, String> node1Env = new HashMap<>(appEnv);
-                runRegistryNode(path, node1Env, String.valueOf(TestUtils.getRegistryPort()));
+                runRegistry(node1Env, "node-1" ,String.valueOf(TestUtils.getRegistryPort()));
 
                 int c2port = TestUtils.getRegistryPort() + 1;
 
                 Map<String, String> node2Env = new HashMap<>(appEnv);
-                runRegistryNode(path, node2Env, String.valueOf(c2port));
+                runRegistry(node2Env, "node-2" ,String.valueOf(c2port));
 
                 int c3port = c2port + 1;
 
                 Map<String, String> node3Env = new HashMap<>(appEnv);
-                runRegistryNode(path, node3Env, String.valueOf(c3port));
+                runRegistry(node3Env, "node-3" ,String.valueOf(c3port));
 
             } else {
                 if (Constants.MULTITENANCY.equals(RegistryUtils.TEST_PROFILE)) {
@@ -218,7 +214,7 @@ public class RegistryFacade {
                     runKeycloak(appEnv);
                 }
 
-                runRegistry(path, appEnv);
+                runRegistry(appEnv, "default", "8081");
             }
         }
 
@@ -280,56 +276,6 @@ public class RegistryFacade {
 
     }
 
-    private void runRegistryNode(String path, Map<String, String> appEnv, String httpPort) {
-        Exec executor = new Exec();
-        LOGGER.info("Starting Registry app from: {}", path);
-        CompletableFuture.supplyAsync(() -> {
-            try {
-
-                List<String> cmd = new ArrayList<>();
-                cmd.add("java");
-                cmd.addAll(Arrays.asList(
-                        // "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005",
-                        "-Dquarkus.http.port=" + httpPort,
-                        "-jar", path));
-                int timeout = executor.execute(cmd, appEnv);
-                return timeout == 0;
-            } catch (Exception e) {
-                LOGGER.error("Failed to start registry (could not find runner JAR).", e);
-                System.exit(1);
-                return false;
-            }
-        }, runnable -> new Thread(runnable).start());
-        processes.add(new RegistryTestProcess() {
-
-            @Override
-            public String getName() {
-                return "registry-node" + httpPort;
-            }
-
-            @Override
-            public void close() throws Exception {
-                executor.stop();
-            }
-
-            @Override
-            public String getStdOut() {
-                return executor.stdOut();
-            }
-
-            @Override
-            public String getStdErr() {
-                return executor.stdErr();
-            }
-
-            @Override
-            public boolean isContainer() {
-                return false;
-            }
-
-        });
-    }
-
     private void runTenantManager(Map<String, String> registryAppEnv) throws Exception {
         Map<String, String> appEnv = new HashMap<>();
         appEnv.put("DATASOURCE_URL", registryAppEnv.get("REGISTRY_DATASOURCE_URL"));
@@ -337,28 +283,47 @@ public class RegistryFacade {
         appEnv.put("DATASOURCE_PASSWORD", registryAppEnv.get("REGISTRY_DATASOURCE_PASSWORD"));
 
         appEnv.put("REGISTRY_ROUTE_URL", TestUtils.getRegistryBaseUrl());
+        appEnv.put("LOG_LEVEL", "DEBUG");
+
+        var nativeExec = getTenantManagerNativeExecutablePath();
 
         Exec executor = new Exec();
-        String path = getTenantManagerJarPath();
-        LOGGER.info("Starting Tenant Manager app from: {}", path);
-        CompletableFuture.supplyAsync(() -> {
-            try {
+        if (nativeExec.isPresent()) {
+            LOGGER.info("Starting Tenant Manager Native Executable app from: {}", nativeExec.get());
+            CompletableFuture.supplyAsync(() -> {
+                try {
 
-                List<String> cmd = new ArrayList<>();
-                cmd.add("java");
-                cmd.addAll(Arrays.asList(
-                        // "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005",
-                        "-Dquarkus.log.console.level=DEBUG",
-                        "-Dquarkus.log.category.\"io\".level=DEBUG",
-                        "-jar", path));
-                int timeout = executor.execute(cmd, appEnv);
-                return timeout == 0;
-            } catch (Exception e) {
-                LOGGER.error("Failed to start tenant manager (could not find runner JAR).", e);
-                System.exit(1);
-                return false;
-            }
-        }, runnable -> new Thread(runnable).start());
+                    List<String> cmd = new ArrayList<>();
+                    cmd.add(nativeExec.get());
+                    int timeout = executor.execute(cmd, appEnv);
+                    return timeout == 0;
+                } catch (Exception e) {
+                    LOGGER.error("Failed to start native tenant-manager.", e);
+                    System.exit(1);
+                    return false;
+                }
+            }, runnable -> new Thread(runnable).start());
+        } else {
+            String path = getTenantManagerJarPath();
+            LOGGER.info("Starting Tenant Manager app from: {}", path);
+            CompletableFuture.supplyAsync(() -> {
+                try {
+
+                    List<String> cmd = new ArrayList<>();
+                    cmd.add("java");
+                    cmd.addAll(Arrays.asList(
+                            // "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005",
+                            "-jar", path));
+                    int timeout = executor.execute(cmd, appEnv);
+                    return timeout == 0;
+                } catch (Exception e) {
+                    LOGGER.error("Failed to start tenant manager (could not find runner JAR).", e);
+                    System.exit(1);
+                    return false;
+                }
+            }, runnable -> new Thread(runnable).start());
+        }
+
         processes.add(new RegistryTestProcess() {
 
             @Override
@@ -534,7 +499,13 @@ public class RegistryFacade {
         processes.add(kafkaFacade);
     }
 
-    private void runRegistry(String path, Map<String, String> appEnv) {
+    private void runRegistry(Map<String, String> appEnv, String nameSuffix, String port) throws IOException {
+        appEnv.put("QUARKUS_HTTP_PORT", port);
+        if (RegistryUtils.DEPLOY_NATIVE_IMAGES.equals("true")) {
+            runRegistryNativeImage(appEnv, nameSuffix);
+            return;
+        }
+        String path = getJarPath();
         Exec executor = new Exec();
         LOGGER.info("Starting Registry app from: {}", path);
         CompletableFuture.supplyAsync(() -> {
@@ -544,7 +515,7 @@ public class RegistryFacade {
                 cmd.add("java");
                 cmd.addAll(Arrays.asList(
                         // "-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005",
-                        "-Dquarkus.http.port=8081",
+//                        "-Dquarkus.http.port=8081",
                         "-jar", path));
                 int timeout = executor.execute(cmd, appEnv);
                 return timeout == 0;
@@ -558,7 +529,7 @@ public class RegistryFacade {
 
             @Override
             public String getName() {
-                return "registry";
+                return "registry-" + nameSuffix;
             }
 
             @Override
@@ -584,23 +555,76 @@ public class RegistryFacade {
         });
     }
 
-    private String findTenantManagerRunner() {
+    private void runRegistryNativeImage(Map<String, String> appEnv, String nameSuffix) throws IOException {
+        String path = getNativeExecutablePath();
+        Exec executor = new Exec();
+        LOGGER.info("Starting Registry Native Executable app from: {}", path);
+        CompletableFuture.supplyAsync(() -> {
+            try {
+
+                List<String> cmd = new ArrayList<>();
+                cmd.add(path);
+                int timeout = executor.execute(cmd, appEnv);
+                return timeout == 0;
+            } catch (Exception e) {
+                LOGGER.error("Failed to start registry.", e);
+                System.exit(1);
+                return false;
+            }
+        }, runnable -> new Thread(runnable).start());
+        processes.add(new RegistryTestProcess() {
+
+            @Override
+            public String getName() {
+                return "registry-native-" + nameSuffix;
+            }
+
+            @Override
+            public void close() throws Exception {
+                executor.stop();
+            }
+
+            @Override
+            public String getStdOut() {
+                return executor.stdOut();
+            }
+
+            @Override
+            public String getStdErr() {
+                return executor.stdErr();
+            }
+
+            @Override
+            public boolean isContainer() {
+                return false;
+            }
+
+        });
+    }
+
+    private String findTenantManagerJar() {
         LOGGER.info("Attempting to find tenant manager runner. Starting at cwd: " + new File("").getAbsolutePath());
-        return findRunner(findTenantManagerModuleDir());
+        return findRunner(findTenantManagerModuleDir(), "jar");
     }
 
     private String findInMemoryRunner() {
         LOGGER.info("Attempting to find runner. Starting at cwd: " + new File("").getAbsolutePath());
-        return findRunner(findAppModuleDir());
+        return findRunner(findAppModuleDir(), "jar");
     }
 
-    private String findRunner(File mavenModuleDir) {
+    private String findRunner(File mavenModuleDir, String extension) {
         File targetDir = new File(mavenModuleDir, "target");
         if (targetDir.isDirectory()) {
             File[] files = targetDir.listFiles();
             for (File file : files) {
-                if (file.getName().contains("-runner") && file.getName().endsWith(".jar")) {
-                    return file.getAbsolutePath();
+                if (file.getName().contains("-runner")) {
+                    if (extension != null) {
+                        if (file.getName().endsWith("." + extension)) {
+                            return file.getAbsolutePath();
+                        }
+                    } else {
+                        return file.getAbsolutePath();
+                    }
                 }
             }
         }
@@ -647,6 +671,17 @@ public class RegistryFacade {
         return file.isFile();
     }
 
+    private String getNativeExecutablePath() throws IOException {
+        String execPath = "../../storage/%s/target/apicurio-registry-storage-%s-%s-runner";
+        String path = String.format(execPath, RegistryUtils.REGISTRY_STORAGE, RegistryUtils.REGISTRY_STORAGE, PROJECT_VERSION);
+        if (!runnerExists(path)) {
+            LOGGER.info("No runner JAR found.  Throwing an exception.");
+            throw new IllegalStateException("Could not determine where to find the executable jar for the server. " +
+                "This may happen if you are using an IDE to debug.");
+        }
+        return path;
+    }
+
     private String getJarPath() throws IOException {
         String path = REGISTRY_JAR_PATH;
         LOGGER.info("Checking runner JAR path (1): " + path);
@@ -668,8 +703,16 @@ public class RegistryFacade {
         return path;
     }
 
+    private Optional<String> getTenantManagerNativeExecutablePath() throws IOException {
+        String path = findRunner(findTenantManagerModuleDir(), null);
+        if (runnerExists(path)) {
+            return Optional.of(path);
+        }
+        return Optional.empty();
+    }
+
     private String getTenantManagerJarPath() throws IOException {
-        String path = findTenantManagerRunner();
+        String path = findTenantManagerJar();
         LOGGER.info("Checking tenant manager runner JAR path: " + path);
         if (!runnerExists(path)) {
             LOGGER.info("No runner JAR found.  Throwing an exception.");

--- a/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/utils/RegistryUtils.java
+++ b/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/utils/RegistryUtils.java
@@ -31,6 +31,11 @@ public class RegistryUtils {
             Optional.ofNullable(System.getProperty("groups"))
                 .orElse("");
 
+    public static final String DEPLOY_NATIVE_IMAGES =
+            Optional.ofNullable(System.getProperty("testNative"))
+                .orElse("");
+
+
     private RegistryUtils() {
         //utils class
     }

--- a/storage/kafkasql/pom.xml
+++ b/storage/kafkasql/pom.xml
@@ -229,22 +229,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-maven-plugin</artifactId>
-                        <version>${quarkus.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>native-image</goal>
-                                </goals>
-                                <configuration>
-                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <executions>
                             <execution>
@@ -253,15 +237,20 @@
                                     <goal>verify</goal>
                                 </goals>
                                 <configuration>
-                                    <systemProperties>
+                                    <systemPropertyVariables>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                                    </systemProperties>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>${maven.home}</maven.home>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
             </build>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ArtifactKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ArtifactKey.java
@@ -19,10 +19,12 @@ package io.apicurio.registry.storage.impl.kafkasql.keys;
 import java.util.UUID;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ArtifactKey extends AbstractMessageKey {
 
     private String groupId;

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ArtifactRuleKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ArtifactRuleKey.java
@@ -18,10 +18,12 @@ package io.apicurio.registry.storage.impl.kafkasql.keys;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
 import io.apicurio.registry.types.RuleType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ArtifactRuleKey extends AbstractMessageKey {
 
     private String groupId;

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ArtifactVersionKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ArtifactVersionKey.java
@@ -17,10 +17,12 @@
 package io.apicurio.registry.storage.impl.kafkasql.keys;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ArtifactVersionKey extends AbstractMessageKey {
 
     private String groupId;

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/BootstrapKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/BootstrapKey.java
@@ -17,10 +17,12 @@
 package io.apicurio.registry.storage.impl.kafkasql.keys;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class BootstrapKey implements MessageKey {
 
     private String bootstrapId;

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ContentIdKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ContentIdKey.java
@@ -17,10 +17,12 @@
 package io.apicurio.registry.storage.impl.kafkasql.keys;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ContentIdKey extends AbstractMessageKey {
 
     private static final String CONTENT_ID_PARTITION_KEY = "__apicurio_registry_content_id__";

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ContentKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ContentKey.java
@@ -17,10 +17,12 @@
 package io.apicurio.registry.storage.impl.kafkasql.keys;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ContentKey extends AbstractMessageKey {
 
     private String contentHash;

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalIdKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalIdKey.java
@@ -17,10 +17,12 @@
 package io.apicurio.registry.storage.impl.kafkasql.keys;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class GlobalIdKey extends AbstractMessageKey {
 
     private static final String GLOBAL_ID_PARTITION_KEY = "__apicurio_registry_global_id__";

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalRuleKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalRuleKey.java
@@ -18,16 +18,18 @@ package io.apicurio.registry.storage.impl.kafkasql.keys;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
 import io.apicurio.registry.types.RuleType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class GlobalRuleKey extends AbstractMessageKey {
-    
+
     private static final String GLOBAL_RULE_PARTITION_KEY = "__apicurio_registry_global_rule__";
-    
+
     private RuleType ruleType;
-    
+
     /**
      * Creator method.
      * @param tenantId

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GroupKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GroupKey.java
@@ -17,10 +17,12 @@
 package io.apicurio.registry.storage.impl.kafkasql.keys;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class GroupKey extends AbstractMessageKey {
 
     private String groupId;

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/LogConfigKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/LogConfigKey.java
@@ -17,10 +17,12 @@
 package io.apicurio.registry.storage.impl.kafkasql.keys;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class LogConfigKey extends AbstractMessageKey {
 
     private static final String LOG_CONFIG_PARTITION_KEY = "__apicurio_registry_log_config__";

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/MessageKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/MessageKey.java
@@ -19,20 +19,22 @@ package io.apicurio.registry.storage.impl.kafkasql.keys;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
- * When the KSQL artifactStore publishes a message to its Kafka topic, the message key will be a class that 
+ * When the KSQL artifactStore publishes a message to its Kafka topic, the message key will be a class that
  * implements this interface.
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public interface MessageKey {
-    
+
     /**
      * Returns the message type.
      */
     @JsonIgnore
     public MessageType getType();
-    
+
     /**
      * Returns the key that should be used when partitioning the messages.
      */

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ActionType.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ActionType.java
@@ -19,9 +19,12 @@ package io.apicurio.registry.storage.impl.kafkasql.values;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public enum ActionType {
 
     Create(1), Update(2), Delete(3), Clear(4), Import(5), Reset(6);

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactRuleValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactRuleValue.java
@@ -18,10 +18,12 @@ package io.apicurio.registry.storage.impl.kafkasql.values;
 
 import io.apicurio.registry.storage.dto.RuleConfigurationDto;
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ArtifactRuleValue extends AbstractMessageValue {
 
     private RuleConfigurationDto config;

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactValue.java
@@ -22,10 +22,12 @@ import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ArtifactValue extends ArtifactVersionValue {
 
     private Long globalId;

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactVersionValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactVersionValue.java
@@ -19,12 +19,14 @@ package io.apicurio.registry.storage.impl.kafkasql.values;
 import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
 import io.apicurio.registry.types.ArtifactState;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ArtifactVersionValue extends AbstractMessageValue {
-    
+
     private ArtifactState state;
     private EditableArtifactMetaDataDto metaData;
 

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ContentIdValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ContentIdValue.java
@@ -17,10 +17,12 @@
 package io.apicurio.registry.storage.impl.kafkasql.values;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ContentIdValue extends AbstractMessageValue {
 
     /**

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/GlobalIdValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/GlobalIdValue.java
@@ -17,10 +17,12 @@
 package io.apicurio.registry.storage.impl.kafkasql.values;
 
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class GlobalIdValue extends AbstractMessageValue {
 
     /**

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/GlobalRuleValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/GlobalRuleValue.java
@@ -18,12 +18,14 @@ package io.apicurio.registry.storage.impl.kafkasql.values;
 
 import io.apicurio.registry.storage.dto.RuleConfigurationDto;
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class GlobalRuleValue extends AbstractMessageValue {
-    
+
     private RuleConfigurationDto config;
 
     /**

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/GroupValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/GroupValue.java
@@ -21,10 +21,12 @@ import java.util.Map;
 import io.apicurio.registry.storage.dto.GroupMetaDataDto;
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
 import io.apicurio.registry.types.ArtifactType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class GroupValue extends AbstractMessageValue {
 
     private String description;

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/LogConfigValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/LogConfigValue.java
@@ -18,10 +18,12 @@ package io.apicurio.registry.storage.impl.kafkasql.values;
 
 import io.apicurio.registry.storage.dto.LogConfigurationDto;
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class LogConfigValue extends AbstractMessageValue {
 
     private LogConfigurationDto config;

--- a/storage/sql/pom.xml
+++ b/storage/sql/pom.xml
@@ -227,22 +227,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-maven-plugin</artifactId>
-                        <version>${quarkus.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>native-image</goal>
-                                </goals>
-                                <configuration>
-                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <executions>
                             <execution>
@@ -251,15 +235,20 @@
                                     <goal>verify</goal>
                                 </goals>
                                 <configuration>
-                                    <systemProperties>
+                                    <systemPropertyVariables>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                                    </systemProperties>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>${maven.home}</maven.home>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
             </build>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/storage/sql/src/main/resources/overlay.properties
+++ b/storage/sql/src/main/resources/overlay.properties
@@ -1,3 +1,5 @@
+quarkus.native.resources.includes=io/apicurio/registry/storage/impl/sql/postgresql.ddl
+
 registry.name=Apicurio Registry (SQL)
 
 %dev.quarkus.datasource.db-kind=postgresql

--- a/utils/importexport/pom.xml
+++ b/utils/importexport/pom.xml
@@ -22,6 +22,12 @@
 			<artifactId>apicurio-registry-common</artifactId>
 		</dependency>
 
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
 		<!-- Test Dependencies -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/utils/importexport/pom.xml
+++ b/utils/importexport/pom.xml
@@ -22,11 +22,11 @@
 			<artifactId>apicurio-registry-common</artifactId>
 		</dependency>
 
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
 		<!-- Test Dependencies -->
 		<dependency>

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/ArtifactRuleEntity.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/ArtifactRuleEntity.java
@@ -17,10 +17,12 @@
 package io.apicurio.registry.utils.impexp;
 
 import io.apicurio.registry.types.RuleType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ArtifactRuleEntity extends Entity {
 
     public String groupId;

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/ArtifactVersionEntity.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/ArtifactVersionEntity.java
@@ -21,10 +21,12 @@ import java.util.Map;
 
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ArtifactVersionEntity extends Entity {
 
     public long globalId;

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/ContentEntity.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/ContentEntity.java
@@ -18,9 +18,12 @@ package io.apicurio.registry.utils.impexp;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ContentEntity extends Entity {
 
     public long contentId;

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/Entity.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/Entity.java
@@ -18,11 +18,14 @@ package io.apicurio.registry.utils.impexp;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public abstract class Entity {
-    
+
     @JsonIgnore
     public abstract EntityType getEntityType();
 

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/EntityType.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/EntityType.java
@@ -16,9 +16,12 @@
 
 package io.apicurio.registry.utils.impexp;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public enum EntityType {
 
     Manifest, GlobalRule, Content, Group, ArtifactVersion, ArtifactRule

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/GlobalRuleEntity.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/GlobalRuleEntity.java
@@ -17,10 +17,12 @@
 package io.apicurio.registry.utils.impexp;
 
 import io.apicurio.registry.types.RuleType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class GlobalRuleEntity extends Entity {
 
     public RuleType ruleType;

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/GroupEntity.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/GroupEntity.java
@@ -19,10 +19,12 @@ package io.apicurio.registry.utils.impexp;
 import java.util.Map;
 
 import io.apicurio.registry.types.ArtifactType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class GroupEntity extends Entity {
 
     public String groupId;

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/ManifestEntity.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/ManifestEntity.java
@@ -18,9 +18,12 @@ package io.apicurio.registry.utils.impexp;
 
 import java.util.Date;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * @author eric.wittmann@gmail.com
  */
+@RegisterForReflection
 public class ManifestEntity extends Entity {
 
     public String systemVersion;


### PR DESCRIPTION
This is not 100% finished, images compile and look like it all works fine, but I still want to improve some things

* build scripts are not 100% , I did not add the native images build to the default build script because that will increase build times a lot, therefore our release jobs are not handling the native images, we need to think how to address this @riprasad 
* I want to add some comments to explain why some things have been added
* I have to ensure that quarkus tests are executed against the native executables
* I want to run integration tests or k8s tests using the native images
* With the lessons learnt from #1482 we could re-implement the tenant-manager client (but this will wait)
* TODO - add `@RegisterForReflection` to all datamodel generated from Apicurio Studio