### PR TITLE
Workaround `jackson-coreutils` download issue

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -38,6 +38,13 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      - name: Workaround jackson-coreutils
+        run: |
+          # upstream issue: https://github.com/java-json-tools/jackson-coreutils/issues/59
+          rm -rf ~/.m2/repository/com/github/java-json-tools
+          mkdir -p /tmp/coreutils-workaround
+          ( cd /tmp/coreutils-workaround && mvn dependency:get -DremoteRepositories=https://repo1.maven.org/maven2 -Dartifact=com.github.java-json-tools:jackson-coreutils:2.0 )
+
       - name: Build api-model
         run: |
           git clone https://github.com/Apicurio/apicurio-registry-operator.git


### PR DESCRIPTION
This should be a viable workaround for this issue:
https://github.com/Apicurio/apicurio-registry/actions/runs/3191285239/jobs/5222146661#step:8:2623

The workaround might be necessary in other workflows ...