### PR TITLE
Better support for unique client and group ids in kafkasql

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -5,6 +5,7 @@ quarkus.index-dependency.jaxrs.group-id=org.jboss.spec.javax.ws.rs
 quarkus.index-dependency.jaxrs.artifact-id=jboss-jaxrs-api_2.1_spec
 
 # Name and description
+registry.id=apicurio-registry
 registry.name=Apicurio Registry (In Memory)
 registry.description=High performance, runtime registry for schemas and API designs.
 registry.version=${project.version}

--- a/storage/kafkasql/src/main/resources/overlay.properties
+++ b/storage/kafkasql/src/main/resources/overlay.properties
@@ -8,12 +8,12 @@ registry.name=Apicurio Registry (Kafka+SQL)
 %dev.quarkus.datasource.jdbc.min-size=20
 %dev.quarkus.datasource.jdbc.max-size=100
 
-#%dev.registry.kafkasql.bootstrap.servers=localhost:9092
-%dev.registry.kafkasql.bootstrap.servers=${kafka.bootstrap.servers}
+%dev.registry.kafkasql.bootstrap.servers=${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
 %dev.registry.kafkasql.topic=kafkasql-journal
+%dev.registry.kafkasql.producer.client.id=${registry.id}-producer-${quarkus.uuid}
 %dev.registry.kafkasql.consumer.startupLag=100
 %dev.registry.kafkasql.consumer.poll.timeout=1000
-
+%dev.registry.kafkasql.consumer.group.id=${registry.id}-group-${quarkus.uuid}
 
 
 %prod.quarkus.datasource.db-kind=h2
@@ -26,5 +26,7 @@ registry.name=Apicurio Registry (Kafka+SQL)
 
 %prod.registry.kafkasql.bootstrap.servers=${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
 %prod.registry.kafkasql.topic=kafkasql-journal
+%prod.registry.kafkasql.producer.client.id=${registry.id}-producer-${quarkus.uuid}
 %prod.registry.kafkasql.consumer.startupLag=100
 %prod.registry.kafkasql.consumer.poll.timeout=100
+%prod.registry.kafkasql.consumer.group.id=${registry.id}-${quarkus.uuid}

--- a/storage/kafkasql/src/main/resources/overlay.properties
+++ b/storage/kafkasql/src/main/resources/overlay.properties
@@ -10,10 +10,10 @@ registry.name=Apicurio Registry (Kafka+SQL)
 
 %dev.registry.kafkasql.bootstrap.servers=${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
 %dev.registry.kafkasql.topic=kafkasql-journal
-%dev.registry.kafkasql.producer.client.id=${registry.id}-producer-${quarkus.uuid}
+%dev.registry.kafkasql.producer.client.id=${registry.id}-producer
 %dev.registry.kafkasql.consumer.startupLag=100
 %dev.registry.kafkasql.consumer.poll.timeout=1000
-%dev.registry.kafkasql.consumer.group.id=${registry.id}-group-${quarkus.uuid}
+%dev.registry.kafkasql.consumer.group.id=${registry.id}-${quarkus.uuid}
 
 
 %prod.quarkus.datasource.db-kind=h2
@@ -26,7 +26,7 @@ registry.name=Apicurio Registry (Kafka+SQL)
 
 %prod.registry.kafkasql.bootstrap.servers=${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
 %prod.registry.kafkasql.topic=kafkasql-journal
-%prod.registry.kafkasql.producer.client.id=${registry.id}-producer-${quarkus.uuid}
+%prod.registry.kafkasql.producer.client.id=${registry.id}-producer
 %prod.registry.kafkasql.consumer.startupLag=100
 %prod.registry.kafkasql.consumer.poll.timeout=100
 %prod.registry.kafkasql.consumer.group.id=${registry.id}-${quarkus.uuid}


### PR DESCRIPTION
See https://github.com/Apicurio/apicurio-registry/issues/1591 for a discussion about this issue.

This PR improves the default values for the KafkaSQL consumer (groupId) and producer (clientId).