### PR TITLE
Enable debugging options for the SQL native image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <!-- JSON Schema Validator -->
         <org.everit.json.schema.version>1.14.1</org.everit.json.schema.version><!-- TODO unification -->
         <jackson-datatype-json-org.version>2.13.4</jackson-datatype-json-org.version>
-        <jackson-dataformat-yaml.version>2.14.0</jackson-dataformat-yaml.version>
+        <jackson-dataformat-yaml.version>2.13.4</jackson-dataformat-yaml.version>
 
         <!-- Dependency versions -->
         <lombok.version>1.18.24</lombok.version>

--- a/storage/sql/src/main/resources/overlay.properties
+++ b/storage/sql/src/main/resources/overlay.properties
@@ -22,4 +22,6 @@ registry.name=Apicurio Registry (SQL)
 %prod.quarkus.datasource.jdbc.max-size=100
 
 quarkus.native.additional-build-args=--initialize-at-run-time=org.apache.kafka.common.security.authenticator.SaslClientAuthenticator,\
-  --allow-incomplete-classpath
+  --allow-incomplete-classpath,-H:-DeleteLocalSymbols,-H:+PreserveFramePointer,-H:+AllowVMInspection
+
+quarkus.native.enable-vm-inspection=true


### PR DESCRIPTION
This enables debugging options for the native-image in Operate First, so that we can further investigate in case something misbehave.