### PR TITLE
tenant-manager: audit logging

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -32,6 +32,12 @@ quarkus.log.console.format=%d{YYYY-MM-DD HH:mm:ss} %p <%X{tenantId}> [%C] (%t) %
 %prod.quarkus.log.console.enable=true
 %prod.quarkus.log.category."io.apicurio".level=${REGISTRY_LOG_LEVEL:INFO}
 
+# Access logs
+quarkus.http.access-log.enabled=${ENABLE_ACCESS_LOG:false}
+quarkus.http.access-log.pattern="apicurio-registry.access method="%{METHOD}" path="%{REQUEST_URL}" response_code="%{RESPONSE_CODE}" response_time="%{RESPONSE_TIME}" remote_ip="%{REMOTE_IP}" remote_user="%{REMOTE_USER}" user_agent="%{i,User-Agent}""
+#this property will be used by Quarkus 2.X
+quarkus.http.access-log.exclude-pattern=/health/.*
+
 # Sentry - the rest of the sentry configuration is picked from sentry own env vars
 registry.enable.sentry=${ENABLE_SENTRY:false}
 

--- a/distro/openshift-template/mt/apicurio-registry-mt-template.yaml
+++ b/distro/openshift-template/mt/apicurio-registry-mt-template.yaml
@@ -147,6 +147,8 @@ objects:
             value: ${REGISTRY_QUARKUS_LOG_LEVEL}
           - name: QUARKUS_PROFILE
             value: prod
+          - name: ENABLE_ACCESS_LOG
+            value: ${ENABLE_ACCESS_LOG}
 
           - name: ENABLE_SENTRY
             value: ${ENABLE_SENTRY}
@@ -318,6 +320,8 @@ objects:
             value: ${TENANT_MANAGER_QUARKUS_LOG_LEVEL}
           - name: TENANT_MANAGER_LOG_LEVEL
             value: ${TENANT_MANAGER_LOG_LEVEL}
+          - name: ENABLE_ACCESS_LOG
+            value: ${ENABLE_ACCESS_LOG}
 
           - name: ENABLE_SENTRY
             value: ${ENABLE_SENTRY}
@@ -430,6 +434,9 @@ parameters:
 
 - name: TENANT_MANAGER_QUARKUS_LOG_LEVEL
   value: INFO
+
+- name: ENABLE_ACCESS_LOG
+  value: false
 
 - name: SERVICE_ACCOUNT_NAME
   displayName: Service Account to use for the deployment

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/api/TenantsResourceImpl.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/api/TenantsResourceImpl.java
@@ -42,6 +42,8 @@ import io.apicurio.multitenant.api.datamodel.SortOrder;
 import io.apicurio.multitenant.api.datamodel.TenantStatusValue;
 import io.apicurio.multitenant.api.datamodel.UpdateRegistryTenantRequest;
 import io.apicurio.multitenant.api.dto.DtoMappers;
+import io.apicurio.multitenant.logging.audit.AuditLogService;
+import io.apicurio.multitenant.logging.audit.Audited;
 import io.apicurio.multitenant.storage.RegistryTenantStorage;
 import io.apicurio.multitenant.storage.TenantNotFoundException;
 import io.apicurio.multitenant.storage.dto.RegistryTenantDto;
@@ -57,6 +59,9 @@ public class TenantsResourceImpl implements TenantsResource {
 
     @Inject
     RegistryTenantStorage tenantsRepository;
+
+    @Inject
+    AuditLogService auditLog;
 
     @Override
     public RegistryTenantList getTenants(@QueryParam("status") String status,
@@ -88,6 +93,7 @@ public class TenantsResourceImpl implements TenantsResource {
 
     @Override
     @Transactional
+    @Audited
     public Response createTenant(NewRegistryTenantRequest tenantRequest) {
 
         required(tenantRequest.getTenantId(), "TenantId is mandatory");
@@ -136,6 +142,7 @@ public class TenantsResourceImpl implements TenantsResource {
      */
     @Override
     @Transactional
+    @Audited
     public void updateTenant(String tenantId, UpdateRegistryTenantRequest tenantRequest) {
         RegistryTenantDto tenant = tenantsRepository.findByTenantId(tenantId).orElseThrow(() -> TenantNotFoundException.create(tenantId));
         if (tenantRequest.getName() != null) {
@@ -176,6 +183,7 @@ public class TenantsResourceImpl implements TenantsResource {
 
     @Override
     @Transactional
+    @Audited
     public void deleteTenant(@PathParam("tenantId") String tenantId) {
         RegistryTenantDto tenant = tenantsRepository.findByTenantId(tenantId).orElseThrow(() -> TenantNotFoundException.create(tenantId));
         tenant.setStatus(TenantStatusValue.TO_BE_DELETED.value());

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/api/services/RegistryDeploymentInfoService.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/api/services/RegistryDeploymentInfoService.java
@@ -24,9 +24,7 @@ import io.apicurio.multitenant.api.datamodel.RegistryDeploymentInfo;
 
 /**
  * This service provides information about the registry deployment paired with this tenant manager.
- * The tenant manager can know what registry deployment is paired with via different ways.
- * Via "registry.route.url" config property or via "registry.route.name", with the latter the tenant manager
- * will use the OpenshiftClient to query the Openshift cluster to get the registry deployment url.
+ * The tenant manager can know what registry deployment is paired with via "registry.route.url" config property.
  *
  * @author Fabian Martinez
  */

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/auth/CustomAuthenticationMechanism.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/auth/CustomAuthenticationMechanism.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.multitenant.auth;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+
+import io.apicurio.multitenant.logging.audit.AuditHttpRequestContext;
+import io.apicurio.multitenant.logging.audit.AuditHttpRequestInfo;
+import io.apicurio.multitenant.logging.audit.AuditLogService;
+import io.quarkus.oidc.runtime.BearerAuthenticationMechanism;
+import io.quarkus.oidc.runtime.OidcAuthenticationMechanism;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.identity.request.TokenAuthenticationRequest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Custom HttpAuthenticationMechanism that simply wraps OidcAuthenticationMechanism.
+ * The only purpose of this HttpAuthenticationMechanism is to handle authentication errors in order to generate audit logs.
+ *
+ * @author Fabian Martinez
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class CustomAuthenticationMechanism implements HttpAuthenticationMechanism {
+
+    @Inject
+    Logger log;
+
+    @Inject
+    OidcAuthenticationMechanism oidcAuthenticationMechanism;
+
+    @Inject
+    AuditHttpRequestContext auditContext;
+    @Inject
+    AuditLogService auditLog;
+
+    private final BearerAuthenticationMechanism bearerAuth = new BearerAuthenticationMechanism();;
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+
+
+        BiConsumer<RoutingContext, Throwable> failureHandler = context.get(QuarkusHttpUser.AUTH_FAILURE_HANDLER);
+        BiConsumer<RoutingContext, Throwable> auditWrapper = (ctx, ex) -> {
+            //this sends the http response
+            failureHandler.accept(ctx, ex);
+            //if it was an error response log it
+            if (ctx.response().getStatusCode() >= 400) {
+                Map<String, String> metadata = new HashMap<>();
+                metadata.put("method", ctx.request().method().name());
+                metadata.put("path", ctx.request().path());
+                metadata.put("response_code", String.valueOf(ctx.response().getStatusCode()));
+                if (ex != null) {
+                    metadata.put("error_msg", ex.getMessage());
+                }
+
+                //request context for AuditHttpRequestContext does not exist at this point
+                auditLog.log("authenticate", AuditHttpRequestContext.FAILURE, metadata, new AuditHttpRequestInfo() {
+                    @Override
+                    public String getSourceIp() {
+                        return ctx.request().remoteAddress().toString();
+                    }
+                    @Override
+                    public String getForwardedFor() {
+                        return ctx.request().getHeader(AuditHttpRequestContext.X_FORWARDED_FOR_HEADER);
+                    }
+                });
+            }
+        };
+        log.info("Setting audit wrapper {}", context.statusCode());
+        context.put(QuarkusHttpUser.AUTH_FAILURE_HANDLER, auditWrapper);
+
+        return oidcAuthenticationMechanism.authenticate(context, identityProviderManager);
+    }
+
+    @Override
+    public Uni<ChallengeData> getChallenge(RoutingContext context) {
+        return bearerAuth.getChallenge(context);
+    }
+
+    @Override
+    public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+        return Collections.singleton(TokenAuthenticationRequest.class);
+    }
+
+    @Override
+    public HttpCredentialTransport getCredentialTransport() {
+        return new HttpCredentialTransport(HttpCredentialTransport.Type.AUTHORIZATION, "bearer");
+    }
+}

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditHttpRequestContext.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditHttpRequestContext.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.multitenant.logging.audit;
+
+import javax.enterprise.context.RequestScoped;
+
+/**
+ * @author Fabian Martinez
+ */
+@RequestScoped
+public class AuditHttpRequestContext implements AuditHttpRequestInfo {
+
+    public static final String X_FORWARDED_FOR_HEADER = "x-forwarded-for";
+    public static final String FAILURE = "failure";
+    public static final String SUCCESS = "success";
+
+    private String sourceIp;
+    private String forwardedFor;
+    private boolean auditEntryGenerated = false;
+
+    @Override
+    public String getSourceIp() {
+        return sourceIp;
+    }
+
+    public void setSourceIp(String sourceIp) {
+        this.sourceIp = sourceIp;
+    }
+
+    @Override
+    public String getForwardedFor() {
+        return forwardedFor;
+    }
+
+    public void setForwardedFor(String forwardedFor) {
+        this.forwardedFor = forwardedFor;
+    }
+
+    public boolean isAuditEntryGenerated() {
+        return auditEntryGenerated;
+    }
+
+    public void setAuditEntryGenerated(boolean auditEntryGenerated) {
+        this.auditEntryGenerated = auditEntryGenerated;
+    }
+
+}

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditHttpRequestInfo.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditHttpRequestInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.multitenant.logging.audit;
+
+/**
+ * @author Fabian Martinez
+ */
+public interface AuditHttpRequestInfo {
+
+    /**
+     * @return the sourceIp
+     */
+    String getSourceIp();
+
+    /**
+     * @return the forwardedFor
+     */
+    String getForwardedFor();
+
+}

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditLogService.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditLogService.java
@@ -34,7 +34,7 @@ public class AuditLogService {
 
     public void log(String action, String result, Map<String, String> metadata) {
         StringBuilder m = new StringBuilder();
-        m.append("tenant-manager")
+        m.append("tenant-manager.audit")
             .append(" ")
             .append("action=\"").append(action).append("\" ")
             .append("result=\"").append(result).append("\" ");

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditLogService.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditLogService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.multitenant.logging.audit;
+
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+
+/**
+ * @author Fabian Martinez
+ */
+@ApplicationScoped
+public class AuditLogService {
+
+    @Inject
+    Logger log;
+
+    public void log(String action, String result, Map<String, String> metadata) {
+        StringBuilder m = new StringBuilder();
+        m.append("tenant-manager")
+            .append(" ")
+            .append("action=\"").append(action).append("\" ")
+            .append("result=\"").append(result).append("\" ");
+        for (Map.Entry<String, String> e : metadata.entrySet()) {
+            m.append(e.getKey()).append("=\"").append(e.getValue()).append("\" ");
+        }
+        log.info(m.toString());
+    }
+
+}

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/Audited.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/Audited.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.multitenant.logging.audit;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+/**
+ * This annotation is processed by {@link AuditedInterceptor}
+ *
+ * *** IMPORTANT NOTE *** TenantId is assumed to be found in the annotated method parameters, either as an Object field or simply as a String.
+ *
+ * @author Fabian Martinez
+ */
+@InterceptorBinding
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface Audited {
+
+    /**
+     * If empty or null the method name will be used as the action identifier
+     * @return
+     */
+    String action() default "";
+
+}

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditedInterceptor.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditedInterceptor.java
@@ -82,15 +82,15 @@ public class AuditedInterceptor {
             action = context.getMethod().getName();
         }
 
-        String result = "success";
+        String result = AuditHttpRequestContext.SUCCESS;
         try {
             return context.proceed();
         } catch (Exception e) {
-            result = "failure";
+            result = AuditHttpRequestContext.FAILURE;
             metadata.put("error_msg", e.getMessage());
             throw e;
         } finally {
-            auditLogService.log(action, result, metadata);
+            auditLogService.log(action, result, metadata, null);
         }
 
     }

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditedInterceptor.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditedInterceptor.java
@@ -49,7 +49,7 @@ public class AuditedInterceptor {
     AuditLogService auditLogService;
 
     @AroundInvoke
-    public Object authorizeMethod(InvocationContext context) throws Exception {
+    public Object auditMethod(InvocationContext context) throws Exception {
 
         Audited annotation = context.getMethod().getAnnotation(Audited.class);
 

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditedInterceptor.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/AuditedInterceptor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.multitenant.logging.audit;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import io.apicurio.multitenant.api.datamodel.NewRegistryTenantRequest;
+import io.apicurio.multitenant.api.datamodel.UpdateRegistryTenantRequest;
+
+/**
+ * Interceptor that executes around methods annotated with {@link Audited}
+ *
+ * This interceptor follows the execution of a method and marks the audit entry as failed if the inner method throws an exception.
+ *
+ * This interceptor reads the inner method parameters to gather extra information for the audit entry.
+ *
+ * *** IMPORTANT NOTE *** TenantId is assumed to be found in the annotated method parameters, either as an Object field or simply as a String.
+ * **Caution** Any string parameter will be considered the tenantId
+ *
+ * @author Fabian Martinez
+ */
+@Audited
+@Interceptor
+@Priority(Interceptor.Priority.APPLICATION)
+public class AuditedInterceptor {
+
+    @Inject
+    AuditLogService auditLogService;
+
+    @AroundInvoke
+    public Object authorizeMethod(InvocationContext context) throws Exception {
+
+        Audited annotation = context.getMethod().getAnnotation(Audited.class);
+
+
+        Map<String, String> metadata = new HashMap<>();
+
+        for (Object parameter : context.getParameters()) {
+            if (parameter instanceof NewRegistryTenantRequest) {
+                NewRegistryTenantRequest tenant = (NewRegistryTenantRequest) parameter;
+                metadata.put("tenantId", tenant.getTenantId());
+                metadata.put("orgId", tenant.getOrganizationId());
+                metadata.put("name", tenant.getName());
+                metadata.put("createdBy", tenant.getCreatedBy());
+            } else if (parameter instanceof String) {
+                metadata.put("tenantId", (String)parameter);
+            } else if (parameter instanceof UpdateRegistryTenantRequest) {
+                UpdateRegistryTenantRequest tenant = (UpdateRegistryTenantRequest) parameter;
+                if (tenant.getStatus() != null) {
+                    metadata.put("tenantStatus", tenant.getStatus().value());
+                }
+                if (tenant.getName() != null) {
+                    metadata.put("name", tenant.getName());
+                }
+            }
+        }
+
+
+        String action = annotation.action();
+        if (action == null || action.isEmpty()) {
+            action = context.getMethod().getName();
+        }
+
+        String result = "success";
+        try {
+            return context.proceed();
+        } catch (Exception e) {
+            result = "failure";
+            metadata.put("error_msg", e.getMessage());
+            throw e;
+        } finally {
+            auditLogService.log(action, result, metadata);
+        }
+
+    }
+
+
+}

--- a/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/HttpRequestsAuditFilter.java
+++ b/multitenancy/tenant-manager-api/src/main/java/io/apicurio/multitenant/logging/audit/HttpRequestsAuditFilter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.multitenant.logging.audit;
+
+import io.vertx.core.http.HttpServerRequest;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.ext.Provider;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Filters REST API requests and responses to generate audit logs for failed requests
+ *
+ * @author Fabian Martinez
+ */
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+@ApplicationScoped
+public class HttpRequestsAuditFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    @Inject
+    Logger log;
+
+    @Context
+    HttpServerRequest request;
+
+    @Inject
+    AuditHttpRequestContext auditContext;
+
+    @Inject
+    AuditLogService auditLog;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        auditContext.setSourceIp(request.remoteAddress().toString());
+        auditContext.setForwardedFor(requestContext.getHeaderString(AuditHttpRequestContext.X_FORWARDED_FOR_HEADER));
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+        throws IOException {
+
+        // check if there is already an audit entry for the logic executed in this request
+        if (auditContext.isAuditEntryGenerated()) {
+            return;
+        }
+
+        if (responseContext.getStatus() >= 400) {
+            //failed request, generate audit log
+            Map<String, String> metadata = new HashMap<>();
+            metadata.put("method", requestContext.getMethod());
+            metadata.put("path", requestContext.getUriInfo().getPath());
+            metadata.put("response_code", String.valueOf(responseContext.getStatus()));
+            metadata.put("user", Optional.ofNullable(requestContext.getSecurityContext()).map(SecurityContext::getUserPrincipal).map(Principal::getName).orElseGet(() -> ""));
+
+            auditLog.log("request", AuditHttpRequestContext.FAILURE, metadata, null);
+        }
+
+    }
+
+}

--- a/multitenancy/tenant-manager-api/src/main/resources/application.properties
+++ b/multitenancy/tenant-manager-api/src/main/resources/application.properties
@@ -44,8 +44,8 @@ quarkus.http.port=${HTTP_PORT:8585}
 quarkus.http.cors=true
 
 # Access logs
-quarkus.http.access-log.enabled=${ENABLE_ACCESS_LOG:true}
-quarkus.http.access-log.pattern="tenant-manager.audit method="%{METHOD}" path="%{REQUEST_URL}" response_code="%{RESPONSE_CODE}" response_time="%{RESPONSE_TIME}" remote_ip="%{REMOTE_IP}" remote_user="%{REMOTE_USER}" user_agent="%{i,User-Agent}""
+quarkus.http.access-log.enabled=${ENABLE_ACCESS_LOG:false}
+quarkus.http.access-log.pattern="tenant-manager.access method="%{METHOD}" path="%{REQUEST_URL}" response_code="%{RESPONSE_CODE}" response_time="%{RESPONSE_TIME}" remote_ip="%{REMOTE_IP}" remote_user="%{REMOTE_USER}" user_agent="%{i,User-Agent}""
 #this property will be used by Quarkus 2.X
 quarkus.http.access-log.exclude-pattern=/q/.*
 

--- a/multitenancy/tenant-manager-api/src/main/resources/application.properties
+++ b/multitenancy/tenant-manager-api/src/main/resources/application.properties
@@ -43,6 +43,12 @@ quarkus.package.type=legacy-jar
 quarkus.http.port=${HTTP_PORT:8585}
 quarkus.http.cors=true
 
+# Access logs
+quarkus.http.access-log.enabled=${ENABLE_ACCESS_LOG:true}
+quarkus.http.access-log.pattern="tenant-manager.audit method="%{METHOD}" path="%{REQUEST_URL}" response_code="%{RESPONSE_CODE}" response_time="%{RESPONSE_TIME}" remote_ip="%{REMOTE_IP}" remote_user="%{REMOTE_USER}" user_agent="%{i,User-Agent}""
+#this property will be used by Quarkus 2.X
+quarkus.http.access-log.exclude-pattern=/q/.*
+
 # Sentry - the rest of the sentry configuration is picked from sentry own env vars
 tenant-manager.enable.sentry=${ENABLE_SENTRY:false}
 
@@ -57,8 +63,6 @@ tenant-manager.keycloak.url=${KEYCLOAK_URL:http://localhost:8090/auth}
 tenant-manager.keycloak.realm=${KEYCLOAK_REALM:apicurio-local}
 
 tenant-manager.keycloak.url.configured=${tenant-manager.keycloak.url}/realms/${tenant-manager.keycloak.realm}/protocol/openid-connect/token
-
-tenant-manager.authz.enabled=${TENANT_MANAGER_AUTHZ_ENABLED:false}
 
 quarkus.oidc.auth-server-url=${tenant-manager.keycloak.url}/realms/${tenant-manager.keycloak.realm}
 quarkus.oidc.client-id=${KEYCLOAK_API_CLIENT_ID:registry-api}

--- a/multitenancy/tenant-manager-api/src/test/java/io/apicurio/multitenant/logging/audit/MockAuditLogService.java
+++ b/multitenancy/tenant-manager-api/src/test/java/io/apicurio/multitenant/logging/audit/MockAuditLogService.java
@@ -35,8 +35,8 @@ public class MockAuditLogService extends AuditLogService {
      * @see io.apicurio.multitenant.logging.audit.AuditLogService#log(java.lang.String, java.lang.String, java.util.Map)
      */
     @Override
-    public void log(String action, String result, Map<String, String> metadata) {
-        super.log(action, result, metadata);
+    public void log(String action, String result, Map<String, String> metadata, AuditHttpRequestInfo requestInfo) {
+        super.log(action, result, metadata, requestInfo);
         Map<String, String> audit = new HashMap<>(metadata);
         audit.put("action", action);
         audit.put("result", result);

--- a/multitenancy/tenant-manager-api/src/test/java/io/apicurio/multitenant/logging/audit/MockAuditLogService.java
+++ b/multitenancy/tenant-manager-api/src/test/java/io/apicurio/multitenant/logging/audit/MockAuditLogService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.multitenant.logging.audit;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.quarkus.test.Mock;
+
+/**
+ * @author Fabian Martinez
+ */
+@Mock
+public class MockAuditLogService extends AuditLogService {
+
+    private static final List<Map<String, String>> auditLogs = new CopyOnWriteArrayList<>();
+
+    /**
+     * @see io.apicurio.multitenant.logging.audit.AuditLogService#log(java.lang.String, java.lang.String, java.util.Map)
+     */
+    @Override
+    public void log(String action, String result, Map<String, String> metadata) {
+        super.log(action, result, metadata);
+        Map<String, String> audit = new HashMap<>(metadata);
+        audit.put("action", action);
+        audit.put("result", result);
+        auditLogs.add(audit);
+    }
+
+    public List<Map<String, String>> getAuditLogs() {
+        return auditLogs;
+    }
+
+    public void resetAuditLogs() {
+        auditLogs.clear();
+    }
+
+}


### PR DESCRIPTION
this PR adds audit logging to the tenant-manager. I implemented it using an interceptor

It's missing adding auditing for authentication failures

and also missing gather client IPs