### PR TITLE
feat: better handling of version string unique key violation exception

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/http/RegistryExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/RegistryExceptionMapperService.java
@@ -52,6 +52,7 @@ import io.apicurio.registry.storage.RoleMappingAlreadyExistsException;
 import io.apicurio.registry.storage.RoleMappingNotFoundException;
 import io.apicurio.registry.storage.RuleAlreadyExistsException;
 import io.apicurio.registry.storage.RuleNotFoundException;
+import io.apicurio.registry.storage.VersionAlreadyExistsException;
 import io.apicurio.registry.storage.VersionNotFoundException;
 import io.apicurio.rest.client.auth.exception.ForbiddenException;
 import io.apicurio.rest.client.auth.exception.NotAuthorizedException;
@@ -102,6 +103,7 @@ public class RegistryExceptionMapperService {
         Map<Class<? extends Exception>, Integer> map = new HashMap<>();
         map.put(AlreadyExistsException.class, HTTP_CONFLICT);
         map.put(ArtifactAlreadyExistsException.class, HTTP_CONFLICT);
+        map.put(VersionAlreadyExistsException.class, HTTP_CONFLICT);
         map.put(ArtifactNotFoundException.class, HTTP_NOT_FOUND);
         map.put(ContentNotFoundException.class, HTTP_NOT_FOUND);
         map.put(BadRequestException.class, HTTP_BAD_REQUEST);

--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
@@ -721,4 +721,14 @@ public interface RegistryStorage extends DynamicConfigStorage {
      * @return list of global ids of schemas that references artifact
      */
     public List<Long> getGlobalIdsReferencingArtifact(String groupId, String artifactId, String version);
+
+    /**
+     *
+     * @param groupId
+     * @param artifactId
+     * @return true if an artifact version exists with the coordinates passed as parameters
+     * @throws RegistryStorageException
+     */
+    public boolean isArtifactVersionExists(String groupId, String artifactId, String version) throws RegistryStorageException;
+
 }

--- a/app/src/main/java/io/apicurio/registry/storage/VersionAlreadyExistsException.java
+++ b/app/src/main/java/io/apicurio/registry/storage/VersionAlreadyExistsException.java
@@ -22,7 +22,7 @@ package io.apicurio.registry.storage;
  */
 public class VersionAlreadyExistsException extends AlreadyExistsException {
 
-    private static final long serialVersionUID = -1015140450163088675L;
+    private static final long serialVersionUID = 3567623491368394677L;
 
     private final String groupId;
     private final String artifactId;

--- a/app/src/main/java/io/apicurio/registry/storage/VersionAlreadyExistsException.java
+++ b/app/src/main/java/io/apicurio/registry/storage/VersionAlreadyExistsException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage;
+
+/**
+ * @author eric.wittmann@gmail.com
+ * @author Miroslav Safar (msafar@redhat.com)
+ */
+public class VersionAlreadyExistsException extends AlreadyExistsException {
+
+    private static final long serialVersionUID = -1015140450163088675L;
+
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+
+    /**
+     * Constructor.
+     *
+     * @param groupId
+     * @param artifactId
+     * @param version
+     */
+    public VersionAlreadyExistsException(String groupId, String artifactId, String version) {
+        this.artifactId = artifactId;
+        this.groupId = groupId;
+        this.version = version;
+    }
+
+    /**
+     * @return the artifactId
+     */
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    /**
+     * @return the groupId
+     */
+    public String getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * @return the version string
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * @see Throwable#getMessage()
+     */
+    @Override
+    public String getMessage() {
+        return "An artifact version '" + this.version + "' for artifact ID '" + this.artifactId + "' in group '" + groupId + "' already exists.";
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/decorator/RegistryStorageDecorator.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/RegistryStorageDecorator.java
@@ -956,6 +956,14 @@ public abstract class RegistryStorageDecorator implements RegistryStorage {
     }
 
     /**
+     * @see io.apicurio.registry.storage.RegistryStorage#isArtifactVersionExists(String, String, String)
+     */
+    @Override
+    public boolean isArtifactVersionExists(String groupId, String artifactId, String version) throws RegistryStorageException {
+        return delegate.isArtifactVersionExists(groupId, artifactId, version);
+    }
+
+    /**
      * @see io.apicurio.registry.storage.RegistryStorage#getArtifactContentIds(String, String)
      */
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -41,6 +41,7 @@ import javax.inject.Inject;
 import javax.transaction.Transactional;
 
 import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.VersionAlreadyExistsException;
 import io.apicurio.registry.utils.impexp.EntityType;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -993,38 +994,45 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
         // Get meta-data from previous (latest) version
         ArtifactMetaDataDto latest = this.getLatestArtifactMetaDataInternal(groupId, artifactId);
 
-        // Create version and return
-        return handles.withHandleNoException(handle -> {
-            // Metadata comes from the latest version
-            String name = latest.getName();
-            String description = latest.getDescription();
-            List<String> labels = latest.getLabels();
-            Map<String, String> properties = latest.getProperties();
+        try {
+            // Create version and return
+            return handles.withHandle(handle -> {
+                // Metadata comes from the latest version
+                String name = latest.getName();
+                String description = latest.getDescription();
+                List<String> labels = latest.getLabels();
+                Map<String, String> properties = latest.getProperties();
 
-            // Provided metadata will override inherited values from latest version
-            if (metaData.getName() != null) {
-                name = metaData.getName();
-            }
-            if (metaData.getDescription() != null) {
-                description = metaData.getDescription();
-            }
-            if (metaData.getLabels() != null) {
-                labels = metaData.getLabels();
-            }
-            if (metaData.getProperties() != null) {
-                properties = metaData.getProperties();
-            }
+                // Provided metadata will override inherited values from latest version
+                if (metaData.getName() != null) {
+                    name = metaData.getName();
+                }
+                if (metaData.getDescription() != null) {
+                    description = metaData.getDescription();
+                }
+                if (metaData.getLabels() != null) {
+                    labels = metaData.getLabels();
+                }
+                if (metaData.getProperties() != null) {
+                    properties = metaData.getProperties();
+                }
 
-            // Now create the version and return the new version metadata.
-            ArtifactVersionMetaDataDto versionDto = this.createArtifactVersion(handle, artifactType, false, groupId, artifactId, version,
-                    name, description, labels, properties, createdBy, createdOn, contentId, globalIdGenerator);
-            ArtifactMetaDataDto dto = versionToArtifactDto(groupId, artifactId, versionDto);
-            dto.setCreatedOn(latest.getCreatedOn());
-            dto.setCreatedBy(latest.getCreatedBy());
-            dto.setLabels(labels);
-            dto.setProperties(properties);
-            return dto;
-        });
+                // Now create the version and return the new version metadata.
+                ArtifactVersionMetaDataDto versionDto = this.createArtifactVersion(handle, artifactType, false, groupId, artifactId, version,
+                        name, description, labels, properties, createdBy, createdOn, contentId, globalIdGenerator);
+                ArtifactMetaDataDto dto = versionToArtifactDto(groupId, artifactId, versionDto);
+                dto.setCreatedOn(latest.getCreatedOn());
+                dto.setCreatedBy(latest.getCreatedBy());
+                dto.setLabels(labels);
+                dto.setProperties(properties);
+                return dto;
+            });
+        } catch (Exception e) {
+            if (sqlStatements.isPrimaryKeyViolation(e)) {
+                throw new VersionAlreadyExistsException(groupId, artifactId, version);
+            }
+            throw new RegistryStorageException(e);
+        }
     }
 
     /**
@@ -2951,6 +2959,19 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
                     .mapTo(Long.class)
                     .list();
         });
+    }
+
+    /**
+     * @see RegistryStorage#isArtifactExists(String, String)
+     */
+    @Override
+    public boolean isArtifactVersionExists(String groupId, String artifactId, String version) throws RegistryStorageException {
+        try {
+            getArtifactVersionMetaData(groupId, artifactId, version);
+            return true;
+        } catch (VersionNotFoundException ignored) {
+            return false;
+        }
     }
 
     private void resolveReferences(Map<String, ContentHandle> resolvedReferences, List<ArtifactReferenceDto> references) {

--- a/client/src/main/java/io/apicurio/registry/rest/client/exception/ExceptionMapper.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/exception/ExceptionMapper.java
@@ -29,6 +29,8 @@ public class ExceptionMapper {
         switch (ex.getError().getName()) {
             case "ArtifactAlreadyExistsException":
                 return new ArtifactAlreadyExistsException(ex.getError());
+            case "VersionAlreadyExistsException":
+                return new VersionAlreadyExistsException(ex.getError());
             case "ArtifactNotFoundException":
                 return new ArtifactNotFoundException(ex.getError());
             case "RuleNotFoundException":

--- a/client/src/main/java/io/apicurio/registry/rest/client/exception/VersionAlreadyExistsException.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/exception/VersionAlreadyExistsException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.rest.client.exception;
+
+
+import io.apicurio.registry.rest.v2.beans.Error;
+
+/**
+ * @author Miroslav Safar 'msafar@redhat.com'
+ */
+public class VersionAlreadyExistsException extends ConflictException {
+
+    private static final long serialVersionUID = 1L;
+
+    public VersionAlreadyExistsException(Error error) {
+        super(error);
+    }
+}

--- a/client/src/main/java/io/apicurio/registry/rest/client/impl/RegistryClientImpl.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/impl/RegistryClientImpl.java
@@ -244,6 +244,9 @@ public class RegistryClientImpl implements RegistryClient {
         if (canonical != null) {
             queryParams.put(Parameters.CANONICAL, Collections.singletonList(String.valueOf(canonical)));
         }
+        if (ifExists != null) {
+            queryParams.put(Parameters.IF_EXISTS, Collections.singletonList(ifExists.value()));
+        }
 
         return apicurioHttpClient.sendRequest(GroupRequestsProvider.createArtifact(normalizeGid(groupId), headers, data, queryParams));
     }

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/ApicurioV2BaseIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/ApicurioV2BaseIT.java
@@ -116,6 +116,16 @@ public class ApicurioV2BaseIT extends ApicurioRegistryBaseIT {
         return amd;
     }
 
+    protected ArtifactMetaData createArtifact(String groupId, String artifactId, String version, IfExists ifExists, ArtifactType artifactType, InputStream artifact) throws Exception {
+        ArtifactMetaData amd = registryClient.createArtifact(groupId, artifactId, version, artifactType, ifExists, false, artifact);
+
+        // make sure we have schema registered
+        ensureClusterSync(amd.getGlobalId());
+        ensureClusterSync(amd.getGroupId(), amd.getId(), String.valueOf(amd.getVersion()));
+
+        return amd;
+    }
+
     protected VersionMetaData createArtifactVersion(String groupId, String artifactId, InputStream artifact) throws Exception {
         VersionMetaData meta = registryClient.createArtifactVersion(groupId, artifactId, null, artifact);
 

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
@@ -19,8 +19,10 @@ import io.apicurio.registry.rest.client.exception.ArtifactAlreadyExistsException
 import io.apicurio.registry.rest.client.exception.ArtifactNotFoundException;
 import io.apicurio.registry.rest.client.exception.InvalidArtifactIdException;
 import io.apicurio.registry.rest.client.exception.RuleViolationException;
+import io.apicurio.registry.rest.client.exception.VersionAlreadyExistsException;
 import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.v2.beans.ArtifactSearchResults;
+import io.apicurio.registry.rest.v2.beans.IfExists;
 import io.apicurio.registry.rest.v2.beans.Rule;
 import io.apicurio.registry.rest.v2.beans.SortBy;
 import io.apicurio.registry.rest.v2.beans.SortOrder;
@@ -202,6 +204,20 @@ class ArtifactsIT extends ApicurioV2BaseIT {
 
         ByteArrayInputStream iad = new ByteArrayInputStream("{\"type\":\"record\",\"name\":\"alreadyExistArtifact\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}".getBytes(StandardCharsets.UTF_8));
         assertClientError(ArtifactAlreadyExistsException.class.getSimpleName(), 409, () -> createArtifact(groupId, artifactId, ArtifactType.AVRO, iad), true, errorCodeExtractor);
+    }
+
+    @Test
+    @Tag(ACCEPTANCE)
+    void testVersionAlreadyExistsIfExistsUpdate() throws Exception {
+        ByteArrayInputStream artifactData = new ByteArrayInputStream("{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}".getBytes(StandardCharsets.UTF_8));
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+        ArtifactMetaData metaData = createArtifact(groupId, artifactId, "1.1", IfExists.FAIL, ArtifactType.AVRO, artifactData);
+        LOGGER.info("Created artifact {} with metadata {}", artifactId, metaData.toString());
+
+        ByteArrayInputStream sameArtifactData = new ByteArrayInputStream("{\"type\":\"record\",\"name\":\"myrecord1\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}".getBytes(StandardCharsets.UTF_8));
+
+        assertClientError(VersionAlreadyExistsException.class.getSimpleName(), 409, () -> createArtifact(groupId, artifactId, "1.1", IfExists.UPDATE, ArtifactType.AVRO, sameArtifactData), true, errorCodeExtractor);
     }
 
     @Test

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -37,6 +37,7 @@ import io.apicurio.registry.storage.RegistryStorageException;
 import io.apicurio.registry.storage.RoleMappingNotFoundException;
 import io.apicurio.registry.storage.RuleAlreadyExistsException;
 import io.apicurio.registry.storage.RuleNotFoundException;
+import io.apicurio.registry.storage.VersionAlreadyExistsException;
 import io.apicurio.registry.storage.VersionNotFoundException;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
@@ -497,6 +498,10 @@ public class KafkaSqlRegistryStorage extends AbstractRegistryStorage {
             ArtifactType artifactType, ContentHandle content, EditableArtifactMetaDataDto metaData, List<ArtifactReferenceDto> references) throws ArtifactNotFoundException, RegistryStorageException {
         if (!sqlStore.isArtifactExists(groupId, artifactId)) {
             throw new ArtifactNotFoundException(groupId, artifactId);
+        }
+
+        if (version != null && sqlStore.isArtifactVersionExists(groupId, artifactId, version)) {
+            throw new VersionAlreadyExistsException(groupId, artifactId, version);
         }
 
         String contentHash = ensureContent(content, groupId, artifactId, artifactType, references);
@@ -1248,6 +1253,14 @@ public class KafkaSqlRegistryStorage extends AbstractRegistryStorage {
     @Override
     public List<Long> getGlobalIdsReferencingArtifact(String groupId, String artifactId, String version) {
         return sqlStore.getGlobalIdsReferencingArtifact(groupId, artifactId, version);
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.RegistryStorage#isArtifactVersionExists(String, String, String)
+     */
+    @Override
+    public boolean isArtifactVersionExists(String groupId, String artifactId, String version) throws RegistryStorageException {
+        return sqlStore.isArtifactVersionExists(groupId, artifactId, version);
     }
 
     protected void importEntity(Entity entity) throws RegistryStorageException {


### PR DESCRIPTION
This PR adds new registry exception - version already exists exception. It is thrown when client tries to create new artifact version with the version string, that is already in use for this artifact.

Fixes  #2609