### PR TITLE
mt: tenant-manager extract to its own deployment

### DIFF
--- a/distro/openshift-template/mt/apicurio-registry-mt-template.yaml
+++ b/distro/openshift-template/mt/apicurio-registry-mt-template.yaml
@@ -62,24 +62,6 @@ objects:
       app: apicurio-registry
       template: multitenant-apicurio-registry
 
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: apicurio-registry
-      template: multitenant-apicurio-registry
-      component: tenant-manager
-    name: tenant-manager
-  spec:
-    ports:
-    - port: 8585
-      protocol: TCP
-      targetPort: 8585
-      name: http
-    selector:
-      app: apicurio-registry
-      template: multitenant-apicurio-registry
-
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -240,6 +222,9 @@ objects:
           - name: CORS_ALLOWED_ORIGINS
             value: ${CORS_ALLOWED_ORIGINS}
 
+          # TODO tenant-manager certificate?
+          - name: TENANT_MANAGER_URL
+            value: https://tenant-manager-envoy:9001
           - name: TENANT_MANAGER_AUTH_URL
             value: ${KEYCLOAK_URL}
           - name: TENANT_MANAGER_REALM
@@ -287,6 +272,180 @@ objects:
               cpu: ${APICURIO_REGISTRY_CPU_REQUEST}
               memory: ${APICURIO_REGISTRY_MEMORY_REQUEST}
           terminationMessagePath: /dev/termination-log
+        - name: envoy
+          image: ${ENVOY_IMAGE}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - name: envoy-tls
+            mountPath: /secrets/tls
+          - name: envoy-config
+            mountPath: /configs/envoy
+          - name: envoy-unix-sockets
+            mountPath: /sockets
+          command:
+          - envoy
+          - --config-path
+          - /configs/envoy/main.yaml
+          ports:
+          - name: api-envoy
+            protocol: TCP
+            containerPort: 9001
+          - name: metrics-envoy
+            protocol: TCP
+            containerPort: 9000
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 9000
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 9000
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+            limits:
+              memory: 512Mi
+              cpu: 500m
+
+- kind: PodDisruptionBudget
+  apiVersion: policy/v1
+  metadata:
+    name: apicurio-registry-pdb
+  spec:
+    maxUnavailabe: "50%"
+    selector:
+      matchLabels:
+        app: apicurio-registry
+        template: multitenant-apicurio-registry
+
+# tenant-manager resources
+# TODO revisit app-interface metrics and alerts
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: tenant-manager
+      template: multitenant-apicurio-registry
+      component: tenant-manager-envoy
+    annotations:
+      description: Exposes and load balances the tenant-manager pods going through envoy beforehand
+      service.alpha.openshift.io/serving-cert-secret-name: tenant-manager-envoy-tls
+    name: tenant-manager-envoy
+  spec:
+    ports:
+    - port: 9001
+      protocol: TCP
+      targetPort: 9001
+      name: api-envoy
+    selector:
+      app: tenant-manager
+      template: multitenant-apicurio-registry
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: tenant-manager
+      template: multitenant-apicurio-registry
+      component: tenant-manager-envoy-metrics
+    name: tenant-manager-envoy-metrics
+  spec:
+    ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+      name: metrics-envoy
+    selector:
+      app: tenant-manager
+      template: multitenant-apicurio-registry
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: tenant-manager
+      template: multitenant-apicurio-registry
+      component: tenant-manager
+    name: tenant-manager
+  spec:
+    ports:
+    - port: 8585
+      protocol: TCP
+      targetPort: 8585
+      name: http
+    selector:
+      app: tenant-manager
+      template: multitenant-apicurio-registry
+
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: tenant-manager
+      template: multitenant-apicurio-registry
+    name: tenant-manager
+  spec:
+    selector:
+      matchLabels:
+        app: tenant-manager
+        template: multitenant-apicurio-registry
+    replicas: ${{TENANT_MANAGER_REPLICAS}}
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        labels:
+          app: tenant-manager
+          template: multitenant-apicurio-registry
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - tenant-manager
+                  - key: template
+                    operator: In
+                    values:
+                    - multitenant-apicurio-registry
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+        serviceAccount: ${SERVICE_ACCOUNT_NAME}
+        serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+        volumes:
+        - name: envoy-config
+          configMap:
+            name: ${TENANT_MANAGER_ENVOY_CONFIG_CM_NAME}
+        - name: envoy-unix-sockets
+          emptyDir:
+            medium: Memory
+        - name: db-ssl-ca
+          secret:
+            secretName: ${DATABASE_SSL_CA_SECRET_NAME}
+        - name: envoy-tls
+          secret:
+            secretName: tenant-manager-envoy-tls
+
+        containers:
         - name: tenant-manager
           image: ${IMAGE_REGISTRY}/${TENANT_MANAGER_IMAGE_REPOSITORY}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
@@ -323,6 +482,7 @@ objects:
                 name:  ${DATABASE_SECRET_NAME}
                 key:  db.password
 
+          #TODO this env will be deleted, this is not useful
           - name: REGISTRY_ROUTE_URL
             value: http://localhost:8080
           - name: QUARKUS_HTTP_PORT
@@ -436,12 +596,12 @@ objects:
 - kind: PodDisruptionBudget
   apiVersion: policy/v1
   metadata:
-    name: apicurio-registry-pdb
+    name: tenant-manager-pdb
   spec:
     maxUnavailabe: "50%"
     selector:
       matchLabels:
-        app: apicurio-registry
+        app: tenant-manager
         template: multitenant-apicurio-registry
 
 parameters:
@@ -466,7 +626,10 @@ parameters:
   required: true
 
 - name: REPLICAS
-  description: Number of replicas of the service to run.
+  description: Number of replicas for apicurio-registry deployment.
+  value: "3"
+- name: TENANT_MANAGER_REPLICAS
+  description: Number of replicas for tenant-manager deployment.
   value: "3"
 
 - name: IMAGE_REGISTRY
@@ -600,6 +763,9 @@ parameters:
 - name: ENVOY_CONFIG_CM_NAME
   description: ConfigMap containing Envoy config file
   value: apicurio-registry-envoy-config
+- name: TENANT_MANAGER_ENVOY_CONFIG_CM_NAME
+  description: ConfigMap containing Envoy config file for tenant-manager
+  value: tenant-manager-envoy-config
 
 - name: ENABLE_SENTRY
   value: "false"


### PR DESCRIPTION
This PR changes the deployment model for multitenant apicurio-registry. Now tenant-manager will be provisioned in a new deployment and we will use envoy proxy as a sidecar. Using envoy will be used for basic rate limiting and to ease TLS setup.

Configuration updates in the control plane components may be needed after this, as well as for metrics and alerts.