### PR TITLE
Change the Create Artifact (by URL) UI to be more consistent with RHOAD

### DIFF
--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/selenium/SeleniumProvider.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/selenium/SeleniumProvider.java
@@ -15,20 +15,9 @@
  */
 package io.apicurio.tests.selenium;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
+import io.apicurio.tests.common.Constants;
+import io.apicurio.tests.selenium.resources.WebItem;
+import io.apicurio.tests.ui.pages.BasePage;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.openqa.selenium.By;
@@ -42,12 +31,25 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.apicurio.tests.common.Constants;
-import io.apicurio.tests.selenium.resources.WebItem;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 public class SeleniumProvider {
@@ -179,6 +181,16 @@ public class SeleniumProvider {
         }
     }
 
+    public void takeScreenShot(String path) {
+        try {
+            log.warn("Taking screenshot");
+            File file = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
+            FileUtils.copyFile(file, new File(path));
+        } catch (Exception ex) {
+            log.warn("Cannot take screenshot: {}", ex.getMessage());
+        }
+    }
+
     public void clearScreenShots() {
         if (browserScreenshots != null) {
             browserScreenshots.clear();
@@ -276,6 +288,10 @@ public class SeleniumProvider {
 
     public <T extends WebItem> T waitUntilItemPresent(int timeInSeconds, Supplier<T> item) throws Exception {
         return waitUntilItem(timeInSeconds, item, true);
+    }
+
+    public void waitUntilItemClickableByDataId(String dataId) {
+        getDriverWait().withTimeout(Duration.ofSeconds(5)).until(ExpectedConditions.elementToBeClickable(BasePage.byDataTestId(dataId)));
     }
 
     public void waitUntilItemNotPresent(int timeInSeconds, Supplier<WebItem> item) throws Exception {

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/ui/RegistryUITester.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/ui/RegistryUITester.java
@@ -89,7 +89,7 @@ public class RegistryUITester {
 
     }
 
-    public String uploadArtifactFromURL(String groupId, String artifactId, ArtifactType type, String url, String artifactSHA) throws UnsupportedEncodingException {
+    public String uploadArtifactFromURL(String groupId, String artifactId, ArtifactType type, String url) throws UnsupportedEncodingException {
 
         UploadArtifactDialog uploadDialog = openUploadArtifactDialog();
 
@@ -104,15 +104,28 @@ public class RegistryUITester {
         selenium.clickOnItem(uploadDialog.getArtifactTypeDropdownToggle());
         selenium.clickOnItem(uploadDialog.getArtifactTypeDropdownItem(type));
 
-        selenium.fillInputItem(uploadDialog.getArtifactURL(), url);
-        if (artifactSHA != null) {
-            selenium.fillInputItem(uploadDialog.getArtifactSHA(), artifactSHA);
-        }
+        // Switch to the "From URL tab"
+        selenium.clickOnItem(uploadDialog.getFromUrlTab());
+
+        // Wait for the tab to switch
+        selenium.waitUntilItemClickableByDataId("artifact-content-url-input");
 
         try {
+            selenium.fillInputItem(uploadDialog.getArtifactURL(), url);
+            selenium.clickOnItem(uploadDialog.getFetchButton());
+        } finally {
+            selenium.takeScreenShot();
+        }
+
+        selenium.takeScreenShot("C:\\Temp\\BEFORE.png");
+
+        try {
+            // Wait for the content to be fetched
+            selenium.waitUntilItemClickableByDataId("modal-btn-upload");
             selenium.clickOnItem(uploadDialog.getUploadButton());
         } finally {
             selenium.takeScreenShot();
+            selenium.takeScreenShot("C:\\Temp\\AFTER.png");
         }
 
         try {

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/ui/UploadArtifactsIT.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/ui/UploadArtifactsIT.java
@@ -58,14 +58,14 @@ public class UploadArtifactsIT extends ApicurioV2BaseIT {
     }
 
     public void doTestFromURL(RegistryClient client, String fromURL, ArtifactType type, String artifactId, boolean autodetect) throws Exception {
-        doTest(client, null, type, artifactId, autodetect, fromURL, null);
+        doTest(client, null, type, artifactId, autodetect, fromURL);
     }
 
     public void doTest(RegistryClient client, String resource, ArtifactType type, String artifactId, boolean autodetect) throws Exception {
-        doTest(client, resource, type, artifactId, autodetect, null, null);
+        doTest(client, resource, type, artifactId, autodetect, null);
     }
 
-    public void doTest(RegistryClient client, String resource, ArtifactType type, String artifactId, boolean autodetect, String fromURL, String sha) throws Exception {
+    public void doTest(RegistryClient client, String resource, ArtifactType type, String artifactId, boolean autodetect, String fromURL) throws Exception {
         String groupId = UploadArtifactsIT.class.getName();
 
         assertNotNull(type);
@@ -75,7 +75,7 @@ public class UploadArtifactsIT extends ApicurioV2BaseIT {
         RegistryUITester page = new RegistryUITester(selenium);
         page.openWebPage();
         String webArtifactId = (fromURL == null) ? page.uploadArtifact(groupId, artifactId, autodetect ? null : type, content) :
-                page.uploadArtifactFromURL(groupId, artifactId, autodetect ? null : type, fromURL, sha);
+                page.uploadArtifactFromURL(groupId, artifactId, autodetect ? null : type, fromURL);
 
         if (artifactId != null) {
             assertEquals(artifactId, webArtifactId);
@@ -125,11 +125,12 @@ public class UploadArtifactsIT extends ApicurioV2BaseIT {
     }
 
     @Test
-    void testJsonSchemaFromURL() throws Exception {
+    void testOpenApiFromURL() throws Exception {
+        String testUrl = SeleniumProvider.getInstance().getUiUrl().replace("/ui", "/api-specifications/registry/v2/openapi.json");
         doTestFromURL(
                 registryClient,
-                "http://localhost:8081/api-specifications/registry/v2/openapi.json",
-                ArtifactType.JSON, null, false);
+                testUrl,
+                ArtifactType.OPENAPI, null, false);
     }
 
     //auto-detect, kafka connect excluded because it's known it does not work

--- a/integration-tests/testsuite/src/test/java/io/apicurio/tests/ui/pages/UploadArtifactDialog.java
+++ b/integration-tests/testsuite/src/test/java/io/apicurio/tests/ui/pages/UploadArtifactDialog.java
@@ -60,11 +60,15 @@ public class UploadArtifactDialog extends BasePage {
     }
 
     public WebElement getArtifactURL() {
-        return getUploadArtifactDialog().findElement(byDataTestId("form-url"));
+        return getUploadArtifactDialog().findElement(byDataTestId("artifact-content-url-input"));
     }
 
-    public WebElement getArtifactSHA() {
-        return getUploadArtifactDialog().findElement(byDataTestId("form-sha"));
+    public WebElement getFromUrlTab() {
+        return getUploadArtifactDialog().findElement(byDataTestId("tab-from-url"));
+    }
+
+    public WebElement getFetchButton() {
+        return getUploadArtifactDialog().findElement(byDataTestId("artifact-content-url-fetch"));
     }
 
     public WebElement getUploadButton() {

--- a/ui/src/app/components/common/if.tsx
+++ b/ui/src/app/components/common/if.tsx
@@ -1,66 +1,25 @@
-/**
- * @license
- * Copyright 2020 JBoss Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-import React from "react";
-import { PureComponent, PureComponentProps, PureComponentState } from "../baseComponent";
+import React, { FunctionComponent } from "react";
 
 /**
  * Properties
  */
-export interface IfProps extends PureComponentProps {
+export type IfProps = {
     condition: boolean | (() => boolean);
     children?: React.ReactNode;
-}
-
-/**
- * State
- */
-// tslint:disable-next-line:no-empty-interface
-export interface IfState extends PureComponentState {
-}
-
+};
 
 /**
  * Wrapper around a set of arbitrary child elements and displays them only if the
  * indicated condition is true.
  */
-export class If extends PureComponent<IfProps, IfState> {
-
-    constructor(props: Readonly<IfProps>) {
-        super(props);
-    }
-
-    public render(): React.ReactElement {
-        if (this.accept()) {
-            return <React.Fragment children={this.props.children} />
+export const If: FunctionComponent<IfProps> = ({ condition, children }: IfProps) => {
+    const accept = () => {
+        if (typeof condition === "boolean") {
+            return condition;
         } else {
-            return <React.Fragment />
+            return condition();
         }
-    }
+    };
 
-    protected initializeState(): IfState {
-        return {};
-    }
-
-    private accept(): boolean {
-        if (typeof this.props.condition === "boolean") {
-            return this.props.condition;
-        } else {
-            return this.props.condition();
-        }
-    }
-
-}
+    return (accept() ? <React.Fragment children={children} /> : <React.Fragment />);
+};

--- a/ui/src/app/components/common/index.ts
+++ b/ui/src/app/components/common/index.ts
@@ -19,4 +19,6 @@ export * from "./artifactTypeIcon";
 export * from "./ifAuth";
 export * from "./ifFeature";
 export * from "./ifNotEmpty";
+export * from "./urlUpload";
+export * from "./isLoading";
 

--- a/ui/src/app/components/common/isLoading.tsx
+++ b/ui/src/app/components/common/isLoading.tsx
@@ -1,0 +1,28 @@
+import React, { FunctionComponent } from "react";
+import { Spinner } from "@patternfly/react-core";
+
+/**
+ * Properties
+ */
+export type IsLoadingProps = {
+    condition: boolean | (() => boolean);
+    loadingComponent?: React.ReactNode;
+    children?: React.ReactNode;
+}
+
+/**
+ * Displays a Spinner control while the condition property is true.  When false, the provided children
+ * are displayed.  Useful when displaying content from the results of an async operation such as a REST
+ * call.
+ */
+export const IsLoading: FunctionComponent<IsLoadingProps> = ({ condition, loadingComponent, children }: IsLoadingProps) => {
+    const accept = () => {
+        if (typeof condition === "boolean") {
+            return condition;
+        } else {
+            return condition();
+        }
+    };
+    const lc: React.ReactNode = loadingComponent || <Spinner />;
+    return (accept() ? <React.Fragment children={lc} /> : <React.Fragment children={children} />);
+};

--- a/ui/src/app/components/common/urlUpload.css
+++ b/ui/src/app/components/common/urlUpload.css
@@ -1,0 +1,31 @@
+.url-upload .url-upload-flex {
+    display: flex;
+}
+
+.url-upload .url-upload-flex .url-upload-url {
+    flex-grow: 1;
+}
+
+.url-upload .url-upload-flex .url-upload-button {
+}
+
+.url-upload .url-upload-preview textarea {
+    min-height: 128px;
+}
+
+.url-upload .url-upload-preview .url-upload-loading, .url-upload .url-upload-preview .url-upload-error {
+    padding: 5px;
+    min-height: 128px;
+    border-right: 0px;
+    border-left: 0px;
+    border-bottom: 1px solid #666;
+    background-color: rgb(240, 240, 240);
+}
+.url-upload .url-upload-preview .url-upload-error {
+    color: red;
+    overflow: auto;
+}
+
+.url-upload .url-upload-preview .url-upload-loading .spinner {
+    margin-right: 5px;
+}

--- a/ui/src/app/components/common/urlUpload.css
+++ b/ui/src/app/components/common/urlUpload.css
@@ -6,9 +6,6 @@
     flex-grow: 1;
 }
 
-.url-upload .url-upload-flex .url-upload-button {
-}
-
 .url-upload .url-upload-preview textarea {
     min-height: 128px;
 }

--- a/ui/src/app/components/common/urlUpload.tsx
+++ b/ui/src/app/components/common/urlUpload.tsx
@@ -1,0 +1,100 @@
+import React, { FunctionComponent, useState } from "react";
+import "./urlUpload.css";
+import { Button, Spinner, TextArea, TextInput } from "@patternfly/react-core";
+import { UrlService, useUrlService } from "../../../services";
+import { If } from "./if";
+import { IsLoading } from "./isLoading";
+
+/**
+ * Properties
+ */
+export type UrlUploadProps = {
+    id: string|"url-upload";
+    urlPlaceholder: string|"";
+    onChange: (value: string|undefined, url: string|undefined) => void;
+};
+
+/**
+ * A control similar to the FileUpload control from patternfly that allows uploading from
+ * a URL instead of a file.
+ */
+export const UrlUpload: FunctionComponent<UrlUploadProps> = ({ id, urlPlaceholder, onChange }: UrlUploadProps) => {
+    const [url, setUrl] = useState<string>();
+    const [previewContent, setPreviewContent] = useState<string>();
+    const [isLoading, setLoading] = useState<boolean>(false);
+    const [downloadError, setDownloadError] = useState<string>();
+
+    const urlService: UrlService = useUrlService();
+
+    const onTextInputChange = (value: string): void => {
+        setUrl(value);
+    };
+
+    const hasUrl = (): boolean => {
+        return url != undefined && url.trim().length > 0;
+    };
+
+    const hasError = (): boolean => {
+        return downloadError != undefined && downloadError.trim().length > 0;
+    };
+
+    const onFetch = (): void => {
+        setLoading(true);
+        urlService.fetchUrlContent(url as string).then(content => {
+            setDownloadError(undefined);
+            setPreviewContent(content);
+            setLoading(false);
+            onChange(content, url);
+        }).catch(error => {
+            setDownloadError(error.message);
+            setLoading(false);
+        });
+    };
+
+    const onClear = (): void => {
+        setUrl("");
+        setPreviewContent("");
+        onChange(undefined, undefined);
+    };
+
+    const spinner: React.ReactNode = (
+        <div className="url-upload-loading">
+            <Spinner size="md" className="spinner" />
+            <span className="spinner-message">Loading URL content</span>
+        </div>
+    );
+
+    return (
+        <div className="url-upload">
+            <div className="url-upload-flex">
+                <div className="url-upload-url">
+                    <TextInput value={url} type="text" placeholder={urlPlaceholder} id={id}
+                        onChange={onTextInputChange} aria-label="url input" />
+                </div>
+                <div className="url-upload-button">
+                    <Button variant="control" isDisabled={!hasUrl()} onClick={onFetch}>Fetch</Button>
+                </div>
+                <div className="url-upload-button">
+                    <Button variant="control" isDisabled={!hasUrl()} onClick={onClear}>Clear</Button>
+                </div>
+            </div>
+            <div className="url-upload-preview">
+                <IsLoading condition={isLoading} loadingComponent={spinner}>
+                    <If condition={hasError}>
+                        <div className="url-upload-error">
+                            <div>
+                                Error getting content from URL.
+                            </div>
+                            <div>
+                                {downloadError}
+                            </div>
+                        </div>
+                    </If>
+                    <If condition={!hasError()}>
+                        <TextArea value={previewContent} isReadOnly={true}></TextArea>
+                    </If>
+                </IsLoading>
+            </div>
+        </div>
+    );
+};

--- a/ui/src/app/components/common/urlUpload.tsx
+++ b/ui/src/app/components/common/urlUpload.tsx
@@ -68,14 +68,14 @@ export const UrlUpload: FunctionComponent<UrlUploadProps> = ({ id, urlPlaceholde
         <div className="url-upload">
             <div className="url-upload-flex">
                 <div className="url-upload-url">
-                    <TextInput value={url} type="text" placeholder={urlPlaceholder} id={id}
+                    <TextInput data-testid={`${id}-input`} value={url} type="text" placeholder={urlPlaceholder} id={id}
                         onChange={onTextInputChange} aria-label="url input" />
                 </div>
-                <div className="url-upload-button">
-                    <Button variant="control" isDisabled={!hasUrl()} onClick={onFetch}>Fetch</Button>
+                <div className="url-fetch-button">
+                    <Button data-testid={`${id}-fetch`} variant="control" isDisabled={!hasUrl()} onClick={onFetch}>Fetch</Button>
                 </div>
-                <div className="url-upload-button">
-                    <Button variant="control" isDisabled={!hasUrl()} onClick={onClear}>Clear</Button>
+                <div className="url-clear-button">
+                    <Button data-testid={`${id}-clear`} variant="control" isDisabled={!hasUrl()} onClick={onClear}>Clear</Button>
                 </div>
             </div>
             <div className="url-upload-preview">

--- a/ui/src/app/pages/artifacts/components/uploadForm/uploadForm.tsx
+++ b/ui/src/app/pages/artifacts/components/uploadForm/uploadForm.tsx
@@ -167,7 +167,7 @@ export class UploadArtifactForm extends PureComponent<UploadArtifactFormProps, U
                         isBox={false}
                         role="region"
                     >
-                        <Tab eventKey={0} title={<TabTitleText>From file</TabTitleText>} aria-label="Default content - from file">
+                        <Tab eventKey={0} data-testid="tab-from-file" title={<TabTitleText>From file</TabTitleText>} aria-label="Default content - from file">
                             <FileUpload
                                 id="artifact-content"
                                 data-testid="form-upload"
@@ -182,9 +182,9 @@ export class UploadArtifactForm extends PureComponent<UploadArtifactFormProps, U
                                 isLoading={this.state.contentIsLoading}
                             />
                         </Tab>
-                        <Tab eventKey={1} title={<TabTitleText>From URL</TabTitleText>}>
+                        <Tab eventKey={1} data-testid="tab-from-url" title={<TabTitleText>From URL</TabTitleText>}>
                             <UrlUpload
-                                id="design-text-url"
+                                id="artifact-content-url"
                                 urlPlaceholder="Enter a valid and accessible URL"
                                 onChange={(value, url) => {
                                     this.onContentChange(value, url, {});

--- a/ui/src/services/groups/groups.service.ts
+++ b/ui/src/services/groups/groups.service.ts
@@ -31,9 +31,9 @@ export interface CreateArtifactData {
     groupId: string;
     id: string|null;
     type: string;
-    fromURL: string|null;
-    sha: string|null;
-    content: string|null;
+    fromURL?: string|null;
+    sha?: string|null;
+    content?: string|null;
 }
 
 export interface CreateVersionData {

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -24,3 +24,4 @@ export * from "./groups";
 export * from "./logger";
 export * from "./services";
 export * from "./users";
+export * from "./url";

--- a/ui/src/services/url.ts
+++ b/ui/src/services/url.ts
@@ -1,0 +1,38 @@
+const githubRegex: RegExp = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/([^/]+)\/(.+)$/;
+
+
+async function fetchUrlContent(url: string): Promise<string> {
+    const match: RegExpMatchArray | null = url.match(githubRegex);
+    if (match !== null) {
+        const org: string = match[1];
+        const repo: string = match[2];
+        const branch: string = match[3];
+        const path: string = match[4];
+
+        url = `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${path}`;
+    }
+
+    console.info("[UrlService] Fetching content from a URL: ", url);
+
+    return fetch(url).then(response => {
+        return response.text();
+    });
+}
+
+
+/**
+ * The URL Service interface.
+ */
+export interface UrlService {
+    fetchUrlContent(url: string): Promise<string>;
+}
+
+
+/**
+ * React hook to get the URL service.
+ */
+export const useUrlService: () => UrlService = (): UrlService => {
+    return {
+        fetchUrlContent
+    };
+};


### PR DESCRIPTION
Instead of providing the URL and a SHA, the UI now uses the same `UrlUpload` control as RHOAD.  It looks like this now:

![image](https://user-images.githubusercontent.com/1890703/188209128-640f7e03-0667-4993-b260-60153053af68.png)

The API change that allows users to upload by a URL still exists and works, but he UI now doesn't use it.