### PR TITLE
release exportV1 tool

### DIFF
--- a/.github/workflows/tool-exportV1-release.yaml
+++ b/.github/workflows/tool-exportV1-release.yaml
@@ -1,0 +1,41 @@
+name: tool-exportV1-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release Version (e.g. 2.0.0.Final)'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Configure Environment (dispatch)
+      if: github.event.inputs.tag_name != null
+      run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
+    - name: Get Upload URL
+      run: |
+        UPLOAD_URL=`curl https://api.github.com/repos/Apicurio/apicurio-registry/releases/tags/$TAG_NAME | jq -r ".upload_url"`
+        echo "UPLOAD_URL=$UPLOAD_URL" >> $GITHUB_ENV
+    - name: Log Environment Variables
+      run: |
+        echo "Tag name:   $TAG_NAME"
+        echo "Upload URL: $UPLOAD_URL"
+    - name: Get maven wrapper
+      run: mvn -N io.takari:maven:wrapper -Dmaven=3.6.3
+    - name: Set version
+      run: ./mvnw versions:set -DnewVersion="$TAG_NAME"
+    - name: Build exportV1 jar
+      run: ./mvnw package -pl utils/exportV1/ -am
+    - name: Upload exportV1 jar
+      id: upload-jar
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ env.UPLOAD_URL }}
+        asset_path: ./utils/exportV1/target/apicurio-registry-utils-exportV1-${{ env.TAG_NAME }}-runner.jar
+        asset_name: apicurio-registry-utils-exportV1-${{ env.TAG_NAME }}.jar
+        asset_content_type: application/octet-stream


### PR DESCRIPTION
This PR adds a GH workflow to build and attach to a release the exportV1 tool.

Because the exportV1 tool is likely only going to be released one or two times this workflow has only a manual dispatch trigger configuration.