### PR TITLE
Use Temurin Distribution and Attach built JARs and Libraries to the release

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -27,10 +27,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: 11
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Cache Dependencies
         uses: actions/cache@v2

--- a/.github/workflows/kubernetes-tests-manual.yaml
+++ b/.github/workflows/kubernetes-tests-manual.yaml
@@ -29,11 +29,11 @@ jobs:
       - run: go version
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: '11'
-          architecture: x64
-
+          java-version: '11'
+          distribution: 'temurin'
+          
       - name: Cache Dependencies
         uses: actions/cache@v1
         with:

--- a/.github/workflows/kubernetes-tests.yaml
+++ b/.github/workflows/kubernetes-tests.yaml
@@ -31,10 +31,10 @@ jobs:
       - run: go version
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: 11
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Get maven wrapper
         run: mvn -N io.takari:maven:wrapper -Dmaven=3.8.2
@@ -82,10 +82,10 @@ jobs:
       - run: go version
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: 11
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Build api-model
         run: |

--- a/.github/workflows/maven-snapshot-release.yaml
+++ b/.github/workflows/maven-snapshot-release.yaml
@@ -9,10 +9,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: '11'
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Set up settings.xml
         run: echo "<settings><servers><server><id>github</id><username>${{ github.repository_owner }}</username><password>${{ secrets.GITHUB_TOKEN }}</password></server></servers></settings>" > /home/runner/.m2/settings.xml

--- a/.github/workflows/registry-rhbq-build.yaml
+++ b/.github/workflows/registry-rhbq-build.yaml
@@ -31,10 +31,10 @@ jobs:
     steps:
             
         - name: Set up JDK 11
-          uses: AdoptOpenJDK/install-jdk@v1
+          uses: actions/setup-java@v3
           with:
-            version: '11'
-            architecture: x64
+            java-version: '11'
+            distribution: 'temurin'
             
         - name: Configure Red Hat Repository
           run: |

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -69,10 +69,10 @@ jobs:
           fi
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: '11'
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Build Project
         run: cd registry && make SKIP_TESTS=true BUILD_FLAGS='-Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5' build-all

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,10 +30,10 @@ jobs:
           node-version: 12
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: '11'
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Set up settings.xml
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,11 +100,24 @@ jobs:
           echo "This is a pre-release. Setting environment variable 'IS_PRE_RELEASE' to true"
           echo "IS_PRE_RELEASE=true" >> $GITHUB_ENV
       
-      - name: Create GitHub Release
+      - name: Fetch Latest Commit SHA
         run: |
-          echo "IS_PRE_RELEASE=$IS_PRE_RELEASE"
           cd registry
-          ./.github/scripts/create-github-release.sh ${{ github.event.inputs.release-version}} ${{ github.event.inputs.branch}} $GITHUB_REPOSITORY ${{ secrets.ACCESS_TOKEN }} ${{ env.IS_PRE_RELEASE }}
+          echo "latest_commit_sha=$(git log -n 1 --pretty=format:"%H")" >> $GITHUB_ENV
+      
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ github.event.inputs.release-version }} 
+          tag_name: ${{ github.event.inputs.release-version }} 
+          token: ${{ secrets.ACCESS_TOKEN }}
+          target_commitish: ${{ env.latest_commit_sha }} # explicitly passing the commit hash so that the latest commit is tagged and released
+          prerelease: ${{ env.IS_PRE_RELEASE }}
+          files: |
+            registry/distro/docker/target/docker/app-files/apicurio-registry-app-${{ github.event.inputs.release-version }}-all.tar.gz
+            registry/distro/docker/target/docker/app-files/apicurio-registry-storage-sql-${{ github.event.inputs.release-version }}-all.tar.gz
+            registry/distro/docker/target/docker/app-files/apicurio-registry-storage-kafkasql-${{ github.event.inputs.release-version }}-all.tar.gz
+            registry/distro/docker/target/docker/app-files/apicurio-registry-tenant-manager-api-${{ github.event.inputs.release-version }}-all.tar.gz
 
       - name: Generate Release Notes
         run: |

--- a/.github/workflows/tag-registry-examples.yaml
+++ b/.github/workflows/tag-registry-examples.yaml
@@ -42,10 +42,10 @@ jobs:
           echo "Snapshot Version: $SNAPSHOT_VERSION"
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: 11
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
       
       - name: Configure Git
         run: |

--- a/.github/workflows/tool-exportV1-release.yaml
+++ b/.github/workflows/tool-exportV1-release.yaml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
     - name: Configure Environment (dispatch)
       if: github.event.inputs.tag_name != null
       run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV

--- a/.github/workflows/tool-exportV1-release.yaml
+++ b/.github/workflows/tool-exportV1-release.yaml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
     - name: Configure Environment (dispatch)
       if: github.event.inputs.tag_name != null
       run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV

--- a/.github/workflows/update-openapi.yaml
+++ b/.github/workflows/update-openapi.yaml
@@ -25,10 +25,10 @@ jobs:
           git pull
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: '11'
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -30,10 +30,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK ${{ matrix.jdk-version }}
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: ${{ matrix.jdk-version }}
-          architecture: x64
+          java-version: ${{ matrix.jdk-version }}
+          distribution: 'temurin'
 
       # Open-Source Machine emulator that allows you to emulate multiple CPU architectures on your machine
       - name: Set up QEMU
@@ -98,10 +98,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: 11
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Cache Dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates.