### PR TITLE
Added configuration of the date-time format for the REST API

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -14,7 +14,7 @@ on:
       - 'LICENSE'
       - 'README*'
       - 'docs/**'
-    branches: [main, 2.0.x]
+    branches: [main, '[1-9].[0-9].x']
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -33,6 +33,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
             <scope>provided</scope>
@@ -83,7 +95,7 @@
             <plugin>
                 <groupId>io.apicurio</groupId>
                 <artifactId>apicurio-codegen-maven-plugin</artifactId>
-                <version>1.0.12.Final</version>
+                <version>1.0.12.1</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/common/src/main/java/io/apicurio/registry/rest/JacksonDateTimeCustomizer.java
+++ b/common/src/main/java/io/apicurio/registry/rest/JacksonDateTimeCustomizer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Red Hat Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.rest;
+
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+@Singleton
+public class JacksonDateTimeCustomizer implements ObjectMapperCustomizer {
+    
+    @Inject
+    Logger log;
+    
+    @ConfigProperty(name = "registry.apis.v2.date-format", defaultValue = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    String dateFormat;
+    @ConfigProperty(name = "registry.apis.v2.date-format-timezone", defaultValue = "UTC")
+    String timezone;
+
+    @PostConstruct
+    protected void postConstruct() {
+        log.info("Setting REST API date format to: {}", dateFormat);
+    }
+
+    public void customize(ObjectMapper mapper) {
+        try {
+            configureDateFormat(mapper, dateFormat, timezone);
+        } catch (Exception e) {
+            log.error("Error setting REST API date format.", e);
+            configureDateFormat(mapper, "yyyy-MM-dd'T'HH:mm:ss'Z'", "UTC");
+        }
+    }
+
+    protected static void configureDateFormat(ObjectMapper mapper, String format, String tz) {
+        SimpleDateFormat df = new SimpleDateFormat(format);
+        df.setTimeZone(TimeZone.getTimeZone(tz));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(df);
+    }
+    
+}

--- a/common/src/main/java/io/apicurio/registry/rest/JacksonDateTimeCustomizer.java
+++ b/common/src/main/java/io/apicurio/registry/rest/JacksonDateTimeCustomizer.java
@@ -69,6 +69,10 @@ public class JacksonDateTimeCustomizer implements ObjectMapperCustomizer {
             log.info("Doing this will result in a REST API that is OpenAPI compliant, but");
             log.info("please remember to upgrade all your client applications first!");
             log.info("---------------------------------------------------------------------");
+        } else {
+            log.info("---------------------------------------------------------------------");
+            log.info("Overriding REST API date format.  Using: " + dateFormat);
+            log.info("---------------------------------------------------------------------");
         }
     }
 

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -4692,6 +4692,7 @@
         }
     ],
     "x-codegen": {
+        "suppress-date-time-formatting": true,
         "bean-annotations": [
             "io.quarkus.runtime.annotations.RegisterForReflection",
             {


### PR DESCRIPTION


This change allows us to customize the date-time format for responses in the REST API. The specific use-case this addresses is the ability to put the server into a legacy mode where the old 2.3 date formats can be used. This could be important for anyone wanting to upgrade their Registry server before upgrading their clients (to fix the date format bug).
