### PR TITLE
Implement the `jackson-coreutils` workaround in more CI workflows

### DIFF
--- a/.github/workflows/registry-rhbq-build.yaml
+++ b/.github/workflows/registry-rhbq-build.yaml
@@ -36,6 +36,13 @@ jobs:
             java-version: '11'
             distribution: 'temurin'
 
+        - name: Workaround jackson-coreutils
+          run: |
+            # upstream issue: https://github.com/java-json-tools/jackson-coreutils/issues/59
+            rm -rf ~/.m2/repository/com/github/java-json-tools
+            mkdir -p /tmp/coreutils-workaround
+            ( cd /tmp/coreutils-workaround && mvn dependency:get -DremoteRepositories=https://repo1.maven.org/maven2 -Dartifact=com.github.java-json-tools:jackson-coreutils:2.0 )
+
         - name: Configure Red Hat Repository
           run: |
            pwd

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -104,6 +104,13 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      - name: Workaround jackson-coreutils
+        run: |
+          # upstream issue: https://github.com/java-json-tools/jackson-coreutils/issues/59
+          rm -rf ~/.m2/repository/com/github/java-json-tools
+          mkdir -p /tmp/coreutils-workaround
+          ( cd /tmp/coreutils-workaround && mvn dependency:get -DremoteRepositories=https://repo1.maven.org/maven2 -Dartifact=com.github.java-json-tools:jackson-coreutils:2.0 )
+
       - name: Get maven wrapper
         run: mvn -N io.takari:maven:wrapper -Dmaven=3.8.2
 


### PR DESCRIPTION
The workaround seems to be effective.