### PR TITLE
New(system-tests, OLMTests): Multinamespace test

### DIFF
--- a/system-tests/src/main/java/io/apicurio/registry/systemtests/framework/DatabaseUtils.java
+++ b/system-tests/src/main/java/io/apicurio/registry/systemtests/framework/DatabaseUtils.java
@@ -23,4 +23,21 @@ public class DatabaseUtils {
             e.printStackTrace();
         }
     }
+
+    public static void deployPostgresqlDatabase(ExtensionContext testContext, String name, String namespace) {
+        PersistentVolumeClaim persistentVolumeClaim = PersistentVolumeClaimResourceType.getDefaultPostgresql(
+                name,
+                namespace
+        );
+        Deployment deployment = DeploymentResourceType.getDefaultPostgresql(name, namespace);
+        Service service = ServiceResourceType.getDefaultPostgresql(name, namespace);
+
+        try {
+            ResourceManager.getInstance().createResource(testContext, false, persistentVolumeClaim);
+            ResourceManager.getInstance().createResource(testContext, true, deployment);
+            ResourceManager.getInstance().createResource(testContext, false, service);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/system-tests/src/main/java/io/apicurio/registry/systemtests/registryinfra/resources/ApicurioRegistryResourceType.java
+++ b/system-tests/src/main/java/io/apicurio/registry/systemtests/registryinfra/resources/ApicurioRegistryResourceType.java
@@ -113,6 +113,12 @@ public class ApicurioRegistryResourceType implements ResourceType<ApicurioRegist
     }
 
     public static ApicurioRegistry getDefaultSql(String name, String namespace) {
+        return getDefaultSql(name, namespace, "postgresql", "postgresql");
+    }
+
+    public static ApicurioRegistry getDefaultSql(String name, String namespace, String sqlName, String sqlNamespace) {
+        String sqlUrl = "jdbc:postgresql://" + sqlName + "." + sqlNamespace + ".svc.cluster.local:5432/postgresdb";
+
         return new ApicurioRegistryBuilder()
                 .withNewMetadata()
                     .withName(name)
@@ -123,7 +129,7 @@ public class ApicurioRegistryResourceType implements ResourceType<ApicurioRegist
                         .withPersistence("sql")
                         .withNewSql()
                             .withNewDataSource()
-                                .withUrl("jdbc:postgresql://postgresql.postgresql.svc.cluster.local:5432/postgresdb")
+                                .withUrl(sqlUrl)
                                 .withUserName("postgresuser")
                                 .withPassword("postgrespassword")
                             .endDataSource()

--- a/system-tests/src/test/java/io/apicurio/registry/systemtests/OLMTests.java
+++ b/system-tests/src/test/java/io/apicurio/registry/systemtests/OLMTests.java
@@ -1,9 +1,20 @@
 package io.apicurio.registry.systemtests;
 
+import io.apicurio.registry.operator.api.model.ApicurioRegistry;
+import io.apicurio.registry.systemtests.framework.ApicurioRegistryUtils;
+import io.apicurio.registry.systemtests.framework.Constants;
+import io.apicurio.registry.systemtests.framework.DatabaseUtils;
 import io.apicurio.registry.systemtests.operator.types.ApicurioRegistryOLMOperatorType;
+import io.apicurio.registry.systemtests.registryinfra.ResourceManager;
+import io.apicurio.registry.systemtests.registryinfra.resources.ApicurioRegistryResourceType;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.opentest4j.AssertionFailedError;
+
+import java.text.MessageFormat;
 
 @Disabled
 public abstract class OLMTests extends Tests {
@@ -24,5 +35,55 @@ public abstract class OLMTests extends Tests {
         ApicurioRegistryOLMOperatorType registryOLMOperator = new ApicurioRegistryOLMOperatorType(clusterWide);
 
         operatorManager.installOperator(testContext, registryOLMOperator);
+    }
+
+    @Test
+    public void testMultipleNamespaces(ExtensionContext testContext) {
+        // Deploy default PostgreSQL database
+        DatabaseUtils.deployDefaultPostgresqlDatabase(testContext);
+        // Deploy default Apicurio Registry with default PostgreSQL database
+        ApicurioRegistryUtils.deployDefaultApicurioRegistrySql(testContext, false);
+
+        // Set suffix of second resources
+        String suffix = "-multi";
+        // Get second PostgreSQL database name
+        String secondSqlName = "postgresql" + suffix;
+        // Get second PostgreSQL database namespace
+        String secondSqlNamespace = "postgresql" + suffix;
+
+        // Deploy second PostgreSQL database
+        DatabaseUtils.deployPostgresqlDatabase(testContext, secondSqlName, secondSqlNamespace);
+        // Get second Apicurio Registry with second PostgreSQL database
+        ApicurioRegistry secondSqlRegistry = ApicurioRegistryResourceType.getDefaultSql(
+                Constants.REGISTRY + suffix,
+                Constants.TESTSUITE_NAMESPACE + suffix,
+                secondSqlName,
+                secondSqlNamespace
+        );
+
+        // Deploy second Apicurio Registry with second PostgreSQL database
+        if (clusterWide) {
+            // If OLM operator is installed as cluster wide,
+            // second Apicurio Registry should be deployed successfully
+            ResourceManager.getInstance().createResource(testContext, true, secondSqlRegistry);
+        } else {
+            // If OLM operator is installed as namespaced,
+            // second Apicurio Registry deployment should fail
+            AssertionFailedError assertionFailedError = Assertions.assertThrows(
+                    AssertionFailedError.class,
+                    () -> ResourceManager.getInstance().createResource(testContext, true, secondSqlRegistry)
+            );
+
+            Assertions.assertEquals(
+                    MessageFormat.format(
+                            "Timed out waiting for resource {0} with name {1} in namespace {2} to be ready. " +
+                                    "==> expected: <true> but was: <false>",
+                            secondSqlRegistry.getKind(),
+                            secondSqlRegistry.getMetadata().getName(),
+                            secondSqlRegistry.getMetadata().getNamespace()
+                    ),
+                    assertionFailedError.getMessage()
+            );
+        }
     }
 }


### PR DESCRIPTION
This test tries if we are able to create Apicurio Registry instances in multiple namespaces when OLM operator is installed cluster-wide, and we are NOT able to create Apicurio Registry instances in multiple namespaces when OLM operator is installed as namespaced.