### PR TITLE
Update artifact body to accept any input type

### DIFF
--- a/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json
+++ b/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json
@@ -25,11 +25,11 @@
                     "200": {
                         "$ref": "#/components/responses/ArtifactContent"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/ServerError"
-                    },
                     "404": {
                         "$ref": "#/components/responses/NotFound"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/ServerError"
                     }
                 },
                 "operationId": "getContentById",
@@ -69,11 +69,11 @@
                     "200": {
                         "$ref": "#/components/responses/ArtifactContent"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/ServerError"
-                    },
                     "404": {
                         "$ref": "#/components/responses/NotFound"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/ServerError"
                     }
                 },
                 "operationId": "getContentByGlobalId",
@@ -103,11 +103,11 @@
                     "200": {
                         "$ref": "#/components/responses/ArtifactContent"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/ServerError"
-                    },
                     "404": {
                         "$ref": "#/components/responses/NotFound"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/ServerError"
                     }
                 },
                 "operationId": "getContentByHash",
@@ -356,7 +356,7 @@
                 },
                 "operationId": "getLogConfiguration",
                 "summary": "Get a single logger configuration",
-                "description": "Returns the configured logger configuration for the provided logger name, if no logger configuration is persisted it will return the current default log configuration in the system."
+                "description": "Returns the configured logger configuration for the provided logger name. If no logger configuration is persisted, this returns the current default log configuration in the system."
             },
             "put": {
                 "requestBody": {
@@ -587,7 +587,7 @@
                     "content": {
                         "*/*": {
                             "schema": {
-                                "$ref": "#/components/schemas/FileContent"
+                                "$ref": "#/components/schemas/File"
                             }
                         }
                     },
@@ -700,7 +700,7 @@
                         "content": {
                             "application/zip": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/FileContent"
+                                    "$ref": "#/components/schemas/File"
                                 }
                             }
                         },
@@ -712,18 +712,18 @@
                 },
                 "operationId": "exportData",
                 "summary": "Export registry data",
-                "description": "Exports registry data as a ZIP archive."
+                "description": "Exports registry data as a `.zip` archive."
             }
         },
         "/admin/import": {
             "summary": "Provides a way to import data into the registry.",
             "post": {
                 "requestBody": {
-                    "description": "The ZIP file representing the previously exported registry data.",
+                    "description": "The `.zip` file representing the previously exported registry data.",
                     "content": {
                         "application/zip": {
                             "schema": {
-                                "$ref": "#/components/schemas/FileContent"
+                                "$ref": "#/components/schemas/File"
                             }
                         }
                     },
@@ -735,7 +735,7 @@
                 "parameters": [
                     {
                         "name": "X-Registry-Preserve-GlobalId",
-                        "description": "If this header is set to false, global ids of imported data will be ignored and replaced by next id in global id sequence. This allows to import any data even thought the global ids would cause a conflict.",
+                        "description": "If this header is set to false, global IDs of imported data are ignored and replaced by the next ID in the global ID sequence. This allows importing any data even though the global IDs would cause a conflict.",
                         "schema": {
                             "type": "boolean"
                         },
@@ -743,7 +743,7 @@
                     },
                     {
                         "name": "X-Registry-Preserve-ContentId",
-                        "description": "If this header is set to false, content ids of imported data will be ignored and replaced by next id in content id sequence. The mapping between content and artifacts will be preserved. This allows to import any data even thought the content ids would cause a conflict.",
+                        "description": "If this header is set to false, content IDs of imported data are ignored and replaced by the next ID in the content ID sequence. The mapping between content and artifacts is preserved. This allows importing any data even though the content IDs would cause a conflict.",
                         "schema": {
                             "type": "boolean"
                         },
@@ -883,7 +883,7 @@
                     "content": {
                         "*/*": {
                             "schema": {
-                                "$ref": "#/components/schemas/FileContent"
+
                             },
                             "examples": {
                                 "OpenAPI": {
@@ -1123,14 +1123,14 @@
                     }
                 ],
                 "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/ArtifactContent"
+                    },
                     "404": {
                         "$ref": "#/components/responses/NotFound"
                     },
                     "500": {
                         "$ref": "#/components/responses/ServerError"
-                    },
-                    "200": {
-                        "$ref": "#/components/responses/ArtifactContent"
                     }
                 },
                 "operationId": "getArtifactVersion",
@@ -1459,7 +1459,7 @@
                     "content": {
                         "*/*": {
                             "schema": {
-                                "$ref": "#/components/schemas/FileContent"
+
                             }
                         }
                     },
@@ -1572,7 +1572,7 @@
                     "content": {
                         "*/*": {
                             "schema": {
-                                "$ref": "#/components/schemas/FileContent"
+
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -1802,7 +1802,7 @@
                     "content": {
                         "*/*": {
                             "schema": {
-                                "$ref": "#/components/schemas/FileContent"
+
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -2037,7 +2037,7 @@
                     "content": {
                         "*/*": {
                             "schema": {
-                                "$ref": "#/components/schemas/FileContent"
+
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -2215,7 +2215,7 @@
                 },
                 "operationId": "getRoleMapping",
                 "summary": "Return a single role mapping",
-                "description": "Gets the details of a single role mapping (by principalId).\n\nThis operation can fail for the following reasons:\n\n* No role mapping for the principalId exists (HTTP error `404`)\n* A server error occurred (HTTP error `500`)\n"
+                "description": "Gets the details of a single role mapping (by `principalId`).\n\nThis operation can fail for the following reasons:\n\n* No role mapping for the principalId exists (HTTP error `404`)\n* A server error occurred (HTTP error `500`)\n"
             },
             "put": {
                 "requestBody": {
@@ -2358,154 +2358,6 @@
                 "description": "Returns information about the currently authenticated user."
             }
         },
-        "/ids/contentHashes/{contentHash}/references": {
-            "get": {
-                "parameters": [
-                    {
-                        "name": "contentHash",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ArtifactReference"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "A list containing all the references for the artifact with the given content hash."
-                    }
-                },
-                "operationId": "referencesByContentHash",
-                "summary": "Returns a list with all the references for the artifact with the given hash",
-                "description": "Returns a list containing all the artifact references using the artifact content hash.\n\nThis operation may fail for one of the following reasons:\n\n* A server error occurred (HTTP error `500`)\n"
-            }
-        },
-        "/ids/contentIds/{contentId}/references": {
-            "get": {
-                "parameters": [
-                    {
-                        "name": "contentId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ArtifactReference"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "A list containing all the references for the artifact with the given content id."
-                    }
-                },
-                "operationId": "referencesByContentId",
-                "summary": "Returns a list with all the references for the artifact with the given content id.",
-                "description": "Returns a list containing all the artifact references using the artifact contentId.\n\nThis operation may fail for one of the following reasons:\n\n* A server error occurred (HTTP error `500`)"
-            }
-        },
-        "/ids/globalIds/{globalId}/references": {
-            "get": {
-                "parameters": [
-                    {
-                        "name": "globalId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ArtifactReference"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "A list containing all the references for the artifact with the given global id."
-                    }
-                },
-                "operationId": "referencesByGlobalId",
-                "summary": "Returns a list with all the references for the artifact with the given global id.",
-                "description": "Returns a list containing all the artifact references using the artifact global id.\n\nThis operation may fail for one of the following reasons:\n\n* A server error occurred (HTTP error `500`)"
-            }
-        },
-        "/groups/{groupId}/artifacts/{artifactId}/versions/{version}/references": {
-            "summary": "Manage the references for a single version of an artifact in the registry.",
-            "get": {
-                "tags": [
-                    "Versions"
-                ],
-                "responses": {
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/ServerError"
-                    },
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ArtifactReference"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "List of all the artifact references for this artifact."
-                    }
-                },
-                "operationId": "getArtifactVersionReferences",
-                "summary": "Get artifact version",
-                "description": "Retrieves a single version of the artifact content.  Both the `artifactId` and the\nunique `version` number must be provided.  The `Content-Type` of the response depends \non the artifact type.  In most cases, this is `application/json`, but for some types \nit may be different (for example, `PROTOBUF`).\n\nThis operation can fail for the following reasons:\n\n* No artifact with this `artifactId` exists (HTTP error `404`)\n* No version with this `version` exists (HTTP error `404`)\n* A server error occurred (HTTP error `500`)\n"
-            },
-            "parameters": [
-                {
-                    "name": "groupId",
-                    "description": "The artifact group ID.  Must be a string provided by the client, representing the name of the grouping of artifacts.",
-                    "schema": {
-                        "$ref": "#/components/schemas/GroupId"
-                    },
-                    "in": "path",
-                    "required": true
-                },
-                {
-                    "name": "artifactId",
-                    "description": "The artifact ID.  Can be a string (client-provided) or UUID (server-generated), representing the unique artifact identifier.",
-                    "schema": {
-                        "$ref": "#/components/schemas/ArtifactId"
-                    },
-                    "in": "path",
-                    "required": true
-                },
-                {
-                    "name": "version",
-                    "description": "The unique identifier of a specific version of the artifact content.",
-                    "schema": {
-                        "$ref": "#/components/schemas/Version"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
-        },
         "/admin/config/properties": {
             "summary": "Manage configuration properties.",
             "get": {
@@ -2552,11 +2404,11 @@
                         },
                         "description": "The configuration property value."
                     },
-                    "500": {
-                        "$ref": "#/components/responses/ServerError"
-                    },
                     "404": {
                         "$ref": "#/components/responses/NotFound"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/ServerError"
                     }
                 },
                 "operationId": "getConfigProperty",
@@ -2581,11 +2433,11 @@
                     "204": {
                         "description": "The configuration property was updated."
                     },
-                    "500": {
-                        "$ref": "#/components/responses/ServerError"
-                    },
                     "404": {
                         "$ref": "#/components/responses/NotFound"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/ServerError"
                     }
                 },
                 "operationId": "updateConfigProperty",
@@ -2622,6 +2474,189 @@
                     "required": true
                 }
             ]
+        },
+        "/ids/contentHashes/{contentHash}/references": {
+            "get": {
+                "tags": [
+                    "Artifacts"
+                ],
+                "parameters": [
+                    {
+                        "name": "contentHash",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/ArtifactReference"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "A list containing all the references for the artifact with the given content hash."
+                    }
+                },
+                "operationId": "referencesByContentHash",
+                "summary": "List artifact references with given hash",
+                "description": "Returns a list containing all the artifact references using the artifact content hash.\n\nThis operation may fail for one of the following reasons:\n\n* A server error occurred (HTTP error `500`)\n"
+            }
+        },
+        "/ids/contentIds/{contentId}/references": {
+            "get": {
+                "tags": [
+                    "Artifacts"
+                ],
+                "parameters": [
+                    {
+                        "name": "contentId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/ArtifactReference"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "A list containing all the references for the artifact with the given content id."
+                    }
+                },
+                "operationId": "referencesByContentId",
+                "summary": "List artifact references with given content ID",
+                "description": "Returns a list containing all the artifact references using the artifact content ID.\n\nThis operation may fail for one of the following reasons:\n\n* A server error occurred (HTTP error `500`)"
+            }
+        },
+        "/ids/globalIds/{globalId}/references": {
+            "get": {
+                "tags": [
+                    "Artifacts"
+                ],
+                "parameters": [
+                    {
+                        "name": "globalId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/ArtifactReference"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "A list containing all the references for the artifact with the given global id."
+                    }
+                },
+                "operationId": "referencesByGlobalId",
+                "summary": "List artifact references with given global ID",
+                "description": "Returns a list containing all the artifact references using the artifact global ID.\n\nThis operation may fail for one of the following reasons:\n\n* A server error occurred (HTTP error `500`)"
+            }
+        },
+        "/groups/{groupId}/artifacts/{artifactId}/versions/{version}/references": {
+            "summary": "Manage the references for a single version of an artifact in the registry.",
+            "get": {
+                "tags": [
+                    "Versions"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/ArtifactReference"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "List of all the artifact references for this artifact."
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/NotFound"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/ServerError"
+                    }
+                },
+                "operationId": "getArtifactVersionReferences",
+                "summary": "Get artifact version",
+                "description": "Retrieves a single version of the artifact content.  Both the `artifactId` and the\nunique `version` number must be provided.  The `Content-Type` of the response depends \non the artifact type.  In most cases, this is `application/json`, but for some types \nit may be different (for example, `PROTOBUF`).\n\nThis operation can fail for the following reasons:\n\n* No artifact with this `artifactId` exists (HTTP error `404`)\n* No version with this `version` exists (HTTP error `404`)\n* A server error occurred (HTTP error `500`)\n"
+            },
+            "parameters": [
+                {
+                    "name": "groupId",
+                    "description": "The artifact group ID.  Must be a string provided by the client, representing the name of the grouping of artifacts.",
+                    "schema": {
+                        "$ref": "#/components/schemas/GroupId"
+                    },
+                    "in": "path",
+                    "required": true
+                },
+                {
+                    "name": "artifactId",
+                    "description": "The artifact ID.  Can be a string (client-provided) or UUID (server-generated), representing the unique artifact identifier.",
+                    "schema": {
+                        "$ref": "#/components/schemas/ArtifactId"
+                    },
+                    "in": "path",
+                    "required": true
+                },
+                {
+                    "name": "version",
+                    "description": "The unique identifier of a specific version of the artifact content.",
+                    "schema": {
+                        "$ref": "#/components/schemas/Version"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/system/limits": {
+            "summary": "Retrieve resource limits information",
+            "get": {
+                "tags": [
+                    "System"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Limits"
+                                }
+                            }
+                        },
+                        "description": "On success, returns resource limits"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/ServerError"
+                    }
+                },
+                "operationId": "getResourceLimits",
+                "summary": "Get resource limits information",
+                "description": "This operation retrieves the list of limitations on used resources, that are applied on the current instance of Registry."
+            }
         },
         "x-codegen-contextRoot": "/apis/registry/v2"
     },
@@ -2951,11 +2986,6 @@
                     "version": "2.0.0.Final",
                     "builtOn": "2021-03-19T12:55:00Z"
                 }
-            },
-            "FileContent": {
-                "format": "binary",
-                "type": "string",
-                "x-codegen-inline": true
             },
             "RoleMapping": {
                 "description": "The mapping between a user/principal and their role.",
@@ -3621,6 +3651,80 @@
                 "example": {
                     "value": "true"
                 }
+            },
+            "Limits": {
+                "title": "Root Type for Limits",
+                "description": "List of limitations on used resources, that are applied on the current instance of Registry.\nKeys represent the resource type and are suffixed by the corresponding unit.\nValues are integers. Only non-negative values are allowed, with the exception of -1, which means that the limit is not applied.",
+                "type": "object",
+                "properties": {
+                    "maxTotalSchemasCount": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "maxSchemaSizeBytes": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "maxArtifactsCount": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "maxVersionsPerArtifactCount": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "maxArtifactPropertiesCount": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "maxPropertyKeySizeBytes": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "maxPropertyValueSizeBytes": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "maxArtifactLabelsCount": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "maxLabelSizeBytes": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "maxNameLengthChars": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "maxDescriptionLengthChars": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "maxRequestsPerSecondCount": {
+                        "format": "int64",
+                        "type": "integer"
+                    }
+                },
+                "example": {
+                    "maxTotalSchemasCount": -1,
+                    "maxSchemaSizeBytes": -1,
+                    "maxArtifactsCount": -1,
+                    "maxVersionsPerArtifactCount": -1,
+                    "maxArtifactPropertiesCount": -1,
+                    "maxPropertyKeySizeBytes": -1,
+                    "maxPropertyValueSizeBytes": -1,
+                    "maxArtifactLabelsCount": -1,
+                    "maxLabelSizeBytes": -1,
+                    "maxNameLengthChars": -1,
+                    "maxDescriptionLengthChars": -1,
+                    "maxRequestsPerSecondCount": -1
+                }
+            },
+            "File": {
+                "format": "binary",
+                "type": "string",
+                "x-codegen-inline": true
             }
         },
         "responses": {
@@ -3720,7 +3824,7 @@
                 "content": {
                     "*/*": {
                         "schema": {
-                            "$ref": "#/components/schemas/FileContent"
+
                         },
                         "examples": {
                             "OpenAPI": {

--- a/common/src/main/java/io/apicurio/registry/rest/v2/beans/ArtifactMetaData.java
+++ b/common/src/main/java/io/apicurio/registry/rest/v2/beans/ArtifactMetaData.java
@@ -18,8 +18,8 @@ import io.apicurio.registry.types.ArtifactType;
 /**
  * Root Type for ArtifactMetaData
  * <p>
- *
- *
+ * 
+ * 
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -50,31 +50,31 @@ public class ArtifactMetaData {
     @JsonProperty("description")
     private String description;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdBy")
     private String createdBy;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
     @JsonProperty("createdOn")
     private Date createdOn;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("modifiedBy")
     private String modifiedBy;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
     @JsonProperty("modifiedOn")
@@ -82,31 +82,31 @@ public class ArtifactMetaData {
     /**
      * The ID of a single artifact.
      * (Required)
-     *
+     * 
      */
     @JsonProperty("id")
     @JsonPropertyDescription("The ID of a single artifact.")
     private String id;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("version")
     @JsonPropertyDescription("")
     private String version;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("type")
     @JsonPropertyDescription("")
     private ArtifactType type;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("globalId")
     @JsonPropertyDescription("")
@@ -114,47 +114,47 @@ public class ArtifactMetaData {
     /**
      * Describes the state of an artifact or artifact version.  The following states
      * are possible:
-     *
+     * 
      * * ENABLED
      * * DISABLED
      * * DEPRECATED
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("state")
     @JsonPropertyDescription("Describes the state of an artifact or artifact version.  The following states\nare possible:\n\n* ENABLED\n* DISABLED\n* DEPRECATED\n")
     private ArtifactState state;
     /**
-     *
+     * 
      */
     @JsonProperty("labels")
     @JsonPropertyDescription("")
     private List<String> labels = new ArrayList<String>();
     /**
      * User-defined name-value pairs. Name and value must be strings.
-     *
+     * 
      */
     @JsonProperty("properties")
     @JsonPropertyDescription("User-defined name-value pairs. Name and value must be strings.")
     private Map<String, String> properties;
     /**
      * An ID of a single artifact group.
-     *
+     * 
      */
     @JsonProperty("groupId")
     @JsonPropertyDescription("An ID of a single artifact group.")
     private String groupId;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("contentId")
     @JsonPropertyDescription("")
     private Long contentId;
     /**
-     *
+     * 
      */
     @JsonProperty("references")
     @JsonPropertyDescription("")
@@ -181,9 +181,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdBy")
     public String getCreatedBy() {
@@ -191,9 +191,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdBy")
     public void setCreatedBy(String createdBy) {
@@ -201,9 +201,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdOn")
     public Date getCreatedOn() {
@@ -211,9 +211,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdOn")
     public void setCreatedOn(Date createdOn) {
@@ -221,9 +221,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("modifiedBy")
     public String getModifiedBy() {
@@ -231,9 +231,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("modifiedBy")
     public void setModifiedBy(String modifiedBy) {
@@ -241,9 +241,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("modifiedOn")
     public Date getModifiedOn() {
@@ -251,9 +251,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("modifiedOn")
     public void setModifiedOn(Date modifiedOn) {
@@ -263,7 +263,7 @@ public class ArtifactMetaData {
     /**
      * The ID of a single artifact.
      * (Required)
-     *
+     * 
      */
     @JsonProperty("id")
     public String getId() {
@@ -273,7 +273,7 @@ public class ArtifactMetaData {
     /**
      * The ID of a single artifact.
      * (Required)
-     *
+     * 
      */
     @JsonProperty("id")
     public void setId(String id) {
@@ -281,9 +281,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("version")
     public String getVersion() {
@@ -291,9 +291,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("version")
     public void setVersion(String version) {
@@ -301,9 +301,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("type")
     public ArtifactType getType() {
@@ -311,9 +311,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("type")
     public void setType(ArtifactType type) {
@@ -321,9 +321,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("globalId")
     public Long getGlobalId() {
@@ -331,9 +331,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("globalId")
     public void setGlobalId(Long globalId) {
@@ -343,13 +343,13 @@ public class ArtifactMetaData {
     /**
      * Describes the state of an artifact or artifact version.  The following states
      * are possible:
-     *
+     * 
      * * ENABLED
      * * DISABLED
      * * DEPRECATED
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("state")
     public ArtifactState getState() {
@@ -359,13 +359,13 @@ public class ArtifactMetaData {
     /**
      * Describes the state of an artifact or artifact version.  The following states
      * are possible:
-     *
+     * 
      * * ENABLED
      * * DISABLED
      * * DEPRECATED
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("state")
     public void setState(ArtifactState state) {
@@ -373,7 +373,7 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      */
     @JsonProperty("labels")
     public List<String> getLabels() {
@@ -381,7 +381,7 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      */
     @JsonProperty("labels")
     public void setLabels(List<String> labels) {
@@ -390,7 +390,7 @@ public class ArtifactMetaData {
 
     /**
      * User-defined name-value pairs. Name and value must be strings.
-     *
+     * 
      */
     @JsonProperty("properties")
     public Map<String, String> getProperties() {
@@ -399,7 +399,7 @@ public class ArtifactMetaData {
 
     /**
      * User-defined name-value pairs. Name and value must be strings.
-     *
+     * 
      */
     @JsonProperty("properties")
     public void setProperties(Map<String, String> properties) {
@@ -408,7 +408,7 @@ public class ArtifactMetaData {
 
     /**
      * An ID of a single artifact group.
-     *
+     * 
      */
     @JsonProperty("groupId")
     public String getGroupId() {
@@ -417,7 +417,7 @@ public class ArtifactMetaData {
 
     /**
      * An ID of a single artifact group.
-     *
+     * 
      */
     @JsonProperty("groupId")
     public void setGroupId(String groupId) {
@@ -425,9 +425,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("contentId")
     public Long getContentId() {
@@ -435,9 +435,9 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("contentId")
     public void setContentId(Long contentId) {
@@ -445,7 +445,7 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      */
     @JsonProperty("references")
     public List<ArtifactReference> getReferences() {
@@ -453,7 +453,7 @@ public class ArtifactMetaData {
     }
 
     /**
-     *
+     * 
      */
     @JsonProperty("references")
     public void setReferences(List<ArtifactReference> references) {

--- a/common/src/main/java/io/apicurio/registry/rest/v2/beans/ArtifactReference.java
+++ b/common/src/main/java/io/apicurio/registry/rest/v2/beans/ArtifactReference.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 @Generated("jsonschema2pojo")
 @io.quarkus.runtime.annotations.RegisterForReflection
+@lombok.ToString
 public class ArtifactReference {
 
     /**

--- a/common/src/main/java/io/apicurio/registry/rest/v2/beans/ConfigurationProperty.java
+++ b/common/src/main/java/io/apicurio/registry/rest/v2/beans/ConfigurationProperty.java
@@ -42,25 +42,25 @@ public class ConfigurationProperty {
     @JsonProperty("value")
     private String value;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("type")
     @JsonPropertyDescription("")
     private String type;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("label")
     @JsonPropertyDescription("")
     private String label;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("description")
     @JsonPropertyDescription("")
@@ -107,9 +107,9 @@ public class ConfigurationProperty {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("type")
     public String getType() {
@@ -117,9 +117,9 @@ public class ConfigurationProperty {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("type")
     public void setType(String type) {
@@ -127,9 +127,9 @@ public class ConfigurationProperty {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("label")
     public String getLabel() {
@@ -137,9 +137,9 @@ public class ConfigurationProperty {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("label")
     public void setLabel(String label) {
@@ -147,9 +147,9 @@ public class ConfigurationProperty {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("description")
     public String getDescription() {
@@ -157,9 +157,9 @@ public class ConfigurationProperty {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("description")
     public void setDescription(String description) {

--- a/common/src/main/java/io/apicurio/registry/rest/v2/beans/ContentCreateRequest.java
+++ b/common/src/main/java/io/apicurio/registry/rest/v2/beans/ContentCreateRequest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 @Generated("jsonschema2pojo")
 @io.quarkus.runtime.annotations.RegisterForReflection
+@lombok.ToString
 public class ContentCreateRequest {
 
     /**

--- a/common/src/main/java/io/apicurio/registry/rest/v2/beans/Limits.java
+++ b/common/src/main/java/io/apicurio/registry/rest/v2/beans/Limits.java
@@ -1,0 +1,183 @@
+
+package io.apicurio.registry.rest.v2.beans;
+
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * Root Type for Limits
+ * <p>
+ * List of limitations on used resources, that are applied on the current instance of Registry.
+ * Keys represent the resource type and are suffixed by the corresponding unit.
+ * Values are integers. Only non-negative values are allowed, with the exception of -1, which means that the limit is not applied.
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "maxTotalSchemasCount",
+    "maxSchemaSizeBytes",
+    "maxArtifactsCount",
+    "maxVersionsPerArtifactCount",
+    "maxArtifactPropertiesCount",
+    "maxPropertyKeySizeBytes",
+    "maxPropertyValueSizeBytes",
+    "maxArtifactLabelsCount",
+    "maxLabelSizeBytes",
+    "maxNameLengthChars",
+    "maxDescriptionLengthChars",
+    "maxRequestsPerSecondCount"
+})
+@Generated("jsonschema2pojo")
+@io.quarkus.runtime.annotations.RegisterForReflection
+@lombok.ToString
+public class Limits {
+
+    @JsonProperty("maxTotalSchemasCount")
+    private Long maxTotalSchemasCount;
+    @JsonProperty("maxSchemaSizeBytes")
+    private Long maxSchemaSizeBytes;
+    @JsonProperty("maxArtifactsCount")
+    private Long maxArtifactsCount;
+    @JsonProperty("maxVersionsPerArtifactCount")
+    private Long maxVersionsPerArtifactCount;
+    @JsonProperty("maxArtifactPropertiesCount")
+    private Long maxArtifactPropertiesCount;
+    @JsonProperty("maxPropertyKeySizeBytes")
+    private Long maxPropertyKeySizeBytes;
+    @JsonProperty("maxPropertyValueSizeBytes")
+    private Long maxPropertyValueSizeBytes;
+    @JsonProperty("maxArtifactLabelsCount")
+    private Long maxArtifactLabelsCount;
+    @JsonProperty("maxLabelSizeBytes")
+    private Long maxLabelSizeBytes;
+    @JsonProperty("maxNameLengthChars")
+    private Long maxNameLengthChars;
+    @JsonProperty("maxDescriptionLengthChars")
+    private Long maxDescriptionLengthChars;
+    @JsonProperty("maxRequestsPerSecondCount")
+    private Long maxRequestsPerSecondCount;
+
+    @JsonProperty("maxTotalSchemasCount")
+    public Long getMaxTotalSchemasCount() {
+        return maxTotalSchemasCount;
+    }
+
+    @JsonProperty("maxTotalSchemasCount")
+    public void setMaxTotalSchemasCount(Long maxTotalSchemasCount) {
+        this.maxTotalSchemasCount = maxTotalSchemasCount;
+    }
+
+    @JsonProperty("maxSchemaSizeBytes")
+    public Long getMaxSchemaSizeBytes() {
+        return maxSchemaSizeBytes;
+    }
+
+    @JsonProperty("maxSchemaSizeBytes")
+    public void setMaxSchemaSizeBytes(Long maxSchemaSizeBytes) {
+        this.maxSchemaSizeBytes = maxSchemaSizeBytes;
+    }
+
+    @JsonProperty("maxArtifactsCount")
+    public Long getMaxArtifactsCount() {
+        return maxArtifactsCount;
+    }
+
+    @JsonProperty("maxArtifactsCount")
+    public void setMaxArtifactsCount(Long maxArtifactsCount) {
+        this.maxArtifactsCount = maxArtifactsCount;
+    }
+
+    @JsonProperty("maxVersionsPerArtifactCount")
+    public Long getMaxVersionsPerArtifactCount() {
+        return maxVersionsPerArtifactCount;
+    }
+
+    @JsonProperty("maxVersionsPerArtifactCount")
+    public void setMaxVersionsPerArtifactCount(Long maxVersionsPerArtifactCount) {
+        this.maxVersionsPerArtifactCount = maxVersionsPerArtifactCount;
+    }
+
+    @JsonProperty("maxArtifactPropertiesCount")
+    public Long getMaxArtifactPropertiesCount() {
+        return maxArtifactPropertiesCount;
+    }
+
+    @JsonProperty("maxArtifactPropertiesCount")
+    public void setMaxArtifactPropertiesCount(Long maxArtifactPropertiesCount) {
+        this.maxArtifactPropertiesCount = maxArtifactPropertiesCount;
+    }
+
+    @JsonProperty("maxPropertyKeySizeBytes")
+    public Long getMaxPropertyKeySizeBytes() {
+        return maxPropertyKeySizeBytes;
+    }
+
+    @JsonProperty("maxPropertyKeySizeBytes")
+    public void setMaxPropertyKeySizeBytes(Long maxPropertyKeySizeBytes) {
+        this.maxPropertyKeySizeBytes = maxPropertyKeySizeBytes;
+    }
+
+    @JsonProperty("maxPropertyValueSizeBytes")
+    public Long getMaxPropertyValueSizeBytes() {
+        return maxPropertyValueSizeBytes;
+    }
+
+    @JsonProperty("maxPropertyValueSizeBytes")
+    public void setMaxPropertyValueSizeBytes(Long maxPropertyValueSizeBytes) {
+        this.maxPropertyValueSizeBytes = maxPropertyValueSizeBytes;
+    }
+
+    @JsonProperty("maxArtifactLabelsCount")
+    public Long getMaxArtifactLabelsCount() {
+        return maxArtifactLabelsCount;
+    }
+
+    @JsonProperty("maxArtifactLabelsCount")
+    public void setMaxArtifactLabelsCount(Long maxArtifactLabelsCount) {
+        this.maxArtifactLabelsCount = maxArtifactLabelsCount;
+    }
+
+    @JsonProperty("maxLabelSizeBytes")
+    public Long getMaxLabelSizeBytes() {
+        return maxLabelSizeBytes;
+    }
+
+    @JsonProperty("maxLabelSizeBytes")
+    public void setMaxLabelSizeBytes(Long maxLabelSizeBytes) {
+        this.maxLabelSizeBytes = maxLabelSizeBytes;
+    }
+
+    @JsonProperty("maxNameLengthChars")
+    public Long getMaxNameLengthChars() {
+        return maxNameLengthChars;
+    }
+
+    @JsonProperty("maxNameLengthChars")
+    public void setMaxNameLengthChars(Long maxNameLengthChars) {
+        this.maxNameLengthChars = maxNameLengthChars;
+    }
+
+    @JsonProperty("maxDescriptionLengthChars")
+    public Long getMaxDescriptionLengthChars() {
+        return maxDescriptionLengthChars;
+    }
+
+    @JsonProperty("maxDescriptionLengthChars")
+    public void setMaxDescriptionLengthChars(Long maxDescriptionLengthChars) {
+        this.maxDescriptionLengthChars = maxDescriptionLengthChars;
+    }
+
+    @JsonProperty("maxRequestsPerSecondCount")
+    public Long getMaxRequestsPerSecondCount() {
+        return maxRequestsPerSecondCount;
+    }
+
+    @JsonProperty("maxRequestsPerSecondCount")
+    public void setMaxRequestsPerSecondCount(Long maxRequestsPerSecondCount) {
+        this.maxRequestsPerSecondCount = maxRequestsPerSecondCount;
+    }
+
+}

--- a/common/src/main/java/io/apicurio/registry/rest/v2/beans/SearchedVersion.java
+++ b/common/src/main/java/io/apicurio/registry/rest/v2/beans/SearchedVersion.java
@@ -17,7 +17,7 @@ import io.apicurio.registry.types.ArtifactType;
 
 /**
  * Models a single artifact from the result set returned when searching for artifacts.
- *
+ * 
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -40,44 +40,44 @@ import io.apicurio.registry.types.ArtifactType;
 public class SearchedVersion {
 
     /**
-     *
+     * 
      */
     @JsonProperty("name")
     @JsonPropertyDescription("")
     private String name;
     /**
-     *
+     * 
      */
     @JsonProperty("description")
     @JsonPropertyDescription("")
     private String description;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
     @JsonProperty("createdOn")
     @JsonPropertyDescription("")
     private Date createdOn;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdBy")
     @JsonPropertyDescription("")
     private String createdBy;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("type")
     @JsonPropertyDescription("")
     private ArtifactType type;
     /**
-     *
+     * 
      */
     @JsonProperty("labels")
     @JsonPropertyDescription("")
@@ -85,59 +85,59 @@ public class SearchedVersion {
     /**
      * Describes the state of an artifact or artifact version.  The following states
      * are possible:
-     *
+     * 
      * * ENABLED
      * * DISABLED
      * * DEPRECATED
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("state")
     @JsonPropertyDescription("Describes the state of an artifact or artifact version.  The following states\nare possible:\n\n* ENABLED\n* DISABLED\n* DEPRECATED\n")
     private ArtifactState state;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("globalId")
     @JsonPropertyDescription("")
     private Long globalId;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("version")
     @JsonPropertyDescription("")
     private String version;
     /**
      * User-defined name-value pairs. Name and value must be strings.
-     *
+     * 
      */
     @JsonProperty("properties")
     @JsonPropertyDescription("User-defined name-value pairs. Name and value must be strings.")
     private Map<String, String> properties;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("contentId")
     @JsonPropertyDescription("")
     private Long contentId;
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("references")
     @JsonPropertyDescription("")
     private List<ArtifactReference> references = new ArrayList<ArtifactReference>();
 
     /**
-     *
+     * 
      */
     @JsonProperty("name")
     public String getName() {
@@ -145,7 +145,7 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      */
     @JsonProperty("name")
     public void setName(String name) {
@@ -153,7 +153,7 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      */
     @JsonProperty("description")
     public String getDescription() {
@@ -161,7 +161,7 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      */
     @JsonProperty("description")
     public void setDescription(String description) {
@@ -169,9 +169,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdOn")
     public Date getCreatedOn() {
@@ -179,9 +179,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdOn")
     public void setCreatedOn(Date createdOn) {
@@ -189,9 +189,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdBy")
     public String getCreatedBy() {
@@ -199,9 +199,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("createdBy")
     public void setCreatedBy(String createdBy) {
@@ -209,9 +209,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("type")
     public ArtifactType getType() {
@@ -219,9 +219,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("type")
     public void setType(ArtifactType type) {
@@ -229,7 +229,7 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      */
     @JsonProperty("labels")
     public List<String> getLabels() {
@@ -237,7 +237,7 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      */
     @JsonProperty("labels")
     public void setLabels(List<String> labels) {
@@ -247,13 +247,13 @@ public class SearchedVersion {
     /**
      * Describes the state of an artifact or artifact version.  The following states
      * are possible:
-     *
+     * 
      * * ENABLED
      * * DISABLED
      * * DEPRECATED
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("state")
     public ArtifactState getState() {
@@ -263,13 +263,13 @@ public class SearchedVersion {
     /**
      * Describes the state of an artifact or artifact version.  The following states
      * are possible:
-     *
+     * 
      * * ENABLED
      * * DISABLED
      * * DEPRECATED
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("state")
     public void setState(ArtifactState state) {
@@ -277,9 +277,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("globalId")
     public Long getGlobalId() {
@@ -287,9 +287,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("globalId")
     public void setGlobalId(Long globalId) {
@@ -297,9 +297,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("version")
     public String getVersion() {
@@ -307,9 +307,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("version")
     public void setVersion(String version) {
@@ -318,7 +318,7 @@ public class SearchedVersion {
 
     /**
      * User-defined name-value pairs. Name and value must be strings.
-     *
+     * 
      */
     @JsonProperty("properties")
     public Map<String, String> getProperties() {
@@ -327,7 +327,7 @@ public class SearchedVersion {
 
     /**
      * User-defined name-value pairs. Name and value must be strings.
-     *
+     * 
      */
     @JsonProperty("properties")
     public void setProperties(Map<String, String> properties) {
@@ -335,9 +335,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("contentId")
     public Long getContentId() {
@@ -345,9 +345,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("contentId")
     public void setContentId(Long contentId) {
@@ -355,9 +355,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("references")
     public List<ArtifactReference> getReferences() {
@@ -365,9 +365,9 @@ public class SearchedVersion {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("references")
     public void setReferences(List<ArtifactReference> references) {


### PR DESCRIPTION
This changes the data type when uploading an artifact to `{}`, which keeps the data type generic and allows any type to be used.