### PR TITLE
Updates for the Python SDK release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,10 @@ jobs:
           sed -i  "s/version\:\s.*/version: \'${DOCS_VERSION}\'/g" docs/antora.yml
           sed -i  "5s/\"version\"\:\s\".*\"/\"version\": \"${DOCS_VERSION}\"/g" app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json
 
+          # take only the major, minor and patch
+          PYTHON_SDK_VERSION=$(echo "${{ github.event.inputs.release-version}}" | awk -F '.' '{print $1"."$2"."$3}')
+          sed -i "s/^version.*/version \= \"${PYTHON_SDK_VERSION}\"/" ../python-sdk/pyproject.toml
+
       - name: Build Registry (All Variants)
         run: |
           cd registry
@@ -89,6 +93,19 @@ jobs:
           (echo "===== Maven Deploy Attempt: 2 ====" && mvn deploy --batch-mode -Pprod -Prelease -DskipTests --settings /home/runner/.m2/settings.xml) || \
           (echo "===== Maven Deploy Attempt: 3 ====" && mvn deploy --batch-mode -Pprod -Prelease -DskipTests --settings /home/runner/.m2/settings.xml) || \
           (echo "==== Maven Deploy Step Failed ====" && exit 1)
+
+      # Python SDK release
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install Poetry
+        uses: snok/install-poetry@d45b6d76012debf457ab49dffc7fb7b2efe8071d
+      - name: Release Python SDK
+        working-directory: python-sdk
+        run: make publish
+        env:
+          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 
       - name: Commit Release Version Change
         run: |
@@ -132,6 +149,10 @@ jobs:
           sed -i  "s/version\:\s.*/version: \'${DOCS_VERSION}\'/g" docs/antora.yml
           sed -i  "5s/\"version\"\:\s\".*\"/\"version\": \"${DOCS_VERSION}\"/g" app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json
 
+          # take only the major, minor and patch
+          PYTHON_SDK_VERSION=$(echo "${{ github.event.inputs.release-version}}" | awk -F '.' '{print $1"."$2"."$3}')
+          sed -i "s/^version.*/version \= \"${PYTHON_SDK_VERSION}\"/" ../python-sdk/pyproject.toml
+
       - name: Commit Snapshot Version ${{ github.event.inputs.snapshot-version}}
         run: |
           cd registry
@@ -148,19 +169,6 @@ jobs:
       #     consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
       #     access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
       #     access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-
-      # Python SDK release
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Install Poetry
-        uses: snok/install-poetry@d45b6d76012debf457ab49dffc7fb7b2efe8071d
-      - name: Release Python SDK
-        working-directory: python-sdk
-        run: make publish
-        env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 
       - name: Google Chat Notification
         if: ${{ failure() }}

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
-name = "apicurio-registry-python-sdk"
-version = "0.1.0"
+name = "apicurioregistrysdk"
+version = "2.4.2"
 description = ""
 authors = ["Andrea Peruffo <andrea.peruffo1982@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
I manually published 2.4.2:
https://pypi.org/manage/project/apicurioregistrysdk/releases/

~~Next time we should probably automate the version bump.~~

Update the release workflow to be fully automated, this would need to be tested.