### PR TITLE
Preserve global IDs when exporting from Confluent

### DIFF
--- a/utils/exportConfluent/src/main/java/io/apicurio/registry/utils/export/Export.java
+++ b/utils/exportConfluent/src/main/java/io/apicurio/registry/utils/export/Export.java
@@ -237,7 +237,7 @@ public class Export implements QuarkusApplication {
         versionEntity.createdBy = "export-confluent-utility";
         versionEntity.createdOn = System.currentTimeMillis();
         versionEntity.description = null;
-        versionEntity.globalId = -1;
+        versionEntity.globalId = metadata.getId();
         versionEntity.groupId = null;
         versionEntity.isLatest = isLatest;
         versionEntity.labels = null;


### PR DESCRIPTION
This changes preserves global IDs in the .zip file generated by "exportConfluent", and now matches the behavior of exporting data from an Apicurio registry.