### PR TITLE
Restore the docs version in antora.yml to something other than main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,10 @@ on:
         description: 'Branch to release from'
         required: true
         default: 'main'
+      docs-version:
+        description: 'Docs version (antora.yml)'
+        required: true
+        default: '2.4.x'
 jobs:
   release:
     runs-on: ubuntu-20.04
@@ -121,7 +125,7 @@ jobs:
         run: |
           cd registry
           mvn versions:set -DnewVersion=${{ github.event.inputs.snapshot-version}} -DgenerateBackupPoms=false -DprocessAllModules=true
-          sed -i  "s/version\:\s.*/version: \'main\'/g" docs/antora.yml
+          sed -i  "s/version\:\s.*/version: \'${{ github.event.inputs.docs-version}}\'/g" docs/antora.yml
 
       - name: Commit Snapshot Version ${{ github.event.inputs.snapshot-version}}
         run: |


### PR DESCRIPTION
This changes the release workflow so that it restores the value of the docs version found in `antora.yml` to something other than `main`.  This is so that the `antora.yml` file that's located on `main` can be set to something like `2.4.x` - useful when generating the documentation.

A better solution than this would probably be to **read** [the value of the `version` property](https://github.com/Apicurio/apicurio-registry/blob/main/docs/antora.yml#L3) as one of the first steps of the release workflow, and then restore **that** value at the end.  @riprasad if you're looking for what I'm guessing is an easy task for you, this might be a nice distraction.  :)