### PR TITLE
fix: load the required css files from PatternFly when running the app in standalone mode

### DIFF
--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -14,63 +14,73 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import "./app.css";
 
 import React from "react";
-import {Page} from "@patternfly/react-core";
-import {BrowserRouter as Router, Route, Switch} from 'react-router-dom';
-import {AppHeader} from "./components/header";
-import {RulesPage} from "./pages/rules";
-import {ArtifactsPage} from "./pages/artifacts";
-import {ArtifactRedirectPage} from "./pages/artifact";
-import {ArtifactVersionPage} from "./pages/artifactVersion";
-import {RootRedirectPage} from "./pages/root";
-import {NotFoundPage} from "./pages/404";
-import {Services} from "../services";
-import {RolesPage, SettingsPage} from "./pages";
-
+import { Page } from "@patternfly/react-core";
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { AppHeader } from "./components/header";
+import { RulesPage } from "./pages/rules";
+import { ArtifactsPage } from "./pages/artifacts";
+import { ArtifactRedirectPage } from "./pages/artifact";
+import { ArtifactVersionPage } from "./pages/artifactVersion";
+import { RootRedirectPage } from "./pages/root";
+import { NotFoundPage } from "./pages/404";
+import { Services } from "../services";
+import { RolesPage, SettingsPage } from "./pages";
 
 /**
  * The main application class.
  */
 export default class App extends React.PureComponent<{}, {}> {
+  constructor(props: Readonly<any>) {
+    super(props);
+  }
 
-    constructor(props: Readonly<any>) {
-        super(props);
-    }
+  public render() {
+    const contextPath:
+      | string
+      | undefined = Services.getConfigService().uiContextPath();
+    Services.getLoggerService().info(
+      "[App] Using app contextPath: ",
+      contextPath
+    );
 
-    public render() {
-        const contextPath: string|undefined = Services.getConfigService().uiContextPath();
-        Services.getLoggerService().info("[App] Using app contextPath: ", contextPath);
+    // Function to force the Artifact Version Page to fully remount each time we navigate to it.  This
+    // is needed because we want the page to fully rerender whenever the browser location changes, which
+    // happens when switching between versions of the artifact content (e.g. switch from version 1 to version 3).
+    const artifactVersionPage = (props: any): React.ReactElement => {
+      const location: string = props.location.pathname;
+      return <ArtifactVersionPage key={location} {...props} />;
+    };
 
-        // Function to force the Artifact Version Page to fully remount each time we navigate to it.  This
-        // is needed because we want the page to fully rerender whenever the browser location changes, which
-        // happens when switching between versions of the artifact content (e.g. switch from version 1 to version 3).
-        const artifactVersionPage = (props: any): React.ReactElement => {
-            const location: string = props.location.pathname;
-            return (
-                <ArtifactVersionPage key={location} {...props} />
-            );
-        };
-
-        return (
-            <Router basename={contextPath}>
-                <Page
-                    className="pf-m-redhat-font"
-                    isManagedSidebar={false}
-                    header={<AppHeader/>}
-                >
-                    <Switch>
-                        <Route path='/' exact={true} component={RootRedirectPage}/>
-                        <Route path='/rules' exact={true} component={RulesPage}/>
-                        <Route path='/roles' exact={true} component={RolesPage}/>
-                        <Route path='/settings' exact={true} component={SettingsPage}/>
-                        <Route path='/artifacts' exact={true} component={ArtifactsPage}/>
-                        <Route path='/artifacts/:groupId/:artifactId' exact={true} component={ArtifactRedirectPage}/>
-                        <Route path='/artifacts/:groupId/:artifactId/versions/:version' exact={true} component={artifactVersionPage} />
-                        <Route component={NotFoundPage} />
-                    </Switch>
-                </Page>
-            </Router>
-        );
-    }
+    return (
+      <Router basename={contextPath}>
+        <Page
+          className="pf-m-redhat-font"
+          isManagedSidebar={false}
+          header={<AppHeader />}
+        >
+          <Switch>
+            <Route path="/" exact={true} component={RootRedirectPage} />
+            <Route path="/rules" exact={true} component={RulesPage} />
+            <Route path="/roles" exact={true} component={RolesPage} />
+            <Route path="/settings" exact={true} component={SettingsPage} />
+            <Route path="/artifacts" exact={true} component={ArtifactsPage} />
+            <Route
+              path="/artifacts/:groupId/:artifactId"
+              exact={true}
+              component={ArtifactRedirectPage}
+            />
+            <Route
+              path="/artifacts/:groupId/:artifactId/versions/:version"
+              exact={true}
+              component={artifactVersionPage}
+            />
+            <Route component={NotFoundPage} />
+          </Switch>
+        </Page>
+      </Router>
+    );
+  }
 }

--- a/ui/src/bootstrap.tsx
+++ b/ui/src/bootstrap.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import "@patternfly/react-core/dist/styles/base.css";
 import App from "./app/app";
-import "./app/app.css";
-import {Services} from "./services";
+import { Services } from "./services";
 
-
-const renderApp = () => ReactDOM.render(<App />, document.getElementById("root") as HTMLElement);
+const renderApp = () =>
+  ReactDOM.render(<App />, document.getElementById("root") as HTMLElement);
 Services.getAuthService().authenticateAndRender(renderApp);
-

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -1,1 +1,11 @@
-import('./bootstrap');
+import "@patternfly/patternfly/patternfly.css";
+import "@patternfly/patternfly/utilities/Accessibility/accessibility.css";
+import "@patternfly/patternfly/utilities/BackgroundColor/BackgroundColor.css";
+import "@patternfly/patternfly/utilities/Display/display.css";
+import "@patternfly/patternfly/utilities/Flex/flex.css";
+import "@patternfly/patternfly/utilities/Sizing/sizing.css";
+import "@patternfly/patternfly/utilities/Spacing/spacing.css";
+import "@patternfly/patternfly/utilities/Text/text.css";
+import "@patternfly/react-core/dist/styles/base.css";
+
+import("./bootstrap");


### PR DESCRIPTION
I'm not sure you need all the CSS file I added, that's the list we use on ui-components and should do the trick.