### PR TITLE
Add util methods to parse proto files with dependencies

### DIFF
--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
@@ -153,8 +153,21 @@ public class ProtobufSchemaLoader {
             String dirPath = createDirectory(dirs, inMemoryFileSystem);
             okio.Path path = writeFile(schemaDefinition, fileName, dirPath, inMemoryFileSystem);
 
-            for (String depKey: deps.keySet()) {
-                writeFile(deps.get(depKey), depKey, dirPath, inMemoryFileSystem);
+            for (Map.Entry<String, String> schema : deps.entrySet()) {
+                final String depKey = schema.getKey();
+                final String depSchema = schema.getValue();
+                int beforeFileName = depKey.lastIndexOf('/');
+                if (beforeFileName != -1) {
+                    final String packageNameDep = depKey.substring(0, beforeFileName);
+                    String depDirPath = dirPath;
+                    if (!packageName.isPresent() || !packageName.get().equals(packageNameDep)) {
+                        // apply the same logic used for dirs of the root one
+                        depDirPath = createDirectory(packageNameDep.split("\\."), inMemoryFileSystem);
+                    }
+                    writeFile(depSchema, depKey.substring(beforeFileName + 1), depDirPath, inMemoryFileSystem);
+                } else {
+                    writeFile(depSchema, depKey, dirPath, inMemoryFileSystem);
+                }
             }
 
             SchemaLoader schemaLoader = new SchemaLoader(inMemoryFileSystem);

--- a/utils/protobuf-schema-utilities/src/test/resources/parseWithDeps/broken/helloworld.proto
+++ b/utils/protobuf-schema-utilities/src/test/resources/parseWithDeps/broken/helloworld.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package mypackage3;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+  rpc SayHelloStreamReply (HelloRequest) returns (stream HelloReply) {}
+
+  rpc SayHelloBidiStream (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;

--- a/utils/protobuf-schema-utilities/src/test/resources/parseWithDeps/mypackage0/producerId.proto
+++ b/utils/protobuf-schema-utilities/src/test/resources/parseWithDeps/mypackage0/producerId.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+import "mypackage2/version.proto";
+package mypackage0;
+
+message ProducerId {
+  string name = 1;
+  mypackage2.Version id = 2;
+}

--- a/utils/protobuf-schema-utilities/src/test/resources/parseWithDeps/mypackage2/version.proto
+++ b/utils/protobuf-schema-utilities/src/test/resources/parseWithDeps/mypackage2/version.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package mypackage2;
+
+message Version {
+  string id = 1;
+}

--- a/utils/protobuf-schema-utilities/src/test/resources/parseWithDeps/producer.proto
+++ b/utils/protobuf-schema-utilities/src/test/resources/parseWithDeps/producer.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+import "mypackage0/producerId.proto";
+import "google/protobuf/timestamp.proto";
+package mypackage1;
+
+message Producer {
+  mypackage0.ProducerId id = 1;
+  string name = 2;
+  google.protobuf.Timestamp timestamp = 3;
+}
+
+service MyService {
+  rpc Foo (Producer) returns (Producer);
+}


### PR DESCRIPTION
This is to open a discussion about a new public API to parse a file and its dependencies.

In the current state I don't like (at all) the other public API I've exposed for https://github.com/Apicurio/apicurio-registry/discussions/3819

ie

```java
        Descriptors.FileDescriptor mainProtoFd = FileDescriptorUtils.parseProtoFileWithDependencies(mainProto,
                mainProtoFileName,
                Map.of("mypackage0/producerId.proto", importedProto1, "mypackage2/version.proto", importedProto2));
```

