### PR TITLE
Fix a bug with Delete All Artifact Rules (kafkasql storage only)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -444,14 +444,8 @@ public class KafkaSqlRegistryStorage extends RegistryStorageDecoratorReadOnlyBas
             throw new ArtifactNotFoundException(groupId, artifactId);
         }
 
-        submitter.submitArtifactRule(groupId, artifactId, RuleType.COMPATIBILITY, ActionType.DELETE);
-
-        UUID reqId = ConcurrentUtil.get(submitter.submitArtifactRule(groupId, artifactId, RuleType.VALIDITY, ActionType.DELETE));
-        try {
-            coordinator.waitForResponse(reqId);
-        } catch (RuleNotFoundException e) {
-            // Eat this exception - we don't care if the rule didn't exist.
-        }
+        UUID reqId = ConcurrentUtil.get(submitter.submitArtifactRules(groupId, artifactId, ActionType.DELETE));
+        coordinator.waitForResponse(reqId);
     }
 
 
@@ -533,17 +527,8 @@ public class KafkaSqlRegistryStorage extends RegistryStorageDecoratorReadOnlyBas
 
     @Override
     public void deleteGlobalRules() {
-        // TODO This should use "DELETE FROM" instead of being rule specific
-
-        getGlobalRules().stream()
-                .map(r -> ConcurrentUtil.get(submitter.submitGlobalRule(r, ActionType.DELETE)))
-                .forEach(reqId -> {
-                    try {
-                        coordinator.waitForResponse(reqId);
-                    } catch (RuleNotFoundException e) {
-                        // Eat this exception - we don't care if the rule didn't exist.
-                    }
-                });
+        UUID reqId = ConcurrentUtil.get(submitter.submitGlobalRules(ActionType.DELETE));
+        coordinator.waitForResponse(reqId);
     }
 
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
@@ -72,7 +72,7 @@ public class KafkaSqlSubmitter {
      * Content
      * ****************************************************************************************** */
     public CompletableFuture<UUID> submitContent(long contentId, String contentHash, ActionType action, String canonicalHash, ContentHandle content, String serializedReferences) {
-        ContentKey key = ContentKey.create( contentId, contentHash);
+        ContentKey key = ContentKey.create(contentId, contentHash);
         ContentValue value = ContentValue.create(action, canonicalHash, content, serializedReferences);
         return send(key, value);
     }
@@ -87,7 +87,7 @@ public class KafkaSqlSubmitter {
         return send(key, value);
     }
     public CompletableFuture<UUID> submitGroup(String groupId, ActionType action, boolean onlyArtifacts) {
-        GroupKey key = GroupKey.create( groupId);
+        GroupKey key = GroupKey.create(groupId);
         GroupValue value = GroupValue.create(action, onlyArtifacts);
         return send(key, value);
     }
@@ -99,7 +99,7 @@ public class KafkaSqlSubmitter {
     public CompletableFuture<UUID> submitArtifact(String groupId, String artifactId, String version, ActionType action,
             Long globalId, String artifactType, String contentHash, String createdBy, Date createdOn,
             EditableArtifactMetaDataDto metaData, Integer versionOrder, ArtifactState state, Long contentId) {
-        ArtifactKey key = ArtifactKey.create( groupId, artifactId);
+        ArtifactKey key = ArtifactKey.create(groupId, artifactId);
         ArtifactValue value = ArtifactValue.create(action, globalId, version, artifactType, contentHash, createdBy, createdOn, metaData,
                 versionOrder, state, contentId);
         return send(key, value);
@@ -107,11 +107,11 @@ public class KafkaSqlSubmitter {
     public CompletableFuture<UUID> submitArtifact(String groupId, String artifactId, String version, ActionType action,
             Long globalId, String artifactType, String contentHash, String createdBy, Date createdOn,
             EditableArtifactMetaDataDto metaData) {
-        return submitArtifact( groupId, artifactId, version, action, globalId, artifactType, contentHash, createdBy, createdOn,
+        return submitArtifact(groupId, artifactId, version, action, globalId, artifactType, contentHash, createdBy, createdOn,
                 metaData, null, null, null);
     }
     public CompletableFuture<UUID> submitArtifact(String groupId, String artifactId, ActionType action) {
-        return this.submitArtifact( groupId, artifactId, null, action, null, null, null, null, null, null);
+        return this.submitArtifact(groupId, artifactId, null, action, null, null, null, null, null, null);
     }
 
 
@@ -120,12 +120,12 @@ public class KafkaSqlSubmitter {
      * ****************************************************************************************** */
     public CompletableFuture<UUID> submitArtifactVersion(String groupId, String artifactId, String version, ActionType action, ArtifactState state,
             EditableArtifactMetaDataDto metaData) {
-        ArtifactVersionKey key = ArtifactVersionKey.create( groupId, artifactId, version);
+        ArtifactVersionKey key = ArtifactVersionKey.create(groupId, artifactId, version);
         ArtifactVersionValue value = ArtifactVersionValue.create(action, state, metaData);
         return send(key, value);
     }
     public CompletableFuture<UUID> submitVersion(String groupId, String artifactId, String version, ActionType action) {
-        return submitArtifactVersion( groupId, artifactId, version, action, null, null);
+        return submitArtifactVersion(groupId, artifactId, version, action, null, null);
     }
 
 
@@ -133,7 +133,7 @@ public class KafkaSqlSubmitter {
      * Artifact Owner
      * ****************************************************************************************** */
     public CompletableFuture<UUID> submitArtifactOwner(String groupId, String artifactId, ActionType action, String owner) {
-        ArtifactOwnerKey key = ArtifactOwnerKey.create( groupId, artifactId);
+        ArtifactOwnerKey key = ArtifactOwnerKey.create(groupId, artifactId);
         ArtifactOwnerValue value = ArtifactOwnerValue.create(action, owner);
         return send(key, value);
     }
@@ -144,12 +144,22 @@ public class KafkaSqlSubmitter {
      * ****************************************************************************************** */
     public CompletableFuture<UUID> submitArtifactRule(String groupId, String artifactId, RuleType rule, ActionType action,
             RuleConfigurationDto config) {
-        ArtifactRuleKey key = ArtifactRuleKey.create( groupId, artifactId, rule);
+        ArtifactRuleKey key = ArtifactRuleKey.create(groupId, artifactId, rule);
         ArtifactRuleValue value = ArtifactRuleValue.create(action, config);
         return send(key, value);
     }
     public CompletableFuture<UUID> submitArtifactRule(String groupId, String artifactId, RuleType rule, ActionType action) {
-        return submitArtifactRule( groupId, artifactId, rule, action, null);
+        return submitArtifactRule(groupId, artifactId, rule, action, null);
+    }
+
+
+    /* ******************************************************************************************
+     * Artifact Rules
+     * ****************************************************************************************** */
+    public CompletableFuture<UUID> submitArtifactRules(String groupId, String artifactId, ActionType action) {
+        ArtifactRulesKey key = ArtifactRulesKey.create(groupId, artifactId);
+        ArtifactRulesValue value = ArtifactRulesValue.create(action);
+        return send(key, value);
     }
 
 
@@ -158,21 +168,21 @@ public class KafkaSqlSubmitter {
      * ****************************************************************************************** */
     public CompletableFuture<UUID> submitComment(String groupId, String artifactId, String version,
             String commentId, ActionType action, long globalId, String createdBy, Date createdOn, String value) {
-        CommentKey key = CommentKey.create( groupId, artifactId, version, commentId);
+        CommentKey key = CommentKey.create(groupId, artifactId, version, commentId);
         CommentValue cv = CommentValue.create(action, globalId, createdBy, createdOn, value);
         return send(key, cv);
     }
     public CompletableFuture<UUID> submitComment(String groupId, String artifactId, String version,
             String commentId, ActionType action, String createdBy, Date createdOn, String value) {
-        return submitComment( groupId, artifactId, version, commentId, action, -1, createdBy, createdOn, value);
+        return submitComment(groupId, artifactId, version, commentId, action, -1, createdBy, createdOn, value);
     }
     public CompletableFuture<UUID> submitComment(String groupId, String artifactId, String version,
             String commentId, ActionType action) {
-        return submitComment( groupId, artifactId, version, commentId, action, null, null, null);
+        return submitComment(groupId, artifactId, version, commentId, action, null, null, null);
     }
     public CompletableFuture<UUID> submitComment(String commentId, ActionType action, long globalId,
             String createdBy, Date createdOn, String value) {
-        return submitComment( "<import-comments>", "_", "_", commentId, action, globalId, createdBy, createdOn, value);
+        return submitComment("<import-comments>", "_", "_", commentId, action, globalId, createdBy, createdOn, value);
     }
 
 
@@ -185,7 +195,17 @@ public class KafkaSqlSubmitter {
         return send(key, value);
     }
     public CompletableFuture<UUID> submitGlobalRule(RuleType rule, ActionType action) {
-        return submitGlobalRule( rule, action, null);
+        return submitGlobalRule(rule, action, null);
+    }
+
+
+    /* ******************************************************************************************
+     * Global Rules
+     * ****************************************************************************************** */
+    public CompletableFuture<UUID> submitGlobalRules(ActionType action) {
+        GlobalRulesKey key = GlobalRulesKey.create();
+        GlobalRulesValue value = GlobalRulesValue.create(action);
+        return send(key, value);
     }
 
 
@@ -193,12 +213,12 @@ public class KafkaSqlSubmitter {
      * Role Mappings
      * ****************************************************************************************** */
     public CompletableFuture<UUID> submitRoleMapping(String principalId, ActionType action, String role, String principalName) {
-        RoleMappingKey key = RoleMappingKey.create( principalId);
+        RoleMappingKey key = RoleMappingKey.create(principalId);
         RoleMappingValue value = RoleMappingValue.create(action, role, principalName);
         return send(key, value);
     }
     public CompletableFuture<UUID> submitRoleMapping(String principalId, ActionType action) {
-        return submitRoleMapping( principalId, action, null, null);
+        return submitRoleMapping(principalId, action, null, null);
     }
 
 
@@ -237,12 +257,12 @@ public class KafkaSqlSubmitter {
      * ****************************************************************************************** */
 
     public CompletableFuture<UUID> submitDownload(String downloadId, ActionType action, DownloadContextDto context) {
-        DownloadKey key = DownloadKey.create( downloadId);
+        DownloadKey key = DownloadKey.create(downloadId);
         DownloadValue value = DownloadValue.create(action, context);
         return send(key, value);
     }
     public CompletableFuture<UUID> submitDownload(String downloadId, ActionType action) {
-        return submitDownload( downloadId, action, null);
+        return submitDownload(downloadId, action, null);
     }
 
 
@@ -251,12 +271,12 @@ public class KafkaSqlSubmitter {
      * ****************************************************************************************** */
 
     public CompletableFuture<UUID> submitConfigProperty(String propertyName, ActionType action, String propertyValue) {
-        ConfigPropertyKey key = ConfigPropertyKey.create( propertyName);
+        ConfigPropertyKey key = ConfigPropertyKey.create(propertyName);
         ConfigPropertyValue value = ConfigPropertyValue.create(action, propertyValue);
         return send(key, value);
     }
     public CompletableFuture<UUID> submitConfigProperty(String propertyName, ActionType action) {
-        return submitConfigProperty( propertyName, action, null);
+        return submitConfigProperty(propertyName, action, null);
     }
 
 
@@ -300,7 +320,7 @@ public class KafkaSqlSubmitter {
      * Tombstones
      * ****************************************************************************************** */
     public void submitArtifactVersionTombstone(String groupId, String artifactId, String version) {
-        ArtifactVersionKey key = ArtifactVersionKey.create( groupId, artifactId, version);
+        ArtifactVersionKey key = ArtifactVersionKey.create(groupId, artifactId, version);
         send(key, null);
     }
     public void submitArtifactRuleTombstone(String groupId, String artifactId, RuleType rule) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/MessageType.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/MessageType.java
@@ -23,6 +23,8 @@ public enum MessageType {
     CommentId(15),
     Comment(16),
     ArtifactBranch(17),
+    GlobalRules(18),
+    ArtifactRules(19),
     ;
 
     private final byte ord;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ArtifactRulesKey.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/ArtifactRulesKey.java
@@ -1,0 +1,78 @@
+package io.apicurio.registry.storage.impl.kafkasql.keys;
+
+import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class ArtifactRulesKey implements MessageKey {
+
+    private String groupId;
+    private String artifactId;
+
+    /**
+     * Creator method.
+     * @param groupId
+     * @param artifactId
+     * @param ruleType
+     */
+    public static final ArtifactRulesKey create(String groupId, String artifactId) {
+        ArtifactRulesKey key = new ArtifactRulesKey();
+        key.setGroupId(groupId);
+        key.setArtifactId(artifactId);
+        return key;
+    }
+
+    /**
+     * @see MessageKey#getType()
+     */
+    @Override
+    public MessageType getType() {
+        return MessageType.ArtifactRules;
+    }
+
+    /**
+     * @see MessageKey#getPartitionKey()
+     */
+    @Override
+    public String getPartitionKey() {
+        return groupId + "/" + artifactId;
+    }
+
+    /**
+     * @return the groupId
+     */
+    public String getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * @param groupId the groupId to set
+     */
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    /**
+     * @return the artifactId
+     */
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    /**
+     * @param artifactId the artifactId to set
+     */
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    /**
+     * @see Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "ArtifactRuleKey [groupId=" + groupId + ", artifactId=" + artifactId
+                + "]";
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalRuleKey.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalRuleKey.java
@@ -7,7 +7,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 @RegisterForReflection
 public class GlobalRuleKey implements MessageKey {
 
-    private static final String GLOBAL_RULE_PARTITION_KEY = "__apicurio_registry_global_rule__";
+    static final String GLOBAL_RULE_PARTITION_KEY = "__apicurio_registry_global_rule__";
 
     private RuleType ruleType;
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalRulesKey.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/GlobalRulesKey.java
@@ -1,0 +1,41 @@
+package io.apicurio.registry.storage.impl.kafkasql.keys;
+
+import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class GlobalRulesKey implements MessageKey {
+
+    /**
+     * Creator method.
+     * @param ruleType
+     */
+    public static final GlobalRulesKey create() {
+        return new GlobalRulesKey();
+    }
+    
+    /**
+     * @see MessageKey#getType()
+     */
+    @Override
+    public MessageType getType() {
+        return MessageType.GlobalRules;
+    }
+
+    /**
+     * @see MessageKey#getPartitionKey()
+     */
+    @Override
+    public String getPartitionKey() {
+        return GlobalRuleKey.GLOBAL_RULE_PARTITION_KEY;
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.kafkasql.keys.AbstractMessageKey#toString()
+     */
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/MessageTypeToKeyClass.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/keys/MessageTypeToKeyClass.java
@@ -67,6 +67,12 @@ public class MessageTypeToKeyClass {
                 case ArtifactBranch:
                     index.put(type, ArtifactBranchKey.class);
                     break;
+                case ArtifactRules:
+                    index.put(type, ArtifactRulesKey.class);
+                    break;
+                case GlobalRules:
+                    index.put(type, GlobalRulesKey.class);
+                    break;
                 default:
                     throw new RuntimeAssertionFailedException("[MessageTypeToKeyClass] Type not mapped: " + type);
             }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlSink.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlSink.java
@@ -117,32 +117,36 @@ public class KafkaSqlSink {
                 return processArtifactMessage((ArtifactKey) key, (ArtifactValue) value);
             case ArtifactRule:
                 return processArtifactRuleMessage((ArtifactRuleKey) key, (ArtifactRuleValue) value);
+            case ArtifactRules:
+                return processArtifactRulesMessage((ArtifactRulesKey) key, (ArtifactRulesValue) value);
             case ArtifactVersion:
-                return processArtifactVersion((ArtifactVersionKey) key, (ArtifactVersionValue) value);
+                return processArtifactVersionMessage((ArtifactVersionKey) key, (ArtifactVersionValue) value);
             case Content:
-                return processContent((ContentKey) key, (ContentValue) value);
+                return processContentMessage((ContentKey) key, (ContentValue) value);
             case GlobalRule:
-                return processGlobalRule((GlobalRuleKey) key, (GlobalRuleValue) value);
+                return processGlobalRuleMessage((GlobalRuleKey) key, (GlobalRuleValue) value);
+            case GlobalRules:
+                return processGlobalRulesMessage((GlobalRulesKey) key, (GlobalRulesValue) value);
             case GlobalId:
-                return processGlobalId((GlobalIdKey) key, (GlobalIdValue) value);
+                return processGlobalIdMessage((GlobalIdKey) key, (GlobalIdValue) value);
             case ContentId:
-                return processContentId((ContentIdKey) key, (ContentIdValue) value);
+                return processContentIdMessage((ContentIdKey) key, (ContentIdValue) value);
             case RoleMapping:
-                return processRoleMapping((RoleMappingKey) key, (RoleMappingValue) value);
+                return processRoleMappingMessage((RoleMappingKey) key, (RoleMappingValue) value);
             case GlobalAction:
-                return processGlobalAction((GlobalActionKey) key, (GlobalActionValue) value);
+                return processGlobalActionMessage((GlobalActionKey) key, (GlobalActionValue) value);
             case Download:
-                return processDownload((DownloadKey) key, (DownloadValue) value);
+                return processDownloadMessage((DownloadKey) key, (DownloadValue) value);
             case ConfigProperty:
-                return processConfigProperty((ConfigPropertyKey) key, (ConfigPropertyValue) value);
+                return processConfigPropertyMessage((ConfigPropertyKey) key, (ConfigPropertyValue) value);
             case ArtifactOwner:
                 return processArtifactOwnerMessage((ArtifactOwnerKey) key, (ArtifactOwnerValue) value);
             case CommentId:
-                return processCommentId((CommentIdKey) key, (CommentIdValue) value);
+                return processCommentIdMessage((CommentIdKey) key, (CommentIdValue) value);
             case Comment:
-                return processComment((CommentKey) key, (CommentValue) value);
+                return processCommentMessage((CommentKey) key, (CommentValue) value);
             case ArtifactBranch:
-                return processArtifactBranch((ArtifactBranchKey) key, (ArtifactBranchValue) value);
+                return processArtifactBranchMessage((ArtifactBranchKey) key, (ArtifactBranchValue) value);
             case Bootstrap:
                 throw new UnreachableCodeException();
         }
@@ -156,7 +160,7 @@ public class KafkaSqlSink {
      * @param key
      * @param value
      */
-    private Object processGlobalAction(GlobalActionKey key, GlobalActionValue value) {
+    private Object processGlobalActionMessage(GlobalActionKey key, GlobalActionValue value) {
         switch (value.getAction()) {
             case DELETE_ALL_USER_DATA:
                 sqlStore.deleteAllUserData();
@@ -172,7 +176,7 @@ public class KafkaSqlSink {
      * @param key
      * @param value
      */
-    private Object processDownload(DownloadKey key, DownloadValue value) {
+    private Object processDownloadMessage(DownloadKey key, DownloadValue value) {
         switch (value.getAction()) {
             case CREATE:
                 return sqlStore.createDownload(value.getDownloadContext());
@@ -189,7 +193,7 @@ public class KafkaSqlSink {
      * @param key
      * @param value
      */
-    private Object processConfigProperty(ConfigPropertyKey key, ConfigPropertyValue value) {
+    private Object processConfigPropertyMessage(ConfigPropertyKey key, ConfigPropertyValue value) {
         switch (value.getAction()) {
             case UPDATE:
                 DynamicConfigPropertyDto dto = new DynamicConfigPropertyDto(key.getPropertyName(), value.getValue());
@@ -335,6 +339,22 @@ public class KafkaSqlSink {
     }
 
     /**
+     * Process a Kafka message of type "artifact rules".  This includes deleting all artifact rules.
+     *
+     * @param key
+     * @param value
+     */
+    private Object processArtifactRulesMessage(ArtifactRulesKey key, ArtifactRulesValue value) {
+        switch (value.getAction()) {
+            case DELETE:
+                sqlStore.deleteArtifactRules(key.getGroupId(), key.getArtifactId());
+                return null;
+            default:
+                return unsupported(key, value);
+        }
+    }
+
+    /**
      * Process a Kafka message of type "artifact owner".  This includes updating the owner for
      * a specific artifact.
      *
@@ -361,7 +381,7 @@ public class KafkaSqlSink {
      * @param key
      * @param value
      */
-    private Object processArtifactVersion(ArtifactVersionKey key, ArtifactVersionValue value) {
+    private Object processArtifactVersionMessage(ArtifactVersionKey key, ArtifactVersionValue value) {
         switch (value.getAction()) {
             case UPDATE:
                 sqlStore.updateArtifactVersionMetaData(key.getGroupId(), key.getArtifactId(), key.getVersion(), value.getMetaData());
@@ -385,7 +405,7 @@ public class KafkaSqlSink {
      * @param key
      * @param value
      */
-    private Object processContent(ContentKey key, ContentValue value) {
+    private Object processContentMessage(ContentKey key, ContentValue value) {
         switch (value.getAction()) {
             case CREATE:
                 if (!sqlStore.isContentExists(key.getContentHash())) {
@@ -425,7 +445,7 @@ public class KafkaSqlSink {
      * @param key
      * @param value
      */
-    private Object processGlobalRule(GlobalRuleKey key, GlobalRuleValue value) {
+    private Object processGlobalRuleMessage(GlobalRuleKey key, GlobalRuleValue value) {
         switch (value.getAction()) {
             case CREATE:
                 sqlStore.createGlobalRule(key.getRuleType(), value.getConfig());
@@ -448,13 +468,29 @@ public class KafkaSqlSink {
     }
 
     /**
+     * Process a Kafka message of type "global rules".  This includes deleting all global rules.
+     *
+     * @param key
+     * @param value
+     */
+    private Object processGlobalRulesMessage(GlobalRulesKey key, GlobalRulesValue value) {
+        switch (value.getAction()) {
+            case DELETE:
+                sqlStore.deleteGlobalRules();
+                return null;
+            default:
+                return unsupported(key, value);
+        }
+    }
+
+    /**
      * Process a Kafka message of type "role mapping".  This includes creating, updating, and deleting
      * role mappings.
      *
      * @param key
      * @param value
      */
-    private Object processRoleMapping(RoleMappingKey key, RoleMappingValue value) {
+    private Object processRoleMappingMessage(RoleMappingKey key, RoleMappingValue value) {
         switch (value.getAction()) {
             case CREATE:
                 sqlStore.createRoleMapping(key.getPrincipalId(), value.getRole(), value.getPrincipalName());
@@ -484,7 +520,7 @@ public class KafkaSqlSink {
      * @param key
      * @param value
      */
-    private Object processGlobalId(GlobalIdKey key, GlobalIdValue value) {
+    private Object processGlobalIdMessage(GlobalIdKey key, GlobalIdValue value) {
         switch (value.getAction()) {
             case CREATE:
                 return sqlStore.nextGlobalId();
@@ -503,7 +539,7 @@ public class KafkaSqlSink {
      * @param key
      * @param value
      */
-    private Object processContentId(ContentIdKey key, ContentIdValue value) {
+    private Object processContentIdMessage(ContentIdKey key, ContentIdValue value) {
         switch (value.getAction()) {
             case CREATE:
                 return sqlStore.nextContentId();
@@ -522,7 +558,7 @@ public class KafkaSqlSink {
      * @param key
      * @param value
      */
-    private Object processCommentId(CommentIdKey key, CommentIdValue value) {
+    private Object processCommentIdMessage(CommentIdKey key, CommentIdValue value) {
         switch (value.getAction()) {
             case CREATE:
                 return sqlStore.nextCommentId();
@@ -548,7 +584,7 @@ public class KafkaSqlSink {
      * @param key
      * @param value
      */
-    private Object processComment(CommentKey key, CommentValue value) {
+    private Object processCommentMessage(CommentKey key, CommentValue value) {
         switch (value.getAction()) {
             case CREATE:
                 return sqlStore.createArtifactVersionCommentRaw(key.getGroupId(), key.getArtifactId(), key.getVersion(),
@@ -575,7 +611,7 @@ public class KafkaSqlSink {
     }
 
 
-    private Object processArtifactBranch(ArtifactBranchKey key, ArtifactBranchValue value) {
+    private Object processArtifactBranchMessage(ArtifactBranchKey key, ArtifactBranchValue value) {
         switch (value.getAction()) {
             case CREATE_OR_UPDATE:
                 sqlStore.createOrUpdateArtifactBranch(new GAV(key.getGroupId(), key.getArtifactId(), value.getVersion()), new BranchId(key.getBranchId()));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactRulesValue.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactRulesValue.java
@@ -23,7 +23,7 @@ public class ArtifactRulesValue extends AbstractMessageValue {
      */
     @Override
     public MessageType getType() {
-        return MessageType.ArtifactRule;
+        return MessageType.ArtifactRules;
     }
     
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactRulesValue.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/ArtifactRulesValue.java
@@ -1,0 +1,29 @@
+package io.apicurio.registry.storage.impl.kafkasql.values;
+
+import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.ToString;
+
+@RegisterForReflection
+@ToString
+public class ArtifactRulesValue extends AbstractMessageValue {
+
+    /**
+     * Creator method.
+     * @param action
+     */
+    public static final ArtifactRulesValue create(ActionType action) {
+        ArtifactRulesValue value = new ArtifactRulesValue();
+        value.setAction(action);
+        return value;
+    }
+    
+    /**
+     * @see MessageValue#getType()
+     */
+    @Override
+    public MessageType getType() {
+        return MessageType.ArtifactRule;
+    }
+    
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/GlobalRulesValue.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/GlobalRulesValue.java
@@ -1,0 +1,29 @@
+package io.apicurio.registry.storage.impl.kafkasql.values;
+
+import io.apicurio.registry.storage.impl.kafkasql.MessageType;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.ToString;
+
+@RegisterForReflection
+@ToString
+public class GlobalRulesValue extends AbstractMessageValue {
+
+    /**
+     * Creator method.
+     * @param action
+     */
+    public static final GlobalRulesValue create(ActionType action) {
+        GlobalRulesValue value = new GlobalRulesValue();
+        value.setAction(action);
+        return value;
+    }
+    
+    /**
+     * @see MessageValue#getType()
+     */
+    @Override
+    public MessageType getType() {
+        return MessageType.GlobalRules;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/MessageTypeToValueClass.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/MessageTypeToValueClass.java
@@ -66,6 +66,12 @@ public class MessageTypeToValueClass {
                 case ArtifactBranch:
                     index.put(type, ArtifactBranchValue.class);
                     break;
+                case ArtifactRules:
+                    index.put(type, ArtifactRulesValue.class);
+                    break;
+                case GlobalRules:
+                    index.put(type, GlobalRulesValue.class);
+                    break;
                 default:
                     throw new RuntimeAssertionFailedException("[MessageTypeToValueClass] Type not mapped: " + type);
             }

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
@@ -1,32 +1,33 @@
 package io.apicurio.tests.smokeTests.apicurio;
 
-import io.apicurio.registry.types.ArtifactType;
-import io.apicurio.tests.ApicurioRegistryBaseIT;
-import io.apicurio.tests.utils.Constants;
-import io.apicurio.registry.rest.client.models.ArtifactMetaData;
-import io.apicurio.registry.rest.client.models.Rule;
-import io.apicurio.registry.rest.client.models.RuleType;
-import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
-import io.apicurio.registry.rules.integrity.IntegrityLevel;
-import io.apicurio.registry.rules.validity.ValidityLevel;
-import io.apicurio.registry.utils.IoUtil;
-import io.apicurio.registry.utils.tests.TestUtils;
-import io.quarkus.test.junit.QuarkusIntegrationTest;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import io.apicurio.registry.rest.client.models.ArtifactMetaData;
+import io.apicurio.registry.rest.client.models.Rule;
+import io.apicurio.registry.rest.client.models.RuleType;
+import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
+import io.apicurio.registry.rules.integrity.IntegrityLevel;
+import io.apicurio.registry.rules.validity.ValidityLevel;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.utils.IoUtil;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.apicurio.tests.ApicurioRegistryBaseIT;
+import io.apicurio.tests.utils.Constants;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @Tag(Constants.SMOKE)
 @QuarkusIntegrationTest
@@ -36,34 +37,56 @@ class RulesResourceIT extends ApicurioRegistryBaseIT {
 
     @Test
     void createAndDeleteGlobalRules() throws Exception {
-        // Create a global rule
+        // Create a global rule (VALIDITY)
         Rule rule = new Rule();
         rule.setType(RuleType.VALIDITY);
-        rule.setConfig("SYNTAX_ONLY");
+        rule.setConfig(ValidityLevel.SYNTAX_ONLY.name());
+        registryClient.admin().rules().post(rule);
 
-        TestUtils.retry(() -> registryClient.admin().rules().post(rule));
+        // Create a global rule (INTEGRITY)
+        rule = new Rule();
+        rule.setType(RuleType.INTEGRITY);
+        rule.setConfig(IntegrityLevel.ALL_REFS_MAPPED.name());
+        registryClient.admin().rules().post(rule);
 
-        // Check the rule was created.
-        retryOp((rc) -> {
-            Rule ruleConfig = rc.admin().rules().byRule(RuleType.VALIDITY.name()).get();
-            assertNotNull(ruleConfig);
-            assertEquals("SYNTAX_ONLY", ruleConfig.getConfig());
-        });
+        // Create a global rule (COMPATIBILITY)
+        rule = new Rule();
+        rule.setType(RuleType.COMPATIBILITY);
+        rule.setConfig(CompatibilityLevel.FORWARD_TRANSITIVE.name());
+        registryClient.admin().rules().post(rule);
+
+        // Check the rules were created.
+        List<RuleType> rules = registryClient.admin().rules().get();
+        assertThat(rules.size(), is(3));
+        
+        // Check the rules were configured properly.
+        Rule ruleConfig = registryClient.admin().rules().byRule(RuleType.VALIDITY.name()).get();
+        assertNotNull(ruleConfig);
+        assertEquals(ValidityLevel.SYNTAX_ONLY.name(), ruleConfig.getConfig());
+        
+        ruleConfig = registryClient.admin().rules().byRule(RuleType.INTEGRITY.name()).get();
+        assertNotNull(ruleConfig);
+        assertEquals(IntegrityLevel.ALL_REFS_MAPPED.name(), ruleConfig.getConfig());
+
+        ruleConfig = registryClient.admin().rules().byRule(RuleType.COMPATIBILITY.name()).get();
+        assertNotNull(ruleConfig);
+        assertEquals(CompatibilityLevel.FORWARD_TRANSITIVE.name(), ruleConfig.getConfig());
 
         // Delete all rules
         registryClient.admin().rules().delete();
 
         // No rules listed now
-        retryOp((rc) -> {
-            List<RuleType> rules = rc.admin().rules().get();
-            assertEquals(0, rules.size());
-        });
+        rules = registryClient.admin().rules().get();
+        assertThat(rules.size(), is(0));
 
         // Should be null/error (never configured the COMPATIBILITY rule)
         retryAssertClientError("RuleNotFoundException", 404, (rc) -> rc.admin().rules().byRule(RuleType.COMPATIBILITY.name()).get(), errorCodeExtractor);
 
         // Should be null/error (deleted the VALIDITY rule)
-        retryAssertClientError("RuleNotFoundException", 404, (rc) -> rc.admin().rules().byRule(RuleType.COMPATIBILITY.name()).get(), errorCodeExtractor);
+        retryAssertClientError("RuleNotFoundException", 404, (rc) -> rc.admin().rules().byRule(RuleType.VALIDITY.name()).get(), errorCodeExtractor);
+
+        // Should be null/error (deleted the INTEGRITY rule)
+        retryAssertClientError("RuleNotFoundException", 404, (rc) -> rc.admin().rules().byRule(RuleType.INTEGRITY.name()).get(), errorCodeExtractor);
     }
 
     @Test


### PR DESCRIPTION
I'm opening this PR to add an integration test that should get run against both storages.  It should pass for sql but fail for kafkasql.

Once I confirm that the test fails for kafkasql I will try to fix the bug and update this PR.

The test failed, as expected.  I will now work on a fix for this problem in the kafkasql storage.