### PR TITLE
Use `workflow_call` to trigger generation job in SDK repo

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -162,7 +162,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target-repo: [Apicurio/apicurio-registry-client-sdk-go]
+        target-workflow:
+          - https://github.com/Apicurio/apicurio-registry-client-sdk-go/.github/workflows/generate_sdk.yaml
     steps:
       - uses: actions/checkout@v2
 
@@ -176,9 +177,6 @@ jobs:
 
       - name: Repository Dispatch
         if: steps.changes.outputs.openapi == 'true'
-        uses: peter-evans/repository-dispatch@v1
+        uses: ${{matrix.target-workflow}}
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
-          repository: ${{matrix.target-repo}}
-          event-type: on-oas-updated
-          client-payload: '{"openapi_file_path": "app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json"}'
+          openapiSpecUrl: https://raw.githubusercontent.com/Apicurio/apicurio-registry/master/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -172,8 +172,9 @@ jobs:
               - 'app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json'
 
       - name: Repository Dispatch
-         uses: peter-evans/repository-dispatch@v1
-         with:
+        if: steps.changes.outputs.openapi == 'true'
+        uses: peter-evans/repository-dispatch@v1
+        with:
            token: ${{ secrets.ACCESS_TOKEN }}
            repository: Apicurio/apicurio-registry-client-sdk-go
            event-type: on-oas-updated

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -160,10 +160,6 @@ jobs:
   notify-sdk:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target-workflow:
-          - https://github.com/Apicurio/apicurio-registry-client-sdk-go/.github/workflows/generate_sdk.yaml
     steps:
       - uses: actions/checkout@v2
 
@@ -176,7 +172,9 @@ jobs:
               - 'app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json'
 
       - name: Repository Dispatch
-        if: steps.changes.outputs.openapi == 'true'
-        uses: ${{matrix.target-workflow}}
-        with:
-          openapiSpecUrl: https://raw.githubusercontent.com/Apicurio/apicurio-registry/master/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json
+         uses: peter-evans/repository-dispatch@v1
+         with:
+           token: ${{ secrets.ACCESS_TOKEN }}
+           repository: Apicurio/apicurio-registry-client-sdk-go
+           event-type: on-oas-updated
+           client-payload: '{"openapi_file_path": "app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json"}'

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -156,3 +156,29 @@ jobs:
 
       - name: List All The Images
         run: docker images
+
+  notify-sdk:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target-repo: [Apicurio/apicurio-registry-client-sdk-go]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          base: master
+          filters: |
+            openapi:
+              - 'app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json'
+
+      - name: Repository Dispatch
+        if: steps.changes.outputs.openapi == 'true'
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: ${{matrix.target-repo}}
+          event-type: on-oas-updated
+          client-payload: '{"openapi_file_path": "app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json"}'


### PR DESCRIPTION
This will cause a [Repository Dispatch](https://docs.github.com/en/rest/reference/repos#create-a-repository-dispatch-event) to be sent to the SDK repo, which will trigger a workflow there to generate a new SDK.

I just need to obtain a PAT for this with the required scope (repo) - maybe I can reuse an existing one?

## Verification

If you want to verify this use [act](https://github.com/nektos/act) with a personal access token, and comment out lines 178 & 161.

```shell
act -j notify-sdk --secret $REPO_ACCESS_TOKEN
```