### PR TITLE
Fix remainder comparison for multipleOf

### DIFF
--- a/schema-util/json/src/main/java/io/apicurio/registry/rules/compatibility/jsonschema/diff/DiffUtil.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/rules/compatibility/jsonschema/diff/DiffUtil.java
@@ -135,7 +135,7 @@ public class DiffUtil {
         requireNonNull(updated);
         BigDecimal o = new BigDecimal(original.toString()); // Not pretty but it works:/
         BigDecimal u = new BigDecimal(updated.toString());
-        if (o.remainder(u).equals(BigDecimal.ZERO)) {
+        if (o.remainder(u).compareTo(BigDecimal.ZERO) == 0) {
             ctx.addDifference(multipleOfType, original, updated);
         } else {
             ctx.addDifference(notMultipleOfType, original, updated);

--- a/schema-util/json/src/test/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonSchemaDiffUtilTest.java
+++ b/schema-util/json/src/test/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonSchemaDiffUtilTest.java
@@ -3,7 +3,6 @@ package io.apicurio.registry.rules.compatibility.jsonschema;
 import io.apicurio.registry.rules.compatibility.jsonschema.diff.DiffContext;
 import io.apicurio.registry.rules.compatibility.jsonschema.diff.DiffType;
 import io.apicurio.registry.rules.compatibility.jsonschema.diff.DiffUtil;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -11,8 +10,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JsonSchemaDiffUtilTest {
     public static Stream<Arguments> multipleOfCases() {

--- a/schema-util/json/src/test/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonSchemaDiffUtilTest.java
+++ b/schema-util/json/src/test/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonSchemaDiffUtilTest.java
@@ -1,0 +1,46 @@
+package io.apicurio.registry.rules.compatibility.jsonschema;
+
+import io.apicurio.registry.rules.compatibility.jsonschema.diff.DiffContext;
+import io.apicurio.registry.rules.compatibility.jsonschema.diff.DiffType;
+import io.apicurio.registry.rules.compatibility.jsonschema.diff.DiffUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JsonSchemaDiffUtilTest {
+    public static Stream<Arguments> multipleOfCases() {
+        return Stream.of(
+                Arguments.of(10, 5, false),
+                Arguments.of(10.0, 5, false),
+                Arguments.of(10.0, 5.0, false),
+                Arguments.of(10.0, 10, false),
+                Arguments.of(10.0, 10.0, false),
+                Arguments.of(10.1, 10, true),
+                Arguments.of(13, 5, true),
+                Arguments.of(13.0, 5, true),
+                Arguments.of(13, 5.0, true)
+        );
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("multipleOfCases")
+    public void multipleOfDivisibility(Number original, Number updated, boolean isIncompatible) {
+        DiffContext context = DiffContext.createRootContext();
+        DiffUtil.diffNumberOriginalMultipleOfUpdated(
+                context,
+                original,
+                updated,
+                DiffType.NUMBER_TYPE_MULTIPLE_OF_UPDATED_IS_DIVISIBLE,
+                DiffType.NUMBER_TYPE_MULTIPLE_OF_UPDATED_IS_NOT_DIVISIBLE
+        );
+        assertEquals(context.foundIncompatibleDifference(), isIncompatible);
+    }
+}


### PR DESCRIPTION
Problem: Compatibility check fails for following JSON Schema case (it can be found in tests) when uploading schemas via UI or API.
Compatibility - Backward

Original schema:
`{
        "$schema": "http://json-schema.org/draft-07/schema#",
        "type": "number",
        "multipleOf": 10.0
}`

Updated schema:
`{
        "$schema": "http://json-schema.org/draft-07/schema#",
        "type": "number",
        "multipleOf": 5.0
}`

Problem is that it is saved in DB with scale and original code uses .equals to check that remainder is zero. Equals in BigDecimal compares not only value, but also scale, so 0.0 is not equal to 0.
In this PR compareTo is used making this method working for all cases as expected - tests included.

