### PR TITLE
fix: too verbose warn log

### DIFF
--- a/app/src/main/java/io/apicurio/registry/metrics/health/readiness/ResponseTimeoutReadinessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/readiness/ResponseTimeoutReadinessCheck.java
@@ -89,7 +89,7 @@ public class ResponseTimeoutReadinessCheck extends AbstractErrorCounterHealthChe
                 log.error("Value '{}' of header '{}' is the wrong format!", requestStart, HEADER_NAME);
             }
 
-        } else {
+        } else if (responseContext.getStatus() != 404){
             log.warn("Expected header '{}' not found.", HEADER_NAME);
         }
     }


### PR DESCRIPTION
this should fix the unexpected log message 
`Expected header X-Apicurio-Registry-ResponseTimeoutReadinessCheck-RequestStart not found.`