### PR TITLE
Add a reusable image scan GH Action

### DIFF
--- a/.github/workflows/image-scan-impl.yaml
+++ b/.github/workflows/image-scan-impl.yaml
@@ -1,0 +1,17 @@
+name: Trivy Image Scan - Implementation
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+  # TODO: calling reusable workflows works across organizations, decide where to store them and re-use in fleet-manager
+  call-image-scan-registry:
+    uses: ./.github/workflows/image-scan-reusable.yaml
+    with:
+      image: quay.io/apicurio/apicurio-registry-mem:latest-snapshot
+  call-image-scan-tenant-manager:
+    uses: ./.github/workflows/image-scan-reusable.yaml
+    with:
+      image: quay.io/apicurio/apicurio-registry-tenant-manager-api:latest-snapshot

--- a/.github/workflows/image-scan-reusable.yaml
+++ b/.github/workflows/image-scan-reusable.yaml
@@ -1,0 +1,33 @@
+name: Trivy Image Scan - Reusable
+
+# Reusable workflow:
+# https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow
+on:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+
+jobs:
+  vulnerability-scan:
+    name: Docker vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout "${{ github.ref }}"
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.6.2
+        with:
+          image-ref: ${{ inputs.image }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          vuln-type: 'os,library'
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Question:
- Should we have a separate repository for "reusable workflows"? Or should we use one of the already available?

It just needs to be a public repo:
https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow
