### PR TITLE
docs: copy edits to ui text for dynamic config props

### DIFF
--- a/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
@@ -42,22 +42,22 @@ public class AuthConfig {
     @ConfigProperty(name = "registry.auth.role-based-authorization", defaultValue = "false")
     boolean roleBasedAuthorizationEnabled;
 
-    @Dynamic(label = "Owner Only Authorization", description = "When enabled, the registry will allow only the artifact owner (creator) to modify an artifact.", requires = "registry.auth.enabled=true")
+    @Dynamic(label = "Artifact owner-only authorization", description = "When enabled, Service Registry allows only the artifact owner (creator) to modify an artifact.", requires = "registry.auth.enabled=true")
     @ConfigProperty(name = "registry.auth.owner-only-authorization", defaultValue = "false")
     Supplier<Boolean> ownerOnlyAuthorizationEnabled;
 
-    @Dynamic(label = "Owner Only Authorization (Limit Groups)", description = "When enabled, the registry will limit access to groups to only the user who created the group.", requires = {
+    @Dynamic(label = "Artifact group owner-only authorization", description = "When enabled, Service Registry allows only the artifact group owner (creator) to access an artifact group.", requires = {
             "registry.auth.enabled=true",
             "registry.auth.owner-only-authorization=true"
     })
     @ConfigProperty(name = "registry.auth.owner-only-authorization.limit-group-access", defaultValue = "false")
     Supplier<Boolean> ownerOnlyAuthorizationLimitGroupAccess;
 
-    @Dynamic(label = "Anonymous Read Access", description = "When enabled, requests from anonymous users (requests without any credentials) will be granted read-only access.", requires = "registry.auth.enabled=true")
+    @Dynamic(label = "Anonymous read access", description = "When enabled, requests from anonymous users (requests without any credentials) are granted read-only access.", requires = "registry.auth.enabled=true")
     @ConfigProperty(name = "registry.auth.anonymous-read-access.enabled", defaultValue = "false")
     Supplier<Boolean> anonymousReadAccessEnabled;
 
-    @Dynamic(label = "Authenticated Read Access", description = "When enabled, requests from any authenticated user will be granted at least read-only access.", requires = "registry.auth.enabled=true")
+    @Dynamic(label = "Authenticated read access", description = "When enabled, requests from any authenticated user are granted at least read-only access.", requires = "registry.auth.enabled=true")
     @ConfigProperty(name = "registry.auth.authenticated-read-access.enabled", defaultValue = "false")
     Supplier<Boolean> authenticatedReadAccessEnabled;
 

--- a/app/src/main/java/io/apicurio/registry/ccompat/store/CCompatConfig.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/store/CCompatConfig.java
@@ -30,7 +30,7 @@ import io.apicurio.common.apps.config.Dynamic;
 @Singleton
 public class CCompatConfig {
 
-    @Dynamic(label = "Legacy ID Mode (Compat API)", description =  "When enabled, this option causes the ccompat API to use 'globalId' instead of 'contentId' for artifact identifiers.")
+    @Dynamic(label = "Legacy ID mode (compatibility API)", description =  "When enabled, the Schema Registry compatibility API uses 'globalId' instead of 'contentId' for artifact identifiers.")
     @ConfigProperty(name = "registry.ccompat.legacy-id-mode.enabled", defaultValue = "false")
     Supplier<Boolean> legacyIdModeEnabled;
 

--- a/app/src/main/java/io/apicurio/registry/rest/v2/AdminResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/AdminResourceImpl.java
@@ -121,7 +121,7 @@ public class AdminResourceImpl implements AdminResource {
     @Context
     HttpServletRequest request;
 
-    @Dynamic(label = "Download HREF Time to Live", description = "Determines the number of seconds that a generated download link should remain active.")
+    @Dynamic(label = "Download link time to live", description = "The number of seconds that a generated link to a download .zip file remains active.")
     @ConfigProperty(name = "registry.download.href.ttl", defaultValue = "30")
     Supplier<Long> downloadHrefTtl;
 

--- a/app/src/main/java/io/apicurio/registry/services/auth/CustomAuthenticationMechanism.java
+++ b/app/src/main/java/io/apicurio/registry/services/auth/CustomAuthenticationMechanism.java
@@ -65,7 +65,7 @@ public class CustomAuthenticationMechanism implements HttpAuthenticationMechanis
     @ConfigProperty(name = "registry.auth.enabled")
     boolean authEnabled;
 
-    @Dynamic(label = "BASIC Authentication", description = "When enabled, users are permitted to authenticate using BASIC authentication (in addition to OAuth).", requires = "registry.auth.enabled=true")
+    @Dynamic(label = "HTTP basic authentication", description = "When enabled, users are permitted to authenticate using HTTP basic authentication (in addition to OAuth).", requires = "registry.auth.enabled=true")
     @ConfigProperty(name = "registry.auth.basic-auth-client-credentials.enabled", defaultValue = "false")
     Supplier<Boolean> fakeBasicAuthEnabled;
 

--- a/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
+++ b/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
@@ -42,7 +42,7 @@ public class UiConfigProperties {
     Logger log;
 
     @Inject
-    @Dynamic(label = "UI Read-Only Mode", description = "When enabled, the user interface will be set to Read-Only mode, preventing CRUD operations.")
+    @Dynamic(label = "UI read-only mode", description = "When enabled, the Service Registry web console is set to read-only, preventing create, read, update, or delete operations.")
     @ConfigProperty(name = "registry.ui.features.readOnly", defaultValue = "false")
     Supplier<Boolean> featureReadOnly;
 

--- a/ui/src/app/pages/settings/settings.tsx
+++ b/ui/src/app/pages/settings/settings.tsx
@@ -58,7 +58,7 @@ export class SettingsPage extends PageComponent<SettingsPageProps, SettingsPageS
                 </PageSection>
                 <PageSection className="ps_settings-description" variant={PageSectionVariants.light}>
                     <TextContent>
-                        Configure some global settings for this Service Registry instance.
+                        Configure global settings for this Service Registry instance.
                     </TextContent>
                 </PageSection>
                 <PageSection variant={PageSectionVariants.default} isFilled={true}>


### PR DESCRIPTION
Copy edits to UI labels and descriptions only, mostly for consistency with text used elsewhere in the UI and docs. 