### PR TITLE
chore: upgrade common components version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <jboss-slf4j.version>1.2.1.Final</jboss-slf4j.version>
         <httpclient.version>4.5.14</httpclient.version>
         <apicurio-common-rest-client.version>0.1.13.Final</apicurio-common-rest-client.version>
-        <apicurio-common-app-components.version>0.1.14.Final</apicurio-common-app-components.version>
+        <apicurio-common-app-components.version>0.1.15-SNAPSHOT</apicurio-common-app-components.version>
         <sentry.version>1.7.30</sentry.version>
         <kafka-oauth-client.version>0.11.0</kafka-oauth-client.version>
         <kafka-clients.version>2.8.1</kafka-clients.version>


### PR DESCRIPTION
For testing https://github.com/Apicurio/apicurio-common-app-components/pull/55 and eventual upgrade when a new version is released.