### PR TITLE
Maven directory resolver

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithAutoReferencesTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithAutoReferencesTest.java
@@ -20,8 +20,10 @@ import io.apicurio.registry.maven.DownloadRegistryMojo;
 import io.apicurio.registry.maven.RegisterArtifact;
 import io.apicurio.registry.maven.RegisterRegistryMojo;
 import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rest.v2.beans.IfExists;
 import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.utils.IoUtil;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -31,10 +33,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @QuarkusTest
 public class RegistryMojoWithAutoReferencesTest extends RegistryMojoTestBase {
+
+    private static final String PROTO_SCHEMA_EXTENSION = ".proto";
+    private static final String AVSC_SCHEMA_EXTENSION = ".avsc";
 
     RegisterRegistryMojo registerMojo;
     DownloadRegistryMojo downloadMojo;
@@ -50,39 +62,126 @@ public class RegistryMojoWithAutoReferencesTest extends RegistryMojoTestBase {
 
     @Test
     public void autoRegisterAvroWithReferences() throws MojoExecutionException, MojoFailureException {
-        String groupId = "RegistryMojoWithAutoReferencesTest";
+        String groupId = "autoRegisterAvroWithReferences";
+        String artifactId = "tradeRaw";
 
         File tradeRawFile = new File(getClass().getResource("TradeRawArray.avsc").getFile());
 
+        Set<String> avroFiles = Arrays.stream(Objects.requireNonNull(tradeRawFile.getParentFile().listFiles((dir, name) -> name.endsWith(AVSC_SCHEMA_EXTENSION))))
+                .map(file -> {
+                    FileInputStream fis = null;
+                    try {
+                        fis = new FileInputStream(file);
+                    } catch (FileNotFoundException e) {
+                    }
+                    return IoUtil.toString(fis);
+                })
+                .collect(Collectors.toSet());
+
         RegisterArtifact tradeRawArtifact = new RegisterArtifact();
         tradeRawArtifact.setGroupId(groupId);
-        tradeRawArtifact.setArtifactId("tradeRaw");
+        tradeRawArtifact.setArtifactId(artifactId);
         tradeRawArtifact.setType(ArtifactType.AVRO);
         tradeRawArtifact.setFile(tradeRawFile);
         tradeRawArtifact.setAnalyzeDirectory(true);
 
         registerMojo.setArtifacts(Collections.singletonList(tradeRawArtifact));
         registerMojo.execute();
+
+        //Assertions
+        validateStructure(groupId, artifactId, 1, 3, avroFiles);
     }
 
     @Test
     public void autoRegisterProtoWithReferences() throws MojoExecutionException, MojoFailureException {
+        //Preparation
         String groupId = "autoRegisterProtoWithReferences";
+        String artifactId = "tableNotification";
 
-        File tradeRawFile = new File(getClass().getResource("table_notification.proto").getFile());
+        File tableNotificationFile = new File(getClass().getResource("table_notification.proto").getFile());
+
+        Set<String> protoFiles = Arrays.stream(Objects.requireNonNull(tableNotificationFile.getParentFile().listFiles((dir, name) -> name.endsWith(PROTO_SCHEMA_EXTENSION))))
+                .map(file -> {
+                    FileInputStream fis = null;
+                    try {
+                        fis = new FileInputStream(file);
+                    } catch (FileNotFoundException e) {
+                    }
+                    return IoUtil.toString(fis).trim();
+                })
+                .collect(Collectors.toSet());
 
         RegisterArtifact tableNotification = new RegisterArtifact();
         tableNotification.setGroupId(groupId);
-        tableNotification.setArtifactId("tableNotification");
+        tableNotification.setArtifactId(artifactId);
         tableNotification.setType(ArtifactType.PROTOBUF);
-        tableNotification.setFile(tradeRawFile);
+        tableNotification.setFile(tableNotificationFile);
         tableNotification.setAnalyzeDirectory(true);
         tableNotification.setIfExists(IfExists.RETURN);
 
         registerMojo.setArtifacts(Collections.singletonList(tableNotification));
+
+        //Execution
         registerMojo.execute();
 
-        final ArtifactMetaData artifactWithReferences = clientV2.getArtifactMetaData(groupId, "tableNotification");
-        Assertions.assertNotNull(artifactWithReferences);
+        //Assertions
+        validateStructure(groupId, artifactId, 2, 4, protoFiles);
+    }
+
+    private void validateStructure(String groupId, String artifactId, int expectedMainReferences, int expectedTotalArtifacts, Set<String> originalContents) {
+        final ArtifactMetaData artifactWithReferences = clientV2.getArtifactMetaData(groupId, artifactId);
+        final String mainContent = IoUtil.toString(clientV2.getArtifactVersion(groupId, artifactId, artifactWithReferences.getVersion()));
+
+        Assertions.assertTrue(originalContents.contains(mainContent)); //The main content has been registered as-is.
+
+        final List<ArtifactReference> mainArtifactReferences = clientV2.getArtifactReferencesByGlobalId(artifactWithReferences.getGlobalId());
+
+        //The main artifact has the expected number of references
+        Assertions.assertEquals(expectedMainReferences, clientV2.getArtifactReferencesByGlobalId(artifactWithReferences.getGlobalId()).size());
+
+        //Validate all the contents are registered as they are in the file system.
+        validateReferences(mainArtifactReferences, originalContents);
+
+        //The total number of artifacts for the directory structure is the expected.
+        Assertions.assertEquals(expectedTotalArtifacts, clientV2.listArtifactsInGroup(groupId).getCount());
+    }
+
+    private void validateReferences(List<ArtifactReference> artifactReferences, Set<String> loadedContents) {
+        for (ArtifactReference artifactReference : artifactReferences) {
+            String referenceContent = IoUtil.toString(clientV2.getArtifactVersion(artifactReference.getGroupId(), artifactReference.getArtifactId(), artifactReference.getVersion()));
+            ArtifactMetaData referenceMetadata = clientV2.getArtifactMetaData(artifactReference.getGroupId(), artifactReference.getArtifactId());
+            Assertions.assertTrue(loadedContents.contains(referenceContent.trim()));
+
+            List<ArtifactReference> nestedReferences = clientV2.getArtifactReferencesByGlobalId(referenceMetadata.getGlobalId());
+
+            if (!nestedReferences.isEmpty()) {
+                validateReferences(nestedReferences, loadedContents);
+            }
+        }
     }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithAutoReferencesTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithAutoReferencesTest.java
@@ -19,12 +19,14 @@ package io.apicurio.registry.noprofile.maven;
 import io.apicurio.registry.maven.DownloadRegistryMojo;
 import io.apicurio.registry.maven.RegisterArtifact;
 import io.apicurio.registry.maven.RegisterRegistryMojo;
+import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.v2.beans.IfExists;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -77,8 +79,10 @@ public class RegistryMojoWithAutoReferencesTest extends RegistryMojoTestBase {
         tableNotification.setAnalyzeDirectory(true);
         tableNotification.setIfExists(IfExists.RETURN);
 
-
         registerMojo.setArtifacts(Collections.singletonList(tableNotification));
         registerMojo.execute();
+
+        final ArtifactMetaData artifactWithReferences = clientV2.getArtifactMetaData(groupId, "tableNotification");
+        Assertions.assertNotNull(artifactWithReferences);
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithAutoReferencesTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithAutoReferencesTest.java
@@ -86,6 +86,7 @@ public class RegistryMojoWithAutoReferencesTest extends RegistryMojoTestBase {
         tradeRawArtifact.setType(ArtifactType.AVRO);
         tradeRawArtifact.setFile(tradeRawFile);
         tradeRawArtifact.setAnalyzeDirectory(true);
+        tradeRawArtifact.setIfExists(IfExists.FAIL);
 
         registerMojo.setArtifacts(Collections.singletonList(tradeRawArtifact));
         registerMojo.execute();
@@ -119,7 +120,7 @@ public class RegistryMojoWithAutoReferencesTest extends RegistryMojoTestBase {
         tableNotification.setType(ArtifactType.PROTOBUF);
         tableNotification.setFile(tableNotificationFile);
         tableNotification.setAnalyzeDirectory(true);
-        tableNotification.setIfExists(IfExists.RETURN);
+        tableNotification.setIfExists(IfExists.FAIL);
 
         registerMojo.setArtifacts(Collections.singletonList(tableNotification));
 
@@ -155,7 +156,7 @@ public class RegistryMojoWithAutoReferencesTest extends RegistryMojoTestBase {
         citizen.setType(ArtifactType.JSON);
         citizen.setFile(citizenFile);
         citizen.setAnalyzeDirectory(true);
-        citizen.setIfExists(IfExists.RETURN);
+        citizen.setIfExists(IfExists.FAIL);
 
         registerMojo.setArtifacts(Collections.singletonList(citizen));
 
@@ -198,28 +199,3 @@ public class RegistryMojoWithAutoReferencesTest extends RegistryMojoTestBase {
         }
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithAutoReferencesTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithAutoReferencesTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.noprofile.maven;
+
+import io.apicurio.registry.maven.DownloadRegistryMojo;
+import io.apicurio.registry.maven.RegisterArtifact;
+import io.apicurio.registry.maven.RegisterRegistryMojo;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Collections;
+
+@QuarkusTest
+public class RegistryMojoWithAutoReferencesTest extends RegistryMojoTestBase {
+
+    RegisterRegistryMojo registerMojo;
+    DownloadRegistryMojo downloadMojo;
+
+    @BeforeEach
+    public void createMojos() {
+        this.registerMojo = new RegisterRegistryMojo();
+        this.registerMojo.setRegistryUrl(TestUtils.getRegistryV2ApiUrl(testPort));
+
+        this.downloadMojo = new DownloadRegistryMojo();
+        this.downloadMojo.setRegistryUrl(TestUtils.getRegistryV2ApiUrl(testPort));
+    }
+
+    @Test
+    public void autoRegisterAvroWithReferences() throws MojoExecutionException, MojoFailureException {
+        String groupId = "RegistryMojoWithAutoReferencesTest";
+
+        File tradeRawFile = new File(getClass().getResource("TradeRawArray.avsc").getFile());
+
+        RegisterArtifact tradeRawArtifact = new RegisterArtifact();
+        tradeRawArtifact.setGroupId(groupId);
+        tradeRawArtifact.setArtifactId("tradeRaw");
+        tradeRawArtifact.setType(ArtifactType.AVRO);
+        tradeRawArtifact.setFile(tradeRawFile);
+        tradeRawArtifact.setAnalyzeDirectory(true);
+
+        registerMojo.setArtifacts(Collections.singletonList(tradeRawArtifact));
+        registerMojo.execute();
+    }
+
+    @Test
+    public void autoRegisterProtoWithReferences() throws MojoExecutionException, MojoFailureException {
+        String groupId = "autoRegisterProtoWithReferences";
+
+        File tradeRawFile = new File(getClass().getResource("table_notification.proto").getFile());
+
+        RegisterArtifact tableNotification = new RegisterArtifact();
+        tableNotification.setGroupId(groupId);
+        tableNotification.setArtifactId("tableNotification");
+        tableNotification.setType(ArtifactType.PROTOBUF);
+        tableNotification.setFile(tradeRawFile);
+        tableNotification.setAnalyzeDirectory(true);
+
+        registerMojo.setArtifacts(Collections.singletonList(tableNotification));
+        registerMojo.execute();
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithAutoReferencesTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/maven/RegistryMojoWithAutoReferencesTest.java
@@ -19,6 +19,7 @@ package io.apicurio.registry.noprofile.maven;
 import io.apicurio.registry.maven.DownloadRegistryMojo;
 import io.apicurio.registry.maven.RegisterArtifact;
 import io.apicurio.registry.maven.RegisterRegistryMojo;
+import io.apicurio.registry.rest.v2.beans.IfExists;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
@@ -74,6 +75,8 @@ public class RegistryMojoWithAutoReferencesTest extends RegistryMojoTestBase {
         tableNotification.setType(ArtifactType.PROTOBUF);
         tableNotification.setFile(tradeRawFile);
         tableNotification.setAnalyzeDirectory(true);
+        tableNotification.setIfExists(IfExists.RETURN);
+
 
         registerMojo.setArtifacts(Collections.singletonList(tableNotification));
         registerMojo.execute();

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/TradeRawArray.avsc
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/TradeRawArray.avsc
@@ -1,0 +1,26 @@
+{
+  "namespace": "com.kubetrade.schema.trade",
+  "type": "record",
+  "name": "TradeRawArray",
+  "fields": [
+    {
+      "name": "tradeKeyList",
+      "type": {
+        "type": "array",
+        "items": {
+          "name": "tradeKey",
+          "type": "com.kubetrade.schema.trade.TradeKey"
+        }
+      }
+
+    },
+    {
+      "name": "symbol",
+      "type": "string"
+    },
+    {
+      "name": "payload",
+      "type": "string"
+    }
+  ]
+}

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/TradeRawArray.avsc
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/TradeRawArray.avsc
@@ -12,7 +12,6 @@
           "type": "com.kubetrade.schema.trade.TradeKey"
         }
       }
-
     },
     {
       "name": "symbol",

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/citizen.json
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/citizen.json
@@ -1,0 +1,36 @@
+{
+  "$id": "https://example.com/citizen.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Citizen",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "description": "The citizen's first name."
+    },
+    "lastName": {
+      "type": "string",
+      "description": "The citizen's last name."
+    },
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "city": {
+      "$ref": "city.schema.json"
+    },
+    "identifier": {
+      "$ref": "citizenIdentifier.schema.json"
+    },
+    "qualifications": {
+      "type": "array",
+      "items": {
+        "$ref": "qualification.schema.json"
+      }
+    }
+  },
+  "required": [
+    "city"
+  ]
+}

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/citizenIdentifier.json
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/citizenIdentifier.json
@@ -1,0 +1,13 @@
+{
+  "$id": "https://example.com/citizenIdentifier.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Identifier",
+  "type": "object",
+  "properties": {
+    "identifier": {
+      "type": "integer",
+      "description": "The citizen identifier.",
+      "minimum": 0
+    }
+  }
+}

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/city.json
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/city.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://example.com/city.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "City",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The city's name."
+    },
+    "zipCode": {
+      "type": "integer",
+      "description": "The zip code.",
+      "minimum": 0
+    }
+  }
+}

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/mode.proto
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/mode.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+package sample;
+option java_package = "io.api.sample";
+option java_multiple_files = true;
+
+enum Mode {
+
+	MODE_UNKNOWN = 0; //default unset value
+
+	RAW = 1; //no assumption is made on the nature of the data, leading to less optimization in data delivery
+
+	MERGE = 2; //an item represents a row in a table. Real-time updates to that item are used to update the contents of the cells (fields) for that row
+
+	DISTINCT = 3; //an item represents a list of events. Real-time updates tothat item are used to add lines to that list (where each line is made up of fields)
+
+	COMMAND = 4; //an item represents a full table. Real-time updates tothat item are used to change the contents of that table, by adding rows, removing rows, andupdating cells
+
+}

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/qualification.json
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/qualification.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://example.com/qualification.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Qualification",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The subject's name"
+    },
+    "qualification": {
+      "type": "integer",
+      "description": "The qualification.",
+      "minimum": 0
+    }
+  }
+}

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/table_info.proto
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/table_info.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+package sample;
+option java_package = "io.api.sample";
+option java_multiple_files = true;
+
+import "sample/mode.proto";
+
+message TableInfo {
+
+  int32 winIndex = 1;
+
+  Mode mode = 2;
+
+  int32 min = 3;
+
+  int32 max = 4;
+
+  string id = 5;
+
+  string dataAdapter = 6;
+
+  string schema = 7;
+
+  string selector = 8;
+
+  string subscription_id = 9;
+}

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/table_notification.proto
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/table_notification.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+package sample;
+option java_package = "io.api.sample";
+option java_multiple_files = true;
+
+import "google/protobuf/timestamp.proto";
+import "sample/table_info.proto";
+import "sample/table_notification_type.proto";
+
+message TableNotification {
+
+  google.protobuf.Timestamp timestamp = 1;
+
+  string user = 2;
+
+  string session_id = 3;
+
+  TableNotificationType table_notification_type = 4;
+
+  TableInfo table_info = 5;
+
+}

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/table_notification_type.proto
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/table_notification_type.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package sample;
+option java_package = "io.api.sample";
+option java_multiple_files = true;
+
+enum TableNotificationType {
+
+	TABLE_NOTIFICATION_TYPE_UNKNOWN = 0;
+
+	NEW = 1;
+
+	CLOSE = 2;
+
+}

--- a/schema-util/json/src/main/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonUtil.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonUtil.java
@@ -64,10 +64,14 @@ public class JsonUtil {
     }
 
     public static Schema readSchema(String content) throws JsonProcessingException {
-        return readSchema(content, Collections.emptyMap());
+        return readSchema(content, Collections.emptyMap(), true);
     }
 
     public static Schema readSchema(String content, Map<String, ContentHandle> resolvedReferences) throws JsonProcessingException {
+        return readSchema(content, resolvedReferences, true);
+    }
+
+    public static Schema readSchema(String content, Map<String, ContentHandle> resolvedReferences, boolean validateDangling) throws JsonProcessingException {
         JsonNode jsonNode = MAPPER.readTree(content);
         Schema schemaObj;
         // Extract the $schema to use for determining the id keyword
@@ -121,7 +125,7 @@ public class JsonUtil {
             }
         }
         // Check for dangling references. Do we want to do this as a separate rule?
-        if (!resolvedReferencesCopy.isEmpty()) {
+        if (validateDangling && !resolvedReferencesCopy.isEmpty()) {
             var msg = "There are unused references recorded for this content. " +
                     "Make sure you have not made a typo, otherwise remove the unused reference record(s). " +
                     "References in the content: " + referenceURIs + ", " +

--- a/utils/maven-plugin/pom.xml
+++ b/utils/maven-plugin/pom.xml
@@ -25,6 +25,18 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <scope>provided</scope>
@@ -34,6 +46,19 @@
             <artifactId>maven-plugin-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-protobuf-schema-utilities</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/utils/maven-plugin/pom.xml
+++ b/utils/maven-plugin/pom.xml
@@ -58,6 +58,10 @@
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-protobuf-schema-utilities</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-schema-util-json</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/AbstractDirectoryParser.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/AbstractDirectoryParser.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.maven;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
+import io.apicurio.registry.rest.v2.beans.IfExists;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.IoUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractDirectoryParser<Schema> {
+
+    private final RegistryClient client;
+
+    public AbstractDirectoryParser(RegistryClient client) {
+        this.client = client;
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractDirectoryParser.class);
+
+    public abstract ParsedDirectoryWrapper<Schema> parse(File rootSchema);
+
+    public abstract List<ArtifactReference> handleSchemaReferences(RegisterArtifact rootArtifact, Schema schema, Map<String, ContentHandle> fileContents) throws FileNotFoundException;
+
+    protected ContentHandle readSchemaContent(File schemaFile) {
+        try {
+            return ContentHandle.create(Files.readAllBytes(schemaFile.toPath()));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read schema file: " + schemaFile, e);
+        }
+    }
+
+    protected RegisterArtifact buildFromRoot(RegisterArtifact rootArtifact, String artifactId) {
+        RegisterArtifact nestedSchema = new RegisterArtifact();
+        nestedSchema.setCanonicalize(rootArtifact.getCanonicalize());
+        nestedSchema.setArtifactId(artifactId);
+        nestedSchema.setGroupId(rootArtifact.getGroupId());
+        nestedSchema.setContentType(rootArtifact.getContentType());
+        nestedSchema.setType(rootArtifact.getType());
+        nestedSchema.setMinify(rootArtifact.getMinify());
+        nestedSchema.setContentType(rootArtifact.getContentType());
+        nestedSchema.setIfExists(rootArtifact.getIfExists());
+        return nestedSchema;
+    }
+
+    protected ArtifactReference registerNestedSchema(String referenceName, List<ArtifactReference> nestedArtifactReferences, RegisterArtifact nestedSchema, String artifactContent) throws FileNotFoundException {
+        ArtifactMetaData referencedArtifactMetadata = registerArtifact(nestedSchema, IoUtil.toStream(artifactContent), nestedArtifactReferences);
+        ArtifactReference referencedArtifact = new ArtifactReference();
+        referencedArtifact.setName(referenceName);
+        referencedArtifact.setArtifactId(referencedArtifactMetadata.getId());
+        referencedArtifact.setGroupId(referencedArtifactMetadata.getGroupId());
+        referencedArtifact.setVersion(referencedArtifactMetadata.getVersion());
+        return referencedArtifact;
+    }
+
+    private ArtifactMetaData registerArtifact(RegisterArtifact artifact, InputStream artifactContent, List<ArtifactReference> references) {
+        String groupId = artifact.getGroupId();
+        String artifactId = artifact.getArtifactId();
+        String version = artifact.getVersion();
+        String type = artifact.getType();
+        IfExists ifExists = artifact.getIfExists();
+        Boolean canonicalize = artifact.getCanonicalize();
+        if (artifact.getMinify() != null && artifact.getMinify()) {
+            try {
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode jsonNode = objectMapper.readValue(artifactContent, JsonNode.class);
+                artifactContent = new ByteArrayInputStream(jsonNode.toString().getBytes());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        ArtifactMetaData amd = client.createArtifact(groupId, artifactId, version, type, ifExists, canonicalize, null, null, ContentTypes.APPLICATION_CREATE_EXTENDED, null, null, artifactContent, references);
+        log.info(String.format("Successfully registered artifact [%s] / [%s].  GlobalId is [%d]", groupId, artifactId, amd.getGlobalId()));
+
+        return amd;
+    }
+}

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/AvroDirectoryParser.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/AvroDirectoryParser.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.maven;
+
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaParseException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class AvroDirectoryParser {
+
+    private static final String AVRO_SCHEMA_EXTENSION = ".avsc";
+
+    public static Schema parse(File rootSchemaFile) {
+        return parseDirectory(rootSchemaFile.getParentFile(), rootSchemaFile);
+    }
+
+    private static String readSchemaContent(File schemaFile) {
+        try {
+            return new String(Files.readAllBytes(schemaFile.toPath()));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read schema file: " + schemaFile, e);
+        }
+    }
+
+    private static Schema parseDirectory(File directory, File rootSchema) {
+        Set<File> schemaFiles = Arrays.stream(Objects.requireNonNull(directory.listFiles((dir, name) -> name.endsWith(AVRO_SCHEMA_EXTENSION))))
+                .collect(Collectors.toSet());
+
+        schemaFiles.remove(rootSchema);
+
+        Set<File> typesToAdd = new HashSet<>(schemaFiles);
+
+        Map<String, Schema> processed = new HashMap<>();
+
+        Schema.Parser rootSchemaParser = new Schema.Parser();
+        Schema.Parser partialParser = new Schema.Parser();
+        while (processed.size() != typesToAdd.size()) {
+            for (File typeToAdd: typesToAdd) {
+                if (typeToAdd.getName().equals(rootSchema.getName())) {
+                   continue;
+                }
+                try {
+                    final Schema schema = partialParser.parse(readSchemaContent(typeToAdd));
+                    processed.put(schema.getFullName(), schema);
+                } catch (SchemaParseException ex) {
+                }
+            }
+            partialParser = new Schema.Parser();
+            partialParser.addTypes(processed);
+        }
+
+        rootSchemaParser.addTypes(processed);
+
+        return rootSchemaParser.parse(readSchemaContent(rootSchema));
+    }
+}

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/AvroDirectoryParser.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/AvroDirectoryParser.java
@@ -17,8 +17,11 @@
 package io.apicurio.registry.maven;
 
 
+import io.apicurio.registry.content.ContentHandle;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,14 +36,15 @@ import java.util.stream.Collectors;
 public class AvroDirectoryParser {
 
     private static final String AVRO_SCHEMA_EXTENSION = ".avsc";
+    private static final Logger log = LoggerFactory.getLogger(AvroDirectoryParser.class);
 
     public static AvroSchemaWrapper parse(File rootSchemaFile) {
         return parseDirectory(rootSchemaFile.getParentFile(), rootSchemaFile);
     }
 
-    private static String readSchemaContent(File schemaFile) {
+    private static ContentHandle readSchemaContent(File schemaFile) {
         try {
-            return new String(Files.readAllBytes(schemaFile.toPath()));
+            return ContentHandle.create(Files.readAllBytes(schemaFile.toPath()));
         } catch (IOException e) {
             throw new RuntimeException("Failed to read schema file: " + schemaFile, e);
         }
@@ -51,7 +55,7 @@ public class AvroDirectoryParser {
                 .filter(file -> !file.getName().equals(rootSchema.getName())).collect(Collectors.toSet());
 
         Map<String, Schema> processed = new HashMap<>();
-        Map<String, String> schemaContents = new HashMap<>();
+        Map<String, ContentHandle> schemaContents = new HashMap<>();
 
         Schema.Parser rootSchemaParser = new Schema.Parser();
         Schema.Parser partialParser = new Schema.Parser();
@@ -62,11 +66,12 @@ public class AvroDirectoryParser {
                     continue;
                 }
                 try {
-                    final String schemaContent = readSchemaContent(typeToAdd);
-                    final Schema schema = partialParser.parse(schemaContent);
+                    final ContentHandle schemaContent = readSchemaContent(typeToAdd);
+                    final Schema schema = partialParser.parse(schemaContent.content());
                     processed.put(schema.getFullName(), schema);
                     schemaContents.put(schema.getFullName(), schemaContent);
                 } catch (SchemaParseException ex) {
+                    log.warn("Error processing Avro schema with name {}. This usually means that the references are not ready yet to parse it", typeToAdd.getName());
                 }
             }
             partialParser = new Schema.Parser();
@@ -75,14 +80,14 @@ public class AvroDirectoryParser {
 
         rootSchemaParser.addTypes(processed);
 
-        return new AvroSchemaWrapper(rootSchemaParser.parse(readSchemaContent(rootSchema)), schemaContents);
+        return new AvroSchemaWrapper(rootSchemaParser.parse(readSchemaContent(rootSchema).content()), schemaContents);
     }
 
     public static class AvroSchemaWrapper {
         final Schema schema;
-        final Map<String, String> fileContents; //Original file contents from the file system.
+        final Map<String, ContentHandle> fileContents; //Original file contents from the file system.
 
-        public AvroSchemaWrapper(Schema schema, Map<String, String> fileContents) {
+        public AvroSchemaWrapper(Schema schema, Map<String, ContentHandle> fileContents) {
             this.schema = schema;
             this.fileContents = fileContents;
         }
@@ -91,7 +96,7 @@ public class AvroDirectoryParser {
             return schema;
         }
 
-        public Map<String, String> getFileContents() {
+        public Map<String, ContentHandle> getFileContents() {
             return fileContents;
         }
     }

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/JsonSchemaDirectoryParser.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/JsonSchemaDirectoryParser.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.maven;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JsonSchemaDirectoryParser {
+
+    private static final String JSON_EXTENSION = ".json";
+
+    private final File directory;
+    private final ObjectMapper mapper;
+    private final List<JsonNode> schemas;
+
+    public JsonSchemaDirectoryParser(File directory) {
+        this.directory = directory;
+        this.mapper = new ObjectMapper();
+        this.schemas = new ArrayList<>();
+    }
+
+    public List<JsonNode> parse() throws IOException {
+        for (File file : directory.listFiles()) {
+            if (file.isFile() && file.getName().endsWith(JSON_EXTENSION)) {
+                String json = new String(Files.readAllBytes(Paths.get(file.getPath())));
+                JsonNode node = mapper.readTree(json);
+                parseNode(node);
+            }
+        }
+        return schemas;
+    }
+
+    private void parseNode(JsonNode node) {
+        if (node.isArray()) {
+            ArrayNode array = (ArrayNode) node;
+            for (JsonNode item : array) {
+                parseNode(item);
+            }
+        } else if (node.isObject()) {
+            ObjectNode object = (ObjectNode) node;
+            if (object.has("$ref")) {
+                String ref = object.get("$ref").asText();
+                String[] parts = ref.split("/");
+                String name = parts[parts.length - 1];
+                JsonNode schema = findOrCreateSchema(name);
+                object.putAll((ObjectNode) schema);
+            } else {
+                for (JsonNode child : node) {
+                    parseNode(child);
+                }
+            }
+        }
+    }
+
+    private JsonNode findOrCreateSchema(String name) {
+        for (JsonNode schema : schemas) {
+            if (schema.get("title").asText().equals(name)) {
+                return schema;
+            }
+        }
+        String path = directory.getPath() + File.separator + name + JSON_EXTENSION;
+        String json = null;
+        try {
+            json = new String(Files.readAllBytes(Paths.get(path)));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        JsonNode schema = null;
+        try {
+            schema = mapper.readTree(json);
+            schemas.add(schema);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return schema;
+    }
+}
+

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ParsedDirectoryWrapper.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ParsedDirectoryWrapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.maven;
+
+import io.apicurio.registry.content.ContentHandle;
+
+import java.util.Map;
+
+public interface ParsedDirectoryWrapper<Schema> {
+
+    public Schema getSchema();
+
+    public Map<String, ContentHandle> getSchemaContents();
+}

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ProtobufDirectoryParser.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ProtobufDirectoryParser.java
@@ -9,7 +9,6 @@ import io.apicurio.registry.utils.protobuf.schema.FileDescriptorUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ProtobufDirectoryParser.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ProtobufDirectoryParser.java
@@ -4,11 +4,14 @@ import com.google.protobuf.Descriptors;
 import com.squareup.wire.schema.Location;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import com.squareup.wire.schema.internal.parser.ProtoParser;
-import io.apicurio.registry.utils.IoUtil;
+import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.utils.protobuf.schema.FileDescriptorUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,6 +23,7 @@ import java.util.stream.Collectors;
 public class ProtobufDirectoryParser {
 
     private static final String PROTO_SCHEMA_EXTENSION = ".proto";
+    private static final Logger log = LoggerFactory.getLogger(ProtobufDirectoryParser.class);
 
     public static DescriptorWrapper parse(File protoFile) {
 
@@ -37,37 +41,36 @@ public class ProtobufDirectoryParser {
                     continue;
                 }
                 try {
-                    FileInputStream fis = new FileInputStream(fileToProcess);
-                    final String schemaContent = IoUtil.toString(fis);
+                    final ContentHandle schemaContent = readProtoFile(fileToProcess);
                     parsedFiles.put(fileToProcess.getName(), parseProtoFile(fileToProcess, schemaDefs, parsedFiles, schemaContent));
-                    schemaDefs.put(fileToProcess.getName(), schemaContent);
-                    fis.close();
+                    schemaDefs.put(fileToProcess.getName(), schemaContent.content());
                 } catch (Exception ex) {
-                    System.out.println("");
-                    //Just ignore, the schema cannot be parsed yet.
+                    log.warn("Error processing Avro schema with name {}. This usually means that the references are not ready yet to parse it", fileToProcess.getName());
                 }
             }
         }
 
         //parse the main schema
-        try {
-            FileInputStream fis = new FileInputStream(protoFile);
-            final String schemaContent = IoUtil.toString(fis);
-            final Descriptors.FileDescriptor schemaDescriptor = parseProtoFile(protoFile, schemaDefs, parsedFiles, schemaContent);
-            fis.close();
-            return new DescriptorWrapper(schemaDescriptor, schemaDefs);
-        } catch (Exception ex) {
-            System.out.println("");
-            //TODO log exception
-        }
-
-        return null;
+        final ContentHandle schemaContent = readProtoFile(protoFile);
+        final Descriptors.FileDescriptor schemaDescriptor = parseProtoFile(protoFile, schemaDefs, parsedFiles, schemaContent);
+        return new DescriptorWrapper(schemaDescriptor, schemaDefs);
     }
 
+    private static ContentHandle readProtoFile(File schemaFile) {
+        try {
+            return ContentHandle.create(Files.readAllBytes(schemaFile.toPath()));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read schema file: " + schemaFile, e);
+        }
+    }
 
-    private static Descriptors.FileDescriptor parseProtoFile(File protoFile, Map<String, String> schemaDefs, Map<String, Descriptors.FileDescriptor> dependencies, String schemaContent) throws Descriptors.DescriptorValidationException {
-        ProtoFileElement protoFileElement = ProtoParser.Companion.parse(Location.get(protoFile.getAbsolutePath()), schemaContent);
-        return FileDescriptorUtils.protoFileToFileDescriptor(schemaContent, protoFile.getName(), Optional.ofNullable(protoFileElement.getPackageName()), schemaDefs, dependencies);
+    private static Descriptors.FileDescriptor parseProtoFile(File protoFile, Map<String, String> schemaDefs, Map<String, Descriptors.FileDescriptor> dependencies, ContentHandle schemaContent) {
+        ProtoFileElement protoFileElement = ProtoParser.Companion.parse(Location.get(protoFile.getAbsolutePath()), schemaContent.content());
+        try {
+            return FileDescriptorUtils.protoFileToFileDescriptor(schemaContent.content(), protoFile.getName(), Optional.ofNullable(protoFileElement.getPackageName()), schemaDefs, dependencies);
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new RuntimeException("Failed to read schema file: " + protoFile, e);
+        }
     }
 
     public static class DescriptorWrapper {

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ProtobufDirectoryParser.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ProtobufDirectoryParser.java
@@ -1,0 +1,72 @@
+package io.apicurio.registry.maven;
+
+import com.google.protobuf.Descriptors;
+import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.internal.parser.ProtoFileElement;
+import com.squareup.wire.schema.internal.parser.ProtoParser;
+import io.apicurio.registry.utils.IoUtil;
+import io.apicurio.registry.utils.protobuf.schema.FileDescriptorUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ProtobufDirectoryParser {
+
+    private static final String PROTO_SCHEMA_EXTENSION = ".proto";
+
+    public static Descriptors.FileDescriptor parse(File protoFile) throws IOException, Descriptors.DescriptorValidationException {
+
+        Set<File> protoFiles = Arrays.stream(Objects.requireNonNull(protoFile.getParentFile().listFiles((dir, name) -> name.endsWith(PROTO_SCHEMA_EXTENSION))))
+                .filter(file -> !file.getName().equals(protoFile.getName()))
+                .collect(Collectors.toSet());
+
+        Map<String, Descriptors.FileDescriptor> parsedFiles = new HashMap<>();
+        Map<String, String> schemaDefs = new HashMap<>();
+
+        // Add file to set of parsed files to avoid circular dependencies
+        while (parsedFiles.size() != protoFiles.size()) {
+            for (File fileToProcess : protoFiles) {
+                if (fileToProcess.getName().equals(protoFile.getName()) || parsedFiles.containsKey(fileToProcess.getName())) {
+                    continue;
+                }
+                try {
+                    FileInputStream fis = new FileInputStream(fileToProcess);
+                    final String schemaContent = IoUtil.toString(fis);
+                    parsedFiles.put(fileToProcess.getName(), parseProtoFile(fileToProcess, schemaDefs, parsedFiles, schemaContent));
+                    schemaDefs.put(fileToProcess.getName(), schemaContent);
+                    fis.close();
+                } catch (Exception ex) {
+                    //Just ignore, the schema cannot be parsed yet.
+                }
+            }
+        }
+
+        //parse the main schema
+        try {
+            FileInputStream fis = new FileInputStream(protoFile);
+            final String schemaContent = IoUtil.toString(fis);
+            final Descriptors.FileDescriptor schemaDescriptor = parseProtoFile(protoFile, schemaDefs, parsedFiles, schemaContent);
+            fis.close();
+            return schemaDescriptor;
+        } catch (Exception ex) {
+
+        }
+
+        return null;
+    }
+
+
+    private static Descriptors.FileDescriptor parseProtoFile(File protoFile, Map<String, String> schemaDefs, Map<String, Descriptors.FileDescriptor> dependencies, String schemaContent) throws IOException, Descriptors.DescriptorValidationException {
+        ProtoFileElement protoFileElement = ProtoParser.Companion.parse(Location.get(protoFile.getAbsolutePath()), schemaContent);
+        return FileDescriptorUtils.protoFileToFileDescriptor(schemaContent, protoFile.getName(), Optional.ofNullable(protoFileElement.getPackageName()), schemaDefs, dependencies);
+    }
+}
+

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ProtobufDirectoryParser.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ProtobufDirectoryParser.java
@@ -44,6 +44,7 @@ public class ProtobufDirectoryParser {
                     schemaDefs.put(fileToProcess.getName(), schemaContent);
                     fis.close();
                 } catch (Exception ex) {
+                    System.out.println("");
                     //Just ignore, the schema cannot be parsed yet.
                 }
             }
@@ -57,7 +58,8 @@ public class ProtobufDirectoryParser {
             fis.close();
             return schemaDescriptor;
         } catch (Exception ex) {
-
+            System.out.println("");
+            //TODO log exception
         }
 
         return null;

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ProtobufDirectoryParser.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/ProtobufDirectoryParser.java
@@ -5,34 +5,43 @@ import com.squareup.wire.schema.Location;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import com.squareup.wire.schema.internal.parser.ProtoParser;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.utils.protobuf.schema.FileDescriptorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ProtobufDirectoryParser {
+public class ProtobufDirectoryParser extends AbstractDirectoryParser<Descriptors.FileDescriptor> {
 
     private static final String PROTO_SCHEMA_EXTENSION = ".proto";
     private static final Logger log = LoggerFactory.getLogger(ProtobufDirectoryParser.class);
 
-    public static DescriptorWrapper parse(File protoFile) {
+    public ProtobufDirectoryParser(RegistryClient client) {
+        super(client);
+    }
+
+    @Override
+    public ParsedDirectoryWrapper<Descriptors.FileDescriptor> parse(File protoFile) {
 
         Set<File> protoFiles = Arrays.stream(Objects.requireNonNull(protoFile.getParentFile().listFiles((dir, name) -> name.endsWith(PROTO_SCHEMA_EXTENSION))))
                 .filter(file -> !file.getName().equals(protoFile.getName()))
                 .collect(Collectors.toSet());
 
         Map<String, Descriptors.FileDescriptor> parsedFiles = new HashMap<>();
-        Map<String, String> schemaDefs = new HashMap<>();
+        Map<String, ContentHandle> schemaDefs = new HashMap<>();
 
         // Add file to set of parsed files to avoid circular dependencies
         while (parsedFiles.size() != protoFiles.size()) {
@@ -41,9 +50,9 @@ public class ProtobufDirectoryParser {
                     continue;
                 }
                 try {
-                    final ContentHandle schemaContent = readProtoFile(fileToProcess);
+                    final ContentHandle schemaContent = readSchemaContent(fileToProcess);
                     parsedFiles.put(fileToProcess.getName(), parseProtoFile(fileToProcess, schemaDefs, parsedFiles, schemaContent));
-                    schemaDefs.put(fileToProcess.getName(), schemaContent.content());
+                    schemaDefs.put(fileToProcess.getName(), schemaContent);
                 } catch (Exception ex) {
                     log.warn("Error processing Avro schema with name {}. This usually means that the references are not ready yet to parse it", fileToProcess.getName());
                 }
@@ -51,43 +60,67 @@ public class ProtobufDirectoryParser {
         }
 
         //parse the main schema
-        final ContentHandle schemaContent = readProtoFile(protoFile);
+        final ContentHandle schemaContent = readSchemaContent(protoFile);
         final Descriptors.FileDescriptor schemaDescriptor = parseProtoFile(protoFile, schemaDefs, parsedFiles, schemaContent);
         return new DescriptorWrapper(schemaDescriptor, schemaDefs);
     }
 
-    private static ContentHandle readProtoFile(File schemaFile) {
-        try {
-            return ContentHandle.create(Files.readAllBytes(schemaFile.toPath()));
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to read schema file: " + schemaFile, e);
+    @Override
+    public List<ArtifactReference> handleSchemaReferences(RegisterArtifact rootArtifact, Descriptors.FileDescriptor protoSchema, Map<String, ContentHandle> fileContents) throws FileNotFoundException {
+        List<ArtifactReference> references = new ArrayList<>();
+        final Set<Descriptors.FileDescriptor> baseDeps = new HashSet<>(Arrays.asList(FileDescriptorUtils.baseDependencies()));
+        final ProtoFileElement rootSchemaElement = FileDescriptorUtils.fileDescriptorToProtoFile(protoSchema.toProto());
+
+        for (Descriptors.FileDescriptor dependency : protoSchema.getDependencies()) {
+
+            List<ArtifactReference> nestedArtifactReferences = new ArrayList<>();
+            String dependencyFullName = dependency.getPackage() + "/" + dependency.getName(); //FIXME find a better wat to do this
+            if (!baseDeps.contains(dependency) && rootSchemaElement.getImports().contains(dependencyFullName)) {
+
+                RegisterArtifact nestedArtifact = buildFromRoot(rootArtifact, dependencyFullName);
+
+                if (!dependency.getDependencies().isEmpty()) {
+                    nestedArtifactReferences = handleSchemaReferences(nestedArtifact, dependency, fileContents);
+                }
+
+                references.add(registerNestedSchema(dependencyFullName, nestedArtifactReferences, nestedArtifact, fileContents.get(dependency.getName()).content()));
+            }
         }
+
+        return references;
     }
 
-    private static Descriptors.FileDescriptor parseProtoFile(File protoFile, Map<String, String> schemaDefs, Map<String, Descriptors.FileDescriptor> dependencies, ContentHandle schemaContent) {
+    private Descriptors.FileDescriptor parseProtoFile(File protoFile, Map<String, ContentHandle> schemaDefs, Map<String, Descriptors.FileDescriptor> dependencies, ContentHandle schemaContent) {
         ProtoFileElement protoFileElement = ProtoParser.Companion.parse(Location.get(protoFile.getAbsolutePath()), schemaContent.content());
         try {
-            return FileDescriptorUtils.protoFileToFileDescriptor(schemaContent.content(), protoFile.getName(), Optional.ofNullable(protoFileElement.getPackageName()), schemaDefs, dependencies);
+
+            final Map<String, String> schemaStrings = schemaDefs.entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey,
+                            e -> e.getValue().content()));
+
+            return FileDescriptorUtils.protoFileToFileDescriptor(schemaContent.content(), protoFile.getName(), Optional.ofNullable(protoFileElement.getPackageName()), schemaStrings, dependencies);
         } catch (Descriptors.DescriptorValidationException e) {
             throw new RuntimeException("Failed to read schema file: " + protoFile, e);
         }
     }
 
-    public static class DescriptorWrapper {
+    public static class DescriptorWrapper implements ParsedDirectoryWrapper<Descriptors.FileDescriptor> {
         final Descriptors.FileDescriptor fileDescriptor;
-        final Map<String, String> fileContents; //used to store the original file content to register the content as-is.
+        final Map<String, ContentHandle> schemaContents; //used to store the original file content to register the content as-is.
 
-        public DescriptorWrapper(Descriptors.FileDescriptor fileDescriptor, Map<String, String> fileContents) {
+        public DescriptorWrapper(Descriptors.FileDescriptor fileDescriptor, Map<String, ContentHandle> schemaContents) {
             this.fileDescriptor = fileDescriptor;
-            this.fileContents = fileContents;
+            this.schemaContents = schemaContents;
         }
 
-        public Descriptors.FileDescriptor getFileDescriptor() {
+        @Override
+        public Descriptors.FileDescriptor getSchema() {
             return fileDescriptor;
         }
 
-        public Map<String, String> getFileContents() {
-            return fileContents;
+        public Map<String, ContentHandle> getSchemaContents() {
+            return schemaContents;
         }
     }
 }

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterArtifact.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterArtifact.java
@@ -34,6 +34,7 @@ public class RegisterArtifact {
     private IfExists ifExists;
     private Boolean canonicalize;
     private Boolean minify;
+    private Boolean analyzeDirectory;
     private String contentType;
     private List<RegisterArtifactReference> references;
 
@@ -181,5 +182,13 @@ public class RegisterArtifact {
      */
     public void setReferences(List<RegisterArtifactReference> references) {
         this.references = references;
+    }
+
+    public Boolean getAnalyzeDirectory() {
+        return analyzeDirectory;
+    }
+
+    public void setAnalyzeDirectory(Boolean analyzeDirectory) {
+        this.analyzeDirectory = analyzeDirectory;
     }
 }

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
@@ -40,10 +40,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -152,7 +150,6 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
         final Set<Descriptors.FileDescriptor> baseDeps = new HashSet<>(Arrays.asList(FileDescriptorUtils.baseDependencies()));
 
         final ProtoFileElement rootSchemaElement = FileDescriptorUtils.fileDescriptorToProtoFile(protoSchema.toProto());
-        final Map<String, ArtifactReference> registered = new HashMap<>();
 
         for (Descriptors.FileDescriptor dependency : protoSchema.getDependencies()) {
             List<ArtifactReference> nestedArtifactReferences = new ArrayList<>();
@@ -165,54 +162,46 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
                     nestedArtifactReferences = handleProtobufSchemaReferences(nestedArtifact, dependency);
                 }
 
-                ArtifactReference registeredReference;
-                if (!registered.containsKey(dependencyFullName)) {
-                     registeredReference = registerNestedSchema(dependencyFullName, nestedArtifactReferences, nestedArtifact, FileDescriptorUtils.fileDescriptorToProtoFile(dependency.toProto()).toSchema());
-                     registered.put(dependencyFullName, registeredReference);
-                } else {
-                    registeredReference = registered.get(dependencyFullName);
-                }
-
-                references.add(registeredReference);
+                references.add(registerNestedSchema(dependencyFullName, nestedArtifactReferences, nestedArtifact, FileDescriptorUtils.fileDescriptorToProtoFile(dependency.toProto()).toSchema()));
             }
         }
 
         return references;
     }
 
-/*
+    /*
 
-    public static Descriptors.FileDescriptor protoFileToFileDescriptor(String schemaDefinition, String protoFileName, Optional<String> optionalPackageName, Map<String, String> schemaDefs, Map<String, Descriptors.FileDescriptor> dependencies)
-            throws Descriptors.DescriptorValidationException {
-        Objects.requireNonNull(schemaDefinition);
-        Objects.requireNonNull(protoFileName);
+        public static Descriptors.FileDescriptor protoFileToFileDescriptor(String schemaDefinition, String protoFileName, Optional<String> optionalPackageName, Map<String, String> schemaDefs, Map<String, Descriptors.FileDescriptor> dependencies)
+                throws Descriptors.DescriptorValidationException {
+            Objects.requireNonNull(schemaDefinition);
+            Objects.requireNonNull(protoFileName);
 
-        final DescriptorProtos.FileDescriptorProto fileDescriptorProto = toFileDescriptorProto(schemaDefinition, protoFileName, optionalPackageName, schemaDefs);
-        final Set<Descriptors.FileDescriptor> requiredDependencies = new HashSet<>();
+            final DescriptorProtos.FileDescriptorProto fileDescriptorProto = toFileDescriptorProto(schemaDefinition, protoFileName, optionalPackageName, schemaDefs);
+            final Set<Descriptors.FileDescriptor> requiredDependencies = new HashSet<>();
 
-        Arrays.stream(baseDependencies()).forEach(baseDependency -> {
-            String dependencyFullName = baseDependency.getPackage() + "/" + baseDependency.getName(); //FIXME find a better way to do this...
-            if (fileDescriptorProto.getDependencyList().contains(dependencyFullName)) {
-                requiredDependencies.add(baseDependency);
-            }
-        });
+            Arrays.stream(baseDependencies()).forEach(baseDependency -> {
+                String dependencyFullName = baseDependency.getPackage() + "/" + baseDependency.getName(); //FIXME find a better way to do this...
+                if (fileDescriptorProto.getDependencyList().contains(dependencyFullName)) {
+                    requiredDependencies.add(baseDependency);
+                }
+            });
 
-        dependencies.keySet().forEach(dependencyName -> {
-            Descriptors.FileDescriptor dependencyDescriptor = dependencies.get(dependencyName);
-            String dependencyFullName = dependencyDescriptor.getPackage() + "/" + dependencyDescriptor.getName(); //FIXME find a better way to do this...
-            if (fileDescriptorProto.getDependencyList().contains(dependencyFullName)) {
-                requiredDependencies.add(dependencyDescriptor);
-            }
-        });
+            dependencies.keySet().forEach(dependencyName -> {
+                Descriptors.FileDescriptor dependencyDescriptor = dependencies.get(dependencyName);
+                String dependencyFullName = dependencyDescriptor.getPackage() + "/" + dependencyDescriptor.getName(); //FIXME find a better way to do this...
+                if (fileDescriptorProto.getDependencyList().contains(dependencyFullName)) {
+                    requiredDependencies.add(dependencyDescriptor);
+                }
+            });
 
-        final Set<Descriptors.FileDescriptor> joinedDependencies = new HashSet<>(requiredDependencies);
+            final Set<Descriptors.FileDescriptor> joinedDependencies = new HashSet<>(requiredDependencies);
 
-        Descriptors.FileDescriptor[] dependenciesArray = new Descriptors.FileDescriptor[joinedDependencies.size()];
+            Descriptors.FileDescriptor[] dependenciesArray = new Descriptors.FileDescriptor[joinedDependencies.size()];
 
-        return Descriptors.FileDescriptor.buildFrom(fileDescriptorProto, joinedDependencies.toArray(dependenciesArray));
-    }
+            return Descriptors.FileDescriptor.buildFrom(fileDescriptorProto, joinedDependencies.toArray(dependenciesArray));
+        }
 
-*/
+    */
     private List<ArtifactReference> handleAvroSchemaReferences(RegisterArtifact rootArtifact, Schema rootSchema) throws FileNotFoundException {
 
         List<ArtifactReference> references = new ArrayList<>();

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
@@ -140,6 +140,8 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
                 final ParsedDirectoryWrapper<org.everit.json.schema.Schema> jsonSchema = jsonSchemaDirectoryParser.parse(artifact.getFile());
                 registerArtifact(artifact, jsonSchemaDirectoryParser.handleSchemaReferences(artifact, jsonSchema.getSchema(), jsonSchema.getSchemaContents()));
                 break;
+            default:
+                throw new IllegalArgumentException(String.format("Artifact type not recognized for analyzing a directory structure %s", artifact.getType()));
         }
     }
 

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
@@ -17,20 +17,27 @@
 
 package io.apicurio.registry.maven;
 
-import java.io.*;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.Descriptors;
+import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.v2.beans.ArtifactReference;
+import io.apicurio.registry.rest.v2.beans.IfExists;
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.IoUtil;
+import org.apache.avro.Schema;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
-import io.apicurio.registry.rest.v2.beans.IfExists;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Register artifacts against registry.
@@ -67,8 +74,8 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
                 if (artifact.getFile() == null) {
                     getLog().error(String.format("File is required when registering an artifact.  Missing from artifacts[%s].", idx));
                     errorCount++;
-                } else if (!artifact.getFile().isFile()) {
-                    getLog().error(String.format("Artifact file to register is configured but file does not exist or is not a file: %s", artifact.getFile().getPath()));
+                } else if (!artifact.getFile().exists()) {
+                    getLog().error(String.format("Artifact file to register is configured but file does not exist: %s", artifact.getFile().getPath()));
                     errorCount++;
                 }
 
@@ -87,61 +94,155 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
 
         int errorCount = 0;
         if (artifacts != null) {
-            for (RegisterArtifact artifact : artifacts) {
 
+            for (RegisterArtifact artifact : artifacts) {
                 String groupId = artifact.getGroupId();
                 String artifactId = artifact.getArtifactId();
-
                 try {
-                    List<ArtifactReference> references = new ArrayList<>();
-                    //First, we check if the artifact being processed has references defined
-                    if (hasReferences(artifact)) {
-                        references = registerArtifactReferences(artifact.getReferences());
+
+                    if (artifact.getAnalyzeDirectory()) { //Auto register selected, we must figure out if the artifact has reference using the directory structure
+                        registerDirectory(artifact);
+                    } else {
+
+                        List<ArtifactReference> references = new ArrayList<>();
+                        //First, we check if the artifact being processed has references defined
+                        if (hasReferences(artifact)) {
+                            references = registerArtifactReferences(artifact.getReferences());
+                        }
+                        registerArtifact(artifact, references);
                     }
-                    registerArtifact(artifact, references);
                 } catch (Exception e) {
                     errorCount++;
                     getLog().error(String.format("Exception while registering artifact [%s] / [%s]", groupId, artifactId), e);
                 }
-            }
-        }
 
-        if (errorCount > 0) {
-            throw new MojoExecutionException("Errors while registering artifacts ...");
+            }
+
+            if (errorCount > 0) {
+                throw new MojoExecutionException("Errors while registering artifacts ...");
+            }
         }
     }
 
-    private ArtifactMetaData registerArtifact(RegisterArtifact artifact, List<ArtifactReference> references) throws FileNotFoundException {
+    private void registerDirectory(RegisterArtifact artifact) throws IOException, Descriptors.DescriptorValidationException {
+        switch (artifact.getType()) {
+            case ArtifactType.AVRO -> {
+                final Schema schema = AvroDirectoryParser.parse(artifact.getFile());
+                registerArtifact(artifact, handleSchemaReferences(artifact, schema));
+            }
+            case ArtifactType.PROTOBUF -> {
+                final Descriptors.FileDescriptor protoSchema = ProtobufDirectoryParser.parse(artifact.getFile());
+
+            }
+            case ArtifactType.JSON -> {
+
+            }
+        }
+    }
+
+
+
+    private List<ArtifactReference> handleSchemaReferences(RegisterArtifact rootArtifact, Schema rootSchema) throws FileNotFoundException {
+
+        List<ArtifactReference> references = new ArrayList<>();
+
+        //Iterate through all the fields of the schema
+        for (Schema.Field field : rootSchema.getFields()) {
+            List<ArtifactReference> nestedArtifactReferences = new ArrayList<>();
+            if (field.schema().getType() == Schema.Type.RECORD) { //If the field is a sub-schema, recursively check for nested sub-schemas and register all of them
+
+                RegisterArtifact nestedSchema = buildFromRoot(rootArtifact, field.schema());
+
+                if (field.schema().hasFields()) {
+                    nestedArtifactReferences = handleSchemaReferences(nestedSchema, field.schema());
+                }
+
+                registerNestedSchema(references, field.schema(), nestedArtifactReferences, nestedSchema);
+            } else if (field.schema().getType() == Schema.Type.ENUM) { //If the nested schema is an enum, just register
+
+                RegisterArtifact nestedSchema = buildFromRoot(rootArtifact, field.schema());
+                registerNestedSchema(references, field.schema(), nestedArtifactReferences, nestedSchema);
+            } else if (isArrayWithSubschemaElement(field)) { //If the nested schema is an array and the element is a sub-schema, handle it
+
+                Schema elementSchema = field.schema().getElementType();
+
+                RegisterArtifact nestedSchema = buildFromRoot(rootArtifact, elementSchema);
+
+                if (elementSchema.hasFields()) {
+                    nestedArtifactReferences = handleSchemaReferences(nestedSchema, elementSchema);
+                }
+
+                registerNestedSchema(references, elementSchema,  nestedArtifactReferences, nestedSchema);
+            }
+        }
+        return references;
+    }
+
+    private boolean isArrayWithSubschemaElement(Schema.Field field) {
+        return field.schema().getType() == Schema.Type.ARRAY && field.schema().getElementType().getType() == Schema.Type.RECORD;
+    }
+
+    private RegisterArtifact buildFromRoot(RegisterArtifact rootArtifact, Schema schema) {
+        RegisterArtifact nestedSchema = new RegisterArtifact();
+        nestedSchema.setCanonicalize(rootArtifact.getCanonicalize());
+        nestedSchema.setArtifactId(schema.getFullName());
+        nestedSchema.setGroupId(rootArtifact.getGroupId());
+        nestedSchema.setContentType(rootArtifact.getContentType());
+        nestedSchema.setType(rootArtifact.getType());
+        nestedSchema.setMinify(rootArtifact.getMinify());
+        nestedSchema.setContentType(rootArtifact.getContentType());
+        nestedSchema.setIfExists(rootArtifact.getIfExists());
+
+        return nestedSchema;
+    }
+
+    private void registerNestedSchema(List<ArtifactReference> references, Schema schema, List<ArtifactReference> nestedArtifactReferences, RegisterArtifact nestedSchema) throws FileNotFoundException {
+        ArtifactMetaData referencedArtifactMetadata = registerArtifact(nestedSchema, IoUtil.toStream(schema.toString()), nestedArtifactReferences);
+        ArtifactReference referencedArtifact = new ArtifactReference();
+        referencedArtifact.setName(schema.getFullName());
+        referencedArtifact.setArtifactId(referencedArtifactMetadata.getId());
+        referencedArtifact.setGroupId(referencedArtifactMetadata.getGroupId());
+        referencedArtifact.setVersion(referencedArtifactMetadata.getVersion());
+        references.add(referencedArtifact);
+    }
+
+    private ArtifactMetaData registerArtifact(RegisterArtifact artifact, List<ArtifactReference> references) throws
+            FileNotFoundException {
+        return registerArtifact(artifact, new FileInputStream(artifact.getFile()), references);
+
+    }
+
+    private ArtifactMetaData registerArtifact(RegisterArtifact artifact, InputStream artifactContent, List<ArtifactReference> references) throws FileNotFoundException {
         String groupId = artifact.getGroupId();
         String artifactId = artifact.getArtifactId();
         String version = artifact.getVersion();
         String type = artifact.getType();
         IfExists ifExists = artifact.getIfExists();
         Boolean canonicalize = artifact.getCanonicalize();
-        String contentType = contentType(artifact);
-        InputStream data = new FileInputStream(artifact.getFile());
         if (artifact.getMinify() != null && artifact.getMinify()) {
             try {
                 ObjectMapper objectMapper = new ObjectMapper();
-                JsonNode jsonNode = objectMapper.readValue(data, JsonNode.class);
-                data = new ByteArrayInputStream(jsonNode.toString().getBytes());
+                JsonNode jsonNode = objectMapper.readValue(artifactContent, JsonNode.class);
+                artifactContent = new ByteArrayInputStream(jsonNode.toString().getBytes());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
         }
-        ArtifactMetaData amd = this.getClient().createArtifact(groupId, artifactId, version, type, ifExists, canonicalize, null, null, ContentTypes.APPLICATION_CREATE_EXTENDED, null, null, data, references);
+        ArtifactMetaData amd = this.getClient().createArtifact(groupId, artifactId, version, type, ifExists, canonicalize, null, null, ContentTypes.APPLICATION_CREATE_EXTENDED, null, null, artifactContent, references);
         getLog().info(String.format("Successfully registered artifact [%s] / [%s].  GlobalId is [%d]", groupId, artifactId, amd.getGlobalId()));
 
         return amd;
     }
 
+
     private boolean hasReferences(RegisterArtifact artifact) {
         return artifact.getReferences() != null && !artifact.getReferences().isEmpty();
     }
 
-    private List<ArtifactReference> registerArtifactReferences(List<RegisterArtifactReference> referencedArtifacts) throws FileNotFoundException {
+    private List<ArtifactReference> registerArtifactReferences
+            (List<RegisterArtifactReference> referencedArtifacts) throws FileNotFoundException {
         List<ArtifactReference> references = new ArrayList<>();
-        for (RegisterArtifactReference artifact: referencedArtifacts) {
+        for (RegisterArtifactReference artifact : referencedArtifacts) {
             List<ArtifactReference> nestedReferences = new ArrayList<>();
             //First, we check if the artifact being processed has references defined, and register them if needed
             if (hasReferences(artifact)) {
@@ -164,7 +265,7 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
 
     private String contentType(RegisterArtifact registerArtifact) {
         String contentType = registerArtifact.getContentType();
-        if(contentType != null) {
+        if (contentType != null) {
             return contentType;
         }
         return getContentTypeByExtension(registerArtifact.getFile().getName());

--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
@@ -184,7 +184,9 @@ public class ProtobufSchemaLoader {
             fileHandle.close();
             return path;
         } finally {
-            fileHandle.close();
+            if (fileHandle != null) {
+                fileHandle.close();
+            }
         }
     }
 

--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -124,21 +125,37 @@ public class ProtobufSchemaLoader {
      */
     public static ProtobufSchemaLoaderContext loadSchema(Optional<String> packageName, String fileName, String schemaDefinition)
         throws IOException {
+        return loadSchema(packageName, fileName, schemaDefinition, Collections.emptyMap());
+    }
+
+    /**
+     * Creates a schema loader using a in-memory file system. This is required for square wire schema parser and linker
+     * to load the types correctly. See https://github.com/square/wire/issues/2024#
+     * As of now this only supports reading one .proto file but can be extended to support reading multiple files.
+     * @param packageName Package name for the .proto if present
+     * @param fileName Name of the .proto file.
+     * @param schemaDefinition Schema Definition to parse.
+     * @param schemaDefinition Schema Definition to parse.
+     * @return Schema - parsed and properly linked Schema.
+     */
+    public static ProtobufSchemaLoaderContext loadSchema(Optional<String> packageName, String fileName, String schemaDefinition, Map<String, String> deps)
+            throws IOException {
         final FileSystem inMemoryFileSystem = getFileSystem();
 
         String[] dirs = {};
         if (packageName.isPresent()) {
             dirs = packageName.get().split("\\.");
         }
+
         String protoFileName = fileName.endsWith(".proto") ? fileName : fileName + ".proto";
-        FileHandle fileHandle = null;
+
         try {
             String dirPath = createDirectory(dirs, inMemoryFileSystem);
-            okio.Path path = okio.Path.get((dirPath + "/" + protoFileName));
-            final byte[] schemaBytes = schemaDefinition.getBytes(StandardCharsets.UTF_8);
-            fileHandle = inMemoryFileSystem.openReadWrite(path);
-            fileHandle.write(0, schemaBytes, 0, schemaBytes.length);
-            fileHandle.close();
+            okio.Path path = writeFile(schemaDefinition, fileName, dirPath, inMemoryFileSystem);
+
+            for (String depKey: deps.keySet()) {
+                writeFile(deps.get(depKey), depKey, dirPath, inMemoryFileSystem);
+            }
 
             SchemaLoader schemaLoader = new SchemaLoader(inMemoryFileSystem);
             schemaLoader.initRoots(Lists.newArrayList(Location.get("/")), Lists.newArrayList(Location.get("/")));
@@ -153,10 +170,21 @@ public class ProtobufSchemaLoader {
             return new ProtobufSchemaLoaderContext(schema, protoFile);
         } catch (Exception e) {
             throw e;
+        }
+    }
+
+    private static okio.Path writeFile(String schemaDefinition, String fileName, String dirPath, FileSystem inMemoryFileSystem) throws IOException {
+        FileHandle fileHandle = null;
+        try {
+            String protoFileName = fileName.endsWith(".proto") ? fileName : fileName + ".proto";
+            okio.Path path = okio.Path.get((dirPath + "/" + protoFileName));
+            final byte[] schemaBytes = schemaDefinition.getBytes(StandardCharsets.UTF_8);
+            fileHandle = inMemoryFileSystem.openReadWrite(path);
+            fileHandle.write(0, schemaBytes, 0, schemaBytes.length);
+            fileHandle.close();
+            return path;
         } finally {
-            if (fileHandle != null) {
-                fileHandle.close();
-            }
+            fileHandle.close();
         }
     }
 

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -55,7 +54,8 @@ public class TestUtils {
     private static final String DEFAULT_REGISTRY_HOST = "localhost";
     private static final int DEFAULT_REGISTRY_PORT = 8081;
 
-    public static URL REGISTRY_URL;
+    private static final String REGISTRY_HOST = System.getenv().getOrDefault("REGISTRY_HOST", DEFAULT_REGISTRY_HOST);
+    private static final int REGISTRY_PORT = Integer.parseInt(System.getenv().getOrDefault("REGISTRY_PORT", String.valueOf(DEFAULT_REGISTRY_PORT)));
     private static final String EXTERNAL_REGISTRY = System.getenv().getOrDefault("EXTERNAL_REGISTRY", "false");
 
     private TestUtils() {
@@ -67,11 +67,11 @@ public class TestUtils {
     }
 
     public static String getRegistryHost() {
-        return REGISTRY_URL.getHost();
+        return REGISTRY_HOST;
     }
 
     public static int getRegistryPort() {
-        return REGISTRY_URL.getPort();
+        return REGISTRY_PORT;
     }
 
     public static String getRegistryUIUrl() {
@@ -100,7 +100,7 @@ public class TestUtils {
 
     public static String getRegistryBaseUrl() {
         if (isExternalRegistry()) {
-            return String.format("http://%s:%s", REGISTRY_URL.getHost(), REGISTRY_URL.getPort());
+            return String.format("http://%s:%s", REGISTRY_HOST, REGISTRY_PORT);
         } else {
             return String.format("http://%s:%s", DEFAULT_REGISTRY_HOST, DEFAULT_REGISTRY_PORT);
         }
@@ -108,7 +108,7 @@ public class TestUtils {
 
     public static String getRegistryBaseUrl(int port) {
         if (isExternalRegistry()) {
-            return String.format("http://%s:%s", REGISTRY_URL.getHost(), port);
+            return String.format("http://%s:%s", REGISTRY_HOST, port);
         } else {
             return String.format("http://%s:%s", DEFAULT_REGISTRY_HOST, port);
         }
@@ -121,8 +121,8 @@ public class TestUtils {
      */
     public static boolean isReachable() {
         try (Socket socket = new Socket()) {
-            String host = isExternalRegistry() ? REGISTRY_URL.getHost() : DEFAULT_REGISTRY_HOST;
-            int port = isExternalRegistry() ? REGISTRY_URL.getPort() : DEFAULT_REGISTRY_PORT;
+            String host = isExternalRegistry() ? REGISTRY_HOST : DEFAULT_REGISTRY_HOST;
+            int port = isExternalRegistry() ? REGISTRY_PORT : DEFAULT_REGISTRY_PORT;
             log.info("Trying to connect to {}:{}", host, port);
             socket.connect(new InetSocketAddress(host, port), 5_000);
             log.info("Client is able to connect to Registry instance");

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -54,8 +55,7 @@ public class TestUtils {
     private static final String DEFAULT_REGISTRY_HOST = "localhost";
     private static final int DEFAULT_REGISTRY_PORT = 8081;
 
-    private static final String REGISTRY_HOST = System.getenv().getOrDefault("REGISTRY_HOST", DEFAULT_REGISTRY_HOST);
-    private static final int REGISTRY_PORT = Integer.parseInt(System.getenv().getOrDefault("REGISTRY_PORT", String.valueOf(DEFAULT_REGISTRY_PORT)));
+    public static URL REGISTRY_URL;
     private static final String EXTERNAL_REGISTRY = System.getenv().getOrDefault("EXTERNAL_REGISTRY", "false");
 
     private TestUtils() {
@@ -67,11 +67,11 @@ public class TestUtils {
     }
 
     public static String getRegistryHost() {
-        return REGISTRY_HOST;
+        return REGISTRY_URL.getHost();
     }
 
     public static int getRegistryPort() {
-        return REGISTRY_PORT;
+        return REGISTRY_URL.getPort();
     }
 
     public static String getRegistryUIUrl() {
@@ -100,7 +100,7 @@ public class TestUtils {
 
     public static String getRegistryBaseUrl() {
         if (isExternalRegistry()) {
-            return String.format("http://%s:%s", REGISTRY_HOST, REGISTRY_PORT);
+            return String.format("http://%s:%s", REGISTRY_URL.getHost(), REGISTRY_URL.getPort());
         } else {
             return String.format("http://%s:%s", DEFAULT_REGISTRY_HOST, DEFAULT_REGISTRY_PORT);
         }
@@ -108,7 +108,7 @@ public class TestUtils {
 
     public static String getRegistryBaseUrl(int port) {
         if (isExternalRegistry()) {
-            return String.format("http://%s:%s", REGISTRY_HOST, port);
+            return String.format("http://%s:%s", REGISTRY_URL.getHost(), port);
         } else {
             return String.format("http://%s:%s", DEFAULT_REGISTRY_HOST, port);
         }
@@ -121,8 +121,8 @@ public class TestUtils {
      */
     public static boolean isReachable() {
         try (Socket socket = new Socket()) {
-            String host = isExternalRegistry() ? REGISTRY_HOST : DEFAULT_REGISTRY_HOST;
-            int port = isExternalRegistry() ? REGISTRY_PORT : DEFAULT_REGISTRY_PORT;
+            String host = isExternalRegistry() ? REGISTRY_URL.getHost() : DEFAULT_REGISTRY_HOST;
+            int port = isExternalRegistry() ? REGISTRY_URL.getPort() : DEFAULT_REGISTRY_PORT;
             log.info("Trying to connect to {}:{}", host, port);
             socket.connect(new InetSocketAddress(host, port), 5_000);
             log.info("Client is able to connect to Registry instance");


### PR DESCRIPTION
This PR adds support for, given a set of artifacts (protobuf, avro or json schema) setting the main schema and figuring out all the references between them and registering everything in Registry properly. Essentially, what we can call, automatic, client-side reference resolving. The specific unit tests are already passing but I still want to implement a few more and also add documentation and examples.


@smccarthy-ie we must document this properly since this will reduce a lot of burden when it comes to artifact references usage.