### PR TITLE
Fix Owner Validation

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
@@ -258,6 +258,11 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     public void updateArtifactOwner(String groupId, String artifactId, ArtifactOwner data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
+        requireParameter("data", data);
+
+        if (data.getOwner().isEmpty()) {
+            throw new MissingRequiredParameterException("Missing required owner");
+        }
 
         ArtifactOwnerDto dto = new ArtifactOwnerDto(data.getOwner());
         storage.updateArtifactOwner(defaultGroupIdToNull(groupId), artifactId, dto);

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/GroupsResourceTest.java
@@ -59,6 +59,7 @@ import com.google.common.hash.Hashing;
 
 import io.apicurio.registry.AbstractResourceTestBase;
 import io.apicurio.registry.rest.client.exception.RuleViolationException;
+import io.apicurio.registry.rest.v2.beans.ArtifactOwner;
 import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rest.v2.beans.Comment;
@@ -178,6 +179,41 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .body("info.title", equalTo("Empty API"));
     }
 
+    @Test
+    public void testUpdateArtifactOwner() throws Exception {
+        String oaiArtifactContent = resourceToString("openapi-empty.json");
+        createArtifact("testUpdateArtifactOwner", "testUpdateArtifactOwner/EmptyAPI/1",ArtifactType.OPENAPI, oaiArtifactContent);
+
+        ArtifactOwner artifactOwner = new ArtifactOwner("newOwner");
+
+        given()
+                .when()
+                .contentType(CT_JSON)
+                .pathParam("groupId", "testUpdateArtifactOwner")
+                .pathParam("artifactId", "testUpdateArtifactOwner/EmptyAPI/1")
+                .body(artifactOwner)
+                .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}/owner")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    public void testUpdateEmptyArtifactOwner() throws Exception {
+        String oaiArtifactContent = resourceToString("openapi-empty.json");
+        createArtifact("testUpdateEmptyArtifactOwner", "testUpdateEmptyArtifactOwner/EmptyAPI/1",ArtifactType.OPENAPI, oaiArtifactContent);
+
+        ArtifactOwner artifactOwner = new ArtifactOwner("");
+
+        given()
+                .when()
+                .contentType(CT_JSON)
+                .pathParam("groupId", "testUpdateEmptyArtifactOwner")
+                .pathParam("artifactId", "testUpdateEmptyArtifactOwner/EmptyAPI/1")
+                .body(artifactOwner)
+                .put("/registry/v2/groups/{groupId}/artifacts/{artifactId}/owner")
+                .then()
+                .statusCode(400);
+    }
 
     @Test
     public void testMultipleGroups() throws Exception {


### PR DESCRIPTION
Hi @EricWittmann  and @carlesarnal ,

In this PR I have added checks for the `owner` to ensure it's neither `null` or an empty string. `MissingRequiredParameterException` will be thrown if the check fails.

It will close #3476 .

Thank you for reviewing.