### PR TITLE
Prevent compaction of messages related to sequences

### DIFF
--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ContentIdKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ContentIdKey.java
@@ -19,6 +19,8 @@ package io.apicurio.registry.storage.impl.kafkasql.keys;
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.UUID;
+
 /**
  * @author eric.wittmann@gmail.com
  */
@@ -27,8 +29,11 @@ public class ContentIdKey extends AbstractMessageKey {
 
     private static final String CONTENT_ID_PARTITION_KEY = "__apicurio_registry_content_id__";
 
+    private final String uuid = UUID.randomUUID().toString();
+
     /**
      * Creator method.
+     *
      * @param tenantId
      * @param ruleType
      */
@@ -52,6 +57,10 @@ public class ContentIdKey extends AbstractMessageKey {
     @Override
     public String getPartitionKey() {
         return getTenantId() + CONTENT_ID_PARTITION_KEY;
+    }
+
+    public String getUuid() {
+        return uuid;
     }
 
     /**

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalIdKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalIdKey.java
@@ -19,6 +19,8 @@ package io.apicurio.registry.storage.impl.kafkasql.keys;
 import io.apicurio.registry.storage.impl.kafkasql.MessageType;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.UUID;
+
 /**
  * @author eric.wittmann@gmail.com
  */
@@ -27,8 +29,11 @@ public class GlobalIdKey extends AbstractMessageKey {
 
     private static final String GLOBAL_ID_PARTITION_KEY = "__apicurio_registry_global_id__";
 
+    private final String uuid = UUID.randomUUID().toString();
+
     /**
      * Creator method.
+     *
      * @param tenantId
      * @param ruleType
      */
@@ -52,6 +57,10 @@ public class GlobalIdKey extends AbstractMessageKey {
     @Override
     public String getPartitionKey() {
         return getTenantId() + GLOBAL_ID_PARTITION_KEY;
+    }
+
+    public String getUuid() {
+        return uuid;
     }
 
     /**

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ActionType.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ActionType.java
@@ -16,10 +16,12 @@
 
 package io.apicurio.registry.storage.impl.kafkasql.values;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -39,14 +41,12 @@ public enum ActionType {
      */
     DELETE_ALL_USER_DATA(7);
 
-    ;
-
     private final byte ord;
 
     /**
      * Constructor.
      */
-    private ActionType(int ord) {
+    ActionType(int ord) {
         this.ord = (byte) ord;
     }
 
@@ -55,16 +55,55 @@ public enum ActionType {
     }
 
     private static final Map<Byte, ActionType> ordIndex = new HashMap<>();
+    private static final Map<String, ActionType> normalizedStringMapping = new HashMap<>();
+
     static {
         for (ActionType at : ActionType.values()) {
             if (ordIndex.containsKey(at.getOrd())) {
                 throw new IllegalArgumentException(String.format("Duplicate ord value %d for ActionType %s", at.getOrd(), at.name()));
             }
             ordIndex.put(at.getOrd(), at);
+
+            // For backwards compatibility
+            String normalizedString = at.name().toLowerCase();
+            if (normalizedStringMapping.containsKey(normalizedString)) {
+                throw new IllegalArgumentException(String.format("Duplicate normalized string value %s for ActionType %s", normalizedString, at.name()));
+            }
+            normalizedStringMapping.put(normalizedString, at);
         }
     }
 
-    public static final ActionType fromOrd(byte ord) {
-        return ordIndex.get(ord);
+    public static ActionType fromOrd(byte ord) {
+        ActionType res = ordIndex.get(ord);
+        if(res == null) {
+            throw new IllegalArgumentException(String.format("Could not find ActionType with ord value %s", ord));
+        }
+        return res;
+    }
+
+    @JsonValue
+    public Object serialize() {
+        return getOrd();
+    }
+
+    @JsonCreator
+    public static ActionType deserialize(Object value) {
+        if(value instanceof Number) {
+            Number num = (Number) value;
+            // Sanity check
+            if(num.longValue() > Byte.MAX_VALUE) {
+                throw new IllegalArgumentException(String.format("Unexpectedly high numeric value %s for ActionType ord", num));
+            }
+            return fromOrd(num.byteValue());
+        }
+        // For backwards compatibility
+        if(value instanceof String) {
+            String normalizedString = ((String) value).toLowerCase();
+            ActionType res = normalizedStringMapping.get(normalizedString);
+            if(res != null) {
+                return res;
+            }
+        }
+        throw new IllegalArgumentException(String.format("Could not deserialize value %s to ActionType", value));
     }
 }


### PR DESCRIPTION
Resolves #1993 and #1873 

TODO:
Needs a test:
 - Start Kafka
 - Create the `kafkasql-journal` topic with aggressive log compaction 
   ```
   bin/kafka-topics.sh --bootstrap-server localhost:9092 --create --topic kafkasql-journal --partitions 1 --replication-factor 1 --config min.cleanable.dirty.ratio=0.000001 --config cleanup.policy=compact --config segment.ms=100 --config delete.retention.ms=100
   ```
 - Start Registry
 - Add ~3 artifacts
 - Stop Registry
 - Restart Registry to load data from the topic
 - Add another artifact -> exception

@famartinrh Could you please work on the tests if you have some time?