### PR TITLE
ui: auto format json content and fix modifiedOn on info tab

### DIFF
--- a/ui/src/app/pages/artifactVersion/artifactVersion.tsx
+++ b/ui/src/app/pages/artifactVersion/artifactVersion.tsx
@@ -95,6 +95,7 @@ export class ArtifactVersionPage extends PageComponent<ArtifactVersionPageProps,
         const tabs: React.ReactNode[] = [
             <Tab eventKey={0} title="Info" key="info" tabContentId="tab-info">
                 <InfoTabContent artifact={artifact}
+                                isLatest={this.versionParam() === "latest"}
                                 rules={this.rules()}
                                 onEnableRule={this.doEnableRule}
                                 onDisableRule={this.doDisableRule}

--- a/ui/src/app/pages/artifactVersion/components/tabs/content.tsx
+++ b/ui/src/app/pages/artifactVersion/components/tabs/content.tsx
@@ -24,8 +24,6 @@ import "ace-builds/src-noconflict/mode-protobuf";
 import "ace-builds/src-noconflict/mode-xml";
 import "ace-builds/src-noconflict/mode-graphqlschema";
 import "ace-builds/src-noconflict/theme-monokai";
-import {Button} from "@patternfly/react-core";
-import {Services} from "../../../../../services";
 
 
 /**
@@ -43,8 +41,6 @@ export interface ContentTabContentProps extends PureComponentProps {
 // tslint:disable-next-line:no-empty-interface
 export interface ContentTabContentState extends PureComponentState {
     content: string;
-    contentIsJson: boolean;
-    formatBtnClasses: string;
     editorWidth: string;
     editorHeight: string;
 }
@@ -96,23 +92,15 @@ export class ContentTabContent extends PureComponent<ContentTabContentProps, Con
                         useWorker: false
                     }}
                 />
-                <Button className={this.state.formatBtnClasses} key="format" variant="primary" data-testid="modal-btn-edit" onClick={this.format}>Format</Button>
             </div>
         );
     }
 
     protected initializeState(): ContentTabContentState {
-        const contentIsJson: boolean = this.isJson(this.props.artifactContent);
-        let formatBtnClasses: string = "format-btn";
-        if (!contentIsJson) {
-            formatBtnClasses += " hidden";
-        }
         return {
-            content: this.props.artifactContent,
-            contentIsJson,
+            content: this.formatContent(),
             editorHeight: "500px",
-            editorWidth: "100%",
-            formatBtnClasses
+            editorWidth: "100%"
         };
     }
 
@@ -129,32 +117,17 @@ export class ContentTabContent extends PureComponent<ContentTabContentProps, Con
         return "json";
     }
 
-    private format = (): void => {
-        if (!this.state.contentIsJson) {
-            return;
-        }
+    private formatContent(): string {
         try {
             const pval: any = JSON.parse(this.props.artifactContent);
             if (pval) {
-                this.setSingleState("content", JSON.stringify(pval, null, 2));
+                return JSON.stringify(pval, null, 2);
             }
         } catch (e) {
             // Do nothing
-            Services.getLoggerService().warn("Failed to format content!");
-            Services.getLoggerService().error(e);
         }
+        return this.props.artifactContent;
     }
 
-    private isJson(content: string): boolean {
-        try {
-            const pval: any = JSON.parse(content);
-            if (pval) {
-                return true;
-            }
-        } catch (e) {
-            // Do nothing
-        }
-        return false;
-    }
 }
 

--- a/ui/src/app/pages/artifactVersion/components/tabs/info.tsx
+++ b/ui/src/app/pages/artifactVersion/components/tabs/info.tsx
@@ -37,6 +37,7 @@ import {ArtifactMetaData, Rule} from "../../../../../models";
 // tslint:disable-next-line:no-empty-interface
 export interface InfoTabContentProps extends PureComponentProps {
     artifact: ArtifactMetaData;
+    isLatest: boolean;
     rules: Rule[];
     onEnableRule: (ruleType: string) => void;
     onDisableRule: (ruleType: string) => void;
@@ -106,10 +107,12 @@ export class InfoTabContent extends PureComponent<InfoTabContentProps, InfoTabCo
                             <span className="label">Created</span>
                             <span className="value"><Moment date={this.props.artifact.createdOn} fromNow={true} /></span>
                         </div>
-                        <div className="metaDataItem">
-                            <span className="label">Modified</span>
-                            <span className="value"><Moment date={this.props.artifact.modifiedOn} fromNow={true} /></span>
-                        </div>
+                        <If condition={this.props.isLatest}>
+                            <div className="metaDataItem">
+                                <span className="label">Modified</span>
+                                <span className="value"><Moment date={this.props.artifact.modifiedOn} fromNow={true} /></span>
+                            </div>
+                        </If>
                         <div className="metaDataItem">
                             <span className="label">Global ID</span>
                             <span className="value">{this.props.artifact.globalId}</span>

--- a/ui/src/models/artifactMetaData.model.ts
+++ b/ui/src/models/artifactMetaData.model.ts
@@ -24,7 +24,7 @@ export class ArtifactMetaData {
     public description: string|null;
     public labels: string[]|null;
     public type: string;
-    public version: number;
+    public version: string;
     public createdBy: string;
     public createdOn: Date;
     public modifiedBy: string;


### PR DESCRIPTION
fix for https://github.com/Apicurio/apicurio-registry/issues/651

and new feature for artifacts whose content is json. This PR removes the format button. Content will be automatically pretty printed if it's json and it can be parsed without errors.