### PR TITLE
updating quarkus to 2.0.3.Final to fix security vulnerabilities

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -205,6 +205,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-apicurio-registry-avro</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/app/src/main/java/io/apicurio/registry/metrics/health/liveness/PersistenceExceptionLivenessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/liveness/PersistenceExceptionLivenessCheck.java
@@ -62,7 +62,7 @@ public class PersistenceExceptionLivenessCheck extends AbstractErrorCounterHealt
         return HealthCheckResponse.builder()
                 .name("PersistenceExceptionLivenessCheck")
                 .withData("errorCount", errorCounter)
-                .state(up)
+                .up()
                 .build();
     }
 

--- a/app/src/main/java/io/apicurio/registry/metrics/health/liveness/ResponseErrorLivenessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/liveness/ResponseErrorLivenessCheck.java
@@ -60,7 +60,7 @@ public class ResponseErrorLivenessCheck extends AbstractErrorCounterHealthCheck 
         return HealthCheckResponse.builder()
                 .name("ResponseErrorLivenessCheck")
                 .withData("errorCount", errorCounter)
-                .state(up)
+                .up()
                 .build();
     }
 

--- a/app/src/main/java/io/apicurio/registry/metrics/health/liveness/StorageLivenessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/liveness/StorageLivenessCheck.java
@@ -42,7 +42,7 @@ public class StorageLivenessCheck implements HealthCheck {
     public synchronized HealthCheckResponse call() {
         return HealthCheckResponse.builder()
                                   .name("StorageLivenessCheck")
-                                  .state(storage.isAlive())
+                                  .status(storage.isAlive())
                                   .build();
     }
 }

--- a/app/src/main/java/io/apicurio/registry/metrics/health/readiness/PersistenceSimpleReadinessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/readiness/PersistenceSimpleReadinessCheck.java
@@ -44,7 +44,7 @@ public class PersistenceSimpleReadinessCheck implements HealthCheck {
     public synchronized HealthCheckResponse call() {
         return HealthCheckResponse.builder()
             .name("PersistenceSimpleReadinessCheck")
-            .state(test())
+            .status(test())
             .build();
     }
 }

--- a/app/src/main/java/io/apicurio/registry/metrics/health/readiness/PersistenceTimeoutReadinessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/readiness/PersistenceTimeoutReadinessCheck.java
@@ -69,7 +69,7 @@ public class PersistenceTimeoutReadinessCheck extends AbstractErrorCounterHealth
         return HealthCheckResponse.builder()
                 .name("PersistenceTimeoutReadinessCheck")
                 .withData("errorCount", errorCounter)
-                .state(up)
+                .up()
                 .build();
     }
 

--- a/app/src/main/java/io/apicurio/registry/metrics/health/readiness/ResponseTimeoutReadinessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/readiness/ResponseTimeoutReadinessCheck.java
@@ -100,7 +100,7 @@ public class ResponseTimeoutReadinessCheck extends AbstractErrorCounterHealthChe
         return HealthCheckResponse.builder()
                 .name("ResponseTimeoutReadinessCheck")
                 .withData("errorCount", errorCounter)
-                .state(up)
+                .up()
                 .build();
     }
 }

--- a/app/src/main/java/io/apicurio/registry/services/RegistryConfigSource.java
+++ b/app/src/main/java/io/apicurio/registry/services/RegistryConfigSource.java
@@ -20,7 +20,9 @@ import io.quarkus.runtime.configuration.ProfileManager;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * ConfigSource that turns env vars into plain properties.
@@ -50,6 +52,11 @@ public class RegistryConfigSource implements ConfigSource {
             }
         }
         return properties;
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return new HashSet<>(properties.values());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <yarn.version>1.22.4</yarn.version>
         
         <!-- Quarkus Version -->
-        <quarkus.version>1.13.2.Final</quarkus.version>
+        <quarkus.version>2.0.3.Final</quarkus.version>
 
         <!-- Jandex -->
         <jandex.version>1.1.1</jandex.version>

--- a/storage/kafkasql/pom.xml
+++ b/storage/kafkasql/pom.xml
@@ -42,6 +42,10 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-apicurio-registry-avro</artifactId>
+        </dependency>
 
         <!-- Test Only -->
         <dependency>


### PR DESCRIPTION
To fix security vulnerabilities mentioned in #1808 and #1807.

I tried with the latest quarkus minor in `2.0.x`, the latest is actually `2.2.1.Final`. It should be fairly easy to try with the latest.
Functionality wise it seems to be working in my environments.

I'm not completely sure about the `getPropertyNames()` and `sendEventHttp()` methods, please verify them.
I will check the tests results here as I couldn't run them locally.