### PR TITLE
feat: Expose listArtifactTypes in the client library

### DIFF
--- a/app/src/test/java/io/apicurio/registry/rbac/AdminClientTest.java
+++ b/app/src/test/java/io/apicurio/registry/rbac/AdminClientTest.java
@@ -18,9 +18,11 @@ package io.apicurio.registry.rbac;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.List;
 
+import io.apicurio.registry.rest.v2.beans.ArtifactTypeInfo;
 import io.apicurio.registry.utils.tests.ApicurioTestTags;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
@@ -138,6 +140,15 @@ public class AdminClientTest extends AbstractResourceTestBase {
         assertEquals(1, logConfigurations.size());
 
         adminClientV2.removeLogConfiguration(logger);
+    }
+
+    @Test
+    public void listArtifactTypes() {
+        final List<ArtifactTypeInfo> artifactTypes = adminClientV2.listArtifactTypes();
+
+        assertTrue(artifactTypes.size() > 0);
+        assertTrue(artifactTypes.stream().anyMatch(t -> t.getName().equals("OPENAPI")));
+        assertFalse(artifactTypes.stream().anyMatch(t -> t.getName().equals("UNKNOWN")));
     }
 
     @Test

--- a/client/src/main/java/io/apicurio/registry/rest/client/AdminClient.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/AdminClient.java
@@ -16,6 +16,7 @@
 
 package io.apicurio.registry.rest.client;
 
+import io.apicurio.registry.rest.v2.beans.ArtifactTypeInfo;
 import io.apicurio.registry.rest.v2.beans.LogConfiguration;
 import io.apicurio.registry.rest.v2.beans.NamedLogConfiguration;
 import io.apicurio.registry.rest.v2.beans.RoleMapping;
@@ -68,4 +69,6 @@ public interface AdminClient extends Closeable {
     void importData(InputStream data);
 
     void importData(InputStream data, boolean preserveGlobalIds, boolean preserveContentIds);
+
+    List<ArtifactTypeInfo> listArtifactTypes();
 }

--- a/client/src/main/java/io/apicurio/registry/rest/client/impl/AdminClientImpl.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/impl/AdminClientImpl.java
@@ -153,6 +153,11 @@ public class AdminClientImpl implements AdminClient {
         apicurioHttpClient.sendRequest(AdminRequestsProvider.importData(data, preserveGlobalIds, preserveContentIds));
     }
 
+    @Override
+    public List<ArtifactTypeInfo> listArtifactTypes() {
+        return apicurioHttpClient.sendRequest(AdminRequestsProvider.listArtifactTypes());
+    }
+
 
     private static RestClientException parseSerializationError(JsonProcessingException ex) {
         final Error error = new Error();

--- a/client/src/main/java/io/apicurio/registry/rest/client/request/provider/AdminRequestsProvider.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/request/provider/AdminRequestsProvider.java
@@ -21,6 +21,7 @@ import static io.apicurio.registry.rest.client.request.provider.Routes.CONFIG_PR
 import static io.apicurio.registry.rest.client.request.provider.Routes.CONFIG_PROPERTY_PATH;
 import static io.apicurio.registry.rest.client.request.provider.Routes.EXPORT_PATH;
 import static io.apicurio.registry.rest.client.request.provider.Routes.IMPORT_PATH;
+import static io.apicurio.registry.rest.client.request.provider.Routes.LIST_ARTIFACT_PATH;
 import static io.apicurio.registry.rest.client.request.provider.Routes.LOGS_BASE_PATH;
 import static io.apicurio.registry.rest.client.request.provider.Routes.LOG_PATH;
 import static io.apicurio.registry.rest.client.request.provider.Routes.ROLE_MAPPINGS_BASE_PATH;
@@ -42,6 +43,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.apicurio.registry.rest.Headers;
+import io.apicurio.registry.rest.v2.beans.ArtifactTypeInfo;
 import io.apicurio.registry.rest.v2.beans.ConfigurationProperty;
 import io.apicurio.registry.rest.v2.beans.LogConfiguration;
 import io.apicurio.registry.rest.v2.beans.NamedLogConfiguration;
@@ -177,6 +179,14 @@ public class AdminRequestsProvider {
                 .responseType(new TypeReference<Void>() {})
                 .data(data)
                 .headers(new HashMap<>(Map.of(Request.CONTENT_TYPE, "application/zip", Headers.PRESERVE_GLOBAL_ID, Boolean.toString(preserveGlobalIds), Headers.PRESERVE_CONTENT_ID, Boolean.toString(preserveContentIds))))
+                .build();
+    }
+
+    public static Request<List<ArtifactTypeInfo>> listArtifactTypes() {
+        return new Request.RequestBuilder<List<ArtifactTypeInfo>>()
+                .operation(GET)
+                .path(LIST_ARTIFACT_PATH)
+                .responseType(new TypeReference<List<ArtifactTypeInfo>>() {})
                 .build();
     }
 

--- a/client/src/main/java/io/apicurio/registry/rest/client/request/provider/Routes.java
+++ b/client/src/main/java/io/apicurio/registry/rest/client/request/provider/Routes.java
@@ -71,4 +71,6 @@ public class Routes {
 
     protected static final String EXPORT_PATH = ADMIN_BASE_PATH + "/export";
     protected static final String IMPORT_PATH = ADMIN_BASE_PATH + "/import";
+
+    protected static final String LIST_ARTIFACT_PATH = ADMIN_BASE_PATH + "/artifactTypes";
 }


### PR DESCRIPTION
I forgot to expose the new endpoint through the client library, and apparently, this is a blocker for further development of the Gradle plugin: https://github.com/croz-ltd/apicurio-registry-gradle-plugin/pull/16#discussion_r1241268248

Fixing this now 🙂 