### PR TITLE
Enable full DI for ArtifactTypeUtilProviderImpl

### DIFF
--- a/schema-util/util-provider/pom.xml
+++ b/schema-util/util-provider/pom.xml
@@ -17,6 +17,11 @@
     <dependencies>
 
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-schema-util-common</artifactId>
         </dependency>

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ArtifactTypeUtilProviderImpl.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ArtifactTypeUtilProviderImpl.java
@@ -17,6 +17,8 @@
 package io.apicurio.registry.types.provider;
 
 import io.apicurio.registry.types.ArtifactType;
+import javax.enterprise.inject.Default;
+import javax.enterprise.context.ApplicationScoped;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +29,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Ales Justin
  * @author famartin
  */
+@Default
+@ApplicationScoped
 public class ArtifactTypeUtilProviderImpl implements ArtifactTypeUtilProviderFactory {
 
     private Map<ArtifactType, ArtifactTypeUtilProvider> map = new ConcurrentHashMap<>();
@@ -45,6 +49,7 @@ public class ArtifactTypeUtilProviderImpl implements ArtifactTypeUtilProviderFac
                         new XsdArtifactTypeUtilProvider())
             );
 
+    
     @Override
     public ArtifactTypeUtilProvider getArtifactTypeProvider(ArtifactType type) {
         return map.computeIfAbsent(type, t ->

--- a/utils/exportV1/src/main/java/io/apicurio/registry/utils/export/Export.java
+++ b/utils/exportV1/src/main/java/io/apicurio/registry/utils/export/Export.java
@@ -49,7 +49,6 @@ import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
-import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderImpl;
 import io.apicurio.registry.utils.IoUtil;
 import io.apicurio.registry.utils.impexp.ArtifactRuleEntity;
 import io.apicurio.registry.utils.impexp.ArtifactVersionEntity;
@@ -75,7 +74,8 @@ public class Export implements QuarkusApplication {
     @Inject
     Logger log;
 
-    ArtifactTypeUtilProviderFactory factory = new ArtifactTypeUtilProviderImpl();
+    @Inject
+    ArtifactTypeUtilProviderFactory factory;
 
     private boolean matchContentId = false;
 

--- a/utils/exportV1/src/main/resources/application.properties
+++ b/utils/exportV1/src/main/resources/application.properties
@@ -3,3 +3,6 @@ quarkus.package.main-class=RegistryExport
 quarkus.package.type=uber-jar
 
 quarkus.log.level=WARN
+
+quarkus.index-dependency.artifact-type-util-provider-factory.group-id=io.apicurio
+quarkus.index-dependency.artifact-type-util-provider-factory.artifact-id=apicurio-registry-schema-util-provider


### PR DESCRIPTION
Reviewing #2923 I noticed exactly one place where DI was bypassed in order to fully inject a custom `ArtifactTypeUtilProviderFactory`.