### PR TITLE
fix: Build for MySQL Registry Storage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,8 @@ Be sure to test your pull request using all storage variants:
 
 1. SQL storage (using the `-Psql` profile)
 2. SQL Server storage (using the `-Pmssql` profile)
-3. KafkaSQL storage (using the `-Pkafkasql` profile)
+3. MySQL storage (using the `-Pmysql` profile)
+4. KafkaSQL storage (using the `-Pkafkasql` profile)
 
 ### Customizing Registry supported ArtifactTypes
 

--- a/Makefile
+++ b/Makefile
@@ -516,7 +516,7 @@ run-kafkasql-legacy-tests: build-integration-tests-common
 	./mvnw verify --no-transfer-progress -Pintegration-tests -P$(INTEGRATION_TESTS_PROFILE) -Pkafkasql -pl integration-tests/legacy-tests -Dmaven.javadoc.skip=true --no-transfer-progress
 
 .PHONY: integration-tests ## Runs all integration tests [SKIP_TESTS, BUILD_FLAGS]
-integration-tests: build-all build-integration-tests-common run-ui-tests run-sql-integration-tests run-sql-clustered-integration-tests run-mssql-integration-tests run-mssql-clustered-integration-tests run-kafkasql-integration-tests run-kafkasql-clustered-integration-tests run-multitenancy-integration-tests run-sql-migration-integration-tests run-mssql-migration-integration-tests run-kafkasql-migration-integration-tests run-sql-auth-integration-tests run-mssql-auth-integration-tests run-kafkasql-auth-integration-tests run-sql-legacy-tests run-mssql-legacy-tests run-kafkasql-legacy-tests
+integration-tests: build-all build-integration-tests-common run-ui-tests run-sql-integration-tests run-sql-clustered-integration-tests run-mssql-integration-tests run-mssql-clustered-integration-tests run-mysql-integration-tests run-mysql-clustered-integration-tests run-kafkasql-integration-tests run-kafkasql-clustered-integration-tests run-multitenancy-integration-tests run-sql-migration-integration-tests run-mssql-migration-integration-tests run-kafkasql-migration-integration-tests run-sql-auth-integration-tests run-mssql-auth-integration-tests run-kafkasql-auth-integration-tests run-sql-legacy-tests run-mssql-legacy-tests run-kafkasql-legacy-tests
 
 # Please declare your targets as .PHONY in the format shown below, so that the 'make help' parses the information correctly.
 #

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This should result in Quarkus and the in-memory registry starting up, with the u
   and `PostgreSQL` driver in *prod* mode.
 - `-Pmssql` enables a build of `storage/mssql` module and produces `apicurio-registry-storage-mssql-<version>-all.zip`. This artifact uses `H2` driver in *dev* mode,
   and `SQL Server` driver in *prod* mode.
-- `-Pmysql` enables a build of `storage/mssql` module and produces `apicurio-registry-storage-mssql-<version>-all.zip`. This artifact uses `H2` driver in *dev* mode,
+- `-Pmysql` enables a build of `storage/mysql` module and produces `apicurio-registry-storage-mssql-<version>-all.zip`. This artifact uses `H2` driver in *dev* mode,
   and `MySQL` driver in *prod* mode.
 - `-Pkafkasql` enables a build of the `storage/kafkasql` module and produces the `apicurio-registry-storage-kafkasql-<version>-all.zip` artifact.
 - `-Pnative` *(experimental)* builds native executables. See [Building a native executable](https://quarkus.io/guides/maven-tooling#building-a-native-executable).
@@ -59,7 +59,7 @@ The following parameters are available for executable files:
 
 ### SQL
  - In the *dev* mode, the application expects an H2 server running at `jdbc:h2:tcp://localhost:9123/mem:registry`.
- - In the *prod* mode, you have to provide connection configuration for a PostgreSQL (or SQL Server) server as follows:
+ - In the *prod* mode, you have to provide connection configuration for a PostgreSQL (or SQL Server, or MySQL) server as follows:
   
 |Option|Command argument|Env. variable|
 |---|---|---|

--- a/TESTING.md
+++ b/TESTING.md
@@ -33,7 +33,7 @@ This is the normal mode used when you execute the testsuite. Because Apicurio Re
 The configuration is provided via maven profiles. You can find all the available maven profiles [here](integration-tests/testsuite/pom.xml)
 When executing the testsuite you normally provide two profiles:
 + test profile (which determines the tests that will be executed), some options are acceptance , multitenancy ,...
-+ storage variant to test (which determines the storage backend that will be deployed, and therefore tested), the available options are: inmemory , sql, mssql , kafkasql .
++ storage variant to test (which determines the storage backend that will be deployed, and therefore tested), the available options are: inmemory , sql, mssql, mysql, kafkasql.
 
 You can find multiple examples of how to run the testsuite in this mode in our [Github Actions Workflows](.github/workflows/integration-tests.yaml)
 

--- a/distro/docker/pom.xml
+++ b/distro/docker/pom.xml
@@ -17,6 +17,7 @@
         <docker.app.file>app-files/apicurio-registry-app-${project.version}-all.tar.gz</docker.app.file>
         <docker.sql.file>app-files/apicurio-registry-storage-sql-${project.version}-all.tar.gz</docker.sql.file>
         <docker.mssql.file>app-files/apicurio-registry-storage-mssql-${project.version}-all.tar.gz</docker.mssql.file>
+        <docker.mysql.file>app-files/apicurio-registry-storage-mysql-${project.version}-all.tar.gz</docker.mysql.file>
         <docker.kafkasql.file>app-files/apicurio-registry-storage-kafkasql-${project.version}-all.tar.gz</docker.kafkasql.file>
         <docker.tenant-manager.file>app-files/apicurio-registry-tenant-manager-api-${project.version}-all.tar.gz</docker.tenant-manager.file>
     </properties>
@@ -63,6 +64,14 @@
                                 </resource>
                                 <resource>
                                     <directory>${basedir}/../../storage/mssql/target</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>apicurio-*.tar.gz</include>
+                                        <include>apicurio-*runner</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <directory>${basedir}/../../storage/mysql/target</directory>
                                     <filtering>false</filtering>
                                     <includes>
                                         <include>apicurio-*.tar.gz</include>
@@ -138,6 +147,18 @@
                 <dependency>
                     <groupId>io.apicurio</groupId>
                     <artifactId>apicurio-registry-storage-mssql</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>mysql</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.apicurio</groupId>
+                    <artifactId>apicurio-registry-storage-mysql</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>
                 </dependency>

--- a/srcclr.yml
+++ b/srcclr.yml
@@ -1,1 +1,1 @@
-custom_maven_command: -Pprod,sql,mssql,kafkasql clean install -DskipTests
+custom_maven_command: -Pprod,sql,mssql,mysql,kafkasql clean install -DskipTests


### PR DESCRIPTION
## Summary

- Add `mysql` entry to `srcclr.yml` and to the Docker submodule (`pom.xml`)
- Add `run-mysql-integration-tests` and `run-mysql-clustered-integration-tests to integration-test task on Makefile
- Typo fix on README.md, and add entry for `mysql` on CONTRIBUTING.md