### PR TITLE
Check and convert data type for INT64

### DIFF
--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
@@ -1349,8 +1349,13 @@ public class AvroData {
                     break;
                 }
                 case INT64: {
-                    Long longValue = (Long) value; // Validate type
-                    converted = value;
+                    long longValue;
+                    if (value instanceof Integer) { // Convert up
+                        longValue = ((Integer) value).longValue();
+                    } else { // Validate type
+                        longValue = (Long) value;
+                    }
+                    converted = longValue;
                     break;
                 }
                 case FLOAT32: {

--- a/utils/converter/src/test/java/io/apicurio/registry/utils/converter/avro/AvroDataTest.java
+++ b/utils/converter/src/test/java/io/apicurio/registry/utils/converter/avro/AvroDataTest.java
@@ -1,10 +1,13 @@
 package io.apicurio.registry.utils.converter.avro;
 
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class AvroDataTest {
+
     @Test
     public void testIntWithConnectDefault() {
         final String s = "{"
@@ -55,5 +58,25 @@ public class AvroDataTest {
         Schema schema = avroData.toConnectSchema(avroSchema);
 
         Assertions.assertEquals(42L, schema.field("prop").schema().defaultValue());
+    }
+
+    @Test
+    public void testAvroInt64WithInteger() {
+        final String s = "{"
+            + "  \"type\": \"record\","
+            + "  \"name\": \"sample\","
+            + "  \"namespace\": \"io.apicurio\","
+            + "  \"fields\": ["
+            + "    {"
+            + "      \"name\": \"someprop\","
+            + "      \"type\": [\"long\",\"null\"]"
+            + "    }"
+            + "  ]"
+            + "}";
+
+        org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(s);
+        GenericRecord outputRecord = new GenericRecordBuilder(avroSchema).set("someprop", 42).build();
+        AvroData avroData = new AvroData(0);
+        Assertions.assertDoesNotThrow(() -> avroData.toConnectData(avroSchema, outputRecord));
     }
 }


### PR DESCRIPTION
Fix for #1825. This PR handles an issue with type conversion when schema of a field is `INT64` but the value is small enough to fit an `int`. `toConnectData` throws a `DataException`. The fix is to check if the class of the value is `Integer` and explicitly cast it to a `long`. The method already checks if the value is null or not to there is no need to use `Long`.