### PR TITLE
Changes to support references in RHOAS CLI

### DIFF
--- a/.github/workflows/update-openapi.yaml
+++ b/.github/workflows/update-openapi.yaml
@@ -45,11 +45,13 @@ jobs:
           cd registry/utils/tools
           mvn clean package
           mvn exec:java -Dexec.mainClass="io.apicurio.registry.utils.tools.AddOpenApiAuth" -Dexec.args="../../app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json ../../app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi-auth.json"
+          mvn exec:java -Dexec.mainClass="io.apicurio.registry.utils.tools.TransformOpenApiForClientGen" -Dexec.args="../../app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json ../../app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi-gen.json"
 
       - name: Commit Release Version Change
         run: |
           cd registry
           git add ./app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json
           git add ./app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi-auth.json
+          git add ./app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi-gen.json
           git commit -m "Automatically updated the core v2 API OpenAPI definition."
           git push

--- a/app/src/main/java/io/apicurio/registry/rest/ConflictException.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ConflictException.java
@@ -1,0 +1,16 @@
+package io.apicurio.registry.rest;
+
+import io.apicurio.registry.types.RegistryException;
+
+public class ConflictException extends RegistryException {
+
+    private static final long serialVersionUID = -210884502298134398L;
+
+    public ConflictException(String message) {
+        super(message);
+    }
+
+    public ConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/rest/ParametersConflictException.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ParametersConflictException.java
@@ -16,11 +16,9 @@
 
 package io.apicurio.registry.rest;
 
-import io.apicurio.registry.types.RegistryException;
-
 import java.util.Arrays;
 
-public class ParametersConflictException extends RegistryException {
+public class ParametersConflictException extends ConflictException {
 
     private static final long serialVersionUID = 247427865185425744L;
 
@@ -28,7 +26,7 @@ public class ParametersConflictException extends RegistryException {
 
     public ParametersConflictException(String parameter1, String parameter2) {
         super("Conflict: '" + parameter1 + "' and '" + parameter2 + "' are mutually exclusive.");
-        this.parameters = new String[] {parameter1, parameter2};
+        this.parameters = new String[]{parameter1, parameter2};
     }
 
     public ParametersConflictException(String... parameters) {

--- a/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
@@ -25,6 +25,7 @@ import io.apicurio.registry.auth.AuthorizedStyle;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
+import io.apicurio.registry.rest.ConflictException;
 import io.apicurio.registry.rest.HeadersHack;
 import io.apicurio.registry.rest.MissingRequiredParameterException;
 import io.apicurio.registry.rest.ParametersConflictException;
@@ -45,10 +46,12 @@ import io.apicurio.registry.rest.v2.beans.SortOrder;
 import io.apicurio.registry.rest.v2.beans.UpdateState;
 import io.apicurio.registry.rest.v2.beans.VersionMetaData;
 import io.apicurio.registry.rest.v2.beans.VersionSearchResults;
+import io.apicurio.registry.rest.v2.shared.CommonResourceOperations;
 import io.apicurio.registry.rules.RuleApplicationType;
 import io.apicurio.registry.rules.RulesService;
 import io.apicurio.registry.storage.ArtifactAlreadyExistsException;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
+import io.apicurio.registry.storage.ContentNotFoundException;
 import io.apicurio.registry.storage.InvalidArtifactIdException;
 import io.apicurio.registry.storage.InvalidGroupIdException;
 import io.apicurio.registry.storage.RegistryStorage;
@@ -109,6 +112,7 @@ import javax.ws.rs.core.Response;
 
 import static io.apicurio.common.apps.logging.audit.AuditingConstants.*;
 import static io.apicurio.registry.logging.audit.AuditingConstants.KEY_OWNER;
+import static io.apicurio.registry.rest.v2.V2ApiUtil.defaultGroupIdToNull;
 
 /**
  * Implements the {@link GroupsResource} JAX-RS interface.
@@ -145,11 +149,14 @@ public class GroupsResourceImpl implements GroupsResource {
     @Inject
     SecurityIdentity securityIdentity;
 
+    @Inject
+    CommonResourceOperations common;
+
     /**
      * @see io.apicurio.registry.rest.v2.GroupsResource#getLatestArtifact(java.lang.String, java.lang.String, java.lang.Boolean)
      */
     @Override
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public Response getLatestArtifact(String groupId, String artifactId, Boolean dereference) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
@@ -158,11 +165,11 @@ public class GroupsResourceImpl implements GroupsResource {
             dereference = Boolean.FALSE;
         }
 
-        ArtifactMetaDataDto metaData = storage.getArtifactMetaData(gidOrNull(groupId), artifactId);
+        ArtifactMetaDataDto metaData = storage.getArtifactMetaData(defaultGroupIdToNull(groupId), artifactId);
         if (ArtifactState.DISABLED.equals(metaData.getState())) {
             throw new ArtifactNotFoundException(groupId, artifactId);
         }
-        StoredArtifactDto artifact = storage.getArtifact(gidOrNull(groupId), artifactId);
+        StoredArtifactDto artifact = storage.getArtifact(defaultGroupIdToNull(groupId), artifactId);
 
         MediaType contentType = factory.getArtifactMediaType(metaData.getType());
 
@@ -212,11 +219,11 @@ public class GroupsResourceImpl implements GroupsResource {
     @Override
     public List<ArtifactReference> getArtifactVersionReferences(String groupId, String artifactId, String version) {
         if (null == version) {
-            return storage.getArtifact(gidOrNull(groupId), artifactId).getReferences().stream()
+            return storage.getArtifact(defaultGroupIdToNull(groupId), artifactId).getReferences().stream()
                     .map(V2ApiUtil::referenceDtoToReference)
                     .collect(Collectors.toList());
         } else {
-            return storage.getArtifactVersion(gidOrNull(groupId), artifactId, version).getReferences().stream()
+            return storage.getArtifactVersion(defaultGroupIdToNull(groupId), artifactId, version).getReferences().stream()
                     .map(V2ApiUtil::referenceDtoToReference)
                     .collect(Collectors.toList());
         }
@@ -245,25 +252,25 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID})
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void deleteArtifact(String groupId, String artifactId) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
 
-        storage.deleteArtifact(gidOrNull(groupId), artifactId);
+        storage.deleteArtifact(defaultGroupIdToNull(groupId), artifactId);
     }
 
     /**
      * @see io.apicurio.registry.rest.v2.GroupsResource#getArtifactMetaData(java.lang.String, java.lang.String)
      */
     @Override
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public ArtifactMetaData getArtifactMetaData(String groupId, String artifactId) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
 
-        ArtifactMetaDataDto dto = storage.getArtifactMetaData(gidOrNull(groupId), artifactId);
-        return V2ApiUtil.dtoToMetaData(gidOrNull(groupId), artifactId, dto.getType(), dto);
+        ArtifactMetaDataDto dto = storage.getArtifactMetaData(defaultGroupIdToNull(groupId), artifactId);
+        return V2ApiUtil.dtoToMetaData(defaultGroupIdToNull(groupId), artifactId, dto.getType(), dto);
     }
 
     /**
@@ -271,13 +278,13 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_EDITABLE_METADATA})
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactMetaData(String groupId, String artifactId, EditableMetaData data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
 
         if (data.getProperties() != null) {
-            data.getProperties().forEach((k,v) -> requireParameter("property value", v));
+            data.getProperties().forEach((k, v) -> requireParameter("property value", v));
         }
 
         EditableArtifactMetaDataDto dto = new EditableArtifactMetaDataDto();
@@ -285,16 +292,16 @@ public class GroupsResourceImpl implements GroupsResource {
         dto.setDescription(data.getDescription());
         dto.setLabels(data.getLabels());
         dto.setProperties(data.getProperties());
-        storage.updateArtifactMetaData(gidOrNull(groupId), artifactId, dto);
+        storage.updateArtifactMetaData(defaultGroupIdToNull(groupId), artifactId, dto);
     }
-    
+
     @Override
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public ArtifactOwner getArtifactOwner(String groupId, String artifactId) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
 
-        ArtifactMetaDataDto dto = storage.getArtifactMetaData(gidOrNull(groupId), artifactId);
+        ArtifactMetaDataDto dto = storage.getArtifactMetaData(defaultGroupIdToNull(groupId), artifactId);
         ArtifactOwner owner = new ArtifactOwner();
         owner.setOwner(dto.getCreatedBy());
         return owner;
@@ -302,30 +309,30 @@ public class GroupsResourceImpl implements GroupsResource {
 
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_OWNER})
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.AdminOrOwner)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.AdminOrOwner)
     public void updateArtifactOwner(String groupId, String artifactId, ArtifactOwner data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
 
         ArtifactOwnerDto dto = new ArtifactOwnerDto(data.getOwner());
-        storage.updateArtifactOwner(gidOrNull(groupId), artifactId, dto);
+        storage.updateArtifactOwner(defaultGroupIdToNull(groupId), artifactId, dto);
     }
 
     @Override
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public GroupMetaData getGroupById(String groupId) {
         GroupMetaDataDto group = storage.getGroupMetaData(groupId);
         return V2ApiUtil.groupDtoToGroup(group);
     }
 
     @Override
-    @Authorized(style=AuthorizedStyle.GroupOnly, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void deleteGroupById(String groupId) {
         storage.deleteGroup(groupId);
     }
 
     @Override
-    @Authorized(style=AuthorizedStyle.None, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
     public GroupSearchResults listGroups(Integer limit, Integer offset, SortOrder order, SortBy orderby) {
         if (orderby == null) {
             orderby = SortBy.name;
@@ -366,7 +373,7 @@ public class GroupsResourceImpl implements GroupsResource {
      * @see io.apicurio.registry.rest.v2.GroupsResource#getArtifactVersionMetaDataByContent(java.lang.String, java.lang.String, java.lang.Boolean, java.io.InputStream)
      */
     @Override
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public VersionMetaData getArtifactVersionMetaDataByContent(String groupId, String artifactId, Boolean canonical, InputStream data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
@@ -382,20 +389,20 @@ public class GroupsResourceImpl implements GroupsResource {
             content = ContentTypeUtil.yamlToJson(content);
         }
 
-        ArtifactVersionMetaDataDto dto = storage.getArtifactVersionMetaData(gidOrNull(groupId), artifactId, canonical, content);
-        return V2ApiUtil.dtoToVersionMetaData(gidOrNull(groupId), artifactId, dto.getType(), dto);
+        ArtifactVersionMetaDataDto dto = storage.getArtifactVersionMetaData(defaultGroupIdToNull(groupId), artifactId, canonical, content);
+        return V2ApiUtil.dtoToVersionMetaData(defaultGroupIdToNull(groupId), artifactId, dto.getType(), dto);
     }
 
     /**
      * @see io.apicurio.registry.rest.v2.GroupsResource#listArtifactRules(java.lang.String, java.lang.String)
      */
     @Override
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public List<RuleType> listArtifactRules(String groupId, String artifactId) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
 
-        return storage.getArtifactRules(gidOrNull(groupId), artifactId);
+        return storage.getArtifactRules(defaultGroupIdToNull(groupId), artifactId);
     }
 
     /**
@@ -403,7 +410,7 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_RULE})
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void createArtifactRule(String groupId, String artifactId, Rule data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
@@ -411,11 +418,11 @@ public class GroupsResourceImpl implements GroupsResource {
         RuleConfigurationDto config = new RuleConfigurationDto();
         config.setConfiguration(data.getConfig());
 
-        if (!storage.isArtifactExists(gidOrNull(groupId), artifactId)) {
+        if (!storage.isArtifactExists(defaultGroupIdToNull(groupId), artifactId)) {
             throw new ArtifactNotFoundException(groupId, artifactId);
         }
 
-        storage.createArtifactRule(gidOrNull(groupId), artifactId, data.getType(), config);
+        storage.createArtifactRule(defaultGroupIdToNull(groupId), artifactId, data.getType(), config);
     }
 
     /**
@@ -423,25 +430,25 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID})
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void deleteArtifactRules(String groupId, String artifactId) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
 
-        storage.deleteArtifactRules(gidOrNull(groupId), artifactId);
+        storage.deleteArtifactRules(defaultGroupIdToNull(groupId), artifactId);
     }
 
     /**
      * @see io.apicurio.registry.rest.v2.GroupsResource#getArtifactRuleConfig(java.lang.String, java.lang.String, io.apicurio.registry.types.RuleType)
      */
     @Override
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public Rule getArtifactRuleConfig(String groupId, String artifactId, RuleType rule) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
         requireParameter("rule", rule);
 
-        RuleConfigurationDto dto = storage.getArtifactRule(gidOrNull(groupId), artifactId, rule);
+        RuleConfigurationDto dto = storage.getArtifactRule(defaultGroupIdToNull(groupId), artifactId, rule);
         Rule rval = new Rule();
         rval.setConfig(dto.getConfiguration());
         rval.setType(rule);
@@ -453,14 +460,14 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_RULE_TYPE, "3", KEY_RULE})
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public Rule updateArtifactRuleConfig(String groupId, String artifactId, RuleType rule, Rule data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
         requireParameter("rule", rule);
 
         RuleConfigurationDto dto = new RuleConfigurationDto(data.getConfig());
-        storage.updateArtifactRule(gidOrNull(groupId), artifactId, rule, dto);
+        storage.updateArtifactRule(defaultGroupIdToNull(groupId), artifactId, rule, dto);
         Rule rval = new Rule();
         rval.setType(rule);
         rval.setConfig(data.getConfig());
@@ -472,13 +479,13 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_RULE_TYPE})
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void deleteArtifactRule(String groupId, String artifactId, RuleType rule) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
         requireParameter("rule", rule);
 
-        storage.deleteArtifactRule(gidOrNull(groupId), artifactId, rule);
+        storage.deleteArtifactRule(defaultGroupIdToNull(groupId), artifactId, rule);
     }
 
     /**
@@ -486,19 +493,19 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_UPDATE_STATE})
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactState(String groupId, String artifactId, UpdateState data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
         requireParameter("body.state", data.getState());
-        storage.updateArtifactState(gidOrNull(groupId), artifactId, data.getState());
+        storage.updateArtifactState(defaultGroupIdToNull(groupId), artifactId, data.getState());
     }
 
     /**
      * @see io.apicurio.registry.rest.v2.GroupsResource#testUpdateArtifact(java.lang.String, java.lang.String, java.io.InputStream)
      */
     @Override
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void testUpdateArtifact(String groupId, String artifactId, InputStream data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
@@ -513,14 +520,14 @@ public class GroupsResourceImpl implements GroupsResource {
         }
 
         String artifactType = lookupArtifactType(groupId, artifactId);
-        rulesService.applyRules(gidOrNull(groupId), artifactId, artifactType, content, RuleApplicationType.UPDATE, Collections.emptyMap()); //TODO:references not supported for testing update
+        rulesService.applyRules(defaultGroupIdToNull(groupId), artifactId, artifactType, content, RuleApplicationType.UPDATE, Collections.emptyMap()); //TODO:references not supported for testing update
     }
 
     /**
      * @see io.apicurio.registry.rest.v2.GroupsResource#getArtifactVersion(java.lang.String, java.lang.String, java.lang.String, java.lang.Boolean)
      */
     @Override
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public Response getArtifactVersion(String groupId, String artifactId, String version, Boolean dereference) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
@@ -530,11 +537,11 @@ public class GroupsResourceImpl implements GroupsResource {
             dereference = Boolean.FALSE;
         }
 
-        ArtifactVersionMetaDataDto metaData = storage.getArtifactVersionMetaData(gidOrNull(groupId), artifactId, version);
+        ArtifactVersionMetaDataDto metaData = storage.getArtifactVersionMetaData(defaultGroupIdToNull(groupId), artifactId, version);
         if (ArtifactState.DISABLED.equals(metaData.getState())) {
             throw new VersionNotFoundException(groupId, artifactId, version);
         }
-        StoredArtifactDto artifact = storage.getArtifactVersion(gidOrNull(groupId), artifactId, version);
+        StoredArtifactDto artifact = storage.getArtifactVersion(defaultGroupIdToNull(groupId), artifactId, version);
 
         MediaType contentType = factory.getArtifactMediaType(metaData.getType());
 
@@ -555,14 +562,14 @@ public class GroupsResourceImpl implements GroupsResource {
      * @see io.apicurio.registry.rest.v2.GroupsResource#getArtifactVersionMetaData(java.lang.String, java.lang.String, java.lang.String)
      */
     @Override
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public VersionMetaData getArtifactVersionMetaData(String groupId, String artifactId, String version) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
         requireParameter("version", version);
 
-        ArtifactVersionMetaDataDto dto = storage.getArtifactVersionMetaData(gidOrNull(groupId), artifactId, version);
-        return V2ApiUtil.dtoToVersionMetaData(gidOrNull(groupId), artifactId, dto.getType(), dto);
+        ArtifactVersionMetaDataDto dto = storage.getArtifactVersionMetaData(defaultGroupIdToNull(groupId), artifactId, version);
+        return V2ApiUtil.dtoToVersionMetaData(defaultGroupIdToNull(groupId), artifactId, dto.getType(), dto);
     }
 
     /**
@@ -570,20 +577,20 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION, "3", KEY_EDITABLE_METADATA})
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactVersionMetaData(String groupId, String artifactId, String version, EditableMetaData data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
         requireParameter("version", version);
         if (data.getProperties() != null) {
-            data.getProperties().forEach((k,v) -> requireParameter("property value", v));
+            data.getProperties().forEach((k, v) -> requireParameter("property value", v));
         }
         EditableArtifactMetaDataDto dto = new EditableArtifactMetaDataDto();
         dto.setName(data.getName());
         dto.setDescription(data.getDescription());
         dto.setLabels(data.getLabels());
         dto.setProperties(data.getProperties());
-        storage.updateArtifactVersionMetaData(gidOrNull(groupId), artifactId, version, dto);
+        storage.updateArtifactVersionMetaData(defaultGroupIdToNull(groupId), artifactId, version, dto);
     }
 
     /**
@@ -591,13 +598,13 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION})
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void deleteArtifactVersionMetaData(String groupId, String artifactId, String version) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
         requireParameter("version", version);
 
-        storage.deleteArtifactVersionMetaData(gidOrNull(groupId), artifactId, version);
+        storage.deleteArtifactVersionMetaData(defaultGroupIdToNull(groupId), artifactId, version);
     }
 
     /**
@@ -605,22 +612,22 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION, "3", KEY_UPDATE_STATE})
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactVersionState(String groupId, String artifactId, String version, UpdateState data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
         requireParameter("version", version);
 
-        storage.updateArtifactState(gidOrNull(groupId), artifactId, version, data.getState());
+        storage.updateArtifactState(defaultGroupIdToNull(groupId), artifactId, version, data.getState());
     }
 
     /**
      * @see io.apicurio.registry.rest.v2.GroupsResource#listArtifactsInGroup(java.lang.String, java.lang.Integer, java.lang.Integer, io.apicurio.registry.rest.v2.beans.SortOrder, io.apicurio.registry.rest.v2.beans.SortBy)
      */
     @Override
-    @Authorized(style=AuthorizedStyle.GroupOnly, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Read)
     public ArtifactSearchResults listArtifactsInGroup(String groupId, Integer limit, Integer offset,
-            SortOrder order, SortBy orderby) {
+                                                      SortOrder order, SortBy orderby) {
         requireParameter("groupId", groupId);
 
         if (orderby == null) {
@@ -637,7 +644,7 @@ public class GroupsResourceImpl implements GroupsResource {
         final OrderDirection oDir = order == null || order == SortOrder.asc ? OrderDirection.asc : OrderDirection.desc;
 
         Set<SearchFilter> filters = new HashSet<>();
-        filters.add(SearchFilter.ofGroup(gidOrNull(groupId)));
+        filters.add(SearchFilter.ofGroup(defaultGroupIdToNull(groupId)));
 
         ArtifactSearchResultsDto resultsDto = storage.searchArtifacts(filters, oBy, oDir, offset, limit);
         return V2ApiUtil.dtoToSearchResults(resultsDto);
@@ -648,11 +655,11 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID})
-    @Authorized(style=AuthorizedStyle.GroupOnly, level=AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void deleteArtifactsInGroup(String groupId) {
         requireParameter("groupId", groupId);
 
-        storage.deleteArtifacts(gidOrNull(groupId));
+        storage.deleteArtifacts(defaultGroupIdToNull(groupId));
     }
 
     /**
@@ -714,6 +721,7 @@ public class GroupsResourceImpl implements GroupsResource {
 
     /**
      * Return an InputStream for the resource to be downloaded
+     *
      * @param url
      */
     private InputStream fetchContentFromURL(Client client, URI url) {
@@ -757,6 +765,7 @@ public class GroupsResourceImpl implements GroupsResource {
 
     /**
      * Creates an artifact with references.  Shared by both variants of createArtifact.
+     *
      * @param groupId
      * @param xRegistryArtifactType
      * @param xRegistryArtifactId
@@ -838,20 +847,30 @@ public class GroupsResourceImpl implements GroupsResource {
 
             String artifactType = ArtifactTypeUtil.determineArtifactType(content, xRegistryArtifactType, ct, factory.getAllArtifactTypes());
 
-            final List<ArtifactReferenceDto> referencesAsDtos = references.stream()
-                    .map(r -> { r.setGroupId(gidOrNull(r.getGroupId())); return r; }) // .peek(...) may be optimized away
-                    .map(V2ApiUtil::referenceToDto)
-                    .collect(Collectors.toList());
-            
+            final List<ArtifactReferenceDto> referencesAsDtos = toReferenceDtos(references);
+
             //Try to resolve the new artifact references and the nested ones (if any)
             final Map<String, ContentHandle> resolvedReferences = storage.resolveReferences(referencesAsDtos);
 
-            rulesService.applyRules(gidOrNull(groupId), artifactId, artifactType, content, RuleApplicationType.CREATE, resolvedReferences);
+            rulesService.applyRules(defaultGroupIdToNull(groupId), artifactId, artifactType, content, RuleApplicationType.CREATE, resolvedReferences);
 
             final String finalArtifactId = artifactId;
             EditableArtifactMetaDataDto metaData = getEditableMetaData(artifactName, artifactDescription);
-            ArtifactMetaDataDto amd = storage.createArtifactWithMetadata(gidOrNull(groupId), artifactId, xRegistryVersion, artifactType, content, metaData, referencesAsDtos);
-            return V2ApiUtil.dtoToMetaData(gidOrNull(groupId), finalArtifactId, artifactType, amd);
+
+            // Check for reference conflict
+            try {
+                var existingReferences = new HashSet<>(common.getReferencesByContentHash(content.getSha256Hash()));
+                var newReferences = new HashSet<>(references);
+                if (!existingReferences.equals(newReferences)) {
+                    throw new ConflictException("References are already defined for the provided content: " +
+                            "[" + V2ApiUtil.prettyPrintReferences(existingReferences) + "]");
+                }
+            } catch (ContentNotFoundException ex) {
+                // OK
+            }
+
+            ArtifactMetaDataDto amd = storage.createArtifactWithMetadata(defaultGroupIdToNull(groupId), artifactId, xRegistryVersion, artifactType, content, metaData, referencesAsDtos);
+            return V2ApiUtil.dtoToMetaData(defaultGroupIdToNull(groupId), finalArtifactId, artifactType, amd);
         } catch (ArtifactAlreadyExistsException ex) {
             return handleIfExists(groupId, xRegistryArtifactId, xRegistryVersion, ifExists, content, ct, fcanonical, references);
         }
@@ -861,7 +880,7 @@ public class GroupsResourceImpl implements GroupsResource {
      * @see io.apicurio.registry.rest.v2.GroupsResource#listArtifactVersions(java.lang.String, java.lang.String, java.lang.Integer, java.lang.Integer)
      */
     @Override
-    @Authorized(style=AuthorizedStyle.GroupAndArtifact, level=AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public VersionSearchResults listArtifactVersions(String groupId, String artifactId, Integer offset, Integer limit) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
@@ -873,7 +892,7 @@ public class GroupsResourceImpl implements GroupsResource {
             limit = 20;
         }
 
-        VersionSearchResultsDto resultsDto = storage.searchVersions(gidOrNull(groupId), artifactId, offset, limit);
+        VersionSearchResultsDto resultsDto = storage.searchVersions(defaultGroupIdToNull(groupId), artifactId, offset, limit);
         return V2ApiUtil.dtoToSearchResults(resultsDto);
     }
 
@@ -906,6 +925,7 @@ public class GroupsResourceImpl implements GroupsResource {
 
     /**
      * Creates an artifact version with references.  Shared implementation for both variants of createArtifactVersion.
+     *
      * @param groupId
      * @param artifactId
      * @param xRegistryVersion
@@ -937,18 +957,16 @@ public class GroupsResourceImpl implements GroupsResource {
         }
 
         //Transform the given references into dtos and set the contentId, this will also detect if any of the passed references does not exist.
-        final List<ArtifactReferenceDto> referencesAsDtos = references.stream()
-                .map(V2ApiUtil::referenceToDto)
-                .collect(Collectors.toList());
+        final List<ArtifactReferenceDto> referencesAsDtos = toReferenceDtos(references);
 
         //Try to resolve the new artifact references and the nested ones (if any)
         final Map<String, ContentHandle> resolvedReferences = storage.resolveReferences(referencesAsDtos);
 
         String artifactType = lookupArtifactType(groupId, artifactId);
-        rulesService.applyRules(gidOrNull(groupId), artifactId, artifactType, content, RuleApplicationType.UPDATE, resolvedReferences);
+        rulesService.applyRules(defaultGroupIdToNull(groupId), artifactId, artifactType, content, RuleApplicationType.UPDATE, resolvedReferences);
         EditableArtifactMetaDataDto metaData = getEditableMetaData(artifactName, artifactDescription);
-        ArtifactMetaDataDto amd = storage.updateArtifactWithMetadata(gidOrNull(groupId), artifactId, xRegistryVersion, artifactType, content, metaData, referencesAsDtos);
-        return V2ApiUtil.dtoToVersionMetaData(gidOrNull(groupId), artifactId, artifactType, amd);
+        ArtifactMetaDataDto amd = storage.updateArtifactWithMetadata(defaultGroupIdToNull(groupId), artifactId, xRegistryVersion, artifactType, content, metaData, referencesAsDtos);
+        return V2ApiUtil.dtoToVersionMetaData(defaultGroupIdToNull(groupId), artifactId, artifactType, amd);
     }
 
     /**
@@ -966,11 +984,12 @@ public class GroupsResourceImpl implements GroupsResource {
 
     /**
      * Looks up the artifact type for the given artifact.
+     *
      * @param groupId
      * @param artifactId
      */
     private String lookupArtifactType(String groupId, String artifactId) {
-        return storage.getArtifactMetaData(gidOrNull(groupId), artifactId).getType();
+        return storage.getArtifactMetaData(defaultGroupIdToNull(groupId), artifactId).getType();
     }
 
     /**
@@ -1005,7 +1024,7 @@ public class GroupsResourceImpl implements GroupsResource {
     }
 
     private ArtifactMetaData handleIfExists(String groupId, String artifactId, String version,
-            IfExists ifExists, ContentHandle content, String contentType, boolean canonical, List<ArtifactReference> references) {
+                                            IfExists ifExists, ContentHandle content, String contentType, boolean canonical, List<ArtifactReference> references) {
         final ArtifactMetaData artifactMetaData = getArtifactMetaData(groupId, artifactId);
         if (ifExists == null) {
             ifExists = IfExists.FAIL;
@@ -1024,10 +1043,10 @@ public class GroupsResourceImpl implements GroupsResource {
     }
 
     private ArtifactMetaData handleIfExistsReturnOrUpdate(String groupId, String artifactId, String version,
-            ContentHandle content, String contentType, boolean canonical, List<ArtifactReference> references) {
+                                                          ContentHandle content, String contentType, boolean canonical, List<ArtifactReference> references) {
         try {
-            ArtifactVersionMetaDataDto mdDto = this.storage.getArtifactVersionMetaData(gidOrNull(groupId), artifactId, canonical, content);
-            ArtifactMetaData md = V2ApiUtil.dtoToMetaData(gidOrNull(groupId), artifactId, null, mdDto);
+            ArtifactVersionMetaDataDto mdDto = this.storage.getArtifactVersionMetaData(defaultGroupIdToNull(groupId), artifactId, canonical, content);
+            ArtifactMetaData md = V2ApiUtil.dtoToMetaData(defaultGroupIdToNull(groupId), artifactId, null, mdDto);
             return md;
         } catch (ArtifactNotFoundException nfe) {
             // This is OK - we'll update the artifact if there is no matching content already there.
@@ -1051,16 +1070,14 @@ public class GroupsResourceImpl implements GroupsResource {
         String artifactType = lookupArtifactType(groupId, artifactId);
 
         //Transform the given references into dtos and set the contentId, this will also detect if any of the passed references does not exist.
-        final List<ArtifactReferenceDto> referencesAsDtos = references.stream()
-                .map(V2ApiUtil::referenceToDto)
-                .collect(Collectors.toList());
+        final List<ArtifactReferenceDto> referencesAsDtos = toReferenceDtos(references);
 
         final Map<String, ContentHandle> resolvedReferences = storage.resolveReferences(referencesAsDtos);
 
-        rulesService.applyRules(gidOrNull(groupId), artifactId, artifactType, content, RuleApplicationType.UPDATE, resolvedReferences);
+        rulesService.applyRules(defaultGroupIdToNull(groupId), artifactId, artifactType, content, RuleApplicationType.UPDATE, resolvedReferences);
         EditableArtifactMetaDataDto metaData = getEditableMetaData(name, description);
-        ArtifactMetaDataDto dto = storage.updateArtifactWithMetadata(gidOrNull(groupId), artifactId, version, artifactType, content, metaData, referencesAsDtos);
-        return V2ApiUtil.dtoToMetaData(gidOrNull(groupId), artifactId, artifactType, dto);
+        ArtifactMetaDataDto dto = storage.updateArtifactWithMetadata(defaultGroupIdToNull(groupId), artifactId, version, artifactType, content, metaData, referencesAsDtos);
+        return V2ApiUtil.dtoToMetaData(defaultGroupIdToNull(groupId), artifactId, artifactType, dto);
     }
 
     private EditableArtifactMetaDataDto getEditableMetaData(String name, String description) {
@@ -1070,10 +1087,16 @@ public class GroupsResourceImpl implements GroupsResource {
         return null;
     }
 
-    private String gidOrNull(String groupId) {
-        if ("default".equalsIgnoreCase(groupId)) {
-            return null;
+    private List<ArtifactReferenceDto> toReferenceDtos(List<ArtifactReference> references) {
+        if (references == null) {
+            references = Collections.emptyList();
         }
-        return groupId;
+        return references.stream()
+                .map(r -> {
+                    r.setGroupId(defaultGroupIdToNull(r.getGroupId()));
+                    return r;
+                }) // .peek(...) may be optimized away
+                .map(V2ApiUtil::referenceToDto)
+                .collect(Collectors.toList());
     }
 }

--- a/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
@@ -839,9 +839,10 @@ public class GroupsResourceImpl implements GroupsResource {
             String artifactType = ArtifactTypeUtil.determineArtifactType(content, xRegistryArtifactType, ct, factory.getAllArtifactTypes());
 
             final List<ArtifactReferenceDto> referencesAsDtos = references.stream()
+                    .map(r -> { r.setGroupId(gidOrNull(r.getGroupId())); return r; }) // .peek(...) may be optimized away
                     .map(V2ApiUtil::referenceToDto)
                     .collect(Collectors.toList());
-
+            
             //Try to resolve the new artifact references and the nested ones (if any)
             final Map<String, ContentHandle> resolvedReferences = storage.resolveReferences(referencesAsDtos);
 

--- a/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
@@ -80,15 +80,6 @@ import io.apicurio.registry.utils.JAXRSClientUtil;
 import io.quarkus.security.identity.SecurityIdentity;
 import org.jose4j.base64url.Base64;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.interceptor.Interceptors;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -106,23 +97,17 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.interceptor.Interceptors;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_ARTIFACT_ID;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_ARTIFACT_TYPE;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_CANONICAL;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_DESCRIPTION;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_DESCRIPTION_ENCODED;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_EDITABLE_METADATA;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_FROM_URL;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_GROUP_ID;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_IF_EXISTS;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_NAME;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_NAME_ENCODED;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_RULE;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_RULE_TYPE;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_SHA;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_UPDATE_STATE;
-import static io.apicurio.common.apps.logging.audit.AuditingConstants.KEY_VERSION;
+import static io.apicurio.common.apps.logging.audit.AuditingConstants.*;
 import static io.apicurio.registry.logging.audit.AuditingConstants.KEY_OWNER;
 
 /**
@@ -195,26 +180,28 @@ public class GroupsResourceImpl implements GroupsResource {
     }
 
     /**
-     * @see io.apicurio.registry.rest.v2.GroupsResource#updateArtifact(String, String, String, String, String, String, String, InputStream)
+     * @see io.apicurio.registry.rest.v2.GroupsResource#updateArtifact(String, String, String, String, String, String, String, String, java.io.InputStream)
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION, "3", KEY_NAME, "4", KEY_NAME_ENCODED, "5", KEY_DESCRIPTION, "6", KEY_DESCRIPTION_ENCODED})
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public ArtifactMetaData updateArtifact(String groupId, String artifactId, String xRegistryVersion,
-                                           String xRegistryName, String xRegistryNameEncoded, String xRegistryDescription,
-                                           String xRegistryDescriptionEncoded, InputStream data) {
+                                           String xRegistryName, String xRegistryNameEncoded,
+                                           String xRegistryDescription, String xRegistryDescriptionEncoded,
+                                           String __ignore, InputStream data) {
         return this.updateArtifactWithRefs(groupId, artifactId, xRegistryVersion, xRegistryName, xRegistryNameEncoded, xRegistryDescription, xRegistryDescriptionEncoded, data, Collections.emptyList());
     }
 
     /**
-     * @see io.apicurio.registry.rest.v2.GroupsResource#updateArtifact(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, io.apicurio.registry.rest.v2.beans.ContentCreateRequest)
+     * @see io.apicurio.registry.rest.v2.GroupsResource#updateArtifact(String, String, String, String, String, String, String, String, io.apicurio.registry.rest.v2.beans.ContentCreateRequest)
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION, "3", KEY_NAME, "4", KEY_NAME_ENCODED, "5", KEY_DESCRIPTION, "6", KEY_DESCRIPTION_ENCODED})
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public ArtifactMetaData updateArtifact(String groupId, String artifactId, String xRegistryVersion,
-                                           String xRegistryName, String xRegistryNameEncoded, String xRegistryDescription,
-                                           String xRegistryDescriptionEncoded, ContentCreateRequest data) {
+                                           String xRegistryName, String xRegistryNameEncoded,
+                                           String xRegistryDescription, String xRegistryDescriptionEncoded,
+                                           String __ignore, ContentCreateRequest data) {
         requireParameter("content", data.getContent());
         return this.updateArtifactWithRefs(groupId, artifactId, xRegistryVersion, xRegistryName, xRegistryNameEncoded, xRegistryDescription, xRegistryDescriptionEncoded, IoUtil.toStream(data.getContent()), data.getReferences());
     }
@@ -669,7 +656,7 @@ public class GroupsResourceImpl implements GroupsResource {
     }
 
     /**
-     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifact(String, ArtifactType, String, String, IfExists, Boolean, String, String, String, String, String, String, InputStream)
+     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifact(String, String, String, String, io.apicurio.registry.rest.v2.beans.IfExists, Boolean, String, String, String, String, String, String, String, java.io.InputStream)
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_TYPE, "2", KEY_ARTIFACT_ID, "3", KEY_VERSION, "4", KEY_IF_EXISTS, "5", KEY_CANONICAL, "6", KEY_DESCRIPTION, "7", KEY_DESCRIPTION_ENCODED, "8", KEY_NAME, "9", KEY_NAME_ENCODED, "10", KEY_FROM_URL, "11", KEY_SHA})
@@ -678,12 +665,13 @@ public class GroupsResourceImpl implements GroupsResource {
                                            String xRegistryVersion, IfExists ifExists, Boolean canonical,
                                            String xRegistryDescription, String xRegistryDescriptionEncoded,
                                            String xRegistryName, String xRegistryNameEncoded,
-                                           String xRegistryContentHash, String xRegistryHashAlgorithm, InputStream data) {
+                                           String xRegistryContentHash, String xRegistryHashAlgorithm,
+                                           String __ignore, InputStream data) {
         return this.createArtifactWithRefs(groupId, xRegistryArtifactType, xRegistryArtifactId, xRegistryVersion, ifExists, canonical, xRegistryDescription, xRegistryDescriptionEncoded, xRegistryName, xRegistryNameEncoded, xRegistryContentHash, xRegistryHashAlgorithm, data, Collections.emptyList());
     }
 
     /**
-     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifact(String, ArtifactType, String, String, IfExists, Boolean, String, String, String, String, String, String, ContentCreateRequest)
+     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifact(String, String, String, String, io.apicurio.registry.rest.v2.beans.IfExists, Boolean, String, String, String, String, String, String, String, io.apicurio.registry.rest.v2.beans.ContentCreateRequest)
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_TYPE, "2", KEY_ARTIFACT_ID, "3", KEY_VERSION, "4", KEY_IF_EXISTS, "5", KEY_CANONICAL, "6", KEY_DESCRIPTION, "7", KEY_DESCRIPTION_ENCODED, "8", KEY_NAME, "9", KEY_NAME_ENCODED, "10", "from_url" /*KEY_FROM_URL*/, "11", "artifact_sha" /*KEY_SHA*/})
@@ -692,7 +680,8 @@ public class GroupsResourceImpl implements GroupsResource {
                                            String xRegistryVersion, IfExists ifExists, Boolean canonical,
                                            String xRegistryDescription, String xRegistryDescriptionEncoded,
                                            String xRegistryName, String xRegistryNameEncoded,
-                                           String xRegistryContentHash, String xRegistryHashAlgorithm, ContentCreateRequest data) {
+                                           String xRegistryContentHash, String xRegistryHashAlgorithm,
+                                           String __ignore, ContentCreateRequest data) {
         requireParameter("content", data.getContent());
 
         Client client = null;
@@ -888,7 +877,7 @@ public class GroupsResourceImpl implements GroupsResource {
     }
 
     /**
-     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifactVersion(String, String, String, String, String, String, String, InputStream)
+     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifactVersion(String, String, String, String, String, String, String, String, java.io.InputStream)
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION, "3", KEY_NAME, "4", KEY_DESCRIPTION, "5", KEY_DESCRIPTION_ENCODED, "6", KEY_NAME_ENCODED})
@@ -896,19 +885,20 @@ public class GroupsResourceImpl implements GroupsResource {
     public VersionMetaData createArtifactVersion(String groupId, String artifactId,
                                                  String xRegistryVersion, String xRegistryName,
                                                  String xRegistryDescription, String xRegistryDescriptionEncoded,
-                                                 String xRegistryNameEncoded, InputStream data) {
+                                                 String xRegistryNameEncoded, String __ignore, InputStream data) {
         return this.createArtifactVersionWithRefs(groupId, artifactId, xRegistryVersion, xRegistryName, xRegistryDescription, xRegistryDescriptionEncoded, xRegistryNameEncoded, data, Collections.emptyList());
     }
 
     /**
-     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifactVersion(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, io.apicurio.registry.rest.v2.beans.ContentCreateRequest)
+     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifactVersion(String, String, String, String, String, String, String, String, io.apicurio.registry.rest.v2.beans.ContentCreateRequest)
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION, "3", KEY_NAME, "4", KEY_DESCRIPTION, "5", KEY_DESCRIPTION_ENCODED, "6", KEY_NAME_ENCODED})
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public VersionMetaData createArtifactVersion(String groupId, String artifactId, String xRegistryVersion,
-                                                 String xRegistryName, String xRegistryDescription, String xRegistryDescriptionEncoded,
-                                                 String xRegistryNameEncoded, ContentCreateRequest data) {
+                                                 String xRegistryName, String xRegistryDescription,
+                                                 String xRegistryDescriptionEncoded, String xRegistryNameEncoded,
+                                                 String __ignore, ContentCreateRequest data) {
         requireParameter("content", data.getContent());
         return this.createArtifactVersionWithRefs(groupId, artifactId, xRegistryVersion, xRegistryName, xRegistryDescription, xRegistryDescriptionEncoded, xRegistryNameEncoded, IoUtil.toStream(data.getContent()), data.getReferences());
     }

--- a/app/src/main/java/io/apicurio/registry/rest/v2/IdsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/IdsResourceImpl.java
@@ -16,25 +16,16 @@
 
 package io.apicurio.registry.rest.v2;
 
-import java.util.List;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.interceptor.Interceptors;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
+import io.apicurio.common.apps.logging.Logged;
 import io.apicurio.registry.auth.Authorized;
 import io.apicurio.registry.auth.AuthorizedLevel;
 import io.apicurio.registry.auth.AuthorizedStyle;
 import io.apicurio.registry.content.ContentHandle;
-import io.apicurio.common.apps.logging.Logged;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
 import io.apicurio.registry.rest.HeadersHack;
 import io.apicurio.registry.rest.v2.beans.ArtifactReference;
+import io.apicurio.registry.rest.v2.shared.CommonResourceOperations;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
@@ -44,6 +35,15 @@ import io.apicurio.registry.types.ArtifactMediaTypes;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.Current;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.interceptor.Interceptors;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -59,6 +59,9 @@ public class IdsResourceImpl implements IdsResource {
 
     @Inject
     ArtifactTypeUtilProviderFactory factory;
+
+    @Inject
+    CommonResourceOperations common;
 
     private void checkIfDeprecated(Supplier<ArtifactState> stateSupplier, String artifactId, String version, Response.ResponseBuilder builder) {
         HeadersHack.checkIfDeprecated(stateSupplier, null, artifactId, version, builder);
@@ -120,10 +123,7 @@ public class IdsResourceImpl implements IdsResource {
 
     @Override
     public List<ArtifactReference> referencesByContentHash(String contentHash) {
-        ContentWrapperDto artifact = storage.getArtifactByContentHash(contentHash);
-        return artifact.getReferences().stream()
-                .map(V2ApiUtil::referenceDtoToReference)
-                .collect(Collectors.toList());
+        return common.getReferencesByContentHash(contentHash);
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/rest/v2/shared/CommonResourceOperations.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/shared/CommonResourceOperations.java
@@ -1,0 +1,27 @@
+package io.apicurio.registry.rest.v2.shared;
+
+import io.apicurio.registry.rest.v2.V2ApiUtil;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.dto.ContentWrapperDto;
+import io.apicurio.registry.types.Current;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class CommonResourceOperations {
+
+    @Inject
+    @Current
+    RegistryStorage storage;
+
+    public List<ArtifactReference> getReferencesByContentHash(String contentHash) {
+        ContentWrapperDto artifact = storage.getArtifactByContentHash(contentHash);
+        return artifact.getReferences().stream()
+                .map(V2ApiUtil::referenceDtoToReference)
+                .collect(Collectors.toList());
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/services/http/RegistryExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/RegistryExceptionMapperService.java
@@ -17,7 +17,6 @@
 package io.apicurio.registry.services.http;
 
 import io.apicurio.common.apps.config.Info;
-import io.apicurio.tenantmanager.client.exception.TenantManagerClientException;
 import io.apicurio.registry.ccompat.rest.error.ConflictException;
 import io.apicurio.registry.ccompat.rest.error.UnprocessableEntityException;
 import io.apicurio.registry.metrics.health.liveness.LivenessUtil;
@@ -57,6 +56,7 @@ import io.apicurio.registry.storage.VersionAlreadyExistsException;
 import io.apicurio.registry.storage.VersionNotFoundException;
 import io.apicurio.rest.client.auth.exception.ForbiddenException;
 import io.apicurio.rest.client.auth.exception.NotAuthorizedException;
+import io.apicurio.tenantmanager.client.exception.TenantManagerClientException;
 import io.smallrye.mutiny.TimeoutException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -132,6 +132,7 @@ public class RegistryExceptionMapperService {
         map.put(RoleMappingAlreadyExistsException.class, HTTP_CONFLICT);
         map.put(RoleMappingNotFoundException.class, HTTP_NOT_FOUND);
         map.put(TenantManagerClientException.class, HTTP_INTERNAL_ERROR);
+        map.put(io.apicurio.registry.rest.ConflictException.class, HTTP_CONFLICT);
         map.put(ParametersConflictException.class, HTTP_CONFLICT);
         map.put(DownloadNotFoundException.class, HTTP_NOT_FOUND);
         map.put(ConfigPropertyNotFoundException.class, HTTP_NOT_FOUND);

--- a/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactMetaDataDto.java
@@ -21,6 +21,8 @@ import io.apicurio.registry.types.ArtifactState;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 import java.util.List;
@@ -31,6 +33,8 @@ import java.util.Map;
  */
 @AllArgsConstructor
 @Builder
+@Getter
+@Setter
 @EqualsAndHashCode
 @ToString
 public class ArtifactMetaDataDto {
@@ -51,234 +55,8 @@ public class ArtifactMetaDataDto {
     private ArtifactState state;
     private List<String> labels;
     private Map<String, String> properties;
+    private List<ArtifactReferenceDto> references;
 
-    /**
-     * Constructor.
-     */
     public ArtifactMetaDataDto() {
-    }
-
-    /**
-     * @return the description
-     */
-    public String getDescription() {
-        return description;
-    }
-
-    /**
-     * @param description the description to set
-     */
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    /**
-     * @return the createdBy
-     */
-    public String getCreatedBy() {
-        return createdBy;
-    }
-
-    /**
-     * @param createdBy the createdBy to set
-     */
-    public void setCreatedBy(String createdBy) {
-        this.createdBy = createdBy;
-    }
-
-    /**
-     * @return the createdOn
-     */
-    public long getCreatedOn() {
-        return createdOn;
-    }
-
-    /**
-     * @param createdOn the createdOn to set
-     */
-    public void setCreatedOn(long createdOn) {
-        this.createdOn = createdOn;
-    }
-
-    /**
-     * @return the modifiedBy
-     */
-    public String getModifiedBy() {
-        return modifiedBy;
-    }
-
-    /**
-     * @param modifiedBy the modifiedBy to set
-     */
-    public void setModifiedBy(String modifiedBy) {
-        this.modifiedBy = modifiedBy;
-    }
-
-    /**
-     * @return the modifiedOn
-     */
-    public long getModifiedOn() {
-        return modifiedOn;
-    }
-
-    /**
-     * @param modifiedOn the modifiedOn to set
-     */
-    public void setModifiedOn(long modifiedOn) {
-        this.modifiedOn = modifiedOn;
-    }
-
-    /**
-     * @return the version
-     */
-    public String getVersion() {
-        return version;
-    }
-
-    /**
-     * @param version the version to set
-     */
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    /**
-     * @return the type
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * @param type the type to set
-     */
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    /**
-     * @return the state
-     */
-    public ArtifactState getState() {
-        return state;
-    }
-
-    /**
-     * @param state the state to set
-     */
-    public void setState(ArtifactState state) {
-        this.state = state;
-    }
-
-    /**
-     * @return the name
-     */
-    public String getName() {
-        return name;
-    }
-
-    /**
-     * @param name the name to set
-     */
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    /**
-     * @return the id
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * @param id the id to set
-     */
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    /**
-     * @return the globalId
-     */
-    public long getGlobalId() {
-        return globalId;
-    }
-
-    /**
-     * @param globalId the globalId to set
-     */
-    public void setGlobalId(long globalId) {
-        this.globalId = globalId;
-    }
-
-    /**
-     * @return the contentId
-     */
-    public long getContentId() {
-        return contentId;
-    }
-
-    /**
-     * @param contentId the contentId to set
-     */
-    public void setContentId(long contentId) {
-        this.contentId = contentId;
-    }
-
-    /**
-     * @return the labels
-     */
-    public List<String> getLabels() {
-        return labels;
-    }
-
-    /**
-     * @param labels the labels to set
-     */
-    public void setLabels(List<String> labels) {
-        this.labels = labels;
-    }
-
-    /**
-     * @return the user-defined properties
-     */
-    public Map<String, String> getProperties() {
-        return properties;
-    }
-
-    /**
-     * @param properties the user-defined properties to set
-     */
-    public void setProperties(Map<String, String> properties) {
-        this.properties = properties;
-    }
-
-    /**
-     * @return the groupId
-     */
-    public String getGroupId() {
-        return groupId;
-    }
-
-    /**
-     * @param groupId the groupId to set
-     */
-    public void setGroupId(String groupId) {
-        this.groupId = groupId;
-    }
-
-    /**
-     * @return the versionId
-     */
-    public int getVersionId() {
-        return versionId;
-    }
-
-    /**
-     * @param versionId the versionId to set
-     */
-    public void setVersionId(int versionId) {
-        this.versionId = versionId;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -16,39 +16,8 @@
 
 package io.apicurio.registry.storage.impl.sql;
 
-import static io.apicurio.registry.storage.impl.sql.SqlUtil.denormalizeGroupId;
-import static io.apicurio.registry.storage.impl.sql.SqlUtil.normalizeGroupId;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.time.Instant;
-import java.util.Collections;
-import java.util.Date;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import javax.annotation.PostConstruct;
-import javax.enterprise.event.Event;
-import javax.inject.Inject;
-import javax.transaction.Transactional;
-
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.tuple.Pair;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.slf4j.Logger;
-
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.apicurio.common.apps.config.DynamicConfigPropertyDto;
 import io.apicurio.common.apps.config.Info;
 import io.apicurio.common.apps.core.System;
@@ -134,6 +103,34 @@ import io.apicurio.registry.utils.impexp.GlobalRuleEntity;
 import io.apicurio.registry.utils.impexp.GroupEntity;
 import io.apicurio.registry.utils.impexp.ManifestEntity;
 import io.quarkus.security.identity.SecurityIdentity;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.PostConstruct;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+
+import static io.apicurio.registry.storage.impl.sql.SqlUtil.denormalizeGroupId;
+import static io.apicurio.registry.storage.impl.sql.SqlUtil.normalizeGroupId;
 
 
 /**
@@ -764,8 +761,9 @@ public abstract class AbstractSqlRegistryStorage extends AbstractRegistryStorage
         if (md == null) {
             md = extractMetaData(artifactType, content);
         }
-
-        return createArtifactWithMetadata(groupId, artifactId, version, artifactType, contentId, createdBy, createdOn, md, globalIdGenerator);
+        var metadataDto = createArtifactWithMetadata(groupId, artifactId, version, artifactType, contentId, createdBy, createdOn, md, globalIdGenerator);
+        metadataDto.setReferences(references); // Keep the references
+        return metadataDto;
     }
 
     protected ArtifactMetaDataDto createArtifactWithMetadata(String groupId, String artifactId, String version,

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/StoredArtifactMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/StoredArtifactMapper.java
@@ -16,15 +16,15 @@
 
 package io.apicurio.registry.storage.impl.sql.mappers;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.List;
-
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
 import io.apicurio.registry.storage.dto.StoredArtifactDto;
 import io.apicurio.registry.storage.impl.sql.SqlUtil;
 import io.apicurio.registry.storage.impl.sql.jdb.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -50,7 +50,25 @@ public class StoredArtifactMapper implements RowMapper<StoredArtifactDto> {
         Long contentId = rs.getLong("contentId");
         byte[] contentBytes = rs.getBytes("content");
         ContentHandle content = ContentHandle.create(contentBytes);
-        List<ArtifactReferenceDto> references = SqlUtil.deserializeReferences(rs.getString("artifactreferences"));
+        List<ArtifactReferenceDto> references = SqlUtil.deserializeReferences(rs.getString("artifactreferences")); // ARTIFACTREFERENCES
+
+//        var meta = rs.getMetaData();
+//        for (int i = 1; i <= meta.getColumnCount(); i++) {
+//            var cname = meta.getColumnName(i);
+//            var ctype = meta.getColumnTypeName(i);
+//            System.out.println(">>> " + cname + " is " + ctype);
+//        }
+//
+//        var ref1 = rs.getString("artifactreferences");
+//        var ref2 = rs.getString("ARTIFACTREFERENCES");
+//        try {
+//            var ref3 = rs.getCharacterStream("artifactreferences");
+//            var ref4 = rs.getCharacterStream("artifactreferences");
+//            var ref5 = CharStreams.toString(ref3);
+//            var ref6 = CharStreams.toString(ref4);
+//        } catch (IOException e) {
+//            throw new RuntimeException(e);
+//        }
 
         return StoredArtifactDto.builder().content(content).contentId(contentId).globalId(globalId).version(version).versionId(versionId).references(references).build();
     }

--- a/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json
+++ b/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json
@@ -1827,7 +1827,6 @@
                     "content": {
                         "*/*": {
                             "schema": {
-
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -2068,7 +2067,6 @@
                     "content": {
                         "*/*": {
                             "schema": {
-
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -2293,7 +2291,6 @@
                     "content": {
                         "*/*": {
                             "schema": {
-
                             }
                         }
                     },
@@ -2405,7 +2402,6 @@
                     "content": {
                         "*/*": {
                             "schema": {
-
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -2626,7 +2622,6 @@
                     "content": {
                         "*/*": {
                             "schema": {
-
                             },
                             "examples": {
                                 "OpenAPI": {
@@ -3814,11 +3809,9 @@
                     "globalId": 37,
                     "version": 85,
                     "properties": {
-
                     },
                     "contentId": 62,
                     "references": {
-
                     }
                 }
             },
@@ -4367,7 +4360,23 @@
         "bean-annotations": [
             "io.quarkus.runtime.annotations.RegisterForReflection",
             {
-                "annotation": "lombok.ToString",
+                "annotation": "lombok.experimental.SuperBuilder",
+                "excludeEnums": true
+            },
+            {
+                "annotation": "lombok.AllArgsConstructor",
+                "excludeEnums": true
+            },
+            {
+                "annotation": "lombok.NoArgsConstructor",
+                "excludeEnums": true
+            },
+            {
+                "annotation": "lombok.EqualsAndHashCode",
+                "excludeEnums": true
+            },
+            {
+                "annotation": "lombok.ToString(callSuper = true)",
                 "excludeEnums": true
             }
         ]

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/GroupsResourceTest.java
@@ -2240,8 +2240,9 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         metadata = response
                 .statusCode(HTTP_OK)
                 .extract().as(ArtifactMetaData.class);
-        assertEquals(references, metadata.getReferences());
         waitForArtifact(metadata.getId());
+        assertEquals(references, metadata.getReferences());
+
 
         // Trying to use different references with the same content fails
         List<ArtifactReference> references2 = List.of(ArtifactReference.builder()

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/GroupsResourceTest.java
@@ -16,10 +16,32 @@
 
 package io.apicurio.registry.noprofile.rest.v2;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.anything;
-import static org.hamcrest.Matchers.*;
+import com.google.common.hash.Hashing;
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
+import io.apicurio.registry.rest.v2.beans.EditableMetaData;
+import io.apicurio.registry.rest.v2.beans.Error;
+import io.apicurio.registry.rest.v2.beans.IfExists;
+import io.apicurio.registry.rest.v2.beans.Rule;
+import io.apicurio.registry.rest.v2.beans.VersionMetaData;
+import io.apicurio.registry.rules.compatibility.jsonschema.diff.DiffType;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.RuleType;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.config.EncoderConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import org.hamcrest.Matchers;
+import org.jose4j.base64url.Base64;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -29,30 +51,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import com.google.common.hash.Hashing;
-import org.hamcrest.Matchers;
-import org.jose4j.base64url.Base64;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
-
-import io.apicurio.registry.AbstractResourceTestBase;
-import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
-import io.apicurio.registry.rest.v2.beans.EditableMetaData;
-import io.apicurio.registry.rest.v2.beans.IfExists;
-import io.apicurio.registry.rest.v2.beans.Rule;
-import io.apicurio.registry.rest.v2.beans.VersionMetaData;
-import io.apicurio.registry.rules.compatibility.jsonschema.diff.DiffType;
-import io.apicurio.registry.types.ArtifactType;
-import io.apicurio.registry.types.RuleType;
-import io.apicurio.registry.utils.tests.TestUtils;
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.config.EncoderConfig;
-import io.restassured.config.RestAssuredConfig;
-import io.restassured.http.ContentType;
-import io.restassured.response.ValidatableResponse;
+import static io.restassured.RestAssured.given;
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.anything;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -83,46 +88,46 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Search each group to ensure the correct # of artifacts.
         given()
-            .when()
+                .when()
                 .queryParam("group", nullGroup)
                 .get("/registry/v2/search/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", greaterThanOrEqualTo(5));
         given()
-            .when()
+                .when()
                 .queryParam("group", group)
                 .get("/registry/v2/search/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", equalTo(2));
 
         // Get the artifact content
         given()
-            .when()
+                .when()
                 .pathParam("groupId", nullGroup)
                 .pathParam("artifactId", "testDefaultGroup/EmptyAPI/1")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", equalTo("3.0.2"))
                 .body("info.title", equalTo("Empty API"));
         given()
-            .when()
+                .when()
                 .pathParam("groupId", group)
                 .pathParam("artifactId", "testDefaultGroup/EmptyAPI/1")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", not(equalTo("3.0.2")))
                 .body("info.title", not(equalTo("Empty API")));
 
         // Test using v1 API to access artifact in the null group
         given()
-            .when()
+                .when()
                 .pathParam("artifactId", "testDefaultGroup/EmptyAPI/1")
                 .get("/registry/v1/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", equalTo("3.0.2"))
                 .body("info.title", equalTo("Empty API"));
@@ -132,21 +137,21 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Test using v1 API to access artifact
         given()
-            .when()
+                .when()
                 .pathParam("artifactId", "testDefaultGroup/EmptyAPI/6")
                 .get("/registry/v1/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", equalTo("3.0.2"))
                 .body("info.title", equalTo("Empty API"));
 
         // Test using v2 API to access artifact
         given()
-            .when()
+                .when()
                 .pathParam("groupId", nullGroup)
                 .pathParam("artifactId", "testDefaultGroup/EmptyAPI/6")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", equalTo("3.0.2"))
                 .body("info.title", equalTo("Empty API"));
@@ -192,36 +197,36 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Search each group to ensure the correct # of artifacts.
         given()
-            .when()
+                .when()
                 .queryParam("group", group1)
                 .get("/registry/v2/search/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", equalTo(5));
         given()
-            .when()
+                .when()
                 .queryParam("group", group2)
                 .get("/registry/v2/search/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", equalTo(2));
 
         // Get the artifact content
         given()
-            .when()
+                .when()
                 .pathParam("groupId", group1)
                 .pathParam("artifactId", "testMultipleGroups/EmptyAPI/1")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", equalTo("3.0.2"))
                 .body("info.title", equalTo("Empty API"));
         given()
-            .when()
+                .when()
                 .pathParam("groupId", group2)
                 .pathParam("artifactId", "testMultipleGroups/EmptyAPI/1")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", not(equalTo("3.0.2")))
                 .body("info.title", not(equalTo("Empty API")));
@@ -269,13 +274,13 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Create OpenAPI artifact - indicate the type via the content-type
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifact/EmptyAPI/2")
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("groupId", equalTo(GROUP))
                 .body("version", equalTo("1"))
@@ -284,62 +289,62 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Try to create a duplicate artifact ID (should fail)
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifact/EmptyAPI/1")
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(409)
                 .body("error_code", equalTo(409))
                 .body("message", equalTo("An artifact with ID 'testCreateArtifact/EmptyAPI/1' in group 'GroupsResourceTest' already exists."));
 
         // Try to create an artifact with an invalid artifact type
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=INVALID_ARTIFACT_TYPE")
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifact/InvalidAPI")
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(400);
 
         // Create OpenAPI artifact - don't provide the artifact type
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifact/EmptyAPI/detect")
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", equalTo("testCreateArtifact/EmptyAPI/detect"))
                 .body("type", equalTo(ArtifactType.OPENAPI));
 
         // Create artifact with empty content (should fail)
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifact/EmptyContent")
                 .body("")
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(400);
 
         // Create OpenAPI artifact - provide a custom version #
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifact/EmptyAPI-customVersion")
                 .header("X-Registry-Version", "1.0.2")
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("groupId", equalTo(GROUP))
                 .body("version", equalTo("1.0.2"))
@@ -349,14 +354,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Create OpenAPI artifact - provide a custom name
         String customName = "CUSTOM NAME";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifact/EmptyAPI-customName")
                 .header("X-Registry-Name", customName)
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("groupId", equalTo(GROUP))
                 .body("name", equalTo(customName))
@@ -366,14 +371,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Create OpenAPI artifact - provide a custom description
         String customDescription = "CUSTOM DESCRIPTION";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifact/EmptyAPI-customDescription")
                 .header("X-Registry-Description", customDescription)
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("groupId", equalTo(GROUP))
                 .body("description", equalTo(customDescription))
@@ -390,14 +395,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Create OpenAPI artifact - provide a custom No-ASCII name
         String customNoASCIIName = "CUSTOM NAME with NO-ASCII char č";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifact/EmptyAPI-customNameEncoded")
                 .header("X-Registry-Name-Encoded", Base64.encode(customNoASCIIName.getBytes(StandardCharsets.UTF_8)))
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("groupId", equalTo(GROUP))
                 .body("name", equalTo(customNoASCIIName))
@@ -407,14 +412,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Create OpenAPI artifact - provide a custom No-ASCII description
         String customNoASCIIDescription = "CUSTOM DESCRIPTION with NO-ASCII char č";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifact/EmptyAPI-customDescriptionEncoded")
                 .header("X-Registry-Description-Encoded", Base64.encode(customNoASCIIDescription.getBytes(StandardCharsets.UTF_8)))
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("groupId", equalTo(GROUP))
                 .body("description", equalTo(customNoASCIIDescription))
@@ -424,7 +429,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Create OpenAPI artifact - provide a custom name and encoded custom name (conflict - should fail)
         String customName = "CUSTOM NAME";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifact/EmptyAPI-customNameConflict")
@@ -432,7 +437,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .header("X-Registry-Name-Encoded", Base64.encode(customNoASCIIName.getBytes(StandardCharsets.UTF_8)))
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(409);
     }
 
@@ -445,22 +450,22 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Get the artifact content
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifact/EmptyAPI")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", equalTo("3.0.2"))
                 .body("info.title", equalTo("Empty API"));
 
         // Try to get artifact content for an artifact that doesn't exist.
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifact/MissingAPI")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(404)
                 .body("error_code", equalTo(404))
                 .body("message", equalTo("No artifact with ID 'testGetArtifact/MissingAPI' in group 'GroupsResourceTest' was found."));
@@ -476,56 +481,56 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Update OpenAPI artifact
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                 .pathParam("artifactId", "testUpdateArtifact/EmptyAPI")
                 .body(updatedArtifactContent)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", equalTo("testUpdateArtifact/EmptyAPI"))
                 .body("type", equalTo(ArtifactType.OPENAPI));
 
         // Get the artifact content (should be the updated content)
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testUpdateArtifact/EmptyAPI")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", equalTo("3.0.2"))
                 .body("info.title", equalTo("Empty API (Updated)"));
 
         // Try to update an artifact that doesn't exist.
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                 .pathParam("artifactId", "testUpdateArtifact/MissingAPI")
                 .body(updatedArtifactContent)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(404);
 
         // Try to update an artifact with empty content
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                 .pathParam("artifactId", "testUpdateArtifact/EmptyAPI")
                 .body("")
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(400);
 
         // Update OpenAPI artifact with a custom version
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
@@ -533,7 +538,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .pathParam("artifactId", "testUpdateArtifact/EmptyAPI")
                 .body(updatedArtifactContent)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("version", equalTo("3.0.0.Final"))
                 .body("id", equalTo("testUpdateArtifact/EmptyAPI"))
@@ -542,7 +547,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Update OpenAPI artifact with a custom name
         String customName = "CUSTOM NAME";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
@@ -550,7 +555,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .pathParam("artifactId", "testUpdateArtifact/EmptyAPI")
                 .body(updatedArtifactContent)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("name", equalTo(customName))
                 .body("id", equalTo("testUpdateArtifact/EmptyAPI"))
@@ -559,7 +564,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Update OpenAPI artifact with a custom description
         String customDescription = "CUSTOM DESCRIPTION";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
@@ -567,7 +572,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .pathParam("artifactId", "testUpdateArtifact/EmptyAPI")
                 .body(updatedArtifactContent)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("description", equalTo(customDescription))
                 .body("id", equalTo("testUpdateArtifact/EmptyAPI"))
@@ -588,7 +593,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Update OpenAPI artifact with a custom no-ascii name
         String customNoASCIIName = "CUSTOM NAME with NO-ASCII char ě";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
@@ -596,7 +601,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .pathParam("artifactId", "testUpdateArtifactNoAscii/EmptyAPI")
                 .body(updatedArtifactContent)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("name", equalTo(customNoASCIIName))
                 .body("id", equalTo("testUpdateArtifactNoAscii/EmptyAPI"))
@@ -605,7 +610,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Update OpenAPI artifact with a custom no-ascii description
         String customNoASCIIDescription = "CUSTOM DESCRIPTION with NO-ASCII char ě";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
@@ -613,7 +618,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .pathParam("artifactId", "testUpdateArtifactNoAscii/EmptyAPI")
                 .body(updatedArtifactContent)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("description", equalTo(customNoASCIIDescription))
                 .body("id", equalTo("testUpdateArtifactNoAscii/EmptyAPI"))
@@ -622,7 +627,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Try to Update artifact with a custom name and encoded name (conflict - should fail)
         String customName = "CUSTOM NAME";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
@@ -631,7 +636,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .pathParam("artifactId", "testUpdateArtifactNoAscii/EmptyAPI")
                 .body(updatedArtifactContent)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(409);
     }
 
@@ -644,32 +649,32 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Make sure we can get the artifact content
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testDeleteArtifact/EmptyAPI")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", equalTo("3.0.2"))
                 .body("info.title", equalTo("Empty API"));
 
         // Delete the artifact
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testDeleteArtifact/EmptyAPI")
                 .delete("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(204);
 
         // Try to get artifact content for an artifact that doesn't exist.
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", "testDeleteArtifact/EmptyAPI")
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-                .then()
+                    .then()
                     .statusCode(404)
                     .body("error_code", equalTo(404))
                     .body("message", equalTo("No artifact with ID 'testDeleteArtifact/EmptyAPI' in group 'GroupsResourceTest' was found."));
@@ -677,11 +682,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Try to delete an artifact that doesn't exist.
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testDeleteArtifact/MissingAPI")
                 .delete("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(404);
     }
 
@@ -697,30 +702,30 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Make sure we can search for all three artifacts in the group.
         given()
-            .when()
+                .when()
                 .queryParam("group", group)
                 .get("/registry/v2/search/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", equalTo(3));
 
         // Delete the artifacts in the group
         given()
-            .when()
+                .when()
                 .pathParam("groupId", group)
                 .delete("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(204);
 
         // Verify that all 3 artifacts were deleted
         TestUtils.retry(() -> {
             given()
-            .when()
-                .queryParam("group", group)
-                .get("/registry/v2/search/artifacts")
-            .then()
-                .statusCode(200)
-                .body("count", equalTo(0));
+                    .when()
+                    .queryParam("group", group)
+                    .get("/registry/v2/search/artifacts")
+                    .then()
+                    .statusCode(200)
+                    .body("count", equalTo(0));
         });
     }
 
@@ -736,10 +741,10 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // List the artifacts in the group
         given()
-            .when()
+                .when()
                 .pathParam("groupId", group)
                 .get("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", equalTo(3));
 
@@ -749,10 +754,10 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // List the artifacts in the group again
         given()
-            .when()
+                .when()
                 .pathParam("groupId", group)
                 .get("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", equalTo(5));
 
@@ -760,10 +765,10 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // List the artifacts in the group
         given()
-            .when()
+                .when()
                 .pathParam("groupId", group + "-doesnotexist")
                 .get("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", equalTo(0));
 
@@ -780,14 +785,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Update the artifact 5 times
         for (int idx = 0; idx < 5; idx++) {
             given()
-                .when()
+                    .when()
                     .contentType(CT_JSON)
                     .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .body(artifactContent.replace("Empty API", "Empty API (Update " + idx + ")"))
                     .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-                .then()
+                    .then()
                     .statusCode(200)
                     .body("id", equalTo(artifactId))
                     .body("type", equalTo(ArtifactType.OPENAPI));
@@ -795,11 +800,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // List the artifact versions
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
 //                .log().all()
                 .statusCode(200)
                 .body("count", equalTo(6))
@@ -807,11 +812,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Try to list artifact versions for an artifact that doesn't exist.
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testListArtifactVersions/MissingAPI")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(404);
 
     }
@@ -826,63 +831,63 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Create a new version of the artifact
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                 .pathParam("artifactId", "testCreateArtifactVersion/EmptyAPI")
                 .body(updatedArtifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("version", equalTo("2"))
                 .body("type", equalTo(ArtifactType.OPENAPI));
 
         // Get the artifact content (should be the updated content)
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testCreateArtifactVersion/EmptyAPI")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", equalTo("3.0.2"))
                 .body("info.title", equalTo("Empty API (Updated)"));
 
         // Try to create a new version of an artifact that doesn't exist.
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                 .pathParam("artifactId", "testCreateArtifactVersion/MissingAPI")
                 .body(updatedArtifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(404);
 
         // Try to create a new version of the artifact with empty content
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testCreateArtifactVersion/EmptyAPI")
                 .body("")
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(400);
 
         // Create another new version of the artifact with a custom version #
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-Version", "3.0.0.Final")
                 .pathParam("artifactId", "testCreateArtifactVersion/EmptyAPI")
                 .body(updatedArtifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("version", equalTo("3.0.0.Final"))
                 .body("type", equalTo(ArtifactType.OPENAPI));
@@ -891,14 +896,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         String customName = "CUSTOM NAME";
 
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-Name", customName)
                 .pathParam("artifactId", "testCreateArtifactVersion/EmptyAPI")
                 .body(updatedArtifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("name", equalTo(customName));
 
@@ -906,14 +911,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         String customDescription = "CUSTOM DESCRIPTION";
 
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-Description", customDescription)
                 .pathParam("artifactId", "testCreateArtifactVersion/EmptyAPI")
                 .body(updatedArtifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("description", equalTo(customDescription));
 
@@ -934,7 +939,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         String customDescriptionNoASCII = "CUSTOM DESCRIPTION WITH NO-ASCII CHAR ě";
 
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-Name-Encoded", Base64.encode(customNameNoASCII.getBytes(StandardCharsets.UTF_8)))
@@ -942,19 +947,19 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .pathParam("artifactId", "testCreateArtifactVersionNoAscii/EmptyAPI")
                 .body(updatedArtifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("name", equalTo(customNameNoASCII))
                 .body("description", equalTo(customDescriptionNoASCII));
 
         // Get artifact metadata (should has the custom name and description)
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testCreateArtifactVersionNoAscii/EmptyAPI")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("name", equalTo(customNameNoASCII))
                 .body("description", equalTo(customDescriptionNoASCII));
@@ -962,7 +967,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Try to create new version of the artifact with a custom name and encoded name (conflict)
         String customName = "CUSTOM NAME";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-Name-Encoded", Base64.encode(customNameNoASCII.getBytes(StandardCharsets.UTF_8)))
@@ -970,7 +975,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .pathParam("artifactId", "testCreateArtifactVersionNoAscii/EmptyAPI")
                 .body(updatedArtifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(409);
     }
 
@@ -986,24 +991,24 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         rule.setType(RuleType.VALIDITY);
         rule.setConfig("FULL");
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .body(rule)
                 .pathParam("artifactId", artifactId)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-            .then()
+                .then()
                 .statusCode(204)
                 .body(anything());
 
         // Verify the rule was added
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules/VALIDITY")
-                .then()
+                    .then()
                     .statusCode(200)
                     .contentType(ContentType.JSON)
                     .body("type", equalTo("VALIDITY"))
@@ -1012,14 +1017,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Create a new version of the artifact with invalid syntax
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .header("X-Registry-ArtifactType", ArtifactType.JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .body(artifactContentInvalidSyntax)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(409)
                 .body("error_code", equalTo(409))
                 .body("message", equalTo("Syntax or semantic violation for JSON Schema artifact."));
@@ -1030,31 +1035,31 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         String artifactContent = resourceToString("jsonschema-valid.json");
         String artifactContentInvalidSyntax = resourceToString("jsonschema-valid-incompatible.json");
         String artifactId = "testCreateArtifact/ValidJson";
-        createArtifact(GROUP, artifactId,ArtifactType.JSON, artifactContent);
+        createArtifact(GROUP, artifactId, ArtifactType.JSON, artifactContent);
 
         // Add a rule
         Rule rule = new Rule();
         rule.setType(RuleType.COMPATIBILITY);
         rule.setConfig("BACKWARD");
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .body(rule)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-            .then()
+                .then()
                 .statusCode(204)
                 .body(anything());
 
         // Verify the rule was added
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules/COMPATIBILITY")
-                .then()
+                    .then()
                     .statusCode(200)
                     .contentType(ContentType.JSON)
                     .body("type", equalTo("COMPATIBILITY"))
@@ -1063,14 +1068,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Create a new version of the artifact with invalid syntax
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .header("X-Registry-ArtifactType", ArtifactType.JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .body(artifactContentInvalidSyntax)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(409)
                 .body("error_code", equalTo(409))
                 .body("message", equalTo("Incompatible artifact: testCreateArtifact/ValidJson [JSON], num" +
@@ -1091,18 +1096,18 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         List<String> versions = new ArrayList<>();
         for (int idx = 0; idx < 5; idx++) {
             String version = given()
-                .when()
+                    .when()
                     .contentType(CT_JSON)
                     .pathParam("groupId", GROUP)
                     .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                     .pathParam("artifactId", "testGetArtifactVersion/EmptyAPI")
                     .body(artifactContent.replace("Empty API", "Empty API (Update " + idx + ")"))
                     .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-                .then()
+                    .then()
                     .statusCode(200)
                     .body("id", equalTo("testGetArtifactVersion/EmptyAPI"))
                     .body("type", equalTo(ArtifactType.OPENAPI))
-                .extract().body().path("version");
+                    .extract().body().path("version");
             versions.add(version);
         }
 
@@ -1111,34 +1116,34 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
             String version = versions.get(idx);
             String expected = "Empty API (Update " + idx + ")";
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", "testGetArtifactVersion/EmptyAPI")
                     .pathParam("version", version)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}")
-                .then()
+                    .then()
                     .statusCode(200)
                     .body("info.title", equalTo(expected));
         }
 
         // Now get a version that doesn't exist.
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactVersion/EmptyAPI")
                 .pathParam("version", 12345)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}")
-            .then()
+                .then()
                 .statusCode(404);
 
         // Now get a version of an artifact that doesn't exist.
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactVersion/MissingAPI")
                 .pathParam("version", "1")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}")
-            .then()
+                .then()
                 .statusCode(404);
     }
 
@@ -1152,74 +1157,74 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Update the artifact 5 times
         for (int idx = 0; idx < 5; idx++) {
             given()
-                .when()
+                    .when()
                     .contentType(CT_JSON)
                     .pathParam("groupId", GROUP)
                     .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                     .pathParam("artifactId", "testGetArtifactMetaDataByContent/EmptyAPI")
                     .body(artifactContent.replace("Empty API", "Empty API (Update " + idx + ")"))
                     .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-                .then()
+                    .then()
                     .statusCode(200)
                     .body("id", equalTo("testGetArtifactMetaDataByContent/EmptyAPI"))
                     .body("groupId", equalTo(GROUP))
                     .body("type", equalTo(ArtifactType.OPENAPI))
-                .extract().body().path("version");
+                    .extract().body().path("version");
         }
 
         // Get meta-data by content
         String searchContent = artifactContent.replace("Empty API", "Empty API (Update 2)");
         Integer globalId1 = given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactMetaDataByContent/EmptyAPI")
                 .body(searchContent)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("type", equalTo(ArtifactType.OPENAPI))
-            .extract().body().path("globalId");
+                .extract().body().path("globalId");
 
         // Now add some extra whitespace/formatting to the content and try again
         searchContent = searchContent.replace("{", "{\n").replace("}", "\n}");
         Integer globalId2 = given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactMetaDataByContent/EmptyAPI")
                 .queryParam("canonical", "true")
                 .body(searchContent)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("type", equalTo(ArtifactType.OPENAPI))
-            .extract().body().path("globalId");
+                .extract().body().path("globalId");
 
         // Should return the same meta-data
-        Assertions.assertEquals(globalId1, globalId2);
+        assertEquals(globalId1, globalId2);
 
         // Try the same (extra whitespace) content but without the "canonical=true" param (should fail with 404)
         searchContent = searchContent.replace("{", "{\n").replace("}", "\n}");
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactMetaDataByContent/EmptyAPI")
                 .body(searchContent)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(404);
 
         // Get meta-data by empty content (400 error)
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactMetaDataByContent/EmptyAPI")
                 .body("")
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(400);
 
     }
@@ -1230,31 +1235,31 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         String artifactId = "testArtifactRules/EmptyAPI";
 
         // Create an artifact
-        createArtifact(GROUP, artifactId,ArtifactType.OPENAPI, artifactContent);
+        createArtifact(GROUP, artifactId, ArtifactType.OPENAPI, artifactContent);
 
         // Add a rule
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
         rule.setConfig("FULL");
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .body(rule)
                 .pathParam("artifactId", artifactId)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-            .then()
+                .then()
                 .statusCode(204)
                 .body(anything());
 
         // Verify the rule was added
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules/VALIDITY")
-                .then()
+                    .then()
                     .statusCode(200)
                     .contentType(ContentType.JSON)
                     .body("type", equalTo("VALIDITY"))
@@ -1265,13 +1270,13 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         final Rule finalRule = rule;
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .contentType(CT_JSON)
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .body(finalRule)
                     .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-                .then()
+                    .then()
                     .statusCode(409)
                     .body("error_code", equalTo(409))
                     .body("message", equalTo("A rule named 'VALIDITY' already exists."));
@@ -1281,24 +1286,24 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         rule.setType(RuleType.COMPATIBILITY);
         rule.setConfig("BACKWARD");
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .body(rule)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-            .then()
+                .then()
                 .statusCode(204)
                 .body(anything());
 
         // Verify the rule was added
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules/COMPATIBILITY")
-                .then()
+                    .then()
                     .statusCode(200)
                     .contentType(ContentType.JSON)
                     .body("type", equalTo("COMPATIBILITY"))
@@ -1307,11 +1312,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Get the list of rules (should be 2 of them)
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-            .then()
+                .then()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
                 .body("[0]", anyOf(equalTo("VALIDITY"), equalTo("COMPATIBILITY")))
@@ -1322,13 +1327,13 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         rule.setType(RuleType.COMPATIBILITY);
         rule.setConfig("FULL");
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .body(rule)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules/COMPATIBILITY")
-            .then()
+                .then()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
                 .body("type", equalTo("COMPATIBILITY"))
@@ -1337,11 +1342,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Get a single (updated) rule by name
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules/COMPATIBILITY")
-                .then()
+                    .then()
                     .statusCode(200)
                     .contentType(ContentType.JSON)
                     .body("type", equalTo("COMPATIBILITY"))
@@ -1350,22 +1355,22 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Delete a rule
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .delete("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules/COMPATIBILITY")
-            .then()
+                .then()
                 .statusCode(204)
                 .body(anything());
 
         // Get a single (deleted) rule by name (should fail with a 404)
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules/COMPATIBILITY")
-                .then()
+                    .then()
                     .statusCode(404)
                     .contentType(ContentType.JSON)
                     .body("error_code", equalTo(404))
@@ -1374,11 +1379,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Get the list of rules (should be 1 of them)
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-            .then()
+                .then()
 //                .log().all()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
@@ -1387,21 +1392,21 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Delete all rules
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .delete("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-            .then()
+                .then()
                 .statusCode(204);
 
         // Get the list of rules (no rules now)
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-                .then()
+                    .then()
                     .statusCode(200)
                     .contentType(ContentType.JSON)
                     .body("[0]", nullValue());
@@ -1412,13 +1417,13 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         rule.setType(RuleType.VALIDITY);
         rule.setConfig("FULL");
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "MissingArtifact")
                 .body(rule)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-            .then()
+                .then()
                 .statusCode(404)
                 .body(anything());
     }
@@ -1432,11 +1437,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Get the artifact meta-data
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactMetaData/EmptyAPI")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", equalTo("testGetArtifactMetaData/EmptyAPI"))
                 .body("version", anything())
@@ -1444,16 +1449,16 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .body("createdOn", anything())
                 .body("name", equalTo("Empty API"))
                 .body("description", equalTo("An example API design using OpenAPI."))
-        .extract()
-            .as(ArtifactMetaData.class);
+                .extract()
+                .as(ArtifactMetaData.class);
 
         // Try to get artifact meta-data for an artifact that doesn't exist.
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactMetaData/MissingAPI")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(404)
                 .body("error_code", equalTo(404))
                 .body("message", equalTo("No artifact with ID 'testGetArtifactMetaData/MissingAPI' in group 'GroupsResourceTest' was found."));
@@ -1461,13 +1466,13 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         // Update the artifact meta-data
         String metaData = "{\"name\": \"Empty API Name\", \"description\": \"Empty API description.\", \"labels\":[\"Empty API label 1\",\"Empty API label 2\"], \"properties\":{\"additionalProp1\": \"Empty API additional property\"}}";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactMetaData/EmptyAPI")
                 .body(metaData)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(204);
 
 
@@ -1478,11 +1483,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
             expectedProperties.put("additionalProp1", "Empty API additional property");
 
             String version = given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", "testGetArtifactMetaData/EmptyAPI")
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-                .then()
+                    .then()
                     .statusCode(200)
                     .body("id", equalTo("testGetArtifactMetaData/EmptyAPI"))
                     .body("version", anything())
@@ -1490,46 +1495,46 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                     .body("description", equalTo("Empty API description."))
                     .body("labels", equalToObject(expectedLabels))
                     .body("properties", equalToObject(expectedProperties))
-                .extract().body().path("version");
+                    .extract().body().path("version");
 
             // Make sure the version specific meta-data also returns all the custom meta-data
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", "testGetArtifactMetaData/EmptyAPI")
                     .pathParam("version", version)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}/meta")
-                .then()
+                    .then()
                     .statusCode(200)
                     .body("name", equalTo("Empty API Name"))
                     .body("description", equalTo("Empty API description."))
                     .body("labels", equalToObject(expectedLabels))
                     .body("properties", equalToObject(expectedProperties))
-                .extract().body().path("version");
+                    .extract().body().path("version");
         });
 
         // Update the artifact content and then make sure the name/description meta-data is still available
         String updatedArtifactContent = artifactContent.replace("Empty API", "Empty API (Updated)");
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactMetaData/EmptyAPI")
                 .body(updatedArtifactContent)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", equalTo("testGetArtifactMetaData/EmptyAPI"))
                 .body("type", equalTo(ArtifactType.OPENAPI));
 
         // Verify the artifact meta-data name and description are still set.
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactMetaData/EmptyAPI")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", equalTo("testGetArtifactMetaData/EmptyAPI"))
                 .body("version", anything())
@@ -1557,13 +1562,13 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         metaData.setDescription("Some description of an API");
         metaData.setProperties(props);
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", group)
                 .pathParam("artifactId", artifactId)
                 .body(metaData)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(400);
 
     }
@@ -1579,73 +1584,73 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Create a new version of the artifact
         String version2 = given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testArtifactVersionMetaData/EmptyAPI")
                 .body(updatedArtifactContent_v2)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("version", notNullValue())
                 .body("type", equalTo(ArtifactType.OPENAPI))
-            .extract().body().path("version");
+                .extract().body().path("version");
 
         // Create another new version of the artifact
         String version3 = given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testArtifactVersionMetaData/EmptyAPI")
                 .body(updatedArtifactContent_v3)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("version", notNullValue())
                 .body("type", equalTo(ArtifactType.OPENAPI))
-            .extract().body().path("version");
+                .extract().body().path("version");
 
         // Get meta-data for v2
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testArtifactVersionMetaData/EmptyAPI")
                 .pathParam("version", version2)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}/meta")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("version", equalTo(version2))
                 .body("type", equalTo(ArtifactType.OPENAPI))
                 .body("createdOn", anything())
                 .body("name", equalTo("Empty API (v2)"))
                 .body("description", equalTo("An example API design using OpenAPI."))
-        .extract()
-            .as(VersionMetaData.class);
+                .extract()
+                .as(VersionMetaData.class);
 
         // Update the version meta-data
         String metaData = "{\"name\": \"Updated Name\", \"description\": \"Updated description.\"}";
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testArtifactVersionMetaData/EmptyAPI")
                 .pathParam("version", version2)
                 .body(metaData)
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}/meta")
-            .then()
+                .then()
                 .statusCode(204);
 
         // Get the (updated) artifact meta-data
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", "testArtifactVersionMetaData/EmptyAPI")
                     .pathParam("version", version2)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}/meta")
-                .then()
+                    .then()
                     .statusCode(200)
                     .body("version", equalTo(version2))
                     .body("type", equalTo(ArtifactType.OPENAPI))
@@ -1656,12 +1661,12 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Get the version meta-data for the version we **didn't** update
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testArtifactVersionMetaData/EmptyAPI")
                 .pathParam("version", version3)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}/meta")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("version", equalTo(version3))
                 .body("type", equalTo(ArtifactType.OPENAPI))
@@ -1671,12 +1676,12 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Get the version meta-data for a non-existant version
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testArtifactVersionMetaData/EmptyAPI")
                 .pathParam("version", 12345)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}/meta")
-            .then()
+                .then()
                 .statusCode(404);
 
     }
@@ -1689,15 +1694,15 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Create OpenAPI artifact (from YAML)
         given()
-            .config(RestAssuredConfig.config().encoderConfig(EncoderConfig.encoderConfig().encodeContentTypeAs(CT_YAML, ContentType.TEXT)))
-            .when()
+                .config(RestAssuredConfig.config().encoderConfig(EncoderConfig.encoderConfig().encodeContentTypeAs(CT_YAML, ContentType.TEXT)))
+                .when()
                 .contentType(CT_YAML)
                 .header("X-Registry-ArtifactId", artifactId)
                 .header("X-Registry-ArtifactType", artifactType)
                 .pathParam("groupId", GROUP)
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", equalTo(artifactId))
                 .body("name", equalTo("Empty API"))
@@ -1708,11 +1713,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Get the artifact content (should be JSON)
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testYamlContentType")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .header("Content-Type", Matchers.containsString(CT_JSON))
                 .body("openapi", equalTo("3.0.2"))
@@ -1728,15 +1733,15 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Create OpenAPI artifact (from YAML)
         given()
-            .config(RestAssuredConfig.config().encoderConfig(EncoderConfig.encoderConfig().encodeContentTypeAs(CT_XML, ContentType.TEXT)))
-            .when()
+                .config(RestAssuredConfig.config().encoderConfig(EncoderConfig.encoderConfig().encodeContentTypeAs(CT_XML, ContentType.TEXT)))
+                .when()
                 .contentType(CT_XML)
                 .header("X-Registry-ArtifactId", artifactId)
                 .header("X-Registry-ArtifactType", artifactType)
                 .pathParam("groupId", GROUP)
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", equalTo(artifactId))
                 .body("type", equalTo(artifactType));
@@ -1745,11 +1750,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Get the artifact content (should be XML)
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testWsdlArtifact")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .header("Content-Type", Matchers.containsString(CT_XML));
     }
@@ -1762,31 +1767,31 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         final String v3ArtifactContent = artifactContent.replace("Empty API", "Empty API (Version 3)");
 
         // Create OpenAPI artifact - indicate the type via a header param
-        Integer globalId1 = createArtifact(GROUP, artifactId,ArtifactType.OPENAPI, artifactContent);
+        Integer globalId1 = createArtifact(GROUP, artifactId, ArtifactType.OPENAPI, artifactContent);
 
         // Try to create the same artifact ID (should fail)
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .header("X-Registry-ArtifactId", artifactId)
                 .pathParam("groupId", GROUP)
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(409)
                 .body("error_code", equalTo(409))
                 .body("message", equalTo("An artifact with ID '" + artifactId + "' in group 'GroupsResourceTest' already exists."));
 
         // Try to create the same artifact ID with Return for if exists (should return same artifact)
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .header("X-Registry-ArtifactId", artifactId)
                 .pathParam("groupId", GROUP)
                 .queryParam("ifExists", IfExists.RETURN)
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("type", equalTo(ArtifactType.OPENAPI))
                 .body("version", equalTo("1"))
@@ -1796,14 +1801,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Try to create the same artifact ID with Update for if exists (should update the artifact)
         ValidatableResponse resp = given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .header("X-Registry-ArtifactId", artifactId)
                 .pathParam("groupId", GROUP)
                 .queryParam("ifExists", IfExists.UPDATE)
                 .body(updatedArtifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("type", equalTo(ArtifactType.OPENAPI))
                 .body("createdOn", anything())
@@ -1815,31 +1820,31 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Try to create the same artifact ID with ReturnOrUpdate - should return v1 (matching content)
         resp = given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .header("X-Registry-ArtifactId", artifactId)
                 .pathParam("groupId", GROUP)
                 .queryParam("ifExists", IfExists.RETURN_OR_UPDATE)
                 .body(artifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("type", equalTo(ArtifactType.OPENAPI));
 
         Integer globalId3 = resp.extract().body().path("globalId");
 
-        Assertions.assertEquals(globalId1, globalId3);
+        assertEquals(globalId1, globalId3);
 
         // Try to create the same artifact ID with ReturnOrUpdate and updated content - should create a new version
         resp = given()
-            .when()
+                .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .header("X-Registry-ArtifactId", artifactId)
                 .pathParam("groupId", GROUP)
                 .queryParam("ifExists", IfExists.RETURN_OR_UPDATE)
                 .body(v3ArtifactContent)
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("version", equalTo("3"))
                 .body("type", equalTo(ArtifactType.OPENAPI));
@@ -1851,31 +1856,31 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         String artifactId = "testDeleteArtifactWithRule/EmptyAPI";
 
         // Create an artifact
-        createArtifact(GROUP, artifactId,ArtifactType.OPENAPI, artifactContent);
+        createArtifact(GROUP, artifactId, ArtifactType.OPENAPI, artifactContent);
 
         // Add a rule
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
         rule.setConfig("FULL");
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .body(rule)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-            .then()
+                .then()
                 .statusCode(204)
                 .body(anything());
 
         // Get a single rule by name
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules/VALIDITY")
-                .then()
+                    .then()
                     .statusCode(200)
                     .contentType(ContentType.JSON)
                     .body("type", equalTo("VALIDITY"))
@@ -1884,29 +1889,29 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Delete the artifact
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .delete("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(204);
 
         // Get a single rule by name (should be 404 because the artifact is gone)
         // Also try to get the artifact itself (should be 404)
         TestUtils.retry(() -> {
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules/VALIDITY")
-                .then()
+                    .then()
                     .statusCode(404);
             given()
-                .when()
+                    .when()
                     .pathParam("groupId", GROUP)
                     .pathParam("artifactId", artifactId)
                     .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-                .then()
+                    .then()
                     .statusCode(404);
         });
 
@@ -1915,11 +1920,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Get a single rule by name (should be 404 because the artifact is gone)
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules/VALIDITY")
-            .then()
+                .then()
                 .statusCode(404);
 
         // Add the same rule - should work because the old rule was deleted when the artifact was deleted.
@@ -1927,13 +1932,13 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         rule.setType(RuleType.VALIDITY);
         rule.setConfig("FULL");
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .body(rule)
                 .post("/registry/v2/groups/{groupId}/artifacts/{artifactId}/rules")
-            .then()
+                .then()
                 .statusCode(204)
                 .body(anything());
     }
@@ -1955,46 +1960,46 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Search each group to ensure the correct # of artifacts.
         given()
-            .when()
+                .when()
                 .get("/registry/v2/search/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", greaterThanOrEqualTo(2));
         given()
-            .when()
+                .when()
                 .queryParam("group", groupId)
                 .get("/registry/v2/search/artifacts")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", equalTo(1));
 
         // Get the artifact content
         given()
-            .when()
+                .when()
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", equalTo("3.0.2"))
                 .body("info.title", equalTo("Empty API"));
 
         given()
-            .when()
+                .when()
                 .pathParam("artifactId", artifactId)
                 .get("/registry/v1/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", not(equalTo("3.0.2")))
                 .body("info.title", not(equalTo("Empty API")));
 
         // Verify the metadata
         given()
-            .when()
+                .when()
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("groupId", equalTo(groupId))
                 .body("id", equalTo(artifactId))
@@ -2005,10 +2010,10 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .body("description", equalTo("An example API design using OpenAPI."));
 
         given()
-            .when()
+                .when()
                 .pathParam("artifactId", artifactId)
                 .get("/registry/v1/artifacts/{artifactId}/meta")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("groupId", nullValue())
                 .body("id", equalTo(artifactId))
@@ -2029,15 +2034,15 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Create OpenAPI artifact version 1.0.0
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", groupId)
                 .header("X-Registry-ArtifactId", artifactId)
                 .header("X-Registry-ArtifactType", ArtifactType.OPENAPI)
                 .header("X-Registry-Version", "1.0.0")
                 .body(artifactContent)
-            .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .post("/registry/v2/groups/{groupId}/artifacts")
+                .then()
                 .statusCode(200)
                 .body("id", equalTo(artifactId))
                 .body("groupId", equalTo(groupId))
@@ -2046,24 +2051,24 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Make sure we can get the artifact content by version
         given()
-            .when()
+                .when()
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
                 .pathParam("version", "1.0.0")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("openapi", equalTo("3.0.2"))
                 .body("info.title", equalTo("Empty API"));
 
         // Make sure we can get the artifact meta-data by version
         given()
-            .when()
+                .when()
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
                 .pathParam("version", "1.0.0")
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}/meta")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", equalTo(artifactId))
                 .body("groupId", equalTo(groupId))
@@ -2071,14 +2076,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Add version 1.0.1
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .header("X-Registry-Version", "1.0.1")
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
                 .body(artifactContent.replace("Empty API", "Empty API (Version 1.0.1)"))
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", equalTo(artifactId))
                 .body("version", equalTo("1.0.1"))
@@ -2086,11 +2091,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // List the artifact versions
         given()
-            .when()
+                .when()
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", equalTo(2))
                 .body("versions[0].version", equalTo("1.0.0"))
@@ -2098,14 +2103,14 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Add version 1.0.2
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON)
                 .header("X-Registry-Version", "1.0.2")
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
                 .body(artifactContent.replace("Empty API", "Empty API (Version 1.0.2)"))
                 .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("id", equalTo(artifactId))
                 .body("version", equalTo("1.0.2"))
@@ -2113,11 +2118,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // List the artifact versions
         given()
-            .when()
+                .when()
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
                 .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
-            .then()
+                .then()
                 .statusCode(200)
                 .body("count", equalTo(3))
                 .body("versions[0].version", equalTo("1.0.0"))
@@ -2135,11 +2140,11 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Delete the artifact
         given()
-            .when()
+                .when()
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testCreateArtifactAfterDelete/EmptyAPI")
                 .delete("/registry/v2/groups/{groupId}/artifacts/{artifactId}")
-            .then()
+                .then()
                 .statusCode(204);
 
         // Create the same artifact
@@ -2151,20 +2156,20 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
     public void testCreateArtifactFromURL() throws Exception {
         // Create Artifact from URL should support `HEAD`
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON_EXTENDED)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifactFromURL/Empty")
                 .header("X-Registry-ArtifactType", ArtifactType.JSON)
                 .body("{ \"content\" : \"http://localhost:" + testPort + "/health/group\" }")
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(400)
                 .body("message", containsString("Content-Length"));
 
         // Create Artifact from URL should check the SHA
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON_EXTENDED)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifactFromURL/OpenApi2")
@@ -2172,7 +2177,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .header("X-Registry-Content-Hash", "123")
                 .body("{ \"content\" : \"http://localhost:" + testPort + "/api-specifications/registry/v2/openapi.json\" }")
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(400)
                 .body("message", containsString("Hash doesn't match"));
 
@@ -2187,7 +2192,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .header("X-Registry-Content-Hash", "123")
                 .body("{ \"content\" : \"http://localhost:" + testPort + "/api-specifications/registry/v2/openapi.json\" }")
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(400)
                 .body("message", containsString("hash algorithm not supported"));
 
@@ -2200,7 +2205,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
 
         // Create Artifact from URL should eventually succeed
         given()
-            .when()
+                .when()
                 .contentType(CT_JSON_EXTENDED)
                 .pathParam("groupId", GROUP)
                 .header("X-Registry-ArtifactId", "testCreateArtifactFromURL/OpenApi3")
@@ -2208,8 +2213,99 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .header("X-Registry-Content-Hash", artifactSHA)
                 .body("{ \"content\" : \"http://localhost:" + testPort + "/api-specifications/registry/v2/openapi.json\" }")
                 .post("/registry/v2/groups/{groupId}/artifacts")
-            .then()
+                .then()
                 .statusCode(200);
     }
 
+    @Test
+    void testArtifactWithReferences() throws Exception {
+        String artifactContent = getRandomValidJsonSchemaContent();
+
+        // Create #1 without references
+        var response = createArtifactExtendedRaw("default", null, null, artifactContent, null);
+        var metadata = response
+                .statusCode(HTTP_OK)
+                .extract().as(ArtifactMetaData.class);
+        waitForArtifact(metadata.getId());
+
+        // Create #2 referencing the #1, using different content
+        List<ArtifactReference> references = List.of(ArtifactReference.builder()
+                .groupId(metadata.getGroupId())
+                .artifactId(metadata.getId())
+                .version(metadata.getVersion())
+                .name("foo")
+                .build());
+        artifactContent = getRandomValidJsonSchemaContent();
+        response = createArtifactExtendedRaw("default", null, null, artifactContent, references);
+        metadata = response
+                .statusCode(HTTP_OK)
+                .extract().as(ArtifactMetaData.class);
+        assertEquals(references, metadata.getReferences());
+        waitForArtifact(metadata.getId());
+
+        // Trying to use different references with the same content fails
+        List<ArtifactReference> references2 = List.of(ArtifactReference.builder()
+                .groupId(metadata.getGroupId())
+                .artifactId(metadata.getId())
+                .version(metadata.getVersion())
+                .name("foo2")
+                .build());
+        response = createArtifactExtendedRaw("default", null, null, artifactContent, references2);
+        var error = response
+                .statusCode(HTTP_CONFLICT)
+                .extract().as(Error.class);
+        assertEquals("ConflictException", error.getName());
+
+        // Same references are not an issue
+        response = createArtifactExtendedRaw("default2", null, null, artifactContent, references);
+        metadata = response
+                .statusCode(HTTP_OK)
+                .extract().as(ArtifactMetaData.class);
+
+        // Get references via globalId
+        var referenceResponse = given()
+                .when()
+                .pathParam("globalId", metadata.getGlobalId())
+                .get("/registry/v2/ids/globalIds/{globalId}/references")
+                .then()
+                .statusCode(HTTP_OK)
+                .extract().as(new TypeRef<List<ArtifactReference>>() {
+                });
+        assertEquals(references, referenceResponse);
+
+        // Get references via contentId
+        referenceResponse = given()
+                .when()
+                .pathParam("contentId", metadata.getContentId())
+                .get("/registry/v2/ids/contentIds/{contentId}/references")
+                .then()
+                .statusCode(HTTP_OK)
+                .extract().as(new TypeRef<List<ArtifactReference>>() {
+                });
+        assertEquals(references, referenceResponse);
+
+        // Get references via contentHash
+        referenceResponse = given()
+                .when()
+                .pathParam("contentHash", ContentHandle.create(artifactContent).getSha256Hash())
+                .get("/registry/v2/ids/contentHashes/{contentHash}/references")
+                .then()
+                .statusCode(HTTP_OK)
+                .extract().as(new TypeRef<List<ArtifactReference>>() {
+                });
+        assertEquals(references, referenceResponse);
+
+        // Get references via GAV
+        referenceResponse = given()
+                .when()
+                .pathParam("groupId", metadata.getGroupId())
+                .pathParam("artifactId", metadata.getId())
+                .pathParam("version", metadata.getVersion())
+                .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}/references")
+                .then()
+                .statusCode(HTTP_OK)
+                .extract().as(new TypeRef<List<ArtifactReference>>() {
+                });
+        assertEquals(references, referenceResponse);
+    }
 }

--- a/app/src/test/java/io/apicurio/registry/rbac/AdminResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/rbac/AdminResourceTest.java
@@ -16,47 +16,10 @@
 
 package io.apicurio.registry.rbac;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.anything;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-
-import io.apicurio.registry.rest.v2.beans.ArtifactReference;
-import io.apicurio.registry.utils.tests.ApicurioTestTags;
-import io.apicurio.registry.utils.tests.ApplicationRbacEnabledProfile;
-import io.quarkus.test.junit.TestProfile;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-
 import io.apicurio.common.apps.config.Info;
 import io.apicurio.registry.AbstractResourceTestBase;
 import io.apicurio.registry.rest.client.exception.ArtifactNotFoundException;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rest.v2.beans.LogConfiguration;
 import io.apicurio.registry.rest.v2.beans.NamedLogConfiguration;
 import io.apicurio.registry.rest.v2.beans.RoleMapping;
@@ -68,12 +31,44 @@ import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.LogLevel;
 import io.apicurio.registry.types.RoleType;
 import io.apicurio.registry.types.RuleType;
+import io.apicurio.registry.utils.tests.ApicurioTestTags;
+import io.apicurio.registry.utils.tests.ApplicationRbacEnabledProfile;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import io.vertx.core.json.JsonObject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.anything;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -569,10 +564,12 @@ public class AdminResourceTest extends AbstractResourceTestBase {
     void testExportForBrowser() throws Exception {
         String artifactContent = resourceToString("openapi-empty.json");
         String group = "testExportForBrowser";
+        // Avoid the reference conflict by appending a UUID to the title
+        var suffix = UUID.randomUUID().toString();
 
         // Create 5 artifacts in the UUID group
         for (int idx = 0; idx < 5; idx++) {
-            String title = "Empty API " + idx;
+            String title = "Empty API " + idx + " " + suffix;
             String artifactId = "Empty-" + idx;
             List<ArtifactReference> refs = idx > 0 ? getSingletonRefList(group, "Empty-" + (idx - 1), "1", "ref") : Collections.emptyList();
             this.createArtifactWithReferences(group, artifactId, ArtifactType.OPENAPI, artifactContent.replaceAll("Empty API", title), refs);

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -1827,6 +1827,7 @@
                     "content": {
                         "*/*": {
                             "schema": {
+                                "$ref": "#/components/schemas/FileContent"
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -2080,6 +2081,7 @@
                     "content": {
                         "*/*": {
                             "schema": {
+                                "$ref": "#/components/schemas/FileContent"
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -2317,6 +2319,7 @@
                     "content": {
                         "*/*": {
                             "schema": {
+                                "$ref": "#/components/schemas/FileContent"
                             }
                         }
                     },
@@ -2428,6 +2431,7 @@
                     "content": {
                         "*/*": {
                             "schema": {
+                                "$ref": "#/components/schemas/FileContent"
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -2661,6 +2665,7 @@
                     "content": {
                         "*/*": {
                             "schema": {
+                                "$ref": "#/components/schemas/FileContent"
                             },
                             "examples": {
                                 "OpenAPI": {

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -1888,6 +1888,11 @@
                             "schema": {
                                 "$ref": "#/components/schemas/ContentCreateRequest"
                             }
+                        },
+                        "application/vnd.create.extended+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ContentCreateRequest"
+                            }
                         }
                     },
                     "required": true
@@ -2133,6 +2138,11 @@
                             }
                         },
                         "application/create.extended+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ContentCreateRequest"
+                            }
+                        },
+                        "application/vnd.create.extended+json": {
                             "schema": {
                                 "$ref": "#/components/schemas/ContentCreateRequest"
                             }
@@ -2476,6 +2486,11 @@
                             }
                         },
                         "application/create.extended+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ContentCreateRequest"
+                            }
+                        },
+                        "application/vnd.create.extended+json": {
                             "schema": {
                                 "$ref": "#/components/schemas/ContentCreateRequest"
                             }

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -1827,7 +1827,6 @@
                     "content": {
                         "*/*": {
                             "schema": {
-
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -1934,6 +1933,14 @@
                         "description": "Specifies the artifact description of this new version of the artifact content. Value of this must be Base64 encoded string. If this is not provided, the server will extract the description from the artifact content.",
                         "schema": {
                             "$ref": "#/components/schemas/EncodedArtifactDescription"
+                        },
+                        "in": "header"
+                    },
+                    {
+                        "name": "Content-Type",
+                        "description": "This header is explicit so clients using the OpenAPI Generator are able select the content type. Ignore otherwise.",
+                        "schema": {
+                            "type": "string"
                         },
                         "in": "header"
                     }
@@ -2068,7 +2075,6 @@
                     "content": {
                         "*/*": {
                             "schema": {
-
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -2230,6 +2236,14 @@
                             "type": "string"
                         },
                         "in": "header"
+                    },
+                    {
+                        "name": "Content-Type",
+                        "description": "This header is explicit so clients using the OpenAPI Generator are able select the content type. Ignore otherwise.",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -2293,7 +2307,6 @@
                     "content": {
                         "*/*": {
                             "schema": {
-
                             }
                         }
                     },
@@ -2405,7 +2418,6 @@
                     "content": {
                         "*/*": {
                             "schema": {
-
                             },
                             "examples": {
                                 "OpenAPI Example": {
@@ -2512,6 +2524,14 @@
                         "description": "Specifies the artifact name of this new version of the artifact content. Value of this must be Base64 encoded string. If this is not provided, the server will extract the name from the artifact content.",
                         "schema": {
                             "$ref": "#/components/schemas/EncodedArtifactName"
+                        },
+                        "in": "header"
+                    },
+                    {
+                        "name": "Content-Type",
+                        "description": "This header is explicit so clients using the OpenAPI Generator are able select the content type. Ignore otherwise.",
+                        "schema": {
+                            "type": "string"
                         },
                         "in": "header"
                     }
@@ -2626,7 +2646,6 @@
                     "content": {
                         "*/*": {
                             "schema": {
-
                             },
                             "examples": {
                                 "OpenAPI": {
@@ -3814,11 +3833,9 @@
                     "globalId": 37,
                     "version": 85,
                     "properties": {
-
                     },
                     "contentId": 62,
                     "references": {
-
                     }
                 }
             },

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -4405,7 +4405,23 @@
         "bean-annotations": [
             "io.quarkus.runtime.annotations.RegisterForReflection",
             {
-                "annotation": "lombok.ToString",
+                "annotation": "lombok.experimental.SuperBuilder",
+                "excludeEnums": true
+            },
+            {
+                "annotation": "lombok.AllArgsConstructor",
+                "excludeEnums": true
+            },
+            {
+                "annotation": "lombok.NoArgsConstructor",
+                "excludeEnums": true
+            },
+            {
+                "annotation": "lombok.EqualsAndHashCode",
+                "excludeEnums": true
+            },
+            {
+                "annotation": "lombok.ToString(callSuper = true)",
                 "excludeEnums": true
             }
         ]

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -1941,14 +1941,6 @@
                             "$ref": "#/components/schemas/EncodedArtifactDescription"
                         },
                         "in": "header"
-                    },
-                    {
-                        "name": "Content-Type",
-                        "description": "This header is explicit so clients using the OpenAPI Generator are able select the content type. Ignore otherwise.",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -2248,14 +2240,6 @@
                             "type": "string"
                         },
                         "in": "header"
-                    },
-                    {
-                        "name": "Content-Type",
-                        "description": "This header is explicit so clients using the OpenAPI Generator are able select the content type. Ignore otherwise.",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "header"
                     }
                 ],
                 "responses": {
@@ -2543,14 +2527,6 @@
                         "description": "Specifies the artifact name of this new version of the artifact content. Value of this must be Base64 encoded string. If this is not provided, the server will extract the name from the artifact content.",
                         "schema": {
                             "$ref": "#/components/schemas/EncodedArtifactName"
-                        },
-                        "in": "header"
-                    },
-                    {
-                        "name": "Content-Type",
-                        "description": "This header is explicit so clients using the OpenAPI Generator are able select the content type. Ignore otherwise.",
-                        "schema": {
-                            "type": "string"
                         },
                         "in": "header"
                     }

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/AbstractContentHandle.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/AbstractContentHandle.java
@@ -16,6 +16,8 @@
 
 package io.apicurio.registry.content;
 
+import org.apache.commons.codec.digest.DigestUtils;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -49,5 +51,10 @@ abstract class AbstractContentHandle implements ContentHandle {
     @Override
     public int getSizeBytes() {
         return bytes().length;
+    }
+
+    @Override
+    public String getSha256Hash() {
+        return DigestUtils.sha256Hex(bytes());
     }
 }

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/ContentHandle.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/ContentHandle.java
@@ -42,4 +42,6 @@ public interface ContentHandle {
     String content();
 
     int getSizeBytes();
+
+    String getSha256Hash();
 }

--- a/utils/tools/src/main/java/io/apicurio/registry/utils/tools/TransformOpenApiForClientGen.java
+++ b/utils/tools/src/main/java/io/apicurio/registry/utils/tools/TransformOpenApiForClientGen.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.tools;
+
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.openapi.models.OasOperation;
+import io.apicurio.datamodels.openapi.v3.models.Oas30Document;
+import io.apicurio.datamodels.openapi.v3.models.Oas30Schema;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static java.lang.System.out;
+
+/**
+ * @author eric.wittmann@gmail.com
+ * @author Jakub Senko <m@jsenko.net>
+ */
+public class TransformOpenApiForClientGen {
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 2) {
+            out.println("Usage: TransformOpenApiForClientGen <inputFile> <outputFile>");
+            System.exit(1);
+        }
+        File inputFile = new File(args[0]);
+        File outputFile = new File(args[1]);
+
+        if (!inputFile.isFile()) {
+            out.println("File not found: " + inputFile.getAbsolutePath());
+            System.exit(1);
+        }
+
+        out.println("Loading input file from: " + inputFile.getAbsolutePath());
+
+        // Read the input file
+        String inputDocumentString;
+        try (FileInputStream fis = new FileInputStream(inputFile)) {
+            inputDocumentString = IOUtils.toString(fis, StandardCharsets.UTF_8);
+        }
+
+        // Read the source openapi document.
+        Oas30Document document = (Oas30Document) Library.readDocumentFromJSONString(inputDocumentString);
+
+        attachHeaderSchema(document.paths.getItem("/groups/{groupId}/artifacts/{artifactId}").put, "/groups/{groupId}/artifacts/{artifactId} PUT");
+        attachHeaderSchema(document.paths.getItem("/groups/{groupId}/artifacts").post, "/groups/{groupId}/artifacts POST");
+        attachHeaderSchema(document.paths.getItem("/groups/{groupId}/artifacts/{artifactId}/versions").post, "/groups/{groupId}/artifacts/{artifactId}/versions POST");
+
+        // Now write out the modified document
+        String outputDocumentString = Library.writeDocumentToJSONString(document);
+
+        out.println("Writing modified document to: " + outputFile.getAbsolutePath());
+
+        // Write the output to a file
+        FileUtils.writeStringToFile(outputFile, outputDocumentString, StandardCharsets.UTF_8);
+    }
+
+    private static void attachHeaderSchema(OasOperation operation, String info) {
+        out.println("Adding explicit Content-Type header to " + info);
+        var param = operation.createParameter();
+        param.name = "Content-Type";
+        param.description = "This header is explicit so clients using the OpenAPI Generator are able select the content type. Ignore otherwise.";
+        var schema = (Oas30Schema) param.createSchema();
+        schema.type = "string";
+        param.schema = schema;
+        param.in = "header";
+        operation.addParameter(param);
+    }
+}


### PR DESCRIPTION
There are following changes:
- Add an explicit `Content-Type` header for generated client to work (later reverted)
- Add an alternative content type for extended operations with references. We had `application/create.extended+json` and I've added `application/vnd.create.extended+json`. The second CT is more in line with how vendor extensions are customary defined. (I could workaround this on the client side, but I think we may want to keep this change)
- Use `#/components/schemas/FileContent` in some places where it was missing (We used empty schema).
- Fix some small issues with references, mainly: The returned reference list being empty on artifact creation, and add conflict detection until we decide to do https://github.com/Apicurio/apicurio-registry/issues/3109
- Added some tests
- Finally reverted the first commit and decided to generate an alternative schema, similar to what we have for basic auth