### PR TITLE
Update keycloak javascript adapter version

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -19,7 +19,7 @@
         "@patternfly/react-table": "4.71.16",
         "ace-builds": "1.7.1",
         "axios": "0.21.2",
-        "keycloak-js": "^10.0.2",
+        "keycloak-js": "^19.0.2",
         "mobx": "^6.5.0",
         "moment": "2.29.4",
         "oidc-client-ts": "^2.0.3",
@@ -4693,7 +4693,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13986,20 +13985,13 @@
       "license": "MIT"
     },
     "node_modules/keycloak-js": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-10.0.2.tgz",
-      "integrity": "sha512-7nkg4Ob1khHGcNbuK36AMndKUEuIQFpNlWU9ygWs7nSBPCI9VZ8dJjjXfKJHm0ewgcqLFGPIJ6bxxRlfcQ6sLg==",
-      "license": "Apache-2.0",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-19.0.3.tgz",
+      "integrity": "sha512-mzCBxrzfl+vB551Q7MB+T9+40IHU4i0a6g1eTatzeEGrQMis5m/BqvPC3kxTsI+/LxHbB9XYQE3u9SlWKDHQCw==",
       "dependencies": {
-        "base64-js": "1.3.1",
-        "js-sha256": "0.9.0"
+        "base64-js": "^1.5.1",
+        "js-sha256": "^0.9.0"
       }
-    },
-    "node_modules/keycloak-js/node_modules/base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "license": "MIT"
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -24209,8 +24201,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "basic-auth": {
       "version": "1.1.0",
@@ -31139,19 +31130,12 @@
       "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "keycloak-js": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-10.0.2.tgz",
-      "integrity": "sha512-7nkg4Ob1khHGcNbuK36AMndKUEuIQFpNlWU9ygWs7nSBPCI9VZ8dJjjXfKJHm0ewgcqLFGPIJ6bxxRlfcQ6sLg==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-19.0.3.tgz",
+      "integrity": "sha512-mzCBxrzfl+vB551Q7MB+T9+40IHU4i0a6g1eTatzeEGrQMis5m/BqvPC3kxTsI+/LxHbB9XYQE3u9SlWKDHQCw==",
       "requires": {
-        "base64-js": "1.3.1",
-        "js-sha256": "0.9.0"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-          "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-        }
+        "base64-js": "^1.5.1",
+        "js-sha256": "^0.9.0"
       }
     },
     "kind-of": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -66,7 +66,7 @@
     "ace-builds": "1.7.1",
     "@apicurio/data-models": "^1.1.26",
     "axios": "0.21.2",
-    "keycloak-js": "^10.0.2",
+    "keycloak-js": "^19.0.2",
     "mobx": "^6.5.0",
     "moment": "2.29.4",
     "react": "17.0.2",


### PR DESCRIPTION
This updates the version of the keycloak js library so the logout redirect works with newer versions of Keycloak.