### PR TITLE
Added import/export functions in UI

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -15,6 +15,10 @@ registry.date=${timestamp}
 quarkus.log.console.format=%d{YYYY-MM-dd HH:mm:ss} %p <%X{tenantId}> [%C] (%t) %m%n
 quarkus.log.console.color=false
 
+# Max HTTP request body size (large files needed to support Import functionality)
+# (Set to 50MB)
+quarkus.http.limits.max-body-size=52428800
+
 # === Dev profile - see README
 %dev.quarkus.http.port=${HTTP_PORT:8080}
 %dev.quarkus.log.level=${LOG_LEVEL:INFO}

--- a/ui/src/app/components/modals/progressModal.css
+++ b/ui/src/app/components/modals/progressModal.css
@@ -1,0 +1,13 @@
+.progress {
+}
+
+.progress > .pf-c-title + .pf-c-modal-box__body {
+    overflow: hidden;
+    margin-top: 5px;
+}
+
+.progress .message {
+    font-size: 15px;
+    color: #333;
+    margin-left: 10px;
+}

--- a/ui/src/app/components/modals/progressModal.tsx
+++ b/ui/src/app/components/modals/progressModal.tsx
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2022 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import "./progressModal.css";
+import {Modal, Progress} from "@patternfly/react-core";
+import {PureComponent, PureComponentProps, PureComponentState} from "../baseComponent";
+
+
+/**
+ * Properties
+ */
+export interface ProgressModalProps extends PureComponentProps {
+    message: string;
+    isOpen: boolean;
+    progress: number | undefined;
+}
+
+/**
+ * State
+ */
+// tslint:disable-next-line:no-empty-interface
+export interface ProgressModalState extends PureComponentState {
+}
+
+/**
+ * Models the "progress" modal.  This is shown when the user performs an asynchronous operation
+ * with trackable progress (by percentage).
+ */
+export class ProgressModal extends PureComponent<ProgressModalProps, ProgressModalState> {
+
+    constructor(props: Readonly<ProgressModalProps>) {
+        super(props);
+    }
+
+    public render(): React.ReactElement {
+        return (
+            <Modal
+                title="Working"
+                variant="small"
+                isOpen={this.props.isOpen}
+                header={<a href="#" />}
+                showClose={false}
+                className="progress pf-m-redhat-font"
+                aria-label="progress-modal"
+            >
+                <Progress title={this.props.message} value={this.props.progress} />
+            </Modal>
+        );
+    }
+
+    protected initializeState(): ProgressModalState {
+        return {};
+    }
+
+}

--- a/ui/src/app/pages/artifacts/artifacts.tsx
+++ b/ui/src/app/pages/artifacts/artifacts.tsx
@@ -385,7 +385,6 @@ export class ArtifactsPage extends PageComponent<ArtifactsPageProps, ArtifactsPa
     };
 
     private onImportFileChange = (value: string | File, filename: string, event: any): void => {
-        Services.getLoggerService().debug("====> onImportFileChange: ", value, filename, event);
         if (value == "" && filename == "") {
             this.setMultiState({
                 importFilename: "",

--- a/ui/src/app/pages/artifacts/components/toolbar/toolbar.tsx
+++ b/ui/src/app/pages/artifacts/components/toolbar/toolbar.tsx
@@ -23,7 +23,7 @@ import {
     DropdownItem,
     DropdownToggle,
     Form,
-    InputGroup,
+    InputGroup, KebabToggle,
     Pagination,
     TextInput,
     Toolbar,
@@ -53,6 +53,8 @@ export interface ArtifactsPageToolbarProps extends PureComponentProps {
     onPerPageSelect: OnPerPageSelect;
     onSetPage: OnSetPage;
     onUploadArtifact: () => void;
+    onImportArtifacts: () => void;
+    onExportArtifacts: () => void;
 }
 
 /**
@@ -61,6 +63,7 @@ export interface ArtifactsPageToolbarProps extends PureComponentProps {
 export interface ArtifactsPageToolbarState extends PureComponentState {
     filterIsExpanded: boolean;
     criteria: ArtifactsPageToolbarFilterCriteria;
+    kebabIsOpen: boolean;
 }
 
 /**
@@ -132,6 +135,24 @@ export class ArtifactsPageToolbar extends PureComponent<ArtifactsPageToolbarProp
                             </IfFeature>
                         </IfAuth>
                     </ToolbarItem>
+                    <ToolbarItem className="admin-actions-item">
+                        <IfAuth isAdmin={true}>
+                            <Dropdown
+                                onSelect={this.onKebabSelect}
+                                toggle={<KebabToggle onToggle={this.onKebabToggle} />}
+                                isOpen={this.state.kebabIsOpen}
+                                isPlain
+                                dropdownItems={[
+                                    <DropdownItem key="import" id="import-action" data-testid="toolbar-import" component="button">Upload multiple artifacts</DropdownItem>,
+                                    <DropdownItem key="export" id="export-action" data-testid="toolbar-export" component="button">Download all artifacts (zip)</DropdownItem>
+                                ]}
+                            />
+
+
+                            {/*<Button className="btn-header-export-artifacts" data-testid="btn-header-export-artifacts"*/}
+                            {/*        variant="secondary" onClick={this.props.onExportArtifacts}>Export all artifacts</Button>*/}
+                        </IfAuth>
+                    </ToolbarItem>
                     <ToolbarItem className="artifact-paging-item">
                         <Pagination
                             variant="bottom"
@@ -153,7 +174,8 @@ export class ArtifactsPageToolbar extends PureComponent<ArtifactsPageToolbarProp
     protected initializeState(): ArtifactsPageToolbarState {
         return {
             filterIsExpanded: false,
-            criteria: this.props.criteria
+            criteria: this.props.criteria,
+            kebabIsOpen: false
         }
     }
 
@@ -179,6 +201,24 @@ export class ArtifactsPageToolbar extends PureComponent<ArtifactsPageToolbarProp
         }, () => {
             this.fireOnChange();
         });
+    };
+
+    private onKebabSelect = (event: React.SyntheticEvent<HTMLDivElement>|undefined): void => {
+        const value: string = event && event.currentTarget && event.currentTarget.id ? event.currentTarget.id : "";
+        Services.getLoggerService().debug("[ArtifactsPageToolbar] Toolbar action: ", value);
+        this.onKebabToggle(false);
+        switch (value) {
+            case "import-action":
+                this.props.onImportArtifacts();
+                break;
+            case "export-action":
+                this.props.onExportArtifacts();
+                break;
+        }
+    };
+
+    private onKebabToggle = (isOpen: boolean) => {
+        this.setSingleState("kebabIsOpen", isOpen);
     };
 
     private onFilterValueChange = (value: any): void => {

--- a/ui/src/services/admin/admin.service.ts
+++ b/ui/src/services/admin/admin.service.ts
@@ -125,8 +125,16 @@ export class AdminService extends BaseService {
                 ref.href = ref.href.replace("/apis/registry", this.apiBaseHref());
                 ref.href = ref.href + "/" + filename;
             }
+
             return ref;
         });
     }
 
+    public importFrom(file: File, progressFunction: (progressEvent: any) => void): Promise<void> {
+        const endpoint: string = this.endpoint("/v2/admin/import");
+        const headers: any = {
+            "Content-Type": "application/zip"
+        };
+        return this.httpPost(endpoint, file, this.options(headers),undefined, progressFunction);
+    }
 }


### PR DESCRIPTION
This pull request adds support for Importing and Exporting content (ZIP file) in the UI.  These functions have been available in the REST API for some time, and also in the MAS CLI, but not in the UI.  The functionality is admin-only, so the new UI changes will only be available to admin users.  Here's what it looks like:

![image](https://user-images.githubusercontent.com/1890703/151369037-1258f4b0-ad03-46fa-922a-4a8c54f6a2ac.png)

When downloading artifacts, clicking the menu item simply starts a download of the ZIP file.  Nothing additional needs to be done.  When uploading artifacts, there is a followup modal dialog that lets the user choose the ZIP file they want to upload.  Then there is a progress dialog that appears while the import is happening.

![image](https://user-images.githubusercontent.com/1890703/151369297-6c50e67c-0e6a-4900-9d72-d176adf6c57c.png)

![image](https://user-images.githubusercontent.com/1890703/151369591-e813dbf5-5900-4214-860d-0ae5858039ec.png)

