### PR TITLE
Update(OperatorGroup): Create OperatorGroup at the beginning of test(s)

### DIFF
--- a/new-system-tests/src/test/java/io/apicurio/registry/systemtests/SqlKeycloak.java
+++ b/new-system-tests/src/test/java/io/apicurio/registry/systemtests/SqlKeycloak.java
@@ -14,6 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KubernetesTest
 @LoadKubernetesManifests({
+        // Shared resources
+        "/common/00_operator_group.yaml", // Operator group for installed operators in namespace
         // Keycloak IAM
         "/keycloak/00_service.yaml", // Service
         "/keycloak/01_realm.yaml", // Keycloak realm as realm.json in ConfigMap
@@ -22,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         "/sql/00_service.yaml", // Service
         "/sql/01_deployment.yaml", // Deployment
         // Apicurio Registry operator
-        "/apicurio/00_operator_group.yaml", // Operator group for Apicurio Registry operator
         "/apicurio/01_subscription.yaml", // Apicurio Registry operator subscription
         // Apicurio Registry instance
         "/apicurio/02_registry_sql_keycloak.yaml" // Apicurio Registry instance with PostgreSQL storage and Keycloak IAM

--- a/new-system-tests/src/test/java/io/apicurio/registry/systemtests/SqlNoIAM.java
+++ b/new-system-tests/src/test/java/io/apicurio/registry/systemtests/SqlNoIAM.java
@@ -14,11 +14,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KubernetesTest
 @LoadKubernetesManifests({
+        // Shared resources
+        "/common/00_operator_group.yaml", // Operator group for installed operators in namespace
         // PostgreSQL database resources
         "/sql/00_service.yaml", // Service
         "/sql/01_deployment.yaml", // Deployment
         // Apicurio Registry operator
-        "/apicurio/00_operator_group.yaml", // Operator group for Apicurio Registry operator
         "/apicurio/01_subscription.yaml", // Apicurio Registry operator subscription
         // Apicurio Registry instance
         "/apicurio/02_registry_sql_no_iam.yaml" // Apicurio Registry instance with PostgreSQL storage and without IAM

--- a/new-system-tests/src/test/resources/common/00_operator_group.yaml
+++ b/new-system-tests/src/test/resources/common/00_operator_group.yaml
@@ -1,4 +1,4 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: apicurio-registry-operator-group
+  name: system-tests-operator-group


### PR DESCRIPTION
`OperatorGroup` for operators installed in namespace is shared between more operators, it can be placed in `common` resources directory and created before all other test resources.