### PR TITLE
connect.default on long avro field

### DIFF
--- a/utils/converter/pom.xml
+++ b/utils/converter/pom.xml
@@ -37,5 +37,10 @@
             <artifactId>connect-json</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
@@ -32,6 +32,7 @@ import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.util.internal.JacksonUtils;
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
 import org.apache.kafka.common.cache.SynchronizedCache;
@@ -1487,7 +1488,7 @@ public class AvroData {
                     throw new DataException("Unknown Connect schema type: " + schema.type());
             }
 
-            if (schema != null && schema.name() != null && doLogicalConversion) {
+            if (schema.name() != null && doLogicalConversion) {
                 LogicalTypeConverter logicalConverter = TO_CONNECT_LOGICAL_CONVERTERS.get(schema.name());
                 if (logicalConverter != null) {
                     converted = logicalConverter.convert(schema, converted);
@@ -1788,7 +1789,7 @@ public class AvroData {
         }
 
         if (fieldDefaultVal == null) {
-            fieldDefaultVal = schema.getObjectProp(CONNECT_DEFAULT_VALUE_PROP);
+            fieldDefaultVal = JacksonUtils.toJsonNode(schema.getObjectProp(CONNECT_DEFAULT_VALUE_PROP));
         }
         if (fieldDefaultVal != null) {
             builder.defaultValue(

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
@@ -1488,7 +1488,7 @@ public class AvroData {
                     throw new DataException("Unknown Connect schema type: " + schema.type());
             }
 
-            if (schema.name() != null && doLogicalConversion) {
+            if (schema != null && schema.name() != null && doLogicalConversion) {
                 LogicalTypeConverter logicalConverter = TO_CONNECT_LOGICAL_CONVERTERS.get(schema.name());
                 if (logicalConverter != null) {
                     converted = logicalConverter.convert(schema, converted);

--- a/utils/converter/src/test/java/io/apicurio/registry/utils/converter/avro/AvroDataTest.java
+++ b/utils/converter/src/test/java/io/apicurio/registry/utils/converter/avro/AvroDataTest.java
@@ -1,0 +1,59 @@
+package io.apicurio.registry.utils.converter.avro;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AvroDataTest {
+    @Test
+    public void testIntWithConnectDefault() {
+        final String s = "{"
+            + "  \"type\": \"record\","
+            + "  \"name\": \"sample\","
+            + "  \"namespace\": \"io.apicurio\","
+            + "  \"fields\": ["
+            + "    {"
+            + "      \"name\": \"prop\","
+            + "      \"type\": {"
+            + "        \"type\": \"int\","
+            + "        \"connect.default\": 42,"
+            + "        \"connect.version\": 1"
+            + "      }"
+            + "    }"
+            + "  ]"
+            + "}";
+
+        org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(s);
+
+        AvroData avroData = new AvroData(0);
+        Schema schema = avroData.toConnectSchema(avroSchema);
+
+        Assertions.assertEquals(42, schema.field("prop").schema().defaultValue());
+    }
+
+    @Test
+    public void testLongWithConnectDefault() {
+        final String s = "{"
+            + "  \"type\": \"record\","
+            + "  \"name\": \"sample\","
+            + "  \"namespace\": \"io.apicurio\","
+            + "  \"fields\": ["
+            + "    {"
+            + "      \"name\": \"prop\","
+            + "      \"type\": {"
+            + "        \"type\": \"long\","
+            + "        \"connect.default\": 42,"
+            + "        \"connect.version\": 1"
+            + "      }"
+            + "    }"
+            + "  ]"
+            + "}";
+
+        org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(s);
+
+        AvroData avroData = new AvroData(0);
+        Schema schema = avroData.toConnectSchema(avroSchema);
+
+        Assertions.assertEquals(42L, schema.field("prop").schema().defaultValue());
+    }
+}


### PR DESCRIPTION
Fixes [1740](https://github.com/Apicurio/apicurio-registry/issues/1740)
Original fix https://github.com/confluentinc/schema-registry/issues/1376.

The issue happens with Avro 1.9+ where if a field of type `long` has `connect.default` property, e.g.
```
"type": "record"
"name": "sample"
"namespace": "io.apicurio",
"fields": [
  {
    "name": "prop",
    "type": {
      "type": "long",
      "connect.default": 42,
      "connect.version": 1
    }
  }
]
```

then `AvroData.toConnectSchema` throws
```
org.apache.kafka.connect.errors.DataException: Invalid type for INT64: class java.lang.Integer
	at io.apicurio.registry.utils.converter.avro.AvroData.toConnectData(AvroData.java:1498)
	at io.apicurio.registry.utils.converter.avro.AvroData.toConnectData(AvroData.java:1230)
	at io.apicurio.registry.utils.converter.avro.AvroData.toConnectData(AvroData.java:1478)
	at io.apicurio.registry.utils.converter.avro.AvroData.toConnectData(AvroData.java:1230)
	at io.apicurio.registry.utils.converter.avro.AvroData.toConnectData(AvroData.java:1226)
	at io.apicurio.registry.utils.converter.avro.AvroData.toConnectData(AvroData.java:1205)
	at com.github.drnushooz.kafka.connect.sqs.source.SqsSourceTask.lambda$poll$0(SqsSourceTask.java:138)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at com.github.drnushooz.kafka.connect.sqs.source.SqsSourceTask.poll(SqsSourceTask.java:149)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.poll(WorkerSourceTask.java:265)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.execute(WorkerSourceTask.java:232)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:177)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:227)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
The issue is caused by the change in the call to get the value of `connect.default`. The underlying API was switched from `schema.getJsonProp`, which returned a IntNode, to `schema.getObjectProp`, which returns an int. Later code that uses this default value differentiates between `JsonNode`s and non-`JsonNode`s. Depending on the type the treatment of the node is as follows.
* JsonNodes - Have their values extracted using type coercion to ensure default value matches the schema type.
* Non-JsonNodes are treated literally.  As the default is small enough to fit into an int, but the type is a long, the code throws the DataException.

The fix is to convert the returned default value back into a JsonNode so that the type coercion can happen.