### PR TITLE
fix: add Download button

### DIFF
--- a/ui/src/app/pages/artifactVersion/components/tabs/info.css
+++ b/ui/src/app/pages/artifactVersion/components/tabs/info.css
@@ -27,7 +27,7 @@
 }
 
 .artifact-tab-content .artifact-basics .metaData {
-    margin-bottom: 10px;
+    margin-bottom: 20px;
 }
 
 .artifact-tab-content .artifact-basics .actions {

--- a/ui/src/app/pages/artifactVersion/components/tabs/info.tsx
+++ b/ui/src/app/pages/artifactVersion/components/tabs/info.tsx
@@ -138,8 +138,14 @@ export class InfoTabContent extends PureComponent<InfoTabContentProps, InfoTabCo
                                 )}</DescriptionListDescription>
                             }
                         </DescriptionListGroup>
-
                     </DescriptionList>
+                    <div className="actions">
+                        <Button id="download-action"
+                                data-testid="artifact-btn-download"
+                                title="Download artifact content"
+                                onClick={this.props.onDownloadArtifact}
+                                variant="secondary"><DownloadIcon /> Download</Button>
+                    </div>
                 </FlexItem>
                 <FlexItem className="artifact-rules">
                     <div className="rules-label">Content Rules</div>
@@ -175,6 +181,6 @@ export class InfoTabContent extends PureComponent<InfoTabContentProps, InfoTabCo
 
     private isArtifactInGroup = (): boolean => {
         const groupId: string | null = this.props.artifact.groupId;
-        return groupId != null && groupId != "default";
+        return groupId != null && groupId !== "default";
     };
 }


### PR DESCRIPTION
This PR returns the Download button which was mistakenly removed in https://github.com/Apicurio/apicurio-registry/pull/2525/files

![Screenshot 2022-05-31 at 14 24 14](https://user-images.githubusercontent.com/11743717/171184059-371803b3-d7ae-4139-b2fa-bdcef290c93b.png)
