### PR TITLE
tmp: use PostgreSQL version 12.13 for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -743,6 +743,13 @@
                 <version>${google.truth.extension.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>io.zonky.test.postgres</groupId>
+                <artifactId>embedded-postgres-binaries-bom</artifactId>
+                <version>12.13.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Do Not Merge. I've removed the label so the tests can run.