### PR TITLE
Publish a mem image to ease the reviews

### DIFF
--- a/.github/workflows/publish-debug-image.yaml
+++ b/.github/workflows/publish-debug-image.yaml
@@ -1,0 +1,36 @@
+name: Publish debug mem image
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-push-mem-image:
+    name: Docker image from PR
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Apicurio'
+    steps:
+      - name: Checkout Code with Ref '${{ github.ref }}'
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build the project
+        env:
+          SKIP_TESTS: true
+        run: make build-all
+
+      - name: Build and Push Mem image
+        env:
+          IMAGE_REPO: ttl.sh/${{ github.sha }}
+          # maximum allowed
+          IMAGE_TAG: 1d
+        run: make build-mem-image push-mem-image
+      
+      - name: EXECUTABLE COMMAND
+        run: echo "docker run --rm -it -p 8080:8080 ttl.sh/${{ github.sha }}/apicurio/apicurio-registry-mem:1d"


### PR DESCRIPTION
This is the example output on how to run the generated Docker image:
https://github.com/andreaTP/apicurio-registry/runs/7862757374?check_suite_focus=true#step:6:7

The Docker image will be available for one day only, but you can always re-run the CI or trigger any action on the PR will rebuild it.