### PR TITLE
rename the root folder of the Python SDK

### DIFF
--- a/.github/workflows/python-sdk.yaml
+++ b/.github/workflows/python-sdk.yaml
@@ -1,20 +1,20 @@
 name: Verify Python SDK
 on:
   push:
-  #   paths-ignore:
-  #     - '.gitignore'
-  #     - 'LICENSE'
-  #     - 'README*'
-  #     - 'docs/**'
-  #     - '.github/workflows/**'
-  #   branches: [main, '[1-9].[0-9].x']
-  # pull_request:
-  #   paths-ignore:
-  #     - '.gitignore'
-  #     - 'LICENSE'
-  #     - 'README*'
-  #     - 'docs/**'
-  #   branches: [main]
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - 'README*'
+      - 'docs/**'
+      - '.github/workflows/**'
+    branches: [main, '[1-9].[0-9].x']
+  pull_request:
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - 'README*'
+      - 'docs/**'
+    branches: [main]
 
 jobs:
   build-verify:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,11 @@ website
 apicurio-codegen
 /multitenancy/
 /docs/.jbang/
+
+python-sdk/dist
+python-sdk/kiota_tmp
+python-sdk/apicurioregistrysdk/client
+python-sdk/openapi.json
+__pycache__
+
+

--- a/python-sdk/.gitignore
+++ b/python-sdk/.gitignore
@@ -1,6 +1,2 @@
-dist
-kiota_tmp
-apicurioregistrysdk/client
-
 __pycache__
-
+.pytest_cache

--- a/python-sdk/.gitignore
+++ b/python-sdk/.gitignore
@@ -1,6 +1,6 @@
 dist
 kiota_tmp
-python_sdk/client
+apicurioregistrysdk/client
 
 __pycache__
 

--- a/python-sdk/kiota-gen.py
+++ b/python-sdk/kiota-gen.py
@@ -4,6 +4,7 @@ import io
 import os
 import stat
 import sys
+import shutil
 import platform
 from pathlib import Path
 
@@ -47,16 +48,20 @@ def generate_kiota_client_files(setup_kwargs):
     st = os.stat(kiota_bin)
     os.chmod(kiota_bin, st.st_mode | stat.S_IEXEC)
 
-    openapi_doc = os.path.join(
-        sys.path[0],
-        "..",
-        "common",
-        "src",
-        "main",
-        "resources",
-        "META-INF",
-        "openapi.json",
-    )
+    openapi_doc = Path(__file__).parent.joinpath("openapi.json")
+    # TODO: improve this to do a better clean-install
+    if not os.path.exists(openapi_doc):
+        shutil.copyfile(os.path.join(
+            sys.path[0],
+            "..",
+            "common",
+            "src",
+            "main",
+            "resources",
+            "META-INF",
+            "openapi.json",
+        ), openapi_doc)
+
     output = Path(__file__).parent.joinpath("apicurioregistrysdk", "client")
 
     command = f'{kiota_bin} generate --language=python --openapi="{openapi_doc}" --output="{output}" --class-name=RegistryClient --namespace-name=client --clean-output --clear-cache'

--- a/python-sdk/kiota-gen.py
+++ b/python-sdk/kiota-gen.py
@@ -57,7 +57,7 @@ def generate_kiota_client_files(setup_kwargs):
         "META-INF",
         "openapi.json",
     )
-    output = Path(__file__).parent.joinpath("python_sdk", "client")
+    output = Path(__file__).parent.joinpath("apicurioregistrysdk", "client")
 
     command = f'{kiota_bin} generate --language=python --openapi="{openapi_doc}" --output="{output}" --class-name=RegistryClient --namespace-name=client --clean-output --clear-cache'
     print(f"Executing kiota command: {command}")

--- a/python-sdk/kiota-gen.py
+++ b/python-sdk/kiota-gen.py
@@ -51,16 +51,19 @@ def generate_kiota_client_files(setup_kwargs):
     openapi_doc = Path(__file__).parent.joinpath("openapi.json")
     # TODO: improve this to do a better clean-install
     if not os.path.exists(openapi_doc):
-        shutil.copyfile(os.path.join(
-            sys.path[0],
-            "..",
-            "common",
-            "src",
-            "main",
-            "resources",
-            "META-INF",
-            "openapi.json",
-        ), openapi_doc)
+        shutil.copyfile(
+            os.path.join(
+                sys.path[0],
+                "..",
+                "common",
+                "src",
+                "main",
+                "resources",
+                "META-INF",
+                "openapi.json",
+            ),
+            openapi_doc,
+        )
 
     output = Path(__file__).parent.joinpath("apicurioregistrysdk", "client")
 

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -6,8 +6,7 @@ authors = ["Andrea Peruffo <andrea.peruffo1982@gmail.com>"]
 readme = "README.md"
 packages = [{include = "apicurioregistrysdk"}]
 include = [
-    { path = "apicurioregistrysdk/client/*" },
-    { path = "apicurioregistrysdk/client/**/*" }
+    { path = "apicurioregistrysdk/client/**/*" },
 ]
 license = "Apache 2.0"
 homepage = "https://github.com/apicurio/apicurio-registry"

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -6,7 +6,11 @@ authors = ["Andrea Peruffo <andrea.peruffo1982@gmail.com>"]
 readme = "README.md"
 packages = [{include = "apicurioregistrysdk"}]
 include = [
-    { path = "apicurioregistrysdk/client/**/*" },
+    { path = "openapi.json", format=["sdist", "wheel"] },
+    { path = "apicurioregistrysdk/client/**/*", format=["sdist", "wheel"] },
+]
+exclude = [
+    { path = "apicurioregistrysdk/__pycache__", format=["sdist", "wheel"] },
 ]
 license = "Apache 2.0"
 homepage = "https://github.com/apicurio/apicurio-registry"

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -39,7 +39,7 @@ generate-setup-file = false
 script = "kiota-gen.py"
 
 [tool.pytest.ini_options]
-pythonpath = [ "python_sdk" ]
+pythonpath = [ "apicurioregistrysdk" ]
 
 [tool.black]
 extend-exclude = 'client'

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -4,10 +4,10 @@ version = "2.4.2"
 description = ""
 authors = ["Andrea Peruffo <andrea.peruffo1982@gmail.com>"]
 readme = "README.md"
-packages = [{include = "python_sdk"}]
+packages = [{include = "apicurioregistrysdk"}]
 include = [
-    { path = "python_sdk/client/*" },
-    { path = "python_sdk/client/**/*" }
+    { path = "apicurioregistrysdk/client/*" },
+    { path = "apicurioregistrysdk/client/**/*" }
 ]
 license = "Apache 2.0"
 homepage = "https://github.com/apicurio/apicurio-registry"
@@ -15,7 +15,7 @@ repository = "https://github.com/apicurio/apicurio-registry"
 keywords = ["apicurio", "registry"]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.9"
 microsoft-kiota-abstractions = "^0.5.1"
 microsoft-kiota-http = "^0.4.1"
 microsoft-kiota-serialization-json = "^0.3.2"

--- a/python-sdk/tests/basic_test.py
+++ b/python-sdk/tests/basic_test.py
@@ -9,8 +9,8 @@ from kiota_abstractions.authentication.anonymous_authentication_provider import 
     AnonymousAuthenticationProvider,
 )
 from kiota_http.httpx_request_adapter import HttpxRequestAdapter
-from client.registry_client import RegistryClient
-from client.models.artifact_content import ArtifactContent
+from apicurioregistrysdk.client.registry_client import RegistryClient
+from apicurioregistrysdk.client.models.artifact_content import ArtifactContent
 
 REGISTRY_HOST = "localhost"
 REGISTRY_PORT = 8080


### PR DESCRIPTION
`python_sdk` is ways too generic.

cc. @forsberg