### PR TITLE
Implement anonymous read-only access (optional config)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
@@ -44,6 +44,9 @@ public class AuthConfig {
     @ConfigProperty(name = "registry.auth.owner-only-authorization.limit-group-access", defaultValue = "false")
     boolean ownerOnlyAuthorizationLimitGroupAccess;
 
+    @ConfigProperty(name = "registry.auth.anonymous-read-access.enabled", defaultValue = "false")
+    boolean anonymousReadAccessEnabled;
+
     @ConfigProperty(name = "registry.auth.roles.readonly", defaultValue = "sr-readonly")
     String readOnlyRole;
 
@@ -81,6 +84,7 @@ public class AuthConfig {
     void onConstruct() {
         log.debug("===============================");
         log.debug("Auth Enabled: " + authenticationEnabled);
+        log.debug("Anonymous Read Access Enabled: " + anonymousReadAccessEnabled);
         log.debug("RBAC Enabled: " + roleBasedAuthorizationEnabled);
         if (roleBasedAuthorizationEnabled) {
             log.debug("   RBAC Roles: " + readOnlyRole + ", " + developerRole + ", " + adminRole);

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -124,6 +124,7 @@ registry.limits.config.cache.check-period=30000
 #Auth - disabled by default
 
 registry.auth.enabled=${AUTH_ENABLED:false}
+registry.auth.anonymous-read-access.enabled=${ANONYMOUS_READ_ACCESS_ENABLED:false}
 registry.auth.owner-only-authorization=${OWNER_ONLY_AUTHZ_ENABLED:false}
 registry.auth.role-based-authorization=${ROLE_BASED_AUTHZ_ENABLED:false}
 registry.auth.role-source=${ROLE_BASED_AUTHZ_SOURCE:token}

--- a/app/src/test/java/io/apicurio/registry/auth/AuthTestAnonymousCredentials.java
+++ b/app/src/test/java/io/apicurio/registry/auth/AuthTestAnonymousCredentials.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.auth;
+
+import java.util.Collections;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.RegistryClientFactory;
+import io.apicurio.registry.rest.v2.beans.ArtifactSearchResults;
+import io.apicurio.registry.utils.tests.ApicurioTestTags;
+import io.apicurio.registry.utils.tests.AuthTestProfileAnonymousCredentials;
+import io.apicurio.rest.client.auth.Auth;
+import io.apicurio.rest.client.auth.OidcAuth;
+import io.apicurio.rest.client.auth.exception.NotAuthorizedException;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+@QuarkusTest
+@TestProfile(AuthTestProfileAnonymousCredentials.class)
+@Tag(ApicurioTestTags.DOCKER)
+public class AuthTestAnonymousCredentials extends AbstractResourceTestBase {
+
+    @ConfigProperty(name = "registry.auth.token.endpoint")
+    String authServerUrl;
+
+    String noRoleClientId = "registry-api-no-role";
+
+    final String groupId = getClass().getSimpleName() + "Group";
+
+    private RegistryClient createClient(Auth auth) {
+        return RegistryClientFactory.create(registryV2ApiUrl, Collections.emptyMap(), auth);
+    }
+
+    @Override
+    protected RegistryClient createRestClientV2() {
+        Auth auth = new OidcAuth(authServerUrl, noRoleClientId, "test1");
+        return this.createClient(auth);
+    }
+
+    @Test
+    public void testWrongCreds() throws Exception {
+        Auth auth = new OidcAuth(authServerUrl, noRoleClientId, "test55");
+        RegistryClient client = createClient(auth);
+        Assertions.assertThrows(NotAuthorizedException.class, () -> {
+            client.listArtifactsInGroup(groupId);
+        });
+    }
+
+    @Test
+    public void testNoCredentials() throws Exception {
+        RegistryClient client = RegistryClientFactory.create(registryV2ApiUrl, Collections.emptyMap(), null);
+        ArtifactSearchResults results = client.searchArtifacts(groupId, null, null, null, null, null, null, null, null);
+        Assertions.assertTrue(results.getCount() >= 0);
+    }
+}

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/AuthTestProfileAnonymousCredentials.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/AuthTestProfileAnonymousCredentials.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.tests;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+public class AuthTestProfileAnonymousCredentials implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("registry.auth.anonymous-read-access.enabled", "true");
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return Collections.singletonList(
+                new TestResourceEntry(KeycloakTestResourceWithoutRoles.class));
+    }
+}


### PR DESCRIPTION
This PR implements an optional security feature for enabling unauthenticated read-only access.  This means that anonymous users (aka REST requests made without providing any credentials) will be allowed to invoke ReadOnly operations.

@carlesarnal and @christofluethi please let me know what you think.

This feature is disabled by default.  The `ANONYMOUS_READ_ACCESS_ENABLED` ENV var can be used to enable it.
