### PR TITLE
bugfix: deleteArtifactVersion leaves artifacts.latest column corrupted

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/impl/ConfigResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/impl/ConfigResourceImpl.java
@@ -23,6 +23,8 @@ import io.apicurio.registry.ccompat.dto.CompatibilityLevelDto;
 import io.apicurio.registry.ccompat.dto.CompatibilityLevelParamDto;
 import io.apicurio.registry.ccompat.rest.ConfigResource;
 import io.apicurio.registry.logging.Logged;
+import io.apicurio.registry.logging.audit.Audited;
+import io.apicurio.registry.logging.audit.AuditingConstants;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
 import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
@@ -31,6 +33,7 @@ import io.apicurio.registry.storage.dto.RuleConfigurationDto;
 import io.apicurio.registry.types.RuleType;
 
 import javax.interceptor.Interceptors;
+
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -87,6 +90,7 @@ public class ConfigResourceImpl extends AbstractResource implements ConfigResour
 
 
     @Override
+    @Audited(extractParameters = {"0", AuditingConstants.KEY_RULE})
     @Authorized(style=AuthorizedStyle.None, level=AuthorizedLevel.Admin)
     public CompatibilityLevelDto updateGlobalCompatibilityLevel(
             CompatibilityLevelDto request) {
@@ -99,6 +103,7 @@ public class ConfigResourceImpl extends AbstractResource implements ConfigResour
 
 
     @Override
+    @Audited(extractParameters = {"0", AuditingConstants.KEY_ARTIFACT_ID, "1", AuditingConstants.KEY_RULE})
     @Authorized(style=AuthorizedStyle.ArtifactOnly, level=AuthorizedLevel.Write)
     public CompatibilityLevelDto updateSubjectCompatibilityLevel(
             String subject,

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/impl/SubjectVersionsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/impl/SubjectVersionsResourceImpl.java
@@ -16,6 +16,9 @@
 
 package io.apicurio.registry.ccompat.rest.impl;
 
+import static io.apicurio.registry.logging.audit.AuditingConstants.KEY_ARTIFACT_ID;
+import static io.apicurio.registry.logging.audit.AuditingConstants.KEY_VERSION;
+
 import java.util.List;
 
 import javax.inject.Inject;
@@ -31,6 +34,7 @@ import io.apicurio.registry.ccompat.dto.SchemaInfo;
 import io.apicurio.registry.ccompat.rest.SubjectVersionsResource;
 import io.apicurio.registry.ccompat.store.FacadeConverter;
 import io.apicurio.registry.logging.Logged;
+import io.apicurio.registry.logging.audit.Audited;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
 
@@ -52,6 +56,7 @@ public class SubjectVersionsResourceImpl extends AbstractResource implements Sub
     }
 
     @Override
+    @Audited(extractParameters = {"0", KEY_ARTIFACT_ID})
     @Authorized(style=AuthorizedStyle.ArtifactOnly, level=AuthorizedLevel.Write)
     public SchemaId register(String subject, SchemaInfo request) throws Exception {
         Long id = facade.createSchema(subject, request.getSchema(), request.getSchemaType());
@@ -69,6 +74,7 @@ public class SubjectVersionsResourceImpl extends AbstractResource implements Sub
     }
 
     @Override
+    @Audited(extractParameters = {"0", KEY_ARTIFACT_ID, "1", KEY_VERSION})
     @Authorized(style=AuthorizedStyle.ArtifactOnly, level=AuthorizedLevel.Write)
     public int deleteSchemaVersion(
             String subject,

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/impl/SubjectsResourceImpl.java
@@ -23,10 +23,13 @@ import io.apicurio.registry.ccompat.dto.Schema;
 import io.apicurio.registry.ccompat.dto.SchemaContent;
 import io.apicurio.registry.ccompat.rest.SubjectsResource;
 import io.apicurio.registry.logging.Logged;
+import io.apicurio.registry.logging.audit.Audited;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
 
 import javax.interceptor.Interceptors;
+
+import static io.apicurio.registry.logging.audit.AuditingConstants.KEY_ARTIFACT_ID;
 import java.util.List;
 
 /**
@@ -50,6 +53,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
     }
 
     @Override
+    @Audited(extractParameters = {"0", KEY_ARTIFACT_ID})
     @Authorized(style=AuthorizedStyle.ArtifactOnly, level=AuthorizedLevel.Write)
     public List<Integer> deleteSubject(String subject) throws Exception {
 

--- a/app/src/main/java/io/apicurio/registry/logging/audit/AuditingConstants.java
+++ b/app/src/main/java/io/apicurio/registry/logging/audit/AuditingConstants.java
@@ -18,10 +18,10 @@ package io.apicurio.registry.logging.audit;
 
 public interface AuditingConstants {
 
-    String KEY_GROUP_ID = "artifact_id";
+    String KEY_GROUP_ID = "group_id";
     String KEY_ARTIFACT_ID = "artifact_id";
     String KEY_UPDATE_STATE = "update_state";
-    String KEY_VERSION = "update_state";
+    String KEY_VERSION = "version";
     String KEY_ARTIFACT_TYPE = "artifact_type";
     String KEY_IF_EXISTS = "if_exists";
     String KEY_CANONICAL = "canonical";

--- a/app/src/test/java/io/apicurio/registry/ccompat/rest/ConfluentCompatApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/ccompat/rest/ConfluentCompatApiTest.java
@@ -20,6 +20,8 @@ import io.apicurio.registry.AbstractResourceTestBase;
 import io.apicurio.registry.ccompat.dto.CompatibilityLevelDto;
 import io.apicurio.registry.ccompat.dto.CompatibilityLevelParamDto;
 import io.apicurio.registry.rest.v1.beans.UpdateState;
+import io.apicurio.registry.rest.v2.beans.ArtifactSearchResults;
+import io.apicurio.registry.rest.v2.beans.VersionSearchResults;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.utils.tests.TestUtils;
@@ -623,5 +625,146 @@ public class ConfluentCompatApiTest extends AbstractResourceTestBase {
         assertEquals("AVRO", types[2]);
     }
 
+    @Test
+    public void testDeleteSchemaVersion() throws Exception {
+        final String SUBJECT = "testDeleteSchemaVersion";
+
+        final Integer contentId1 = given()
+                .when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(SCHEMA_1_WRAPPED)
+                .post("/ccompat/v6/subjects/{subject}/versions", SUBJECT)
+                .then()
+                .statusCode(200)
+                .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)))
+                .extract().body().jsonPath().get("id");
+        Assertions.assertNotNull(contentId1);
+
+        this.waitForArtifact(SUBJECT);
+
+        final Integer contentId2 = given()
+                .when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(SCHEMA_2_WRAPPED)
+                .post("/ccompat/v6/subjects/{subject}/versions", SUBJECT)
+                .then()
+                .statusCode(200)
+                .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)))
+                .extract().body().jsonPath().get("id");
+
+        Assertions.assertNotNull(contentId2);
+
+        this.waitForContentId(contentId2);
+
+        //check versions list
+        var versionsConfluent = given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .get("/ccompat/v6/subjects/{subject}/versions", SUBJECT)
+            .then()
+            .statusCode(200)
+            .extract().as(Integer[].class);
+
+        assertEquals(2, versionsConfluent.length);
+
+        given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .get("/ccompat/v6/subjects/{subject}/versions/{version}", SUBJECT, "1")
+            .then()
+            .statusCode(200);
+        given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .get("/ccompat/v6/subjects/{subject}/versions/{version}", SUBJECT, "2")
+            .then()
+            .statusCode(200);
+
+
+        var versionsApicurio = given()
+                .when()
+                .get("/registry/v2/groups/default/artifacts/{subject}/versions", SUBJECT)
+                .then()
+                .statusCode(200)
+                .extract().as(VersionSearchResults.class)
+                .getVersions();
+
+        assertEquals(2, versionsApicurio.size());
+
+        var searchApicurio = given()
+                .when()
+                .get("/registry/v2/search/artifacts")
+                .then()
+                .statusCode(200)
+                .extract().as(ArtifactSearchResults.class)
+                .getArtifacts();
+
+        assertEquals(1, searchApicurio.size());
+
+        //delete version 2
+        given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .delete("/ccompat/v6/subjects/{subject}/versions/{version}", SUBJECT, "2")
+            .then()
+            .statusCode(200);
+
+        versionsConfluent = given()
+                .when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .get("/ccompat/v6/subjects/{subject}/versions", SUBJECT)
+                .then()
+                .statusCode(200)
+                .extract().as(Integer[].class);
+
+            assertEquals(1, versionsConfluent.length);
+
+        given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .get("/ccompat/v6/subjects/{subject}/versions/{version}", SUBJECT, "1")
+            .then()
+            .statusCode(200);
+
+        versionsApicurio = given()
+                .when()
+                .get("/registry/v2/groups/default/artifacts/{subject}/versions", SUBJECT)
+                .then()
+                .statusCode(200)
+                .extract().as(VersionSearchResults.class)
+                .getVersions();
+
+        assertEquals(1, versionsApicurio.size());
+
+        given()
+            .when()
+            .get("/registry/v2/groups/default/artifacts/{subject}/versions/1", SUBJECT)
+            .then()
+            .statusCode(200);
+        given()
+            .when()
+            .get("/registry/v2/groups/default/artifacts/{subject}/versions/1/meta", SUBJECT)
+            .then()
+            .statusCode(200);
+        given()
+            .when()
+            .get("/registry/v2/groups/default/artifacts/{subject}/meta", SUBJECT)
+            .then()
+            .statusCode(200);
+        given()
+            .when()
+            .get("/registry/v2/groups/default/artifacts/{subject}", SUBJECT)
+            .then()
+            .statusCode(200);
+        searchApicurio = given()
+                .when()
+                .get("/registry/v2/search/artifacts")
+                .then()
+                .statusCode(200)
+                .extract().as(ArtifactSearchResults.class)
+                .getArtifacts();
+
+        assertEquals(1, searchApicurio.size());
+    }
 
 }


### PR DESCRIPTION
from #2185 

the issue is that `deleteArtifactVersion` method leaved the latest column in artifact table corrupted (with null value) that made a lot APIs to break

this PR also adds some missing audit logging