### PR TITLE
Add support for interpreting nested and internal / external types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
       - dependency-name: com.squareup.wire:wire-schema
         versions:
           - ">= 3.6.a, < 3.7"
+      - dependency-name: com.squareup.wire:wire-compiler
+        versions:
+          - ">= 3.6.a, < 3.7"
+      - dependency-name: com.google.jimfs:jimfs
+        versions:
+          - ">= 1.1, < 1.3"
+      - dependency-name: com.ibm.icu:icu4j
+        versions:
+          - ">= 69.1, < 70.1"
       - dependency-name: org.apache.kafka:connect-api
         versions:
           - "> 2.2.1, < 2.3"

--- a/integration-tests/testsuite/pom.xml
+++ b/integration-tests/testsuite/pom.xml
@@ -125,6 +125,20 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.wire</groupId>
+            <artifactId>wire-schema</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.wire</groupId>
+            <artifactId>wire-compiler</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.jimfs/jimfs -->
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <tar.long.file.mode>gnu</tar.long.file.mode>
+        <tar.long.file.mode>posix</tar.long.file.mode>
         
         <!-- UI Build Tools -->
         <node.version>12.13.0</node.version>
@@ -141,6 +141,9 @@
         <avro.version>1.10.2</avro.version>
         <json-schema-validator.version>1.0.57</json-schema-validator.version>
         <wire-schema.version>3.7.0</wire-schema.version>
+        <wire-compiler.version>3.7.0</wire-compiler.version>
+        <jimfs.version>1.1</jimfs.version>
+        <icu4j.version>69.1</icu4j.version>
         <protobuf.version>3.17.3</protobuf.version>
         <xmlsec.version>2.1.5</xmlsec.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
@@ -409,6 +412,21 @@
                 <groupId>com.squareup.wire</groupId>
                 <artifactId>wire-schema</artifactId>
                 <version>${wire-schema.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-compiler</artifactId>
+                <version>${wire-compiler.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.jimfs</groupId>
+                <artifactId>jimfs</artifactId>
+                <version>${jimfs.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ibm.icu</groupId>
+                <artifactId>icu4j</artifactId>
+                <version>${icu4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <tar.long.file.mode>posix</tar.long.file.mode>
+        <tar.long.file.mode>gnu</tar.long.file.mode>
         
         <!-- UI Build Tools -->
         <node.version>12.13.0</node.version>

--- a/schema-compatibility/protobuf/pom.xml
+++ b/schema-compatibility/protobuf/pom.xml
@@ -25,6 +25,16 @@
             <groupId>com.squareup.wire</groupId>
             <artifactId>wire-schema</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.wire</groupId>
+            <artifactId>wire-compiler</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.jimfs/jimfs -->
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+        </dependency>
     
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/serdes/protobuf-serde/pom.xml
+++ b/serdes/protobuf-serde/pom.xml
@@ -33,6 +33,16 @@
             <groupId>com.squareup.wire</groupId>
             <artifactId>wire-schema</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.wire</groupId>
+            <artifactId>wire-compiler</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.jimfs/jimfs -->
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/utils/protobuf-schema-utilities/pom.xml
+++ b/utils/protobuf-schema-utilities/pom.xml
@@ -35,6 +35,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/utils/protobuf-schema-utilities/pom.xml
+++ b/utils/protobuf-schema-utilities/pom.xml
@@ -27,13 +27,11 @@
         <dependency>
             <groupId>com.squareup.wire</groupId>
             <artifactId>wire-compiler</artifactId>
-            <version>3.7.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.jimfs/jimfs -->
         <dependency>
             <groupId>com.google.jimfs</groupId>
             <artifactId>jimfs</artifactId>
-            <version>1.1</version>
         </dependency>
 
         <dependency>

--- a/utils/protobuf-schema-utilities/pom.xml
+++ b/utils/protobuf-schema-utilities/pom.xml
@@ -25,6 +25,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.wire</groupId>
+            <artifactId>wire-compiler</artifactId>
+            <version>3.7.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.jimfs/jimfs -->
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>1.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
@@ -1,52 +1,24 @@
-/*
- * Copyright 2021 Red Hat
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.apicurio.registry.utils.protobuf.schema;
-
-import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
-import static com.google.common.base.CaseFormat.UPPER_CAMEL;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.DescriptorProtos;
-import com.google.protobuf.TimestampProto;
-import com.google.protobuf.WrappersProto;
-import com.google.protobuf.DescriptorProtos.DescriptorProto;
-import com.google.protobuf.DescriptorProtos.EnumDescriptorProto;
-import com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto;
-import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
-import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
-import com.google.protobuf.DescriptorProtos.FileOptions;
-import com.google.protobuf.DescriptorProtos.OneofDescriptorProto;
 import com.google.protobuf.Descriptors.DescriptorValidationException;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.TimestampProto;
+import com.google.protobuf.WrappersProto;
 import com.squareup.wire.Syntax;
+import com.squareup.wire.schema.EnumConstant;
+import com.squareup.wire.schema.EnumType;
 import com.squareup.wire.schema.Field;
 import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.MessageType;
+import com.squareup.wire.schema.OneOf;
+import com.squareup.wire.schema.Options;
+import com.squareup.wire.schema.ProtoFile;
 import com.squareup.wire.schema.ProtoType;
+import com.squareup.wire.schema.Schema;
+import com.squareup.wire.schema.Type;
 import com.squareup.wire.schema.internal.parser.EnumConstantElement;
 import com.squareup.wire.schema.internal.parser.EnumElement;
 import com.squareup.wire.schema.internal.parser.ExtensionsElement;
@@ -57,11 +29,32 @@ import com.squareup.wire.schema.internal.parser.OptionElement;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import com.squareup.wire.schema.internal.parser.ReservedElement;
 import com.squareup.wire.schema.internal.parser.TypeElement;
-
 import kotlin.ranges.IntRange;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
+import static com.google.common.base.CaseFormat.UPPER_CAMEL;
+import static com.google.protobuf.DescriptorProtos.DescriptorProto;
+import static com.google.protobuf.DescriptorProtos.EnumDescriptorProto;
+import static com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto;
+import static com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import static com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import static com.google.protobuf.DescriptorProtos.FileOptions;
+import static com.google.protobuf.DescriptorProtos.OneofDescriptorProto;
+
 /**
- * @author Fabian Martinez
+ * @author Fabian Martinez, Ravindranath Kakarla
  */
 public class FileDescriptorUtils {
 
@@ -95,11 +88,35 @@ public class FileDescriptorUtils {
     }
 
     public static FileDescriptor protoFileToFileDescriptor(ProtoFileElement element, String protoFileName) throws DescriptorValidationException {
-        return FileDescriptor.buildFrom(toFileDescriptorProto(element, protoFileName), baseDependencies());
+        Objects.requireNonNull(element);
+        Objects.requireNonNull(protoFileName);
+
+        return protoFileToFileDescriptor(element.toSchema(), protoFileName,
+            Optional.ofNullable(element.getPackageName()));
     }
 
-    private static FileDescriptorProto toFileDescriptorProto(ProtoFileElement element, String protoFileName) {
+    public static FileDescriptor protoFileToFileDescriptor(String schemaDefinition, String protoFileName, Optional<String> optionalPackageName)
+        throws DescriptorValidationException {
+        Objects.requireNonNull(schemaDefinition);
+        Objects.requireNonNull(protoFileName);
+
+        return FileDescriptor.buildFrom(toFileDescriptorProto(schemaDefinition, protoFileName, optionalPackageName), baseDependencies());
+    }
+
+    private static FileDescriptorProto toFileDescriptorProto(String schemaDefinition, String protoFileName, Optional<String> optionalPackageName) {
+        final ProtobufSchemaLoader.ProtobufSchemaLoaderContext protobufSchemaLoaderContext;
+        try {
+            protobufSchemaLoaderContext =
+                ProtobufSchemaLoader.loadSchema(optionalPackageName, protoFileName, schemaDefinition);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
         FileDescriptorProto.Builder schema = FileDescriptorProto.newBuilder();
+
+        ProtoFile element = protobufSchemaLoaderContext.getProtoFile();
+        Schema schemaContext = protobufSchemaLoaderContext.getSchema();
+
         schema.setName(protoFileName);
 
         Syntax syntax = element.getSyntax();
@@ -110,13 +127,19 @@ public class FileDescriptorUtils {
             schema.setPackage(element.getPackageName());
         }
 
-        for (TypeElement typeElem : element.getTypes()) {
-            if (typeElem instanceof MessageElement) {
-                DescriptorProto message = messageElementToDescriptorProto((MessageElement) typeElem);
+        for (ProtoType protoType: schemaContext.getTypes()) {
+            if (!isParentLevelType(protoType, optionalPackageName)) {
+                continue;
+            }
+
+            Type type = schemaContext.getType(protoType);
+            if (type instanceof MessageType) {
+                DescriptorProto
+                    message = messageElementToDescriptorProto((MessageType) type, schemaContext);
                 schema.addMessageType(message);
-            } else if (typeElem instanceof EnumElement) {
-                EnumDescriptorProto enumer = enumElementToProto((EnumElement) typeElem);
-                schema.addEnumType(enumer);
+            } else if (type instanceof  EnumType) {
+                EnumDescriptorProto message = enumElementToProto((EnumType) type);
+                schema.addEnumType(message);
             }
         }
 
@@ -165,45 +188,76 @@ public class FileDescriptorUtils {
         return schema.build();
     }
 
-    private static DescriptorProto messageElementToDescriptorProto(MessageElement messageElem) {
-        ProtobufMessage message = new ProtobufMessage();
-        message.protoBuilder().setName(messageElem.getName());
+    /**
+     * When schema loader links the schema, it also includes google.protobuf types in it.
+     * We want to ignore all the other types except for the ones that are present in the current file.
+     * @return true if a type is a parent type, false otherwise.
+     */
+    private static boolean isParentLevelType(ProtoType protoType, Optional<String> optionalPackageName) {
+        if (optionalPackageName.isPresent()) {
+            String packageName = optionalPackageName.get();
+            String typeName = protoType.toString();
 
-        for (TypeElement type : messageElem.getNestedTypes()) {
-            if (type instanceof MessageElement) {
-                message.protoBuilder().addNestedType(messageElementToDescriptorProto((MessageElement) type));
-            } else if (type instanceof EnumElement) {
-                message.protoBuilder().addEnumType(enumElementToProto((EnumElement) type));
+            //If the type doesn't start with the package name, ignore it.
+            if (!typeName.startsWith(packageName)) {
+                return false;
+            }
+            //We only want to consider the parent level types. The list can contain following,
+            //[io.apicurio.foo.bar.Customer.Address, io.apicurio.foo.bar.Customer, google.protobuf.Timestamp]
+            //We want to only get the type "io.apicurio.foo.bar.Customer" which is parent level type.
+            String [] typeNames = typeName.split(packageName)[1].split("\\.");
+            boolean isNotNested = typeNames.length <= 2;
+            return isNotNested;
+        }
+
+        //If package is not present,
+        //TODO: Square wire has a bug loading schemas without packageName, update the logic when
+        //https://github.com/square/wire/issues/2042 is fixed.
+        return false;
+    }
+
+    private static DescriptorProto messageElementToDescriptorProto(
+        MessageType messageElem, Schema schema) {
+        ProtobufMessage message = new ProtobufMessage();
+        message.protoBuilder().setName(messageElem.getType().getSimpleName());
+
+        for (Type type : messageElem.getNestedTypes()) {
+            if (type instanceof MessageType) {
+                message.protoBuilder().addNestedType(
+                    messageElementToDescriptorProto((MessageType) type, schema));
+            } else if (type instanceof EnumType) {
+                message.protoBuilder().addEnumType(enumElementToProto((EnumType) type));
             }
         }
 
-        Set<String> added = new HashSet<>();
+        Set<String> added = new LinkedHashSet<>();
 
-        for (OneOfElement oneof : messageElem.getOneOfs()) {
+        for (OneOf oneof : messageElem.getOneOfs()) {
             OneofDescriptorProto.Builder oneofBuilder = OneofDescriptorProto.newBuilder().setName(oneof.getName());
             message.protoBuilder().addOneofDecl(oneofBuilder);
 
-            for (FieldElement field : oneof.getFields()) {
-                String jsonName = findOptionString(JSON_NAME_OPTION, field.getOptions());
-                Boolean isDeprecated = findOptionBoolean(DEPRECATED_OPTION, field.getOptions());
+            for (Field oneOfField : oneof.getFields()) {
+                String oneOfJsonName = findOptionString(JSON_NAME_OPTION, oneOfField.getOptions());
+                Boolean oneOfIsDeprecated = findOptionBoolean(DEPRECATED_OPTION, oneOfField.getOptions());
 
                 message.addFieldDescriptorProto(
-                        FieldDescriptorProto.Label.LABEL_OPTIONAL,
-                        field.getType(),
-                        field.getName(),
-                        field.getTag(),
-                        field.getDefaultValue(),
-                        jsonName,
-                        isDeprecated,
-                        null,
-                        message.protoBuilder().getOneofDeclCount() - 1);
+                    FieldDescriptorProto.Label.LABEL_OPTIONAL,
+                    null,
+                    String.valueOf(oneOfField.getType()),
+                    oneOfField.getName(),
+                    oneOfField.getTag(),
+                    oneOfField.getDefault(),
+                    oneOfJsonName,
+                    oneOfIsDeprecated,
+                    null,
+                    message.protoBuilder().getOneofDeclCount() - 1);
 
-                added.add(field.getName());
+                added.add(oneOfField.getName());
             }
         }
 
         // Process fields after messages so that any newly created map entry messages are at the end
-        for (FieldElement field : messageElem.getFields()) {
+        for (Field field : messageElem.getDeclaredFields()) {
             if (added.contains(field.getName())) {
                 continue;
             }
@@ -211,36 +265,45 @@ public class FileDescriptorUtils {
             //Fields are optional by default in Proto3.
             String label = fieldLabel != null ? fieldLabel.toString().toLowerCase() : OPTIONAL;
 
-            String fieldType = field.getType();
-
-            ProtoType protoType = ProtoType.get(fieldType);
+            ProtoType protoType = field.getType();
+            String fieldTypeName = String.valueOf(protoType);
             ProtoType keyType = protoType.getKeyType();
             ProtoType valueType = protoType.getValueType();
             // Map fields are only permitted in messages
             if (protoType.isMap() && keyType != null && valueType != null) {
                 label = "repeated";
-                fieldType = toMapEntry(field.getName());
+                fieldTypeName = toMapEntry(field.getName());
                 ProtobufMessage protobufMapMessage = new ProtobufMessage();
                 DescriptorProto.Builder mapMessage = protobufMapMessage
                         .protoBuilder()
-                        .setName(fieldType)
+                        .setName(fieldTypeName)
                         .mergeOptions(DescriptorProtos.MessageOptions.newBuilder()
                                 .setMapEntry(true)
                                 .build());
 
-                protobufMapMessage.addField(null, keyType.getSimpleName(), KEY_FIELD, 1, null, null, null, null, null);
-                protobufMapMessage.addField(null, valueType.getSimpleName(), VALUE_FIELD, 2, null, null, null, null, null);
+                protobufMapMessage.addField(null, null, keyType.getSimpleName(), KEY_FIELD, 1, null, null, null, null, null);
+                protobufMapMessage.addField(null, null, valueType.getSimpleName(), VALUE_FIELD, 2, null, null, null, null, null);
                 message.protoBuilder().addNestedType(mapMessage.build());
             }
 
-            String jsonName = field.getJsonName();
+            String jsonName = field.getDeclaredJsonName();
             Boolean isDeprecated = findOptionBoolean(DEPRECATED_OPTION, field.getOptions());
             Boolean isPacked = findOptionBoolean(PACKED_OPTION, field.getOptions());
 
-            message.addField(label, fieldType, field.getName(), field.getTag(), field.getDefaultValue(), jsonName, isDeprecated, isPacked, null);
+            String fieldType = null;
+            Type typeReference = schema.getType(protoType);
+            if (typeReference != null) {
+                if (typeReference instanceof MessageType) {
+                    fieldType = "message";
+                }
+                if (typeReference instanceof EnumType) {
+                    fieldType = "enum";
+                }
+            }
+            message.addField(label, fieldType, fieldTypeName, field.getName(), field.getTag(), field.getDefault(), jsonName, isDeprecated, isPacked, null);
         }
 
-        for (ReservedElement reserved : messageElem.getReserveds()) {
+        for (ReservedElement reserved : messageElem.toElement().getReserveds()) {
             for (Object elem : reserved.getValues()) {
                 if (elem instanceof String) {
                     message.protoBuilder().addReservedName((String) elem);
@@ -262,7 +325,7 @@ public class FileDescriptorUtils {
                 }
             }
         }
-        for (ExtensionsElement extensions : messageElem.getExtensions()) {
+        for (ExtensionsElement extensions : messageElem.toElement().getExtensions()) {
             for (Object elem : extensions.getValues()) {
                 if (elem instanceof Integer) {
                     int tag = (Integer) elem;
@@ -292,7 +355,7 @@ public class FileDescriptorUtils {
         return message.build();
     }
 
-    private static EnumDescriptorProto enumElementToProto(EnumElement enumElem) {
+    private static EnumDescriptorProto enumElementToProto(EnumType enumElem) {
         Boolean allowAlias = findOptionBoolean(ALLOW_ALIAS_OPTION, enumElem.getOptions());
 
         EnumDescriptorProto.Builder builder = EnumDescriptorProto.newBuilder()
@@ -302,7 +365,7 @@ public class FileDescriptorUtils {
                     .setAllowAlias(allowAlias);
             builder.mergeOptions(optionsBuilder.build());
         }
-        for (EnumConstantElement constant : enumElem.getConstants()) {
+        for (EnumConstant constant : enumElem.getConstants()) {
             builder.addValue(EnumValueDescriptorProto.newBuilder()
                     .setName(constant.getName())
                     .setNumber(constant.getTag())
@@ -318,15 +381,15 @@ public class FileDescriptorUtils {
         return s + MAP_ENTRY_SUFFIX;
     }
 
-    private static Optional<OptionElement> findOption(String name, List<OptionElement> options) {
-        return options.stream().filter(o -> o.getName().equals(name)).findFirst();
+    private static Optional<OptionElement> findOption(String name, Options options) {
+        return options.getElements().stream().filter(o -> o.getName().equals(name)).findFirst();
     }
 
-    private static String findOptionString(String name, List<OptionElement> options) {
+    private static String findOptionString(String name, Options options) {
         return findOption(name, options).map(o -> o.getValue().toString()).orElse(null);
     }
 
-    private static Boolean findOptionBoolean(String name, List<OptionElement> options) {
+    private static Boolean findOptionBoolean(String name, Options options) {
         return findOption(name, options).map(o -> Boolean.valueOf(o.getValue().toString())).orElse(null);
     }
 

--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
@@ -84,7 +84,7 @@ public class FileDescriptorUtils {
 
     public static FileDescriptor protoFileToFileDescriptor(ProtoFileElement element)
         throws DescriptorValidationException {
-        return protoFileToFileDescriptor(element, "default");
+        return protoFileToFileDescriptor(element, "default.proto");
     }
 
     public static FileDescriptor protoFileToFileDescriptor(ProtoFileElement element, String protoFileName) throws DescriptorValidationException {

--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
@@ -1,0 +1,79 @@
+package io.apicurio.registry.utils.protobuf.schema;
+
+import com.google.common.collect.Lists;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.ProtoFile;
+import com.squareup.wire.schema.Schema;
+import com.squareup.wire.schema.SchemaLoader;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class ProtobufSchemaLoader {
+    /**
+     * Creates a schema loader using a in-memory file system. This is required for square wire schema parser and linker
+     * to load the types correctly. See https://github.com/square/wire/issues/2024#
+     * As of now this only supports reading one .proto file but can be extended to support reading multiple files.
+     * @param packageName Package name for the .proto if present
+     * @param fileName Name of the .proto file.
+     * @param schemaDefinition Schema Definition to parse.
+     * @return Schema - parsed and properly linked Schema.
+     */
+    public static ProtobufSchemaLoaderContext loadSchema(Optional<String> packageName, String fileName, String schemaDefinition)
+        throws IOException {
+        final FileSystem inMemoryFileSystem = Jimfs.newFileSystem(Configuration.unix());
+        String [] dirs = {};
+        if (packageName.isPresent()) {
+            dirs = packageName.get().split("\\.");
+        }
+        try {
+            String dirPath = "";
+            for (String dir: dirs) {
+                dirPath = dirPath + "/" + dir;
+                Path path = inMemoryFileSystem.getPath(dirPath);
+                Files.createDirectory(path);
+            }
+            Path path = inMemoryFileSystem.getPath(dirPath, fileName);
+            Files.write(path, schemaDefinition.getBytes());
+
+            SchemaLoader schemaLoader = new SchemaLoader(inMemoryFileSystem);
+            schemaLoader.initRoots(Lists.newArrayList(Location.get("/")), Lists.newArrayList(Location.get("/")));
+
+            Schema schema = schemaLoader.loadSchema();
+            ProtoFile protoFile = schema.protoFile(path.toString().replaceFirst("/", ""));
+
+            if (protoFile == null) {
+                throw new RuntimeException("Error loading Protobuf File: " + fileName);
+            }
+
+            return new ProtobufSchemaLoaderContext(schema, protoFile);
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            inMemoryFileSystem.close();
+        }
+    }
+
+    protected static class ProtobufSchemaLoaderContext {
+        private final Schema schema;
+        private final ProtoFile protoFile;
+
+        public Schema getSchema() {
+            return schema;
+        }
+
+        public ProtoFile getProtoFile() {
+            return protoFile;
+        }
+
+        public ProtobufSchemaLoaderContext(Schema schema, ProtoFile protoFile) {
+            this.schema = schema;
+            this.protoFile = protoFile;
+        }
+    }
+}

--- a/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
+++ b/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
@@ -8,6 +8,7 @@ import io.apicurio.registry.utils.protobuf.schema.syntax2.TestOrderingSyntax2;
 import io.apicurio.registry.utils.protobuf.schema.syntax2.specified.TestOrderingSyntax2Specified;
 import io.apicurio.registry.utils.protobuf.schema.syntax2.references.TestOrderingSyntax2References;
 import io.apicurio.registry.utils.protobuf.schema.syntax3.TestOrderingSyntax3;
+import io.apicurio.registry.utils.protobuf.schema.syntax3.references.TestOrderingSyntax3References;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -27,7 +28,8 @@ public class FileDescriptorUtilsTest {
             TestOrderingSyntax2.getDescriptor(),
             TestOrderingSyntax2Specified.getDescriptor(),
             TestOrderingSyntax3.getDescriptor(),
-            TestOrderingSyntax2References.getDescriptor()
+            TestOrderingSyntax2References.getDescriptor(),
+            TestOrderingSyntax3References.getDescriptor()
         )
         .map(Descriptors.FileDescriptor::getFile)
         .map(Arguments::of);

--- a/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
+++ b/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
@@ -6,12 +6,14 @@ import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import com.squareup.wire.schema.internal.parser.ProtoParser;
 import io.apicurio.registry.utils.protobuf.schema.syntax2.TestOrderingSyntax2;
 import io.apicurio.registry.utils.protobuf.schema.syntax2.specified.TestOrderingSyntax2Specified;
+import io.apicurio.registry.utils.protobuf.schema.syntax2.references.TestOrderingSyntax2References;
 import io.apicurio.registry.utils.protobuf.schema.syntax3.TestOrderingSyntax3;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,7 +26,8 @@ public class FileDescriptorUtilsTest {
             Stream.of(
             TestOrderingSyntax2.getDescriptor(),
             TestOrderingSyntax2Specified.getDescriptor(),
-            TestOrderingSyntax3.getDescriptor()
+            TestOrderingSyntax3.getDescriptor(),
+            TestOrderingSyntax2References.getDescriptor()
         )
         .map(Descriptors.FileDescriptor::getFile)
         .map(Arguments::of);
@@ -64,6 +67,6 @@ public class FileDescriptorUtilsTest {
 
     private Descriptors.FileDescriptor schemaTextToFileDescriptor(String schema, String fileName) throws Exception {
         ProtoFileElement protoFileElement = ProtoParser.Companion.parse(FileDescriptorUtils.DEFAULT_LOCATION, schema);
-        return FileDescriptorUtils.protoFileToFileDescriptor(protoFileElement, fileName);
+        return FileDescriptorUtils.protoFileToFileDescriptor(schema, fileName, Optional.ofNullable(protoFileElement.getPackageName()));
     }
 }

--- a/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
+++ b/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
@@ -54,7 +54,7 @@ public class FileDescriptorUtilsTest {
         DescriptorProtos.FileDescriptorProto fileDescriptorProto = fileDescriptor.toProto();
         String actualSchema = FileDescriptorUtils.fileDescriptorToProtoFile(fileDescriptorProto).toSchema();
 
-        String fileName = fileDescriptor.toProto().getName();
+        String fileName = fileDescriptorProto.getName();
         String expectedSchema = ProtobufTestCaseReader.getRawSchema(fileName);
 
         //Convert to Proto and compare

--- a/utils/protobuf-schema-utilities/src/test/proto/TestOrderingSyntax2References.proto
+++ b/utils/protobuf-schema-utilities/src/test/proto/TestOrderingSyntax2References.proto
@@ -1,0 +1,69 @@
+package io.apicurio.registry.utils.protobuf.schema.syntax2.references;
+
+option java_package = "io.apicurio.registry.utils.protobuf.schema.syntax2.references";
+import "google/protobuf/timestamp.proto";
+
+message Customer {
+  required string name = 1;
+  message Address {}
+  message Nesting1 {
+    message Nesting2 {
+        //Explicit reference to Customer.Address
+        required Customer.Address add = 1;
+    }
+  }
+  //This should resolve to Customer.Address
+  required Address address = 3;
+  //This should resolve to parent level AddressType
+  required AddressType addressType = 4;
+}
+
+message Address {
+  enum AddressType {
+      RESIDENTIAL = 1;
+      COMMERCIAL = 2;
+  }
+
+  required string street = 1 [json_name = "Address_Street"];
+
+  optional int32 zip = 2 [deprecated = true];
+
+  optional string city = 3 [default = "Seattle"];
+
+  repeated int32 samples = 6 [packed=true];
+
+  //Reference by relative complete path
+  required io.apicurio.registry.utils.protobuf.schema.syntax2.references.AddressType addressType = 9;
+  optional .google.protobuf.Timestamp time_name1 = 10;
+  optional google.protobuf.Timestamp time_name2 = 11;
+
+  //Reference by .complete path
+  required .io.apicurio.registry.utils.protobuf.schema.syntax2.references.AddressType completeAddressType = 12;
+
+  message Nesting1 {
+
+    message Customer { }
+    message Nesting2 {
+      //Resolves to Address.Nesting1.Customer
+      required Customer foo = 1;
+
+      //Resolves to Address
+      required Address a = 2;
+
+      //Resolves to Address.AddressType
+      required AddressType b = 3;
+
+      //Explicit reference to AnotherType
+      required AnotherType.Address aa = 4;
+    }
+  }
+}
+
+enum AddressType {
+    RESIDENTIAL = 1;
+    COMMERCIAL = 2;
+}
+
+message AnotherType {
+    message Address {}
+}

--- a/utils/protobuf-schema-utilities/src/test/proto/TestOrderingSyntax3.proto
+++ b/utils/protobuf-schema-utilities/src/test/proto/TestOrderingSyntax3.proto
@@ -10,10 +10,21 @@ message Address {
   string city = 3;
 
   repeated int32 samples = 6 [packed=true];
+
+  message Customer {
+    int32 f = 1;
+  }
 }
 
 message Customer {
   string name = 1;
 
   reserved 2, 15, 10 to 11, 800 to 899;
+  Address address = 3;
+  AddressType addressType = 4;
+
+  enum AddressType {
+    RESIDENTIAL = 0;
+    COMMERCIAL = 1;
+  }
 }

--- a/utils/protobuf-schema-utilities/src/test/proto/TestOrderingSyntax3References.proto
+++ b/utils/protobuf-schema-utilities/src/test/proto/TestOrderingSyntax3References.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+package io.apicurio.registry.utils.protobuf.schema.syntax3.references;
+
+option java_package = "io.apicurio.registry.utils.protobuf.schema.syntax3.references";
+import "google/protobuf/timestamp.proto";
+
+message Customer {
+  string name = 1;
+  message Address {}
+  message Nesting1 {
+    message Nesting2 {
+        //Explicit reference to Customer.Address
+        Customer.Address add = 1;
+    }
+  }
+  //This should resolve to Customer.Address
+  Address address = 3;
+  //This should resolve to parent level AddressType
+  AddressType addressType = 4;
+}
+
+message Address {
+  enum AddressType {
+      RESIDENTIAL = 0;
+      COMMERCIAL = 1;
+  }
+
+  string street = 1 [json_name = "Address_Street"];
+
+  int32 zip = 2 [deprecated = true];
+
+  string city = 3;
+
+  repeated int32 samples = 6 [packed=true];
+
+  //Reference by relative complete path
+  io.apicurio.registry.utils.protobuf.schema.syntax3.references.AddressType addressType = 9;
+  .google.protobuf.Timestamp time_name1 = 10;
+  google.protobuf.Timestamp time_name2 = 11;
+
+  //Reference by .complete path
+  .io.apicurio.registry.utils.protobuf.schema.syntax3.references.AddressType completeAddressType = 12;
+
+  message Nesting1 {
+
+    message Customer { }
+    message Nesting2 {
+      //Resolves to Address.Nesting1.Customer
+      Customer foo = 1;
+
+      //Resolves to Address
+      Address a = 2;
+
+      //Resolves to Address.AddressType
+      AddressType b = 3;
+
+      //Explicit reference to AnotherType
+      AnotherType.Address aa = 4;
+    }
+  }
+}
+
+enum AddressType {
+    RESIDENTIAL = 0;
+    COMMERCIAL = 1;
+}
+
+message AnotherType {
+    message Address {}
+}


### PR DESCRIPTION
This issue adds supports for parsing the nested references in the Proto schema correctly. This bug was raised as part of [issue](https://github.com/Apicurio/apicurio-registry/issues/1671). 

**Background**

When a nested reference is present in the schema, it is not interpreted correctly,

For example,
```
package foo.bar;

message A {
}

message  B {
    A a = 1;
}
```

When a `FileDescriptorProto` is generated for above schema, 

**Current behavior**

```
name: "fileName.proto"
package: "foo.bar"
message_type {
  name: "A"
  field {
  }
message_type {
  name: "B"
  field {
    name: "A"
    number: 1
    label: LABEL_OPTIONAL
    type: TYPE_MESSAGE
  }
}
```

**Expected behavior**

```
name: "fileName.proto"
package: "foo.bar"
message_type {
  name: "A"
  field {
  }
message_type {
  name: "B"
  field {
    name: "A"
    number: 1
    label: LABEL_OPTIONAL
    type: TYPE_MESSAGE
    type_name: ".foo.bar.A"

  }
}
```
In order to resolve the types of nested / internal types, square wire schema loader needs to be used instead of Proto parser [Reference](https://github.com/square/wire/issues/2024). 

**Summary of PR**

1. Create a `SchemaLoader` that can parse and link the Proto files.
2. Migrate `FileDescriptorUtils` to use `SchemaLoader` instead of just using `ProtoParser`.


**TODOs**

1. There is a [bug](https://github.com/square/wire/issues/2042) with square/wire library that prevents parsing schemas with no packages. Fix it here once it's fixed in the library.
2. The code here is lengthy, separate it into different modules. I didn't take it up in this PR to keep the diff easier to read.

**Testing**

1. Added unit tests that cover different scenarios.
2. Tests compare the generated `FileDescriptorProtos` against the one generated by Protobuf library.