### PR TITLE
fix everit-json maven coordinates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <graphql.version>18.1</graphql.version>
 
         <!-- JSON Schema Validator -->
-        <org.everit.json.schema.version>1.14.1</org.everit.json.schema.version><!-- TODO unification -->
+        <everit.json.schema.version>1.14.1</everit.json.schema.version><!-- TODO unification -->
         <jackson-datatype-json-org.version>2.13.0</jackson-datatype-json-org.version>
         <jackson-dataformat-yaml.version>2.12.5</jackson-dataformat-yaml.version>
 
@@ -590,9 +590,9 @@
             </dependency>
 
             <dependency>
-                <groupId>com.github.everit-org.json-schema</groupId>
-                <artifactId>org.everit.json.schema</artifactId>
-                <version>${org.everit.json.schema.version}</version>
+                <groupId>com.github.erosb</groupId>
+                <artifactId>everit-json-schema</artifactId>
+                <version>${everit.json.schema.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/schema-util/json/pom.xml
+++ b/schema-util/json/pom.xml
@@ -31,8 +31,8 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.everit-org.json-schema</groupId>
-            <artifactId>org.everit.json.schema</artifactId>
+            <groupId>com.github.erosb</groupId>
+            <artifactId>everit-json-schema</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/serdes/jsonschema-serde/pom.xml
+++ b/serdes/jsonschema-serde/pom.xml
@@ -25,8 +25,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.everit-org.json-schema</groupId>
-            <artifactId>org.everit.json.schema</artifactId>
+            <groupId>com.github.erosb</groupId>
+            <artifactId>everit-json-schema</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
See https://github.com/everit-org/json-schema#maven-installation & https://search.maven.org/search?q=everit%20json .

Ran into this when trying to update `io.apicurio:apicurio-registry-utils-converter` from version 2.2.1.Final to 2.2.4.Final.

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':writer:connectorConfigDoc'.
> Could not resolve all files for configuration ':writer:runtimeClasspath'.
   > Could not find com.github.everit-org.json-schema:org.everit.json.schema:1.14.1.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/github/everit-org/json-schema/org.everit.json.schema/1.14.1/org.everit.json.schema-1.14.1.pom
       - https://packages.confluent.io/maven/com/github/everit-org/json-schema/org.everit.json.schema/1.14.1/org.everit.json.schema-1.14.1.pom
     Required by:
         project :writer > io.apicurio:apicurio-registry-utils-converter:2.2.4.Final > io.apicurio:apicurio-registry-serdes-jsonschema-serde:2.2.4.Final
```

Note: untested. (And given the bug exists I assume there's no github action that will do a proper validation of the fix...)
I'll need some guidance if you want me to validate the change