### PR TITLE
docs: actualise validity rules values for XSD & WSDL

### DIFF
--- a/docs/modules/ROOT/partials/getting-started/ref-registry-rule-maturity-matrix.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-rule-maturity-matrix.adoc
@@ -35,9 +35,9 @@ a| None
 a| Syntax Only
 a| None
 |*WSDL*
-a| Syntax Only
+a| Full
 a| None
 |*XSD*
-a| Syntax Only
+a| Full
 a| None
 |===


### PR DESCRIPTION
Full validation rules (syntax and semantic) are already implemented for XSD and WSDL artifacts:
https://github.com/Apicurio/apicurio-registry/blob/09a65c9562a38db10c748c876123fbfd0bd336c8/schema-util/wsdl/src/main/java/io/apicurio/registry/rules/validity/WsdlContentValidator.java#L46

https://github.com/Apicurio/apicurio-registry/blob/09a65c9562a38db10c748c876123fbfd0bd336c8/schema-util/xsd/src/main/java/io/apicurio/registry/rules/validity/XsdContentValidator.java#L47

So the documentation should be updated accordingly.