### PR TITLE
build(deps): bump quarkus from 2.2.3.Final to 2.2.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <yarn.version>1.22.4</yarn.version>
         
         <!-- Quarkus Version -->
-        <quarkus.version>2.2.3.Final</quarkus.version>
+        <quarkus.version>2.2.5.Final</quarkus.version>
 
         <!-- Jandex -->
         <jandex.version>1.1.1</jandex.version>


### PR DESCRIPTION
- Bump the quarkus version to avoid critical CVE in the
com.cronutils:cron-utils sub-dependency. See:
https://nvd.nist.gov/vuln/detail/CVE-2021-41269

Signed-off-by: Andrew Borley <BORLEY@uk.ibm.com>