### PR TITLE
build(deps): Bump quarkus version from 2.7.5.Final to 2.7.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <yarn.version>1.22.4</yarn.version>
         
         <!-- Quarkus Version -->
-        <quarkus.version>2.7.5.Final</quarkus.version>
+        <quarkus.version>2.7.6.Final</quarkus.version>
 
         <!-- Jandex -->
         <jandex.version>1.1.1</jandex.version>


### PR DESCRIPTION
- Mitigates
[CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518)
- Mitigates
[CVE-2021-43797](https://nvd.nist.gov/vuln/detail/CVE-2021-43797)

Signed-off-by: Andrew Borley <BORLEY@uk.ibm.com>