### PR TITLE
Revert upgrader back to original SQL

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/upgrader/ProtobufCanonicalHashUpgrader.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/upgrader/ProtobufCanonicalHashUpgrader.java
@@ -47,7 +47,7 @@ public class ProtobufCanonicalHashUpgrader implements IDbUpgrader {
     @Override
     public void upgrade(Handle dbHandle) throws Exception {
 
-        String sql = "SELECT c.contentId, c.content, c.canonicalHash, c.contentHash, c.artifactreferences"
+        String sql = "SELECT c.contentId, c.content, c.canonicalHash, c.contentHash "
                 + "FROM versions v "
                 + "JOIN content c on c.contentId = v.contentId "
                 + "JOIN artifacts a ON v.tenantId = a.tenantId AND v.groupId = a.groupId AND v.artifactId = a.artifactId "


### PR DESCRIPTION
This was a mistake - the upgrader runs as part of upgrading the DB.  The artifact references was added to the DB schema in REV 8.  The proto upgrader is REV 5.  So it should have older SQL, since it's upgrading from REV 4 to REV 5... which is pre-refs.