### PR TITLE
fix(schema-resolver): caching of latest artifacts #3834

### DIFF
--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
@@ -99,6 +99,7 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
         schemaCache.configureLifetime(config.getCheckPeriod());
         schemaCache.configureRetryBackoff(config.getRetryBackoff());
         schemaCache.configureRetryCount(config.getRetryCount());
+        schemaCache.configureCacheLatest(config.getCacheLatest());
         schemaCache.configureFaultTolerantRefresh(config.getFaultTolerantRefresh());
 
         schemaCache.configureGlobalIdKeyExtractor(SchemaLookupResult::getGlobalId);

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/SchemaResolverConfig.java
@@ -64,6 +64,13 @@ public class SchemaResolverConfig {
     public static final boolean FIND_LATEST_ARTIFACT_DEFAULT = false;
 
     /**
+     * If {@code true}, will cache schema lookups that either have `latest` or no version specified.  Setting this to false
+     * will effectively disable caching for schema lookups that do not specify a version.
+     */
+    public static final String CACHE_LATEST = "apicurio.registry.cache-latest";
+    public static final boolean CACHE_LATEST_DEFAULT = true;
+
+    /**
      * If {@code true}, will log exceptions instead of throwing them when an error occurs trying to refresh a schema
      * in the cache.  This is useful for production situations where a stale schema is better than completely failing
      * schema resolution.  Note that this will not impact trying of retries, as retries are attempted before this flag

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/DefaultSchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/DefaultSchemaResolverConfig.java
@@ -35,6 +35,7 @@ public class DefaultSchemaResolverConfig {
             entry(ARTIFACT_RESOLVER_STRATEGY, ARTIFACT_RESOLVER_STRATEGY_DEFAULT),
             entry(AUTO_REGISTER_ARTIFACT, AUTO_REGISTER_ARTIFACT_DEFAULT),
             entry(AUTO_REGISTER_ARTIFACT_IF_EXISTS, AUTO_REGISTER_ARTIFACT_IF_EXISTS_DEFAULT),
+            entry(CACHE_LATEST, CACHE_LATEST_DEFAULT),
             entry(FAULT_TOLERANT_REFRESH, FAULT_TOLERANT_REFRESH_DEFAULT),
             entry(FIND_LATEST_ARTIFACT, FIND_LATEST_ARTIFACT_DEFAULT),
             entry(CHECK_PERIOD_MS, CHECK_PERIOD_MS_DEFAULT),
@@ -96,6 +97,10 @@ public class DefaultSchemaResolverConfig {
 
     public String autoRegisterArtifactIfExists() {
         return getStringOneOf(AUTO_REGISTER_ARTIFACT_IF_EXISTS, "FAIL", "UPDATE", "RETURN", "RETURN_OR_UPDATE");
+    }
+
+    public boolean getCacheLatest() {
+        return getBoolean(CACHE_LATEST);
     }
 
     public boolean getFaultTolerantRefresh() {

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/AbstractSchemaResolverTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/AbstractSchemaResolverTest.java
@@ -63,6 +63,18 @@ public class AbstractSchemaResolverTest {
         }
     }
 
+    @Test
+    void testDefaultsToCacheLatestEnabled() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost");
+
+        try (TestAbstractSchemaResolver<Object, Object> resolver = new TestAbstractSchemaResolver<>()) {
+            resolver.configure(configs, null);
+
+            assertTrue(resolver.schemaCache.isCacheLatest());
+        }
+    }
+
     class TestAbstractSchemaResolver<SCHEMA, DATA> extends AbstractSchemaResolver<SCHEMA, DATA> {
 
         @Override

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/ERCacheTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/ERCacheTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
@@ -132,6 +133,56 @@ public class ERCacheTest {
 
         assertEquals("some value", originalLoadValue);
         assertEquals("some value", failingLoadValue);
+    }
+
+    @Test
+    void testCanCacheLatestWhenEnabled() {
+        ERCache<String> cache = newCache("some key");
+        cache.configureLifetime(Duration.ofMinutes(10));
+        cache.configureCacheLatest(true);
+
+        ArtifactCoordinates latestKey = new ArtifactCoordinates.ArtifactCoordinatesBuilder()
+            .artifactId("someArtifactId")
+            .groupId("someGroupId")
+            .build();
+        final AtomicInteger loadCount = new AtomicInteger(0);
+        Function<ArtifactCoordinates, String> countingLoader = (key) -> {
+            loadCount.incrementAndGet();
+            return "some value";
+        };
+
+        // Seed a value
+        String firstLookupValue = cache.getByArtifactCoordinates(latestKey, countingLoader);
+        // Try the same lookup
+        String secondLookupValue = cache.getByArtifactCoordinates(latestKey, countingLoader);
+
+        assertEquals(firstLookupValue, secondLookupValue);
+        assertEquals(1, loadCount.get());
+    }
+
+    @Test
+    void doesNotCacheLatestWhenDisabled() {
+        ERCache<String> cache = newCache("some key");
+        cache.configureLifetime(Duration.ofMinutes(10));
+        cache.configureCacheLatest(false);
+
+        ArtifactCoordinates latestKey = new ArtifactCoordinates.ArtifactCoordinatesBuilder()
+            .artifactId("someArtifactId")
+            .groupId("someGroupId")
+            .build();
+        final AtomicInteger loadCount = new AtomicInteger(0);
+        Function<ArtifactCoordinates, String> countingLoader = (key) -> {
+            loadCount.incrementAndGet();
+            return "some value";
+        };
+
+        // Seed a value
+        String firstLookupValue = cache.getByArtifactCoordinates(latestKey, countingLoader);
+        // Try the same lookup
+        String secondLookupValue = cache.getByArtifactCoordinates(latestKey, countingLoader);
+
+        assertEquals(firstLookupValue, secondLookupValue);
+        assertEquals(2, loadCount.get());
     }
 
     private ERCache<String> newCache(String contentHashKey) {


### PR DESCRIPTION
Caching of artifacts with no version (e.g. latest) did not work because reindex would use the new key that has the artifact version that was found in the lookup.  This code changes the default behavior to index both the artifact with its version and the latest/null version.  It also exposes a configuration property (`apicurio.registry.cache-latest`) where this behavior can be disabled for use cases where caching of latest is not desired.  See #3824 for details.