### PR TITLE
Make AvroConverter look up schema version #3810

### DIFF
--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/SchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/SchemaResolver.java
@@ -59,6 +59,14 @@ public interface SchemaResolver<SCHEMA, DATA> extends Closeable {
      */
     public SchemaLookupResult<SCHEMA> resolveSchemaByArtifactReference(ArtifactReference reference);
 
+    /** Retrieve Schema Metadata by Schema Content
+     * @param artifactGroup
+     * @param artifactId
+     * @param schema
+     * @return SchemaLookupResult
+     */
+    public SchemaLookupResult<SCHEMA> getSchemaMetadataByContent(String artifactGroup, String artifactId, ParsedSchema<SCHEMA> schema);
+
     /**
      * Hard reset cache
      */

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/AbstractKafkaDeserializer.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/AbstractKafkaDeserializer.java
@@ -107,7 +107,9 @@ public abstract class AbstractKafkaDeserializer<T, U> extends AbstractKafkaSerDe
         int start = buffer.position() + buffer.arrayOffset();
 
         return readData(schema.getParsedSchema(), buffer, start, length);
+
     }
+
 
     @Override
     public U deserialize(String topic, Headers headers, byte[] data) {
@@ -142,7 +144,7 @@ public abstract class AbstractKafkaDeserializer<T, U> extends AbstractKafkaSerDe
         return readData(headers, schema.getParsedSchema(), buffer, start, length);
     }
 
-    private SchemaLookupResult<T> resolve(String topic, Headers headers, byte[] data, ArtifactReference artifactReference) {
+    protected SchemaLookupResult<T> resolve(String topic, Headers headers, byte[] data, ArtifactReference artifactReference) {
         try {
             return getSchemaResolver().resolveSchemaByArtifactReference(artifactReference);
         } catch (RuntimeException e) {

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/data/ContainerWithVersion.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/data/ContainerWithVersion.java
@@ -1,0 +1,41 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package io.apicurio.registry.serde.data;
+
+public class ContainerWithVersion<U> {
+    private final U container;
+    private final String schemaVersion;
+
+    public ContainerWithVersion(U container, String schemaVersion) {
+        this.container = container;
+        this.schemaVersion = schemaVersion;
+    }
+
+    public U container() {
+        return container;
+    }
+
+    public Integer schemaVersionAsInteger() {
+        return Integer.valueOf(schemaVersion);
+    }
+
+    public String schemaVersion() {
+        return schemaVersion;
+    }
+
+
+}


### PR DESCRIPTION
Schema Version is passed into Kafka Connect schema.

This is required for some connectors to work with multiple versions of same schema.

VERY MUCH a draft, pushing to get some CI.