### PR TITLE
Initial support for using different oauth servers

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
+++ b/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
@@ -76,7 +76,7 @@ public class UiConfigProperties {
 
     @Inject
     @ConfigProperty(name = "registry.ui.config.auth.oidc.redirect-url", defaultValue = "none")
-    String oidcRedirectUrl;
+    String oidcRedirectUri;
 
     private final Map<String, Object> keycloakConfig;
 
@@ -136,6 +136,6 @@ public class UiConfigProperties {
     }
 
     public String getOidcRedirectUrl() {
-        return oidcRedirectUrl;
+        return oidcRedirectUri;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
+++ b/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
@@ -62,6 +62,10 @@ public class UiConfigProperties {
     @ConfigProperty(name = "quarkus.oidc.tenant-enabled", defaultValue = "false")
     boolean tenantEnabled;
 
+    @Inject
+    @ConfigProperty(name = "registry.ui.config.auth.type", defaultValue = "none")
+    String uiAuthType;
+
     private final Map<String, Object> keycloakConfig;
 
     /**
@@ -103,8 +107,11 @@ public class UiConfigProperties {
         return apiUrl;
     }
 
-    public boolean isKeycloakAuthEnabled() {
+    public boolean isAuthenticationEnabled() {
         return tenantEnabled;
     }
 
+    public String getUiAuthType() {
+        return uiAuthType;
+    }
 }

--- a/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
+++ b/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
@@ -66,6 +66,18 @@ public class UiConfigProperties {
     @ConfigProperty(name = "registry.ui.config.auth.type", defaultValue = "none")
     String uiAuthType;
 
+    @Inject
+    @ConfigProperty(name = "registry.ui.config.auth.oidc.url", defaultValue = "none")
+    String oidcUrl;
+
+    @Inject
+    @ConfigProperty(name = "registry.ui.config.auth.oidc.client-id", defaultValue = "none")
+    String oidcClientId;
+
+    @Inject
+    @ConfigProperty(name = "registry.ui.config.auth.oidc.redirect-url", defaultValue = "none")
+    String oidcRedirectUrl;
+
     private final Map<String, Object> keycloakConfig;
 
     /**
@@ -113,5 +125,17 @@ public class UiConfigProperties {
 
     public String getUiAuthType() {
         return uiAuthType;
+    }
+
+    public String getOidcUrl() {
+        return oidcUrl;
+    }
+
+    public String getOidcClientId() {
+        return oidcClientId;
+    }
+
+    public String getOidcRedirectUrl() {
+        return oidcRedirectUrl;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/ui/servlets/ConfigJsServlet.java
+++ b/app/src/main/java/io/apicurio/registry/ui/servlets/ConfigJsServlet.java
@@ -108,7 +108,7 @@ public class ConfigJsServlet extends HttpServlet {
                 config.auth.options = new HashMap<>();
                 config.auth.options.put("clientId", uiConfig.getOidcClientId());
                 config.auth.options.put("url", uiConfig.getOidcUrl());
-                config.auth.options.put("redirectUrl", uiConfig.getOidcRedirectUrl());
+                config.auth.options.put("redirectUri", uiConfig.getOidcRedirectUrl());
             }
 
             config.auth.rbacEnabled = authConfig.isRbacEnabled();

--- a/app/src/main/java/io/apicurio/registry/ui/servlets/ConfigJsServlet.java
+++ b/app/src/main/java/io/apicurio/registry/ui/servlets/ConfigJsServlet.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 
 import javax.inject.Inject;
 import javax.servlet.ServletException;
@@ -101,12 +102,15 @@ public class ConfigJsServlet extends HttpServlet {
         if (uiConfig.isAuthenticationEnabled()) {
             if (uiConfig.getUiAuthType().equals("keycloakjs")) {
                 config.auth.type = "keycloakjs";
-
+                config.auth.options = uiConfig.getKeycloakProperties();
             } else if (uiConfig.getUiAuthType().equals("oidc")) {
                 config.auth.type = "oidc";
+                config.auth.options = new HashMap<>();
+                config.auth.options.put("clientId", uiConfig.getOidcClientId());
+                config.auth.options.put("url", uiConfig.getOidcUrl());
+                config.auth.options.put("redirectUrl", uiConfig.getOidcRedirectUrl());
             }
 
-            config.auth.options = uiConfig.getKeycloakProperties();
             config.auth.rbacEnabled = authConfig.isRbacEnabled();
             config.auth.obacEnabled = authConfig.isObacEnabled();
             config.features.roleManagement = authConfig.isApplicationRbacEnabled();

--- a/app/src/main/java/io/apicurio/registry/ui/servlets/ConfigJsServlet.java
+++ b/app/src/main/java/io/apicurio/registry/ui/servlets/ConfigJsServlet.java
@@ -98,8 +98,14 @@ public class ConfigJsServlet extends HttpServlet {
      * @param config
      */
     private void configureAuth(ConfigJs config) {
-        if (uiConfig.isKeycloakAuthEnabled()) {
-            config.auth.type = "keycloakjs";
+        if (uiConfig.isAuthenticationEnabled()) {
+            if (uiConfig.getUiAuthType().equals("keycloakjs")) {
+                config.auth.type = "keycloakjs";
+
+            } else if (uiConfig.getUiAuthType().equals("oidc")) {
+                config.auth.type = "oidc";
+            }
+
             config.auth.options = uiConfig.getKeycloakProperties();
             config.auth.rbacEnabled = authConfig.isRbacEnabled();
             config.auth.obacEnabled = authConfig.isObacEnabled();

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -45,7 +45,7 @@ registry.auth.tenant-owner-is-admin.enabled=${REGISTRY_AUTH_TENANT_OWNER_IS_ADMI
 
 quarkus.oidc.enabled=true
 quarkus.oidc.tenant-enabled=${registry.auth.enabled}
-quarkus.oidc.auth-server-url=${registry.keycloak.url}/realms/${registry.keycloak.realm}
+quarkus.oidc.auth-server-url=${REGISTRY_AUTH_URL_CONFIGURED:${registry.keycloak.url}/realms/${registry.keycloak.realm}
 quarkus.oidc.client-id=${KEYCLOAK_API_CLIENT_ID:registry-api}
 
 # Admin override indicates whether the existence of a role somewhere
@@ -64,7 +64,7 @@ registry.auth.basic-auth-client-credentials.enabled=${CLIENT_CREDENTIALS_BASIC_A
 registry.keycloak.url=${KEYCLOAK_URL:http://localhost:8090/auth}
 registry.keycloak.realm=${KEYCLOAK_REALM:apicurio-local}
 
-registry.auth.url.configured=${registry.keycloak.url}/realms/${registry.keycloak.realm}
+registry.auth.url.configured=${registry.keycloak.url}/realms/${registry.keycloak.realm}}
 registry.auth.token.endpoint=${TOKEN_ENDPOINT:${registry.keycloak.url}/realms/${registry.keycloak.realm}/protocol/openid-connect/token}
 registry.auth.client-secret=${KEYCLOAK_API_CLIENT_SECRET:}
 
@@ -72,6 +72,8 @@ registry.ui.config.auth.keycloak.url=${registry.keycloak.url}
 registry.ui.config.auth.keycloak.realm=${registry.keycloak.realm}
 registry.ui.config.auth.keycloak.clientId=${KEYCLOAK_UI_CLIENT_ID:apicurio-registry}
 registry.ui.config.auth.keycloak.onLoad=login-required
+registry.ui.config.auth.type=${REGISTRY_UI_AUTH_TYPE:none}
+
 
 quarkus.http.non-application-root-path=/
 

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -64,15 +64,21 @@ registry.auth.basic-auth-client-credentials.enabled=${CLIENT_CREDENTIALS_BASIC_A
 registry.keycloak.url=${KEYCLOAK_URL:http://localhost:8090/auth}
 registry.keycloak.realm=${KEYCLOAK_REALM:apicurio-local}
 
-registry.auth.url.configured=${registry.keycloak.url}/realms/${registry.keycloak.realm}}
+registry.auth.url.configured=${registry.keycloak.url}/realms/${registry.keycloak.realm}
 registry.auth.token.endpoint=${TOKEN_ENDPOINT:${registry.keycloak.url}/realms/${registry.keycloak.realm}/protocol/openid-connect/token}
 registry.auth.client-secret=${KEYCLOAK_API_CLIENT_SECRET:}
+
+registry.ui.config.auth.type=${REGISTRY_UI_AUTH_TYPE:none}
 
 registry.ui.config.auth.keycloak.url=${registry.keycloak.url}
 registry.ui.config.auth.keycloak.realm=${registry.keycloak.realm}
 registry.ui.config.auth.keycloak.clientId=${KEYCLOAK_UI_CLIENT_ID:apicurio-registry}
 registry.ui.config.auth.keycloak.onLoad=login-required
-registry.ui.config.auth.type=${REGISTRY_UI_AUTH_TYPE:none}
+
+registry.ui.config.auth.oidc.url=${REGISTRY_AUTH_URL_CONFIGURED:http://localhost:8090}
+registry.ui.config.auth.oidc.client-id=${REGISTRY_OIDC_UI_CLIENT_ID:default_client}
+registry.ui.config.auth.oidc.redirect-url=${REGOSTRY_OIDC_UI_REDIRECT_URL:http://localhost:8080}
+
 
 
 quarkus.http.non-application-root-path=/

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -77,7 +77,7 @@ registry.ui.config.auth.keycloak.onLoad=login-required
 
 registry.ui.config.auth.oidc.url=${REGISTRY_AUTH_URL_CONFIGURED:http://localhost:8090}
 registry.ui.config.auth.oidc.client-id=${REGISTRY_OIDC_UI_CLIENT_ID:default_client}
-registry.ui.config.auth.oidc.redirect-url=${REGOSTRY_OIDC_UI_REDIRECT_URL:http://localhost:8080}
+registry.ui.config.auth.oidc.redirect-url=${REGISTRY_OIDC_UI_REDIRECT_URL:http://localhost:8080}
 
 
 

--- a/ui/config/config-oidcjs.js
+++ b/ui/config/config-oidcjs.js
@@ -1,0 +1,25 @@
+var ApicurioRegistryConfig = {
+    artifacts: {
+        url: "http://localhost:8080/apis/registry"
+    },
+    ui: {
+        contextPath: "/",
+        navPrefixPath: "/"
+    },
+    auth: {
+        type: "oidc",
+        rbacEnabled: true,
+        obacEnabled: false,
+        options: {
+            url: "http://localhost:8090",
+            redirectUri: "http://localhost:8888",
+            clientId:"apicurio-registry",
+        }
+    },
+    features: {
+        readOnly: false,
+        breadcrumbs: true,
+        roleManagement: false,
+        settings: true
+    }
+};

--- a/ui/package.json
+++ b/ui/package.json
@@ -72,6 +72,7 @@
     "react-ace": "10.1.0",
     "react-dom": "17.0.2",
     "react-moment": "1.1.2",
+    "oidc-client-ts": "^2.0.3",
     "react-router-dom": "5.2.1",
     "redoc": "2.0.0-rc.72",
     "styled-components": "^4.2.0",

--- a/ui/src/services/auth/auth.service.ts
+++ b/ui/src/services/auth/auth.service.ts
@@ -5,8 +5,9 @@ import {AxiosRequestConfig} from "axios";
 import {LoggerService} from "../logger";
 import {UsersService} from "../users";
 import {Services} from "../services";
+import {User, UserManager, UserManagerSettings} from "oidc-client-ts";
 
-const KC_CONFIG_OPTIONS: string[] = ["url", "realm", "clientId"];
+const KC_CONFIG_OPTIONS: string[] = ["url", "realm", "clientId, redirectUri"];
 const KC_INIT_OPTIONS: string[] = [
     "useNonce", "adapter", "onLoad", "token", "refreshToken", "idToken", "timeSkew", "checkLoginIframe",
     "checkLoginIframeInterval", "responseMode", "redirectUri", "silentCheckSsoRedirectUri", "flow",
@@ -49,9 +50,30 @@ export class AuthService implements Service {
     private keycloak: Keycloak.KeycloakInstance;
     // @ts-ignore
     private user: AuthenticatedUser;
+    // @ts-ignore
+    private userManager: UserManager;
+    // @ts-ignore
+    private oidcUser: User;
 
     public init = () => {
-        // no init?
+        if (this.config.authType() === "oidc") {
+            this.userManager = new UserManager(this.getClientSettings());
+        }
+    }
+
+    public authenticateUsingOidc = (onAuthenticatedCallback: () => void) => {
+        this.userManager.getUser().then((authenticatedUser) => {
+            if (authenticatedUser) {
+                onAuthenticatedCallback();
+            } else {
+                console.warn("Not authenticated!");
+                this.doLogin();
+            }
+
+        }).catch(() => {
+            this.user = this.fakeUser();
+            onAuthenticatedCallback();
+        })
     }
 
     public authenticateUsingKeycloak = (onAuthenticatedCallback: () => void) => {
@@ -72,15 +94,6 @@ export class AuthService implements Service {
             this.logger.info("----------------");
         };
 
-        const fakeUser: (() => AuthenticatedUser) = () => {
-            return {
-                displayName: "User",
-                fullName: "User",
-                roles: [],
-                username: "User"
-            };
-        };
-
         const infoToUser: (() => AuthenticatedUser) = () => {
             const ui: any = this.keycloak.userInfo;
             return {
@@ -99,7 +112,7 @@ export class AuthService implements Service {
                         addRoles(this.user);
                         onAuthenticatedCallback();
                     }).catch(() => {
-                        this.user = fakeUser();
+                        this.user = this.fakeUser();
                         addRoles(this.user);
                         onAuthenticatedCallback();
                     })
@@ -110,17 +123,77 @@ export class AuthService implements Service {
             })
     };
 
-    public isAuthenticated = () => this.keycloak != null && this.keycloak.authenticated;
+    public getClientSettings(): UserManagerSettings {
+        const configOptions: any = only(KC_CONFIG_OPTIONS, this.config.authOptions());
 
-    public doLogin = () => this.keycloak.login;
+        return {
+            authority: configOptions.url,
+            client_id: configOptions.clientId,
+            redirect_uri: configOptions.redirectUri,
+            response_type: "code",
+            scope: "openid profile api1",
+            filterProtocolClaims: true,
+            loadUserInfo: true
+        };
+    }
 
-    public doLogout = () =>  {
-        this.keycloak.logout({
-            redirectUri: window.location.href
-        });
+    public fakeUser: (() => AuthenticatedUser) = () => {
+        return {
+            displayName: "User",
+            fullName: "User",
+            roles: [],
+            username: "User"
+        };
+    };
+
+    public oidcInfoToUser(user: User): AuthenticatedUser {
+        // @ts-ignore
+        return {
+            displayName: user.profile.given_name != undefined ? user.profile.given_name : "User",
+            fullName: user.profile.preferred_username != undefined ? user.profile.preferred_username : "User",
+            username: user.profile.name != undefined ? user.profile.name : "User"
+        };
+    }
+
+    public oidcAddRoles(user: User): void {
+
+    }
+
+    public isAuthenticated(): boolean {
+        return (this.isKeycloakAuthenticated() || this.isOidcAuthenticated())
+    }
+
+    public isKeycloakAuthenticated = () => (this.keycloak != null && this.keycloak.authenticated);
+
+    private isOidcAuthenticated(): boolean {
+        return this.userManager != null && this.oidcUser != null && !this.oidcUser.expired;
+    }
+
+    public doLogin = () => {
+        if (this.config.authType() === "keycloakjs") {
+            this.keycloak.login();
+        } else if (this.config.authType() === "oidc") {
+            this.userManager.signinRedirect()
+                .catch(reason => {
+                console.log(reason)
+            });
+        }
+    }
+
+    public doLogout = () => {
+        if (this.config.authType() === "keycloakjs") {
+            this.keycloak.logout({
+                redirectUri: window.location.href
+            });
+        } else if (this.config.authType() === "oidc") {
+            this.userManager.signoutRedirect();
+        }
     }
 
     public getToken = () => this.keycloak.token;
+
+    public getOidcToken = () => this.oidcUser.access_token;
+
 
     public isAuthenticationEnabled(): boolean {
         return this.enabled;
@@ -167,6 +240,17 @@ export class AuthService implements Service {
         if (this.config.authType() === "keycloakjs") {
             this.enabled = true;
             this.authenticateUsingKeycloak(render);
+        } else if (this.config.authType() === "oidc") {
+            this.enabled = true;
+            let url = new URL(window.location.href);
+            if (url.searchParams.get('state')) {
+                this.userManager.signinRedirectCallback().then(user => {
+                    this.oidcUser = user;
+                    render();
+                })
+            } else {
+                this.authenticateUsingOidc(render);
+            }
         } else {
             this.enabled = false;
             render();
@@ -191,6 +275,9 @@ export class AuthService implements Service {
                     this.logger.info("[AuthService] Failed to acquire token: ", error);
                     return Promise.reject(error);
                 });
+            } else if (self.config.authType() === "oidc") {
+                config.headers.Authorization = `Bearer ${this.getOidcToken()}`;
+                return Promise.resolve(config);
             } else {
                 return Promise.resolve(config);
             }

--- a/ui/src/services/auth/auth.service.ts
+++ b/ui/src/services/auth/auth.service.ts
@@ -64,6 +64,8 @@ export class AuthService implements Service {
     public authenticateUsingOidc = (onAuthenticatedCallback: () => void) => {
         this.userManager.getUser().then((authenticatedUser) => {
             if (authenticatedUser) {
+                this.oidcUser = authenticatedUser;
+                this.userManager.startSilentRenew()
                 onAuthenticatedCallback();
             } else {
                 console.warn("Not authenticated!");

--- a/ui/src/services/config/config.service.ts
+++ b/ui/src/services/config/config.service.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {Alerts, ConfigType, FeaturesConfig, GetTokenAuthConfig, KeycloakJsAuthConfig} from './config.type';
+import {Alerts, ConfigType, FeaturesConfig, GetTokenAuthConfig, OidcJsAuthConfig} from './config.type';
 import {Service} from "../baseService";
 
 const DEFAULT_CONFIG: ConfigType = {
@@ -152,7 +152,7 @@ export class ConfigService implements Service {
 
     public authOptions(): any {
         if (this.config.auth) {
-            const auth: KeycloakJsAuthConfig = this.config.auth as KeycloakJsAuthConfig;
+            const auth: OidcJsAuthConfig = this.config.auth as OidcJsAuthConfig;
             return auth.options;
         }
         return {};

--- a/ui/src/services/config/config.type.ts
+++ b/ui/src/services/config/config.type.ts
@@ -96,7 +96,7 @@ export interface AuthConfig {
 }
 
 // Used when `type=keycloakjs`
-export interface KeycloakJsAuthConfig extends AuthConfig {
+export interface OidcJsAuthConfig extends AuthConfig {
     options?: any;
 }
 
@@ -119,7 +119,7 @@ export interface Principal {
 
 export interface ConfigType {
     artifacts: ArtifactsConfig;
-    auth: KeycloakJsAuthConfig | NoneAuthConfig | GetTokenAuthConfig;
+    auth: OidcJsAuthConfig | NoneAuthConfig | GetTokenAuthConfig;
     principals?: Principal[];
     features?: FeaturesConfig;
     ui: UiConfig;

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1823,6 +1823,11 @@ crypto-browserify@^3.12.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
+
 css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
@@ -3812,6 +3817,11 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 keycloak-js@^10.0.2:
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-10.0.2.tgz#f0cf5b942627c5221f1466552c40e4624503b77b"
@@ -4475,6 +4485,14 @@ obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
+
+oidc-client-ts@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.0.5.tgz#1c36d4dca16e16cc6a96484050522dbdb3e023b2"
+  integrity sha512-OXIuuLU2iSEtLblM+xR6+SE0GWjyUMVH6HtKpvZnV2AQt0irWZ+yAXGVB8EgNBu0lAQ/UN40EIme+uC0p7WwKw==
+  dependencies:
+    crypto-js "^4.1.1"
+    jwt-decode "^3.1.2"
 
 on-finished@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
Opening in draft for early feedback. This introduces the support for using different oauth servers in the UI instead of just use keycloak. I still want to test and refactor a few things, especially around properties management (right now some oauth and keycloak ones are mixed) and I also want to test the new code to see if I can make it work with keycloak allowing us to remove keycloak-js from the project and just use the generic solution.


