### PR TITLE
fix: free disk space on runner to fix out of space issue

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -31,7 +31,7 @@ jobs:
 
       # https://github.com/marketplace/actions/free-disk-space-ubuntu
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.2.0
+        uses: jlumbroso/free-disk-space@76866dbe54312617f00798d1762df7f43def6e5c
         with:
           android: true
           dotnet: true

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -25,6 +25,25 @@ jobs:
     env:
       RELEASE_TYPE: release
     steps:
+
+      - name: View Disk Usage
+        run: df -h
+
+      # https://github.com/marketplace/actions/free-disk-space-ubuntu
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.2.0
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          swap-storage: true
+          large-packages: false
+          # this might remove tools that are actually needed, but frees about 6 GB
+          tool-cache: false
+
+      - name: View Disk Usage
+        run: df -h
+
         # Open-Source Machine emulator that allows you to emulate multiple CPU architectures on your machine
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
Using a customizable GitHub Actions to free disk space on Linux GitHub Actions runners.