### PR TITLE
Implemented support for "gettoken" style auth in the UI

### DIFF
--- a/app/src/main/resources-unfiltered/META-INF/resources/apidocs/index.html
+++ b/app/src/main/resources-unfiltered/META-INF/resources/apidocs/index.html
@@ -56,6 +56,7 @@
         </div>
         
         <!-- IBM Compatible API (v6) -->
+        <!--
         <div class="apidocs-api">
           <div class="name">IBM Schema Registry API (Version 1)</div>
           <div class="description">
@@ -66,6 +67,7 @@
             <a href="/apis/ibmcompat/v1" class="url"><code>/apis/ibmcompat/v1</code></a>
           </div>
         </div>
+         -->
         
         <!-- CNCF Schema Registry API (v0) -->
         <div class="apidocs-api">

--- a/ui/src/services/auth/auth.service.ts
+++ b/ui/src/services/auth/auth.service.ts
@@ -166,6 +166,13 @@ export class AuthService implements Service {
                     config.headers.Authorization = `Bearer ${this.getToken()}`;
                     return Promise.resolve(config);
                 });
+            } else if (self.config.authType() === "gettoken") {
+                this.logger.info("[AuthService] Using 'getToken' auth type.")
+                return self.config.authGetToken()().then(token => {
+                    this.logger.info("[AuthService] Token acquired.");
+                    config.headers.Authorization = `Bearer ${token}`;
+                    return Promise.resolve(config);
+                });
             } else {
                 return Promise.resolve(config);
             }

--- a/ui/src/services/config/config.service.ts
+++ b/ui/src/services/config/config.service.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {ConfigType, FeaturesConfig, KeycloakJsAuthConfig} from './config.type';
+import {ConfigType, FeaturesConfig, GetTokenAuthConfig, KeycloakJsAuthConfig} from './config.type';
 import {Service} from "../baseService";
 
 const DEFAULT_CONFIG: ConfigType = {
@@ -126,6 +126,17 @@ export class ConfigService implements Service {
             return auth.options;
         }
         return {};
+    }
+
+    public authGetToken(): () => Promise<string> {
+        if (this.config.auth) {
+            const auth: GetTokenAuthConfig = this.config.auth as GetTokenAuthConfig;
+            return auth.getToken;
+        }
+        return () => {
+            console.error("[ConfigService] Missing: 'getToken' from auth config.");
+            return Promise.resolve("");
+        };
     }
 
     public featureMultiTenant(): boolean {

--- a/ui/src/services/config/config.type.ts
+++ b/ui/src/services/config/config.type.ts
@@ -46,7 +46,7 @@ export interface NoneAuthConfig extends AuthConfig {
 
 // Used when `type=gettoken`
 export interface GetTokenAuthConfig extends AuthConfig {
-    getToken: () => string;
+    getToken: () => Promise<string>;
 }
 
 export interface ConfigType {


### PR DESCRIPTION
This modification supports authentication when the UI is used in a federated (micro UI) environment.  This allows the host page to pass a `getToken` function into the federate components.  That can be done via the standard `config` property currently required by all the federated components.  The config should look something like this:

```javascript
{
        apis: "http://localhost:8080/t/:tenantId/apis",
        config: {
            artifacts: {
                url: "url-to-artifacts-api"
            },
            auth: {
                type: "gettoken",
                getToken: function() => Promise<string>
            },
            features: {
                readOnly: false,
                breadcrumbs: false,
                multiTenant: true
            },
            ui: {
                navPrefixPath: "navigation-prefix-path"
            }
        }
    }
```

The new bit is the `auth` section.  The type of auth should be set to `gettoken` and then the `getToken` property should be a function with the following signature:

```typescript
export interface GetTokenAuthConfig extends AuthConfig {
    getToken: () => Promise<string>;
}
```
