### PR TITLE
[feat] Better error handling when downloading artifact contents from URL

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
@@ -716,6 +716,8 @@ public class GroupsResourceImpl implements GroupsResource {
                     .request()
                     .get()
                     .readEntity(InputStream.class), contentLength);
+        } catch (BadRequestException bre) {
+            throw bre;
         } catch (Exception e) {
             throw new BadRequestException("Errors downloading the artifact content.", e);
         }

--- a/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
@@ -685,32 +685,40 @@ public class GroupsResourceImpl implements GroupsResource {
             throw new RuntimeException(nsae);
         }
 
-        // 1. Registry issues HTTP HEAD request to the target URL.
-        List<Object> contentLengthHeaders = client
-                .target(url)
-                .request()
-                .head()
-                .getHeaders()
-                .get("Content-Length");
+        try {
+            // 1. Registry issues HTTP HEAD request to the target URL.
+            List<Object> contentLengthHeaders = client
+                    .target(url)
+                    .request()
+                    .head()
+                    .getHeaders()
+                    .get("Content-Length");
 
-        if (contentLengthHeaders == null || contentLengthHeaders.size() < 1) {
-            throw new BadRequestException("Requested resource URL does not provide 'Content-Length' in the headers");
+            if (contentLengthHeaders == null || contentLengthHeaders.size() < 1) {
+                throw new BadRequestException("Requested resource URL does not provide 'Content-Length' in the headers");
+            }
+
+            // 2. According to HTTP specification, target server must return Content-Length header.
+            int contentLength = Integer.parseInt(contentLengthHeaders.get(0).toString());
+
+            // 3. Registry analyzes value of Content-Length to check if file with declared size could be processed securely.
+            if (contentLength > restConfig.getDownloadMaxSize()) {
+                throw new BadRequestException("Requested resource is bigger than " + restConfig.getDownloadMaxSize() + " and cannot be downloaded.");
+            }
+
+            if (contentLength <= 0) {
+                throw new BadRequestException("Requested resource URL is providing 'Content-Length' <= 0.");
+            }
+
+            // 4. Finally, registry issues HTTP GET to the target URL and fetches only amount of bytes specified by HTTP HEAD from step 1.
+            return new BufferedInputStream(client
+                    .target(url)
+                    .request()
+                    .get()
+                    .readEntity(InputStream.class), contentLength);
+        } catch (Exception e) {
+            throw new BadRequestException("Errors downloading the artifact content.", e);
         }
-
-        // 2. According to HTTP specification, target server must return Content-Length header.
-        int contentLength = Integer.parseInt(contentLengthHeaders.get(0).toString());
-
-        // 3. Registry analyzes value of Content-Length to check if file with declared size could be processed securely.
-        if (contentLength > restConfig.getDownloadMaxSize()) {
-            throw new BadRequestException("Requested resource is bigger than " + restConfig.getDownloadMaxSize() + " and cannot be downloaded.");
-        }
-
-        // 4. Finally, registry issues HTTP GET to the target URL and fetches only amount of bytes specified by HTTP HEAD from step 1.
-        return new BufferedInputStream(client
-                .target(url)
-                .request()
-                .get()
-                .readEntity(InputStream.class), contentLength);
     }
 
     /**


### PR DESCRIPTION
This avoids returning `500` when there are issues downloading the artifact content.

Thanks, @jsenko for noticing it!

resolves #2758