### PR TITLE
reduce number of ci jobs

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -20,18 +20,15 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-18.04
     if: github.repository_owner == 'Apicurio'
-    strategy:
-      matrix:
-        jdk-version: [11, 17]
     steps:
       - name: Show Actor
         run: echo ${{github.actor}}
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Set up JDK ${{ matrix.jdk-version }}
+      - name: Set up JDK 11
         uses: AdoptOpenJDK/install-jdk@v1
         with:
-          version: ${{ matrix.jdk-version }}
+          version: 11
           architecture: x64
 
       - name: Cache Dependencies
@@ -65,35 +62,35 @@ jobs:
         run: ./mvnw verify -Pintegration-tests -Pui -Pinmemory -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       
       - name: Run Integration Tests - sql
-        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Integration Tests - sql clustered
-        run: ./mvnw verify -Pintegration-tests -Pclustered -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -Pclustered -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Integration Tests - kafkasql
-        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Integration Tests - kafkasql clustered
         if: github.ref == 'refs/heads/master'
-        run: ./mvnw verify -Pintegration-tests -Pclustered -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -Pclustered -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Integration Tests - multitenancy
         run: ./mvnw verify -Pintegration-tests -Pmultitenancy -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Integration Tests - sql migration
-        run: ./mvnw verify -Pintegration-tests -Pmigration -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -Pmigration -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Integration Tests - kafkasql migration
-        run: ./mvnw verify -Pintegration-tests -Pmigration -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -Pmigration -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Integration Tests - sql auth
-        run: ./mvnw verify -Pintegration-tests -Pauth -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -Pauth -Psql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Integration Tests - kafkasql auth
-        run: ./mvnw verify -Pintegration-tests -Pauth -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -Pauth -Pkafkasql -pl integration-tests/testsuite -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Integration Tests - sql dbupgrade
         run: ./mvnw verify -Pintegration-tests -Pdbupgrade -Psql -pl integration-tests/testsuite -DtrimStackTrace=false -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
 
       - name: Run Legacy Tests - kafkasql
         env:
           TEST_APP_ENV_ENABLE_CCOMPAT_LEGACY_ID_MODE: "true"
-        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Pkafkasql -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Pkafkasql -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
       - name: Run Legacy Tests - sql
         env:
           TEST_APP_ENV_ENABLE_CCOMPAT_LEGACY_ID_MODE: "true"
-        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Psql -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress
+        run: ./mvnw verify -Pintegration-tests -P${{ env.test_profile }} -Psql -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress -DtrimStackTrace=false
 
       - name: Collect logs
         if: failure()

--- a/.github/workflows/kubernetes-tests.yaml
+++ b/.github/workflows/kubernetes-tests.yaml
@@ -20,9 +20,6 @@ jobs:
     name: Kubernetes Tests Basic
     runs-on: ubuntu-18.04
     if: github.repository_owner == 'Apicurio'
-    strategy:
-      matrix:
-        jdk-version: [11, 17]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -32,10 +29,10 @@ jobs:
           go-version: '^1.16.8'
       - run: go version
 
-      - name: Set up JDK ${{ matrix.jdk-version }}
+      - name: Set up JDK 11
         uses: AdoptOpenJDK/install-jdk@v1
         with:
-          version: ${{ matrix.jdk-version }}
+          version: 11
           architecture: x64
 
       - name: Get maven wrapper
@@ -68,9 +65,6 @@ jobs:
     name: Kubernetes Tests Clustered
     runs-on: ubuntu-18.04
     if: github.repository_owner == 'Apicurio'
-    strategy:
-      matrix:
-        jdk-version: [11, 17]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -80,10 +74,10 @@ jobs:
           go-version: '^1.16.8'
       - run: go version
 
-      - name: Set up JDK ${{ matrix.jdk-version }}
+      - name: Set up JDK 11
         uses: AdoptOpenJDK/install-jdk@v1
         with:
-          version: ${{ matrix.jdk-version }}
+          version: 11
           architecture: x64
 
       - name: Build All Variants

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -80,17 +80,14 @@ jobs:
     name: Build native images
     runs-on: ubuntu-18.04
     if: github.repository_owner == 'Apicurio'
-    strategy:
-      matrix:
-        jdk-version: [11, 17]
     steps:
       - name: Checkout Code with Ref '${{ github.ref }}'
         uses: actions/checkout@v2
 
-      - name: Set up JDK ${{ matrix.jdk-version }}
+      - name: Set up JDK 11
         uses: AdoptOpenJDK/install-jdk@v1
         with:
-          version: ${{ matrix.jdk-version }}
+          version: 11
           architecture: x64
 
       - name: Cache Dependencies


### PR DESCRIPTION
This PR leaves the matrix job to test java 11 and 17 only for the verify build job