### PR TITLE
docs: use correct sso token url downstream

### DIFF
--- a/docs/modules/ROOT/partials/getting-started/proc-adding-artifact-references-using-maven-plugin.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-adding-artifact-references-using-maven-plugin.adoc
@@ -110,7 +110,7 @@ ifdef::apicurio-registry,rh-service-registry[]
 . If authentication is required, you can specify your authentication server and client credentials.
 endif::[]
 ifdef::rh-openshift-sr[]
-. Specify your service account ID and secret and the OpenShift Application Services authentication server: `\https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token`
+. Specify your service account ID and secret and the {org-name} Single Sign-On authentication server: `{sso-token-url}`
 endif::[]
 . Specify the {registry} artifact group ID. You can specify the `default` group if you do not want to use a unique group ID.
 . Specify the {registry} artifact reference using its group ID, artifact ID, version, type, and location. You can register multiple artifact references in this way.

--- a/docs/modules/ROOT/partials/getting-started/proc-adding-artifacts-using-maven-plugin.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-adding-artifacts-using-maven-plugin.adoc
@@ -63,7 +63,7 @@ ifdef::apicurio-registry,rh-service-registry[]
 . If authentication is required, you can specify your authentication server and client credentials.
 endif::[]
 ifdef::rh-openshift-sr[]
-. Specify your service account ID and secret and the OpenShift Application Services authentication server: `\https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token`
+. Specify your service account ID and secret and the {org-name} Single Sign-On authentication server: `{sso-token-url}`
 endif::[]
 . Specify the {registry} artifact group ID. You can specify the `default` group if you do not want to use a unique group ID.
 . You can register multiple artifacts using the specified group ID, artifact ID, and location.

--- a/docs/modules/ROOT/partials/getting-started/proc-creating-access-token-rest-api.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-creating-access-token-rest-api.adoc
@@ -26,12 +26,11 @@ https://console.redhat.com/application-services/service-accounts
 
 . Create an OAuth Bearer token using your service account client ID and client secret:  
 +
-[source,bash]
+[source,bash, subs="+quotes,attributes"]
 ----
 $ curl -X POST \
   -d "grant_type=client_credentials&client_id=MY-CLIENT-ID&client_secret=MY-CLIENT-SECRET" \ 
-  https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token
-----
+  {sso-token-url}
 +
 .  Copy the access token generated in the response to a secure location:
 +

--- a/docs/modules/ROOT/partials/getting-started/proc-downloading-artifacts-using-maven-plugin.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-downloading-artifacts-using-maven-plugin.adoc
@@ -61,7 +61,7 @@ ifdef::apicurio-registry,rh-service-registry[]
 . If authentication is required, you can specify your authentication server and client credentials.
 endif::[]
 ifdef::rh-openshift-sr[]
-. Specify your service account ID and secret and the OpenShift Application Services authentication server: `\https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token`
+. Specify your service account ID and secret and {org-name} Single Sign-On authentication server: `{sso-token-url}`
 endif::[]
 . Specify the {registry} artifact group ID. You can specify the `default` group if you do not want to use a unique group.
 . You can download multiple artifacts to a specified directory using the artifact ID. 

--- a/docs/modules/ROOT/partials/getting-started/proc-testing-artifacts-using-maven-plugin.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-testing-artifacts-using-maven-plugin.adoc
@@ -62,7 +62,7 @@ ifdef::apicurio-registry,rh-service-registry[]
 . If authentication is required, you can specify your authentication server and client credentials.
 endif::[]
 ifdef::rh-openshift-sr[]
-. Specify your service account ID and secret and the OpenShift Application Services authentication server: `\https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token`
+. Specify your service account ID and secret and the {org-name} Single Sign-On authentication server: `{sso-token-url}`
 endif::[]
 . Specify the {registry} artifact group ID. You can specify the `default` group if you do not want to use a unique group.
 . You can test multiple artifacts from a specified directory using the artifact ID. 

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-client.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-client.adoc
@@ -20,10 +20,11 @@ The {registry} Java client includes the following configuration options, based o
 |Registry client using the configuration provided by the user. 
 |`baseUrl`, `Map<String Object> configs`
 |Client with custom configuration and authentication
-| Registry client that accepts a map containing custom configuration. This is useful, for example, to add custom headers to the calls. This also requires providing an `auth` instance used to authenticate requests. 
-
-The OpenShift Application Services authentication server is `\https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token`
-
+| Registry client that accepts a map containing custom configuration. For example, this is useful to add custom headers to the calls. 
+You must also provide an authentication server to authenticate the requests. 
+ifdef::rh-openshift-sr[]
+The {org-name} Single Sign-On authentication server is `{sso-url}`.
+endif::[]
 |`baseUrl, Map<String Object> configs, Auth auth`
 |===
 

--- a/docs/modules/ROOT/partials/shared/attributes.adoc
+++ b/docs/modules/ROOT/partials/shared/attributes.adoc
@@ -32,24 +32,26 @@ endif::[]
 // downstream
 ifdef::service-registry-downstream[]
 :rh-service-registry:
+:org-name: Red Hat
 :registry: Service Registry
-:registry-version: 2.2
+:registry-version: 2.1
 :registry-v1: 1.1
 :operator-version: 1.0.0.redhat.x
 :kafka-streams: AMQ Streams
 :registry-streams-version: 1.8
-:keycloak: Red Hat Single Sign-On
+:keycloak: {org-name} Single Sign-On
 :keycloak-version: 7.4
+:sso-token-url: \https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
 endif::[]
 
 //common
+:context: registry
 :version: 2022.Q1
 :attachmentsdir: files
 :registry-release: 2.2.1.Final
 :registry-ocp-version: 4.6
 :registry-db-version: 12
 :registry-url: \http://MY_REGISTRY_URL/ui
-:context: registry
 
 //integration products
 :amq-version: 2021.q3


### PR DESCRIPTION
- Replaces MAS SSO with RH SSO token URL for downstream