### PR TITLE
Update(deployments): Pull container images if not present

### DIFF
--- a/new-system-tests/src/test/resources/keycloak/02_deployment.yaml
+++ b/new-system-tests/src/test/resources/keycloak/02_deployment.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
         - name: keycloak
           image: quay.io/keycloak/keycloak:20.0.1
+          imagePullPolicy: IfNotPresent
           args: ["start-dev", "--import-realm"]
           env:
             - name: KEYCLOAK_ADMIN

--- a/new-system-tests/src/test/resources/sql/01_deployment.yaml
+++ b/new-system-tests/src/test/resources/sql/01_deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: postgresql
               containerPort: 5432
               protocol: TCP
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           image: postgres:15
           volumeMounts:
             - mountPath: /postgresql


### PR DESCRIPTION
Pull image for container if not present only to prevent Docker Hub rate limit exhaustion.