### PR TITLE
Add option to minify avro with maven plugin

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithMinifyTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithMinifyTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.noprofile.maven;
+
+import io.apicurio.registry.maven.RegisterArtifact;
+import io.apicurio.registry.maven.RegisterRegistryMojo;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * @author Ales Justin
+ */
+@QuarkusTest
+public class RegistryMojoWithMinifyTest extends RegistryMojoTestBase {
+    RegisterRegistryMojo registerMojo;
+
+    @BeforeEach
+    public void createMojo() {
+        this.registerMojo = new RegisterRegistryMojo();
+        this.registerMojo.setRegistryUrl(TestUtils.getRegistryV2ApiUrl(testPort));
+    }
+
+    @Test
+    public void testMinify() throws Exception {
+        String groupId = "RegisterWithMinifyRegistryMojoTest";
+
+        File avroFile = new File(getClass().getResource("avro.avsc").getFile());
+
+        RegisterArtifact avroMinifiedArtifact = new RegisterArtifact();
+        avroMinifiedArtifact.setGroupId(groupId);
+        avroMinifiedArtifact.setArtifactId("userInfoMinified");
+        avroMinifiedArtifact.setType(ArtifactType.AVRO);
+        avroMinifiedArtifact.setMinify(true);
+        avroMinifiedArtifact.setFile(avroFile);
+
+        RegisterArtifact avroNotMinifiedArtifact = new RegisterArtifact();
+        avroNotMinifiedArtifact.setGroupId(groupId);
+        avroNotMinifiedArtifact.setArtifactId("userInfoNotMinified");
+        avroNotMinifiedArtifact.setType(ArtifactType.AVRO);
+        avroNotMinifiedArtifact.setFile(avroFile);
+
+        registerMojo.setArtifacts(List.of(avroMinifiedArtifact, avroNotMinifiedArtifact));
+        registerMojo.execute();
+
+        // Wait for the artifact to be created.
+        TestUtils.retry(() -> {
+            InputStream artifactInputStream = clientV2.getLatestArtifact(groupId, "userInfoMinified");
+            String artifactContent = new String(artifactInputStream.readAllBytes(), StandardCharsets.UTF_8);
+            Assertions.assertEquals("{\"type\":\"record\",\"name\":\"userInfo\",\"namespace\":\"my.example\",\"fields\":[{\"name\":\"age\",\"type\":\"int\"}]}", artifactContent);
+        });
+
+        // Wait for the artifact to be created.
+        TestUtils.retry(() -> {
+            InputStream artifactInputStream = clientV2.getLatestArtifact(groupId, "userInfoNotMinified");
+            String artifactContent = new String(artifactInputStream.readAllBytes(), StandardCharsets.UTF_8);
+            Assertions.assertEquals("{\n" +
+                    "  \"type\" : \"record\",\n" +
+                    "  \"name\" : \"userInfo\",\n" +
+                    "  \"namespace\" : \"my.example\",\n" +
+                    "  \"fields\" : [{\"name\" : \"age\", \"type\" : \"int\"}]\n" +
+                    "}", artifactContent);
+        });
+    }
+
+}

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/avro.avsc
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/avro.avsc
@@ -1,0 +1,6 @@
+{
+  "type" : "record",
+  "name" : "userInfo",
+  "namespace" : "my.example",
+  "fields" : [{"name" : "age", "type" : "int"}]
+}

--- a/utils/maven-plugin/pom.xml
+++ b/utils/maven-plugin/pom.xml
@@ -21,6 +21,10 @@
             <artifactId>apicurio-registry-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <scope>provided</scope>

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterArtifact.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterArtifact.java
@@ -33,6 +33,7 @@ public class RegisterArtifact {
     private File file;
     private IfExists ifExists;
     private Boolean canonicalize;
+    private Boolean minify;
     private String contentType;
     private List<RegisterArtifactReference> references;
 
@@ -110,6 +111,20 @@ public class RegisterArtifact {
      */
     public void setCanonicalize(Boolean canonicalize) {
         this.canonicalize = canonicalize;
+    }
+
+    /**
+     * @return the minify
+     */
+    public Boolean getMinify() {
+        return minify;
+    }
+
+    /**
+     * @param minify the minify to set
+     */
+    public void setMinify(Boolean minify) {
+        this.minify = minify;
     }
 
     /**

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
@@ -17,12 +17,12 @@
 
 package io.apicurio.registry.maven;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.types.ContentTypes;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -120,6 +120,15 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
         Boolean canonicalize = artifact.getCanonicalize();
         String contentType = contentType(artifact);
         InputStream data = new FileInputStream(artifact.getFile());
+        if (artifact.getMinify() != null && artifact.getMinify()) {
+            try {
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode jsonNode = objectMapper.readValue(data, JsonNode.class);
+                data = new ByteArrayInputStream(jsonNode.toString().getBytes());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
         ArtifactMetaData amd = this.getClient().createArtifact(groupId, artifactId, version, type, ifExists, canonicalize, null, null, ContentTypes.APPLICATION_CREATE_EXTENDED, null, null, data, references);
         getLog().info(String.format("Successfully registered artifact [%s] / [%s].  GlobalId is [%d]", groupId, artifactId, amd.getGlobalId()));
 


### PR DESCRIPTION
Providing the option to minify avro files and use the minified version to be stored in the registry.

We have the use case that some applications provide the avro schemas using the apicurio maven plugin.
But as the avsc file is taken as is, with newlines and spaces and stored other applications using confluent/avro tools have issues, as they are using the avro-maven-plugin which will minify everything.

Whit this change we are following the same behaviour as avro-maven-plugin or give at least the option to do so.