### PR TITLE
Added search by property key and relevant tests

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v2/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/SearchResourceImpl.java
@@ -117,17 +117,21 @@ public class SearchResourceImpl implements SearchResource {
             properties.stream()
                 .map(prop -> {
                    int delimiterIndex = prop.indexOf(":");
-                   if (delimiterIndex < 0) {
-                       throw new BadRequestException("property search filter wrong formatted, missing ':' delimiter");
-                   }
+                   String propertyKey;
+                   String propertyValue;
                    if (delimiterIndex == 0) {
                        throw new BadRequestException("property search filter wrong formatted, missing left side of  ':' delimiter");
                    }
                    if (delimiterIndex == (prop.length() - 1)) {
                        throw new BadRequestException("property search filter wrong formatted, missing right side of  ':' delimiter");
                    }
-                   String propertyKey = prop.substring(0, delimiterIndex);
-                   String propertyValue = prop.substring(delimiterIndex + 1);
+                   if (delimiterIndex < 0) {
+                       propertyKey = prop;
+                       propertyValue = "";
+                   }else{
+                       propertyKey = prop.substring(0, delimiterIndex);
+                       propertyValue = prop.substring(delimiterIndex + 1);
+                   }
                    return SearchFilter.ofProperty(propertyKey, propertyValue);
                 })
                 .forEach(filters::add);

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -1082,13 +1082,17 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                         //    Note: convert search to lowercase when searching for properties (case-insensitivity support).
                         String propKey = property.getKey().toLowerCase();
                         String propValue = property.getValue().toLowerCase();
-                        where.append("EXISTS(SELECT p.globalId FROM properties p WHERE p.pkey = ? AND p.pvalue = ? AND p.globalId = v.globalId AND p.tenantId = v.tenantId)");
+                        where.append("EXISTS(SELECT p.globalId FROM properties p WHERE p.pkey = ? ");
                         binders.add((query, idx) -> {
                             query.bind(idx, propKey);
                         });
-                        binders.add((query, idx) -> {
-                            query.bind(idx, propValue);
-                        });
+                        if(propValue != ""){
+                            where.append("AND p.pvalue = ? ");
+                            binders.add((query, idx) -> {
+                                query.bind(idx, propValue);
+                            });
+                        }
+                        where.append("AND p.globalId = v.globalId AND p.tenantId = v.tenantId)");
                         break;
                     case globalId:
                         where.append("(v.globalId = ?)");

--- a/app/src/test/java/io/apicurio/registry/ArtifactSearchTest.java
+++ b/app/src/test/java/io/apicurio/registry/ArtifactSearchTest.java
@@ -81,7 +81,7 @@ public class ArtifactSearchTest extends AbstractResourceTestBase {
         clientV2.updateArtifactMetaData(groupId, artifactId, metaData);
 
         TestUtils.retry(() -> {
-            // Now try various cases when seaching by labels and properties
+            // Now try various cases when searching by labels
             ArtifactSearchResults ires = clientV2.searchArtifacts(groupId, null, null, List.of("testCaseInsensitiveSearchLabel"), null, SortBy.name, SortOrder.asc, 0, 10);
             Assertions.assertNotNull(ires);
             Assertions.assertEquals(1, ires.getCount());
@@ -95,7 +95,7 @@ public class ArtifactSearchTest extends AbstractResourceTestBase {
             Assertions.assertNotNull(ires);
             Assertions.assertEquals(1, ires.getCount());
 
-
+            // Now try various cases when searching by properties and values
             ArtifactSearchResults propertiesSearch = clientV2.searchArtifacts(groupId, null, null, null, List.of("testCaseInsensitiveSearchKey:testCaseInsensitiveSearchValue"), SortBy.name, SortOrder.asc, 0, 10);
             Assertions.assertNotNull(propertiesSearch);
             Assertions.assertEquals(1, propertiesSearch.getCount());
@@ -107,6 +107,20 @@ public class ArtifactSearchTest extends AbstractResourceTestBase {
             Assertions.assertEquals(1, propertiesSearch.getCount());
             propertiesSearch = clientV2.searchArtifacts(groupId, null, null, null, List.of("TESTCaseInsensitiveSEARCHKey:TESTCaseInsensitiveSearchVALUE"), SortBy.name, SortOrder.asc, 0, 10);
             Assertions.assertNotNull(propertiesSearch);
+            Assertions.assertEquals(1, propertiesSearch.getCount());
+
+            // Now try various cases when searching by properties
+            ArtifactSearchResults propertiesKeySearch = clientV2.searchArtifacts(groupId, null, null, null, List.of("testCaseInsensitiveSearchKey"), SortBy.name, SortOrder.asc, 0, 10);
+            Assertions.assertNotNull(propertiesKeySearch);
+            Assertions.assertEquals(1, propertiesKeySearch.getCount());
+            propertiesKeySearch = clientV2.searchArtifacts(groupId, null, null, null, List.of("testCaseInsensitiveSearchKey".toLowerCase()), SortBy.name, SortOrder.asc, 0, 10);
+            Assertions.assertNotNull(propertiesKeySearch);
+            Assertions.assertEquals(1, propertiesKeySearch.getCount());
+            propertiesKeySearch = clientV2.searchArtifacts(groupId, null, null, null,  List.of("testCaseInsensitiveSearchKey".toUpperCase()), SortBy.name, SortOrder.asc, 0, 10);
+            Assertions.assertNotNull(propertiesKeySearch);
+            Assertions.assertEquals(1, propertiesKeySearch.getCount());
+            propertiesKeySearch = clientV2.searchArtifacts(groupId, null, null, null, List.of("TESTCaseInsensitiveSEARCHKey"), SortBy.name, SortOrder.asc, 0, 10);
+            Assertions.assertNotNull(propertiesKeySearch);
             Assertions.assertEquals(1, propertiesSearch.getCount());
         });
     }


### PR DESCRIPTION
Work for #2187. Used this [bug fix](https://github.com/Apicurio/apicurio-registry/pull/2166/files) as a guide.

- Added `testSearchByPropertyKey()` to `SearchResourceTest.java`
- Added functional code to make the test pass. 
- Broadened the test cases to ensure correct behaviour in a variety of situations (following cases given in `testSearchByPropertyKey()`).
- Added cases to `testCaseInsensitiveSearch()` and tidied comments.