### PR TITLE
Updated the Settings page L&F based on UX designs

### DIFF
--- a/ui/src/app/components/common/ifNotEmpty.tsx
+++ b/ui/src/app/components/common/ifNotEmpty.tsx
@@ -1,0 +1,35 @@
+import React, {FunctionComponent} from "react";
+import {Button, EmptyState, EmptyStateBody, EmptyStateVariant, Title} from "@patternfly/react-core";
+
+/**
+ * Properties
+ */
+export interface IfNotEmptyProps {
+    collection?: any[] | undefined;
+    emptyState?: React.ReactNode;
+    emptyStateTitle?: string;
+    emptyStateMessage?: string;
+    children?: React.ReactNode;
+}
+
+/**
+ * Wrapper around a set of arbitrary child elements and displays them only if the
+ * provided collection is not empty.  If the provided collection is empty, then
+ * an empty state control is displayed instead.
+ */
+export const IfNotEmpty: FunctionComponent<IfNotEmptyProps> = ({collection, emptyState, emptyStateTitle, emptyStateMessage, children}: IfNotEmptyProps) => {
+    const isEmpty = () => {
+        return !collection || collection.length === 0;
+    };
+
+    const empty: React.ReactNode = emptyState || (
+        <EmptyState variant={EmptyStateVariant.xs}>
+            <Title headingLevel="h4" size="md">{emptyStateTitle || "None found"}</Title>
+            <EmptyStateBody>{emptyStateMessage || "No items found."}</EmptyStateBody>
+        </EmptyState>
+    );
+
+    return isEmpty() ?
+        <React.Fragment children={empty}/> :
+        <React.Fragment children={children} />
+};

--- a/ui/src/app/components/common/index.ts
+++ b/ui/src/app/components/common/index.ts
@@ -18,3 +18,5 @@
 export * from "./artifactTypeIcon";
 export * from "./ifAuth";
 export * from "./ifFeature";
+export * from "./ifNotEmpty";
+

--- a/ui/src/app/pages/settings/components/configProperty.css
+++ b/ui/src/app/pages/settings/components/configProperty.css
@@ -1,16 +1,43 @@
 .configuration-property {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    padding-top: 15px;
     padding-bottom: 15px;
-    border-bottom: 1px solid #fafafa;
-    margin-bottom: 15px;
+    border-bottom: 2px solid #eee;
 }
 
-.configuration-property > .property-name {
+.configuration-property:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
 }
-.configuration-property > .property-description {
+
+.configuration-property .property-name {
+    font-weight: bold;
+    color: #333;
+    margin-bottom: 5px;
+}
+.configuration-property .property-description {
     color: rgb(106, 110, 115);
     font-size: 14px;
 }
-.configuration-property > .property-value {
-    margin-top: 5px;
-    max-width: 740px;
+
+.configuration-property .property-name .value {
+    margin-left: 8px;
+    text-decoration: underline;
+}
+
+.configuration-property .actions {
+}
+
+.configuration-property .actions .action {
+}
+
+.configuration-property .actions button.action {
+    padding: 0;
+    margin: 0;
+    margin-left: 15px;
+}
+.configuration-property .actions button.action.single {
+    padding-right: 15px;
 }

--- a/ui/src/app/pages/settings/settings.css
+++ b/ui/src/app/pages/settings/settings.css
@@ -1,8 +1,10 @@
 .ps_settings-header {
-    border-bottom: 1px solid #ddd;
 }
 
-.config-properties {
-    padding: 20px;
-    background-color: white;
+.config-property-group {
+    width: 80%;
+}
+
+.config-property-group .title {
+    border-bottom: 2px solid #eee;
 }


### PR DESCRIPTION
I think the only thing missing from the designs is the Toasts.  I need to think a little more about how that should be done, especially given the various deployment models for the UI.  (RHOSR vs. community)

Here is a screenshot of the updated UI:

![image](https://user-images.githubusercontent.com/1890703/168382151-38e19d81-7b67-48b7-89a8-31dda8e8b736.png)
