### PR TITLE
Added config for ccompat maximum subjects returned

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -24,6 +24,9 @@ registry.ccompat.legacy-id-mode.enabled=${ENABLE_CCOMPAT_LEGACY_ID_MODE:false}
 ## Make ccompat use canonical hash
 registry.ccompat.use-canonical-hash=${ENABLE_CCOMPAT_CANONICAL_HASH_MODE:false}
 
+## Maximum number of subjects returned by ccompat API
+registry.ccompat.max-subjects=${CCOMPAT_MAX_SUBJECTS:1000}
+
 ##Auth - disabled by default
 
 ## Support some legacy ENV variables.


### PR DESCRIPTION
I believe this should be added in the properties for #3121 to make it configurable by environment variable.

There are the following changes:
registry.ccompat.max-subjects=${CCOMPAT_MAX_SUBJECTS:1000}