### PR TITLE
Increase kafka sql startup lag for tests

### DIFF
--- a/storage/kafkasql/src/test/resources/test-overlay.properties
+++ b/storage/kafkasql/src/test/resources/test-overlay.properties
@@ -11,7 +11,7 @@ quarkus.kafka.devservices.shared=true
 
 #%test.registry.kafkasql.bootstrap.servers=localhost:9092
 %test.registry.kafkasql.topic=kafkasql-journal
-%test.registry.kafkasql.consumer.startupLag=10
+%test.registry.kafkasql.consumer.startupLag=2000
 %test.registry.kafkasql.consumer.poll.timeout=100
 
 


### PR DESCRIPTION
We're having some issues with kafkasql testing and I think the reason is the database not being ready, let's see if this fixes the flaky kafkasql tests and then we can adjust the time if we think 2s is too much (likely yes).