### PR TITLE
Fix a typo in index.html

### DIFF
--- a/app/src/main/resources-unfiltered/META-INF/resources/apidocs/index.html
+++ b/app/src/main/resources-unfiltered/META-INF/resources/apidocs/index.html
@@ -6,7 +6,7 @@
     <title>Apicurio Registry APIs</title>
     <link rel="stylesheet" type="text/css" href="/resources/css/apidocs.css" >
   </head>
-  
+
   <body class="root">
     <div class="apidocs-header">
       <span class="title">- API Documentation</span>
@@ -16,7 +16,7 @@
     </div>
     <div class="apidocs-body">
       <div class="apidocs-listing">
-      
+
         <!-- Apicurio Registry API (v2) -->
         <div class="apidocs-api default">
           <div class="name">Core Registry API (Version 2)</div>
@@ -28,7 +28,7 @@
             <a href="/apis/registry/v2" class="url"><code>/apis/registry/v2</code></a>
           </div>
         </div>
-      
+
         <!-- Apicurio Registry API (v1) -->
         <div class="apidocs-api deprecated">
           <div class="name">Core Registry API (Version 1)</div>
@@ -41,7 +41,7 @@
             <a href="/apis/registry/v1" class="url"><code>/apis/registry/v1</code></a>
           </div>
         </div>
-        
+
         <!-- Confluent Compatible API (v6) -->
         <div class="apidocs-api">
           <div class="name">Confluent Schema Registry API (Version 6)</div>
@@ -60,14 +60,14 @@
           <div class="name">Confluent Schema Registry API (Version 7)</div>
           <div class="description">
             To provide compatibility with Confluent Serdes (and other clients), Apicurio Registry implements the API defined by
-            the Confluent Schema Registry.  Use this endpoint if your tooling is compatible with v6 of that API.  This is only
+            the Confluent Schema Registry.  Use this endpoint if your tooling is compatible with v7 of that API.  This is only
             provided for compatibility purposes, the core Registry API should be used instead when possible.
           </div>
           <div class="endpoint">
             <a href="/apis/ccompat/v7" class="url"><code>/apis/ccompat/v7</code></a>
           </div>
         </div>
-        
+
         <!-- IBM Compatible API (v6) -->
         <!--
         <div class="apidocs-api">
@@ -81,7 +81,7 @@
           </div>
         </div>
          -->
-        
+
         <!-- CNCF Schema Registry API (v0) -->
         <div class="apidocs-api">
           <div class="name">CNCF Schema Registry API (Version 0)</div>
@@ -94,7 +94,7 @@
             <a href="/apis/cncf/v0" class="url"><code>/apis/cncf/v0</code></a>
           </div>
         </div>
-        
+
       </div>
     </div>
   </body>


### PR DESCRIPTION
Version number for confluent schema registry compatibility is v6 instead of v7.