### PR TITLE
chore: add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/target
+.idea
+.github
+.git
+**/node_modules


### PR DESCRIPTION
This allows docker to be run without transferring gigabytes of context