### PR TITLE
Override the version of mime4j used by the KC admin client

### DIFF
--- a/utils/tests/pom.xml
+++ b/utils/tests/pom.xml
@@ -84,4 +84,18 @@
         </dependency>
 
     </dependencies>
+    <dependencyManagement>
+    	<dependencies>
+    		<dependency>
+    			<groupId>org.apache.james</groupId>
+    			<artifactId>apache-mime4j-dom</artifactId>
+    			<version>0.8.9</version>
+    		</dependency>
+    		<dependency>
+    			<groupId>org.apache.james</groupId>
+    			<artifactId>apache-mime4j-storage</artifactId>
+    			<version>0.8.9</version>
+    		</dependency>
+    	</dependencies>
+    </dependencyManagement>
 </project>


### PR DESCRIPTION
Force the version of mime4j used by the KC admin client to a newer version.