### PR TITLE
Upgrade to latest version of square.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,16 +8,16 @@ updates:
     ignore:
       - dependency-name: com.squareup.wire:wire-schema
         versions:
-          - ">= 3.6.a, < 3.7"
+          - ">= 3.6.a, < 4.3"
       - dependency-name: com.squareup.wire:wire-compiler
         versions:
-          - ">= 3.6.a, < 3.7"
-      - dependency-name: com.google.jimfs:jimfs
+          - ">= 3.6.a, < 4.3"
+      - dependency-name: com.squareup.okio:okio-fakefilesystem
         versions:
-          - ">= 1.1, < 1.3"
-      - dependency-name: com.ibm.icu:icu4j
+          - ">= 3.0.0-alpha.9, < 3.0.1"
+      - dependency-name: com.squareup.okio:okio
         versions:
-          - ">= 69.1, < 70.1"
+          - ">= 3.0.0-alpha.9, < 3.0.1"
       - dependency-name: org.apache.kafka:connect-api
         versions:
           - "> 2.2.1, < 2.3"

--- a/integration-tests/testsuite/pom.xml
+++ b/integration-tests/testsuite/pom.xml
@@ -132,10 +132,13 @@
             <groupId>com.squareup.wire</groupId>
             <artifactId>wire-compiler</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.google.jimfs/jimfs -->
         <dependency>
-            <groupId>com.google.jimfs</groupId>
-            <artifactId>jimfs</artifactId>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio-fakefilesystem</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -139,10 +139,9 @@
         <!-- Schema types -->
         <avro.version>1.10.2</avro.version>
         <json-schema-validator.version>1.0.58</json-schema-validator.version>
-        <wire-schema.version>3.7.0</wire-schema.version>
-        <wire-compiler.version>3.7.0</wire-compiler.version>
-        <jimfs.version>1.1</jimfs.version>
-        <icu4j.version>69.1</icu4j.version>
+        <wire-schema.version>4.0.1-SNAPSHOT</wire-schema.version>
+        <wire-compiler.version>4.0.1-SNAPSHOT</wire-compiler.version>
+        <okio.version>3.0.0-alpha.9</okio.version>
         <protobuf.version>3.17.3</protobuf.version>
         <xmlsec.version>2.1.5</xmlsec.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
@@ -416,16 +415,18 @@
                 <artifactId>wire-compiler</artifactId>
                 <version>${wire-compiler.version}</version>
             </dependency>
+            <!-- https://mvnrepository.com/artifact/com.squareup.okio/okio-fakefilesystem -->
             <dependency>
-                <groupId>com.google.jimfs</groupId>
-                <artifactId>jimfs</artifactId>
-                <version>${jimfs.version}</version>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-fakefilesystem</artifactId>
+                <version>${okio.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.ibm.icu</groupId>
-                <artifactId>icu4j</artifactId>
-                <version>${icu4j.version}</version>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>${okio.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>

--- a/schema-compatibility/protobuf/pom.xml
+++ b/schema-compatibility/protobuf/pom.xml
@@ -30,12 +30,16 @@
             <groupId>com.squareup.wire</groupId>
             <artifactId>wire-compiler</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.google.jimfs/jimfs -->
+
         <dependency>
-            <groupId>com.google.jimfs</groupId>
-            <artifactId>jimfs</artifactId>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio-fakefilesystem</artifactId>
         </dependency>
-    
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/serdes/protobuf-serde/pom.xml
+++ b/serdes/protobuf-serde/pom.xml
@@ -38,10 +38,14 @@
             <groupId>com.squareup.wire</groupId>
             <artifactId>wire-compiler</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.google.jimfs/jimfs -->
+
         <dependency>
-            <groupId>com.google.jimfs</groupId>
-            <artifactId>jimfs</artifactId>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio-fakefilesystem</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
         </dependency>
     </dependencies>
 

--- a/utils/protobuf-schema-utilities/pom.xml
+++ b/utils/protobuf-schema-utilities/pom.xml
@@ -28,15 +28,14 @@
             <groupId>com.squareup.wire</groupId>
             <artifactId>wire-compiler</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.google.jimfs/jimfs -->
-        <dependency>
-            <groupId>com.google.jimfs</groupId>
-            <artifactId>jimfs</artifactId>
-        </dependency>
 
         <dependency>
-            <groupId>com.ibm.icu</groupId>
-            <artifactId>icu4j</artifactId>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio-fakefilesystem</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrading to latest version of square wire library.

* The new version uses square FileSystem instead of jimfs.
* The version upgrade will include some of the bug fixes, [Ref](https://github.com/square/wire/issues/2042)