### PR TITLE
bugfix: search by properties, search by key and value

### DIFF
--- a/app/src/main/java/io/apicurio/registry/cncf/schemaregistry/impl/SchemagroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/cncf/schemaregistry/impl/SchemagroupsResourceImpl.java
@@ -43,7 +43,6 @@ import io.apicurio.registry.storage.dto.GroupMetaDataDto;
 import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.SearchFilter;
-import io.apicurio.registry.storage.dto.SearchFilterType;
 import io.apicurio.registry.storage.dto.StoredArtifactDto;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.Current;
@@ -146,7 +145,7 @@ public class SchemagroupsResourceImpl implements SchemagroupsResource {
     public List<String> getSchemasByGroup(String groupId) {
         verifyGroupExists(groupId);
         Set<SearchFilter> filters = new HashSet<>();
-        filters.add(new SearchFilter(SearchFilterType.group, groupId));
+        filters.add(SearchFilter.ofGroup(groupId));
 
         ArtifactSearchResultsDto resultsDto = storage.searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 1000);
 

--- a/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
@@ -53,7 +53,6 @@ import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.RuleConfigurationDto;
 import io.apicurio.registry.storage.dto.SearchFilter;
-import io.apicurio.registry.storage.dto.SearchFilterType;
 import io.apicurio.registry.storage.dto.StoredArtifactDto;
 import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
 import io.apicurio.registry.types.ArtifactMediaTypes;
@@ -213,6 +212,10 @@ public class GroupsResourceImpl implements GroupsResource {
     public void updateArtifactMetaData(String groupId, String artifactId, EditableMetaData data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
+
+        if (data.getProperties() != null) {
+            data.getProperties().forEach((k,v) -> requireParameter("property value", v));
+        }
 
         EditableArtifactMetaDataDto dto = new EditableArtifactMetaDataDto();
         dto.setName(data.getName());
@@ -428,7 +431,9 @@ public class GroupsResourceImpl implements GroupsResource {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
         requireParameter("version", version);
-
+        if (data.getProperties() != null) {
+            data.getProperties().forEach((k,v) -> requireParameter("property value", v));
+        }
         EditableArtifactMetaDataDto dto = new EditableArtifactMetaDataDto();
         dto.setName(data.getName());
         dto.setDescription(data.getDescription());
@@ -488,7 +493,7 @@ public class GroupsResourceImpl implements GroupsResource {
         final OrderDirection oDir = order == null || order == SortOrder.asc ? OrderDirection.asc : OrderDirection.desc;
 
         Set<SearchFilter> filters = new HashSet<>();
-        filters.add(new SearchFilter(SearchFilterType.group, gidOrNull(groupId)));
+        filters.add(SearchFilter.ofGroup(gidOrNull(groupId)));
 
         ArtifactSearchResultsDto resultsDto = storage.searchArtifacts(filters, oBy, oDir, offset, limit);
         return V2ApiUtil.dtoToSearchResults(resultsDto);

--- a/app/src/main/java/io/apicurio/registry/rest/v2/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/SearchResourceImpl.java
@@ -47,7 +47,6 @@ import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
 import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.SearchFilter;
-import io.apicurio.registry.storage.dto.SearchFilterType;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.Current;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
@@ -102,26 +101,42 @@ public class SearchResourceImpl implements SearchResource {
 
         Set<SearchFilter> filters = new HashSet<SearchFilter>();
         if (!StringUtil.isEmpty(name)) {
-            filters.add(new SearchFilter(SearchFilterType.name, name));
+            filters.add(SearchFilter.ofName(name));
         }
         if (!StringUtil.isEmpty(description)) {
-            filters.add(new SearchFilter(SearchFilterType.description, description));
+            filters.add(SearchFilter.ofDescription(description));
         }
         if (!StringUtil.isEmpty(group)) {
-            filters.add(new SearchFilter(SearchFilterType.group, gidOrNull(group)));
+            filters.add(SearchFilter.ofGroup(gidOrNull(group)));
         }
 
         if (labels != null && !labels.isEmpty()) {
-            labels.forEach(label -> filters.add(new SearchFilter(SearchFilterType.labels, label)));
+            labels.forEach(label -> filters.add(SearchFilter.ofLabel(label)));
         }
         if (properties != null && !properties.isEmpty()) {
-            properties.forEach(label -> filters.add(new SearchFilter(SearchFilterType.properties, label)));
+            properties.stream()
+                .map(prop -> {
+                   int delimiterIndex = prop.indexOf(":");
+                   if (delimiterIndex < 0) {
+                       throw new BadRequestException("property search filter wrong formatted, missing ':' delimiter");
+                   }
+                   if (delimiterIndex == 0) {
+                       throw new BadRequestException("property search filter wrong formatted, missing left side of  ':' delimiter");
+                   }
+                   if (delimiterIndex == (prop.length() - 1)) {
+                       throw new BadRequestException("property search filter wrong formatted, missing right side of  ':' delimiter");
+                   }
+                   String propertyKey = prop.substring(0, delimiterIndex);
+                   String propertyValue = prop.substring(delimiterIndex + 1);
+                   return SearchFilter.ofProperty(propertyKey, propertyValue);
+                })
+                .forEach(filters::add);
         }
         if (globalId != null && globalId > 0) {
-            filters.add(new SearchFilter(SearchFilterType.globalId, globalId));
+            filters.add(SearchFilter.ofGlobalId(globalId));
         }
         if (contentId != null && contentId > 0) {
-            filters.add(new SearchFilter(SearchFilterType.contentId, contentId));
+            filters.add(SearchFilter.ofContentId(contentId));
         }
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, offset, limit);
@@ -162,10 +177,10 @@ public class SearchResourceImpl implements SearchResource {
         Set<SearchFilter> filters = new HashSet<SearchFilter>();
         if (canonical && artifactType != null) {
             String canonicalHash = sha256Hash(canonicalizeContent(artifactType, content));
-            filters.add(new SearchFilter(SearchFilterType.canonicalHash, canonicalHash));
+            filters.add(SearchFilter.ofCanonicalHash(canonicalHash));
         } else if (!canonical) {
             String contentHash = sha256Hash(content);
-            filters.add(new SearchFilter(SearchFilterType.contentHash, contentHash));
+            filters.add(SearchFilter.ofContentHash(contentHash));
         } else {
             throw new BadRequestException(CANONICAL_QUERY_PARAM_ERROR_MESSAGE);
         }

--- a/app/src/main/java/io/apicurio/registry/storage/dto/SearchFilter.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/SearchFilter.java
@@ -16,6 +16,8 @@
 
 package io.apicurio.registry.storage.dto;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 /**
  * @author eric.wittmann@gmail.com
  */
@@ -33,21 +35,61 @@ public class SearchFilter {
     /**
      * Constructor.
      * @param type
-     * @param value string
+     * @param value object
      */
-    public SearchFilter(SearchFilterType type, String value) {
+    private SearchFilter(SearchFilterType type, Object value) {
         this.type = type;
         this.value = value;
     }
 
-    /**
-     * Constructor.
-     * @param type
-     * @param value integer
-     */
-    public SearchFilter(SearchFilterType type, Integer value) {
-        this.type = type;
-        this.value = value;
+    public static SearchFilter ofProperty(String propertyKey, String propertyValue) {
+        return new SearchFilter(SearchFilterType.properties, Pair.<String, String>of(propertyKey, propertyValue));
+    }
+
+    public static SearchFilter ofGlobalId(Integer value) {
+        return new SearchFilter(SearchFilterType.globalId, value);
+    }
+
+    public static SearchFilter ofContentId(Integer value) {
+        return new SearchFilter(SearchFilterType.contentId, value);
+    }
+
+    public static SearchFilter ofName(String value) {
+        return new SearchFilter(SearchFilterType.name, value);
+    }
+
+    public static SearchFilter ofDescription(String value) {
+        return new SearchFilter(SearchFilterType.description, value);
+    }
+
+    public static SearchFilter ofGroup(String value) {
+        return new SearchFilter(SearchFilterType.group, value);
+    }
+
+    public static SearchFilter ofLabel(String value) {
+        return new SearchFilter(SearchFilterType.labels, value);
+    }
+
+    public static SearchFilter ofCanonicalHash(String value) {
+        return new SearchFilter(SearchFilterType.canonicalHash, value);
+    }
+
+    public static SearchFilter ofContentHash(String value) {
+        return new SearchFilter(SearchFilterType.contentHash, value);
+    }
+
+    public static SearchFilter ofEverything(String value) {
+        return new SearchFilter(SearchFilterType.everything, value);
+    }
+
+    public Pair<String, String> getPropertyFilterValue() {
+        if (value == null) {
+            return null;
+        }
+        if (this.value instanceof Pair) {
+            return (Pair<String, String>) this.value;
+        }
+        throw new IllegalStateException("value is not of type pair");
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -37,6 +37,7 @@ import javax.inject.Inject;
 import javax.transaction.Transactional;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 
@@ -1077,10 +1078,16 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         });
                         break;
                     case properties:
-                        where.append("EXISTS(SELECT p.globalId FROM properties p WHERE p.pkey = ? AND p.globalId = v.globalId AND p.tenantId = v.tenantId)");
+                        Pair<String, String> property = filter.getPropertyFilterValue();
+                        //    Note: convert search to lowercase when searching for properties (case-insensitivity support).
+                        String propKey = property.getKey().toLowerCase();
+                        String propValue = property.getValue().toLowerCase();
+                        where.append("EXISTS(SELECT p.globalId FROM properties p WHERE p.pkey = ? AND p.pvalue = ? AND p.globalId = v.globalId AND p.tenantId = v.tenantId)");
                         binders.add((query, idx) -> {
-                            //    Note: convert search to lowercase when searching for properties (case-insensitivity support).
-                            query.bind(idx, filter.getStringValue().toLowerCase());
+                            query.bind(idx, propKey);
+                        });
+                        binders.add((query, idx) -> {
+                            query.bind(idx, propValue);
                         });
                         break;
                     case globalId:

--- a/app/src/test/java/io/apicurio/registry/ArtifactSearchTest.java
+++ b/app/src/test/java/io/apicurio/registry/ArtifactSearchTest.java
@@ -96,16 +96,16 @@ public class ArtifactSearchTest extends AbstractResourceTestBase {
             Assertions.assertEquals(1, ires.getCount());
 
 
-            ArtifactSearchResults propertiesSearch = clientV2.searchArtifacts(groupId, null, null, null, List.of("testCaseInsensitiveSearchKey"), SortBy.name, SortOrder.asc, 0, 10);
+            ArtifactSearchResults propertiesSearch = clientV2.searchArtifacts(groupId, null, null, null, List.of("testCaseInsensitiveSearchKey:testCaseInsensitiveSearchValue"), SortBy.name, SortOrder.asc, 0, 10);
             Assertions.assertNotNull(propertiesSearch);
             Assertions.assertEquals(1, propertiesSearch.getCount());
-            propertiesSearch = clientV2.searchArtifacts(groupId, null, null, null, List.of("testCaseInsensitiveSearchKey".toLowerCase()), SortBy.name, SortOrder.asc, 0, 10);
+            propertiesSearch = clientV2.searchArtifacts(groupId, null, null, null, List.of("testCaseInsensitiveSearchKey:testCaseInsensitiveSearchValue".toLowerCase()), SortBy.name, SortOrder.asc, 0, 10);
             Assertions.assertNotNull(propertiesSearch);
             Assertions.assertEquals(1, propertiesSearch.getCount());
-            propertiesSearch = clientV2.searchArtifacts(groupId, null, null, null,  List.of("testCaseInsensitiveSearchKey".toUpperCase()), SortBy.name, SortOrder.asc, 0, 10);
+            propertiesSearch = clientV2.searchArtifacts(groupId, null, null, null,  List.of("testCaseInsensitiveSearchKey:testCaseInsensitiveSearchValue".toUpperCase()), SortBy.name, SortOrder.asc, 0, 10);
             Assertions.assertNotNull(propertiesSearch);
             Assertions.assertEquals(1, propertiesSearch.getCount());
-            propertiesSearch = clientV2.searchArtifacts(groupId, null, null, null, List.of("TESTCaseInsensitiveSEARCHKey"), SortBy.name, SortOrder.asc, 0, 10);
+            propertiesSearch = clientV2.searchArtifacts(groupId, null, null, null, List.of("TESTCaseInsensitiveSEARCHKey:TESTCaseInsensitiveSearchVALUE"), SortBy.name, SortOrder.asc, 0, 10);
             Assertions.assertNotNull(propertiesSearch);
             Assertions.assertEquals(1, propertiesSearch.getCount());
         });

--- a/app/src/test/java/io/apicurio/registry/rest/v2/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/rest/v2/GroupsResourceTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import io.apicurio.registry.AbstractResourceTestBase;
 import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.v2.beans.EditableMetaData;
 import io.apicurio.registry.rest.v2.beans.IfExists;
 import io.apicurio.registry.rest.v2.beans.Rule;
 import io.apicurio.registry.rest.v2.beans.VersionMetaData;
@@ -1483,6 +1484,37 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .body("version", anything())
                 .body("name", equalTo("Empty API (Updated)"))
                 .body("description", equalTo("An example API design using OpenAPI."));
+    }
+
+    @Test
+    public void testPropertyValueNotNull() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String artifactContent = resourceToString("openapi-empty.json");
+
+        int idx = 0;
+        String title = "Empty API " + idx;
+        String artifactId = "Empty-" + idx;
+        this.createArtifact(group, artifactId, ArtifactType.OPENAPI, artifactContent.replaceAll("Empty API", title));
+        waitForArtifact(group, artifactId);
+
+        Map<String, String> props = new HashMap<>();
+        props.put("test-key", null);
+
+        // Update the artifact meta-data
+        EditableMetaData metaData = new EditableMetaData();
+        metaData.setName(title);
+        metaData.setDescription("Some description of an API");
+        metaData.setProperties(props);
+        given()
+            .when()
+                .contentType(CT_JSON)
+                .pathParam("groupId", group)
+                .pathParam("artifactId", artifactId)
+                .body(metaData)
+                .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
+            .then()
+                .statusCode(400);
+
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/storage/AbstractRegistryStorageTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/AbstractRegistryStorageTest.java
@@ -31,7 +31,6 @@ import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.RuleConfigurationDto;
 import io.apicurio.registry.storage.dto.SearchFilter;
-import io.apicurio.registry.storage.dto.SearchFilterType;
 import io.apicurio.registry.storage.dto.StoredArtifactDto;
 import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
 import io.apicurio.registry.types.ArtifactState;
@@ -886,7 +885,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
 
         long start = System.currentTimeMillis();
 
-        Set<SearchFilter> filters = Collections.singleton(new SearchFilter(SearchFilterType.name, "testSearchArtifacts"));
+        Set<SearchFilter> filters = Collections.singleton(SearchFilter.ofName("testSearchArtifacts"));
         ArtifactSearchResultsDto results = storage().searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10);
         Assertions.assertNotNull(results);
         Assertions.assertEquals(50, results.getCount());
@@ -894,7 +893,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals(10, results.getArtifacts().size());
 
 
-        filters = Collections.singleton(new SearchFilter(SearchFilterType.name, "testSearchArtifacts-19-name"));
+        filters = Collections.singleton(SearchFilter.ofName("testSearchArtifacts-19-name"));
         results = storage().searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10);
         Assertions.assertNotNull(results);
         Assertions.assertEquals(1, results.getCount());
@@ -903,7 +902,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals("testSearchArtifacts-19-name", results.getArtifacts().get(0).getName());
 
 
-        filters = Collections.singleton(new SearchFilter(SearchFilterType.description, "testSearchArtifacts-33-description"));
+        filters = Collections.singleton(SearchFilter.ofDescription("testSearchArtifacts-33-description"));
         results = storage().searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10);
         Assertions.assertNotNull(results);
         Assertions.assertEquals(1, results.getCount());
@@ -919,7 +918,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals(10, results.getArtifacts().size());
 
 
-        filters = Collections.singleton(new SearchFilter(SearchFilterType.everything, "testSearchArtifacts"));
+        filters = Collections.singleton(SearchFilter.ofEverything("testSearchArtifacts"));
         results = storage().searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 1000);
         Assertions.assertNotNull(results);
         Assertions.assertEquals(50, results.getCount());
@@ -929,7 +928,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals("testSearchArtifacts-02-name", results.getArtifacts().get(1).getName());
 
 
-        filters = Collections.singleton(new SearchFilter(SearchFilterType.labels, "label-17"));
+        filters = Collections.singleton(SearchFilter.ofLabel("label-17"));
         results = storage().searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10);
         Assertions.assertNotNull(results);
         Assertions.assertEquals(1, results.getCount());
@@ -938,7 +937,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals("testSearchArtifacts-17-name", results.getArtifacts().get(0).getName());
 
 
-        filters = Collections.singleton(new SearchFilter(SearchFilterType.everything, "label-17"));
+        filters = Collections.singleton(SearchFilter.ofEverything("label-17"));
         results = storage().searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10);
         Assertions.assertNotNull(results);
         Assertions.assertEquals(1, results.getCount());
@@ -1156,7 +1155,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
 
         // Search for the artifacts using Tenant 2 (0 results expected)
         tenantCtx.setContext(tenantId2);
-        Set<SearchFilter> filters = Collections.singleton(new SearchFilter(SearchFilterType.labels, "testMultiTenant_Search"));
+        Set<SearchFilter> filters = Collections.singleton(SearchFilter.ofLabel("testMultiTenant_Search"));
         ArtifactSearchResultsDto searchResults = storage().searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 100);
         Assertions.assertNotNull(searchResults);
         Assertions.assertEquals(0, searchResults.getCount());

--- a/app/src/test/java/io/apicurio/registry/storage/RegistryStoragePerformanceTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/RegistryStoragePerformanceTest.java
@@ -35,7 +35,6 @@ import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.SearchFilter;
-import io.apicurio.registry.storage.dto.SearchFilterType;
 import io.apicurio.registry.storage.dto.StoredArtifactDto;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.Current;
@@ -130,14 +129,14 @@ public class RegistryStoragePerformanceTest {
         Assertions.assertEquals(NUM_ARTIFACTS, results.getCount());
 
         long startNameSearch = System.currentTimeMillis();
-        filters = Collections.singleton(new SearchFilter(SearchFilterType.name, "testStoragePerformance-9999"));
+        filters = Collections.singleton(SearchFilter.ofName("testStoragePerformance-9999"));
         results = storage.searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10);
         long endNameSearch = System.currentTimeMillis();
         Assertions.assertNotNull(results);
         Assertions.assertEquals(1, results.getCount());
 
         long startAllNameSearch = System.currentTimeMillis();
-        filters = Collections.singleton(new SearchFilter(SearchFilterType.name, "testStoragePerformance"));
+        filters = Collections.singleton(SearchFilter.ofName("testStoragePerformance"));
         results = storage.searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10);
         long endAllNameSearch = System.currentTimeMillis();
         Assertions.assertNotNull(results);
@@ -145,21 +144,21 @@ public class RegistryStoragePerformanceTest {
 
         long startLabelSearch = System.currentTimeMillis();
 
-        filters = Collections.singleton(new SearchFilter(SearchFilterType.labels, "label-" + (NUM_ARTIFACTS-1)));
+        filters = Collections.singleton(SearchFilter.ofLabel("label-" + (NUM_ARTIFACTS-1)));
         results = storage.searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10);
         long endLabelSearch = System.currentTimeMillis();
         Assertions.assertNotNull(results);
         Assertions.assertEquals(1, results.getCount());
 
         long startAllLabelSearch = System.currentTimeMillis();
-        filters = Collections.singleton(new SearchFilter(SearchFilterType.labels, "the-label"));
+        filters = Collections.singleton(SearchFilter.ofLabel("the-label"));
         results = storage.searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10);
         long endAllLabelSearch = System.currentTimeMillis();
         Assertions.assertNotNull(results);
         Assertions.assertEquals(NUM_ARTIFACTS, results.getCount());
 
         long startEverythingSearch = System.currentTimeMillis();
-        filters = Collections.singleton(new SearchFilter(SearchFilterType.everything, "test"));
+        filters = Collections.singleton(SearchFilter.ofEverything("test"));
         results = storage.searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10);
         long endEverythingSearch = System.currentTimeMillis();
         Assertions.assertNotNull(results);


### PR DESCRIPTION
fix for #2125 , now the REST layer parses que "properties" queryParam looking for ":" delimiter to separate property key and value. Adding another way to provide propertyKey and propertyValue to the API can be implemented later.

we had the implicit requirement in the storage layer that property value must be not null. This PR brings that requirement explicitly to the REST layer.