### PR TITLE
serdes: rate limiting test scenarios

### DIFF
--- a/client/src/main/java/io/apicurio/registry/rest/client/exception/RateLimitedClientException.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/exception/RateLimitedClientException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.rest.client.exception;
+
+import io.apicurio.rest.client.error.ApicurioRestClientException;
+
+/**
+ * @author Fabian Martinez
+ */
+public class RateLimitedClientException extends ApicurioRestClientException {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 2537544296766983921L;
+
+    /**
+     * Constructor.
+     * @param error
+     */
+    public RateLimitedClientException(String error) {
+        super(error);
+    }
+
+}

--- a/integration-tests/testsuite/src/main/java/io/apicurio/tests/utils/RateLimitingProxy.java
+++ b/integration-tests/testsuite/src/main/java/io/apicurio/tests/utils/RateLimitingProxy.java
@@ -66,7 +66,8 @@ public class RateLimitingProxy {
         server = vertx.createHttpServer(new HttpServerOptions().setPort(port)).requestHandler(this::proxyRequest)
             .listen(server -> {
                 if (server.succeeded()) {
-                    logger.info("Proxy server started on port " + port);
+                    logger.info("Proxy server started on port {}", port);
+                    logger.info("Proxying server {}:{}", destinationHost, destinationPort);
                 } else {
                     logger.error("Error starting server", server.cause());
                 }
@@ -94,10 +95,12 @@ public class RateLimitingProxy {
         boolean allowed = allowed();
 
         if (!allowed) {
+            logger.info("Rejecting request, no longer allowed");
             req.response().setStatusCode(429);
             req.response().end();
             return;
         }
+        logger.info("Allowing request, redirecting");
 
         HttpClientRequest clientReq = client.request(req.method(), destinationPort, destinationHost, req.uri(), clientRes -> {
             req.response().setChunked(true);

--- a/integration-tests/testsuite/src/main/java/io/apicurio/tests/utils/RateLimitingProxy.java
+++ b/integration-tests/testsuite/src/main/java/io/apicurio/tests/utils/RateLimitingProxy.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.tests.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpServerRequest;
+
+/**
+ * @author Fabian Martinez
+ */
+public class RateLimitingProxy {
+
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
+
+    private Vertx vertx;
+    private int port = 30001;
+
+    private HttpServer server;
+
+    private HttpClient client;
+    private String destinationHost;
+    private int destinationPort;
+
+    private int buckets;
+
+    public RateLimitingProxy(int failAfterRequests, String destinationHost, int destinationPort) {
+
+        // this will rate limit just based on total requests
+        // that means that if buckets=3 the proxy will successfully redirect the first 3 requests and every request after that will be rejected with 429 status
+        this.buckets = failAfterRequests;
+
+        vertx = Vertx.vertx();
+        client = vertx.createHttpClient(new HttpClientOptions());
+        this.destinationHost = destinationHost;
+        this.destinationPort = destinationPort;
+    }
+
+    public String getServerUrl() {
+        return "http://localhost:" + port;
+    }
+
+    public void start() {
+
+        server = vertx.createHttpServer(new HttpServerOptions().setPort(port)).requestHandler(this::proxyRequest)
+            .listen(server -> {
+                if (server.succeeded()) {
+                    logger.info("Proxy server started on port " + port);
+                } else {
+                    logger.error("Error starting server", server.cause());
+                }
+            });
+
+    }
+
+    public void stop() {
+        if (server != null) {
+            server.close();
+        }
+    }
+
+    private synchronized boolean allowed() {
+        if (buckets > 0) {
+            buckets--;
+            return true;
+        }
+        return false;
+    }
+
+    @SuppressWarnings("deprecation")
+    private void proxyRequest(HttpServerRequest req) {
+
+        boolean allowed = allowed();
+
+        if (!allowed) {
+            req.response().setStatusCode(429);
+            req.response().end();
+            return;
+        }
+
+        HttpClientRequest clientReq = client.request(req.method(), destinationPort, destinationHost, req.uri(), clientRes -> {
+            req.response().setChunked(true);
+            req.response().setStatusCode(clientRes.statusCode());
+            req.response().headers().setAll(clientRes.headers());
+            clientRes.handler(data -> {
+                req.response().write(data);
+            });
+            clientRes.endHandler((v) -> req.response().end());
+            clientRes.exceptionHandler(e -> {
+               logger.error("Error caught in response of request to serverless", e);
+            });
+            req.response().exceptionHandler(e -> {
+               logger.error("Error caught in response to client", e);
+            });
+        });
+        clientReq.setChunked(true);
+        clientReq.headers().setAll(req.headers());
+
+        if (req.isEnded()) {
+            clientReq.end();
+        } else {
+            req.handler(data -> {
+                clientReq.write(data);
+            });
+            req.endHandler((v) -> {
+                clientReq.end();
+            });
+            clientReq.exceptionHandler(e -> {
+                logger.error("Error caught in proxiying request", e);
+                req.response().setStatusCode(500).putHeader("x-error", e.getMessage()).end();
+            });
+        }
+
+        req.exceptionHandler(e -> {
+           logger.error("Error caught in request from client", e);
+        });
+
+    }
+
+}

--- a/integration-tests/testsuite/src/main/java/io/apicurio/tests/utils/RateLimitingProxy.java
+++ b/integration-tests/testsuite/src/main/java/io/apicurio/tests/utils/RateLimitingProxy.java
@@ -53,7 +53,12 @@ public class RateLimitingProxy {
 
         vertx = Vertx.vertx();
         client = vertx.createHttpClient(new HttpClientOptions());
-        this.destinationHost = destinationHost;
+        if (destinationHost.endsWith("127.0.0.1.nip.io")) {
+            logger.info("Changing proxy destination host to localhost");
+            this.destinationHost = "localhost";
+        } else {
+            this.destinationHost = destinationHost;
+        }
         this.destinationPort = destinationPort;
     }
 

--- a/integration-tests/testsuite/src/main/java/io/apicurio/tests/utils/TooManyRequestsMock.java
+++ b/integration-tests/testsuite/src/main/java/io/apicurio/tests/utils/TooManyRequestsMock.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.tests.utils;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+
+
+/**
+ * @author Fabian Martinez
+ */
+public class TooManyRequestsMock {
+
+    static final Logger LOGGER = LoggerFactory.getLogger(TooManyRequestsMock.class);
+
+    private WireMockServer server;
+
+    public void start() {
+        server = new WireMockServer(
+                wireMockConfig()
+                        .dynamicPort());
+        server.start();
+
+//        kind: "Error"
+//        id: "429"
+//        code: "SERVICEREGISTRY-429"
+//        reason: "Too Many Requests"
+
+        JsonNode body = new ObjectMapper().createObjectNode()
+            .put("kind", "Error")
+            .put("id", "429")
+            .put("code", "SERVICEREGISTRY-429")
+            .put("reason", "Too Many Requests");
+
+        server.stubFor(
+                any(anyUrl())
+                        .willReturn(
+                                new ResponseDefinitionBuilder().withStatus(429)
+                                    .withJsonBody(body))
+                        );
+    }
+
+    public String getMockUrl() {
+        return server.baseUrl();
+    }
+
+    public void stop() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+}

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/serdes/apicurio/RateLimitedRegistrySerdeIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/serdes/apicurio/RateLimitedRegistrySerdeIT.java
@@ -81,7 +81,6 @@ public class RateLimitedRegistrySerdeIT extends ApicurioV2BaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
     void testFindLatestRateLimited() throws Exception {
 
         RateLimitingProxy proxy = new RateLimitingProxy(2, TestUtils.getRegistryHost(), TestUtils.getRegistryPort());
@@ -122,7 +121,6 @@ public class RateLimitedRegistrySerdeIT extends ApicurioV2BaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
     void testAutoRegisterRateLimited() throws Exception {
 
         RateLimitingProxy proxy = new RateLimitingProxy(2, TestUtils.getRegistryHost(), TestUtils.getRegistryPort());

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/serdes/apicurio/RateLimitedRegistrySerdeIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/serdes/apicurio/RateLimitedRegistrySerdeIT.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.tests.serdes.apicurio;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.RegistryClientFactory;
+import io.apicurio.registry.rest.client.exception.RateLimitedClientException;
+import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
+import io.apicurio.registry.serde.SerdeConfig;
+import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
+import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
+import io.apicurio.registry.serde.strategy.SimpleTopicIdStrategy;
+import io.apicurio.registry.serde.strategy.TopicIdStrategy;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.utils.IoUtil;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.apicurio.tests.ApicurioV2BaseIT;
+import io.apicurio.tests.common.Constants;
+import io.apicurio.tests.common.KafkaFacade;
+import io.apicurio.tests.utils.RateLimitingProxy;
+import io.apicurio.tests.utils.TooManyRequestsMock;
+
+/**
+ * @author Fabian Martinez
+ */
+@Tag(Constants.SERDES)
+public class RateLimitedRegistrySerdeIT extends ApicurioV2BaseIT {
+
+    private KafkaFacade kafkaCluster = KafkaFacade.getInstance();
+    private TooManyRequestsMock mock = new TooManyRequestsMock();
+
+
+    @BeforeAll
+    void setupEnvironment() {
+        kafkaCluster.startIfNeeded();
+        mock.start();
+    }
+
+    @AfterAll
+    public void teardown() throws Exception {
+        kafkaCluster.stopIfPossible();
+        mock.stop();
+    }
+
+    @Test
+    public void testClientRateLimitError() {
+
+        RegistryClient client = RegistryClientFactory.create(mock.getMockUrl());
+
+        Assertions.assertThrows(RateLimitedClientException.class, () -> client.getLatestArtifact("test", "test"));
+
+        Assertions.assertThrows(RateLimitedClientException.class, () -> client.createArtifact(null, "aaa", IoUtil.toStream("{}")));
+
+        Assertions.assertThrows(RateLimitedClientException.class, () -> client.getContentByGlobalId(5));
+
+    }
+
+    @Test
+    @Tag(Constants.ACCEPTANCE)
+    void testFindLatestRateLimited() throws Exception {
+
+        RateLimitingProxy proxy = new RateLimitingProxy(2, TestUtils.getRegistryHost(), TestUtils.getRegistryPort());
+        try {
+            proxy.start();
+
+            String topicName = TestUtils.generateTopic();
+            String artifactId = topicName;
+            kafkaCluster.createTopic(topicName, 1, 1);
+
+            AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1", List.of("key1"));
+
+            createArtifact(topicName, artifactId, ArtifactType.AVRO, avroSchema.generateSchemaStream());
+
+            new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>()
+                .withTopic(topicName)
+
+                //url of the proxy
+                .withCommonProperty(SerdeConfig.REGISTRY_URL, proxy.getServerUrl())
+
+                .withSerializer(AvroKafkaSerializer.class)
+                .withDeserializer(AvroKafkaDeserializer.class)
+                .withStrategy(SimpleTopicIdStrategy.class)
+                .withDataGenerator(avroSchema::generateRecord)
+                .withDataValidator(avroSchema::validateRecord)
+                .withProducerProperty(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, topicName)
+
+                // make serdes tester send multiple message batches, that will test that the cache is used when loaded
+                .withMessages(4, 5)
+
+                .build()
+                .test();
+
+        } finally {
+            proxy.stop();
+        }
+
+    }
+
+    @Test
+    @Tag(Constants.ACCEPTANCE)
+    void testAutoRegisterRateLimited() throws Exception {
+
+        RateLimitingProxy proxy = new RateLimitingProxy(2, TestUtils.getRegistryHost(), TestUtils.getRegistryPort());
+        try {
+            proxy.start();
+
+            String topicName = TestUtils.generateTopic();
+            //because of using TopicIdStrategy
+            String artifactId = topicName + "-value";
+            kafkaCluster.createTopic(topicName, 1, 1);
+
+            AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1", List.of("key1"));
+
+            new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>()
+                .withTopic(topicName)
+
+                //url of the proxy
+                .withCommonProperty(SerdeConfig.REGISTRY_URL, proxy.getServerUrl())
+
+                .withSerializer(AvroKafkaSerializer.class)
+                .withDeserializer(AvroKafkaDeserializer.class)
+                .withStrategy(TopicIdStrategy.class)
+                .withDataGenerator(avroSchema::generateRecord)
+                .withDataValidator(avroSchema::validateRecord)
+                .withProducerProperty(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true")
+                .withAfterProduceValidator(() -> {
+                    return TestUtils.retry(() -> {
+                        ArtifactMetaData meta = registryClient.getArtifactMetaData(null, artifactId);
+                        registryClient.getContentByGlobalId(meta.getGlobalId());
+                        return true;
+                    });
+                })
+
+                // make serdes tester send multiple message batches, that will test that the cache is used when loaded
+                .withMessages(4, 5)
+
+                .build()
+                .test();
+
+
+            //TODO make serdes tester send a second batch, that will test that the cache is used when loaded
+
+            ArtifactMetaData meta = registryClient.getArtifactMetaData(null, artifactId);
+            byte[] rawSchema = IoUtil.toBytes(registryClient.getContentByGlobalId(meta.getGlobalId()));
+
+            assertEquals(new String(avroSchema.generateSchemaBytes()), new String(rawSchema));
+
+        } finally {
+            proxy.stop();
+        }
+
+    }
+
+    @Test
+    void testFirstRequestFailsRateLimited() throws Exception {
+        String topicName = TestUtils.generateSubject();
+        kafkaCluster.createTopic(topicName, 1, 1);
+
+        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("mygroup", "myrecord", List.of("keyB"));
+
+        new WrongConfiguredSerdesTesterBuilder<GenericRecord>()
+            .withTopic(topicName)
+
+            //mock url that will return 429 status always
+            .withProducerProperty(SerdeConfig.REGISTRY_URL, mock.getMockUrl())
+
+            .withSerializer(AvroKafkaSerializer.class)
+            .withStrategy(TopicIdStrategy.class)
+            .withDataGenerator(avroSchema::generateRecord)
+            .build()
+            .test();
+    }
+
+}


### PR DESCRIPTION
This adds a new exception to our rest client to allow to handle rate limited scenarios.

I wrote a bunch of tests to verify how the serdes behave currently, and it mainly looks good.

We still may have issues in more advanced usecases where the rate limited exception may hit bad :)

One scenario I want to write a test is:
- serdes internal cache expiration, that may force me to implement some logic in the serdes to make it smart enough to use the data that was in the cache before hitting the rate limit exception. Still maybe a pretty rare situation