### PR TITLE
Refactor(Utils): Make method for finding operator deployment more re-…

### DIFF
--- a/new-system-tests/src/test/java/io/apicurio/registry/systemtests/SqlKeycloak.java
+++ b/new-system-tests/src/test/java/io/apicurio/registry/systemtests/SqlKeycloak.java
@@ -7,7 +7,7 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static io.apicurio.registry.systemtests.Utils.findRegistryOperatorDeployment;
+import static io.apicurio.registry.systemtests.Utils.findOperatorDeployment;
 import static io.apicurio.registry.systemtests.Utils.isDeploymentReady;
 import static io.apicurio.registry.systemtests.Utils.waitDeploymentReady;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,7 +47,10 @@ public class SqlKeycloak extends TestBase {
         assertTrue(waitDeploymentReady(client, Constants.POSTGRESQL_NAME));
 
         // Wait for readiness of Apicurio Registry operator deployment
-        assertTrue(waitDeploymentReady(client, findRegistryOperatorDeployment(client).getMetadata().getName()));
+        assertTrue(waitDeploymentReady(
+                client,
+                findOperatorDeployment(client, Constants.REGISTRY_OPERATOR_NAME).getMetadata().getName())
+        );
 
         // Log information about current action
         logger.info("BeforeEach finished.");

--- a/new-system-tests/src/test/java/io/apicurio/registry/systemtests/SqlNoIAM.java
+++ b/new-system-tests/src/test/java/io/apicurio/registry/systemtests/SqlNoIAM.java
@@ -7,7 +7,7 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static io.apicurio.registry.systemtests.Utils.findRegistryOperatorDeployment;
+import static io.apicurio.registry.systemtests.Utils.findOperatorDeployment;
 import static io.apicurio.registry.systemtests.Utils.isDeploymentReady;
 import static io.apicurio.registry.systemtests.Utils.waitDeploymentReady;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,7 +40,10 @@ public class SqlNoIAM extends TestBase {
         assertTrue(waitDeploymentReady(client, Constants.POSTGRESQL_NAME));
 
         // Wait for readiness of Apicurio Registry operator deployment
-        assertTrue(waitDeploymentReady(client, findRegistryOperatorDeployment(client).getMetadata().getName()));
+        assertTrue(waitDeploymentReady(
+                client,
+                findOperatorDeployment(client, Constants.REGISTRY_OPERATOR_NAME).getMetadata().getName())
+        );
 
         // Log information about current action
         logger.info("BeforeEach finished.");

--- a/new-system-tests/src/test/java/io/apicurio/registry/systemtests/Utils.java
+++ b/new-system-tests/src/test/java/io/apicurio/registry/systemtests/Utils.java
@@ -12,13 +12,13 @@ import java.util.concurrent.TimeUnit;
  */
 public class Utils {
     /**
-     * Finds {@link Deployment} of Apicurio Registry operator in provided namespace.
+     * Finds {@link Deployment} of operator in provided namespace.
      *
      * @param client {@link OpenShiftClient} instance to use for interaction with cluster.
-     * @param namespace Name of namespace to search for Apicurio Registry operator {@link Deployment}.
-     * @return {@link Deployment} of Apicurio Registry operator if {@link Deployment} was found; {@code null} otherwise.
+     * @param namespace Name of namespace to search for operator {@link Deployment}.
+     * @return {@link Deployment} of operator if {@link Deployment} was found; {@code null} otherwise.
      */
-    public static Deployment findRegistryOperatorDeployment(OpenShiftClient client, String namespace) {
+    public static Deployment findOperatorDeployment(OpenShiftClient client, String namespace, String name) {
         return client
                 .apps()
                 .deployments()
@@ -26,19 +26,19 @@ public class Utils {
                 .list()
                 .getItems()
                 .stream()
-                .filter(d -> d.getMetadata().getName().startsWith(Constants.REGISTRY_OPERATOR_NAME))
+                .filter(d -> d.getMetadata().getName().startsWith(name))
                 .findFirst()
                 .orElse(null);
     }
 
     /**
-     * Finds {@link Deployment} of Apicurio Registry operator in client's namespace.
+     * Finds {@link Deployment} of operator in client's namespace.
      *
      * @param client {@link OpenShiftClient} instance to use for interaction with cluster.
-     * @return {@link Deployment} of Apicurio Registry operator if {@link Deployment} was found; {@code null} otherwise.
+     * @return {@link Deployment} of operator if {@link Deployment} was found; {@code null} otherwise.
      */
-    public static Deployment findRegistryOperatorDeployment(OpenShiftClient client) {
-        return findRegistryOperatorDeployment(client, client.getNamespace());
+    public static Deployment findOperatorDeployment(OpenShiftClient client, String name) {
+        return findOperatorDeployment(client, client.getNamespace(), name);
     }
 
     /**


### PR DESCRIPTION
…usable

Previous method implementation was specific for Apicurio Registry operator only, it is possible to re-use this method for another operators too.