### PR TITLE
Remove data-models version override from common

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -70,18 +70,6 @@
 
     </dependencies>
     
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.apicurio</groupId>
-                <artifactId>apicurio-data-models</artifactId>
-                <version>1.1.26</version>
-                <scope>compile</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-
     <build>
         <extensions>
             <extension>


### PR DESCRIPTION
No longer need to override the data-models version