### PR TITLE
Use Dockerfile from sources and not target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # used for mem, sql, mssql & kafkasql.
 # 'override' keyword prevents the variable from being overrideen
-override DOCKERFILE_LOCATION := ./distro/docker/target/docker
+override DOCKERFILE_LOCATION := ./distro/docker/src/main/docker
 
 MEM_DOCKERFILE ?= Dockerfile.jvm
 SQL_DOCKERFILE ?= Dockerfile.sql.jvm


### PR DESCRIPTION
I haven't found any specific step done in Maven that should prevent this change.
This is a developer quality-of-life change, having to rebuild the Maven module before triggering the next docker build seems like an unnecessary step.