### PR TITLE
pr-check script, run quarkus tests inside docker

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -14,6 +14,10 @@
     <packaging>jar</packaging>
     <name>apicurio-registry-app</name>
 
+    <properties>
+        <groups></groups>
+    </properties>
+
     <dependencies>
         <!-- Projects -->
         <dependency>
@@ -291,6 +295,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <groups>${groups}</groups>
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemProperties>
@@ -384,6 +389,12 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>no-docker</id>
+            <properties>
+                <groups>!docker</groups>
+            </properties>
+        </profile>
         <profile>
             <id>native</id>
             <activation>

--- a/app/src/test/java/io/apicurio/registry/ApicurioTestTags.java
+++ b/app/src/test/java/io/apicurio/registry/ApicurioTestTags.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package io.apicurio.registry.storage.util;
-
-import io.quarkus.test.common.QuarkusTestResource;
+package io.apicurio.registry;
 
 /**
  * @author Fabian Martinez
  */
-@QuarkusTestResource(value = PostgreSqlEmbeddedTestResource.class)
-public class SqlStorageTestResources {
+public class ApicurioTestTags {
+
+    public static final String DOCKER = "docker";
 
 }

--- a/app/src/test/java/io/apicurio/registry/auth/AuthTestNoRoles.java
+++ b/app/src/test/java/io/apicurio/registry/auth/AuthTestNoRoles.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.auth;
 
 import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ApicurioTestTags;
 import io.apicurio.registry.rest.client.RegistryClient;
 import io.apicurio.registry.rest.client.RegistryClientFactory;
 import io.apicurio.registry.rest.client.exception.NotAuthorizedException;
@@ -29,6 +30,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -38,7 +40,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
 @TestProfile(AuthTestProfileWithoutRoles.class)
-public class AuthTestRolesDisabled extends AbstractResourceTestBase {
+@Tag(ApicurioTestTags.DOCKER)
+public class AuthTestNoRoles extends AbstractResourceTestBase {
 
     @ConfigProperty(name = "registry.keycloak.url")
     String authServerUrl;

--- a/app/src/test/java/io/apicurio/registry/auth/SimpleAuthTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/SimpleAuthTest.java
@@ -23,9 +23,11 @@ import java.util.Collections;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ApicurioTestTags;
 import io.apicurio.registry.rest.client.RegistryClient;
 import io.apicurio.registry.rest.client.RegistryClientFactory;
 import io.apicurio.registry.rest.client.exception.ArtifactNotFoundException;
@@ -47,6 +49,7 @@ import io.quarkus.test.junit.TestProfile;
  */
 @QuarkusTest
 @TestProfile(AuthTestProfile.class)
+@Tag(ApicurioTestTags.DOCKER)
 public class SimpleAuthTest extends AbstractResourceTestBase {
 
     @ConfigProperty(name = "registry.keycloak.url")

--- a/app/src/test/java/io/apicurio/registry/events/KafkaEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/events/KafkaEventsTest.java
@@ -37,12 +37,14 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.rnorth.ducttape.unreliables.Unreliables;
 
 import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ApicurioTestTags;
 import io.apicurio.registry.events.dto.RegistryEventType;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.IoUtil;
@@ -56,6 +58,7 @@ import io.quarkus.test.junit.TestProfile;
 @QuarkusTest
 @TestProfile(KafkaEventsProfile.class)
 @DisabledIfSystemProperty(named = "kafka.storage", matches = "true")
+@Tag(ApicurioTestTags.DOCKER)
 public class KafkaEventsTest extends AbstractResourceTestBase {
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/maven/MojoAuthTest.java
+++ b/app/src/test/java/io/apicurio/registry/maven/MojoAuthTest.java
@@ -16,6 +16,7 @@
 
 package io.apicurio.registry.maven;
 
+import io.apicurio.registry.ApicurioTestTags;
 import io.apicurio.registry.auth.Auth;
 import io.apicurio.registry.auth.AuthTestProfile;
 import io.apicurio.registry.auth.KeycloakAuth;
@@ -27,6 +28,7 @@ import io.quarkus.test.junit.TestProfile;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -34,6 +36,7 @@ import java.util.Collections;
 
 @QuarkusTest
 @TestProfile(AuthTestProfile.class)
+@Tag(ApicurioTestTags.DOCKER)
 public class MojoAuthTest extends RegistryMojoTestBase {
 
     @ConfigProperty(name = "registry.keycloak.url")

--- a/build-deploy.sh
+++ b/build-deploy.sh
@@ -8,8 +8,8 @@ IMAGE_REGISTRY="quay.io"
 IMAGE_ORG="rhoas"
 IMAGE_TAG="latest"
 
-SKIP_TESTS=true # skipping tests since tests require docker. fabian working to fix this
-MVN_BUILD_COMMAND="mvn clean install -Pprod -Psql -Pkafkasql -Pmultitenancy -DskipTests=${SKIP_TESTS}"
+SKIP_TESTS=false
+MVN_BUILD_COMMAND="mvn clean install -Pprod -Pno-docker -Psql -Pmultitenancy -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false -DskipTests=${SKIP_TESTS}"
 
 SERVICE_REGISTRY_IMAGE_NAME="srs-service-registry"
 SERVICE_REGISTRY_DOCKER_BUILD_COMMAND="docker build -f ./distro/docker/target/docker/Dockerfile.sql.jvm -t ${IMAGE_REGISTRY}/${IMAGE_ORG}/${SERVICE_REGISTRY_IMAGE_NAME}:${IMAGE_TAG} ./distro/docker/target/docker"
@@ -63,7 +63,11 @@ build_project() {
     # AppSRE environments doesn't has maven, jdk11, node and yarn which are required depencies for building this project
     # Installing these dependencies is a tedious task and also since it's a shared instance, installing the required versions of these dependencies is not possible sometimes
     # Hence, using custom container that packs the required dependencies with the specific required versions
-    docker run --rm -t -u $(id -u):$(id -g) -w /home/user -v $(pwd):/home/user quay.io/riprasad/srs-project-builder:latest bash -c "${MVN_BUILD_COMMAND}"
+    # docker run --rm -t -u $(id -u):$(id -g) -w /home/user -v $(pwd):/home/user quay.io/riprasad/srs-project-builder:latest bash -c "${MVN_BUILD_COMMAND}"
+    
+    #TODO confirm we are ok with this, using this ci-tools image is the recomended way, but using this we don't control the java nor maven version...
+    docker pull quay.io/app-sre/mk-ci-tools:latest
+    docker run -v $(pwd):/opt/srs -w /opt/srs -e HOME=/tmp -u $(id -u) quay.io/app-sre/mk-ci-tools:latest ${MVN_BUILD_COMMAND}
 }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,7 @@
         <test-containers.version>1.15.3</test-containers.version>
         <keycloak.testcontainers.version>1.6.1</keycloak.testcontainers.version>
         <keycloak-admin-client.version>12.0.3</keycloak-admin-client.version>
+        <embedded-postgres.version>1.2.10</embedded-postgres.version>
     </properties>
 
     <dependencyManagement>

--- a/pr-check.sh
+++ b/pr-check.sh
@@ -4,10 +4,8 @@ set -eo pipefail
 
 
 PROJECT_NAME="multitenant-service-registry"
-
-SKIP_TESTS=true # skipping tests since tests require docker. fabian working to fix this
-MVN_BUILD_COMMAND="mvn clean install -Pprod -Psql -Pkafkasql -Pmultitenancy -DskipTests=${SKIP_TESTS}"
-
+SKIP_TESTS=false
+MVN_BUILD_COMMAND="mvn clean install -Pno-docker -Pprod -Psql -Pmultitenancy -am -pl storage/sql,multitenancy/tenant-manager-api -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false -DskipTests=${SKIP_TESTS}"
 
 display_usage() {
     cat <<EOT
@@ -40,9 +38,12 @@ build_project() {
     # AppSRE environments doesn't has maven, jdk11, node and yarn which are required depencies for building this project
     # Installing these dependencies is a tedious task and also since it's a shared instance, installing the required versions of these dependencies is not possible sometimes
     # Hence, using custom container that packs the required dependencies with the specific required versions
-    docker run --rm -t -u $(id -u):$(id -g) -w /home/user -v $(pwd):/home/user quay.io/riprasad/srs-project-builder:latest bash -c "${MVN_BUILD_COMMAND}"
+    # docker run --rm -t -u $(id -u):$(id -g) -w /home/user -v $(pwd):/home/user quay.io/riprasad/srs-project-builder:latest bash -c "${MVN_BUILD_COMMAND}"
+    
+    #TODO confirm we are ok with this, using this ci-tools image is the recomended way, but using this we don't control the java nor maven version...
+    docker pull quay.io/app-sre/mk-ci-tools:latest
+    docker run -v $(pwd):/opt/srs -w /opt/srs -e HOME=/tmp -u $(id -u) quay.io/app-sre/mk-ci-tools:latest ${MVN_BUILD_COMMAND}
 }
-
 
 main() { 
 

--- a/storage/sql/pom.xml
+++ b/storage/sql/pom.xml
@@ -14,6 +14,10 @@
     <packaging>jar</packaging>
     <name>apicurio-registry-storage-sql</name>
     
+    <properties>
+        <groups></groups>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>io.apicurio</groupId>
@@ -50,11 +54,12 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>${test-containers.version}</version><!--$NO-MVN-MAN-VER$-->
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
+            <version>${embedded-postgres.version}</version><!--$NO-MVN-MAN-VER$-->
             <scope>test</scope>
         </dependency>
+        
     </dependencies>
     
     <build>
@@ -161,6 +166,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <groups>${groups}</groups>
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemProperties>
@@ -205,6 +211,12 @@
     </build>
     
     <profiles>
+        <profile>
+            <id>no-docker</id>
+            <properties>
+                <groups>!docker</groups>
+            </properties>
+        </profile>
         <profile>
             <id>native</id>
             <activation>

--- a/storage/sql/src/test/java/io/apicurio/registry/storage/util/PostgreSqlEmbeddedTestResource.java
+++ b/storage/sql/src/test/java/io/apicurio/registry/storage/util/PostgreSqlEmbeddedTestResource.java
@@ -16,36 +16,40 @@
 
 package io.apicurio.registry.storage.util;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.testcontainers.containers.PostgreSQLContainer;
-
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 
 /**
  * @author Fabian Martinez
  */
-public class PostgreSqlTestContainerResource implements QuarkusTestResourceLifecycleManager {
+public class PostgreSqlEmbeddedTestResource implements QuarkusTestResourceLifecycleManager {
 
-    @SuppressWarnings("rawtypes")
-    private PostgreSQLContainer database;
+    private EmbeddedPostgres database;
 
     /**
      * @see io.quarkus.test.common.QuarkusTestResourceLifecycleManager#start()
      */
     @Override
     public Map<String, String> start() {
-        database = new PostgreSQLContainer<>("postgres:12-alpine");
-        database.start();
 
-        String datasourceUrl = "jdbc:postgresql://" + database.getContainerIpAddress() + ":" +
-                database.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT) + "/" + database.getDatabaseName();
+        try {
+            database = EmbeddedPostgres.start();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+
+        String datasourceUrl = database.getJdbcUrl("postgres", "postgres");
 
         Map<String, String> props = new HashMap<>();
         props.put("quarkus.datasource.jdbc.url", datasourceUrl);
-        props.put("quarkus.datasource.username", database.getUsername());
-        props.put("quarkus.datasource.password", database.getPassword());
+        props.put("quarkus.datasource.username", "postgres");
+        props.put("quarkus.datasource.password", "postgres");
         return props;
     }
 
@@ -54,7 +58,11 @@ public class PostgreSqlTestContainerResource implements QuarkusTestResourceLifec
      */
     @Override
     public void stop() {
-        database.stop();
+        try {
+            database.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
 }


### PR DESCRIPTION
Small modifications to our quarkus tests so we can run them without depending on docker.

Modifications to pr-check and build-deploy scripts to use the latest modifications.