### PR TITLE
increase integration tests timeouts to deploy registry

### DIFF
--- a/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/Constants.java
+++ b/integration-tests/integration-tests-common/src/main/java/io/apicurio/tests/common/Constants.java
@@ -24,8 +24,8 @@ import java.time.Duration;
  */
 public interface Constants {
     long POLL_INTERVAL = Duration.ofSeconds(1).toMillis();
-    long TIMEOUT_FOR_REGISTRY_START_UP = Duration.ofSeconds(15).toMillis();
-    long TIMEOUT_FOR_REGISTRY_READY = Duration.ofSeconds(25).toMillis();
+    long TIMEOUT_FOR_REGISTRY_START_UP = Duration.ofSeconds(25).toMillis();
+    long TIMEOUT_FOR_REGISTRY_READY = Duration.ofSeconds(30).toMillis();
     long TIMEOUT_GLOBAL = Duration.ofSeconds(30).toMillis();
 
     /**


### PR DESCRIPTION
this is to try to make kafkasql clustered tests more stable