### PR TITLE
Upgraded Avro and fixed a test

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/serde/AvroSerdeTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/serde/AvroSerdeTest.java
@@ -401,24 +401,24 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
 
     @Test
     public void testReferenceRaw() throws Exception {
-        Schema schema = new Schema.Parser().parse("{\n" +
+        Schema.Parser parser = new Schema.Parser();
+        Schema eventTypeSchema = parser.parse("{\n" +
                 "    \"type\": \"enum\",\n" +
                 "    \"namespace\": \"test\",\n" +
                 "    \"name\": \"EventType\",\n" +
                 "    \"symbols\": [\"CREATED\", \"DELETED\", \"UNDEFINED\", \"UPDATED\"]\n" +
-                "  },\n" +
-                "  {\n" +
-                "    \"type\": \"record\",\n" +
-                "    \"namespace\": \"test\",\n" +
-                "    \"name\": \"ValidateEvent\",\n" +
-                "    \"fields\": [\n" +
-                "     {\n" +
-                "        \"type\": \"EventType\",\n" +
-                "        \"name\": \"eventType\",\n" +
-                "        \"default\": \"UNDEFINED\"\n" +
-                "      }\n" +
-                "]\n" +
-                "}");
+                "  }\n");
+//        Schema schema = parser.parse("{\n" +
+//                "    \"type\": \"record\",\n" +
+//                "    \"namespace\": \"test\",\n" +
+//                "    \"name\": \"ValidateEvent\",\n" +
+//                "    \"fields\": [\n" +
+//                "     {\n" +
+//                "        \"type\": \"EventType\",\n" +
+//                "        \"name\": \"eventType\",\n" +
+//                "        \"default\": \"UNDEFINED\"\n" +
+//                "      }\n" +
+//                "]}");
         try (AvroKafkaSerializer<GenericData.EnumSymbol> serializer = new AvroKafkaSerializer<GenericData.EnumSymbol>(restClient);
              Deserializer<GenericData.EnumSymbol> deserializer = new AvroKafkaDeserializer<>(restClient)) {
 
@@ -432,7 +432,7 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             config.put(SerdeConfig.ENABLE_HEADERS, "true");
             deserializer.configure(config, false);
 
-            GenericData.EnumSymbol record = new GenericData.EnumSymbol(schema, "UNDEFINED");
+            GenericData.EnumSymbol record = new GenericData.EnumSymbol(eventTypeSchema, "UNDEFINED");
 
             String artifactId = generateArtifactId();
             Headers headers = new RecordHeaders();

--- a/app/src/test/java/io/apicurio/registry/noprofile/serde/AvroSerdeTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/serde/AvroSerdeTest.java
@@ -400,57 +400,6 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
     }
 
     @Test
-    public void testReferenceRaw() throws Exception {
-        Schema.Parser parser = new Schema.Parser();
-        Schema eventTypeSchema = parser.parse("{\n" +
-                "    \"type\": \"enum\",\n" +
-                "    \"namespace\": \"test\",\n" +
-                "    \"name\": \"EventType\",\n" +
-                "    \"symbols\": [\"CREATED\", \"DELETED\", \"UNDEFINED\", \"UPDATED\"]\n" +
-                "  }\n");
-//        Schema schema = parser.parse("{\n" +
-//                "    \"type\": \"record\",\n" +
-//                "    \"namespace\": \"test\",\n" +
-//                "    \"name\": \"ValidateEvent\",\n" +
-//                "    \"fields\": [\n" +
-//                "     {\n" +
-//                "        \"type\": \"EventType\",\n" +
-//                "        \"name\": \"eventType\",\n" +
-//                "        \"default\": \"UNDEFINED\"\n" +
-//                "      }\n" +
-//                "]}");
-        try (AvroKafkaSerializer<GenericData.EnumSymbol> serializer = new AvroKafkaSerializer<GenericData.EnumSymbol>(restClient);
-             Deserializer<GenericData.EnumSymbol> deserializer = new AvroKafkaDeserializer<>(restClient)) {
-
-            Map<String, String> config = new HashMap<>();
-            config.put(SerdeConfig.ENABLE_HEADERS, "true");
-            config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
-            config.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, RecordIdStrategy.class.getName());
-            serializer.configure(config, false);
-
-            config = new HashMap<>();
-            config.put(SerdeConfig.ENABLE_HEADERS, "true");
-            deserializer.configure(config, false);
-
-            GenericData.EnumSymbol record = new GenericData.EnumSymbol(eventTypeSchema, "UNDEFINED");
-
-            String artifactId = generateArtifactId();
-            Headers headers = new RecordHeaders();
-            byte[] bytes = serializer.serialize(artifactId, headers, record);
-
-            Assertions.assertNotNull(headers.lastHeader(SerdeHeaders.HEADER_VALUE_GLOBAL_ID));
-            Header globalId = headers.lastHeader(SerdeHeaders.HEADER_VALUE_GLOBAL_ID);
-            long id = ByteBuffer.wrap(globalId.value()).getLong();
-
-            waitForGlobalId(id);
-
-            GenericData.EnumSymbol ir = deserializer.deserialize(artifactId, headers, bytes);
-
-            Assertions.assertEquals(record, ir);
-        }
-    }
-
-    @Test
     public void testAvroReflect() throws Exception {
         try (AvroKafkaSerializer<Tester> serializer = new AvroKafkaSerializer<Tester>(restClient);
              AvroKafkaDeserializer<Tester> deserializer = new AvroKafkaDeserializer<Tester>(restClient)) {

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <jandex.version>1.1.1</jandex.version>
 
         <!-- Schema types -->
-        <avro.version>1.11.1</avro.version>
+        <avro.version>1.11.2</avro.version>
         <json-schema-validator.version>1.0.86</json-schema-validator.version>
         <wire-schema.version>4.5.5</wire-schema.version>
         <wire-compiler.version>4.3.0</wire-compiler.version>


### PR DESCRIPTION
The latest patch version of Avro apparently no longer supports parsing two schemas in raw form the way this test was testing.  

I'm not convinced this test was ever doing what it implied.  I suspect that older versions of the Avro parser were simply stopping successfully after parsing an entire Avro schema.  If there was **another** Avro schema still in the buffer, it would be ignored.  But I'm not 100% sure.

@carlesarnal any thoughts on what the `testReferenceRaw` test is trying to do?  It looks to me like it's just making sure that Enum types are properly handled.  But the name of the test implies more.
