### PR TITLE
Add ability to store roles in keycloak with a facade for the keycloak api

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -151,6 +151,10 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client</artifactId>
+        </dependency>
 
         <!-- Kafka Connect -->
         <dependency>
@@ -259,11 +263,6 @@
         <dependency>
             <groupId>com.github.dasniko</groupId>
             <artifactId>testcontainers-keycloak</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-admin-client</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
@@ -56,6 +56,9 @@ public class AuthConfig {
     @ConfigProperty(name = "registry.auth.role-source", defaultValue = "token")
     String roleSource;
 
+    @ConfigProperty(name = "registry.auth.role-mapping-storage-source", defaultValue = "database")
+    String rolesMappingStorageSource;
+
     @ConfigProperty(name = "registry.auth.tenant-owner-is-admin.enabled", defaultValue = "true")
     boolean tenantOwnerIsAdminEnabled;
 
@@ -76,6 +79,18 @@ public class AuthConfig {
 
     @ConfigProperty(name = "registry.auth.admin-override.claim-value", defaultValue = "true")
     String adminOverrideClaimValue;
+
+    @ConfigProperty(name = "auth.admin.server-url")
+    String AdminAuthServerUrl;
+
+    @ConfigProperty(name = "auth.admin.realm")
+    String adminRealm;
+
+    @ConfigProperty(name = "auth.admin.client-id")
+    String adminClientId;
+
+    @ConfigProperty(name = "auth.admin.client-secret")
+    String adminClientSecret;
 
     @PostConstruct
     void onConstruct() {
@@ -119,7 +134,26 @@ public class AuthConfig {
     }
 
     public boolean isApplicationRbacEnabled() {
-        return this.roleBasedAuthorizationEnabled && "application".equals(getRoleSource());
+        return this.roleBasedAuthorizationEnabled && ("application".equals(getRoleSource()) || "keycloak".equals(rolesMappingStorageSource));
     }
 
+    public String getRolesMappingStorageSource() {
+        return this.rolesMappingStorageSource;
+    }
+
+    public String getAdminAuthServerUrl() {
+        return AdminAuthServerUrl;
+    }
+
+    public String getAdminRealm() {
+        return adminRealm;
+    }
+
+    public String getAdminClientId() {
+        return adminClientId;
+    }
+
+    public String getAdminClientSecret() {
+        return adminClientSecret;
+    }
 }

--- a/app/src/main/java/io/apicurio/registry/auth/DatabaseRolesSource.java
+++ b/app/src/main/java/io/apicurio/registry/auth/DatabaseRolesSource.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.auth;
+
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.RegistryStorageException;
+import io.apicurio.registry.storage.dto.RoleMappingDto;
+
+import java.util.List;
+
+public class DatabaseRolesSource implements RolesSource {
+
+    private final RegistryStorage registryStorage;
+
+    public DatabaseRolesSource(RegistryStorage registryStorage) {
+        this.registryStorage = registryStorage;
+    }
+
+    @Override
+    public void createRoleMapping(String principalId, String role) throws RegistryStorageException {
+        registryStorage.createRoleMapping(principalId, role);
+    }
+
+    @Override
+    public List<RoleMappingDto> getRoleMappings() throws RegistryStorageException {
+        return registryStorage.getRoleMappings();
+    }
+
+    @Override
+    public RoleMappingDto getRoleMapping(String principalId) throws RegistryStorageException {
+        return registryStorage.getRoleMapping(principalId);
+    }
+
+    @Override
+    public String getRoleForPrincipal(String principalId) throws RegistryStorageException {
+        return registryStorage.getRoleForPrincipal(principalId);
+    }
+
+    @Override
+    public void updateRoleMapping(String principalId, String role) throws RegistryStorageException {
+        registryStorage.updateRoleMapping(principalId, role);
+    }
+
+    @Override
+    public void deleteRoleMapping(String principalId) throws RegistryStorageException {
+        registryStorage.deleteRoleMapping(principalId);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/auth/KeycloakRolesSource.java
+++ b/app/src/main/java/io/apicurio/registry/auth/KeycloakRolesSource.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.auth;
+
+import io.apicurio.registry.mt.TenantContext;
+import io.apicurio.registry.storage.RegistryStorageException;
+import io.apicurio.registry.storage.dto.RoleMappingDto;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.RoleResource;
+import org.keycloak.representations.idm.ClientRepresentation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class KeycloakRolesSource implements RolesSource {
+
+    private static final String GRANT_TYPE = "client_credentials";
+
+    private final AuthConfig authConfig;
+    private final TenantContext tenantContext;
+    Keycloak keycloak;
+
+    public KeycloakRolesSource(AuthConfig authConfig, TenantContext tenantContext) {
+        this.authConfig = authConfig;
+        this.tenantContext = tenantContext;
+        this.keycloak = KeycloakBuilder.builder()
+                .serverUrl(authConfig.getAdminAuthServerUrl())
+                .realm(authConfig.getAdminRealm())
+                .clientId(authConfig.getAdminClientId())
+                .clientSecret(authConfig.getAdminClientSecret())
+                .grantType(GRANT_TYPE)
+                .build();
+    }
+
+    @Override
+    public void createRoleMapping(String principalId, String role) throws RegistryStorageException {
+
+        final RoleResource roleResource = keycloak.realm(authConfig.getAdminRealm())
+                .clients()
+                .get(tenantContext.tenantId())
+                .roles()
+                .get(role);
+    }
+
+    @Override
+    public List<RoleMappingDto> getRoleMappings() throws RegistryStorageException {
+        final List<RoleMappingDto> roleMappings = new ArrayList<>();
+        final List<ClientRepresentation> tenantClientRepresentation = keycloak.realm(authConfig.getAdminRealm())
+                .clients()
+                .findByClientId(tenantContext.tenantId());
+        if (tenantClientRepresentation.size() == 1) {
+            final ClientResource clientResource = keycloak.realm(authConfig.getAdminRealm()).clients().get(tenantClientRepresentation.get(0).getId());
+            clientResource.roles().list().forEach(roleRepresentation -> {
+                final RoleResource roleResource = clientResource.roles().get(roleRepresentation.getName());
+                roleResource.getRoleUserMembers().forEach(userRepresentation -> {
+                    final RoleMappingDto roleMappingDto = new RoleMappingDto();
+                    roleMappingDto.setPrincipalId(userRepresentation.getUsername());
+                    roleMappingDto.setRole(roleRepresentation.getName());
+                    roleMappings.add(roleMappingDto);
+                });
+
+            });
+            return roleMappings;
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public RoleMappingDto getRoleMapping(String principalId) throws RegistryStorageException {
+        return null;
+    }
+
+    @Override
+    public String getRoleForPrincipal(String principalId) throws RegistryStorageException {
+        return null;
+    }
+
+    @Override
+    public void updateRoleMapping(String principalId, String role) throws RegistryStorageException {
+
+    }
+
+    @Override
+    public void deleteRoleMapping(String principalId) throws RegistryStorageException {
+
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/auth/RolesSource.java
+++ b/app/src/main/java/io/apicurio/registry/auth/RolesSource.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.auth;
+
+import io.apicurio.registry.storage.RegistryStorageException;
+import io.apicurio.registry.storage.dto.RoleMappingDto;
+
+import java.util.List;
+
+public interface RolesSource {
+
+    /**
+     * Creates a role mapping for a user.
+     * @param principalId
+     * @param role
+     */
+    public void createRoleMapping(String principalId, String role) throws RegistryStorageException;
+
+    /**
+     * Gets the list of all the role mappings in the registry.
+     */
+    public List<RoleMappingDto> getRoleMappings() throws RegistryStorageException;
+
+    /**
+     * Gets the details of a single role mapping.
+     * @param principalId
+     */
+    public RoleMappingDto getRoleMapping(String principalId) throws RegistryStorageException;
+
+    /**
+     * Gets the role for a single user.  This returns null if there is no role mapped for
+     * the given principal.
+     * @param principalId
+     */
+    public String getRoleForPrincipal(String principalId) throws RegistryStorageException;
+
+    /**
+     * Updates a single role mapping.
+     * @param principalId
+     * @param role
+     */
+    public void updateRoleMapping(String principalId, String role) throws RegistryStorageException;
+
+    /**
+     * Deletes a single role mapping.
+     * @param principalId
+     */
+    public void deleteRoleMapping(String principalId) throws RegistryStorageException;
+}

--- a/app/src/main/java/io/apicurio/registry/auth/RolesSourceProducer.java
+++ b/app/src/main/java/io/apicurio/registry/auth/RolesSourceProducer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.auth;
+
+import io.apicurio.registry.mt.TenantContext;
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.types.Current;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class RolesSourceProducer {
+
+    @Inject
+    AuthConfig authConfig;
+
+    @Inject
+    @Current
+    RegistryStorage registryStorage;
+
+    @Inject
+    TenantContext tenantContext;
+
+    @Produces
+    @ApplicationScoped
+    public RolesSource initRolesSource() {
+        if ("database".equals(authConfig.getRolesMappingStorageSource())) {
+            return new DatabaseRolesSource(registryStorage);
+        } else {
+            return new KeycloakRolesSource(authConfig, tenantContext);
+        }
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/mt/OidcConfigResolver.java
+++ b/app/src/main/java/io/apicurio/registry/mt/OidcConfigResolver.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.mt;
+
+import io.apicurio.multitenant.api.datamodel.RegistryTenant;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.runtime.StartupEvent;
+import io.vertx.ext.web.RoutingContext;
+import org.slf4j.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class OidcConfigResolver implements TenantConfigResolver {
+
+    @Inject
+    Logger log;
+
+    @Inject
+    MultitenancyProperties mtProperties;
+
+    @Inject
+    TenantMetadataService tenantMetadataService;
+
+    String multitenancyBasePath;
+
+    private static final int TENANT_ID_POSITION = 2;
+
+    void init(@Observes StartupEvent ev) {
+        if (mtProperties.isMultitenancyEnabled()) {
+            log.info("Registry running with multitenancy enabled");
+        }
+        multitenancyBasePath = "/" + mtProperties.getNameMultitenancyBasePath() + "/";
+    }
+
+    @Override
+    public OidcTenantConfig resolve(RoutingContext context) {
+        if (!mtProperties.isMultitenancyEnabled()) {
+            log.debug("Multitenancy is disabled, falling back to default oidc config");
+            return null;
+        } else {
+            final String uri = context.request().uri();
+
+            if (uri.startsWith(multitenancyBasePath)) {
+                String[] tokens = uri.split("/");
+                // 0 is empty
+                // 1 is t
+                // 2 is the tenantId
+                String tenantId = tokens[TENANT_ID_POSITION];
+                final RegistryTenant tenant = tenantMetadataService.getTenant(tenantId);
+                final OidcTenantConfig tenantOidcConfig = new OidcTenantConfig();
+                tenantOidcConfig.setTenantId(tenant.getTenantId());
+                tenantOidcConfig.setAuthServerUrl(tenant.getAuthServerUrl());
+                tenantOidcConfig.setClientId(tenant.getAuthClientId());
+
+                return tenantOidcConfig;
+            }
+        }
+        log.debug("Multitenantcy is disabled, falling back to default oidc config");
+        return null;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/rest/v2/AdminResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/AdminResourceImpl.java
@@ -34,6 +34,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 
+import io.apicurio.registry.auth.RolesSource;
 import org.slf4j.Logger;
 
 import io.apicurio.registry.auth.Authorized;
@@ -84,6 +85,9 @@ public class AdminResourceImpl implements AdminResource {
 
     @Inject
     LogConfigurationService logConfigService;
+
+    @Inject
+    RolesSource rolesSource;
 
     /**
      * @see io.apicurio.registry.rest.v2.AdminResource#listGlobalRules()
@@ -297,7 +301,7 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style=AuthorizedStyle.None, level=AuthorizedLevel.Admin)
     @RoleBasedAccessApiOperation
     public void createRoleMapping(RoleMapping data) {
-        storage.createRoleMapping(data.getPrincipalId(), data.getRole().name());
+        rolesSource.createRoleMapping(data.getPrincipalId(), data.getRole().name());
     }
 
     /**
@@ -307,7 +311,7 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style=AuthorizedStyle.None, level=AuthorizedLevel.Admin)
     @RoleBasedAccessApiOperation
     public List<RoleMapping> listRoleMappings() {
-        List<RoleMappingDto> mappings = storage.getRoleMappings();
+        List<RoleMappingDto> mappings = rolesSource.getRoleMappings();
         return mappings.stream().map(dto -> {
             return dtoToRoleMapping(dto);
         }).collect(Collectors.toList());
@@ -320,7 +324,7 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style=AuthorizedStyle.None, level=AuthorizedLevel.Admin)
     @RoleBasedAccessApiOperation
     public RoleMapping getRoleMapping(String principalId) {
-        RoleMappingDto dto = storage.getRoleMapping(principalId);
+        RoleMappingDto dto = rolesSource.getRoleMapping(principalId);
         return dtoToRoleMapping(dto);
     }
 
@@ -331,7 +335,7 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style=AuthorizedStyle.None, level=AuthorizedLevel.Admin)
     @RoleBasedAccessApiOperation
     public void updateRoleMapping(String principalId, UpdateRole data) {
-        storage.updateRoleMapping(principalId, data.getRole().name());
+        rolesSource.updateRoleMapping(principalId, data.getRole().name());
     }
 
     /**
@@ -341,7 +345,7 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style=AuthorizedStyle.None, level=AuthorizedLevel.Admin)
     @RoleBasedAccessApiOperation
     public void deleteRoleMapping(String principalId) {
-        storage.deleteRoleMapping(principalId);
+        rolesSource.deleteRoleMapping(principalId);
     }
 
     private static RoleMapping dtoToRoleMapping(RoleMappingDto dto) {

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -119,6 +119,11 @@ registry.auth.enabled=${AUTH_ENABLED:false}
 registry.auth.owner-only-authorization=${OWNER_ONLY_AUTHZ_ENABLED:false}
 registry.auth.role-based-authorization=${ROLE_BASED_AUTHZ_ENABLED:false}
 registry.auth.role-source=${ROLE_BASED_AUTHZ_SOURCE:token}
+registry.auth.role-mapping-storage-source=${ROLE_MAPPING_STORAGE_SOURCE:database}
+registry.auth.admin.server-url=${AUTH_ADMIN_SERVER_URL:}
+auth.admin.realm=${AUTH_ADMIN_REALM:}
+auth.admin.client-id=${AUTH_ADMIN_CLIENT_ID:}
+auth.admin.client-secret=${AUTH_ADMIN_CLIENT_SECRET:}
 # Admin override indicates whether the existence of a role somewhere 
 # other than the primary role source can override the 'isAdmin' logic.  This
 # is useful when using role-source=database to bypass the DB check when the
@@ -184,16 +189,14 @@ quarkus.http.non-application-root-path=/
 
 # Storage
 %dev.quarkus.datasource.db-kind=h2
-%dev.quarkus.datasource.jdbc.url=${REGISTRY_DATASOURCE_URL:jdbc:h2:mem:registry_db}
-%dev.quarkus.datasource.username=${REGISTRY_DATASOURCE_USERNAME:sa}
-%dev.quarkus.datasource.password=${REGISTRY_DATASOURCE_PASSWORD:sa}
+%dev.quarkus.datasource.jdbc.url=${REGISTRY_DATASOURCE_URL:jdbc:h2:~/data/registry1;AUTO_SERVER=TRUE}
 %dev.quarkus.datasource.jdbc.initial-size=20
 %dev.quarkus.datasource.jdbc.min-size=20
 %dev.quarkus.datasource.jdbc.max-size=100
 %dev.registry.sql.init=true
 
 %prod.quarkus.datasource.db-kind=h2
-%prod.quarkus.datasource.jdbc.url=${REGISTRY_DATASOURCE_URL:jdbc:h2:mem:registry_db}
+%prod.quarkus.datasource.jdbc.url=${REGISTRY_DATASOURCE_URL:jdbc:h2:~/data/registry;AUTO_SERVER=TRUE}
 %prod.quarkus.datasource.username=${REGISTRY_DATASOURCE_USERNAME:sa}
 %prod.quarkus.datasource.password=${REGISTRY_DATASOURCE_PASSWORD:sa}
 %prod.quarkus.datasource.jdbc.initial-size=20

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/api/TenantsResourceImpl.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/api/TenantsResourceImpl.java
@@ -62,6 +62,7 @@ public class TenantsResourceImpl implements TenantsResource {
 
         required(tenantRequest.getTenantId(), "TenantId is mandatory");
         required(tenantRequest.getOrganizationId(), "OrganizationId is mandatory");
+        required(tenantRequest.getClientId(), "ClientId is mandatory");
 
         RegistryTenantDto tenant = new RegistryTenantDto();
 
@@ -71,6 +72,10 @@ public class TenantsResourceImpl implements TenantsResource {
         tenant.setDescription(tenantRequest.getDescription());
         tenant.setCreatedOn(new Date());
         tenant.setCreatedBy(tenantRequest.getCreatedBy());
+        tenant.setAuthClientId(tenantRequest.getClientId());
+        if (tenantRequest.getAuthServerUrl() != null) {
+            tenant.setAuthServerUrl(tenantRequest.getAuthServerUrl());
+        }
 
         if (tenantRequest.getResources() != null) {
             //find duplicates, invalid config

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/storage/dto/RegistryTenantDto.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/storage/dto/RegistryTenantDto.java
@@ -58,6 +58,12 @@ public class RegistryTenantDto {
     @Column(name = "description", length = 2048)
     private String description;
 
+    @Column(name = "authServerUrl")
+    private String authServerUrl;
+
+    @Column(name = "authClientId")
+    private String authClientId;
+
     @OneToMany(mappedBy = "tenant", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RegistryTenantResourceLimitDto> resources = new ArrayList<>();
 
@@ -119,6 +125,22 @@ public class RegistryTenantDto {
         this.description = description;
     }
 
+    public String getAuthServerUrl() {
+        return authServerUrl;
+    }
+
+    public void setAuthServerUrl(String authServerUrl) {
+        this.authServerUrl = authServerUrl;
+    }
+
+    public String getAuthClientId() {
+        return authClientId;
+    }
+
+    public void setAuthClientId(String authClientId) {
+        this.authClientId = authClientId;
+    }
+
     public List<RegistryTenantResourceLimitDto> getResources() {
         return resources;
     }
@@ -145,6 +167,8 @@ public class RegistryTenantDto {
         t.setOrganizationId(this.organizationId);
         t.setName(this.getName());
         t.setDescription(this.getDescription());
+        t.setAuthClientId(this.authClientId);
+        t.setAuthServerUrl(this.authServerUrl);
         t.setResources(
                 Optional.ofNullable(this.resources)
                     .map(Collection::stream)

--- a/multitenancy/tenant-manager-api/src/main/resources/application.properties
+++ b/multitenancy/tenant-manager-api/src/main/resources/application.properties
@@ -5,7 +5,7 @@
 %test.quarkus.hibernate-orm.log.sql=false
 
 %dev.quarkus.datasource.db-kind=h2
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:~/data/registry;AUTO_SERVER=TRUE
 %dev.quarkus.hibernate-orm.database.generation=update
 
 %dev.quarkus.hibernate-orm.log.sql=true

--- a/multitenancy/tenant-manager-datamodel/src/main/java/io/apicurio/multitenant/api/datamodel/NewRegistryTenantRequest.java
+++ b/multitenancy/tenant-manager-datamodel/src/main/java/io/apicurio/multitenant/api/datamodel/NewRegistryTenantRequest.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "resources",
     "name",
     "description",
-    "createdBy"
+    "createdBy",
+    "authServerUrl",
+    "clientId"
 
 })
 @Generated("jsonschema2pojo")
@@ -76,6 +78,22 @@ public class NewRegistryTenantRequest {
     private String createdBy;
 
     /**
+     * Http endpoint for the auth server (including realm) to be used for this tenant to authenticate against the registry
+     *
+     */
+    @JsonProperty("authServerUrl")
+    @JsonPropertyDescription("Http endpoint for the auth server (including realm) to be used for this tenant to authenticate against the registry")
+    private String authServerUrl;
+    /**
+     * ClientId in the authentication server to be used by the registry to authenticate incoming requests made by the tenant
+     * (Required)
+     *
+     */
+    @JsonProperty("clientId")
+    @JsonPropertyDescription("ClientId in the authentication server to be used by the registry to authenticate incoming requests made by the tenant")
+    private String clientId;
+
+    /**
      * Unique identifier of a tenant within a registry deployment
      * (Required)
      * 
@@ -115,9 +133,11 @@ public class NewRegistryTenantRequest {
         this.organizationId = organizationId;
     }
 
+
+
     /**
      * The list of resources that this tenant will have at max. available
-     * 
+     *
      */
     @JsonProperty("resources")
     public List<TenantResource> getResources() {
@@ -126,11 +146,49 @@ public class NewRegistryTenantRequest {
 
     /**
      * The list of resources that this tenant will have at max. available
-     * 
+     *
      */
     @JsonProperty("resources")
     public void setResources(List<TenantResource> resources) {
         this.resources = resources;
+    }
+
+    /**
+     * Http endpoint for the auth server (including realm) to be used for this tenant to authenticate against the registry
+     *
+     */
+    @JsonProperty("authServerUrl")
+    public String getAuthServerUrl() {
+        return authServerUrl;
+    }
+
+    /**
+     * Http endpoint for the auth server (including realm) to be used for this tenant to authenticate against the registry
+     *
+     */
+    @JsonProperty("authServerUrl")
+    public void setAuthServerUrl(String authServerUrl) {
+        this.authServerUrl = authServerUrl;
+    }
+
+    /**
+     * ClientId in the authentication server to be used by the registry to authenticate incoming requests made by the tenant
+     * (Required)
+     *
+     */
+    @JsonProperty("clientId")
+    public String getClientId() {
+        return clientId;
+    }
+
+    /**
+     * ClientId in the authentication server to be used by the registry to authenticate incoming requests made by the tenant
+     * (Required)
+     *
+     */
+    @JsonProperty("clientId")
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
     }
 
     /**

--- a/multitenancy/tenant-manager-datamodel/src/main/java/io/apicurio/multitenant/api/datamodel/RegistryTenant.java
+++ b/multitenancy/tenant-manager-datamodel/src/main/java/io/apicurio/multitenant/api/datamodel/RegistryTenant.java
@@ -26,7 +26,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "organizationId",
     "resources",
     "name",
-    "description"
+    "description",
+    "authServerUrl",
+    "authClientId"
 })
 @Generated("jsonschema2pojo")
 public class RegistryTenant {
@@ -64,6 +66,23 @@ public class RegistryTenant {
     @JsonProperty("organizationId")
     @JsonPropertyDescription("")
     private Object organizationId;
+    /**
+     * Http endpoint for the auth server (including realm) to be used for this tenant to authenticate against the registry
+     * (Required)
+     *
+     */
+    @JsonProperty("authServerUrl")
+    @JsonPropertyDescription("Http endpoint for the auth server (including realm) to be used for this tenant to authenticate against the registry")
+    private String authServerUrl;
+    /**
+     * ClientId in the authentication server to be used by the registry to authenticate incoming requests made by the tenant
+     * (Required)
+     *
+     */
+    @JsonProperty("authClientId")
+    @JsonPropertyDescription("ClientId in the authentication server to be used by the registry to authenticate incoming requests made by the tenant")
+    private String authClientId;
+
     /**
      * The list of resources that this tenant has available
      * 
@@ -164,6 +183,46 @@ public class RegistryTenant {
     @JsonProperty("organizationId")
     public void setOrganizationId(Object organizationId) {
         this.organizationId = organizationId;
+    }
+
+    /**
+     * Http endpoint for the auth server (including realm) to be used for this tenant to authenticate against the registry
+     * (Required)
+     *
+     */
+    @JsonProperty("authServerUrl")
+    public String getAuthServerUrl() {
+        return authServerUrl;
+    }
+
+    /**
+     * Http endpoint for the auth server (including realm) to be used for this tenant to authenticate against the registry
+     * (Required)
+     *
+     */
+    @JsonProperty("authServerUrl")
+    public void setAuthServerUrl(String authServerUrl) {
+        this.authServerUrl = authServerUrl;
+    }
+
+    /**
+     * ClientId in the authentication server to be used by the registry to authenticate incoming requests made by the tenant
+     * (Required)
+     *
+     */
+    @JsonProperty("authClientId")
+    public String getAuthClientId() {
+        return authClientId;
+    }
+
+    /**
+     * ClientId in the authentication server to be used by the registry to authenticate incoming requests made by the tenant
+     * (Required)
+     *
+     */
+    @JsonProperty("authClientId")
+    public void setAuthClientId(String authClientId) {
+        this.authClientId = authClientId;
     }
 
     /**


### PR DESCRIPTION
Some things to consider:

- This pr adds support for storing role mappings in keycloak instead of storing them in the database.
- This is still a PoC
- There will be some problems when running in native since the keycloak admin library is using the Apache HTTP client and that needs proper testing to confirm that is working properly in native mode.