### PR TITLE
Try using @PostConstruct instead of StartupEvent

### DIFF
--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -73,7 +73,6 @@ import io.apicurio.registry.utils.impexp.GlobalRuleEntity;
 import io.apicurio.registry.utils.impexp.GroupEntity;
 import io.apicurio.registry.utils.impexp.ManifestEntity;
 import io.apicurio.registry.utils.kafka.KafkaUtil;
-import io.quarkus.runtime.StartupEvent;
 import io.quarkus.security.identity.SecurityIdentity;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -83,9 +82,9 @@ import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.slf4j.Logger;
 
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.time.Duration;
@@ -157,7 +156,8 @@ public class KafkaSqlRegistryStorage extends AbstractRegistryStorage {
     private boolean bootstrapped = false;
     private boolean stopped = true;
 
-    void onConstruct(@Observes StartupEvent ev) {
+    @PostConstruct
+    void onConstruct() {
         log.info("Using Kafka-SQL artifactStore.");
 
         // Create Kafka topics if needed
@@ -265,7 +265,7 @@ public class KafkaSqlRegistryStorage extends AbstractRegistryStorage {
                                 return;
                             }
 
-                            // If the key is a Bootstrap key, then we have processed all messages and can set boostrapped to 'true'
+                            // If the key is a Bootstrap key, then we have processed all messages and can set bootstrapped to 'true'
                             if (record.key().getType() == MessageType.Bootstrap) {
                                 BootstrapKey bkey = (BootstrapKey) record.key();
                                 if (bkey.getBootstrapId().equals(bootstrapId)) {


### PR DESCRIPTION
It seems that `@Observes StartupEvent ev` causes the code in that method to execute before any of the injected beans have been initialized via their own `@PostConstruct`.  Sample log output proving this:

```
2021-12-03T13:26:13.2355694Z 2021-12-03 13:26:13 INFO <> [io.apicurio.registry.storage.impl.kafkasql.KafkaSqlRegistryStorage] (main) Using Kafka-SQL artifactStore.
2021-12-03T13:26:13.5978267Z 2021-12-03 13:26:13 INFO <> [io.apicurio.registry.utils.kafka.KafkaUtil] (kafka-admin-client-thread | adminclient-1) Creating new Kafka topic: kafkasql-journal
2021-12-03T13:26:13.5981680Z 2021-12-03 13:26:13 INFO <> [io.apicurio.registry.utils.kafka.KafkaUtil] (kafka-admin-client-thread | adminclient-1) Created new topic: kafkasql-journal
2021-12-03T13:26:13.7206836Z 2021-12-03 13:26:13 INFO <> [io.apicurio.registry.storage.impl.kafkasql.KafkaSqlRegistryStorage] (main) Starting KSQL consumer thread on topic: kafkasql-journal
2021-12-03T13:26:13.7216124Z 2021-12-03 13:26:13 INFO <> [io.apicurio.registry.storage.impl.kafkasql.KafkaSqlRegistryStorage] (main) Bootstrap servers: PLAINTEXT://localhost:49161
2021-12-03T13:26:13.7277010Z 2021-12-03 13:26:13 INFO <> [io.apicurio.registry.utils.kafka.AsyncProducer] (main) Creating new resilient producer.
2021-12-03T13:26:13.9567924Z 2021-12-03 13:26:13 INFO <> [io.apicurio.registry.storage.impl.kafkasql.KafkaSqlRegistryStorage] (KSQL Kafka Consumer Thread) KSQL consumer thread startup lag: 10
2021-12-03T13:26:13.9688269Z 2021-12-03 13:26:13 INFO <> [io.apicurio.registry.storage.impl.kafkasql.KafkaSqlRegistryStorage] (KSQL Kafka Consumer Thread) Subscribing to kafkasql-journal
2021-12-03T13:26:14.0131987Z 2021-12-03 13:26:14 INFO <> [io.apicurio.registry.storage.RegistryStorageProducer] (executor-thread-0) Using RegistryStore: io.apicurio.registry.storage.impl.kafkasql.KafkaSqlRegistryStorage_ClientProxy
2021-12-03T13:26:14.0764025Z 2021-12-03 13:26:14 WARN <> [org.apache.kafka.common.config.AbstractConfig] (KSQL Kafka Consumer Thread) The configuration 'poll.timeout' was supplied but isn't a known config.
2021-12-03T13:26:14.0774943Z 2021-12-03 13:26:14 WARN <> [org.apache.kafka.common.config.AbstractConfig] (KSQL Kafka Consumer Thread) The configuration 'startupLag' was supplied but isn't a known config.
2021-12-03T13:26:14.2100624Z 2021-12-03 13:26:14 INFO <> [io.apicurio.registry.storage.impl.sql.AbstractSqlRegistryStorage] (executor-thread-0) SqlRegistryStorage constructed successfully.  JDBC URL: jdbc:h2:mem:registry_db
2021-12-03T13:26:14.2431698Z 2021-12-03 13:26:14 INFO <> [io.apicurio.registry.storage.impl.sql.AbstractSqlRegistryStorage] (executor-thread-0) Checking to see if the DB is initialized.
2021-12-03T13:26:14.3864296Z 2021-12-03 13:26:14 INFO <> [io.apicurio.registry.storage.impl.sql.AbstractSqlRegistryStorage] (executor-thread-0) Database not initialized.
2021-12-03T13:26:14.3874164Z 2021-12-03 13:26:14 INFO <> [io.apicurio.registry.storage.impl.sql.AbstractSqlRegistryStorage] (executor-thread-0) Initializing the Apicurio Registry database.
2021-12-03T13:26:14.3877816Z 2021-12-03 13:26:14 INFO <> [io.apicurio.registry.storage.impl.sql.AbstractSqlRegistryStorage] (executor-thread-0) 	Database type: h2
2021-12-03T13:26:14.4486880Z 2021-12-03 13:26:14 INFO <> [io.apicurio.registry.storage.impl.kafkasql.KafkaSqlRegistryStorage] (KSQL Kafka Consumer Thread) KafkaSQL storage bootstrapped in 504ms.
```

Notice that the `SqlRegistryStorage constructed successfully` message occurs **after** the `Starting KSQL consumer thread on topic: kafkasql-journal` message.  That means it's possible that the H2 DB has not been initialized by the time the KSQL consumer thread has started reading messages from Kafka.  So it might process a message (that requires the DB to exist) before the DB exists.  I'm not sure why we're using `StartupEvent` instead of `@PostConstruct` so this might not work....