### PR TITLE
Fix json_name option bug with FileDescriptionUtils parser

### DIFF
--- a/utils/protobuf-schema-utilities/pom.xml
+++ b/utils/protobuf-schema-utilities/pom.xml
@@ -23,6 +23,12 @@
             <groupId>com.squareup.wire</groupId>
             <artifactId>wire-schema</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -53,11 +59,36 @@
                         <phase>generate-sources</phase>
                         <goals>
                             <goal>compile</goal>
+                            <goal>test-compile</goal>
                         </goals>
                         <configuration>
                             <protocArtifact>
                                 com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
                             </protocArtifact>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dist</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/target/generated-test-sources/protobuf/</directory>
+                                    <filtering>false</filtering>
+                                    <excludes>
+                                    </excludes>
+                                </resource>
+                            </resources>
                         </configuration>
                     </execution>
                 </executions>

--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
@@ -436,10 +436,13 @@ public class FileDescriptorUtils {
             OptionElement option = new OptionElement(JSON_NAME_OPTION, kind, fd.getJsonName(), false);
             options.add(option);
         }
+        //Implicitly jsonName to null as Options is already setting it. Setting it here results in duplicate json_name
+        //option in inferred schema.
+        String jsonName = null;
         String defaultValue = fd.hasDefaultValue() && fd.getDefaultValue() != null ? fd.getDefaultValue()
                 : null;
         return new FieldElement(DEFAULT_LOCATION, inOneof ? null : label(file, fd), dataType(fd), name,
-                defaultValue, fd.getJsonName(), fd.getNumber(), "", options.build());
+                defaultValue, jsonName, fd.getNumber(), "", options.build());
     }
 
     private static Field.Label label(FileDescriptorProto file, FieldDescriptorProto fd) {

--- a/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
+++ b/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
@@ -1,0 +1,26 @@
+package io.apicurio.registry.utils.protobuf.schema;
+
+import com.google.protobuf.Descriptors;
+import com.squareup.wire.schema.internal.parser.ProtoFileElement;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FileDescriptorUtilsTest {
+
+    @Test
+    public void fileDescriptorToProtoFile_ParsesJsonNameOptionCorrectly() {
+        Descriptors.FileDescriptor fileDescriptor = TestOrdering.getDescriptor().getFile();
+        String expectedFieldWithJsonName = "required string street = 1 [json_name = \"Address_Street\"];\n";
+        String expectedFieldWithoutJsonName = "optional int32 zip = 2;\n";
+
+        ProtoFileElement protoFile = FileDescriptorUtils.fileDescriptorToProtoFile(fileDescriptor.toProto());
+
+        String actualSchema = protoFile.toSchema();
+
+        //TODO: Need a better way to compare schema strings.
+        assertTrue(actualSchema.contains(expectedFieldWithJsonName));
+        assertTrue(actualSchema.contains(expectedFieldWithoutJsonName));
+    }
+
+}

--- a/utils/protobuf-schema-utilities/src/test/proto/TestOrdering.proto
+++ b/utils/protobuf-schema-utilities/src/test/proto/TestOrdering.proto
@@ -1,0 +1,15 @@
+syntax = "proto2";
+
+package io.apicurio.registry.utils.protobuf.schema;
+
+message Address {
+  required string street = 1 [json_name = "Address_Street"];
+
+  optional int32 zip = 2;
+
+  optional string city = 3;
+}
+
+message Customer {
+  required string name = 1;
+}


### PR DESCRIPTION
This will fix the [#1617 issue](https://github.com/Apicurio/apicurio-registry/issues/1617). 

Parsed schema looks like below with the fix,

```
// Proto schema formatted by Wire, do not edit.
// Source: 

package io.apicurio.registry.utils.protobuf.schema;

message Address {
  required string street = 1 [json_name = "Address_Street"];

  optional int32 zip = 2;

  optional string city = 3;
}

message Customer {
  required string name = 1;
}

```

