### PR TITLE
Provide user with reasons for incompatible json error.

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityRuleExecutor.java
+++ b/app/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityRuleExecutor.java
@@ -19,10 +19,7 @@ package io.apicurio.registry.rules.compatibility;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -66,9 +63,9 @@ public class CompatibilityRuleExecutor implements RuleExecutor {
              existingArtifacts,
              context.getUpdatedContent());
         if (!compatibilityExecutionResult.isCompatible()) {
-            throw new RuleViolationException(String.format("Incompatible artifact: %s [%s], num of incompatible diffs: {%s}",
+            throw new RuleViolationException(String.format("Incompatible artifact: %s [%s], num of incompatible diffs: {%s}, list of diff types: %s",
                  context.getArtifactId(), context.getArtifactType(),
-                 compatibilityExecutionResult.getIncompatibleDifferences().size()),
+                 compatibilityExecutionResult.getIncompatibleDifferences().size(), outputReadableCompatabilityDiffs(compatibilityExecutionResult.getIncompatibleDifferences())),
                  RuleType.COMPATIBILITY, context.getConfiguration(),
                  transformCompatibilityDiffs(compatibilityExecutionResult.getIncompatibleDifferences()));
         }
@@ -88,6 +85,18 @@ public class CompatibilityRuleExecutor implements RuleExecutor {
             return res;
         } else {
             return Collections.emptySet();
+        }
+    }
+
+    private List<String> outputReadableCompatabilityDiffs(Set<CompatibilityDifference> differences) {
+        if (!differences.isEmpty()) {
+            List<String> res = new ArrayList<String>();
+            for (CompatibilityDifference diff : differences) {
+                res.add(diff.asRuleViolation().getDescription() + " at " + diff.asRuleViolation().getContext());
+            }
+            return res;
+        } else {
+            return new ArrayList<String>();
         }
     }
 

--- a/app/src/test/java/io/apicurio/registry/rest/v1/ArtifactsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/rest/v1/ArtifactsResourceTest.java
@@ -494,7 +494,8 @@ public class ArtifactsResourceTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(409)
                 .body("error_code", equalTo(409))
-                .body("message", equalTo("Incompatible artifact: testCreateArtifact/ValidJson [JSON], num of incompatible diffs: {1}"))
+                .body("message", equalTo("Incompatible artifact: testCreateArtifact/ValidJson [JSON], num " +
+                        "of incompatible diffs: {1}, list of diff types: [SUBSCHEMA_TYPE_CHANGED at /properties/age]"))
                 .body("causes[0].description", equalTo(DiffType.SUBSCHEMA_TYPE_CHANGED.getDescription()))
                 .body("causes[0].context", equalTo("/properties/age"));
 

--- a/app/src/test/java/io/apicurio/registry/rest/v1/TestResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/rest/v1/TestResourceTest.java
@@ -112,7 +112,8 @@ public class TestResourceTest extends AbstractResourceTestBase {
             .log().all()
                 .statusCode(409)
                 .body("error_code", equalTo(409))
-                .body("message", equalTo("Incompatible artifact: testTestArtifactCompatibilityViolation [JSON], num of incompatible diffs: {1}"))
+                .body("message", equalTo("Incompatible artifact: testTestArtifactCompatibilityViolation " +
+                        "[JSON], num of incompatible diffs: {1}, list of diff types: [SUBSCHEMA_TYPE_CHANGED at /properties/age]"))
                 .body("causes[0].description", equalTo(DiffType.SUBSCHEMA_TYPE_CHANGED.getDescription()))
                 .body("causes[0].context", equalTo("/properties/age"));
     }

--- a/app/src/test/java/io/apicurio/registry/rest/v2/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/rest/v2/GroupsResourceTest.java
@@ -1023,7 +1023,8 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
             .then()
                 .statusCode(409)
                 .body("error_code", equalTo(409))
-                .body("message", equalTo("Incompatible artifact: testCreateArtifact/ValidJson [JSON], num of incompatible diffs: {1}"))
+                .body("message", equalTo("Incompatible artifact: testCreateArtifact/ValidJson [JSON], num" +
+                        " of incompatible diffs: {1}, list of diff types: [SUBSCHEMA_TYPE_CHANGED at /properties/age]"))
                 .body("causes[0].description", equalTo(DiffType.SUBSCHEMA_TYPE_CHANGED.getDescription()))
                 .body("causes[0].context", equalTo("/properties/age"));
 


### PR DESCRIPTION
Resolves #2160 

- Added list of diffs to end of printed error message. 
- Added helper method to construct the list of errors along with the location of the compatibility conflict.

~~I couldn't find any tests relevant to these changes, I imagine because they are purely aesthetic.~~
Oh silly me...

- Changed expected returned error message in 3 tests:

1. ArtifactsResourceTest.testCreateArtifactVersionCompatibilityRuleViolation 
2. TestResourceTest.testTestArtifactCompatibilityViolation 
3. GroupsResourceTest.testCreateArtifactVersionCompatibilityRuleViolation