### PR TITLE
Conditional inclusion of system-tests

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -63,8 +63,7 @@ jobs:
           mvn install
 
       - name: Build and Test All Variants
-        #run: make SKIP_TESTS=false BUILD_FLAGS='-Psystem-tests -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5 --no-transfer-progress' build-all Use once operator ingress issue is fixed
-        run: make SKIP_TESTS=false BUILD_FLAGS='-Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5 --no-transfer-progress -pl !system-tests' build-all
+        run: make SKIP_TESTS=false BUILD_FLAGS='-Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5 --no-transfer-progress' build-all
 
       - name: Login to DockerHub Registry
         if: github.event_name == 'push'

--- a/pom.xml
+++ b/pom.xml
@@ -932,6 +932,11 @@
     <profiles>
         <profile>
             <id>system-tests</id>
+            <activation>
+                <property>
+                    <name>includeSystemTests</name>
+                </property>
+            </activation>
             <modules>
                 <!-- Operator tests module -->
                 <module>system-tests</module>
@@ -1091,17 +1096,6 @@
                     <url>https://jitpack.io</url>
                 </repository>
             </repositories>
-        </profile>
-        <profile>
-            <id>system-tests</id>
-                <activation>
-                    <property>
-                        <name>includeSystemTests</name>
-                    </property>
-                </activation>
-            <modules>
-                <module>system-tests</module>
-            </modules>
         </profile>
     </profiles>
     

--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,6 @@
         <module>schema-util/xml</module>
         <module>schema-util/xsd</module>
         <module>schema-util/util-provider</module>
-
-        <module>system-tests</module>
     </modules>
 
     <properties>
@@ -1093,6 +1091,17 @@
                     <url>https://jitpack.io</url>
                 </repository>
             </repositories>
+        </profile>
+        <profile>
+            <id>system-tests</id>
+                <activation>
+                    <property>
+                        <name>includeSystemTests</name>
+                    </property>
+                </activation>
+            <modules>
+                <module>system-tests</module>
+            </modules>
         </profile>
     </profiles>
     

--- a/pom.xml
+++ b/pom.xml
@@ -932,11 +932,6 @@
     <profiles>
         <profile>
             <id>system-tests</id>
-            <activation>
-                <property>
-                    <name>includeSystemTests</name>
-                </property>
-            </activation>
             <modules>
                 <!-- Operator tests module -->
                 <module>system-tests</module>


### PR DESCRIPTION
To reduce compilation time and restore the previous condition of the CI I'm here proposing to have the `system-tests` module only optionally enabled.

It was added to the main pom here: https://github.com/Apicurio/apicurio-registry/pull/2737/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R141
