### PR TITLE
Exclude /metrics endpoint from the access log

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -114,7 +114,7 @@ registry.rest.artifact.deletion.enabled.dynamic.allow=${registry.config.dynamic.
 quarkus.http.access-log.enabled=${ENABLE_ACCESS_LOG:false}
 quarkus.http.access-log.pattern="apicurio-registry.access method="%{METHOD}" path="%{REQUEST_URL}" response_code="%{RESPONSE_CODE}" response_time="%{RESPONSE_TIME}" remote_ip="%{REMOTE_IP}" remote_user="%{REMOTE_USER}" user_agent="%{i,User-Agent}""
 #this property will be used by Quarkus 2.X
-quarkus.http.access-log.exclude-pattern=/health/.*
+quarkus.http.access-log.exclude-pattern=/health/.*|/metrics
 
 # Sentry - the rest of the sentry configuration is picked from sentry own env vars
 registry.enable.sentry=${ENABLE_SENTRY:false}


### PR DESCRIPTION
Hi.

This commit excludes the `/metrics` endpoint from the access log. Useful when running in Kubernetes.
Alternatively, the admin can set the `QUARKUS_HTTP_ACCESS_LOG_EXCLUDE_PATTERN=/health/.*|/metrics` environment variable.

Kind regards,
Alexander
