### PR TITLE
ci: dispatch events to app services SDK repos when the API schema changes

### DIFF
--- a/.github/workflows/update-openapi.yaml
+++ b/.github/workflows/update-openapi.yaml
@@ -77,4 +77,4 @@ jobs:
           token: ${{ env.APP_SERVICES_CI_TOKEN }}
           repository: ${{ matrix.repo }}
           event-type: openapi-spec-change
-          client-payload: '{ "id": "registryinstance/v1", "download_url":"https://raw.githubusercontent.com/Apicurio/apicurio-registry/main/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json"}'
+          client-payload: '{ "id": "registryinstance/v1", "download_url":"https://raw.githubusercontent.com/Apicurio/apicurio-registry/main/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi-gen.json"}'

--- a/.github/workflows/update-openapi.yaml
+++ b/.github/workflows/update-openapi.yaml
@@ -2,8 +2,8 @@ name: Update OpenAPI
 on:
   push:
     paths:
-      - 'common/src/main/resources/META-INF/openapi.json'
-    branches: [main]
+      - common/src/main/resources/META-INF/openapi.json
+    branches: [ main ]
 
 jobs:
   update-openapi:
@@ -53,3 +53,27 @@ jobs:
           git add ./app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi-auth.json
           git commit -m "Automatically updated the core v2 API OpenAPI definition."
           git push
+
+  validate:
+    needs: update-openapi
+    uses: ./.github/workflows/validate-openapi.yaml
+
+  dispatch:
+    needs: validate
+    env:
+      APP_SERVICES_CI_TOKEN: ${{ secrets.APP_SERVICES_CI_TOKEN }}
+    strategy:
+      matrix:
+        repo:
+          - "redhat-developer/app-services-sdk-go"
+          - "redhat-developer/app-services-sdk-js"
+          - "redhat-developer/app-services-sdk-java"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ env.APP_SERVICES_CI_TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: openapi-spec-change
+          client-payload: '{ "id": "registryinstance/v1", "download_url":"https://raw.githubusercontent.com/Apicurio/apicurio-registry/main/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json"}'

--- a/.github/workflows/update-openapi.yaml
+++ b/.github/workflows/update-openapi.yaml
@@ -68,6 +68,7 @@ jobs:
           - "redhat-developer/app-services-sdk-go"
           - "redhat-developer/app-services-sdk-js"
           - "redhat-developer/app-services-sdk-java"
+          - "redhat-developer/app-services-sdk-core"
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch

--- a/.github/workflows/validate-openapi.yaml
+++ b/.github/workflows/validate-openapi.yaml
@@ -1,0 +1,31 @@
+name: Validate OpenAPI schema with Spectral
+on:
+  workflow_call: { }
+  pull_request:
+    branches:
+      - main
+    paths:
+      - common/src/main/resources/META-INF/openapi.json
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install RHOAS Guidelines linter
+        run: |
+          npm i @rhoas/spectral-ruleset
+          echo 'extends: "@rhoas/spectral-ruleset"' > .spectral.yaml
+      - name: Validate OpenAPI schema with Spectral and RHOAS Guidelines (Common)
+        run: npx rhoasapi lint common/src/main/resources/META-INF/openapi.json
+      - name: Validate OpenAPI schema with Spectral and RHOAS Guidelines (Final)
+        run: npx rhoasapi lint app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json
+      - name: Cleanup
+        run: |
+          rm .spectral.yaml


### PR DESCRIPTION
This PR sets up automated notifications to `app-services-sdk-*` when the API schema updates, as well as an spectral check. Needs `APP_SERVICES_CI_TOKEN` set up before merge.