### PR TITLE
Fix incorrect .orElse usage.

### DIFF
--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
@@ -80,15 +80,17 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
         Objects.requireNonNull(data.payload());
 
 
-        ParsedSchema<S> parsedSchema = null;
+        ParsedSchema<S> parsedSchema;
         if (artifactResolverStrategy.loadSchema() && schemaParser.supportsExtractSchemaFromData()) {
             parsedSchema = schemaParser.getSchemaFromData(data, dereference);
+        } else {
+            parsedSchema = null;
         }
 
         final ArtifactReference artifactReference = resolveArtifactReference(data, parsedSchema, false, null);
 
         return getSchemaFromCache(artifactReference)
-                .orElse(getSchemaFromRegistry(parsedSchema, data, artifactReference));
+                .orElseGet(() -> getSchemaFromRegistry(parsedSchema, data, artifactReference));
     }
 
     private Optional<SchemaLookupResult<S>> getSchemaFromCache(ArtifactReference artifactReference) {


### PR DESCRIPTION
Since the parameter of .orElse() is still evaluated we end up calling the registry even if the schema is found in the cache.

Using .orElseGet() instead fixes this issue.

See: https://www.baeldung.com/java-optional-or-else-vs-or-else-get

Fixes: https://github.com/Apicurio/apicurio-registry/issues/3956