### PR TITLE
fix: remove hidden bidi characters

### DIFF
--- a/ui/src/services/groups/groups.service.ts
+++ b/ui/src/services/groups/groups.service.ts
@@ -159,7 +159,7 @@ export class GroupsService extends BaseService {
         const options: any = this.options({
             "Accept": "*"
         });
-        options.maxContentLength = "‭5242880‬"; // TODO 5MB hard-coded, make this configurable?
+        options.maxContentLength = "5242880"; // TODO 5MB hard-coded, make this configurable?
         options.responseType = "text";
         options.transformResponse = (data: any) => data;
         return this.httpGet<string>(endpoint, options);


### PR DESCRIPTION
This appears to have arrived as a copy-paste error some time ago so I have edited this to remove the offending characters.