### PR TITLE
add missing ccompat properties

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -15,6 +15,9 @@ registry.date=${timestamp}
 ## Legacy mode for ccompat API
 registry.ccompat.legacy-id-mode.enabled=${ENABLE_CCOMPAT_LEGACY_ID_MODE:false}
 
+## Max # of subjects returned by ccompat API
+registry.ccompat.max-subjects=${REGISTRY_CCOMPAT_MAX_SUBJECTS:1000}
+
 ## Make ccompat use canonical hash
 registry.ccompat.use-canonical-hash=${ENABLE_CCOMPAT_CANONICAL_HASH_MODE:false}
 
@@ -100,6 +103,8 @@ registry.auth.owner-only-authorization.dynamic.allow=${registry.config.dynamic.a
 registry.auth.owner-only-authorization.limit-group-access.dynamic.allow=${registry.config.dynamic.allow-all}
 registry.auth.anonymous-read-access.enabled.dynamic.allow=${registry.config.dynamic.allow-all}
 registry.ccompat.legacy-id-mode.enabled.dynamic.allow=${registry.config.dynamic.allow-all}
+registry.ccompat.use-canonical-hash.dynamic.allow=${registry.config.dynamic.allow-all}
+registry.ccompat.max-subjects.dynamic.allow=${registry.config.dynamic.allow-all}
 registry.download.href.ttl.dynamic.allow=${registry.config.dynamic.allow-all}
 registry.ui.features.readOnly.dynamic.allow=${registry.config.dynamic.allow-all}
 registry.rest.artifact.deletion.enabled.dynamic.allow=${registry.config.dynamic.allow-all}


### PR DESCRIPTION
I was racking my brain trying to figure out why I couldn't set `registry.ccompat.max-subjects` or `registry.ccompat.use-canonical-hash`.

In our installation, everything is configured with envvars, not java properties.  These configs were not added to application.properties, so they weren't settable via envvars nor dynamically.
 