### PR TITLE
move rate limit tests to multitenancy profile + auth to serdes rate limit tests

### DIFF
--- a/integration-tests/integration-tests-common/pom.xml
+++ b/integration-tests/integration-tests-common/pom.xml
@@ -30,7 +30,8 @@
 
         <!--junit 4 version, required by testcontainers, should be aligned with the version from testcontainers -->
         <junit4.version>4.13.2</junit4.version>
-        <wiremock-jre8.version>2.31.0</wiremock-jre8.version>
+
+        <debezium.version>1.6.2.Final</debezium.version>
     </properties>
 
     <repositories>
@@ -137,11 +138,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
-            <version>${wiremock-jre8.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>com.google.protobuf</groupId>
@@ -157,6 +153,21 @@
             <groupId>io.zonky.test</groupId>
             <artifactId>embedded-postgres</artifactId>
             <version>${embedded-postgres.version}</version><!--$NO-MVN-MAN-VER$-->
+        </dependency>
+
+        <!-- used for embedded kafka -->
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-core</artifactId>
+            <version>${debezium.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-core</artifactId>
+            <version>${debezium.version}</version>
+            <type>test-jar</type>
+            <scope>compile</scope>
         </dependency>
 
     </dependencies>

--- a/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/Constants.java
+++ b/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/Constants.java
@@ -67,4 +67,10 @@ public interface Constants {
     String AUTH = "auth";
 
     Path LOGS_DIR = Paths.get("target/logs/");
+
+    /**
+     * Env var name for mandating the testsuite to avoid using docker for running required infrastructure
+     */
+    public static final String NO_DOCKER_ENV_VAR = "NO_DOCKER";
+
 }

--- a/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
+++ b/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/RegistryFacade.java
@@ -481,7 +481,7 @@ public class RegistryFacade {
     @SuppressWarnings("rawtypes")
     private void setupSQLStorage(Map<String, String> appEnv) throws Exception {
 
-        String noDocker = System.getenv("NO_DOCKER");
+        String noDocker = System.getenv(Constants.NO_DOCKER_ENV_VAR);
         String currentEnv = System.getenv("CURRENT_ENV");
 
         if (currentEnv != null && "mas".equals(currentEnv)) {

--- a/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/kafka/EmbeddedKafka.java
+++ b/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/kafka/EmbeddedKafka.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.tests.common.kafka;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.kafka.KafkaCluster;
+import io.debezium.util.Testing;
+
+/**
+ * @author Fabian Martinez
+ */
+public class EmbeddedKafka {
+    static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedKafka.class);
+
+    protected static final int ZOOKEEPER_PORT = 2181;
+    protected static final int KAFKA_PORT = 9092;
+    protected static final String DATA_DIR = "cluster";
+
+    private static File dataDir;
+    private KafkaCluster kafkaCluster;
+
+    public String bootstrapServers() {
+        return kafkaCluster.brokerList();
+    }
+
+    public void start() {
+        try {
+            dataDir = Testing.Files.createTestingDirectory(DATA_DIR);
+
+            Properties props = new Properties();
+            props.put("auto.create.topics.enable", "false");
+
+            kafkaCluster = new KafkaCluster()
+                    .usingDirectory(dataDir)
+                    .withPorts(ZOOKEEPER_PORT, KAFKA_PORT)
+                    .withKafkaConfiguration(props)
+                    .deleteDataPriorToStartup(true)
+                    .addBrokers(1)
+                    .startup();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void stop() {
+        if (kafkaCluster != null) {
+            LOGGER.info("Shutting down Kafka cluster");
+            kafkaCluster.shutdown();
+            kafkaCluster = null;
+            boolean delete = dataDir.delete();
+            // If files are still locked and a test fails: delete on exit to allow subsequent test execution
+            if (!delete) {
+                dataDir.deleteOnExit();
+            }
+            LOGGER.info("Kafka cluster and all related data was deleted");
+        }
+    }
+}

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/MultitenancySupport.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/MultitenancySupport.java
@@ -45,14 +45,15 @@ public class MultitenancySupport {
     }
 
     public TenantUserClient createTenant() throws Exception {
-        TenantUser user = new TenantUser(UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        TenantUser user = new TenantUser(UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString());
         return createTenant(user);
     }
 
     public TenantUserClient createTenant(TenantUser user) throws Exception {
         String tenantAppUrl = registerTenant(user);
         var client = createUserClient(user, tenantAppUrl);
-        return new TenantUserClient(user, tenantAppUrl, client);
+        registryFacade.getMTOnlyKeycloakMock().addStubForTenant(user.clientId, user.clientSecret, user.organizationId);
+        return new TenantUserClient(user, tenantAppUrl, client, registryFacade.getMTOnlyKeycloakMock().tokenEndpoint);
     }
 
     private String registerTenant(TenantUser user) throws Exception {

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/MultitenancySupport.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/MultitenancySupport.java
@@ -45,14 +45,14 @@ public class MultitenancySupport {
     }
 
     public TenantUserClient createTenant() throws Exception {
-        TenantUser user = new TenantUser(UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        TenantUser user = new TenantUser(UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString());
         return createTenant(user);
     }
 
     public TenantUserClient createTenant(TenantUser user) throws Exception {
         String tenantAppUrl = registerTenant(user);
         var client = createUserClient(user, tenantAppUrl);
-        registryFacade.getMTOnlyKeycloakMock().addStubForTenant(user.clientId, user.clientSecret, user.organizationId);
+        registryFacade.getMTOnlyKeycloakMock().addStubForTenant(user.principalId, user.principalPassword, user.organizationId);
         return new TenantUserClient(user, tenantAppUrl, client, registryFacade.getMTOnlyKeycloakMock().tokenEndpoint);
     }
 

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/MultitenantAuthIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/MultitenantAuthIT.java
@@ -87,8 +87,8 @@ public class MultitenantAuthIT extends ApicurioRegistryBaseIT {
         MultitenancySupport mt = new MultitenancySupport();
 
         String tenantId = UUID.randomUUID().toString();
-        var user1 = new TenantUser(tenantId, "eric", "cool-org");
-        var user2 = new TenantUser(tenantId, "carles", "cool-org");
+        var user1 = new TenantUser(tenantId, "eric", "cool-org", UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        var user2 = new TenantUser(tenantId, "carles", "cool-org", UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
         //user1 is the owner of the tenant
         TenantUserClient tenantOwner = mt.createTenant(user1);
@@ -148,11 +148,11 @@ public class MultitenantAuthIT extends ApicurioRegistryBaseIT {
 
         MultitenancySupport mt = new MultitenancySupport();
 
-        var user1 = new TenantUser(UUID.randomUUID().toString(), "eric", "org1");
+        var user1 = new TenantUser(UUID.randomUUID().toString(), "eric", "org1", UUID.randomUUID().toString(), UUID.randomUUID().toString());
         TenantUserClient tenant1User1Client = mt.createTenant(user1);
         tenant1User1Client.client.listArtifactsInGroup(null);
 
-        var user2 = new TenantUser(UUID.randomUUID().toString(), "carles", "org2");
+        var user2 = new TenantUser(UUID.randomUUID().toString(), "carles", "org2", UUID.randomUUID().toString(), UUID.randomUUID().toString());
         TenantUserClient tenant2User2Client = mt.createTenant(user2);
         tenant2User2Client.client.listArtifactsInGroup(null);
 

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/MultitenantAuthIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/MultitenantAuthIT.java
@@ -87,8 +87,8 @@ public class MultitenantAuthIT extends ApicurioRegistryBaseIT {
         MultitenancySupport mt = new MultitenancySupport();
 
         String tenantId = UUID.randomUUID().toString();
-        var user1 = new TenantUser(tenantId, "eric", "cool-org", UUID.randomUUID().toString(), UUID.randomUUID().toString());
-        var user2 = new TenantUser(tenantId, "carles", "cool-org", UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        var user1 = new TenantUser(tenantId, "eric", "cool-org", UUID.randomUUID().toString());
+        var user2 = new TenantUser(tenantId, "carles", "cool-org", UUID.randomUUID().toString());
 
         //user1 is the owner of the tenant
         TenantUserClient tenantOwner = mt.createTenant(user1);
@@ -148,11 +148,11 @@ public class MultitenantAuthIT extends ApicurioRegistryBaseIT {
 
         MultitenancySupport mt = new MultitenancySupport();
 
-        var user1 = new TenantUser(UUID.randomUUID().toString(), "eric", "org1", UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        var user1 = new TenantUser(UUID.randomUUID().toString(), "eric", "org1", UUID.randomUUID().toString());
         TenantUserClient tenant1User1Client = mt.createTenant(user1);
         tenant1User1Client.client.listArtifactsInGroup(null);
 
-        var user2 = new TenantUser(UUID.randomUUID().toString(), "carles", "org2", UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        var user2 = new TenantUser(UUID.randomUUID().toString(), "carles", "org2", UUID.randomUUID().toString());
         TenantUserClient tenant2User2Client = mt.createTenant(user2);
         tenant2User2Client.client.listArtifactsInGroup(null);
 

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/TenantUser.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/TenantUser.java
@@ -24,11 +24,15 @@ public class TenantUser {
     public final String tenantId;
     public final String principalId;
     public final String organizationId;
+    public final String clientId;
+    public final String clientSecret;
 
-    public TenantUser(String tenantId, String principalId, String organizationId) {
+    public TenantUser(String tenantId, String principalId, String organizationId, String clientId, String clientSecret) {
         this.tenantId = tenantId;
         this.principalId = principalId;
         this.organizationId = organizationId;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
     }
 
 }

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/TenantUser.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/TenantUser.java
@@ -24,15 +24,13 @@ public class TenantUser {
     public final String tenantId;
     public final String principalId;
     public final String organizationId;
-    public final String clientId;
-    public final String clientSecret;
+    public final String principalPassword;
 
-    public TenantUser(String tenantId, String principalId, String organizationId, String clientId, String clientSecret) {
+    public TenantUser(String tenantId, String principalId, String organizationId, String principalPassword) {
         this.tenantId = tenantId;
         this.principalId = principalId;
         this.organizationId = organizationId;
-        this.clientId = clientId;
-        this.clientSecret = clientSecret;
+        this.principalPassword = principalPassword;
     }
 
 }

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/TenantUserClient.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/TenantUserClient.java
@@ -23,15 +23,17 @@ import io.apicurio.registry.rest.client.RegistryClient;
  */
 public class TenantUserClient {
 
-    final TenantUser user;
-    final String tenantAppUrl;
-    final RegistryClient client;
+    public final TenantUser user;
+    public final String tenantAppUrl;
+    public final RegistryClient client;
+    public final String tokenEndpoint;
 
-    public TenantUserClient(TenantUser user, String tenantAppUrl, RegistryClient client) {
+    public TenantUserClient(TenantUser user, String tenantAppUrl, RegistryClient client, String tokenEndpoint) {
         super();
         this.user = user;
         this.tenantAppUrl = tenantAppUrl;
         this.client = client;
+        this.tokenEndpoint = tokenEndpoint;
     }
 
 }

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/serdes/RateLimitedRegistrySerdeIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/serdes/RateLimitedRegistrySerdeIT.java
@@ -100,8 +100,9 @@ public class RateLimitedRegistrySerdeIT extends ApicurioRegistryBaseIT {
 
                 //add auth properties
                 .withCommonProperty(SerdeConfig.AUTH_TOKEN_ENDPOINT, tenant.tokenEndpoint)
-                .withCommonProperty(SerdeConfig.AUTH_CLIENT_ID, tenant.user.clientId)
-                .withCommonProperty(SerdeConfig.AUTH_CLIENT_SECRET, tenant.user.clientSecret)
+                //making use of tenant owner is admin feature
+                .withCommonProperty(SerdeConfig.AUTH_CLIENT_ID, tenant.user.principalId)
+                .withCommonProperty(SerdeConfig.AUTH_CLIENT_SECRET, tenant.user.principalPassword)
 
 
                 .withSerializer(AvroKafkaSerializer.class)
@@ -151,8 +152,9 @@ public class RateLimitedRegistrySerdeIT extends ApicurioRegistryBaseIT {
 
                 //add auth properties
                 .withCommonProperty(SerdeConfig.AUTH_TOKEN_ENDPOINT, tenant.tokenEndpoint)
-                .withCommonProperty(SerdeConfig.AUTH_CLIENT_ID, tenant.user.clientId)
-                .withCommonProperty(SerdeConfig.AUTH_CLIENT_SECRET, tenant.user.clientSecret)
+                //making use of tenant owner is admin feature
+                .withCommonProperty(SerdeConfig.AUTH_CLIENT_ID, tenant.user.principalId)
+                .withCommonProperty(SerdeConfig.AUTH_CLIENT_SECRET, tenant.user.principalPassword)
 
                 .withSerializer(AvroKafkaSerializer.class)
                 .withDeserializer(AvroKafkaDeserializer.class)

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/serdes/RateLimitedRegistrySerdeIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/multitenancy/serdes/RateLimitedRegistrySerdeIT.java
@@ -14,23 +14,22 @@
  * limitations under the License.
  */
 
-package io.apicurio.tests.serdes.apicurio;
+package io.apicurio.tests.multitenancy.serdes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.InputStream;
 import java.util.List;
 
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-
 import io.apicurio.registry.rest.client.RegistryClient;
-import io.apicurio.registry.rest.client.RegistryClientFactory;
-import io.apicurio.registry.rest.client.exception.RateLimitedClientException;
 import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.v2.beans.IfExists;
 import io.apicurio.registry.serde.SerdeConfig;
 import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
 import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
@@ -39,51 +38,49 @@ import io.apicurio.registry.serde.strategy.TopicIdStrategy;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.IoUtil;
 import io.apicurio.registry.utils.tests.TestUtils;
-import io.apicurio.tests.ApicurioV2BaseIT;
+import io.apicurio.tests.common.ApicurioRegistryBaseIT;
 import io.apicurio.tests.common.Constants;
 import io.apicurio.tests.common.KafkaFacade;
+import io.apicurio.tests.multitenancy.MultitenancySupport;
+import io.apicurio.tests.serdes.apicurio.AvroGenericRecordSchemaFactory;
+import io.apicurio.tests.serdes.apicurio.SimpleSerdesTesterBuilder;
 import io.apicurio.tests.utils.RateLimitingProxy;
-import io.apicurio.tests.utils.TooManyRequestsMock;
 
 /**
  * @author Fabian Martinez
  */
-@Tag(Constants.SERDES)
-public class RateLimitedRegistrySerdeIT extends ApicurioV2BaseIT {
+@Tag(Constants.MULTITENANCY)
+public class RateLimitedRegistrySerdeIT extends ApicurioRegistryBaseIT {
 
     private KafkaFacade kafkaCluster = KafkaFacade.getInstance();
-    private TooManyRequestsMock mock = new TooManyRequestsMock();
-
 
     @BeforeAll
     void setupEnvironment() {
         kafkaCluster.startIfNeeded();
-        mock.start();
     }
 
     @AfterAll
     public void teardown() throws Exception {
         kafkaCluster.stopIfPossible();
-        mock.stop();
     }
 
-    @Test
-    public void testClientRateLimitError() {
+    protected void createArtifact(RegistryClient client, String groupId, String artifactId, ArtifactType artifactType, InputStream artifact) throws Exception {
+        ArtifactMetaData meta = client.createArtifact(groupId, artifactId, null, artifactType, IfExists.FAIL, false, artifact);
 
-        RegistryClient client = RegistryClientFactory.create(mock.getMockUrl());
-
-        Assertions.assertThrows(RateLimitedClientException.class, () -> client.getLatestArtifact("test", "test"));
-
-        Assertions.assertThrows(RateLimitedClientException.class, () -> client.createArtifact(null, "aaa", IoUtil.toStream("{}")));
-
-        Assertions.assertThrows(RateLimitedClientException.class, () -> client.getContentByGlobalId(5));
-
+        TestUtils.retry(() -> client.getContentByGlobalId(meta.getGlobalId()));
+        assertNotNull(client.getLatestArtifact(meta.getGroupId(), meta.getId()));
     }
 
     @Test
     void testFindLatestRateLimited() throws Exception {
 
         RateLimitingProxy proxy = new RateLimitingProxy(2, TestUtils.getRegistryHost(), TestUtils.getRegistryPort());
+
+        MultitenancySupport mt = new MultitenancySupport();
+        var tenant = mt.createTenant();
+        RegistryClient clientTenant = tenant.client;
+        String tenantRateLimitedUrl = proxy.getServerUrl() + "/t/" + tenant.user.tenantId;
+
         try {
             proxy.start();
 
@@ -93,13 +90,19 @@ public class RateLimitedRegistrySerdeIT extends ApicurioV2BaseIT {
 
             AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1", List.of("key1"));
 
-            createArtifact(topicName, artifactId, ArtifactType.AVRO, avroSchema.generateSchemaStream());
+            createArtifact(clientTenant, topicName, artifactId, ArtifactType.AVRO, avroSchema.generateSchemaStream());
 
             new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>()
                 .withTopic(topicName)
 
                 //url of the proxy
-                .withCommonProperty(SerdeConfig.REGISTRY_URL, proxy.getServerUrl())
+                .withCommonProperty(SerdeConfig.REGISTRY_URL, tenantRateLimitedUrl)
+
+                //add auth properties
+                .withCommonProperty(SerdeConfig.AUTH_TOKEN_ENDPOINT, tenant.tokenEndpoint)
+                .withCommonProperty(SerdeConfig.AUTH_CLIENT_ID, tenant.user.clientId)
+                .withCommonProperty(SerdeConfig.AUTH_CLIENT_SECRET, tenant.user.clientSecret)
+
 
                 .withSerializer(AvroKafkaSerializer.class)
                 .withDeserializer(AvroKafkaDeserializer.class)
@@ -124,6 +127,12 @@ public class RateLimitedRegistrySerdeIT extends ApicurioV2BaseIT {
     void testAutoRegisterRateLimited() throws Exception {
 
         RateLimitingProxy proxy = new RateLimitingProxy(2, TestUtils.getRegistryHost(), TestUtils.getRegistryPort());
+
+        MultitenancySupport mt = new MultitenancySupport();
+        var tenant = mt.createTenant();
+        RegistryClient clientTenant = tenant.client;
+        String tenantRateLimitedUrl = proxy.getServerUrl() + "/t/" + tenant.user.tenantId;
+
         try {
             proxy.start();
 
@@ -138,7 +147,12 @@ public class RateLimitedRegistrySerdeIT extends ApicurioV2BaseIT {
                 .withTopic(topicName)
 
                 //url of the proxy
-                .withCommonProperty(SerdeConfig.REGISTRY_URL, proxy.getServerUrl())
+                .withCommonProperty(SerdeConfig.REGISTRY_URL, tenantRateLimitedUrl)
+
+                //add auth properties
+                .withCommonProperty(SerdeConfig.AUTH_TOKEN_ENDPOINT, tenant.tokenEndpoint)
+                .withCommonProperty(SerdeConfig.AUTH_CLIENT_ID, tenant.user.clientId)
+                .withCommonProperty(SerdeConfig.AUTH_CLIENT_SECRET, tenant.user.clientSecret)
 
                 .withSerializer(AvroKafkaSerializer.class)
                 .withDeserializer(AvroKafkaDeserializer.class)
@@ -148,8 +162,8 @@ public class RateLimitedRegistrySerdeIT extends ApicurioV2BaseIT {
                 .withProducerProperty(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true")
                 .withAfterProduceValidator(() -> {
                     return TestUtils.retry(() -> {
-                        ArtifactMetaData meta = registryClient.getArtifactMetaData(null, artifactId);
-                        registryClient.getContentByGlobalId(meta.getGlobalId());
+                        ArtifactMetaData meta = clientTenant.getArtifactMetaData(null, artifactId);
+                        clientTenant.getContentByGlobalId(meta.getGlobalId());
                         return true;
                     });
                 })
@@ -161,10 +175,8 @@ public class RateLimitedRegistrySerdeIT extends ApicurioV2BaseIT {
                 .test();
 
 
-            //TODO make serdes tester send a second batch, that will test that the cache is used when loaded
-
-            ArtifactMetaData meta = registryClient.getArtifactMetaData(null, artifactId);
-            byte[] rawSchema = IoUtil.toBytes(registryClient.getContentByGlobalId(meta.getGlobalId()));
+            ArtifactMetaData meta = clientTenant.getArtifactMetaData(null, artifactId);
+            byte[] rawSchema = IoUtil.toBytes(clientTenant.getContentByGlobalId(meta.getGlobalId()));
 
             assertEquals(new String(avroSchema.generateSchemaBytes()), new String(rawSchema));
 
@@ -172,26 +184,6 @@ public class RateLimitedRegistrySerdeIT extends ApicurioV2BaseIT {
             proxy.stop();
         }
 
-    }
-
-    @Test
-    void testFirstRequestFailsRateLimited() throws Exception {
-        String topicName = TestUtils.generateSubject();
-        kafkaCluster.createTopic(topicName, 1, 1);
-
-        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("mygroup", "myrecord", List.of("keyB"));
-
-        new WrongConfiguredSerdesTesterBuilder<GenericRecord>()
-            .withTopic(topicName)
-
-            //mock url that will return 429 status always
-            .withProducerProperty(SerdeConfig.REGISTRY_URL, mock.getMockUrl())
-
-            .withSerializer(AvroKafkaSerializer.class)
-            .withStrategy(TopicIdStrategy.class)
-            .withDataGenerator(avroSchema::generateRecord)
-            .build()
-            .test();
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,7 @@
         <keycloak-admin-client.version>14.0.0</keycloak-admin-client.version>
         <embedded-postgres.version>1.3.1</embedded-postgres.version>
         <strimzi.version>0.25.0</strimzi.version>
+        <wiremock-jre8.version>2.31.0</wiremock-jre8.version>
     </properties>
 
     <dependencyManagement>
@@ -608,6 +609,11 @@
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-admin-client</artifactId>
                 <version>${keycloak-admin-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock-jre8</artifactId>
+                <version>${wiremock-jre8.version}</version>
             </dependency>
 
         </dependencies>

--- a/utils/tests/pom.xml
+++ b/utils/tests/pom.xml
@@ -63,5 +63,10 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TooManyRequestsMock.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TooManyRequestsMock.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.apicurio.tests.utils;
+package io.apicurio.registry.utils.tests;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
-
 
 /**
  * @author Fabian Martinez


### PR DESCRIPTION
Because multitenancy test profile is something with specific infra configuration (multitenancy, auth enabled,...) it's a perfect place to have serdes tests using authentication.

This PR moves some tests to the multitenancy profile and introduces some changes that will allow us to have more serdes tests using authentication