### PR TITLE
docs: updated + new security options

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-using-kafka-client-serdes.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-using-kafka-client-serdes.adoc
@@ -23,7 +23,7 @@ This chapter explains how to use Kafka client SerDes in your producer and consum
 * You have created Kafka producer and consumer client applications
 +
 ifdef::rh-service-registry[]
-For more details on Kafka client applications, see link:https://access.redhat.com/documentation/en-us/red_hat_amq/{amq-version}/html/using_amq_streams_on_openshift[Using AMQ Streams on OpenShift].
+For more details on Kafka client applications, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}].
 endif::[]
 
 //INCLUDES

--- a/docs/modules/ROOT/partials/getting-started/proc-adding-artifacts-using-console.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-adding-artifacts-using-console.adoc
@@ -31,7 +31,7 @@ endif::[]
 NOTE:  {registry} cannot automatically detect the *Kafka Connect Schema* artifact type. You must manually select this artifact type.
 +
 ** *Artifact*: Specify the artifact location using either of the following options: 
-*** *From file*: Click *Browse*, and select a file, or drag and drop a file. For example, `my-schema.json` or `my-openapi.json`.
+*** *From file*: Click *Browse*, and select a file, or drag and drop a file. For example, `my-openapi.json` or `my-schema.proto`.
 *** *From URL*: Enter a valid and accessible URL, and click *Fetch*. For example: `\https://petstore3.swagger.io/api/v3/openapi.json`.
 . Click *Upload* and view the artifact details: 
 +

--- a/docs/modules/ROOT/partials/getting-started/proc-changing-artifact-owner-using-console.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-changing-artifact-owner-using-console.adoc
@@ -16,7 +16,7 @@ endif::[]
 For example, this feature is useful if the *Artifact owner-only authorization* option is set for the {registry} instance on the *Settings* tab so that only owners or administrators can modify artifacts. You might need to change owner if the owner user leaves the organization or the owner account is deleted. 
 
 ifdef::apicurio-registry,rh-service-registry[]
-NOTE: The artifact *Owner* field and the *Artifact owner-only authorization* setting are only displayed in the web console if authentication was already enabled when the {registry} instance was deployed. For more details, see 
+NOTE: The *Artifact owner-only authorization* setting and the artifact *Owner* field are displayed _only if_ authentication was enabled when the {registry} instance was deployed. For more details, see 
 endif::[] 
 ifdef::apicurio-registry[]
 xref:../getting-started/assembly-configuring-the-registry.adoc[].
@@ -27,7 +27,7 @@ endif::[]
 
 .Prerequisites
 
-* The {registry} instance is already deployed and the artifact is created. 
+* The {registry} instance is deployed and the artifact is created. 
 * You are logged in to the {registry} web console as the artifact's current owner or as an administrator:
 +
 `{registry-url}`
@@ -36,15 +36,15 @@ endif::[]
 
 
 ifdef::rh-openshift-sr[]
-. In the {registry} web console, click the existing {registry} instance. 
+. In the {registry} web console, click the {registry} instance containing the artifact that you want to reassign. 
 endif::[]
 . On the *Artifacts* tab, browse the list of artifacts stored in {registry}, or enter a search string to find the artifact. You can select from the list to search by criteria such as name, group, labels, or global ID.  
 
-. Click the artifact and view the *Owner* field in the *Version metadata*.
+. Click the artifact that you want to reassign.
 
-. Click the pencil icon next to the *Owner* field. 
+. In the *Version metadata* section, click the pencil icon next to the *Owner* field. 
 
-. Select or enter an account name in the *New owner* field and confirm the new account name. 
+. In the *New owner* field, select or enter an account name. 
 
 . Click *Change owner*.
 

--- a/docs/modules/ROOT/partials/getting-started/proc-configuring-registry-security.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-configuring-registry-security.adoc
@@ -144,7 +144,7 @@ TIP: For an example of setting environment variables on OpenShift, see xref:conf
 |Java system property
 |Type
 |Default value
-|`REGISTRY_AUTH_OWNER_ONLY_AUTHORIZATION`
+|`REGISTRY_AUTH_OBAC_ENABLED`
 |`registry.auth.owner-only-authorization`
 |Boolean
 |`false`

--- a/docs/modules/ROOT/partials/getting-started/proc-installing-kafka-streams-operatorhub.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-installing-kafka-streams-operatorhub.adoc
@@ -7,14 +7,16 @@
 = Installing {kafka-streams} from the OpenShift OperatorHub
 // Start the title of a procedure module with a verb, such as Creating or Create. See also _Wording of headings_ in _The IBM Style Guide_.
 
-If you do not already have {kafka-streams} installed, you can install the {kafka-streams} Operator on your OpenShift cluster from the OperatorHub. The OperatorHub is available from the OpenShift Container Platform web console and provides an interface for cluster administrators to discover and install Operators. For more details, see the https://docs.openshift.com/container-platform/{registry-ocp-version}/operators/olm-understanding-operatorhub.html[OpenShift documentation].
+If you do not already have {kafka-streams} installed, you can install the {kafka-streams} Operator on your OpenShift cluster from the OperatorHub. The OperatorHub is available from the OpenShift Container Platform web console and provides an interface for cluster administrators to discover and install Operators. For more details, see link:{LinkOpenShiftIntroOperator}[{NameOpenShiftIntroOperator}].
+
 
 .Prerequisites
 
 * You must have cluster administrator access to an OpenShift cluster 
 ifdef::rh-service-registry[]
-* See link:https://access.redhat.com/documentation/en-us/red_hat_amq/{amq-version}/html/using_amq_streams_on_openshift/index[Using AMQ Streams on OpenShift] for detailed information on installing {kafka-streams}. This section shows a simple example of installing using the OpenShift OperatorHub.
+* See link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}] for detailed information on installing {kafka-streams}. This section shows a simple example of installing using the OpenShift OperatorHub.
 endif::[]
+
 
 .Procedure
 
@@ -46,5 +48,5 @@ endif::[]
 . Click *Install*, and wait a few moments until the Operator is ready for use.
 
 .Additional resources
-* link:https://docs.openshift.com/container-platform/{registry-ocp-version}/operators/olm-adding-operators-to-cluster.html[Adding Operators to an OpenShift cluster]
-* link:https://access.redhat.com/documentation/en-us/red_hat_amq/{amq-version}/html/using_amq_streams_on_openshift/index?[Using AMQ Streams on OpenShift] 
+* link:{LinkOpenShiftAddOperator}[{NameOpenShiftAddOperator}]
+* link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}]

--- a/docs/modules/ROOT/partials/getting-started/proc-installing-postgresql-operatorhub.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-installing-postgresql-operatorhub.adoc
@@ -6,7 +6,9 @@
 = Installing a PostgreSQL database from the OpenShift OperatorHub
 // Start the title of a procedure module with a verb, such as Creating or Create. See also _Wording of headings_ in _The IBM Style Guide_.
 
-If you do not already have a PostgreSQL database Operator installed, you can install a PostgreSQL Operator on your OpenShift cluster from the OperatorHub. The OperatorHub is available from the OpenShift Container Platform web console and provides an interface for cluster administrators to discover and install Operators. For more details, see the https://docs.openshift.com/container-platform/{registry-ocp-version}/operators/olm-understanding-operatorhub.html[OpenShift documentation].
+If you do not already have a PostgreSQL database Operator installed, you can install a PostgreSQL Operator on your OpenShift cluster from the OperatorHub. The OperatorHub is available from the OpenShift Container Platform web console and provides an interface for cluster administrators to discover and install Operators. For more details, see link:{LinkOpenShiftIntroOperator}[{NameOpenShiftIntroOperator}].
+
+
 
 .Prerequisites
 
@@ -35,5 +37,7 @@ IMPORTANT: You must read the documentation from your chosen *PostgreSQL* Operato
 
 .Additional resources
 
-* link:https://docs.openshift.com/container-platform/{registry-ocp-version}/operators/olm-adding-operators-to-cluster.html[Adding Operators to an OpenShift cluster]
+* link:{LinkOpenShiftAddOperator}[{NameOpenShiftAddOperator}]
 * link:https://access.crunchydata.com/documentation/postgres-operator/4.3.2/quickstart/[Crunchy PostgreSQL Operator QuickStart]
+
+

--- a/docs/modules/ROOT/partials/getting-started/proc-installing-registry-operatorhub.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-installing-registry-operatorhub.adoc
@@ -7,7 +7,7 @@
 // Start the title of a procedure module with a verb, such as Creating or Create. See also _Wording of headings_ in _The IBM Style Guide_.
 
 [role="_abstract"]
-You can install the {registry} Operator on your OpenShift cluster from the OperatorHub. The OperatorHub is available from the OpenShift Container Platform web console and provides an interface for cluster administrators to discover and install Operators. For more details, see the link:https://docs.openshift.com/container-platform/{registry-ocp-version}/operators/understanding/olm-understanding-operatorhub.html[OpenShift documentation].
+You can install the {registry} Operator on your OpenShift cluster from the OperatorHub. The OperatorHub is available from the OpenShift Container Platform web console and provides an interface for cluster administrators to discover and install Operators. For more details, see link:{LinkOpenShiftIntroOperator}[{NameOpenShiftIntroOperator}].
 
 NOTE: You can install more than one instance of {registry} depending on your environment. The number of instances depends on the number and type of artifacts stored in {registry} and on your chosen storage option.
 
@@ -46,5 +46,6 @@ endif::[]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.openshift.com/container-platform/{registry-ocp-version}/operators/olm-adding-operators-to-cluster.html[Adding Operators to an OpenShift cluster]
+
+* link:{LinkOpenShiftAddOperator}[{NameOpenShiftAddOperator}]
 * link:https://github.com/Apicurio/apicurio-registry-operator[Apicurio Registry Operator community in GitHub]

--- a/docs/modules/ROOT/partials/getting-started/proc-registry-serdes-register.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-registry-serdes-register.adoc
@@ -47,7 +47,6 @@ endif::[]
 <1> Simple Avro schema artifact.
 <2> OpenShift route name that exposes {registry}.
 
-
 [discrete]
 == Maven plug-in example
 

--- a/docs/modules/ROOT/partials/getting-started/proc-setting-up-kafka-streams-storage.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-setting-up-kafka-streams-storage.adoc
@@ -29,7 +29,7 @@ endif::[]
 .. Under *Provided APIs* and then *Kafka*, click *Create Instance* to create a new Kafka cluster.
 .. Edit the custom resource definition as appropriate, and click *Create*.
 +
-WARNING: The default example creates a cluster with 3 Zookeeper nodes and 3 Kafka nodes with `ephemeral` storage. This temporary storage is suitable for development and testing only, and not for production. For more details, see link:https://access.redhat.com/documentation/en-us/red_hat_amq/{amq-version}/html/using_amq_streams_on_openshift/index?[Using AMQ Streams on OpenShift].
+WARNING: The default example creates a cluster with 3 Zookeeper nodes and 3 Kafka nodes with `ephemeral` storage. This temporary storage is suitable for development and testing only, and not for production. For more details, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}].
 
 . After the cluster is ready, click *Provided APIs* > *Kafka* > *my-cluster* > *YAML*.
 
@@ -89,5 +89,5 @@ endif::[]
 
 ifdef::rh-service-registry[]
 //* For more details, including how to configure Transport Layer Security (TLS) and Salted Challenge Response Authentication Mechanism (SCRAM), see the link:https://github.com/redhat-integration/apicurio-registry-install-examples[example custom resource definitions] provided for registry installation.
-* For more details on creating Kafka clusters and topics using {kafka-streams}, see link:https://access.redhat.com/documentation/en-us/red_hat_amq/{amq-version}/html/using_amq_streams_on_openshift/index?[Using AMQ Streams on OpenShift].
+* For more details on creating Kafka clusters and topics using {kafka-streams}, see link:https://access.redhat.com/documentation/en-us/red_hat_amq_streams/{amq-version}/html/deploying_and_upgrading_amq_streams_on_openshift/index[Deploying and Upgrading AMQ Streams on OpenShift].
 endif::[]

--- a/docs/modules/ROOT/partials/getting-started/proc-setting-up-postgresql-storage.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-setting-up-postgresql-storage.adoc
@@ -91,4 +91,4 @@ http://example-apicurioregistry-sql.my-project.my-domain-name.com/
 .Additional resources
 
  * link:https://access.crunchydata.com/documentation/postgres-operator/4.3.2/quickstart/[Crunchy PostgreSQL Operator QuickStart]
- * https://github.com/Apicurio/apicurio-registry-operator/blob/main/docs/minikube-quickstart.md[Apicurio Registry Operator QuickStart]
+ * https://github.com/Apicurio/apicurio-registry-operator[Apicurio Registry Operator QuickStart]

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-security-configuration.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-security-configuration.adoc
@@ -215,7 +215,7 @@ Because there are no default admin users in {registry}, it is usually helpful to
 |The name of a JWT token claim to use for determining admin-override.
 |String
 |`org-admin`
-|`REGISTRY_AUTH_ADMIN_OVERRIDE_CLAIM-VALUE`
+|`REGISTRY_AUTH_ADMIN_OVERRIDE_CLAIM_VALUE`
 |The value that the JWT token claim indicated by the CLAIM variable must be for the user to be granted admin-override.
 |String
 |`true`

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-security-configuration.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-security-configuration.adoc
@@ -5,12 +5,27 @@
 = {registry} authentication and authorization configuration options
 
 [role="_abstract"]
-{registry} provides configuration options for authentication using Keycloak with OpenID Connect or using HTTP basic authentication.  
+{registry} provides authentication options for OpenID Connect with {keycloak} or HTTP basic authentication.  
 
-{registry} provides configuration options for authorization, including role-based and content-based approaches. These include role-based authorization for default admin, write, and read-only user roles. {registry} also provides content-based authorization at the schema or API level, where only the creator of the registry artifact can update or delete it. {registry} authentication and authorization options are disabled by default.
+{registry} provides authorization options for role-based and content-based approaches: 
+
+* Role-based authorization for default admin, write, and read-only user roles. 
+* Content-based authorization for schema or API artifacts, where only the owner of the artifacts or artifact group can update or delete artifacts. 
+
+NOTE: {registry} authentication and authorization options are disabled by default.
+
+This chapter provides details on the following configuration options: 
+
+* xref:registry-security-authn-keycloak[{registry} authentication using OpenID Connect with {keycloak}]
+* xref:registry-security-authn-http[{registry} authentication using HTTP basic]
+* xref:registry-security-rbac-enabled[{registry} role-based authorization] 
+* xref:registry-security-obac-enabled[{registry} owner-only authorization] 
+* xref:registry-security-auth-read[{registry} authenticated read access] 
+* xref:registry-security-anon-read[{registry} anonymous read-only access] 
 
 [discrete]
-== {registry} authentication using {keycloak} and OpenID Connect
+[id="registry-security-authn-keycloak"]
+== {registry} authentication using OpenID Connect with {keycloak} 
 
 You can set the following environment variables to configure authentication for the {registry} web console and API using {keycloak}:
 
@@ -22,7 +37,7 @@ You can set the following environment variables to configure authentication for 
 |Type
 |Default
 |`AUTH_ENABLED`
-|Enables/disables authentication in registry.  When set to `true`, the environment variables that follow are required.
+|Enables or disables authentication in {registry}.  When set to `true`, the environment variables that follow are required.
 |String
 |`false`
 |`KEYCLOAK_URL`
@@ -44,12 +59,13 @@ You can set the following environment variables to configure authentication for 
 |===
 
 [discrete]
+[id="registry-security-authn-http"]
 == {registry} authentication using HTTP basic
 
 NOTE: By default, {registry} supports authentication using OpenID Connect. Users (or API clients) must obtain an access token to make authenticated calls to the {registry} REST API.  However, because some tools do not support OpenID Connect, you can also configure {registry} to support HTTP basic authentication by setting the following configuration option to `true`.
 
-.Configuration for {registry} to enable HTTP basic authentication support
-[%header,cols="2,2,1,1"]
+.Configuration for {registry} HTTP basic authentication
+[%header,cols="4,4,1,1"]
 |===
 |Environment variable
 |Java system property
@@ -63,12 +79,13 @@ NOTE: By default, {registry} supports authentication using OpenID Connect. Users
 
 
 [discrete]
-== Role-based authorization in {registry}
+[id=registry-security-rbac-enabled]
+==  {registry} role-based authorization
 
 You can set the following option to `true` to enable role-based authorization in {registry}:
 
 .Configuration for {registry} role-based authorization
-[%header,cols="2,2,1,1"]
+[%header,cols="4,4,1,1"]
 |===
 |Environment variable
 |Java system property
@@ -80,14 +97,15 @@ You can set the following option to `true` to enable role-based authorization in
 |`false`
 |===
 
-You can then configure role-based authorization to use roles found in the user's authentication token (for example, granted when authenticating using {keycloak}), or to use role mappings managed internally by {registry}.
+You can then configure role-based authorization to use roles included in the user's authentication token (for example, granted when authenticating using {keycloak}), or to use role mappings managed internally by {registry}.
 
 [discrete]
-=== Using roles from {keycloak}
+=== Use roles assigned in {keycloak}
 
 To enable using roles assigned by {keycloak}, set the following environment variables:
 
 .Configuration for {registry} role-based authorization using {keycloak}
+[id="registry-security-rbac-keycloak-settings"]
 [.table-expandable,width="100%",cols="6,6,2,3",options="header"]
 |===
 |Environment variable
@@ -113,7 +131,7 @@ To enable using roles assigned by {keycloak}, set the following environment vari
 |===
 
 When {registry} is configured to use roles from {keycloak}, you must assign {registry} users to at least one
-of the following user roles in {keycloak}. However, you can configure different user role names using the environment variables in the table above:
+of the following user roles in {keycloak}. However, you can configure different user role names using the environment variables in xref:registry-security-rbac-keycloak-settings[].
 
 .{registry} roles for authentication and authorization
 [.table-expandable,width="100%",cols="2,2,2,2,4",options="header"]
@@ -208,38 +226,69 @@ in {keycloak}, which grants that user the admin role.  That user can then use th
 REST API (or associated UI) to grant roles to additional users (including additional admins).
 
 [discrete]
-== {registry} artifact owner-only authorization option
+[id=registry-security-obac-enabled]
+== {registry} owner-only authorization
 
-You can set the following option to `true` to enable owner-only authorization for updates to schema and API artifacts in {registry}:
+You can set the following options to `true` to enable owner-only authorization for updates to artifacts or artifact groups in {registry}:
 
 .Configuration for owner-only authorization
-[%header,cols="2,2,1,1"]
+[%header,cols="4,4,1,1"]
 |===
 |Environment variable
 |Java system property
 |Type
 |Default value
-|`OWNER_ONLY_AUTHZ_ENABLED`
+
+|`REGISTRY_AUTH_OBAC_ENABLED`
 |`registry.auth.owner-only-authorization`
+|Boolean
+|`false`
+
+|`REGISTRY_AUTH_OBAC_LIMIT_GROUP_ACCESS`
+|`registry.auth.owner-only-authorization.limit-group-access`
 |Boolean
 |`false`
 |===
 
-Enabling owner-only authorization results in a configuration where users with write access can only modify
-content that they themselves created. Users will not be able to update or delete artifacts created by
-other users.
+When owner-only authorization is enabled, only the user who created an artifact can modify or delete that artifact.
+
+When owner-only authorization and group owner-only authorization are both enabled, only the user who created an artifact group has write access to that artifact group, for example, to add or remove artifacts in that group.
 
 [discrete]
-== {registry} anonymous read-only access option
+[id=registry-security-auth-read]
+== {registry} authenticated read access
+
+When the authenticated read access option is enabled, {registry} grants at least read-only access to requests from any authenticated user in the same organization, regardless of their user role. 
+
+To enable authenticated read access, you must first enable role-based authorization, and then set the following option to `true`:
+
+.Configuration for authenticated read access
+[%header,cols="4,4,1,1"]
+|===
+|Environment variable
+|Java system property
+|Type
+|Default value
+|`REGISTRY_AUTH_AUTHENTICATED_READS_ENABLED`
+|`registry.auth.authenticated-read-access.enabled`
+|Boolean
+|`false`
+|===
+
+For more details, see xref:registry-security-rbac-enabled[].
+
+[discrete]
+[id=registry-security-anon-read]
+== {registry} anonymous read-only access
 
 In addition to the two main types of authorization (role-based and owner-based authorization), {registry}
 supports an anonymous read-only access option.
 
-To enable anonymous users, such as REST API calls with no authentication credentials provided, to be allowed to make
-read-only calls to the REST API, set the following option to `true`:
+To allow anonymous users, such as REST API calls with no authentication credentials, to make read-only 
+calls to the REST API, set the following option to `true`:
 
 .Configuration for anonymous read-only access
-[%header,cols="2,2,1,1"]
+[%header,cols="4,4,1,1"]
 |===
 |Environment variable
 |Java system property

--- a/docs/modules/ROOT/partials/shared/attributes-links.adoc
+++ b/docs/modules/ROOT/partials/shared/attributes-links.adoc
@@ -157,13 +157,25 @@
 :LinkServiceRegistryMigration: https://access.redhat.com/documentation/en-us/red_hat_integration/{version}/html-single/migrating_service_registry_deployments/index
 :NameServiceRegistryMigration: Migrating Service Registry deployments
 
+:LinkOpenShiftAddOperator: https://docs.openshift.com/container-platform/{registry-ocp-version}/operators/admin/olm-adding-operators-to-cluster.html
+:NameOpenShiftAddOperator: Adding Operators to an OpenShift cluster
+
+:LinkOpenShiftIntroOperator: https://docs.openshift.com/container-platform/{registry-ocp-version}/operators/understanding/olm-understanding-operatorhub.html
+:NameOpenShiftIntroOperator: Understanding OperatorHub
+
 // AMQ Streams titles
+:StreamsName: AMQ Streams
+:AMQStreamsURLVersion: 2.1
 
-:LinkStreamsOpenShift: https://access.redhat.com/documentation/en-us/red_hat_amq/{amq-version}/html-single/using_amq_streams_on_openshift/index
-:NameStreamsOpenShift: Using AMQ Streams on OpenShift
+:LinkStreamsOpenShift: https://access.redhat.com/documentation/en-us/red_hat_amq_streams/{AMQStreamsURLVersion}/html-single/using_amq_streams_on_openshift/index
+:NameStreamsOpenShift: Using {StreamsName} on OpenShift
 
-:LinkStreamsRhel: https://access.redhat.com/documentation/en-us/red_hat_amq/{amq-version}/html-single/using_amq_streams_on_rhel/index
-:NameStreamsRhel: Using AMQ Streams on RHEL
+:LinkDeployStreamsOpenShift: https://access.redhat.com/documentation/en-us/red_hat_amq_streams/{AMQStreamsURLVersion}/html-single/deploying_and_upgrading_amq_streams_on_openshift/index
+:NameDeployStreamsOpenShift: Deploying and Upgrading {StreamsName} on OpenShift
+
+:LinkStreamsRhel: https://access.redhat.com/documentation/en-us/red_hat_amq_streams/{AMQStreamsURLVersion}/html-single/using_amq_streams_on_rhel/index
+:NameStreamsRhel: Using {StreamsName} on RHEL
+
 
 // Debezium titles
 

--- a/docs/modules/ROOT/partials/shared/attributes.adoc
+++ b/docs/modules/ROOT/partials/shared/attributes.adoc
@@ -51,12 +51,12 @@ endif::[]
 :version: 2022.Q3
 :attachmentsdir: files
 :registry-release: 2.3.0.Final
-:registry-ocp-version: 4.6
+:registry-ocp-version: 4.11
 :registry-db-version: 12
 :registry-url: \http://MY_REGISTRY_URL/ui
 
 //integration products
-:amq-version: 2022.q3
+:amq-version: 2.1
 :fuse-version: 7.11
 :3scale-version: 2.12
 


### PR DESCRIPTION
Updates user docs as follows:
- Update to `REGISTRY_AUTH_OBAC_ENABLED` variable
- Add missing variables for 
 --  `REGISTRY_AUTH_AUTHENTICATED_READS_ENABLED`
 --  `REGISTRY_AUTH_OBAC_LIMIT_GROUP_ACCESS`
- Clean up security config and change artifact owner docs 
- Add feedback from QE testing of downstream docs (mostly link fixes)

Documents following issues:
- #2743 
- #2755