### PR TITLE
docs: Clarify AUTH_ENABLED required for auth/authz

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
@@ -6,7 +6,7 @@ include::{mod-loc}shared/all-attributes.adoc[]
 //If the assembly covers a task, start the title with a verb in the gerund form, such as Creating or Configuring.
 
 [role="_abstract"]
-This chapter provides detailed information on how to configure Kafka SerDes in your producer and consumer Java client applications:
+This chapter provides detailed information on how to configure Kafka serializers/deserializers (SerDes) in your producer and consumer Java client applications:
 
 * xref:registry-serdes-concepts-constants_{context}[]
 * xref:registry-serdes-config-props_{context}[]

--- a/docs/modules/ROOT/partials/getting-started/con-registry-serdes-constants.adoc
+++ b/docs/modules/ROOT/partials/getting-started/con-registry-serdes-constants.adoc
@@ -5,9 +5,9 @@
 = {registry} serializer/deserializer configuration in client applications
  
 [role="_abstract"]
-You can configure specific client serializer/deserializer (SerDe) services and schema lookup strategies directly in a client application using the example constants shown in this section. Alternatively, you can configure the corresponding {registry} application properties in a file or an instance. 
+You can configure specific client serializer/deserializer services and schema lookup strategies directly in a client application using the example constants shown in this section. Alternatively, you can configure the corresponding {registry} application properties in a file or an instance. 
 
-The following sections show examples of commonly used SerDe constants and configuration options.
+The following sections show examples of commonly used SerDes constants and configuration options.
 
 
 [discrete]
@@ -44,8 +44,8 @@ public class SerdeConfig {
    public static final String SCHEMA_RESOLVER = "apicurio.registry.schema-resolver"; <2>
 ...      
 ----
-. Java class that implements the artifact resolver strategy and maps between the Kafka SerDe and artifact ID.  Defaults to the topic ID strategy. This is only used by the serializer class.
-. Java class that implements the schema resolver. Defaults to `DefaultSchemaResolver`. This is used by the serializer and deserializer classes.
+<1> Java class that implements the artifact resolver strategy and maps between the Kafka SerDe and artifact ID.  Defaults to the topic ID strategy. This is only used by the serializer class.
+<2> Java class that implements the schema resolver. Defaults to `DefaultSchemaResolver`. This is used by the serializer and deserializer classes.
 
 [role="_additional-resources"]
 .Additional resources
@@ -74,7 +74,7 @@ public class SerdeBasedConverter<S, T> extends SchemaResolverConfigurer<S, T> im
 [discrete]
 == Configuration for different schema types
 
-For details on how to configure SerDe for different schema technologies, see the following: 
+For details on how to configure SerDes for different schema technologies, see the following: 
 
 * xref:registry-serdes-types-avro_registry[]
 * xref:registry-serdes-types-json_registry[]

--- a/docs/modules/ROOT/partials/getting-started/proc-configuring-registry-security.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-configuring-registry-security.adoc
@@ -23,7 +23,7 @@ You can enable authentication for the {registry} web console and core REST API u
 {registry} provides role-based authorization for default admin, write, and read-only user roles. {registry} also provides content-based authorization at the schema or API level, where only the creator of the registry artifact can update or delete it. {registry} authentication and authorization settings are disabled by default. 
 
 .Prerequisites
-* {keycloak} is installed and running. For more details, see
+* {keycloak} is installed and running. For more details, see the 
 ifdef::apicurio-registry[]
 link:https://www.keycloak.org/documentation[{keycloak} user documentation]. 
 endif::[]
@@ -34,9 +34,9 @@ endif::[]
 
 .Procedure
 
-. In the {keycloak} Admin Console, create a {keycloak} realm for {registry}. By default, {registry} expects a realm name of `registry`. For more details on creating realms, see
+. In the {keycloak} Admin Console, create a {keycloak} realm for {registry}. By default, {registry} expects a realm name of `registry`. For details on creating realms, see the 
 ifdef::apicurio-registry[]
-link:https://www.keycloak.org/getting-started[Getting Started with {keycloak}]. 
+link:https://www.keycloak.org/documentation[{keycloak} user documentation]. 
 endif::[]
 ifdef::rh-service-registry[]
 the link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{keycloak-version}[{keycloak} user documentation].

--- a/docs/modules/ROOT/partials/getting-started/proc-registry-serdes-config-consumer.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-registry-serdes-config-consumer.adoc
@@ -39,5 +39,5 @@ props.putIfAbsent(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
 props.putIfAbsent(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
     AvroKafkaDeserializer.class.getName()); <2>
 ----
-* 1. The deserializer provided by {registry}.
-* 2. The deserialization is in Apache Avro JSON format.
+<1> The deserializer provided by {registry}.
+<2> The deserialization is in Apache Avro JSON format.

--- a/docs/modules/ROOT/partials/getting-started/proc-registry-serdes-config-producer.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-registry-serdes-config-producer.adoc
@@ -32,6 +32,6 @@ props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, AvroKafkaSerializer.class.
 props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, AvroKafkaSerializer.class.getName()); <2>
 props.put(SerdeConfig.FIND_LATEST_ARTIFACT, Boolean.TRUE); <3>
 ----
-* 1. The serializer for the message key provided by {registry}.
-* 2. The serializer for the message value provided by {registry}.
-* 3. The lookup strategy to find the global ID for the schema.
+<1> The serializer for the message key provided by {registry}.
+<2> The serializer for the message value provided by {registry}.
+<3> The lookup strategy to find the global ID for the schema.

--- a/docs/modules/ROOT/partials/getting-started/proc-registry-serdes-config-stream.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-registry-serdes-config-stream.adoc
@@ -43,9 +43,9 @@ logSerde.configure(config, false); <3>
 
 ----
 +
- * 1. The Avro serializer provided by {registry}.
- * 2. The Avro deserializer provided by {registry}.
- * 3. Configures the {registry} URL and the Avro reader for deserialization in Avro format.
+<1> The Avro serializer provided by {registry}.
+<2> The Avro deserializer provided by {registry}.
+<3> Configures the {registry} URL and the Avro reader for deserialization in Avro format.
 
 . Create the Kafka Streams client:
 +

--- a/docs/modules/ROOT/partials/getting-started/proc-registry-serdes-register.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-registry-serdes-register.adoc
@@ -44,8 +44,8 @@ endif::[]
      {"name":"price","type":"string"}]}'    
    https://my-cluster-my-registry-my-project.example.com/apis/registry/v2/groups/my-group/artifacts -s <2> 
 ----
-. Simple Avro schema artifact. 
-. OpenShift route name that exposes {registry}. 
+<1> Simple Avro schema artifact. 
+<2> OpenShift route name that exposes {registry}. 
 
 [discrete]
 == Maven plug-in example
@@ -85,10 +85,10 @@ endif::[]
   </executions>
  </plugin>
 ----
-. Specify `register` as the execution goal to upload the schema artifact to the registry.
-. Specify the {registry} URL with the `../apis/registry/v2` endpoint.
-. Specify the {registry} artifact group ID.
-. You can upload multiple artifacts using the specified group ID, artifact ID, and location.
+<1> Specify `register` as the execution goal to upload the schema artifact to the registry.
+<2> Specify the {registry} URL with the `../apis/registry/v2` endpoint.
+<3> Specify the {registry} artifact group ID.
+<4> You can upload multiple artifacts using the specified group ID, artifact ID, and location.
 
 [discrete]
 == Configuration using a producer client example
@@ -111,5 +111,5 @@ try (RegistryService service = RegistryClient.create(registryUrl_node1)) {
     }
 }
 ----
-. You can register properties against more than one URL node.
-. Check to see if the schema already exists based on the artifact ID.
+<1> You can register properties against more than one URL node.
+<2> Check to see if the schema already exists based on the artifact ID.

--- a/docs/modules/ROOT/partials/getting-started/proc-writing-registry-client.adoc
+++ b/docs/modules/ROOT/partials/getting-started/proc-writing-registry-client.adoc
@@ -36,14 +36,14 @@ public class ClientExample {
 
     public static void main(String[] args) throws Exception {
        // Create a registry client
-       String registryUrl = "https://my-registry.my-domain.com/apis/registry/v2"; 
-       RegistryClient client = RegistryClientFactory.create(registryUrl); 
+       String registryUrl = "https://my-registry.my-domain.com/apis/registry/v2"; <1>
+       RegistryClient client = RegistryClientFactory.create(registryUrl); <2>
     }
 }
 ----
 +
-* If you specify an example {registry} URL of `\https://my-registry.my-domain.com`, the client will automatically append `/apis/registry/v2`.
-* For more options when creating a {registry} client, see the Java client configuration in the next section.
+<1> If you specify an example {registry} URL of `\https://my-registry.my-domain.com`, the client will automatically append `/apis/registry/v2`.
+<2> For more options when creating a {registry} client, see the Java client configuration in the next section.
 
 When the client is created, you can use all of the operations available in the {registry} REST API in the client. For more details, see the {registry-rest-api}.
 

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-security-configuration.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-security-configuration.adoc
@@ -12,12 +12,12 @@
 * Role-based authorization for default admin, write, and read-only user roles. 
 * Content-based authorization for schema or API artifacts, where only the owner of the artifacts or artifact group can update or delete artifacts. 
 
-NOTE: {registry} authentication and authorization options are disabled by default.
+IMPORTANT: All authentication and authorization options in {registry} are disabled by default. Before enabling any of these options, you must first set the `AUTH_ENABLED` option to `true`. 
 
 This chapter provides details on the following configuration options: 
 
-* xref:registry-security-authn-keycloak[{registry} authentication using OpenID Connect with {keycloak}]
-* xref:registry-security-authn-http[{registry} authentication using HTTP basic]
+* xref:registry-security-authn-keycloak[{registry} authentication by using OpenID Connect with {keycloak}]
+* xref:registry-security-authn-http[{registry} authentication by using HTTP basic]
 * xref:registry-security-rbac-enabled[{registry} role-based authorization] 
 * xref:registry-security-obac-enabled[{registry} owner-only authorization] 
 * xref:registry-security-auth-read[{registry} authenticated read access] 
@@ -25,7 +25,7 @@ This chapter provides details on the following configuration options:
 
 [discrete]
 [id="registry-security-authn-keycloak"]
-== {registry} authentication using OpenID Connect with {keycloak} 
+== {registry} authentication by using OpenID Connect with {keycloak} 
 
 You can set the following environment variables to configure authentication for the {registry} web console and API with {keycloak}:
 
@@ -37,7 +37,7 @@ You can set the following environment variables to configure authentication for 
 |Type
 |Default
 |`AUTH_ENABLED`
-|Enables authentication in {registry}. When set to `true`, the environment variables that follow are required.
+|Enables authentication in {registry}. When set to `true`, the environment variables that follow are required for authentication in {keycloak}.
 |String
 |`false`
 |`KEYCLOAK_URL`
@@ -60,9 +60,9 @@ You can set the following environment variables to configure authentication for 
 
 [discrete]
 [id="registry-security-authn-http"]
-== {registry} authentication using HTTP basic
+== {registry} authentication by using HTTP basic
 
-By default, {registry} supports authentication using OpenID Connect. Users or API clients must obtain an access token to make authenticated calls to the {registry} REST API.  However, because some tools do not support OpenID Connect, you can also configure {registry} to support HTTP basic authentication by setting the following configuration option to `true`:
+By default, {registry} supports authentication by using OpenID Connect. Users or API clients must obtain an access token to make authenticated calls to the {registry} REST API.  However, because some tools do not support OpenID Connect, you can also configure {registry} to support HTTP basic authentication by setting the following configuration options to `true`:
 
 .Configuration for {registry} HTTP basic authentication
 [%header,cols="4,4,1,1"]
@@ -71,6 +71,10 @@ By default, {registry} supports authentication using OpenID Connect. Users or AP
 |Java system property
 |Type
 |Default value
+|`AUTH_ENABLED`
+|`registry.auth.enabled`
+|Boolean
+|`false`
 |`CLIENT_CREDENTIALS_BASIC_AUTH_ENABLED`
 |`registry.auth.basic-auth-client-credentials.enabled`
 |Boolean
@@ -102,7 +106,7 @@ When using {keycloak}, it is best to set this configuration to your {keycloak} J
 [id=registry-security-rbac-enabled]
 ==  {registry} role-based authorization
 
-You can set the following option to `true` to enable role-based authorization in {registry}:
+You can set the following options to `true` to enable role-based authorization in {registry}:
 
 .Configuration for {registry} role-based authorization
 [%header,cols="4,4,1,1"]
@@ -111,20 +115,24 @@ You can set the following option to `true` to enable role-based authorization in
 |Java system property
 |Type
 |Default value
+|`AUTH_ENABLED`
+|`registry.auth.enabled`
+|Boolean
+|`false`
 |`ROLE_BASED_AUTHZ_ENABLED`
 |`registry.auth.role-based-authorization`
 |Boolean
 |`false`
 |===
 
-You can then configure role-based authorization to use roles included in the user's authentication token (for example, granted when authenticating using {keycloak}), or to use role mappings managed internally by {registry}.
+You can then configure role-based authorization to use roles included in the user's authentication token (for example, granted when authenticating by using {keycloak}), or to use role mappings managed internally by {registry}.
 
 [discrete]
 === Use roles assigned in {keycloak}
 
 To enable using roles assigned by {keycloak}, set the following environment variables:
 
-.Configuration for {registry} role-based authorization using {keycloak}
+.Configuration for {registry} role-based authorization by using {keycloak}
 [id="registry-security-rbac-keycloak-settings"]
 [.table-expandable,width="100%",cols="6,6,2,3",options="header"]
 |===
@@ -151,7 +159,7 @@ To enable using roles assigned by {keycloak}, set the following environment vari
 |===
 
 When {registry} is configured to use roles from {keycloak}, you must assign {registry} users to at least one
-of the following user roles in {keycloak}. However, you can configure different user role names using the environment variables in xref:registry-security-rbac-keycloak-settings[].
+of the following user roles in {keycloak}. However, you can configure different user role names by using the environment variables in xref:registry-security-rbac-keycloak-settings[].
 
 .{registry} roles for authentication and authorization
 [.table-expandable,width="100%",cols="2,2,2,2,4",options="header"]
@@ -181,9 +189,9 @@ of the following user roles in {keycloak}. However, you can configure different 
 [discrete]
 === Manage roles directly in {registry}
 
-To enable using roles managed internally by {registry}, set the following environment variables:
+To enable using roles managed internally by {registry}, set the following environment variable:
 
-.Configuration for {registry} role-based authorization using internal role mappings
+.Configuration for {registry} role-based authorization by using internal role mappings
 [.table-expandable,width="100%",cols="6,6,2,3",options="header"]
 |===
 |Environment variable
@@ -196,7 +204,7 @@ To enable using roles managed internally by {registry}, set the following enviro
 |`token`
 |===
 
-When using internally managed role mappings, users can be assigned a role using the `/admin/roleMappings`
+When using internally managed role mappings, users can be assigned a role by using the `/admin/roleMappings`
 endpoint in the {registry} REST API.  For more details, see {registry-rest-api}.
 
 Users can be granted exactly one role: `ADMIN`, `DEVELOPER`, or `READ_ONLY`. Only users with admin
@@ -206,7 +214,7 @@ privileges can grant access to other users.
 [discrete]
 === {registry} admin-override configuration
 
-Because there are no default admin users in {registry}, it is usually helpful to configure another way for users to be identified as admins. You can configure this admin-override feature using the following environment variables:
+Because there are no default admin users in {registry}, it is usually helpful to configure another way for users to be identified as admins. You can configure this admin-override feature by using the following environment variables:
 
 .Configuration for {registry} admin-override 
 [.table-expandable,width="100%",cols="6,6,2,3",options="header"]
@@ -259,6 +267,11 @@ You can set the following options to `true` to enable owner-only authorization f
 |Type
 |Default value
 
+|`AUTH_ENABLED`
+|`registry.auth.enabled`
+|Boolean
+|`false`
+
 |`REGISTRY_AUTH_OBAC_ENABLED`
 |`registry.auth.owner-only-authorization`
 |Boolean
@@ -280,7 +293,7 @@ When owner-only authorization and group owner-only authorization are both enable
 
 When the authenticated read access option is enabled, {registry} grants at least read-only access to requests from any authenticated user in the same organization, regardless of their user role. 
 
-To enable authenticated read access, you must first enable role-based authorization, and then set the following option to `true`:
+To enable authenticated read access, you must first enable role-based authorization, and then ensure that the following options are set to `true`:
 
 .Configuration for authenticated read access
 [%header,cols="4,4,1,1"]
@@ -289,6 +302,10 @@ To enable authenticated read access, you must first enable role-based authorizat
 |Java system property
 |Type
 |Default value
+|`AUTH_ENABLED`
+|`registry.auth.enabled`
+|Boolean
+|`false`
 |`REGISTRY_AUTH_AUTHENTICATED_READS_ENABLED`
 |`registry.auth.authenticated-read-access.enabled`
 |Boolean
@@ -305,7 +322,7 @@ In addition to the two main types of authorization (role-based and owner-based a
 supports an anonymous read-only access option.
 
 To allow anonymous users, such as REST API calls with no authentication credentials, to make read-only 
-calls to the REST API, set the following option to `true`:
+calls to the REST API, set the following options to `true`:
 
 .Configuration for anonymous read-only access
 [%header,cols="4,4,1,1"]
@@ -314,6 +331,10 @@ calls to the REST API, set the following option to `true`:
 |Java system property
 |Type
 |Default value
+|`AUTH_ENABLED`
+|`registry.auth.enabled`
+|Boolean
+|`false`
 |`REGISTRY_AUTH_ANONYMOUS_READ_ACCESS_ENABLED`
 |`registry.auth.anonymous-read-access.enabled`
 |Boolean

--- a/docs/modules/ROOT/partials/shared/attributes.adoc
+++ b/docs/modules/ROOT/partials/shared/attributes.adoc
@@ -26,7 +26,7 @@ ifndef::service-registry-downstream[]
 :registry-docker-version: latest-release 
 :registry-v1: 1.3
 :registry-v1-release: 1.3.2.Final 
-:operator-version: 1.1.0
+:operator-version: 1.0.0
 :kafka-streams: Strimzi
 :registry-kafka-version: 3.1
 :keycloak: Keycloak


### PR DESCRIPTION
- Clarify that the `AUTH_ENABLED` env var must first be set before all auth/authz config options (see https://issues.redhat.com/browse/IPT-994)
- Fix links to Keycloak and Registry Operator docs
- Minor clean up of code callout formatting

**Note**: Please cherry pick to v2.4.x and v2.5.x branches. 