### PR TITLE
Revert "fix everit-json maven coordinates (#2577)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <graphql.version>18.1</graphql.version>
 
         <!-- JSON Schema Validator -->
-        <everit.json.schema.version>1.14.1</everit.json.schema.version><!-- TODO unification -->
+        <org.everit.json.schema.version>1.14.1</org.everit.json.schema.version><!-- TODO unification -->
         <jackson-datatype-json-org.version>2.13.0</jackson-datatype-json-org.version>
         <jackson-dataformat-yaml.version>2.12.5</jackson-dataformat-yaml.version>
 
@@ -590,9 +590,9 @@
             </dependency>
 
             <dependency>
-                <groupId>com.github.erosb</groupId>
-                <artifactId>everit-json-schema</artifactId>
-                <version>${everit.json.schema.version}</version>
+                <groupId>com.github.everit-org.json-schema</groupId>
+                <artifactId>org.everit.json.schema</artifactId>
+                <version>${org.everit.json.schema.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/schema-util/json/pom.xml
+++ b/schema-util/json/pom.xml
@@ -31,8 +31,8 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.erosb</groupId>
-            <artifactId>everit-json-schema</artifactId>
+            <groupId>com.github.everit-org.json-schema</groupId>
+            <artifactId>org.everit.json.schema</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/serdes/jsonschema-serde/pom.xml
+++ b/serdes/jsonschema-serde/pom.xml
@@ -25,8 +25,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.erosb</groupId>
-            <artifactId>everit-json-schema</artifactId>
+            <groupId>com.github.everit-org.json-schema</groupId>
+            <artifactId>org.everit.json.schema</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This reverts commit c0d89e96e191e231e98abc494d4d205049e77356 which is PR https://github.com/Apicurio/apicurio-registry/pull/2577 , because of the failing CI checks. See 
- https://github.com/Apicurio/apicurio-registry/runs/7022941586?check_suite_focus=true 
- https://github.com/Apicurio/apicurio-registry/runs/7022935420?check_suite_focus=true 