### PR TITLE
Add specific error page for 403 errors.

### DIFF
--- a/ui/src/app/components/errorPage/accessErrorPage.css
+++ b/ui/src/app/components/errorPage/accessErrorPage.css
@@ -1,0 +1,17 @@
+.centerizer {
+    text-align: center;
+}
+
+.centerizer > div {
+    display: inline-block;
+}
+
+.centerizer > div.separator {
+    display: block;
+    height: 0px;
+}
+
+.centerizer > div.ace-wrapper > div {
+    border: 1px solid #ccc;
+}
+

--- a/ui/src/app/components/errorPage/accessErrorPage.tsx
+++ b/ui/src/app/components/errorPage/accessErrorPage.tsx
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2021 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import "./errorPage.css";
+import {
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateIcon,
+    EmptyStateSecondaryActions,
+    EmptyStateVariant,
+    PageSection,
+    PageSectionVariants,
+    Title
+} from '@patternfly/react-core';
+import {LockedIcon} from "@patternfly/react-icons";
+import "ace-builds/src-noconflict/mode-text";
+import "ace-builds/src-noconflict/theme-tomorrow";
+import {ErrorPage, ErrorPageProps} from "./errorPage";
+
+
+export class AccessErrorPage extends ErrorPage {
+
+    constructor(props: Readonly<ErrorPageProps>) {
+        super(props);
+    }
+
+    public render(): React.ReactElement {
+        return (
+            <React.Fragment>
+                <PageSection className="ps_error" variant={PageSectionVariants.light}>
+                    <div className="centerizer">
+                        <EmptyState variant={EmptyStateVariant.large}>
+                            <EmptyStateIcon icon={LockedIcon} />
+                            <Title headingLevel="h5" size="lg">Access Denied</Title>
+                            <EmptyStateBody>
+                                You are not authorized to access this registry instance.  Please request access
+                                from your administrator and then try again.
+                            </EmptyStateBody>
+                            <EmptyStateSecondaryActions>
+                                <Button variant="link"
+                                        data-testid="error-btn-artifacts"
+                                        onClick={this.navigateBack}>Go Back</Button>
+                            </EmptyStateSecondaryActions>
+                        </EmptyState>
+                    </div>
+                </PageSection>
+            </React.Fragment>
+        );
+    }
+
+    protected navigateBack = (): void => {
+        window.history.back();
+    };
+
+}

--- a/ui/src/app/components/errorPage/errorPage.tsx
+++ b/ui/src/app/components/errorPage/errorPage.tsx
@@ -156,7 +156,7 @@ export class ErrorPage extends PureComponent<ErrorPageProps, ErrorPageState> {
         this.setSingleState("isShowDetails", true);
     };
 
-    private reloadPage = (): void => {
+    protected reloadPage = (): void => {
         window.location.reload();
-    }
+    };
 }

--- a/ui/src/app/pages/basePage.tsx
+++ b/ui/src/app/pages/basePage.tsx
@@ -19,6 +19,7 @@ import React from "react";
 import {ErrorPage, PageError, PureComponent, PureComponentProps, PureComponentState} from "../components";
 import {Services} from "../../services";
 import {Flex, FlexItem, PageSection, PageSectionVariants, Spinner} from "@patternfly/react-core";
+import {AccessErrorPage} from "../components/errorPage/accessErrorPage";
 
 // TODO this should be configurable via standard UI config settings
 const MAX_RETRIES: number = 5;
@@ -73,9 +74,15 @@ export abstract class PageComponent<P extends PageProps, S extends PageState> ex
 
     public render(): React.ReactElement {
         if (this.isError()) {
-            return (
-                <ErrorPage error={this.state.error}/>
-            );
+            if (this.is403Error()) {
+                return (
+                    <AccessErrorPage error={this.state.error} />
+                );
+            } else {
+                return (
+                    <ErrorPage error={this.state.error}/>
+                );
+            }
         } else if (this.isLoading()) {
             return (
                 <React.Fragment>
@@ -174,6 +181,11 @@ export abstract class PageComponent<P extends PageProps, S extends PageState> ex
 
     private isError(): boolean {
         return this.state.isError ? true : false;
+    }
+
+    private is403Error(): boolean {
+        return this.state.error && this.state.error.error && this.state.error.error.message &&
+            this.state.error.error.message.includes("403");
     }
 
     private handleError(errorType: PageErrorType, error: any, errorMessage: any): void {

--- a/ui/src/app/pages/basePage.tsx
+++ b/ui/src/app/pages/basePage.tsx
@@ -184,8 +184,7 @@ export abstract class PageComponent<P extends PageProps, S extends PageState> ex
     }
 
     private is403Error(): boolean {
-        return this.state.error && this.state.error.error && this.state.error.error.message &&
-            this.state.error.error.message.includes("403");
+        return this.state.error && this.state.error.error.status && (this.state.error.error.status == 403);
     }
 
     private handleError(errorType: PageErrorType, error: any, errorMessage: any): void {
@@ -194,7 +193,8 @@ export abstract class PageComponent<P extends PageProps, S extends PageState> ex
         Services.getLoggerService().error("[PageComponent] ", error);
         this.setMultiState({
             error: {
-                error, errorMessage,
+                error,
+                errorMessage,
                 type: errorType
             },
             isError: true

--- a/ui/src/services/baseService.ts
+++ b/ui/src/services/baseService.ts
@@ -265,9 +265,16 @@ export abstract class BaseService implements Service {
 
     private unwrapErrorData(error: any): any {
         if (error.response && error.response.data) {
-            return error.response.data;
+            return {
+                message: error.message,
+                ...error.response.data,
+                status: error.response.status
+            };
         }
-        return error;
+        return {
+            message: error.message,
+            status: error.response.status
+        };
     }
 
     private apiBaseHref(): string {


### PR DESCRIPTION
Instead of the generic error page, users will now see a specialty error page for 403 errors.  The error page looks like this:

![image](https://user-images.githubusercontent.com/1890703/143033961-f060f901-0b83-45b8-8280-98475d45c3b5.png)
