### PR TITLE
Fix protobuf bugs where proto2 syntax is specified

### DIFF
--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
@@ -102,7 +102,7 @@ public class FileDescriptorUtils {
         schema.setName(protoFileName);
 
         Syntax syntax = element.getSyntax();
-        if (syntax != null) {
+        if (Syntax.PROTO_3.equals(syntax)) {
             schema.setSyntax(syntax.toString());
         }
         if (element.getPackageName() != null) {

--- a/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
+++ b/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
@@ -5,6 +5,7 @@ import com.google.protobuf.Descriptors;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import com.squareup.wire.schema.internal.parser.ProtoParser;
 import io.apicurio.registry.utils.protobuf.schema.syntax2.TestOrderingSyntax2;
+import io.apicurio.registry.utils.protobuf.schema.syntax2.specified.TestOrderingSyntax2Specified;
 import io.apicurio.registry.utils.protobuf.schema.syntax3.TestOrderingSyntax3;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,6 +23,7 @@ public class FileDescriptorUtilsTest {
         return
             Stream.of(
             TestOrderingSyntax2.getDescriptor(),
+            TestOrderingSyntax2Specified.getDescriptor(),
             TestOrderingSyntax3.getDescriptor()
         )
         .map(Descriptors.FileDescriptor::getFile)

--- a/utils/protobuf-schema-utilities/src/test/proto/TestOrderingSyntax2Specified.proto
+++ b/utils/protobuf-schema-utilities/src/test/proto/TestOrderingSyntax2Specified.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+
+package io.apicurio.registry.utils.protobuf.schema.syntax2.specified;
+
+message Address {
+  required string street = 1 [json_name = "Address_Street"];
+
+  optional int32 zip = 2 [deprecated = true];
+
+  optional string city = 3 [default = "Seattle"];
+
+  repeated int32 samples = 6 [packed=true];
+}
+
+message Customer {
+  required string name = 1;
+}


### PR DESCRIPTION
This commit will fix the following bug with Protobuf FileDescriptor parsing.

1. Interpret correctly when `proto2` syntax is specifically used in `.proto` schema file.

This commit is part of bug fixes reported in issue #1671 