### PR TITLE
fix: Handle export of v1 artifacts in DISABLED state

### DIFF
--- a/utils/exportV1/src/main/java/io/apicurio/registry/utils/export/Export.java
+++ b/utils/exportV1/src/main/java/io/apicurio/registry/utils/export/Export.java
@@ -40,6 +40,7 @@ import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
 import io.apicurio.registry.rest.beans.Rule;
 import io.apicurio.registry.rest.beans.VersionMetaData;
+import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
@@ -126,8 +127,13 @@ public class Export implements QuarkusApplication {
 
                     VersionMetaData meta = client.getArtifactVersionMetaData(id, version.intValue());
 
-                    InputStream contentStream = client.getArtifactVersion(id, version.intValue());
-                    byte[] contentBytes = IoUtil.toBytes(contentStream);
+                    byte[] contentBytes = new byte[0];
+                    // Cannot retrieve content of artifacts in DISABLED state, so just write out metadata.
+                    if (!ArtifactState.DISABLED.equals(meta.getState())) {
+                      InputStream contentStream = client.getArtifactVersion(id, version.intValue());
+                      contentBytes = IoUtil.toBytes(contentStream);
+                    }
+
                     String contentHash = DigestUtils.sha256Hex(contentBytes);
                     ContentHandle canonicalContent = this.canonicalizeContent(meta.getType(), ContentHandle.create(contentBytes));
                     byte[] canonicalContentBytes = canonicalContent.bytes();


### PR DESCRIPTION
 - Retrieving the content of artifacts in DISABLED state from Apicurio
 Registry v1.x returns a 404 Not Found response. This commit allows the
 exportV1 tool to handle artifacts in DISABLED state by not attempting
 to retrieve their content and only writing the metadata to the output
 zip file.
 - When the zip file is supplied to the v2 `/admin/import` endpoint, a
 `Failed to import content entity` message and `RuntimeSqlException`
 stacktrace is seen in the logs but all other artifacts are correctly
 imported.

Signed-off-by: Andrew Borley <borley@uk.ibm.com>