### PR TITLE
Implement Change Owner modal in the UI

### DIFF
--- a/ui/config/config-keycloakjs-rbac.js
+++ b/ui/config/config-keycloakjs-rbac.js
@@ -14,7 +14,8 @@ var ApicurioRegistryConfig = {
             url: "https://studio-auth.apicur.io/auth",
             realm: "apicurio-local",
             clientId:"apicurio-registry",
-            onLoad: "login-required"
+            onLoad: "login-required",
+            checkLoginIframe: false
         }
     },
     features: {

--- a/ui/config/config-keycloakjs.js
+++ b/ui/config/config-keycloakjs.js
@@ -14,7 +14,8 @@ var ApicurioRegistryConfig = {
             url: "https://studio-auth.apicur.io/auth",
             realm: "apicurio-local",
             clientId:"apicurio-registry",
-            onLoad: "login-required"
+            onLoad: "login-required",
+            checkLoginIframe: false
         }
     },
     features: {

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf dist",
     "build": "webpack --config webpack.prod.js",
     "start": "webpack serve --hot --color --progress --config webpack.dev.js",
-    "lint": "eslint src/**/*.ts"
+    "lint": "eslint --ext=.ts ./src"
   },
   "devDependencies": {
     "@apicurio/eslint-config": "0.2.0",

--- a/ui/src/app/components/common/ifAuth.tsx
+++ b/ui/src/app/components/common/ifAuth.tsx
@@ -27,6 +27,8 @@ export interface IfAuthProps extends PureComponentProps {
     isAuthenticated?: boolean;
     isAdmin?: boolean;
     isDeveloper?: boolean;
+    isOwner?: boolean;
+    isAdminOrOwner?: boolean;
     owner?: string;
     children?: React.ReactNode;
 }
@@ -75,6 +77,19 @@ export class IfAuth extends PureComponent<IfAuthProps, IfAuthState> {
         }
         if (this.props.isDeveloper !== undefined) {
             rval = rval && (auth.isUserDeveloper(this.props.owner) === this.props.isDeveloper);
+        }
+        if (this.props.isOwner !== undefined && this.props.owner) {
+            if (this.props.isOwner) {
+                rval = rval && (auth.isUserId(this.props.owner));
+            } else {
+                rval = rval && (!auth.isUserId(this.props.owner));
+            }
+        }
+        if (this.props.isAdminOrOwner === true && this.props.owner) {
+            rval = rval && (
+                auth.isUserAdmin() === true ||
+                auth.isUserId(this.props.owner)
+            );
         }
         return rval;
     }

--- a/ui/src/app/pages/artifactVersion/components/modals/changeOwnerModal.tsx
+++ b/ui/src/app/pages/artifactVersion/components/modals/changeOwnerModal.tsx
@@ -1,0 +1,90 @@
+import React, { FunctionComponent, useEffect, useState } from "react";
+import "./editMetaDataModal.css";
+import { Button, Form, FormGroup, Modal, Text, TextInput } from "@patternfly/react-core";
+import { Principal, Services } from "../../../../../services";
+import { SelectPrincipalAccount } from "../../../roles";
+
+
+/**
+ * Properties
+ */
+export type ChangeOwnerModalProps = {
+    isOpen: boolean;
+    currentOwner: string;
+    onClose: () => void;
+    onChangeOwner: (newOwner: string) => void;
+};
+
+export const ChangeOwnerModal: FunctionComponent<ChangeOwnerModalProps> = (
+    { isOpen, onClose, currentOwner, onChangeOwner }: ChangeOwnerModalProps) => {
+
+    const [isValid, setValid] = useState(false);
+    const [newOwner, setNewOwner] = useState<string>();
+    const [isAccountToggled, setAccountToggled] = useState(false);
+    const principals: Principal[] | undefined = Services.getConfigService().principals();
+
+    // Validate the inputs.
+    useEffect(() => {
+        if (newOwner && newOwner.trim().length > 0 && newOwner !== currentOwner) {
+            setValid(true);
+        } else {
+            setValid(false);
+        }
+    }, [isOpen, newOwner]);
+
+    const onEscapePressed = () => {
+        if (!isAccountToggled) {
+            onClose();
+        }
+    };
+
+    return (
+        <Modal
+            title="Change owner"
+            variant="medium"
+            isOpen={isOpen}
+            onClose={onClose}
+            onEscapePress={onEscapePressed}
+            className="change-owner pf-m-redhat-font"
+            actions={[
+                <Button key="edit" variant="primary" data-testid="modal-btn-edit" onClick={() => { onChangeOwner(newOwner || "") }} isDisabled={!isValid}>Change owner</Button>,
+                <Button key="cancel" variant="link" data-testid="modal-btn-cancel" onClick={onClose}>Cancel</Button>
+            ]}
+        >
+            <Form>
+                <FormGroup label="Current owner" fieldId="form-current-owner">
+                    <Text>{ currentOwner }</Text>
+                </FormGroup>
+                <FormGroup label="New owner" fieldId="form-new-owner" isRequired={true}>
+                    {
+                        principals ?
+                            <SelectPrincipalAccount
+                                id={newOwner}
+                                onToggle={(isToggled) => {
+                                    setAccountToggled(isToggled);
+                                }}
+                                onIdUpdate={(id: string) => {
+                                    console.debug("=====> ID update: ", id);
+                                    setNewOwner(id);
+                                }}
+                                isUsersOnly={true}
+                                initialOptions={principals || []}
+                                isUpdateAccess={false}
+                            />:
+                            <TextInput
+                                isRequired={true}
+                                type="text"
+                                id="form-new-owner"
+                                data-testid="form-new-owner"
+                                name="form-new-owner"
+                                aria-describedby="form-new-owner-helper"
+                                value={newOwner}
+                                onChange={setNewOwner}
+                            />
+                    }
+                </FormGroup>
+            </Form>
+        </Modal>
+    );
+
+};

--- a/ui/src/app/pages/artifactVersion/components/tabs/info.tsx
+++ b/ui/src/app/pages/artifactVersion/components/tabs/info.tsx
@@ -44,6 +44,7 @@ import { DownloadIcon, PencilAltIcon } from "@patternfly/react-icons";
 import Moment from "react-moment";
 import { IfFeature } from "../../../../components/common/ifFeature";
 import { ArtifactMetaData, Rule } from "../../../../../models";
+import { If } from "../../../../components/common/if";
 
 /**
  * Properties
@@ -58,6 +59,7 @@ export interface InfoTabContentProps extends PureComponentProps {
     onConfigureRule: (ruleType: string, config: string) => void;
     onDownloadArtifact: () => void;
     onEditMetaData: () => void;
+    onChangeOwner: () => void;
 }
 
 /**
@@ -93,7 +95,7 @@ export class InfoTabContent extends PureComponent<InfoTabContentProps, InfoTabCo
                                                 <Button id="edit-action"
                                                         data-testid="artifact-btn-edit"
                                                         onClick={this.props.onEditMetaData}
-                                                        variant="link"><PencilAltIcon />{' '}Edit</Button>
+                                                        variant="link"><PencilAltIcon />{" "}Edit</Button>
                                             </IfFeature>
                                         </IfAuth>
                                     </SplitItem>
@@ -105,7 +107,7 @@ export class InfoTabContent extends PureComponent<InfoTabContentProps, InfoTabCo
                             <DescriptionList className="metaData" isCompact={true}>
                                 <DescriptionListGroup>
                                     <DescriptionListTerm>Name</DescriptionListTerm>
-                                    <DescriptionListDescription className={!this.props.artifact.name ? 'empty-state-text' : ''}>{this.artifactName()}</DescriptionListDescription>
+                                    <DescriptionListDescription className={!this.props.artifact.name ? "empty-state-text" : ""}>{this.artifactName()}</DescriptionListDescription>
                                 </DescriptionListGroup>
                                 <DescriptionListGroup>
                                     <DescriptionListTerm>ID</DescriptionListTerm>
@@ -113,7 +115,7 @@ export class InfoTabContent extends PureComponent<InfoTabContentProps, InfoTabCo
                                 </DescriptionListGroup>
                                 <DescriptionListGroup>
                                     <DescriptionListTerm>Description</DescriptionListTerm>
-                                    <DescriptionListDescription className={!this.props.artifact.description ? 'empty-state-text' : ''}>{this.description()}</DescriptionListDescription>
+                                    <DescriptionListDescription className={!this.props.artifact.description ? "empty-state-text" : ""}>{this.description()}</DescriptionListDescription>
                                 </DescriptionListGroup>
                                 <DescriptionListGroup>
                                     <DescriptionListTerm>Status</DescriptionListTerm>
@@ -123,6 +125,24 @@ export class InfoTabContent extends PureComponent<InfoTabContentProps, InfoTabCo
                                     <DescriptionListTerm>Created</DescriptionListTerm>
                                     <DescriptionListDescription><Moment date={this.props.artifact.createdOn} fromNow={true} /></DescriptionListDescription>
                                 </DescriptionListGroup>
+                                <If condition={this.props.artifact.createdBy !== undefined && this.props.artifact.createdBy !== ""}>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Owner</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <span>{this.props.artifact.createdBy}</span>
+                                            <span>
+                                                <IfAuth isAdminOrOwner={true} owner={this.props.artifact.createdBy}>
+                                                    <IfFeature feature="readOnly" isNot={true}>
+                                                        <Button id="edit-action"
+                                                                data-testid="artifact-btn-edit"
+                                                                onClick={this.props.onChangeOwner}
+                                                                variant="link"><PencilAltIcon /></Button>
+                                                    </IfFeature>
+                                                </IfAuth>
+                                            </span>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                </If>
                                 <DescriptionListGroup>
                                     <DescriptionListTerm>Modified</DescriptionListTerm>
                                     <DescriptionListDescription>{<Moment date={this.props.artifact.modifiedOn} fromNow={true} />}</DescriptionListDescription>
@@ -203,11 +223,11 @@ export class InfoTabContent extends PureComponent<InfoTabContentProps, InfoTabCo
     }
 
     private description(): string {
-        return this.props.artifact.description || `No description`;
+        return this.props.artifact.description || "No description";
     }
 
     private artifactName(): string {
-        return this.props.artifact.name || 'No name';
+        return this.props.artifact.name || "No name";
     }
 
     private isArtifactInGroup = (): boolean => {

--- a/ui/src/app/pages/roles/components/modals/grantAccessModal.tsx
+++ b/ui/src/app/pages/roles/components/modals/grantAccessModal.tsx
@@ -103,7 +103,7 @@ export class GrantAccessModal extends PureComponent<GrantAccessModalProps, Grant
     public render(): React.ReactElement {
         const {isFetchingMappingRole, accountId} = this.state;
         const {isUpdateAccess, defaultRole} = this.props;
-        const principals: Principal[] | undefined =Services.getConfigService().principals();
+        const principals: Principal[] | undefined = Services.getConfigService().principals();
 
         return (
             <Modal

--- a/ui/src/app/pages/roles/components/modals/selectPrincipalAccount.tsx
+++ b/ui/src/app/pages/roles/components/modals/selectPrincipalAccount.tsx
@@ -27,6 +27,7 @@ export interface SelectPrincipalAccountProps extends PureComponentProps {
     initialOptions: Principal[];
     onToggle: (isOpen: boolean) => void;
     isUpdateAccess: boolean;
+    isUsersOnly?: boolean;
     defaultRole?: RoleMapping;
 }
 
@@ -57,6 +58,7 @@ export class SelectPrincipalAccount extends PureComponent<SelectPrincipalAccount
             id: "",
             isOpen: false
         });
+        this.props.onIdUpdate("");
     };
 
     private onSelect = (_event: any, selection: any, isPlaceholder: any) => {
@@ -65,8 +67,8 @@ export class SelectPrincipalAccount extends PureComponent<SelectPrincipalAccount
         } else {
             this.setSingleState("id", selection);
             this.onToggle(false);
+            this.props.onIdUpdate(selection);
         }
-        this.props.onIdUpdate(selection);
     };
 
     protected initializeState(): SelectPrincipalAccountState {
@@ -121,8 +123,10 @@ export class SelectPrincipalAccount extends PureComponent<SelectPrincipalAccount
                 principal.principalType === "SERVICE_ACCOUNT"
         ).filter(
             (principal) =>
-                principal.id.toLowerCase().includes(criteria.toLowerCase()) ||
-                principal.displayName?.toLowerCase().includes(criteria.toLowerCase())
+                !this.props.isUsersOnly && (
+                    principal.id.toLowerCase().includes(criteria.toLowerCase()) ||
+                    principal.displayName?.toLowerCase().includes(criteria.toLowerCase())
+                )
         );
         const filteredUsers: Principal[] = this.props.initialOptions.filter(
             (principal) =>

--- a/ui/src/models/artifactOwner.model.ts
+++ b/ui/src/models/artifactOwner.model.ts
@@ -1,0 +1,6 @@
+
+export class ArtifactOwner {
+
+    public owner: string;
+
+}

--- a/ui/src/models/index.ts
+++ b/ui/src/models/index.ts
@@ -26,3 +26,4 @@ export * from "./userInfo.model";
 export * from "./versionMetaData.model";
 export * from "./downloadRef.model";
 export * from "./apiError.model";
+export * from "./artifactOwner.model";

--- a/ui/src/services/auth/auth.service.ts
+++ b/ui/src/services/auth/auth.service.ts
@@ -27,6 +27,7 @@ export interface AuthenticatedUser {
     username: string;
     displayName: string;
     fullName: string;
+    roles?: any;
 }
 
 /**
@@ -223,6 +224,10 @@ export class AuthService implements Service {
             return false;
         }
         return true;
+    }
+
+    public isUserId(userId: string): boolean {
+        return this.users.currentUser().username === userId;
     }
 
     public authenticateAndRender(render: () => void): void {

--- a/ui/src/services/groups/groups.service.ts
+++ b/ui/src/services/groups/groups.service.ts
@@ -15,7 +15,15 @@
  * limitations under the License.
  */
 
-import { ArtifactMetaData, ContentTypes, Rule, SearchedArtifact, SearchedVersion, VersionMetaData } from "../../models";
+import {
+    ArtifactMetaData,
+    ArtifactOwner,
+    ContentTypes,
+    Rule,
+    SearchedArtifact,
+    SearchedVersion,
+    VersionMetaData
+} from "../../models";
 import { BaseService } from "../baseService";
 import YAML from "yaml";
 
@@ -153,6 +161,16 @@ export class GroupsService extends BaseService {
             endpoint = this.endpoint("/v2/groups/:groupId/artifacts/:artifactId/meta", { groupId, artifactId });
         }
         return this.httpPut<EditableMetaData>(endpoint, metaData);
+    }
+
+    public updateArtifactOwner(groupId: string|null, artifactId: string, newOwner: string): Promise<void> {
+        groupId = this.normalizeGroupId(groupId);
+
+        const endpoint: string = this.endpoint("/v2/groups/:groupId/artifacts/:artifactId/owner", { groupId, artifactId });
+        const artifactOwner: ArtifactOwner = {
+            owner: newOwner
+        };
+        return this.httpPut<ArtifactOwner>(endpoint, artifactOwner);
     }
 
     public getArtifactContent(groupId: string|null, artifactId: string, version: string): Promise<string> {

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Implemented the UI for Change Owner.  Includes adding an "Owner" field to the artifact details page, with a pencil icon next to it (only when applicable and allowed).

## New "Owner" property in metadata
![image](https://user-images.githubusercontent.com/1890703/187523977-f2eb695f-207b-409b-bbb2-3e7373ba30f9.png)

## Change Owner modal
![image](https://user-images.githubusercontent.com/1890703/187524117-1933dc67-856e-4ae5-8719-6eae7a331ddd.png)

If a source of principals is available we'll use the typeahead control.  If not we'll use a standard text box.
