### PR TITLE
feat(schema-cache): ERCache.configureFaultTolerantRefresh #3807

### DIFF
--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
@@ -99,6 +99,7 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
         schemaCache.configureLifetime(config.getCheckPeriod());
         schemaCache.configureRetryBackoff(config.getRetryBackoff());
         schemaCache.configureRetryCount(config.getRetryCount());
+        schemaCache.configureFaultTolerantRefresh(config.getFaultTolerantRefresh());
 
         schemaCache.configureGlobalIdKeyExtractor(SchemaLookupResult::getGlobalId);
         schemaCache.configureContentKeyExtractor(schema -> Optional.ofNullable(schema.getParsedSchema().getRawSchema()).map(IoUtil::toString).orElse(null));

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/SchemaResolverConfig.java
@@ -64,6 +64,15 @@ public class SchemaResolverConfig {
     public static final boolean FIND_LATEST_ARTIFACT_DEFAULT = false;
 
     /**
+     * If {@code true}, will log exceptions instead of throwing them when an error occurs trying to refresh a schema
+     * in the cache.  This is useful for production situations where a stale schema is better than completely failing
+     * schema resolution.  Note that this will not impact trying of retries, as retries are attempted before this flag
+     * is considered.
+     */
+    public static final String FAULT_TOLERANT_REFRESH = "apicurio.registry.fault-tolerant-refresh";
+    public static final boolean FAULT_TOLERANT_REFRESH_DEFAULT = false;
+
+    /**
      * Only applicable for serializers
      * Optional, set explicitly the groupId used for querying/creating an artifact.
      * Overrides the groupId returned by the {@link ArtifactReferenceResolverStrategy}

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/DefaultSchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/DefaultSchemaResolverConfig.java
@@ -35,6 +35,7 @@ public class DefaultSchemaResolverConfig {
             entry(ARTIFACT_RESOLVER_STRATEGY, ARTIFACT_RESOLVER_STRATEGY_DEFAULT),
             entry(AUTO_REGISTER_ARTIFACT, AUTO_REGISTER_ARTIFACT_DEFAULT),
             entry(AUTO_REGISTER_ARTIFACT_IF_EXISTS, AUTO_REGISTER_ARTIFACT_IF_EXISTS_DEFAULT),
+            entry(FAULT_TOLERANT_REFRESH, FAULT_TOLERANT_REFRESH_DEFAULT),
             entry(FIND_LATEST_ARTIFACT, FIND_LATEST_ARTIFACT_DEFAULT),
             entry(CHECK_PERIOD_MS, CHECK_PERIOD_MS_DEFAULT),
             entry(RETRY_COUNT, RETRY_COUNT_DEFAULT),
@@ -95,6 +96,10 @@ public class DefaultSchemaResolverConfig {
 
     public String autoRegisterArtifactIfExists() {
         return getStringOneOf(AUTO_REGISTER_ARTIFACT_IF_EXISTS, "FAIL", "UPDATE", "RETURN", "RETURN_OR_UPDATE");
+    }
+
+    public boolean getFaultTolerantRefresh() {
+        return getBoolean(FAULT_TOLERANT_REFRESH);
     }
 
     public boolean findLatest() {

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/AbstractSchemaResolverTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/AbstractSchemaResolverTest.java
@@ -15,15 +15,16 @@
  */
 package io.apicurio.registry.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import io.apicurio.registry.resolver.data.Record;
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractSchemaResolverTest {
     @Test
@@ -34,6 +35,31 @@ public class AbstractSchemaResolverTest {
             resolver.configure(configs, null);
 
             assertDoesNotThrow(() -> {resolver.schemaCache.checkInitialized();});
+        }
+    }
+
+    @Test
+    void testSupportsFailureTolerantSchemaCache() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost");
+        configs.put(SchemaResolverConfig.FAULT_TOLERANT_REFRESH, true);
+
+        try (TestAbstractSchemaResolver<Object, Object> resolver = new TestAbstractSchemaResolver<>()) {
+            resolver.configure(configs, null);
+
+            assertTrue(resolver.schemaCache.isFaultTolerantRefresh());
+        }
+    }
+
+    @Test
+    void testDefaultsToFailureTolerantSchemaCacheDisabled() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost");
+
+        try (TestAbstractSchemaResolver<Object, Object> resolver = new TestAbstractSchemaResolver<>()) {
+            resolver.configure(configs, null);
+
+            assertFalse(resolver.schemaCache.isFaultTolerantRefresh());
         }
     }
 


### PR DESCRIPTION
Adds the notion of a fault tolerance in refresh for production environments where it's better to use a stale cache value than die when a cache entry refresh fails.  See issue #3807 for details.