### PR TITLE
Add '--allow-incomplete-classpath' to native builds

### DIFF
--- a/multitenancy/tenant-manager-api/src/main/resources/application.properties
+++ b/multitenancy/tenant-manager-api/src/main/resources/application.properties
@@ -105,6 +105,7 @@ tenant-manager.metrics.usage-statistics.cache-expiration-period-seconds=${METRIC
 
 #
 quarkus.native.resources.includes=db/migration/postgresql/*.sql
+quarkus.native.additional-build-args=--allow-incomplete-classpath
 
 tenant-manager.tenant-reaper.max-tenants-reaped.count=${TENANT_MANAGER_REAPER_MAX_TENANTS_REAPED_COUNT:100}
 tenant-manager.tenant-reaper.period.seconds=${TENANT_MANAGER_REAPER_PERIOD_SECONDS:10800}

--- a/storage/sql/src/main/resources/overlay.properties
+++ b/storage/sql/src/main/resources/overlay.properties
@@ -21,4 +21,5 @@ registry.name=Apicurio Registry (SQL)
 %prod.quarkus.datasource.jdbc.min-size=20
 %prod.quarkus.datasource.jdbc.max-size=100
 
-quarkus.native.additional-build-args=--initialize-at-run-time=org.apache.kafka.common.security.authenticator.SaslClientAuthenticator
+quarkus.native.additional-build-args=--initialize-at-run-time=org.apache.kafka.common.security.authenticator.SaslClientAuthenticator,\
+  --allow-incomplete-classpath


### PR DESCRIPTION
Fast-forwarding Carles fix for `native-image` since it's failing all the CI rebased on latest main.