### PR TITLE
docs: update links to debezium docs and demos

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
@@ -11,8 +11,14 @@ This chapter provides reference information on the configuration options that ar
 * xref:all-registry-configs_{context}[]
 
 .Additional resources
-* For details on setting configuration options with the Core Registry API, see the `/admin/config/properties` endpoint in the {registry-rest-api}.
-* For details on client configuration options for Kafka serializers and deserializers, see {registry-client-serdes-config}.
+* For details on setting configuration options by using the Core Registry API, see the `/admin/config/properties` endpoint in the {registry-rest-api}.
+* For details on client configuration options for Kafka serializers and deserializers, see 
+ifdef::apicurio-registry[]
+{registry-client-serdes-config}.
+endif::[]
+ifdef::rh-service-registry[]
+the link:{LinkServiceRegistryUser}[{NameServiceRegistryUser}].
+endif::[]
 
 //INCLUDES
 include::{mod-loc}getting-started/ref-registry-all-configs.adoc[leveloffset=+1]

--- a/docs/modules/ROOT/partials/getting-started/con-kafka-connect-converters.adoc
+++ b/docs/modules/ROOT/partials/getting-started/con-kafka-connect-converters.adoc
@@ -20,20 +20,20 @@ endif::[]
 * Kafka Connect converters for Apache Avro and JSON Schema
 * Core Registry API to manage schemas
 
-You can use the Avro and JSON Schema converters to map Kafka Connect schemas into Avro or JSON schemas. Those schemas can then serialize message keys and values into the compact Avro binary format or human-readable JSON format. The converted JSON is also less verbose because the messages do not contain the schema information, only the schema ID.
+You can use the Avro and JSON Schema converters to map Kafka Connect schemas into Avro or JSON schemas. These schemas can then serialize message keys and values into the compact Avro binary format or human-readable JSON format. The converted JSON is less verbose because the messages do not contain the schema information, only the schema ID.
 
 {registry} can manage and track the Avro and JSON schemas used in the Kafka topics. Because the schemas are stored in {registry} and decoupled from the message content, each message must only include a tiny schema identifier. For an I/O bound system like Kafka, this means more total throughput for producers and consumers.
 
-The Avro and JSON Schema serializers and deserializers (SerDes) provided by {registry} are also used by Kafka producers and consumers in this use case. Kafka consumer applications that you write to consume change events can use the Avro or JSON SerDes to deserialize these change events. You can install these SerDes into any Kafka-based system and use them along with Kafka Connect, or with Kafka Connect-based systems such as Debezium and Camel Kafka Connector.
+The Avro and JSON Schema serializers and deserializers (SerDes) provided by {registry} are used by Kafka producers and consumers in this use case. Kafka consumer applications that you write to consume change events can use the Avro or JSON SerDes to deserialize these events. You can install the {registry} SerDes in any Kafka-based system and use them along with Kafka Connect, or with a Kafka Connect-based system such as Debezium.
 
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://kafka.apache.org/documentation/#connect[Apache Kafka Connect documentation]
-ifdef::rh-service-registry,rh-openshift-sr[]
-* link:https://access.redhat.com/documentation/en-us/red_hat_integration/2021.q3/html-single/debezium_user_guide/index#configuring-debezium-connectors-to-use-avro-serialization[Configuring Debezium to use Apache Avro serialization] 
-endif::[] 
 ifdef::rh-service-registry[]
-* link:https://access.redhat.com/documentation/en-us/red_hat_integration/2021.q1/html-single/getting_started_with_camel_kafka_connector/index[Getting Started with Camel Kafka Connector]
+* link:https://access.redhat.com/documentation/en-us/red_hat_integration/2023.q2/html-single/debezium_user_guide/index#configuring-debezium-connectors-to-use-avro-serialization[Configuring Debezium to use Avro serialization and {registry}] 
 endif::[] 
-* link:https://debezium.io/blog/2020/04/09/using-debezium-wit-apicurio-api-schema-registry/[Demonstration of using Kafka Connect with Debezium and Apicurio Registry]
+ifdef::apicurio-registry[]
+* link:https://debezium.io/documentation/reference/stable/configuration/avro.html[Configuring Debezium to use Avro serialization and {registry}]
+endif::[] 
+* link:https://github.com/Apicurio/apicurio-registry-examples/tree/main/event-driven-architecture[Example of using Debezium to monitor the PostgreSQL database used by Apicurio Registry]
+* link:https://kafka.apache.org/documentation/#connect[Apache Kafka Connect documentation]

--- a/docs/modules/ROOT/partials/getting-started/con-registry-demo.adoc
+++ b/docs/modules/ROOT/partials/getting-started/con-registry-demo.adoc
@@ -14,6 +14,7 @@ These applications demonstrate use cases such as the following examples:
 * Cloud Events 
 * Confluent Kafka SerDes
 * Custom ID strategy
+* Event-driven architecture with Debezium
 * Google Protobuf Kafka SerDes
 * JSON Schema Kafka SerDes
 * REST clients 

--- a/docs/modules/ROOT/partials/getting-started/con-registry-serdes-protobuf.adoc
+++ b/docs/modules/ROOT/partials/getting-started/con-registry-serdes-protobuf.adoc
@@ -57,7 +57,7 @@ When a complex Protobuf message with an `import` statement is used, the imported
 
 For example, the following `table_info.proto` schema file includes the imported `mode.proto` schema file:
 
-.table_info.proto file with imported .mode.proto file
+.table_info.proto file with imported mode.proto file
 [source,bash]
 ---- 
 syntax = "proto3";

--- a/docs/modules/ROOT/partials/getting-started/proc-configuring-registry-security.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-configuring-registry-security.adoc
@@ -74,8 +74,7 @@ You can use the defaults for the other client settings.
 |String
 |`false`
 |`KEYCLOAK_URL`
-|The URL of the {keycloak} authentication server to use. Must end with `/auth`.
-|String
+|The URL of the {keycloak} authentication server to use. 
 |None
 |`KEYCLOAK_REALM`
 |The {keycloak} realm used for authentication.


### PR DESCRIPTION
- Replace link to [Debezium + Registry v1.0 demo](https://debezium.io/blog/2020/04/09/using-debezium-with-apicurio-api-schema-registry/) with new [Registry v2 + Debezium](https://github.com/Apicurio/apicurio-registry-examples/tree/main/event-driven-architecture) demo
- Add link to [Configuring Debezium to use Avro serialization and Apicurio Registry](https://debezium.io/documentation/reference/stable/configuration/avro.html)
-  Remove link to unsupported [Camel Kafka Connector Technical Preview](https://access.redhat.com/documentation/en-us/red_hat_integration/2021.q1/html-single/getting_started_with_camel_kafka_connector/index)
- Minor clean up

**Note**: Please also cherry pick this fix to v2.5.x branch.