### PR TITLE
fix: Add JAX-RS implementation to exportV1 tool

### DIFF
--- a/utils/exportV1/pom.xml
+++ b/utils/exportV1/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>apicurio-registry-schema-util-provider</artifactId>
         </dependency>
         
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client</artifactId>
+        </dependency>
     </dependencies>
     
     <build>


### PR DESCRIPTION
 - Adds the quarkus rest client as a dependency to provide the resteasy
 JAX-RS implementation, as the 1.3.x Apicurio rest client uses the
 JAX-RS WebApplicationException class when an API call fails.

Contributes to: #1806

Signed-off-by: Andrew Borley <borley@uk.ibm.com>