### PR TITLE
Add support for export to the AdminService in the UI layer

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v2/DownloadsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/DownloadsResourceImpl.java
@@ -69,4 +69,21 @@ public class DownloadsResourceImpl {
         throw new DownloadNotFoundException();
     }
 
+    /**
+     * A duplicate version of the above that will allow a filename to be added
+     * for download purposes.  So e.g. /apis/registry/v2/downloads/ABCD-1234 can
+     * be aliased as /apis/registry/v2/downloads/ABCD-1234/export.zip and work
+     * the same way.  But when saving from a browser, the filename should be
+     * useful.
+     * @param downloadId
+     * @return
+     */
+    @Authorized(style=AuthorizedStyle.None, level=AuthorizedLevel.None)
+    @GET
+    @Path("{downloadId}/{fileName}")
+    @Produces("*/*")
+    public Response downloadAsFile(@PathParam("downloadId") String downloadId) {
+        return this.download(downloadId);
+    }
+
 }

--- a/ui/src/app/pages/rules/rules.tsx
+++ b/ui/src/app/pages/rules/rules.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import "./rules.css";
-import {PageSection, PageSectionVariants, TextContent} from '@patternfly/react-core';
+import {Button, PageSection, PageSectionVariants, TextContent} from '@patternfly/react-core';
 import {PageComponent, PageProps, PageState} from "../basePage";
 import {RuleList} from "../../components/ruleList";
 import {Rule} from "../../../models";

--- a/ui/src/models/downloadRef.model.ts
+++ b/ui/src/models/downloadRef.model.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 JBoss Inc
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,10 @@
  * limitations under the License.
  */
 
-export * from "./artifactMetaData.model";
-export * from "./artifactTypes.model";
-export * from "./contentTypes.model";
-export * from "./roleMapping.model";
-export * from "./rule.model";
-export * from "./searchedArtifact.model";
-export * from "./searchedVersion.model";
-export * from "./userInfo.model";
-export * from "./versionMetaData.model";
-export * from "./downloadRef.model";
+// tslint:disable-next-line:interface-name
+export interface DownloadRef {
+
+    downloadId: string;
+    href: string;
+
+}

--- a/ui/src/services/admin/admin.service.ts
+++ b/ui/src/services/admin/admin.service.ts
@@ -16,7 +16,7 @@
  */
 
 import {BaseService} from "../baseService";
-import {RoleMapping, Rule} from "../../models";
+import {DownloadRef, RoleMapping, Rule} from "../../models";
 
 /**
  * The Admin service.  Used to get global/settings information from the back-end, like global
@@ -111,6 +111,22 @@ export class AdminService extends BaseService {
             principalId
         });
         return this.httpDelete(endpoint);
+    }
+
+    public exportAs(filename: string): Promise<DownloadRef> {
+        const endpoint: string = this.endpoint("/v2/admin/export", {}, {
+            forBrowser: true
+        });
+        const headers: any = {
+            Accept: "application/zip"
+        };
+        return this.httpGet<DownloadRef>(endpoint, this.options(headers)).then(ref => {
+            if (ref.href.startsWith("/apis/registry")) {
+                ref.href = ref.href.replace("/apis/registry", this.apiBaseHref());
+                ref.href = ref.href + "/" + filename;
+            }
+            return ref;
+        });
     }
 
 }

--- a/ui/src/services/baseService.ts
+++ b/ui/src/services/baseService.ts
@@ -252,6 +252,18 @@ export abstract class BaseService implements Service {
             });
     }
 
+    protected apiBaseHref(): string {
+        let artifactsUrl: string|null = this.config.artifactsUrl();
+        if (artifactsUrl == null) {
+            return "";
+        }
+        if (artifactsUrl.endsWith("/")) {
+            artifactsUrl = artifactsUrl.substring(0, artifactsUrl.length - 1);
+        }
+        this.logger.debug("[BaseService] Base HREF of REST API: ", artifactsUrl);
+        return artifactsUrl;
+    }
+
     private axiosConfig(method: string, url: string, options: any, data?: any): AxiosRequestConfig {
         return {...{
                 data,
@@ -275,17 +287,5 @@ export abstract class BaseService implements Service {
             message: error.message,
             status: error.response.status
         };
-    }
-
-    private apiBaseHref(): string {
-        let artifactsUrl: string|null = this.config.artifactsUrl();
-        if (artifactsUrl == null) {
-            return "";
-        }
-        if (artifactsUrl.endsWith("/")) {
-            artifactsUrl = artifactsUrl.substring(0, artifactsUrl.length - 1);
-        }
-        this.logger.debug("[BaseService] Base HREF of REST API: ", artifactsUrl);
-        return artifactsUrl;
     }
 }


### PR DESCRIPTION
Example usage from somewhere in the UI:

```typescript
    private doExport = (): void => {
        Services.getAdminService().exportAs("export.zip").then((ref) => {
            window.location.href = ref.href;
        }).catch(error => {
            this.handleServerError(error, "Error exporting data.");
        })
    }
```
