### PR TITLE
fix: setting "registry.ccompat.use-canonical-hash" changes schema to canonized form on save

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/store/RegistryStorageFacadeImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/store/RegistryStorageFacadeImpl.java
@@ -342,7 +342,7 @@ public class RegistryStorageFacadeImpl implements RegistryStorageFacade {
         final Map<String, ContentHandle> resolvedReferences = storage.resolveReferences(parsedReferences);
         try {
             ContentHandle schemaContent;
-            if (cconfig.canonicalHashModeEnabled.get() || normalize) {
+            if (normalize) {
                 schemaContent = this.canonicalizeContent(artifactType, ContentHandle.create(schema), references);
             } else {
                 schemaContent = ContentHandle.create(schema);

--- a/app/src/test/java/io/apicurio/registry/ccompat/rest/CCompatCanonicalModeTest.java
+++ b/app/src/test/java/io/apicurio/registry/ccompat/rest/CCompatCanonicalModeTest.java
@@ -18,21 +18,27 @@ package io.apicurio.registry.ccompat.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ccompat.dto.Schema;
 import io.apicurio.registry.ccompat.dto.SchemaContent;
+import io.apicurio.registry.ccompat.dto.SchemaId;
 import io.apicurio.registry.utils.tests.ApicurioTestTags;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
 @TestProfile(CanonicalModeProfile.class)
 @Tag(ApicurioTestTags.SLOW)
 public class CCompatCanonicalModeTest extends AbstractResourceTestBase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * Endpoint: /schemas/ids/{int: id}/versions
@@ -42,21 +48,20 @@ public class CCompatCanonicalModeTest extends AbstractResourceTestBase {
         final String SUBJECT = "testSchemaExpanded";
         String testSchemaExpanded = resourceToString("avro-expanded.avsc");
 
-        ObjectMapper objectMapper = new ObjectMapper();
         SchemaContent schemaContent = new SchemaContent(testSchemaExpanded);
 
         // POST
         final Integer contentId1 = given()
                 .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
-                .body(objectMapper.writeValueAsString(schemaContent))
+                .body(MAPPER.writeValueAsString(schemaContent))
                 .post("/ccompat/v6/subjects/{subject}/versions", SUBJECT)
                 .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)))
                 .extract().body().jsonPath().get("id");
 
-        Assertions.assertNotNull(contentId1);
+        assertNotNull(contentId1);
 
         this.waitForArtifact(SUBJECT);
 
@@ -66,21 +71,57 @@ public class CCompatCanonicalModeTest extends AbstractResourceTestBase {
         given()
                 .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
-                .body(objectMapper.writeValueAsString(minifiedSchemaContent))
+                .body(MAPPER.writeValueAsString(minifiedSchemaContent))
                 .post("/ccompat/v6/subjects/{subject}", SUBJECT)
                 .then()
                 .statusCode(200);
 
         // POST
         //Create just returns the id from the existing schema, since the canonical hash is the same.
-        Assertions.assertEquals(contentId1, given()
+        assertEquals(contentId1, given()
                 .when()
                 .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
-                .body(objectMapper.writeValueAsString(minifiedSchemaContent))
+                .body(MAPPER.writeValueAsString(minifiedSchemaContent))
                 .post("/ccompat/v6/subjects/{subject}/versions", SUBJECT)
                 .then()
                 .statusCode(200)
                 .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.equalTo(contentId1)))
                 .extract().body().jsonPath().get("id"));
+    }
+
+    @Test
+    public void issue2902() throws Exception {
+        final String subject1 = UUID.randomUUID().toString();
+        String schemaString1 = resourceToString("avro2-non-canonical.avsc");
+        SchemaContent schemaContent = new SchemaContent(schemaString1);
+
+        // POST
+        SchemaId schemaId1 = given()
+                .when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(MAPPER.writeValueAsString(schemaContent))
+                .post("/ccompat/v6/subjects/{subject}/versions", subject1)
+                .then()
+                .statusCode(200)
+                .extract().as(SchemaId.class);
+
+        assertNotNull(schemaId1);
+        assertNotNull(schemaId1.getId());
+        assertTrue(schemaId1.getId() > 0);
+
+
+        this.waitForArtifact(subject1);
+
+        // We are able to get the original content
+        Schema schema1R = given()
+                .when()
+                .contentType(ContentTypes.JSON)
+                .get("/ccompat/v6/subjects/{subject}/versions/latest", subject1)
+                .then()
+                .statusCode(200)
+                .extract().as(Schema.class);
+
+        assertEquals(schemaString1, schema1R.getSchema());
+        assertEquals(schemaId1.getId(), schema1R.getId());
     }
 }

--- a/app/src/test/resources/io/apicurio/registry/ccompat/rest/avro2-canonical.avsc
+++ b/app/src/test/resources/io/apicurio/registry/ccompat/rest/avro2-canonical.avsc
@@ -1,0 +1,1 @@
+{"fields":[{"name":"fieldValues","type":{"items":"string","type":"array"}},{"name":"id","type":"string"}],"name":"Test","namespace":"test","type":"record"}

--- a/app/src/test/resources/io/apicurio/registry/ccompat/rest/avro2-non-canonical.avsc
+++ b/app/src/test/resources/io/apicurio/registry/ccompat/rest/avro2-non-canonical.avsc
@@ -1,0 +1,18 @@
+{
+    "fields": [
+        {
+            "name": "id",
+            "type": "string"
+        },
+        {
+            "name": "fieldValues",
+            "type": {
+                "items": "string",
+                "type": "array"
+            }
+        }
+    ],
+    "name": "Test",
+    "namespace": "test",
+    "type": "record"
+}


### PR DESCRIPTION
Fixes: #2902