### PR TITLE
feat: download artifacts

### DIFF
--- a/ui/src/app/pages/DownloadArtifacts/DownloadArtifacts.tsx
+++ b/ui/src/app/pages/DownloadArtifacts/DownloadArtifacts.tsx
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { Button, ButtonVariant } from "@patternfly/react-core";
+import { PageComponent, PageProps, PageState } from "../basePage";
+import { Services } from "../../../services";
+
+export type DownloadArtifactsProps = PageProps & {
+  downloadLinkLabel: string | undefined;
+  instanceName: string;
+};
+export type DownloadArtifactsState = PageState;
+
+export class DownloadArtifacts extends PageComponent<
+  DownloadArtifactsProps,
+  DownloadArtifactsState
+> {
+  constructor(props: Readonly<DownloadArtifactsProps>) {
+    super(props);
+  }
+
+  protected initializePageState(): DownloadArtifactsState {
+    return {};
+  }
+
+  private createDownloadLink = (response: string): void => {
+    const { instanceName = "artifacts" } = this.props;
+    const downloadUrl = window.URL.createObjectURL(
+      new Blob([response], { type: "application/zip" })
+    );
+
+    const link = document.createElement("a");
+    link.href = downloadUrl;
+    link.setAttribute("download", `${instanceName}.zip`);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  };
+
+  private downloadArtifacts = (): void => {
+    Services.getGroupsService()
+      .downloadArtifacts()
+      .then((response: string) => {
+        this.createDownloadLink(response);
+      });
+  };
+
+  public renderPage(): React.ReactElement {
+    const { downloadLinkLabel } = this.props;
+    return (
+      <Button
+        variant={ButtonVariant.link}
+        onClick={this.downloadArtifacts}
+        isInline
+        isActive={true}
+      >
+        {downloadLinkLabel || "Download artifacts (.zip)"}
+      </Button>
+    );
+  }
+}

--- a/ui/src/app/pages/DownloadArtifacts/DownloadArtifacts.tsx
+++ b/ui/src/app/pages/DownloadArtifacts/DownloadArtifacts.tsx
@@ -52,7 +52,10 @@ export class DownloadArtifacts extends PageComponent<
     link.remove();
   };
 
-  private downloadArtifacts = (): void => {
+  private downloadArtifacts = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ): void => {
+    event.preventDefault();
     Services.getGroupsService()
       .downloadArtifacts()
       .then((response: string) => {

--- a/ui/src/app/pages/DownloadArtifacts/DownloadArtifacts.tsx
+++ b/ui/src/app/pages/DownloadArtifacts/DownloadArtifacts.tsx
@@ -56,7 +56,7 @@ export class DownloadArtifacts extends PageComponent<
     event: React.MouseEvent<HTMLButtonElement>
   ): void => {
     event.preventDefault();
-    Services.getGroupsService()
+    Services.getAdminService()
       .downloadArtifacts()
       .then((response: string) => {
         this.createDownloadLink(response);

--- a/ui/src/app/pages/DownloadArtifacts/DownloadArtifactsFederated.tsx
+++ b/ui/src/app/pages/DownloadArtifacts/DownloadArtifactsFederated.tsx
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DownloadArtifacts, DownloadArtifactsProps } from "./DownloadArtifacts";
+import { FederatedPageProps, FederatedUtils } from "../../federated";
+
+export interface DownloadArtifactsFederatedProps
+  extends DownloadArtifactsProps,
+    FederatedPageProps {}
+
+export default class FederatedArtifactsPage extends DownloadArtifacts {
+  constructor(props: Readonly<DownloadArtifactsFederatedProps>) {
+    super(props);
+  }
+
+  protected postConstruct(): void {
+    FederatedUtils.updateConfiguration(this.props as FederatedPageProps);
+    super.postConstruct();
+  }
+}

--- a/ui/src/app/pages/DownloadArtifacts/DownloadArtifactsFederated.tsx
+++ b/ui/src/app/pages/DownloadArtifacts/DownloadArtifactsFederated.tsx
@@ -22,13 +22,15 @@ export interface DownloadArtifactsFederatedProps
   extends DownloadArtifactsProps,
     FederatedPageProps {}
 
-export default class FederatedArtifactsPage extends DownloadArtifacts {
+export default class DownloadArtifactsFederated extends DownloadArtifacts {
   constructor(props: Readonly<DownloadArtifactsFederatedProps>) {
     super(props);
   }
 
   protected postConstruct(): void {
-    FederatedUtils.updateConfiguration(this.props as FederatedPageProps);
+    FederatedUtils.updateConfiguration(
+      this.props as DownloadArtifactsFederatedProps
+    );
     super.postConstruct();
   }
 }

--- a/ui/src/services/admin/admin.service.ts
+++ b/ui/src/services/admin/admin.service.ts
@@ -113,4 +113,18 @@ export class AdminService extends BaseService {
         return this.httpDelete(endpoint);
     }
 
+    public downloadArtifacts(): Promise<string> {
+        this.logger.info("[AdminService] Download the artifacts.");
+
+        const options: any = this.options({
+            "Accept": "*"
+        });
+
+        options.responseType = "blob";
+        options.transformResponse = (data: any) => data;
+        let endpoint: string = this.endpoint("/v2/admin/export");
+
+        return this.httpGet<string>(endpoint, options);
+    }
+
 }

--- a/ui/src/services/groups/groups.service.ts
+++ b/ui/src/services/groups/groups.service.ts
@@ -241,18 +241,6 @@ export class GroupsService extends BaseService {
         return this.httpDelete(endpoint);
     }
 
-    public downloadArtifacts(): Promise<string> {
-        const options: any = this.options({
-            "Accept": "*"
-        });
-
-        options.responseType = "blob";
-        options.transformResponse = (data: any) => data;
-        let endpoint: string = this.endpoint("/v2/admin/export");
-
-        return this.httpGet<string>(endpoint, options);
-    }
-
     private normalizeGroupId(groupId: string|null): string {
         return groupId || "default";
     }

--- a/ui/src/services/groups/groups.service.ts
+++ b/ui/src/services/groups/groups.service.ts
@@ -241,6 +241,18 @@ export class GroupsService extends BaseService {
         return this.httpDelete(endpoint);
     }
 
+    public downloadArtifacts(): Promise<string> {
+        const options: any = this.options({
+            "Accept": "*"
+        });
+
+        options.responseType = "blob";
+        options.transformResponse = (data: any) => data;
+        let endpoint: string = this.endpoint("/v2/admin/export");
+
+        return this.httpGet<string>(endpoint, options);
+    }
+
     private normalizeGroupId(groupId: string|null): string {
         return groupId || "default";
     }

--- a/ui/webpack.common.js
+++ b/ui/webpack.common.js
@@ -49,7 +49,8 @@ module.exports = (mode) => {
           "./FederatedArtifactRedirectPage": "./src/app/pages/artifact/artifact.federated",
           "./FederatedArtifactVersionPage": "./src/app/pages/artifactVersion/artifactVersion.federated",
           "./FederatedRulesPage": "./src/app/pages/rules/rules.federated",
-          "./FederatedRolesPage": "./src/app/pages/roles/roles.federated"
+          "./FederatedRolesPage": "./src/app/pages/roles/roles.federated",
+          "./DownloadArtifactsFederated":"./src/app/pages/DownloadArtifacts/DownloadArtifactsFederated"
         },
         shared: {
           ...dependencies,


### PR DESCRIPTION
Before delete service registry instance user can download artifacts from delete modal by click on link.
Jira: https://issues.redhat.com/browse/MGDSTRM-4979

![image](https://user-images.githubusercontent.com/11775081/135294391-905dc484-3957-46f2-ad93-87cc30afcfbb.png)
