### PR TITLE
Notify multiple SDK repos about OAS change event

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -160,6 +160,9 @@ jobs:
   notify-sdk:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [go, js, python]
     steps:
       - uses: actions/checkout@v2
 
@@ -176,6 +179,6 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
            token: ${{ secrets.ACCESS_TOKEN }}
-           repository: Apicurio/apicurio-registry-client-sdk-go
+           repository: Apicurio/apicurio-registry-client-sdk-${{ matrix.language }}
            event-type: on-oas-updated
            client-payload: '{"openapi_file_path": "app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json"}'


### PR DESCRIPTION
This PR adds multiple SDK repo targets in a matrix, allowing the job to be reused.

See the result in action:

- Python: https://github.com/Apicurio/apicurio-registry-client-sdk-python/pull/2
- JS: https://github.com/Apicurio/apicurio-registry-client-sdk-js/pull/6
- Go: https://github.com/Apicurio/apicurio-registry-client-sdk-go/pull/8