### PR TITLE
New Feature:  Change Artifact Owner(ship)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/auth/AbstractAccessController.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AbstractAccessController.java
@@ -1,0 +1,92 @@
+package io.apicurio.registry.auth;
+
+import io.apicurio.registry.storage.NotFoundException;
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
+import io.apicurio.registry.storage.dto.GroupMetaDataDto;
+import io.apicurio.registry.types.Current;
+import io.quarkus.security.identity.SecurityIdentity;
+
+import javax.inject.Inject;
+import javax.interceptor.InvocationContext;
+
+public abstract class AbstractAccessController implements IAccessController {
+
+    @Inject
+    AuthConfig authConfig;
+
+    @Inject
+    SecurityIdentity securityIdentity;
+
+    @Inject
+    @Current
+    RegistryStorage storage;
+
+    protected boolean isOwner(InvocationContext context) {
+        Authorized annotation = context.getMethod().getAnnotation(Authorized.class);
+        AuthorizedStyle style = annotation.style();
+
+        if (style == AuthorizedStyle.GroupAndArtifact) {
+            String groupId = getStringParam(context, 0);
+            String artifactId = getStringParam(context, 1);
+            return verifyArtifactCreatedBy(groupId, artifactId);
+        } else if (style == AuthorizedStyle.GroupOnly && authConfig.ownerOnlyAuthorizationLimitGroupAccess.get()) {
+            String groupId = getStringParam(context, 0);
+            return verifyGroupCreatedBy(groupId);
+        } else if (style == AuthorizedStyle.ArtifactOnly) {
+            String artifactId = getStringParam(context, 0);
+            return verifyArtifactCreatedBy(null, artifactId);
+        } else if (style == AuthorizedStyle.GlobalId) {
+            long globalId = getLongParam(context, 0);
+            return verifyArtifactCreatedBy(globalId);
+        } else {
+            return true;
+        }
+    }
+
+    private boolean verifyGroupCreatedBy(String groupId) {
+        try {
+            GroupMetaDataDto dto = storage.getGroupMetaData(groupId);
+            String createdBy = dto.getCreatedBy();
+            return createdBy == null || createdBy.equals(securityIdentity.getPrincipal().getName());
+        } catch (NotFoundException nfe) {
+            // If the group is not found, then return true and let the operation proceed.
+            return true;
+        }
+    }
+
+    private boolean verifyArtifactCreatedBy(String groupId, String artifactId) {
+        try {
+            ArtifactMetaDataDto dto = storage.getArtifactMetaData(groupId, artifactId);
+            String createdBy = dto.getCreatedBy();
+            return createdBy == null || createdBy.equals(securityIdentity.getPrincipal().getName());
+        } catch (NotFoundException nfe) {
+            // If the artifact is not found, then return true and let the operation proceed
+            // as normal. The result of which will typically be a 404 response, but sometimes
+            // will be some other result (e.g. creating an artifact that doesn't exist)
+            return true;
+        }
+    }
+
+    private boolean verifyArtifactCreatedBy(long globalId) {
+        try {
+            ArtifactMetaDataDto dto = storage.getArtifactMetaData(globalId);
+            String createdBy = dto.getCreatedBy();
+            return createdBy == null || createdBy.equals(securityIdentity.getPrincipal().getName());
+        } catch (NotFoundException nfe) {
+            // If the artifact is not found, then return true and let the operation proceed
+            // as normal. The result of which will typically be a 404 response, but sometimes
+            // will be some other result (e.g. creating an artifact that doesn't exist)
+            return true;
+        }
+    }
+
+    protected String getStringParam(InvocationContext context, int index) {
+        return (String) context.getParameters()[index];
+    }
+
+    protected Long getLongParam(InvocationContext context, int index) {
+        return (Long) context.getParameters()[index];
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/auth/AuthorizedLevel.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthorizedLevel.java
@@ -21,6 +21,6 @@ package io.apicurio.registry.auth;
  */
 public enum AuthorizedLevel {
 
-    None, Read, Write, Admin
+    None, Read, Write, Admin, AdminOrOwner
 
 }

--- a/app/src/main/java/io/apicurio/registry/auth/OwnerBasedAccessController.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OwnerBasedAccessController.java
@@ -16,32 +16,14 @@
 
 package io.apicurio.registry.auth;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.interceptor.InvocationContext;
-
-import io.apicurio.registry.storage.NotFoundException;
-import io.apicurio.registry.storage.RegistryStorage;
-import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
-import io.apicurio.registry.storage.dto.GroupMetaDataDto;
-import io.apicurio.registry.types.Current;
-import io.quarkus.security.identity.SecurityIdentity;
 
 /**
  * @author eric.wittmann@gmail.com
  */
 @Singleton
-public class OwnerBasedAccessController implements IAccessController {
-
-    @Inject
-    AuthConfig authConfig;
-
-    @Inject
-    SecurityIdentity securityIdentity;
-
-    @Inject
-    @Current
-    RegistryStorage storage;
+public class OwnerBasedAccessController extends AbstractAccessController {
 
     /**
      * @see io.apicurio.registry.auth.IAccessController#isAuthorized(javax.interceptor.InvocationContext)
@@ -49,7 +31,6 @@ public class OwnerBasedAccessController implements IAccessController {
     @Override
     public boolean isAuthorized(InvocationContext context) {
         Authorized annotation = context.getMethod().getAnnotation(Authorized.class);
-        AuthorizedStyle style = annotation.style();
         AuthorizedLevel level = annotation.level();
 
         // Only protect level == Write operations
@@ -57,67 +38,7 @@ public class OwnerBasedAccessController implements IAccessController {
             return true;
         }
 
-        if (style == AuthorizedStyle.GroupAndArtifact) {
-            String groupId = getStringParam(context, 0);
-            String artifactId = getStringParam(context, 1);
-            return verifyArtifactCreatedBy(groupId, artifactId);
-        } else if (style == AuthorizedStyle.GroupOnly && authConfig.ownerOnlyAuthorizationLimitGroupAccess.get()) {
-            String groupId = getStringParam(context, 0);
-            return verifyGroupCreatedBy(groupId);
-        } else if (style == AuthorizedStyle.ArtifactOnly) {
-            String artifactId = getStringParam(context, 0);
-            return verifyArtifactCreatedBy(null, artifactId);
-        } else if (style == AuthorizedStyle.GlobalId) {
-            long globalId = getLongParam(context, 0);
-            return verifyArtifactCreatedBy(globalId);
-        } else {
-            return true;
-        }
-    }
-
-    private boolean verifyGroupCreatedBy(String groupId) {
-        try {
-            GroupMetaDataDto dto = storage.getGroupMetaData(groupId);
-            String createdBy = dto.getCreatedBy();
-            return createdBy == null || createdBy.equals(securityIdentity.getPrincipal().getName());
-        } catch (NotFoundException nfe) {
-            // If the group is not found, then return true and let the operation proceed.
-            return true;
-        }
-    }
-
-    private boolean verifyArtifactCreatedBy(String groupId, String artifactId) {
-        try {
-            ArtifactMetaDataDto dto = storage.getArtifactMetaData(groupId, artifactId);
-            String createdBy = dto.getCreatedBy();
-            return createdBy == null || createdBy.equals(securityIdentity.getPrincipal().getName());
-        } catch (NotFoundException nfe) {
-            // If the artifact is not found, then return true and let the operation proceed
-            // as normal. The result of which will typically be a 404 response, but sometimes
-            // will be some other result (e.g. creating an artifact that doesn't exist)
-            return true;
-        }
-    }
-
-    private boolean verifyArtifactCreatedBy(long globalId) {
-        try {
-            ArtifactMetaDataDto dto = storage.getArtifactMetaData(globalId);
-            String createdBy = dto.getCreatedBy();
-            return createdBy == null || createdBy.equals(securityIdentity.getPrincipal().getName());
-        } catch (NotFoundException nfe) {
-            // If the artifact is not found, then return true and let the operation proceed
-            // as normal. The result of which will typically be a 404 response, but sometimes
-            // will be some other result (e.g. creating an artifact that doesn't exist)
-            return true;
-        }
-    }
-
-    private static String getStringParam(InvocationContext context, int index) {
-        return (String) context.getParameters()[index];
-    }
-
-    private static Long getLongParam(InvocationContext context, int index) {
-        return (Long) context.getParameters()[index];
+        return isOwner(context);
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/auth/RoleBasedAccessController.java
+++ b/app/src/main/java/io/apicurio/registry/auth/RoleBasedAccessController.java
@@ -24,10 +24,7 @@ import javax.interceptor.InvocationContext;
  * @author eric.wittmann@gmail.com
  */
 @Singleton
-public class RoleBasedAccessController implements IAccessController {
-
-    @Inject
-    AuthConfig authConfig;
+public class RoleBasedAccessController extends AbstractAccessController {
 
     @Inject
     StorageRoleProvider storageRoleProvider;
@@ -52,6 +49,8 @@ public class RoleBasedAccessController implements IAccessController {
                 return isReadOnly() || isDeveloper() || isAdmin();
             case Write:
                 return isDeveloper() || isAdmin();
+            case AdminOrOwner:
+                return isAdmin() || isOwner(context);
             default:
                 throw new RuntimeException("Unhandled case: " + level);
         }

--- a/app/src/main/java/io/apicurio/registry/events/EventSourcedRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/events/EventSourcedRegistryStorage.java
@@ -38,6 +38,7 @@ import io.apicurio.registry.storage.RuleNotFoundException;
 import io.apicurio.registry.storage.VersionNotFoundException;
 import io.apicurio.registry.storage.decorator.RegistryStorageDecorator;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
+import io.apicurio.registry.storage.dto.ArtifactOwnerDto;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
 import io.apicurio.registry.storage.dto.ContentWrapperDto;
 import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
@@ -190,6 +191,12 @@ public class EventSourcedRegistryStorage extends RegistryStorageDecorator {
     public void updateArtifactMetaData(String groupId, String artifactId, EditableArtifactMetaDataDto metaData) throws ArtifactNotFoundException, RegistryStorageException {
         delegate.updateArtifactMetaData(groupId, artifactId, metaData);
         //no event here, UPDATE_ARTIFACT is for cases where a new version is added
+    }
+
+    @Override
+    public void updateArtifactOwner(String groupId, String artifactId, ArtifactOwnerDto owner) throws ArtifactNotFoundException, RegistryStorageException {
+        super.updateArtifactOwner(groupId, artifactId, owner);
+        //TODO consider a change ownership event
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/logging/audit/AuditingConstants.java
+++ b/app/src/main/java/io/apicurio/registry/logging/audit/AuditingConstants.java
@@ -22,5 +22,6 @@ package io.apicurio.registry.logging.audit;
 public interface AuditingConstants {
 
     String KEY_PROPERTY_CONFIGURATION = "property_configuration";
+    String KEY_OWNER = "owner";
 
 }

--- a/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
@@ -30,6 +30,7 @@ import io.apicurio.registry.rest.MissingRequiredParameterException;
 import io.apicurio.registry.rest.ParametersConflictException;
 import io.apicurio.registry.rest.RestConfig;
 import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.v2.beans.ArtifactOwner;
 import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rest.v2.beans.ArtifactSearchResults;
 import io.apicurio.registry.rest.v2.beans.ContentCreateRequest;
@@ -116,6 +117,7 @@ import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_RULE_T
 import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_SHA;
 import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_UPDATE_STATE;
 import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_VERSION;
+import static io.apicurio.registry.logging.audit.AuditingConstants.KEY_OWNER;
 
 /**
  * Implements the {@link GroupsResource} JAX-RS interface.
@@ -296,6 +298,21 @@ public class GroupsResourceImpl implements GroupsResource {
         dto.setLabels(data.getLabels());
         dto.setProperties(data.getProperties());
         storage.updateArtifactMetaData(gidOrNull(groupId), artifactId, dto);
+    }
+    
+    @Override
+    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Read)
+    public ArtifactOwner getArtifactOwner(String groupId, String artifactId) {
+    	// TODO Auto-generated method stub
+    	return null;
+    }
+
+    @Override
+    @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_OWNER})
+    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.AdminOrOwner)
+    public void updateArtifactOwner(String groupId, String artifactId, ArtifactOwner data) {
+    	// TODO Auto-generated method stub
+    	
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
@@ -28,6 +28,7 @@ import io.apicurio.common.apps.config.DynamicConfigStorage;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.mt.TenantContext;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
+import io.apicurio.registry.storage.dto.ArtifactOwnerDto;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
 import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
@@ -303,6 +304,16 @@ public interface RegistryStorage extends DynamicConfigStorage {
      * @throws RegistryStorageException
      */
     public void updateArtifactMetaData(String groupId, String artifactId, EditableArtifactMetaDataDto metaData) throws ArtifactNotFoundException, RegistryStorageException;
+
+    /**
+     * Updates the owner (created-by) for an artifact by group and ID.
+     * @param groupId (optional)
+     * @param artifactId
+     * @param owner
+     * @throws ArtifactNotFoundException
+     * @throws RegistryStorageException
+     */
+    public void updateArtifactOwner(String groupId, String artifactId, ArtifactOwnerDto owner) throws ArtifactNotFoundException, RegistryStorageException;
 
     /**
      * Gets a list of rules configured for a specific Artifact (by group and ID).  This will return only the names of the

--- a/app/src/main/java/io/apicurio/registry/storage/decorator/RegistryStorageDecorator.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/RegistryStorageDecorator.java
@@ -36,6 +36,7 @@ import io.apicurio.registry.storage.RuleAlreadyExistsException;
 import io.apicurio.registry.storage.RuleNotFoundException;
 import io.apicurio.registry.storage.VersionNotFoundException;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
+import io.apicurio.registry.storage.dto.ArtifactOwnerDto;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
 import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
@@ -446,6 +447,11 @@ public abstract class RegistryStorageDecorator implements RegistryStorage {
                                    RuleConfigurationDto config)
         throws ArtifactNotFoundException, RuleNotFoundException, RegistryStorageException {
         delegate.updateArtifactRule(groupId, artifactId, rule, config);
+    }
+
+    @Override
+    public void updateArtifactOwner(String groupId, String artifactId, ArtifactOwnerDto owner) throws ArtifactNotFoundException, RegistryStorageException {
+        delegate.updateArtifactOwner(groupId, artifactId, owner);
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactOwnerDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactOwnerDto.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Red Hat
+ * Copyright 2020 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage.dto;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.*;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@EqualsAndHashCode
+@ToString
+@RegisterForReflection
+public class ArtifactOwnerDto {
+
+    private String owner;
+
+    /**
+     * @return the owner
+     */
+    public String getOwner() {
+        return owner;
+    }
+
+    /**
+     * @param Owner the owner to set
+     */
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -41,6 +41,7 @@ import javax.inject.Inject;
 import javax.transaction.Transactional;
 
 import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.dto.ArtifactOwnerDto;
 import io.apicurio.registry.utils.impexp.EntityType;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -1342,6 +1343,38 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
         ArtifactMetaDataDto dto = this.getLatestArtifactMetaDataInternal(groupId, artifactId);
 
         internalUpdateArtifactVersionMetadata(dto.getGlobalId(), groupId, artifactId, dto.getVersion(), metaData);
+    }
+
+    /**
+     * @see RegistryStorage#updateArtifactOwner(String, String, ArtifactOwnerDto)
+     */
+    @Override @Transactional
+    public void updateArtifactOwner(String groupId, String artifactId, ArtifactOwnerDto owner) throws ArtifactNotFoundException, RegistryStorageException {
+        log.debug("Updating ownership of an artifact: {} {}", groupId, artifactId);
+
+        try {
+            this.handles.withHandle( handle -> {
+                String sql = sqlStatements.updateArtifactOwner();
+                int rowCount = handle.createUpdate(sql)
+                        .bind(0, owner.getOwner())
+                        .bind(1, tenantContext.tenantId())
+                        .bind(2, normalizeGroupId(groupId))
+                        .bind(3, artifactId)
+                        .execute();
+                if (rowCount == 0) {
+                    if (!isArtifactExists(groupId, artifactId)) {
+                        throw new ArtifactNotFoundException(groupId, artifactId);
+                    }
+                    // Likely someone tried to set the owner to the same value.  That is
+                    // not an error.  No need to throw.
+                }
+                return null;
+            });
+        } catch (StorageException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RegistryStorageException(e);
+        }
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -319,6 +319,11 @@ public abstract class CommonSqlStatements implements SqlStatements {
         return "UPDATE rules SET configuration = ? WHERE tenantId = ? AND groupId = ? AND artifactId = ? AND type = ?";
     }
 
+    @Override
+    public String updateArtifactOwner() {
+        return "UPDATE artifacts SET createdBy = ? WHERE tenantId = ? AND groupId = ? AND artifactId = ?";
+    }
+
     /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#deleteArtifactRule()
      */

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -233,6 +233,11 @@ public interface SqlStatements {
     public String updateArtifactRule();
 
     /**
+     * A statement to update a single artifact owner.
+     */
+    public String updateArtifactOwner();
+
+    /**
      * A statement to delete a single artifact rule.
      */
     public String deleteArtifactRule();

--- a/client/src/main/java/io/apicurio/registry/rest/client/RegistryClient.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/RegistryClient.java
@@ -22,22 +22,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
-import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
-import io.apicurio.registry.rest.v2.beans.ArtifactReference;
-import io.apicurio.registry.rest.v2.beans.ArtifactSearchResults;
-import io.apicurio.registry.rest.v2.beans.ConfigurationProperty;
-import io.apicurio.registry.rest.v2.beans.EditableMetaData;
-import io.apicurio.registry.rest.v2.beans.IfExists;
-import io.apicurio.registry.rest.v2.beans.LogConfiguration;
-import io.apicurio.registry.rest.v2.beans.NamedLogConfiguration;
-import io.apicurio.registry.rest.v2.beans.RoleMapping;
-import io.apicurio.registry.rest.v2.beans.Rule;
-import io.apicurio.registry.rest.v2.beans.SortBy;
-import io.apicurio.registry.rest.v2.beans.SortOrder;
-import io.apicurio.registry.rest.v2.beans.UpdateState;
-import io.apicurio.registry.rest.v2.beans.UserInfo;
-import io.apicurio.registry.rest.v2.beans.VersionMetaData;
-import io.apicurio.registry.rest.v2.beans.VersionSearchResults;
+import io.apicurio.registry.rest.v2.beans.*;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.RoleType;
 import io.apicurio.registry.types.RuleType;
@@ -69,7 +54,11 @@ public interface RegistryClient extends Closeable {
 
     ArtifactMetaData getArtifactMetaData(String groupId, String artifactId);
 
+    ArtifactOwner getArtifactOwner(String groupId, String artifactId);
+
     void updateArtifactMetaData(String groupId, String artifactId, EditableMetaData data);
+
+    void updateArtifactOwner(String groupId, String artifactId, ArtifactOwner owner);
 
     VersionMetaData getArtifactVersionMetaDataByContent(String groupId, String artifactId, Boolean canonical, String contentType, InputStream data);
 

--- a/client/src/main/java/io/apicurio/registry/rest/client/impl/RegistryClientImpl.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/impl/RegistryClientImpl.java
@@ -27,24 +27,8 @@ import io.apicurio.registry.rest.client.request.provider.GroupRequestsProvider;
 import io.apicurio.registry.rest.client.request.provider.IdRequestsProvider;
 import io.apicurio.registry.rest.client.request.provider.SearchRequestsProvider;
 import io.apicurio.registry.rest.client.request.provider.UsersRequestsProvider;
-import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
-import io.apicurio.registry.rest.v2.beans.ArtifactReference;
-import io.apicurio.registry.rest.v2.beans.ArtifactSearchResults;
-import io.apicurio.registry.rest.v2.beans.ConfigurationProperty;
-import io.apicurio.registry.rest.v2.beans.ContentCreateRequest;
-import io.apicurio.registry.rest.v2.beans.EditableMetaData;
+import io.apicurio.registry.rest.v2.beans.*;
 import io.apicurio.registry.rest.v2.beans.Error;
-import io.apicurio.registry.rest.v2.beans.IfExists;
-import io.apicurio.registry.rest.v2.beans.LogConfiguration;
-import io.apicurio.registry.rest.v2.beans.NamedLogConfiguration;
-import io.apicurio.registry.rest.v2.beans.RoleMapping;
-import io.apicurio.registry.rest.v2.beans.Rule;
-import io.apicurio.registry.rest.v2.beans.SortBy;
-import io.apicurio.registry.rest.v2.beans.SortOrder;
-import io.apicurio.registry.rest.v2.beans.UpdateState;
-import io.apicurio.registry.rest.v2.beans.UserInfo;
-import io.apicurio.registry.rest.v2.beans.VersionMetaData;
-import io.apicurio.registry.rest.v2.beans.VersionSearchResults;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.types.RoleType;
@@ -99,9 +83,23 @@ public class RegistryClientImpl implements RegistryClient {
     }
 
     @Override
+    public ArtifactOwner getArtifactOwner(String groupId, String artifactId) {
+        return apicurioHttpClient.sendRequest(GroupRequestsProvider.getArtifactOwner(normalizeGid(groupId), artifactId));
+    }
+
+    @Override
     public void updateArtifactMetaData(String groupId, String artifactId, EditableMetaData data) {
         try {
             apicurioHttpClient.sendRequest(GroupRequestsProvider.updateArtifactMetaData(normalizeGid(groupId), artifactId, data));
+        } catch (JsonProcessingException e) {
+            throw new RestClientException(new Error());
+        }
+    }
+
+    @Override
+    public void updateArtifactOwner(String groupId, String artifactId, ArtifactOwner owner) {
+        try {
+            apicurioHttpClient.sendRequest(GroupRequestsProvider.updateArtifactOwner(normalizeGid(groupId), artifactId, owner));
         } catch (JsonProcessingException e) {
             throw new RestClientException(new Error());
         }

--- a/client/src/main/java/io/apicurio/registry/rest/client/request/provider/GroupRequestsProvider.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/request/provider/GroupRequestsProvider.java
@@ -294,12 +294,33 @@ public class GroupRequestsProvider {
                 .build();
     }
 
+    public static Request<Void> updateArtifactOwner(String groupId, String artifactId, ArtifactOwner owner) throws JsonProcessingException {
+        return new Request.RequestBuilder<Void>()
+                .operation(Operation.PUT)
+                .path(Routes.ARTIFACT_OWNER)
+                .pathParams(List.of(groupId, artifactId))
+                .data(IoUtil.toStream(mapper.writeValueAsBytes(owner)))
+                .responseType(new TypeReference<Void>() {
+                })
+                .build();
+    }
+
     public static Request<ArtifactMetaData> getArtifactMetaData(String groupId, String artifactId) {
         return new Request.RequestBuilder<ArtifactMetaData>()
                 .operation(Operation.GET)
                 .path(Routes.ARTIFACT_METADATA)
                 .pathParams(List.of(groupId, artifactId))
                 .responseType(new TypeReference<ArtifactMetaData>() {
+                })
+                .build();
+    }
+
+    public static Request<ArtifactOwner> getArtifactOwner(String groupId, String artifactId) {
+        return new Request.RequestBuilder<ArtifactOwner>()
+                .operation(Operation.GET)
+                .path(Routes.ARTIFACT_OWNER)
+                .pathParams(List.of(groupId, artifactId))
+                .responseType(new TypeReference<ArtifactOwner>() {
                 })
                 .build();
     }

--- a/client/src/main/java/io/apicurio/registry/rest/client/request/provider/Routes.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/request/provider/Routes.java
@@ -39,6 +39,7 @@ public class Routes {
     protected static final String ARTIFACT_RULE = ARTIFACT_RULES + "/%s";
     protected static final String ARTIFACT_STATE = ARTIFACT_BASE_PATH + "/state";
     protected static final String ARTIFACT_TEST = ARTIFACT_BASE_PATH + "/test";
+    protected static final String ARTIFACT_OWNER = ARTIFACT_BASE_PATH + "/owner";
 
     protected static final String VERSION_METADATA = ARTIFACT_VERSION + "/meta";
     protected static final String VERSION_STATE = ARTIFACT_VERSION + "/state";

--- a/common/src/main/java/io/apicurio/registry/rest/v2/AdminResource.java
+++ b/common/src/main/java/io/apicurio/registry/rest/v2/AdminResource.java
@@ -179,8 +179,7 @@ public interface AdminResource {
   @Path("/roleMappings/{principalId}")
   @GET
   @Produces("application/json")
-  RoleMapping getRoleMapping(@PathParam("principalId") String principalId,
-      @PathParam("principalId") String principalId);
+  RoleMapping getRoleMapping(@PathParam("principalId") String principalId);
 
   /**
    * Updates a single role mapping for one user/principal.

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-security-configuration.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-security-configuration.adoc
@@ -153,7 +153,7 @@ To enable using roles managed internally by {registry}, set the following enviro
 |Type
 |Default
 |`ROLE_BASED_AUTHZ_SOURCE`
-| When set to `application`, user are managed internally by {registry}.
+| When set to `application`, user roles are managed internally by {registry}.
 |String
 |`token`
 |===

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -39,6 +39,7 @@ import io.apicurio.registry.storage.RuleAlreadyExistsException;
 import io.apicurio.registry.storage.RuleNotFoundException;
 import io.apicurio.registry.storage.VersionNotFoundException;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
+import io.apicurio.registry.storage.dto.ArtifactOwnerDto;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
 import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
@@ -567,6 +568,18 @@ public class KafkaSqlRegistryStorage extends AbstractRegistryStorage {
 
         UUID reqId = ConcurrentUtil.get(submitter.submitArtifactVersion(tenantContext.tenantId(), groupId, artifactId, metaDataDto.getVersion(),
                 ActionType.UPDATE, metaDataDto.getState(), metaData));
+        coordinator.waitForResponse(reqId);
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.RegistryStorage#updateArtifactOwner(String, String, ArtifactOwnerDto)
+     */
+    @Override
+    public void updateArtifactOwner(String groupId, String artifactId, ArtifactOwnerDto owner) throws ArtifactNotFoundException, RegistryStorageException {
+        // Note: the next line will throw ArtifactNotFoundException if the artifact does not exist, so there is no need for an extra check.
+        ArtifactMetaDataDto metaDataDto = sqlStore.getArtifactMetaData(groupId, artifactId);
+
+        UUID reqId = ConcurrentUtil.get(submitter.submitArtifactOwner(tenantContext.tenantId(), groupId, artifactId, ActionType.UPDATE, owner.getOwner()));
         coordinator.waitForResponse(reqId);
     }
 

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
@@ -24,6 +24,8 @@ import java.util.concurrent.CompletableFuture;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import io.apicurio.registry.storage.impl.kafkasql.keys.ArtifactOwnerKey;
+import io.apicurio.registry.storage.impl.kafkasql.values.ArtifactOwnerValue;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 
@@ -162,6 +164,16 @@ public class KafkaSqlSubmitter {
     }
     public CompletableFuture<UUID> submitVersion(String tenantId, String groupId, String artifactId, String version, ActionType action) {
         return submitArtifactVersion(tenantId, groupId, artifactId, version, action, null, null);
+    }
+
+
+    /* ******************************************************************************************
+     * Artifact Owner
+     * ****************************************************************************************** */
+    public CompletableFuture<UUID> submitArtifactOwner(String tenantId, String groupId, String artifactId, ActionType action, String owner) {
+        ArtifactOwnerKey key = ArtifactOwnerKey.create(tenantId, groupId, artifactId);
+        ArtifactOwnerValue value = ArtifactOwnerValue.create(action, owner);
+        return send(key, value);
     }
 
 

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/MessageType.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/MessageType.java
@@ -37,7 +37,8 @@ public enum MessageType {
     RoleMapping(10),
     GlobalAction(11),
     Download(12),
-    ConfigProperty(13)
+    ConfigProperty(13),
+    ArtifactOwner(14),
     ;
 
     private final byte ord;

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ArtifactOwnerKey.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ArtifactOwnerKey.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage.impl.kafkasql.keys;
+
+import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+@RegisterForReflection
+public class ArtifactOwnerKey extends AbstractMessageKey {
+
+    private String groupId;
+    private String artifactId;
+
+    /**
+     * Creator method.
+     * @param tenantId
+     * @param groupId
+     * @param artifactId
+     */
+    public static final ArtifactOwnerKey create(String tenantId, String groupId, String artifactId) {
+        ArtifactOwnerKey key = new ArtifactOwnerKey();
+        key.setTenantId(tenantId);
+        key.setGroupId(groupId);
+        key.setArtifactId(artifactId);
+        return key;
+    }
+
+    /**
+     * @see MessageKey#getType()
+     */
+    @Override
+    public MessageType getType() {
+        return MessageType.ArtifactOwner;
+    }
+
+    /**
+     * @see MessageKey#getPartitionKey()
+     */
+    @Override
+    public String getPartitionKey() {
+        return getTenantId() + "/" + groupId + "/" + artifactId;
+    }
+
+    /**
+     * @return the groupId
+     */
+    public String getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * @param groupId the groupId to set
+     */
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    /**
+     * @return the artifactId
+     */
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    /**
+     * @param artifactId the artifactId to set
+     */
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    /**
+     * @see Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "ArtifactRuleKey [groupId=" + groupId + ", artifactId=" + artifactId + "]";
+    }
+
+}

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/MessageTypeToKeyClass.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/MessageTypeToKeyClass.java
@@ -74,6 +74,9 @@ public class MessageTypeToKeyClass {
                 case ConfigProperty:
                     index.put(type, ConfigPropertyKey.class);
                     break;
+                case ArtifactOwner:
+                    index.put(type, ArtifactOwnerKey.class);
+                    break;
                 default:
                     throw new RuntimeException("[MessageTypeToKeyClass] Type not mapped: " + type);
             }

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactOwnerValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactOwnerValue.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.storage.impl.kafkasql.values;
+
+import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.ToString;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+@RegisterForReflection
+@ToString
+public class ArtifactOwnerValue extends AbstractMessageValue {
+
+    private String owner;
+
+    /**
+     * Creator method.
+     * @param action
+     * @param owner
+     */
+    public static final ArtifactOwnerValue create(ActionType action, String owner) {
+        ArtifactOwnerValue value = new ArtifactOwnerValue();
+        value.setAction(action);
+        value.setOwner(owner);
+        return value;
+    }
+    
+    /**
+     * @see MessageValue#getType()
+     */
+    @Override
+    public MessageType getType() {
+        return MessageType.ArtifactOwner;
+    }
+
+    /**
+     * @return the owner
+     */
+    public String getOwner() {
+        return owner;
+    }
+
+    /**
+     * @param owner the owner to set
+     */
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+    
+}

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/MessageTypeToValueClass.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/MessageTypeToValueClass.java
@@ -73,6 +73,9 @@ public class MessageTypeToValueClass {
                 case ConfigProperty:
                     index.put(type, ConfigPropertyValue.class);
                     break;
+                case ArtifactOwner:
+                    index.put(type, ArtifactOwnerValue.class);
+                    break;
                 default:
                     throw new RuntimeException("[MessageTypeToValueClass] Type not mapped: " + type);
             }

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/JWKSMockServer.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/JWKSMockServer.java
@@ -49,6 +49,7 @@ public class JWKSMockServer implements QuarkusTestResourceLifecycleManager {
 
     public static String ADMIN_CLIENT_ID = "admin-client";
     public static String DEVELOPER_CLIENT_ID = "developer-client";
+    public static String DEVELOPER_2_CLIENT_ID = "developer-2-client";
     public static String READONLY_CLIENT_ID = "readonly-client";
 
     public static String NO_ROLE_CLIENT_ID = "no-role-client";
@@ -92,6 +93,7 @@ public class JWKSMockServer implements QuarkusTestResourceLifecycleManager {
         stubForClient(ADMIN_CLIENT_ID);
         //Developer user stub
         stubForClient(DEVELOPER_CLIENT_ID);
+        stubForClient(DEVELOPER_2_CLIENT_ID);
         //Read only user stub
         stubForClient(READONLY_CLIENT_ID);
         //Token without roles stub
@@ -154,6 +156,8 @@ public class JWKSMockServer implements QuarkusTestResourceLifecycleManager {
         if (userName.equals(ADMIN_CLIENT_ID)) {
             b.claim("groups", "sr-admin");
         } else if (userName.equals(DEVELOPER_CLIENT_ID)) {
+            b.claim("groups", "sr-developer");
+        } else if (userName.equals(DEVELOPER_2_CLIENT_ID)) {
             b.claim("groups", "sr-developer");
         } else if (userName.equals(READONLY_CLIENT_ID)) {
             b.claim("groups", "sr-readonly");


### PR DESCRIPTION
## Overview 
This PR adds support for changing the owner of an Artifact.  Support is only added to the REST API.  A future PR will add support via the UI and another for the CLI.

There are two new REST API operations (for one new endpoint):

### Get Artifact Owner
![image](https://user-images.githubusercontent.com/1890703/186964160-f7cc630e-9138-4807-b5c6-6a0ad4e65605.png)

### Update Artifact Owner
![image](https://user-images.githubusercontent.com/1890703/186964209-7511c037-43d2-4916-90af-82e59d219edd.png)

Note that the `Update Artifact Owner` operation is unique in that it can be called successfully only by the current owner of the artifact or by a user with the Admin role.
