### PR TITLE
Fix expiration check

### DIFF
--- a/app/src/test/resources/test-realm.json
+++ b/app/src/test/resources/test-realm.json
@@ -4,7 +4,7 @@
   "notBefore": 1600933598,
   "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 0,
-  "accessTokenLifespan": 300,
+  "accessTokenLifespan": 8,
   "accessTokenLifespanForImplicitFlow": 900,
   "ssoSessionIdleTimeout": 1800,
   "ssoSessionMaxLifespan": 36000,


### PR DESCRIPTION
This fixes the expiration check since the previous one was setting the expiration time when verifying the token so it was actually never being checked properly, basically, the `isExpired` check would return false even when the token was expired. This will fix that issue.

This also reduces the test access token lifespan so the mechanism is actually triggered.