### PR TITLE
feat: allow plugin properties to be set on command line

### DIFF
--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/AbstractRegistryMojo.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/AbstractRegistryMojo.java
@@ -40,24 +40,24 @@ public abstract class AbstractRegistryMojo extends AbstractMojo {
 
     /**
      * The registry's url.
-     * e.g. http://localhost:8080/api
+     * e.g. http://localhost:8080/api/v2
      */
-    @Parameter(required = true)
+    @Parameter(required = true, property = "registry.url")
     String registryUrl;
 
-    @Parameter
+    @Parameter(property = "auth.server.url")
     String authServerUrl;
 
-    @Parameter
+    @Parameter(property = "client.id")
     String clientId;
 
-    @Parameter
+    @Parameter(property = "client.secret")
     String clientSecret;
 
-    @Parameter
+    @Parameter(property = "username")
     String username;
 
-    @Parameter
+    @Parameter(property = "password")
     String password;
 
     private static RegistryClient client;


### PR DESCRIPTION
I've added the ability to set some of the configuration properties for the plugin on the command line. 

For example, the registryUrl property can be set with `-Dregistry.url`

A complete example using the example from the main README would like this : 
`mvn clean  install -Pupload -Dregistry.url=https://service-registry-stage.apps.app-sre-stage-0.k3s7.p1.openshiftapps.com/t/1602aa52-6cc7-43bc-99a1-7239bd5fef86/api/v2`

