### PR TITLE
[chore] Use built-in caching from `actions/setup-java@v3`

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -31,14 +31,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-
-      - name: Cache Dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-integration-tests-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-integration-tests-
+          cache: 'maven'
 
       - name: Build api-model
         run: |

--- a/.github/workflows/kubernetes-tests-manual.yaml
+++ b/.github/workflows/kubernetes-tests-manual.yaml
@@ -33,14 +33,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          
-      - name: Cache Dependencies
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          cache: 'maven'
 
       - name: Build All Variants
         run: make SKIP_TESTS=true build-all

--- a/.github/workflows/kubernetes-tests.yaml
+++ b/.github/workflows/kubernetes-tests.yaml
@@ -35,6 +35,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
+          cache: 'maven'
 
       - name: Get maven wrapper
         run: mvn -N io.takari:maven:wrapper -Dmaven=3.8.2
@@ -86,6 +87,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
+          cache: 'maven'
 
       - name: Build api-model
         run: |

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           java-version: ${{ matrix.jdk-version }}
           distribution: 'temurin'
+          cache: 'maven'
 
       # Open-Source Machine emulator that allows you to emulate multiple CPU architectures on your machine
       - name: Set up QEMU
@@ -54,14 +55,6 @@ jobs:
           echo "Status:    ${{ steps.buildx.outputs.status }}"
           echo "Flags:     ${{ steps.buildx.outputs.flags }}"
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
-
-      - name: Cache Dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-verify-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-verify-
 
       - name: Build api-model
         run: |
@@ -102,14 +95,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-
-      - name: Cache Dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-verify-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-verify-
+          cache: 'maven'
 
       - name: Get maven wrapper
         run: mvn -N io.takari:maven:wrapper -Dmaven=3.8.2


### PR DESCRIPTION
`actions/setup-java@v3` integrates the caching step, I added the caching in a few places where it makes sense and was missing (e.g. left it out from the release jobs)