### PR TITLE
Chrome YAML file type recognition fix;

### DIFF
--- a/ui/src/services/groups/groups.service.ts
+++ b/ui/src/services/groups/groups.service.ts
@@ -280,7 +280,7 @@ export class GroupsService extends BaseService {
         try {
             const xmlParser: DOMParser = new DOMParser();
             const dom: Document = xmlParser.parseFromString(content, "application/xml");
-            const isParseError: boolean = dom.documentElement.nodeName === "parsererror";
+            const isParseError: boolean = dom.getElementsByTagName("parsererror").length !== 0;
             return !isParseError;
         } catch (e) {
             return false;


### PR DESCRIPTION
This pull request should fix wrong YAML OpenAPI file recognition, which was caused by different result of XML error parsing in Chrome browser.