### PR TITLE
fix: return or update option did not use artifact name and description from headers

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
@@ -676,7 +676,7 @@ public class GroupsResourceImpl implements GroupsResource {
     }
 
     /**
-     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifact(String, ArtifactType, String, String, IfExists, Boolean, String, String, String, String, String, String, InputStream)
+     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifact(String, String, String, String, IfExists, Boolean, String, String, String, String, String, String, InputStream)
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_TYPE, "2", KEY_ARTIFACT_ID, "3", KEY_VERSION, "4", KEY_IF_EXISTS, "5", KEY_CANONICAL, "6", KEY_DESCRIPTION, "7", KEY_DESCRIPTION_ENCODED, "8", KEY_NAME, "9", KEY_NAME_ENCODED, "10", KEY_FROM_URL, "11", KEY_SHA})
@@ -690,7 +690,7 @@ public class GroupsResourceImpl implements GroupsResource {
     }
 
     /**
-     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifact(String, ArtifactType, String, String, IfExists, Boolean, String, String, String, String, String, String, ContentCreateRequest)
+     * @see io.apicurio.registry.rest.v2.GroupsResource#createArtifact(String, String, String, String, IfExists, Boolean, String, String, String, String, String, String, ContentCreateRequest)
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_TYPE, "2", KEY_ARTIFACT_ID, "3", KEY_VERSION, "4", KEY_IF_EXISTS, "5", KEY_CANONICAL, "6", KEY_DESCRIPTION, "7", KEY_DESCRIPTION_ENCODED, "8", KEY_NAME, "9", KEY_NAME_ENCODED, "10", "from_url" /*KEY_FROM_URL*/, "11", "artifact_sha" /*KEY_SHA*/})
@@ -883,7 +883,7 @@ public class GroupsResourceImpl implements GroupsResource {
             ArtifactMetaDataDto amd = storage.createArtifactWithMetadata(defaultGroupIdToNull(groupId), artifactId, xRegistryVersion, artifactType, content, metaData, referencesAsDtos);
             return V2ApiUtil.dtoToMetaData(defaultGroupIdToNull(groupId), finalArtifactId, artifactType, amd);
         } catch (ArtifactAlreadyExistsException ex) {
-            return handleIfExists(groupId, xRegistryArtifactId, xRegistryVersion, ifExists, content, ct, fcanonical, references);
+            return handleIfExists(groupId, xRegistryArtifactId, xRegistryVersion, ifExists, artifactName, artifactDescription, content, ct, fcanonical, references);
         }
     }
 
@@ -1033,8 +1033,9 @@ public class GroupsResourceImpl implements GroupsResource {
         return new String(Base64.decode(encoded));
     }
 
-    private ArtifactMetaData handleIfExists(String groupId, String artifactId, String version,
-                                            IfExists ifExists, ContentHandle content, String contentType, boolean canonical, List<ArtifactReference> references) {
+    private ArtifactMetaData handleIfExists(String groupId, String artifactId, String version, IfExists ifExists,
+                                            String artifactName, String artifactDescription, ContentHandle content,
+                                            String contentType, boolean canonical, List<ArtifactReference> references) {
         final ArtifactMetaData artifactMetaData = getArtifactMetaData(groupId, artifactId);
         if (ifExists == null) {
             ifExists = IfExists.FAIL;
@@ -1042,17 +1043,18 @@ public class GroupsResourceImpl implements GroupsResource {
 
         switch (ifExists) {
             case UPDATE:
-                return updateArtifactInternal(groupId, artifactId, version, content, contentType, references);
+                return updateArtifactInternal(groupId, artifactId, version, artifactName, artifactDescription, content, contentType, references);
             case RETURN:
                 return artifactMetaData;
             case RETURN_OR_UPDATE:
-                return handleIfExistsReturnOrUpdate(groupId, artifactId, version, content, contentType, canonical, references);
+                return handleIfExistsReturnOrUpdate(groupId, artifactId, version, artifactName, artifactDescription, content, contentType, canonical, references);
             default:
                 throw new ArtifactAlreadyExistsException(groupId, artifactId);
         }
     }
 
     private ArtifactMetaData handleIfExistsReturnOrUpdate(String groupId, String artifactId, String version,
+                                                          String artifactName, String artifactDescription,
                                                           ContentHandle content, String contentType, boolean canonical, List<ArtifactReference> references) {
         try {
             ArtifactVersionMetaDataDto mdDto = this.storage.getArtifactVersionMetaData(defaultGroupIdToNull(groupId), artifactId, canonical, content);
@@ -1061,12 +1063,7 @@ public class GroupsResourceImpl implements GroupsResource {
         } catch (ArtifactNotFoundException nfe) {
             // This is OK - we'll update the artifact if there is no matching content already there.
         }
-        return updateArtifactInternal(groupId, artifactId, version, content, contentType, references);
-    }
-
-    private ArtifactMetaData updateArtifactInternal(String groupId, String artifactId, String version,
-                                                    ContentHandle content, String contentType, List<ArtifactReference> references) {
-        return this.updateArtifactInternal(groupId, artifactId, version, null, null, content, contentType, references);
+        return updateArtifactInternal(groupId, artifactId, version, artifactName, artifactDescription, content, contentType, references);
     }
 
     private ArtifactMetaData updateArtifactInternal(String groupId, String artifactId, String version,

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/GroupsResourceTest.java
@@ -1765,6 +1765,8 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         final String artifactContent = resourceToString("openapi-empty.json");
         final String updatedArtifactContent = artifactContent.replace("Empty API", "Empty API (Updated)");
         final String v3ArtifactContent = artifactContent.replace("Empty API", "Empty API (Version 3)");
+        final String artifactName = "ArtifactNameFromHeader";
+        final String artifactDescription = "ArtifactDescriptionFromHeader";
 
         // Create OpenAPI artifact - indicate the type via a header param
         Integer globalId1 = createArtifact(GROUP, artifactId, ArtifactType.OPENAPI, artifactContent);
@@ -1836,10 +1838,13 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
         assertEquals(globalId1, globalId3);
 
         // Try to create the same artifact ID with ReturnOrUpdate and updated content - should create a new version
+        // and use name and description from headers
         resp = given()
                 .when()
                 .contentType(CT_JSON + "; artifactType=OPENAPI")
                 .header("X-Registry-ArtifactId", artifactId)
+                .header("X-Registry-Name", artifactName)
+                .header("X-Registry-Description", artifactDescription)
                 .pathParam("groupId", GROUP)
                 .queryParam("ifExists", IfExists.RETURN_OR_UPDATE)
                 .body(v3ArtifactContent)
@@ -1847,6 +1852,8 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200)
                 .body("version", equalTo("3"))
+                .body("name", equalTo(artifactName))
+                .body("description", equalTo(artifactDescription))
                 .body("type", equalTo(ArtifactType.OPENAPI));
     }
 


### PR DESCRIPTION
This PR is fixing a problem that provided name and description in headers were ignored if a new artifact version was created using IfExists.RETURN_OR_UPDATE option.

Fixes #2826