### PR TITLE
Fix cncf api path and apidocs access

### DIFF
--- a/app/src/main/java/io/apicurio/registry/cncf/schemaregistry/SchemagroupsResource.java
+++ b/app/src/main/java/io/apicurio/registry/cncf/schemaregistry/SchemagroupsResource.java
@@ -21,7 +21,7 @@ import io.apicurio.registry.cncf.schemaregistry.beans.SchemaId;
 /**
  * A JAX-RS interface.  An implementation of this interface must be provided.
  */
-@Path("/cncf/v0/schemagroups")
+@Path("/apis/cncf/v0/schemagroups")
 public interface SchemagroupsResource {
   /**
    * Get all schema groups in namespace.

--- a/app/src/main/java/io/apicurio/registry/rest/RegistryApplicationServletFilter.java
+++ b/app/src/main/java/io/apicurio/registry/rest/RegistryApplicationServletFilter.java
@@ -129,10 +129,8 @@ public class RegistryApplicationServletFilter implements Filter {
                 evaluatedURI = rewriteContext.toString();
             }
 
-            if (mtProperties.isMultitenancyEnabled()
-                    && disabledApisMatcherService.isApiRequest(evaluatedURI)
-                    && (!tenantResolved || tenantContext.getTenantStatus() != TenantStatusValue.READY)) {
-                log.warn("Request {} is rejected because the tenant could not be found, and direct access to apis is disabled in a multitenant deployment", requestURI);
+            if (mtProperties.isMultitenancyEnabled() && tenantContext.getTenantStatus() != TenantStatusValue.READY) {
+                log.warn("Request {} is rejected because the tenant is not ready", requestURI);
                 HttpServletResponse httpResponse = (HttpServletResponse) response;
                 httpResponse.reset();
                 httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);

--- a/app/src/main/resources-unfiltered/META-INF/resources/apidocs/index.html
+++ b/app/src/main/resources-unfiltered/META-INF/resources/apidocs/index.html
@@ -74,7 +74,7 @@
           <div class="name">CNCF Schema Registry API (Version 0)</div>
           <div class="description">
             The CNCF community has worked to create an open standard for schema registries, for cloud events
-            and for other use-cases.  Apicurio Registry implements the <a href="https://github.com/cloudevents/spec/blob/master/schemaregistry/schemaregistry.md">
+            and for other use-cases.  Apicurio Registry implements the <a href="https://github.com/cloudevents/spec/blob/master/schemaregistry/spec.md">
             API defined by this work</a>.
           </div>
           <div class="endpoint">


### PR DESCRIPTION
This PR fixes several things around apidocs and the access to it in a multitenant environment.
- fix for CNCF api path, missing /apis prefix
- fix for CNCF docs url, looks like it changed
- fix for accessing api docs in a multitenant environment

In `RegistryApplicationServletFilter.java` we had a check that did not allow access to `/apis` prefixed endpoints to the default tenant if multitenancy is enabled. That did not allow to access , for instance, `http://localhost:8080/apis/registry/v2` to see the api docs. But that check was added as a security measure to not allow to access the rest of the API with the default tenant in multitenancy mode. 
So the fix consisted of moving the mentioned check to the `AuthorizedInterceptor` that way apidocs can be accessed anonimously and the rest of the API is protected.