### PR TITLE
Implemented the all-refs-must-be-mapped part of the new integrity rule

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rules/integrity/IntegrityRuleExecutor.java
+++ b/app/src/main/java/io/apicurio/registry/rules/integrity/IntegrityRuleExecutor.java
@@ -31,7 +31,9 @@ import io.apicurio.registry.rules.RuleContext;
 import io.apicurio.registry.rules.RuleExecutor;
 import io.apicurio.registry.rules.RuleViolation;
 import io.apicurio.registry.rules.RuleViolationException;
+import io.apicurio.registry.rules.validity.ContentValidator;
 import io.apicurio.registry.types.RuleType;
+import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
 
 /**
@@ -69,8 +71,10 @@ public class IntegrityRuleExecutor implements RuleExecutor {
         }
     }
 
-    private void verifyAllReferencesHaveMappings(RuleContext context) {
-        // TODO implement this rule
+    private void verifyAllReferencesHaveMappings(RuleContext context) throws RuleViolationException {
+        ArtifactTypeUtilProvider artifactTypeProvider = factory.getArtifactTypeProvider(context.getArtifactType());
+        ContentValidator validator = artifactTypeProvider.getContentValidator();
+        validator.validateReferences(context.getUpdatedContent(), context.getReferences());
     }
 
     private void validateReferencesExist(RuleContext context) throws RuleViolationException {

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <skipCommitIdPlugin>true</skipCommitIdPlugin>
 
         <!-- Apicurio Data Models (OpenAPI and AsyncAPI support) -->
-        <apicurio-data-models.version>2.0.0.RC1</apicurio-data-models.version>
+        <apicurio-data-models.version>2.0.2</apicurio-data-models.version>
 
         <!-- Apicurio Tenant Manager -->
         <apicurio-tenant-manager.version>0.1.3.Final</apicurio-tenant-manager.version>

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/ContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/ContentValidator.java
@@ -16,14 +16,18 @@
 
 package io.apicurio.registry.rules.validity;
 
-import io.apicurio.registry.content.ContentHandle;
-import io.apicurio.registry.rules.RuleViolationException;
-
+import java.util.List;
 import java.util.Map;
+
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
+import io.apicurio.registry.rules.RuleViolationException;
 
 /**
  * Validates content.  Syntax and semantic validations are possible based on configuration.  An
  * implementation of this interface should exist for each content-type supported by the registry.
+ * 
+ * Also provides validation of references.
  *
  * @author eric.wittmann@gmail.com
  */
@@ -38,5 +42,15 @@ public interface ContentValidator {
      * @throws RuleViolationException for any invalid content
      */
     public void validate(ValidityLevel level, ContentHandle artifactContent, Map<String, ContentHandle> resolvedReferences) throws RuleViolationException;
+    
+    /**
+     * Ensures that all references in the content are represented in the list of passed references.  This is used
+     * to ensure that the content does not have any references that are unmapped.
+     * 
+     * @param artifactContent
+     * @param references
+     * @throws RuleViolationException
+     */
+    public void validateReferences(ContentHandle artifactContent, List<ArtifactReference> references) throws RuleViolationException;
 
 }

--- a/schema-util/graphql/src/main/java/io/apicurio/registry/rules/validity/GraphQLContentValidator.java
+++ b/schema-util/graphql/src/main/java/io/apicurio/registry/rules/validity/GraphQLContentValidator.java
@@ -18,9 +18,11 @@ package io.apicurio.registry.rules.validity;
 
 import graphql.schema.idl.SchemaParser;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rules.RuleViolationException;
 import io.apicurio.registry.types.RuleType;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -47,6 +49,14 @@ public class GraphQLContentValidator implements ContentValidator {
                 throw new RuleViolationException("Syntax violation for GraphQL artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
+    }
+
+    /**
+     * @see io.apicurio.registry.rules.validity.ContentValidator#validateReferences(io.apicurio.registry.content.ContentHandle, java.util.List)
+     */
+    @Override
+    public void validateReferences(ContentHandle artifactContent, List<ArtifactReference> references) throws RuleViolationException {
+        // Note: not yet implemented!
     }
 
 }

--- a/schema-util/json/src/main/java/io/apicurio/registry/rules/validity/JsonSchemaContentValidator.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/rules/validity/JsonSchemaContentValidator.java
@@ -18,10 +18,13 @@ package io.apicurio.registry.rules.validity;
 
 
 import java.util.Collections;
+import java.util.List;
+
 import org.everit.json.schema.SchemaException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rules.RuleViolation;
 import io.apicurio.registry.rules.RuleViolationException;
 import io.apicurio.registry.rules.compatibility.jsonschema.JsonUtil;
@@ -72,5 +75,13 @@ public class JsonSchemaContentValidator implements ContentValidator {
                         Collections.singleton(violation));
             }
         }
+    }
+    
+    /**
+     * @see io.apicurio.registry.rules.validity.ContentValidator#validateReferences(io.apicurio.registry.content.ContentHandle, java.util.List)
+     */
+    @Override
+    public void validateReferences(ContentHandle artifactContent, List<ArtifactReference> references) throws RuleViolationException {
+        // TODO Implement this for JSON Schema!
     }
 }

--- a/schema-util/kconnect/src/main/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidator.java
+++ b/schema-util/kconnect/src/main/java/io/apicurio/registry/rules/validity/KafkaConnectContentValidator.java
@@ -17,6 +17,7 @@
 package io.apicurio.registry.rules.validity;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.kafka.connect.json.JsonConverter;
@@ -26,6 +27,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rules.RuleViolationException;
 import io.apicurio.registry.types.RuleType;
 
@@ -65,6 +67,14 @@ public class KafkaConnectContentValidator implements ContentValidator {
                 throw new RuleViolationException("Syntax violation for Kafka Connect Schema artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
+    }
+
+    /**
+     * @see io.apicurio.registry.rules.validity.ContentValidator#validateReferences(io.apicurio.registry.content.ContentHandle, java.util.List)
+     */
+    @Override
+    public void validateReferences(ContentHandle artifactContent, List<ArtifactReference> references) throws RuleViolationException {
+        // Note: not yet implemented!
     }
 
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/AvroContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/AvroContentValidatorTest.java
@@ -17,12 +17,15 @@
 package io.apicurio.registry.rules.validity;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rules.RuleViolationException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Tests the Avro content validator.
@@ -43,6 +46,61 @@ public class AvroContentValidatorTest extends ArtifactUtilProviderTestBase {
         AvroContentValidator validator = new AvroContentValidator();
         Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.SYNTAX_ONLY, content, Collections.emptyMap());
+        });
+    }
+
+    @Test
+    public void testValidateReferences() throws Exception {
+        ContentHandle content = resourceToContentHandle("avro-valid-with-refs.json");
+        AvroContentValidator validator = new AvroContentValidator();
+
+        // Properly map both required references - success.
+        {
+            List<ArtifactReference> references = new ArrayList<>();
+            references.add(ArtifactReference.builder()
+                    .groupId("com.example.search")
+                    .artifactId("SearchResultType")
+                    .version("1.0")
+                    .name("com.example.search.SearchResultType").build());
+            references.add(ArtifactReference.builder()
+                    .groupId("com.example.actions")
+                    .artifactId("UserAction")
+                    .version("1.1")
+                    .name("com.example.actions.UserAction").build());
+            validator.validateReferences(content, references);
+        }
+
+        // Don't map either of the required references - failure.
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            List<ArtifactReference> references = new ArrayList<>();
+            validator.validateReferences(content, references);
+        });
+
+        // Only map one of the two required refs - failure.
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            List<ArtifactReference> references = new ArrayList<>();
+            references.add(ArtifactReference.builder()
+                    .groupId("com.example.search")
+                    .artifactId("SearchResultType")
+                    .version("1.0")
+                    .name("com.example.search.SearchResultType").build());
+            validator.validateReferences(content, references);
+        });
+
+        // Only map one of the two required refs - failure.
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            List<ArtifactReference> references = new ArrayList<>();
+            references.add(ArtifactReference.builder()
+                    .groupId("com.example.search")
+                    .artifactId("SearchResultType")
+                    .version("1.0")
+                    .name("com.example.search.SearchResultType").build());
+            references.add(ArtifactReference.builder()
+                    .groupId("default")
+                    .artifactId("WrongType")
+                    .version("2.3")
+                    .name("com.example.invalid.WrongType").build());
+            validator.validateReferences(content, references);
         });
     }
 

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/OpenApiContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/OpenApiContentValidatorTest.java
@@ -16,13 +16,16 @@
 
 package io.apicurio.registry.rules.validity;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rules.RuleViolationException;
-
-import java.util.Collections;
 
 /**
  * Tests the OpenAPI content validator.
@@ -67,6 +70,62 @@ public class OpenApiContentValidatorTest extends ArtifactUtilProviderTestBase {
         OpenApiContentValidator validator = new OpenApiContentValidator();
         Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+    }
+
+    @Test
+    public void testValidateRefs() throws Exception {
+        ContentHandle content = resourceToContentHandle("openapi-valid-with-refs.json");
+        OpenApiContentValidator validator = new OpenApiContentValidator();
+        validator.validate(ValidityLevel.SYNTAX_ONLY, content, Collections.emptyMap());
+
+        // Properly map both required references - success.
+        {
+            List<ArtifactReference> references = new ArrayList<>();
+            references.add(ArtifactReference.builder()
+                    .groupId("default")
+                    .artifactId("ExternalWidget")
+                    .version("1.0")
+                    .name("example.com#/components/schemas/ExternalWidget").build());
+            references.add(ArtifactReference.builder()
+                    .groupId("default")
+                    .artifactId("AnotherWidget")
+                    .version("1.1")
+                    .name("example.com#/components/schemas/AnotherWidget").build());
+            validator.validateReferences(content, references);
+        }
+
+        // Don't map either of the required references - failure.
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            List<ArtifactReference> references = new ArrayList<>();
+            validator.validateReferences(content, references);
+        });
+
+        // Only map one of the two required refs - failure.
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            List<ArtifactReference> references = new ArrayList<>();
+            references.add(ArtifactReference.builder()
+                    .groupId("default")
+                    .artifactId("AnotherWidget")
+                    .version("1.1")
+                    .name("example.com#/components/schemas/AnotherWidget").build());
+            validator.validateReferences(content, references);
+        });
+
+        // Only map one of the two required refs - failure.
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            List<ArtifactReference> references = new ArrayList<>();
+            references.add(ArtifactReference.builder()
+                    .groupId("default")
+                    .artifactId("AnotherWidget")
+                    .version("1.1")
+                    .name("example.com#/components/schemas/AnotherWidget").build());
+            references.add(ArtifactReference.builder()
+                    .groupId("default")
+                    .artifactId("WrongWidget")
+                    .version("2.3")
+                    .name("example.com#/components/schemas/WrongWidget").build());
+            validator.validateReferences(content, references);
         });
     }
 

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/ProtobufContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/ProtobufContentValidatorTest.java
@@ -20,9 +20,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rules.RuleViolationException;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Tests the Protobuf content validator.
@@ -52,6 +55,61 @@ public class ProtobufContentValidatorTest extends ArtifactUtilProviderTestBase {
         ContentHandle tableInfo = resourceToContentHandle("table_info.proto");
         ProtobufContentValidator validator = new ProtobufContentValidator();
         validator.validate(ValidityLevel.SYNTAX_ONLY, tableInfo, Collections.singletonMap("mode.proto", mode));
+    }
+
+    @Test
+    public void testValidateReferences() throws Exception {
+        ContentHandle content = resourceToContentHandle("protobuf-valid-with-refs.proto");
+        ProtobufContentValidator validator = new ProtobufContentValidator();
+
+        // Properly map both required references - success.
+        {
+            List<ArtifactReference> references = new ArrayList<>();
+            references.add(ArtifactReference.builder()
+                    .groupId("default")
+                    .artifactId("message2.proto")
+                    .version("1.0")
+                    .name("message2.proto").build());
+            references.add(ArtifactReference.builder()
+                    .groupId("default")
+                    .artifactId("message3.proto")
+                    .version("1.1")
+                    .name("message3.proto").build());
+            validator.validateReferences(content, references);
+        }
+
+        // Don't map either of the required references - failure.
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            List<ArtifactReference> references = new ArrayList<>();
+            validator.validateReferences(content, references);
+        });
+
+        // Only map one of the two required refs - failure.
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            List<ArtifactReference> references = new ArrayList<>();
+            references.add(ArtifactReference.builder()
+                    .groupId("default")
+                    .artifactId("message2.proto")
+                    .version("1.0")
+                    .name("message2.proto").build());
+            validator.validateReferences(content, references);
+        });
+
+        // Only map one of the two required refs - failure.
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            List<ArtifactReference> references = new ArrayList<>();
+            references.add(ArtifactReference.builder()
+                    .groupId("default")
+                    .artifactId("message2.proto")
+                    .version("1.0")
+                    .name("message2.proto").build());
+            references.add(ArtifactReference.builder()
+                    .groupId("default")
+                    .artifactId("message4.proto")
+                    .version("4.0")
+                    .name("message4.proto").build());
+            validator.validateReferences(content, references);
+        });
     }
 
 }

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/avro-valid-with-refs.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/avro-valid-with-refs.json
@@ -1,0 +1,12 @@
+{
+     "type": "record",
+     "namespace": "com.example.search",
+     "name": "SearchResult",
+     "fields": [
+        {"name": "type", "type": "com.example.search.SearchResultType"},
+        {"name": "keyWord",  "type": "string"},
+        {"name": "searchEngine", "type": "string"},
+        {"name": "position", "type": "int"},
+        {"name": "userAction", "type": "com.example.actions.UserAction"}
+    ]
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/openapi-valid-with-refs.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/openapi-valid-with-refs.json
@@ -1,0 +1,139 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Demo API",
+        "version": "1.0.0",
+        "description": ""
+    },
+    "paths": {
+        "/widgets": {
+            "summary": "Path used to manage the list of widgets.",
+            "description": "The REST endpoint/path used to list and create zero or more `Widget` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.",
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "example.com#/components/schemas/ExternalWidget"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Successful response - returns an array of `Widget` entities."
+                    }
+                },
+                "operationId": "getWidgets",
+                "summary": "List All Widgets",
+                "description": "Gets a list of all `Widget` entities."
+            },
+            "post": {
+                "requestBody": {
+                    "description": "A new `Widget` to be created.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "example.com#/components/schemas/AnotherWidget"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful response."
+                    }
+                },
+                "operationId": "createWidget",
+                "summary": "Create a Widget",
+                "description": "Creates a new instance of a `Widget`."
+            }
+        },
+        "/widgets/{widgetId}": {
+            "summary": "Path used to manage a single Widget.",
+            "description": "The REST endpoint/path used to get, update, and delete single instances of an `Widget`.  This path contains `GET`, `PUT`, and `DELETE` operations used to perform the get, update, and delete tasks, respectively.",
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Widget"
+                                }
+                            }
+                        },
+                        "description": "Successful response - returns a single `Widget`."
+                    }
+                },
+                "operationId": "getWidget",
+                "summary": "Get a Widget",
+                "description": "Gets the details of a single instance of a `Widget`."
+            },
+            "put": {
+                "requestBody": {
+                    "description": "Updated `Widget` information.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Widget"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "Successful response."
+                    }
+                },
+                "operationId": "updateWidget",
+                "summary": "Update a Widget",
+                "description": "Updates an existing `Widget`."
+            },
+            "delete": {
+                "responses": {
+                    "204": {
+                        "description": "Successful response."
+                    }
+                },
+                "operationId": "deleteWidget",
+                "summary": "Delete a Widget",
+                "description": "Deletes an existing `Widget`."
+            },
+            "parameters": [
+                {
+                    "name": "widgetId",
+                    "description": "A unique identifier for a `Widget`.",
+                    "schema": {
+                        "type": "string"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        }
+    },
+    "components": {
+        "schemas": {
+            "Widget": {
+                "title": "Root Type for Widget",
+                "description": "",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "summary": {
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "name": "foo",
+                    "summary": "bar"
+                }
+            }
+        }
+    }
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/protobuf-valid-with-refs.proto
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/protobuf-valid-with-refs.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package example;
+
+import "message2.proto";
+import public "message3.proto";
+
+message Message1 {
+  Message2 field1 = 1;
+  Message3 field2 = 2;
+}

--- a/schema-util/xml/src/main/java/io/apicurio/registry/rules/validity/XmlContentValidator.java
+++ b/schema-util/xml/src/main/java/io/apicurio/registry/rules/validity/XmlContentValidator.java
@@ -17,9 +17,11 @@
 package io.apicurio.registry.rules.validity;
 
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rules.RuleViolationException;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.util.DocumentBuilderAccessor;
@@ -47,6 +49,14 @@ public class XmlContentValidator implements ContentValidator {
                 throw new RuleViolationException("Syntax violation for XML artifact.", RuleType.VALIDITY, level.name(), e);
             }
         }
+    }
+
+    /**
+     * @see io.apicurio.registry.rules.validity.ContentValidator#validateReferences(io.apicurio.registry.content.ContentHandle, java.util.List)
+     */
+    @Override
+    public void validateReferences(ContentHandle artifactContent, List<ArtifactReference> references) throws RuleViolationException {
+        // Note: not yet implemented!
     }
 
 }


### PR DESCRIPTION
I have implemented the `IntegrityLevel.ALL_REFS_MAPPED` option in the new integrity rule.  That part of the rule is artifact type-specific.  I have only implemented it for the following types:

* OpenAPI
* AsyncAPI
* Protobuf
* Avro

Notably missing from the list is JSON Schema, because that one needs a bit of thinking.  We need to have a good way of identifying which $ref is external vs. internal (pointing to something in $defs).  That's easier to do in OpenAPI.  But I think for JSON Schema it has to do with the `$id` and perhaps some other rules.  Just need to make sure we do it right.  I wasn't confident enough to just sling some code at it. :)