### PR TITLE
export v1 tool: feature flag match globalId and contentId

### DIFF
--- a/utils/exportV1/README.md
+++ b/utils/exportV1/README.md
@@ -17,7 +17,20 @@ java -jar target/apicurio-registry-utils-exportV1-2.0.0-SNAPSHOT-runner.jar http
 ```
 It will create a `registry-export.zip` in the current directory.
 
-You can configure the client used to connect to the registry API like this:
+### Feature flags
+
+This tool provides flags for specific features:
+
+***Note: if used, flags have to be provided in the order they are documented here***
+
++ `--match-content-id` This flag will make the globalId and contentId of all artifacts to match. Useful for confluent compatibility.
+i.e:
+```
+java -jar target/apicurio-registry-utils-exportV1-2.0.0-SNAPSHOT-runner.jar http://localhost:8080/api --match-content-id
+```
+
++ `--client-props <config-key>=<config-value>` This flag allows to pass config values to the underlying rest client.
+i.e: You can configure the client used to connect to the registry API like this:
 ```
 java -jar target/apicurio-registry-utils-exportV1-2.0.0-SNAPSHOT-runner.jar http://localhost:8080/api --client-props apicurio.registry.request.headers.x-custom-header=testvalue
 ```

--- a/utils/exportV1/src/main/java/io/apicurio/registry/utils/export/ContentExporter.java
+++ b/utils/exportV1/src/main/java/io/apicurio/registry/utils/export/ContentExporter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.export;
+
+import io.apicurio.registry.rest.beans.VersionMetaData;
+
+/**
+ * @author Fabian Martinez
+ */
+public interface ContentExporter {
+
+    Long writeContent(String contentHash, String canonicalContentHash, byte[] contentBytes,
+            VersionMetaData meta);
+
+}

--- a/utils/exportV1/src/main/java/io/apicurio/registry/utils/export/DefaultContentExporter.java
+++ b/utils/exportV1/src/main/java/io/apicurio/registry/utils/export/DefaultContentExporter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.export;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.apicurio.registry.rest.beans.VersionMetaData;
+import io.apicurio.registry.utils.impexp.ContentEntity;
+import io.apicurio.registry.utils.impexp.EntityWriter;
+
+/**
+ * @author Fabian Martinez
+ */
+public class DefaultContentExporter implements ContentExporter {
+
+    private AtomicInteger contentIdSeq = new AtomicInteger(1);
+    private Map<String, Long> contentIndex = new HashMap<>();
+
+    private EntityWriter writer;
+
+    public DefaultContentExporter(EntityWriter writer) {
+        this.writer = writer;
+    }
+
+    /**
+     * @see io.apicurio.registry.utils.export.ContentExporter#writeContent(java.lang.String, java.lang.String, byte[], io.apicurio.registry.rest.beans.VersionMetaData)
+     */
+    @Override
+    public Long writeContent(String contentHash, String canonicalContentHash, byte[] contentBytes, VersionMetaData meta) {
+        return contentIndex.computeIfAbsent(contentHash, k -> {
+            ContentEntity contentEntity = new ContentEntity();
+            contentEntity.contentId = contentIdSeq.getAndIncrement();
+            contentEntity.contentHash = contentHash;
+            contentEntity.canonicalHash = canonicalContentHash;
+            contentEntity.contentBytes = contentBytes;
+
+            try {
+                writer.writeEntity(contentEntity);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            return contentEntity.contentId;
+        });
+    }
+
+}

--- a/utils/exportV1/src/main/java/io/apicurio/registry/utils/export/MatchContentIdContentExporter.java
+++ b/utils/exportV1/src/main/java/io/apicurio/registry/utils/export/MatchContentIdContentExporter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.export;
+
+import java.io.IOException;
+import io.apicurio.registry.rest.beans.VersionMetaData;
+import io.apicurio.registry.utils.impexp.ContentEntity;
+import io.apicurio.registry.utils.impexp.EntityWriter;
+
+/**
+ * @author Fabian Martinez
+ */
+public class MatchContentIdContentExporter implements ContentExporter {
+
+    private EntityWriter writer;
+
+    public MatchContentIdContentExporter(EntityWriter writer) {
+        this.writer = writer;
+    }
+
+    /**
+     * @see io.apicurio.registry.utils.export.ContentExporter#writeContent(java.lang.String, java.lang.String, byte[], io.apicurio.registry.rest.beans.VersionMetaData)
+     */
+    @Override
+    public Long writeContent(String contentHash, String canonicalContentHash, byte[] contentBytes, VersionMetaData meta) {
+        ContentEntity contentEntity = new ContentEntity();
+        contentEntity.contentId = meta.getGlobalId();
+        contentEntity.contentHash = contentHash;
+        contentEntity.canonicalHash = canonicalContentHash;
+        contentEntity.contentBytes = contentBytes;
+
+        try {
+            writer.writeEntity(contentEntity);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return contentEntity.contentId;
+    }
+
+}


### PR DESCRIPTION
I haven't tested this yet, but I prefer to share it ASAP

This adds a new feature flag to the exportV1 tool in order to force the globalId and the contentId to be equal at the time of exporting the data from 1.X Apicurio Registry. Then when imported to 2.X Apicurio Registry globalId and contentId should be equal for all artifacts and apicurio 1.3.x serdes and confluent serdes of old applications should continue working fine, as well as new applications using apicurio 2.x serdes (configured to use contentId) should be backwards and forward compatible :)