### PR TITLE
[Database] Switch to cascading deletes in the DB layer where possible + some cleanup

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
@@ -568,7 +568,7 @@ public interface RegistryStorage extends DynamicConfigStorage {
     void updateGroupMetaData(GroupMetaDataDto group) throws GroupNotFoundException, RegistryStorageException;
 
     /**
-     * Deletes a group intified by the given groupId and DELETES ALL resources related to this group
+     * Deletes a group identified by the given groupId and DELETES ALL resources related to this group
      *
      * @param groupId (optional)
      * @throws GroupNotFoundException

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -300,7 +300,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
         log.debug("---");
 
         statements.forEach(statement -> {
-            log.info(statement);
+            log.debug(statement);
             handle.createUpdate(statement).execute();
         });
         log.debug("---");
@@ -1055,7 +1055,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                                 + "v.groupId LIKE ? OR "
                                 + "a.artifactId LIKE ? OR "
                                 + "v.description LIKE ? OR "
-                                + "EXISTS(SELECT l.globalId FROM version_labels l WHERE l.pkey = ? AND l.globalId = v.globalId)");
+                                + "EXISTS(SELECT l.globalId FROM version_labels l WHERE l.labelKey = ? AND l.globalId = v.globalId)");
                         binders.add((query, idx) -> {
                             query.bind(idx, "%" + filter.getStringValue() + "%");
                         });
@@ -1104,13 +1104,13 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                         Pair<String, String> label = filter.getLabelFilterValue();
                         //    Note: convert search to lowercase when searching for labels (case-insensitivity support).
                         String labelKey = label.getKey().toLowerCase();
-                        where.append("EXISTS(SELECT l.globalId FROM version_labels l WHERE l.pkey = ?");
+                        where.append("EXISTS(SELECT l.globalId FROM version_labels l WHERE l.labelKey = ?");
                         binders.add((query, idx) -> {
                             query.bind(idx, labelKey);
                         });
                         if (label.getValue() != null) {
                             String labelValue = label.getValue().toLowerCase();
-                            where.append(" AND l.pvalue = ?");
+                            where.append(" AND l.labelValue = ?");
                             binders.add((query, idx) -> {
                                 query.bind(idx, labelValue);
                             });

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -2087,6 +2087,12 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                     .bind(0, normalizeGroupId(groupId))
                     .execute();
 
+            // Delete all artifacts in the group (TODO there is currently no FK from artifacts to groups)
+            handle.createUpdate(sqlStatements.deleteArtifactsByGroupId())
+                    .bind(0, normalizeGroupId(groupId))
+                    .execute();
+
+            // Now delete the group (labels and rules etc will cascade)
             int rows = handle.createUpdate(sqlStatements.deleteGroup())
                     .bind(0, groupId)
                     .execute();
@@ -2719,6 +2725,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     /**
      * IMPORTANT: Private methods can't be @Transactional. Callers MUST have started a transaction.
      */
+    // TODO call this in a cleanup cron job instead?
     private void deleteAllOrphanedContent() {
         log.debug("Deleting all orphaned content");
         handles.withHandleNoException(handle -> {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -56,7 +56,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String getDatabaseVersion() {
-        return "SELECT a.prop_value FROM apicurio a WHERE a.prop_name = ?";
+        return "SELECT a.propValue FROM apicurio a WHERE a.propName = ?";
     }
 
     /**
@@ -411,7 +411,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String insertVersionLabel() {
-        return "INSERT INTO version_labels (globalId, pkey, pvalue) VALUES (?, ?, ?)";
+        return "INSERT INTO version_labels (globalId, labelKey, labelValue) VALUES (?, ?, ?)";
     }
 
     /**
@@ -419,7 +419,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String insertArtifactLabel() {
-        return "INSERT INTO artifact_labels (globalId, pkey, pvalue) VALUES (?, ?, ?)";
+        return "INSERT INTO artifact_labels (globalId, labelKey, labelValue) VALUES (?, ?, ?)";
     }
     
     /**
@@ -427,7 +427,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String insertGroupLabel() {
-        return "INSERT INTO group_labels (globalId, pkey, pvalue) VALUES (?, ?, ?)";
+        return "INSERT INTO group_labels (globalId, labelKey, labelValue) VALUES (?, ?, ?)";
     }
 
     /**
@@ -847,7 +847,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String selectConfigPropertyByName() {
-        return "SELECT c.* FROM config c WHERE c.pname = ?";
+        return "SELECT c.* FROM config c WHERE c.propName = ?";
     }
 
     /**
@@ -855,7 +855,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String deleteConfigProperty() {
-        return "DELETE FROM config WHERE pname = ?";
+        return "DELETE FROM config WHERE propName = ?";
     }
 
     /**
@@ -863,7 +863,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String insertConfigProperty() {
-        return "INSERT INTO config (pname, pvalue, modifiedOn) VALUES (?, ?, ?)";
+        return "INSERT INTO config (propName, propValue, modifiedOn) VALUES (?, ?, ?)";
     }
 
     /**
@@ -909,12 +909,12 @@ public abstract class CommonSqlStatements implements SqlStatements {
 
     @Override
     public String insertSequenceValue() {
-        return "INSERT INTO sequences (seq_name, seq_value) VALUES (?, ?)";
+        return "INSERT INTO sequences (seqName, seqValue) VALUES (?, ?)";
     }
 
     @Override
     public String selectCurrentSequenceValue() {
-        return "SELECT seq_value FROM sequences WHERE seq_name = ? ";
+        return "SELECT seqValue FROM sequences WHERE seqName = ? ";
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -64,7 +64,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String insertGlobalRule() {
-        return "INSERT INTO globalrules (type, configuration) VALUES (?, ?)";
+        return "INSERT INTO global_rules (type, configuration) VALUES (?, ?)";
     }
 
     /**
@@ -72,7 +72,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String selectGlobalRules() {
-        return "SELECT r.type FROM globalrules r ";
+        return "SELECT r.type FROM global_rules r ";
     }
 
     /**
@@ -80,7 +80,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String selectGlobalRuleByType() {
-        return "SELECT r.* FROM globalrules r WHERE r.type = ?";
+        return "SELECT r.* FROM global_rules r WHERE r.type = ?";
     }
 
     /**
@@ -88,7 +88,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String deleteGlobalRule() {
-        return "DELETE FROM globalrules WHERE type = ?";
+        return "DELETE FROM global_rules WHERE type = ?";
     }
 
     /**
@@ -96,7 +96,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String deleteGlobalRules() {
-        return "DELETE FROM globalrules";
+        return "DELETE FROM global_rules";
     }
 
     /**
@@ -104,7 +104,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String updateGlobalRule() {
-        return "UPDATE globalrules SET configuration = ? WHERE type = ?";
+        return "UPDATE global_rules SET configuration = ? WHERE type = ?";
     }
 
     /**
@@ -160,14 +160,6 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     /**
-     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#selectArtifactVersions()
-     */
-    @Override
-    public String selectArtifactVersionsSkipDisabled() {
-        return "SELECT version FROM versions WHERE groupId = ? AND artifactId = ? AND state != 'DISABLED'";
-    }
-
-    /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#selectArtifactVersionMetaData()
      */
     @Override
@@ -212,7 +204,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String selectArtifactVersionContentByGlobalId() {
-        return "SELECT v.globalId, v.version, v.versionOrder, v.contentId, c.content, c.artifactreferences FROM versions v "
+        return "SELECT v.globalId, v.version, v.versionOrder, v.contentId, c.content, c.refs FROM versions v "
                 + "JOIN content c ON v.contentId = c.contentId "
                 + "WHERE v.globalId = ?";
     }
@@ -222,7 +214,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String selectArtifactVersionContent() {
-        return "SELECT v.globalId, v.version, v.versionOrder, c.contentId, c.content, c.artifactreferences FROM versions v "
+        return "SELECT v.globalId, v.version, v.versionOrder, c.contentId, c.content, c.refs FROM versions v "
                 + "JOIN content c ON v.contentId = c.contentId "
                 + "WHERE v.groupId = ? AND v.artifactId = ? AND v.version = ?";
     }
@@ -258,7 +250,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String selectArtifactRules() {
-        return "SELECT r.* FROM rules r WHERE r.groupId = ? AND r.artifactId = ?";
+        return "SELECT r.* FROM artifact_rules r WHERE r.groupId = ? AND r.artifactId = ?";
     }
 
     /**
@@ -266,7 +258,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String insertArtifactRule() {
-        return "INSERT INTO rules (groupId, artifactId, type, configuration) VALUES (?, ?, ?, ?)";
+        return "INSERT INTO artifact_rules (groupId, artifactId, type, configuration) VALUES (?, ?, ?, ?)";
     }
 
     /**
@@ -274,7 +266,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String selectArtifactRuleByType() {
-        return "SELECT r.* FROM rules r WHERE r.groupId = ? AND r.artifactId = ? AND r.type = ?";
+        return "SELECT r.* FROM artifact_rules r WHERE r.groupId = ? AND r.artifactId = ? AND r.type = ?";
     }
 
     /**
@@ -282,7 +274,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String updateArtifactRule() {
-        return "UPDATE rules SET configuration = ? WHERE groupId = ? AND artifactId = ? AND type = ?";
+        return "UPDATE artifact_rules SET configuration = ? WHERE groupId = ? AND artifactId = ? AND type = ?";
     }
 
     @Override
@@ -295,7 +287,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String deleteArtifactRule() {
-        return "DELETE FROM rules WHERE groupId = ? AND artifactId = ? AND type = ?";
+        return "DELETE FROM artifact_rules WHERE groupId = ? AND artifactId = ? AND type = ?";
     }
 
     /**
@@ -303,7 +295,15 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String deleteArtifactRules() {
-        return "DELETE FROM rules WHERE groupId = ? AND artifactId = ?";
+        return "DELETE FROM artifact_rules WHERE groupId = ? AND artifactId = ?";
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#deleteArtifactRulesByGroupId()
+     */
+    @Override
+    public String deleteArtifactRulesByGroupId() {
+        return "DELETE FROM artifact_rules WHERE groupId = ?";
     }
 
     /**
@@ -311,12 +311,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String deleteAllArtifactRules() {
-        return "DELETE FROM rules";
-    }
-
-    @Override
-    public String deleteArtifactRulesByGroupId() {
-        return "DELETE FROM rules WHERE groupId = ?";
+        return "DELETE FROM artifact_rules";
     }
 
     /**
@@ -328,14 +323,6 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     /**
-     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#deleteVersionLabelsByGA()
-     */
-    @Override
-    public String deleteVersionLabelsByGA() {
-        return "DELETE FROM version_labels WHERE globalId IN (SELECT globalId FROM versions WHERE groupId = ? AND artifactId = ?)";
-    }
-
-    /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#deleteVersionLabelsByGlobalId()
      */
     @Override
@@ -344,28 +331,13 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     @Override
-    public String deleteVersionLabelsByGroupId() {
-        return "DELETE FROM version_labels WHERE globalId IN (SELECT globalId FROM versions WHERE groupId = ?)";
-    }
-
-    @Override
     public String deleteVersionLabelsByAll() {
         return "DELETE FROM version_labels WHERE globalId IN (SELECT globalId FROM versions)";
     }
 
     @Override
-    public String deleteAllComments() {
-        return "DELETE FROM comments WHERE globalId IN (SELECT globalId FROM versions)";
-    }
-
-    @Override
-    public String deleteVersions() {
-        return "DELETE FROM versions WHERE groupId = ? AND artifactId = ?";
-    }
-
-    @Override
-    public String deleteVersionsByGroupId() {
-        return "DELETE FROM versions WHERE groupId = ?";
+    public String deleteAllVersionComments() {
+        return "DELETE FROM version_comments WHERE globalId IN (SELECT globalId FROM versions)";
     }
 
     @Override
@@ -397,11 +369,6 @@ public abstract class CommonSqlStatements implements SqlStatements {
     @Override
     public String selectArtifactIds() {
         return "SELECT artifactId FROM artifacts LIMIT ?";
-    }
-
-    @Override
-    public String selectArtifactIdsInGroup() {
-        return "SELECT artifactId FROM artifacts WHERE groupId = ? LIMIT ?";
     }
 
     /**
@@ -437,14 +404,6 @@ public abstract class CommonSqlStatements implements SqlStatements {
     @Override
     public String deleteVersionLabelsByGAV() {
         return "DELETE FROM version_labels WHERE globalId IN (SELECT v.globalId FROM versions v WHERE v.groupId = ? AND v.artifactId = ? AND v.version = ?)";
-    }
-
-    /**
-     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#deleteVersionComments()
-     */
-    @Override
-    public String deleteVersionComments() {
-        return "DELETE FROM comments WHERE globalId IN (SELECT v.globalId FROM versions v WHERE v.groupId = ? AND v.artifactId = ? AND v.version = ?)";
     }
 
     /**
@@ -530,7 +489,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String selectArtifactRuleCountByType() {
-        return "SELECT COUNT(r.type) FROM rules r WHERE r.groupId = ? AND r.artifactId = ? AND r.type = ?";
+        return "SELECT COUNT(r.type) FROM artifact_rules r WHERE r.groupId = ? AND r.artifactId = ? AND r.type = ?";
     }
 
     /**
@@ -538,7 +497,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String selectGlobalRuleCountByType() {
-        return "SELECT COUNT(r.type) FROM globalrules r WHERE r.type = ?";
+        return "SELECT COUNT(r.type) FROM global_rules r WHERE r.type = ?";
     }
 
     /**
@@ -554,7 +513,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String selectContentById() {
-        return "SELECT c.content, c.artifactreferences FROM content c "
+        return "SELECT c.content, c.refs FROM content c "
                 + "WHERE c.contentId = ?";
     }
 
@@ -563,7 +522,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String selectContentByContentHash() {
-        return "SELECT c.content, c.artifactreferences FROM content c "
+        return "SELECT c.content, c.refs FROM content c "
                 + "WHERE c.contentHash = ?";
     }
 
@@ -645,7 +604,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String exportArtifactRules() {
-        return "SELECT * FROM rules r";
+        return "SELECT * FROM artifact_rules r";
     }
 
     /**
@@ -659,11 +618,11 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     /**
-     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#exportComments()
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#exportVersionComments()
      */
     @Override
-    public String exportComments() {
-        return "SELECT * FROM comments c ";
+    public String exportVersionComments() {
+        return "SELECT * FROM version_comments c ";
     }
 
     /**
@@ -671,7 +630,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String exportContent() {
-        return "SELECT c.contentId, c.canonicalHash, c.contentHash, c.content, c.artifactreferences FROM content c ";
+        return "SELECT c.contentId, c.canonicalHash, c.contentHash, c.content, c.refs FROM content c ";
     }
 
     /**
@@ -679,7 +638,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String exportGlobalRules() {
-        return "SELECT * FROM globalrules r ";
+        return "SELECT * FROM global_rules r ";
     }
 
     /**
@@ -702,7 +661,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String importArtifactRule() {
-        return "INSERT INTO rules (groupId, artifactId, type, configuration) VALUES (?, ?, ?, ?)";
+        return "INSERT INTO artifact_rules (groupId, artifactId, type, configuration) VALUES (?, ?, ?, ?)";
     }
 
     /**
@@ -719,7 +678,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String importContent() {
-        return "INSERT INTO content (contentId, canonicalHash, contentHash, content, artifactreferences) VALUES (?, ?, ?, ?, ?)";
+        return "INSERT INTO content (contentId, canonicalHash, contentHash, content, refs) VALUES (?, ?, ?, ?, ?)";
     }
 
     /**
@@ -727,7 +686,7 @@ public abstract class CommonSqlStatements implements SqlStatements {
      */
     @Override
     public String importGlobalRule() {
-        return "INSERT INTO globalrules (type, configuration) VALUES (?, ?)";
+        return "INSERT INTO global_rules (type, configuration) VALUES (?, ?)";
     }
 
     /**
@@ -756,11 +715,11 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     /**
-     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#selectMaxCommentId()
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#selectMaxVersionCommentId()
      */
     @Override
-    public String selectMaxCommentId() {
-        return "SELECT MAX(commentId) FROM comments ";
+    public String selectMaxVersionCommentId() {
+        return "SELECT MAX(commentId) FROM version_comments ";
     }
 
     /**
@@ -924,60 +883,60 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     @Override
-    public String deleteAllReferences() {
-        return "DELETE FROM artifactreferences ";
+    public String deleteAllContentReferences() {
+        return "DELETE FROM content_references ";
     }
 
     @Override
-    public String deleteOrphanedReferences() {
-        return "DELETE FROM artifactreferences WHERE NOT EXISTS (SELECT 1 FROM versions v WHERE v.contentId = contentId)";
+    public String deleteOrphanedContentReferences() {
+        return "DELETE FROM content_references WHERE NOT EXISTS (SELECT 1 FROM versions v WHERE v.contentId = contentId)";
     }
 
     @Override
     public String selectContentIdsReferencingArtifactBy() {
-        return "SELECT contentId FROM artifactreferences WHERE groupId=? AND artifactId=? AND version=?";
+        return "SELECT contentId FROM content_references WHERE groupId=? AND artifactId=? AND version=?";
     }
 
     @Override
     public String selectGlobalIdsReferencingArtifactBy() {
-        return "SELECT DISTINCT v.globalId FROM versions v JOIN artifactreferences ar ON v.contentId=ar.contentId WHERE ar.groupId=? AND ar.artifactId=? AND ar.version=?";
+        return "SELECT DISTINCT v.globalId FROM versions v JOIN content_references ar ON v.contentId=ar.contentId WHERE ar.groupId=? AND ar.artifactId=? AND ar.version=?";
     }
 
     @Override
-    public String selectInboundReferencesByGAV() {
-        return "SELECT DISTINCT v.groupId, v.artifactId, v.version, ar.name as name FROM versions v JOIN artifactreferences ar ON v.contentId=ar.contentId WHERE ar.groupId=? AND ar.artifactId=? AND ar.version=?";
+    public String selectInboundContentReferencesByGAV() {
+        return "SELECT DISTINCT v.groupId, v.artifactId, v.version, ar.name as name FROM versions v JOIN content_references ar ON v.contentId=ar.contentId WHERE ar.groupId=? AND ar.artifactId=? AND ar.version=?";
     }
 
     @Override
     public String insertSequenceValue() {
-        return "INSERT INTO sequences (name, value) VALUES (?, ?)";
+        return "INSERT INTO sequences (seq_name, seq_value) VALUES (?, ?)";
     }
 
     @Override
     public String selectCurrentSequenceValue() {
-        return "SELECT value FROM sequences WHERE name = ? ";
+        return "SELECT seq_value FROM sequences WHERE seq_name = ? ";
     }
 
     @Override
-    public String insertComment() {
-        return "INSERT INTO comments (commentId, globalId, createdBy, createdOn, cvalue) VALUES (?, ?, ?, ?, ?)";
+    public String insertVersionComment() {
+        return "INSERT INTO version_comments (commentId, globalId, createdBy, createdOn, cvalue) VALUES (?, ?, ?, ?, ?)";
     }
 
     @Override
-    public String selectComments() {
+    public String selectVersionComments() {
         return "SELECT c.* "
-                + "FROM comments c JOIN versions v ON v.globalId = c.globalId "
+                + "FROM version_comments c JOIN versions v ON v.globalId = c.globalId "
                 + "WHERE v.groupId = ? AND v.artifactId = ? AND v.version = ? ORDER BY c.createdOn DESC";
     }
 
     @Override
-    public String deleteComment() {
-        return "DELETE FROM comments WHERE globalId = ? AND commentId = ? AND createdBy = ?";
+    public String deleteVersionComment() {
+        return "DELETE FROM version_comments WHERE globalId = ? AND commentId = ? AND createdBy = ?";
     }
 
     @Override
-    public String updateComment() {
-        return "UPDATE comments SET cvalue = ? WHERE globalId = ? AND commentId = ? AND createdBy = ?";
+    public String updateVersionComment() {
+        return "UPDATE version_comments SET cvalue = ? WHERE globalId = ? AND commentId = ? AND createdBy = ?";
     }
 
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/H2SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/H2SqlStatements.java
@@ -49,7 +49,7 @@ public class H2SqlStatements extends CommonSqlStatements {
      */
     @Override
     public String upsertContent() {
-        return "INSERT INTO content (contentId, canonicalHash, contentHash, content, artifactreferences) VALUES (?, ?, ?, ?, ?)";
+        return "INSERT INTO content (contentId, canonicalHash, contentHash, content, refs) VALUES (?, ?, ?, ?, ?)";
     }
 
     /**
@@ -61,34 +61,18 @@ public class H2SqlStatements extends CommonSqlStatements {
     }
 
     /**
-     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#selectCurrentSequenceValue()
-     */
-    @Override
-    public String selectCurrentSequenceValue() {
-        return "SELECT seq_value FROM sequences WHERE name = ? ";
-    }
-
-    /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#resetSequenceValue()
      */
     @Override
     public String resetSequenceValue() {
-        return "MERGE INTO sequences (name, seq_value) KEY (name) VALUES(?, ?)";
+        return "MERGE INTO sequences (seq_name, seq_value) KEY (seq_name) VALUES(?, ?)";
     }
 
     /**
-     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#insertSequenceValue()
+     * @see SqlStatements#upsertContentReference()
      */
     @Override
-    public String insertSequenceValue() {
-        return "INSERT INTO sequences (name, seq_value) VALUES (?, ?)";
-    }
-
-    /**
-     * @see SqlStatements#upsertReference()
-     */
-    @Override
-    public String upsertReference() {
-        return "INSERT INTO artifactreferences (contentId, groupId, artifactId, version, name) VALUES (?, ?, ?, ?, ?)";
+    public String upsertContentReference() {
+        return "INSERT INTO content_references (contentId, groupId, artifactId, version, name) VALUES (?, ?, ?, ?, ?)";
     }
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/H2SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/H2SqlStatements.java
@@ -65,7 +65,7 @@ public class H2SqlStatements extends CommonSqlStatements {
      */
     @Override
     public String resetSequenceValue() {
-        return "MERGE INTO sequences (seq_name, seq_value) KEY (seq_name) VALUES(?, ?)";
+        return "MERGE INTO sequences (seqName, seqValue) KEY (seqName) VALUES(?, ?)";
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
@@ -49,7 +49,7 @@ public class PostgreSQLSqlStatements extends CommonSqlStatements {
      */
     @Override
     public String upsertContent() {
-        return "INSERT INTO content (contentId, canonicalHash, contentHash, content, artifactreferences) VALUES (?, ?, ?, ?, ?) ON CONFLICT (contentHash) DO NOTHING";
+        return "INSERT INTO content (contentId, canonicalHash, contentHash, content, refs) VALUES (?, ?, ?, ?, ?) ON CONFLICT (contentHash) DO NOTHING";
     }
 
     /**
@@ -57,7 +57,7 @@ public class PostgreSQLSqlStatements extends CommonSqlStatements {
      */
     @Override
     public String getNextSequenceValue() {
-        return "INSERT INTO sequences (name, value) VALUES (?, 1) ON CONFLICT (name) DO UPDATE SET value = sequences.value + 1 RETURNING value";
+        return "INSERT INTO sequences (seq_name, seq_value) VALUES (?, 1) ON CONFLICT (seq_name) DO UPDATE SET seq_value = sequences.seq_value + 1 RETURNING seq_value";
     }
 
     /**
@@ -65,14 +65,14 @@ public class PostgreSQLSqlStatements extends CommonSqlStatements {
      */
     @Override
     public String resetSequenceValue() {
-        return "INSERT INTO sequences (name, value) VALUES (?, ?) ON CONFLICT (name) DO UPDATE SET value = ?";
+        return "INSERT INTO sequences (seq_name, seq_value) VALUES (?, ?) ON CONFLICT (seq_name) DO UPDATE SET seq_value = ?";
     }
 
     /**
-     * @see SqlStatements#upsertReference()
+     * @see SqlStatements#upsertContentReference()
      */
     @Override
-    public String upsertReference() {
-        return "INSERT INTO artifactreferences (contentId, groupId, artifactId, version, name) VALUES (?, ?, ?, ?, ?) ON CONFLICT (contentId, name) DO NOTHING";
+    public String upsertContentReference() {
+        return "INSERT INTO content_references (contentId, groupId, artifactId, version, name) VALUES (?, ?, ?, ?, ?) ON CONFLICT (contentId, name) DO NOTHING";
     }
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
@@ -57,7 +57,7 @@ public class PostgreSQLSqlStatements extends CommonSqlStatements {
      */
     @Override
     public String getNextSequenceValue() {
-        return "INSERT INTO sequences (seq_name, seq_value) VALUES (?, 1) ON CONFLICT (seq_name) DO UPDATE SET seq_value = sequences.seq_value + 1 RETURNING seq_value";
+        return "INSERT INTO sequences (seqName, seqValue) VALUES (?, 1) ON CONFLICT (seqName) DO UPDATE SET seqValue = sequences.seqValue + 1 RETURNING seqValue";
     }
 
     /**
@@ -65,7 +65,7 @@ public class PostgreSQLSqlStatements extends CommonSqlStatements {
      */
     @Override
     public String resetSequenceValue() {
-        return "INSERT INTO sequences (seq_name, seq_value) VALUES (?, ?) ON CONFLICT (seq_name) DO UPDATE SET seq_value = ?";
+        return "INSERT INTO sequences (seqName, seqValue) VALUES (?, ?) ON CONFLICT (seqName) DO UPDATE SET seqValue = ?";
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SQLServerSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SQLServerSqlStatements.java
@@ -52,11 +52,11 @@ public class SQLServerSqlStatements extends CommonSqlStatements {
     public String upsertContent() {
         return String.join(" ",
                 "MERGE INTO content AS target",
-                "USING (VALUES (?, ?, ?, ?, ?)) AS source (contentId, canonicalHash, contentHash, content, artifactreferences)",
+                "USING (VALUES (?, ?, ?, ?, ?)) AS source (contentId, canonicalHash, contentHash, content, refs)",
                 "ON (target.contentHash = source.contentHash)",
                 "WHEN NOT MATCHED THEN",
-                    "INSERT (contentId, canonicalHash, contentHash, content, artifactreferences)",
-                    "VALUES (source.contentId, source.canonicalHash, source.contentHash, source.content, source.artifactreferences);");
+                    "INSERT (contentId, canonicalHash, contentHash, content, refs)",
+                    "VALUES (source.contentId, source.canonicalHash, source.contentHash, source.content, source.refs);");
     }
 
     /**
@@ -66,14 +66,14 @@ public class SQLServerSqlStatements extends CommonSqlStatements {
     public String getNextSequenceValue() {
         return String.join(" ",
                 "MERGE INTO sequences AS target",
-                "USING (VALUES  (?)) AS source (name)",
-                "ON (target.name = source.name)",
+                "USING (VALUES  (?)) AS source (seq_name)",
+                "ON (target.seq_name = source.seq_name)",
                 "WHEN MATCHED THEN",
-                    "UPDATE SET value = target.value + 1",
+                    "UPDATE SET seq_value = target.seq_value + 1",
                 "WHEN NOT MATCHED THEN",
-                    "INSERT (name, value)",
-                    "VALUES (source.name, 1)",
-                "OUTPUT INSERTED.value;");
+                    "INSERT (seq_name, seq_value)",
+                    "VALUES (source.seq_name, 1)",
+                "OUTPUT INSERTED.seq_value;");
     }
 
     /**
@@ -83,23 +83,23 @@ public class SQLServerSqlStatements extends CommonSqlStatements {
     public String resetSequenceValue() {
         return String.join(" ",
                 "MERGE INTO sequences AS target",
-                "USING (VALUES (?, ?)) AS source (name, value)",
-                "ON (target.name = source.name)",
+                "USING (VALUES (?, ?)) AS source (seq_name, seq_value)",
+                "ON (target.seq_name = source.seq_name)",
                 "WHEN MATCHED THEN",
-                    "UPDATE SET value = ?",
+                    "UPDATE SET seq_value = ?",
                 "WHEN NOT MATCHED THEN",
-                    "INSERT (name, value)",
-                    "VALUES (source.name, source.value)",
-                "OUTPUT INSERTED.value;");
+                    "INSERT (seq_name, seq_value)",
+                    "VALUES (source.seq_name, source.seq_value)",
+                "OUTPUT INSERTED.seq_value;");
     }
 
     /**
-     * @see SqlStatements#upsertReference()
+     * @see SqlStatements#upsertContentReference()
      */
     @Override
-    public String upsertReference() {
+    public String upsertContentReference() {
         return String.join(" ",
-                "MERGE INTO artifactreferences AS target",
+                "MERGE INTO content_references AS target",
                 "USING (VALUES (?, ?, ?, ?, ?)) AS source (contentId, groupId, artifactId, version, name)",
                 "ON (target.contentId = source.contentId AND target.name = source.name)",
                 "WHEN NOT MATCHED THEN",
@@ -113,11 +113,6 @@ public class SQLServerSqlStatements extends CommonSqlStatements {
     @Override
     public String selectArtifactIds() {
         return "SELECT TOP (?) artifactId FROM artifacts ";
-    }
-
-    @Override
-    public String selectArtifactIdsInGroup() {
-        return "SELECT TOP (?) artifactId FROM artifacts WHERE groupId = ?";
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SQLServerSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SQLServerSqlStatements.java
@@ -66,14 +66,14 @@ public class SQLServerSqlStatements extends CommonSqlStatements {
     public String getNextSequenceValue() {
         return String.join(" ",
                 "MERGE INTO sequences AS target",
-                "USING (VALUES  (?)) AS source (seq_name)",
-                "ON (target.seq_name = source.seq_name)",
+                "USING (VALUES  (?)) AS source (seqName)",
+                "ON (target.seqName = source.seqName)",
                 "WHEN MATCHED THEN",
-                    "UPDATE SET seq_value = target.seq_value + 1",
+                    "UPDATE SET seqValue = target.seqValue + 1",
                 "WHEN NOT MATCHED THEN",
-                    "INSERT (seq_name, seq_value)",
-                    "VALUES (source.seq_name, 1)",
-                "OUTPUT INSERTED.seq_value;");
+                    "INSERT (seqName, seqValue)",
+                    "VALUES (source.seqName, 1)",
+                "OUTPUT INSERTED.seqValue;");
     }
 
     /**
@@ -83,14 +83,14 @@ public class SQLServerSqlStatements extends CommonSqlStatements {
     public String resetSequenceValue() {
         return String.join(" ",
                 "MERGE INTO sequences AS target",
-                "USING (VALUES (?, ?)) AS source (seq_name, seq_value)",
-                "ON (target.seq_name = source.seq_name)",
+                "USING (VALUES (?, ?)) AS source (seqName, seqValue)",
+                "ON (target.seqName = source.seqName)",
                 "WHEN MATCHED THEN",
-                    "UPDATE SET seq_value = ?",
+                    "UPDATE SET seqValue = ?",
                 "WHEN NOT MATCHED THEN",
-                    "INSERT (seq_name, seq_value)",
-                    "VALUES (source.seq_name, source.seq_value)",
-                "OUTPUT INSERTED.seq_value;");
+                    "INSERT (seqName, seqValue)",
+                    "VALUES (source.seqName, source.seqValue)",
+                "OUTPUT INSERTED.seqValue;");
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -86,7 +86,6 @@ public interface SqlStatements {
      */
     public String insertArtifact();
 
-
     /**
      * A statement used to update the 'version' column of the 'versions' table by globalId.  The value of the "versionOrder"
      * column is copied into the "version" column.
@@ -127,11 +126,6 @@ public interface SqlStatements {
      * A statement used to select all version #s for a given artifactId.
      */
     public String selectArtifactVersions();
-
-    /**
-     * A statement used to select all version #s for a given artifactId.
-     */
-    public String selectArtifactVersionsSkipDisabled();
 
     /**
      * A statement used to select all versions for a given artifactId.
@@ -182,7 +176,7 @@ public interface SqlStatements {
     /**
      * A statement to get a single artifact (latest version) meta-data by artifactId.
      */
-    String selectArtifactMetaData();
+    public String selectArtifactMetaData();
 
 
     /**
@@ -228,12 +222,7 @@ public interface SqlStatements {
     /**
      * A statement to delete all rules for a all artifacts.
      */
-    String deleteAllArtifactRules();
-
-    /**
-     * A statement to delete all rules for all artifacts in a groupId.
-     */
-    public String deleteArtifactRulesByGroupId();
+    public String deleteAllArtifactRules();
 
     /**
      * A statement to update the meta-data of a specific artifact version.
@@ -246,19 +235,9 @@ public interface SqlStatements {
     public String deleteVersionLabelsByGAV();
 
     /**
-     * A statement to delete all labels for all versions for a single artifact.
-     */
-    public String deleteVersionLabelsByGA();
-
-    /**
      * A statement to delete all labels for a single artifact version by globalId
      */
     public String deleteVersionLabelsByGlobalId();
-
-    /**
-     * A statement to delete all labels for all versions for all artifacts in a groupId.
-     */
-    public String deleteVersionLabelsByGroupId();
 
     /**
      * A statement to delete all labels for all versions for all artifacts
@@ -268,22 +247,12 @@ public interface SqlStatements {
     /**
      * A statement to delete all comments for all versions for all artifacts
      */
-    public String deleteAllComments();
-
-    /**
-     * A statement to delete all versions for a single artifact.
-     */
-    public String deleteVersions();
-
-    /**
-     * A statement to delete all versions for all artifacts in a groupId.
-     */
-    public String deleteVersionsByGroupId();
+    public String deleteAllVersionComments();
 
     /**
      * A statement to delete all versions for all artifacts.
      */
-    String deleteAllVersions();
+    public String deleteAllVersions();
 
     /**
      * A statement to delete a single row from the artifacts table by artifactId.
@@ -296,16 +265,19 @@ public interface SqlStatements {
     public String deleteArtifactsByGroupId();
 
     /**
+     * A statement to delete a all artifact rules by groupId.
+     */
+    public String deleteArtifactRulesByGroupId();
+
+    /**
      * A statement to delete a all artifacts.
      */
-    String deleteAllArtifacts();
+    public String deleteAllArtifacts();
 
     /**
      * A statement to get all artifacts IDs.
      */
     public String selectArtifactIds();
-
-    String selectArtifactIdsInGroup();
 
     /**
      * A statement to get an artifact's meta-data by version globalId.
@@ -316,10 +288,6 @@ public interface SqlStatements {
      * A statement to update the state of an artifact version (by globalId);
      */
     public String updateArtifactVersionState();
-    /**
-     * A statement to delete the comments for a single artifact version.
-     */
-    public String deleteVersionComments();
 
     /**
      * A statement to delete a single artifact version.
@@ -344,7 +312,7 @@ public interface SqlStatements {
     /**
      * A statement to insert a row in the "references" table.
      */
-    public String upsertReference();
+    public String upsertContentReference();
 
     /**
      * A statement to select ids of content referencing artifact
@@ -359,7 +327,7 @@ public interface SqlStatements {
     /**
      * A statement to select GAV info of artifact versions with content referencing an artifact
      */
-    public String selectInboundReferencesByGAV();
+    public String selectInboundContentReferencesByGAV();
 
     /**
      * A statement to select the number of artifacts with a given artifactId (should be 0 or 1).
@@ -460,11 +428,11 @@ public interface SqlStatements {
 
     public String exportArtifactRules();
 
-    public String exportComments();
+    public String exportVersionComments();
 
     public String exportArtifactVersions();
 
-    String exportArtifactBranches();
+    public String exportArtifactBranches();
 
     /*
      * The next few statements support importing data into the DB.
@@ -480,13 +448,13 @@ public interface SqlStatements {
 
     public String importArtifactVersion();
 
-    String importArtifactBranch();
+    public String importArtifactBranch();
 
     public String selectMaxContentId();
 
     public String selectMaxGlobalId();
 
-    public String selectMaxCommentId();
+    public String selectMaxVersionCommentId();
 
     public String selectContentExists();
 
@@ -501,7 +469,7 @@ public interface SqlStatements {
 
     public String deleteRoleMapping();
 
-    String deleteAllRoleMappings();
+    public String deleteAllRoleMappings();
 
     public String selectRoleMappingByPrincipalId();
 
@@ -543,49 +511,49 @@ public interface SqlStatements {
 
     public String selectStaleConfigProperties();
 
-    public String deleteAllReferences();
+    public String deleteAllContentReferences();
 
-    public String deleteOrphanedReferences();
+    public String deleteOrphanedContentReferences();
 
     /*
      * The next statements relate to comments.
      */
 
-    String insertComment();
+    public String insertVersionComment();
 
-    String selectComments();
+    public String selectVersionComments();
 
-    String deleteComment();
+    public String deleteVersionComment();
 
-    String updateComment();
+    public String updateVersionComment();
 
 
     // ========== Branches ==========
 
 
-    String selectGAVByGlobalId();
+    public String selectGAVByGlobalId();
 
-    String selectArtifactBranches();
+    public String selectArtifactBranches();
 
-    String selectArtifactBranchOrdered();
+    public String selectArtifactBranchOrdered();
 
-    String selectArtifactBranchOrderedNotDisabled();
+    public String selectArtifactBranchOrderedNotDisabled();
 
-    String insertArtifactBranch();
+    public String insertArtifactBranch();
 
-    String selectArtifactBranchTip();
+    public String selectArtifactBranchTip();
 
-    String selectArtifactBranchTipNotDisabled();
+    public String selectArtifactBranchTipNotDisabled();
 
-    String deleteArtifactBranch();
+    public String deleteArtifactBranch();
 
-    String deleteVersionInArtifactBranches();
+    public String deleteVersionInArtifactBranches();
 
-    String deleteAllArtifactBranchesInArtifact();
+    public String deleteAllArtifactBranchesInArtifact();
 
-    String deleteAllArtifactBranchesInGroup();
+    public String deleteAllArtifactBranchesInGroup();
 
-    String deleteAllArtifactBranches();
+    public String deleteAllArtifactBranches();
 
-    String selectVersionsWithoutArtifactBranch();
+    public String selectVersionsWithoutArtifactBranch();
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ContentEntityMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ContentEntityMapper.java
@@ -27,9 +27,9 @@ public class ContentEntityMapper implements RowMapper<ContentEntity> {
         entity.contentHash = rs.getString("contentHash");
         entity.contentBytes = rs.getBytes("content");
         try {
-            entity.serializedReferences = rs.getString("artifactreferences");
+            entity.serializedReferences = rs.getString("refs");
         } catch (Exception e) {
-            //The old database does not have te artifactreferences column, just ignore;
+            //The old database does not have te references column, just ignore;
         }
         return entity;
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ContentMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ContentMapper.java
@@ -27,7 +27,7 @@ public class ContentMapper implements RowMapper<ContentWrapperDto> {
         byte[] contentBytes = rs.getBytes("content");
         ContentHandle content = ContentHandle.create(contentBytes);
         contentWrapperDto.setContent(content);
-        contentWrapperDto.setReferences(SqlUtil.deserializeReferences(rs.getString("artifactreferences")));
+        contentWrapperDto.setReferences(SqlUtil.deserializeReferences(rs.getString("refs")));
         return contentWrapperDto;
     }
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/DynamicConfigPropertyDtoMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/DynamicConfigPropertyDtoMapper.java
@@ -21,8 +21,8 @@ public class DynamicConfigPropertyDtoMapper implements RowMapper<DynamicConfigPr
      */
     @Override
     public DynamicConfigPropertyDto map(ResultSet rs) throws SQLException {
-        String name = rs.getString("pname");
-        String value = rs.getString("pvalue");
+        String name = rs.getString("propName");
+        String value = rs.getString("propValue");
         return new DynamicConfigPropertyDto(name, value);
     }
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/StoredArtifactMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/StoredArtifactMapper.java
@@ -29,7 +29,7 @@ public class StoredArtifactMapper implements RowMapper<StoredArtifactDto> {
                 .globalId(rs.getLong("globalId"))
                 .version(rs.getString("version"))
                 .versionOrder(rs.getInt("versionOrder"))
-                .references(SqlUtil.deserializeReferences(rs.getString("artifactreferences")))
+                .references(SqlUtil.deserializeReferences(rs.getString("refs")))
                 .build();
     }
 }

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
@@ -6,11 +6,44 @@ CREATE TABLE apicurio (prop_name VARCHAR(255) NOT NULL, prop_value VARCHAR(255))
 ALTER TABLE apicurio ADD PRIMARY KEY (prop_name);
 INSERT INTO apicurio (prop_name, prop_value) VALUES ('db_version', 100);
 
-CREATE TABLE sequences (name VARCHAR(32) NOT NULL, seq_value BIGINT NOT NULL);
-ALTER TABLE sequences ADD PRIMARY KEY (name);
+CREATE TABLE sequences (seq_name VARCHAR(32) NOT NULL, seq_value BIGINT NOT NULL);
+ALTER TABLE sequences ADD PRIMARY KEY (seq_name);
 
-CREATE TABLE globalrules (type VARCHAR(32) NOT NULL, configuration TEXT NOT NULL);
-ALTER TABLE globalrules ADD PRIMARY KEY (type);
+CREATE TABLE config (pname VARCHAR(255) NOT NULL, pvalue VARCHAR(1024) NOT NULL, modifiedOn BIGINT NOT NULL);
+ALTER TABLE config ADD PRIMARY KEY (pname);
+CREATE INDEX IDX_config_1 ON config(modifiedOn);
+
+CREATE TABLE acls (principalId VARCHAR(256) NOT NULL, role VARCHAR(32) NOT NULL, principalName VARCHAR(256));
+ALTER TABLE acls ADD PRIMARY KEY (principalId);
+
+CREATE TABLE downloads (downloadId VARCHAR(128) NOT NULL, expires BIGINT NOT NULL, context VARCHAR(1024));
+ALTER TABLE downloads ADD PRIMARY KEY (downloadId);
+CREATE HASH INDEX IDX_down_1 ON downloads(expires);
+
+CREATE TABLE global_rules (type VARCHAR(32) NOT NULL, configuration TEXT NOT NULL);
+ALTER TABLE global_rules ADD PRIMARY KEY (type);
+
+CREATE TABLE content (contentId BIGINT NOT NULL, canonicalHash VARCHAR(64) NOT NULL, contentHash VARCHAR(64) NOT NULL, content BYTEA NOT NULL, refs TEXT);
+ALTER TABLE content ADD PRIMARY KEY (contentId);
+ALTER TABLE content ADD CONSTRAINT UQ_content_1 UNIQUE (contentHash);
+CREATE HASH INDEX IDX_content_1 ON content(canonicalHash);
+CREATE HASH INDEX IDX_content_2 ON content(contentHash);
+
+CREATE TABLE content_references (contentId BIGINT NOT NULL, groupId VARCHAR(512), artifactId VARCHAR(512) NOT NULL, version VARCHAR(256), name VARCHAR(512) NOT NULL);
+ALTER TABLE content_references ADD PRIMARY KEY (contentId, name);
+ALTER TABLE content_references ADD CONSTRAINT FK_content_references_1 FOREIGN KEY (contentId) REFERENCES content(contentId) ON DELETE CASCADE;
+
+CREATE TABLE groups (groupId VARCHAR(512) NOT NULL, description VARCHAR(1024), artifactsType VARCHAR(32), createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, modifiedBy VARCHAR(256), modifiedOn TIMESTAMP WITHOUT TIME ZONE, labels TEXT);
+ALTER TABLE groups ADD PRIMARY KEY (groupId);
+
+CREATE TABLE group_labels (groupId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
+CREATE INDEX IDX_glabels_1 ON group_labels(pkey);
+CREATE INDEX IDX_glabels_2 ON group_labels(pvalue);
+
+CREATE TABLE group_rules (groupId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, configuration VARCHAR(1024) NOT NULL);
+ALTER TABLE group_rules ADD PRIMARY KEY (groupId, type);
+ALTER TABLE group_rules ADD CONSTRAINT FK_grules_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
 
 CREATE TABLE artifacts (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, labels TEXT);
 ALTER TABLE artifacts ADD PRIMARY KEY (groupId, artifactId);
@@ -18,19 +51,15 @@ CREATE HASH INDEX IDX_artifacts_0 ON artifacts(type);
 CREATE HASH INDEX IDX_artifacts_1 ON artifacts(createdBy);
 CREATE INDEX IDX_artifacts_2 ON artifacts(createdOn);
 
-CREATE TABLE artifact_labels (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(1024));
-ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId);
+CREATE TABLE artifact_labels (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
 CREATE INDEX IDX_alabels_1 ON artifact_labels(pkey);
 CREATE INDEX IDX_alabels_2 ON artifact_labels(pvalue);
 
-CREATE TABLE rules (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, configuration VARCHAR(1024) NOT NULL);
-ALTER TABLE rules ADD PRIMARY KEY (groupId, artifactId, type);
-
-CREATE TABLE content (contentId BIGINT NOT NULL, canonicalHash VARCHAR(64) NOT NULL, contentHash VARCHAR(64) NOT NULL, content BYTEA NOT NULL, artifactreferences TEXT);
-ALTER TABLE content ADD PRIMARY KEY (contentId);
-ALTER TABLE content ADD CONSTRAINT UQ_content_1 UNIQUE (contentHash);
-CREATE HASH INDEX IDX_content_1 ON content(canonicalHash);
-CREATE HASH INDEX IDX_content_2 ON content(contentHash);
+CREATE TABLE artifact_rules (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, configuration VARCHAR(1024) NOT NULL);
+ALTER TABLE artifact_rules ADD PRIMARY KEY (groupId, artifactId, type);
+-- Note: no FK constraint between artifact_rules and artifacts because the Confluent API allows
+--       rules to be configured for Artifacts that do not yet exist.
 
 -- The "versionOrder" field is needed to generate "version" when it is not provided.
 -- It contains the same information as the "branchOrder" in the "latest" branch, but we cannot use it because of a chicken-and-egg problem.
@@ -39,7 +68,7 @@ CREATE TABLE versions (globalId BIGINT NOT NULL, groupId VARCHAR(512) NOT NULL, 
 ALTER TABLE versions ADD PRIMARY KEY (globalId);
 ALTER TABLE versions ADD CONSTRAINT UQ_versions_1 UNIQUE (groupId, artifactId, version);
 ALTER TABLE versions ADD CONSTRAINT UQ_versions_2 UNIQUE (globalId, versionOrder);
-ALTER TABLE versions ADD CONSTRAINT FK_versions_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId);
+ALTER TABLE versions ADD CONSTRAINT FK_versions_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
 ALTER TABLE versions ADD CONSTRAINT FK_versions_2 FOREIGN KEY (contentId) REFERENCES content(contentId);
 CREATE INDEX IDX_versions_1 ON versions(version);
 CREATE HASH INDEX IDX_versions_2 ON versions(state);
@@ -49,40 +78,19 @@ CREATE HASH INDEX IDX_versions_5 ON versions(createdBy);
 CREATE INDEX IDX_versions_6 ON versions(createdOn);
 CREATE HASH INDEX IDX_versions_7 ON versions(contentId);
 
-CREATE TABLE artifact_branches (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, branchId VARCHAR(256) NOT NULL, branchOrder INT NOT NULL, version VARCHAR(256) NOT NULL);
-ALTER TABLE artifact_branches ADD PRIMARY KEY (groupId, artifactId, branchId, branchOrder);
-ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId, version) REFERENCES versions(groupId, artifactId, version);
-CREATE INDEX IDX_artifact_branches_1 ON artifact_branches(groupId, artifactId, branchId, branchOrder);
-
-CREATE TABLE version_labels (globalId BIGINT NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(1024));
-ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId);
+CREATE TABLE version_labels (globalId BIGINT NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
 CREATE INDEX IDX_vlabels_1 ON version_labels(pkey);
 CREATE INDEX IDX_vlabels_2 ON version_labels(pvalue);
 
-CREATE TABLE comments (commentId VARCHAR(128) NOT NULL, globalId BIGINT NOT NULL, createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, cvalue VARCHAR(1024) NOT NULL);
-ALTER TABLE comments ADD PRIMARY KEY (commentId);
-ALTER TABLE comments ADD CONSTRAINT FK_comments_1 FOREIGN KEY (globalId) REFERENCES versions(globalId);
-CREATE INDEX IDX_comments_1 ON comments(createdBy);
+CREATE TABLE version_comments (commentId VARCHAR(128) NOT NULL, globalId BIGINT NOT NULL, createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, cvalue VARCHAR(1024) NOT NULL);
+ALTER TABLE version_comments ADD PRIMARY KEY (commentId);
+ALTER TABLE version_comments ADD CONSTRAINT FK_version_comments_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
+CREATE INDEX IDX_version_comments_1 ON version_comments(createdBy);
 
-CREATE TABLE groups (groupId VARCHAR(512) NOT NULL, description VARCHAR(1024), artifactsType VARCHAR(32), createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, modifiedBy VARCHAR(256), modifiedOn TIMESTAMP WITHOUT TIME ZONE, labels TEXT);
-ALTER TABLE groups ADD PRIMARY KEY (groupId);
-
-CREATE TABLE group_labels (groupId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(1024));
-ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId);
-CREATE INDEX IDX_glabels_1 ON group_labels(pkey);
-CREATE INDEX IDX_glabels_2 ON group_labels(pvalue);
-
-CREATE TABLE acls (principalId VARCHAR(256) NOT NULL, role VARCHAR(32) NOT NULL, principalName VARCHAR(256));
-ALTER TABLE acls ADD PRIMARY KEY (principalId);
-
-CREATE TABLE downloads (downloadId VARCHAR(128) NOT NULL, expires BIGINT NOT NULL, context VARCHAR(1024));
-ALTER TABLE downloads ADD PRIMARY KEY (downloadId);
-CREATE HASH INDEX IDX_down_1 ON downloads(expires);
-
-CREATE TABLE config (pname VARCHAR(255) NOT NULL, pvalue VARCHAR(1024), modifiedOn BIGINT NOT NULL);
-ALTER TABLE config ADD PRIMARY KEY (pname);
-CREATE INDEX IDX_config_1 ON config(modifiedOn);
-
-CREATE TABLE artifactreferences (contentId BIGINT NOT NULL, groupId VARCHAR(512), artifactId VARCHAR(512) NOT NULL, version VARCHAR(256), name VARCHAR(512) NOT NULL);
-ALTER TABLE artifactreferences ADD PRIMARY KEY (contentId, name);
-ALTER TABLE artifactreferences ADD CONSTRAINT FK_artifactreferences_1 FOREIGN KEY (contentId) REFERENCES content(contentId) ON DELETE CASCADE;
+-- This table is defined way down here because it has a FK to the artifacts table *and* the versions table
+CREATE TABLE artifact_branches (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, branchId VARCHAR(256) NOT NULL, branchOrder INT NOT NULL, version VARCHAR(256) NOT NULL);
+ALTER TABLE artifact_branches ADD PRIMARY KEY (groupId, artifactId, branchId, branchOrder);
+ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
+ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_2 FOREIGN KEY (groupId, artifactId, version) REFERENCES versions(groupId, artifactId, version) ON DELETE CASCADE;
+CREATE INDEX IDX_artifact_branches_1 ON artifact_branches(groupId, artifactId, branchId, branchOrder);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
@@ -2,15 +2,15 @@
 -- DDL for the Apicurio Registry - Database: H2
 -- *********************************************************************
 
-CREATE TABLE apicurio (prop_name VARCHAR(255) NOT NULL, prop_value VARCHAR(255));
-ALTER TABLE apicurio ADD PRIMARY KEY (prop_name);
-INSERT INTO apicurio (prop_name, prop_value) VALUES ('db_version', 100);
+CREATE TABLE apicurio (propName VARCHAR(255) NOT NULL, propValue VARCHAR(255));
+ALTER TABLE apicurio ADD PRIMARY KEY (propName);
+INSERT INTO apicurio (propName, propValue) VALUES ('db_version', 100);
 
-CREATE TABLE sequences (seq_name VARCHAR(32) NOT NULL, seq_value BIGINT NOT NULL);
-ALTER TABLE sequences ADD PRIMARY KEY (seq_name);
+CREATE TABLE sequences (seqName VARCHAR(32) NOT NULL, seqValue BIGINT NOT NULL);
+ALTER TABLE sequences ADD PRIMARY KEY (seqName);
 
-CREATE TABLE config (pname VARCHAR(255) NOT NULL, pvalue VARCHAR(1024) NOT NULL, modifiedOn BIGINT NOT NULL);
-ALTER TABLE config ADD PRIMARY KEY (pname);
+CREATE TABLE config (propName VARCHAR(255) NOT NULL, propValue VARCHAR(1024) NOT NULL, modifiedOn BIGINT NOT NULL);
+ALTER TABLE config ADD PRIMARY KEY (propName);
 CREATE INDEX IDX_config_1 ON config(modifiedOn);
 
 CREATE TABLE acls (principalId VARCHAR(256) NOT NULL, role VARCHAR(32) NOT NULL, principalName VARCHAR(256));
@@ -36,10 +36,10 @@ ALTER TABLE content_references ADD CONSTRAINT FK_content_references_1 FOREIGN KE
 CREATE TABLE groups (groupId VARCHAR(512) NOT NULL, description VARCHAR(1024), artifactsType VARCHAR(32), createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, modifiedBy VARCHAR(256), modifiedOn TIMESTAMP WITHOUT TIME ZONE, labels TEXT);
 ALTER TABLE groups ADD PRIMARY KEY (groupId);
 
-CREATE TABLE group_labels (groupId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+CREATE TABLE group_labels (groupId VARCHAR(512) NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
 ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
-CREATE INDEX IDX_glabels_1 ON group_labels(pkey);
-CREATE INDEX IDX_glabels_2 ON group_labels(pvalue);
+CREATE INDEX IDX_glabels_1 ON group_labels(labelKey);
+CREATE INDEX IDX_glabels_2 ON group_labels(labelValue);
 
 CREATE TABLE group_rules (groupId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, configuration VARCHAR(1024) NOT NULL);
 ALTER TABLE group_rules ADD PRIMARY KEY (groupId, type);
@@ -51,10 +51,10 @@ CREATE HASH INDEX IDX_artifacts_0 ON artifacts(type);
 CREATE HASH INDEX IDX_artifacts_1 ON artifacts(createdBy);
 CREATE INDEX IDX_artifacts_2 ON artifacts(createdOn);
 
-CREATE TABLE artifact_labels (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+CREATE TABLE artifact_labels (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
 ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
-CREATE INDEX IDX_alabels_1 ON artifact_labels(pkey);
-CREATE INDEX IDX_alabels_2 ON artifact_labels(pvalue);
+CREATE INDEX IDX_alabels_1 ON artifact_labels(labelKey);
+CREATE INDEX IDX_alabels_2 ON artifact_labels(labelValue);
 
 CREATE TABLE artifact_rules (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, configuration VARCHAR(1024) NOT NULL);
 ALTER TABLE artifact_rules ADD PRIMARY KEY (groupId, artifactId, type);
@@ -78,10 +78,10 @@ CREATE HASH INDEX IDX_versions_5 ON versions(createdBy);
 CREATE INDEX IDX_versions_6 ON versions(createdOn);
 CREATE HASH INDEX IDX_versions_7 ON versions(contentId);
 
-CREATE TABLE version_labels (globalId BIGINT NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+CREATE TABLE version_labels (globalId BIGINT NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
 ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
-CREATE INDEX IDX_vlabels_1 ON version_labels(pkey);
-CREATE INDEX IDX_vlabels_2 ON version_labels(pvalue);
+CREATE INDEX IDX_vlabels_1 ON version_labels(labelKey);
+CREATE INDEX IDX_vlabels_2 ON version_labels(labelValue);
 
 CREATE TABLE version_comments (commentId VARCHAR(128) NOT NULL, globalId BIGINT NOT NULL, createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, cvalue VARCHAR(1024) NOT NULL);
 ALTER TABLE version_comments ADD PRIMARY KEY (commentId);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
@@ -91,6 +91,6 @@ CREATE INDEX IDX_version_comments_1 ON version_comments(createdBy);
 -- This table is defined way down here because it has a FK to the artifacts table *and* the versions table
 CREATE TABLE artifact_branches (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, branchId VARCHAR(256) NOT NULL, branchOrder INT NOT NULL, version VARCHAR(256) NOT NULL);
 ALTER TABLE artifact_branches ADD PRIMARY KEY (groupId, artifactId, branchId, branchOrder);
-ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId);
+ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
 ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_2 FOREIGN KEY (groupId, artifactId, version) REFERENCES versions(groupId, artifactId, version) ON DELETE CASCADE;
 CREATE INDEX IDX_artifact_branches_1 ON artifact_branches(groupId, artifactId, branchId, branchOrder);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
@@ -91,6 +91,6 @@ CREATE INDEX IDX_version_comments_1 ON version_comments(createdBy);
 -- This table is defined way down here because it has a FK to the artifacts table *and* the versions table
 CREATE TABLE artifact_branches (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, branchId VARCHAR(256) NOT NULL, branchOrder INT NOT NULL, version VARCHAR(256) NOT NULL);
 ALTER TABLE artifact_branches ADD PRIMARY KEY (groupId, artifactId, branchId, branchOrder);
-ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
+ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId);
 ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_2 FOREIGN KEY (groupId, artifactId, version) REFERENCES versions(groupId, artifactId, version) ON DELETE CASCADE;
 CREATE INDEX IDX_artifact_branches_1 ON artifact_branches(groupId, artifactId, branchId, branchOrder);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/mssql.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/mssql.ddl
@@ -2,15 +2,15 @@
 -- DDL for the Apicurio Registry - Database: MS SQL Server
 -- *********************************************************************
 
-CREATE TABLE apicurio (prop_name NVARCHAR(255) NOT NULL, prop_value NVARCHAR(255));
-ALTER TABLE apicurio ADD PRIMARY KEY (prop_name);
-INSERT INTO apicurio (prop_name, prop_value) VALUES ('db_version', 100);
+CREATE TABLE apicurio (propName NVARCHAR(255) NOT NULL, propValue NVARCHAR(255));
+ALTER TABLE apicurio ADD PRIMARY KEY (propName);
+INSERT INTO apicurio (propName, propValue) VALUES ('db_version', 100);
 
-CREATE TABLE sequences (seq_name NVARCHAR(32) NOT NULL, seq_value BIGINT NOT NULL);
-ALTER TABLE sequences ADD PRIMARY KEY (seq_name);
+CREATE TABLE sequences (seqName NVARCHAR(32) NOT NULL, seqValue BIGINT NOT NULL);
+ALTER TABLE sequences ADD PRIMARY KEY (seqName);
 
-CREATE TABLE config (pname NVARCHAR(255) NOT NULL, pvalue NVARCHAR(1024) NOT NULL, modifiedOn BIGINT NOT NULL);
-ALTER TABLE config ADD PRIMARY KEY (pname);
+CREATE TABLE config (propName NVARCHAR(255) NOT NULL, propValue NVARCHAR(1024) NOT NULL, modifiedOn BIGINT NOT NULL);
+ALTER TABLE config ADD PRIMARY KEY (propName);
 CREATE INDEX IDX_config_1 ON config(modifiedOn);
 
 CREATE TABLE acls (principalId NVARCHAR(256) NOT NULL, role NVARCHAR(32) NOT NULL, principalName NVARCHAR(256));
@@ -36,10 +36,10 @@ ALTER TABLE content_references ADD CONSTRAINT FK_content_references_1 FOREIGN KE
 CREATE TABLE groups (groupId NVARCHAR(512) NOT NULL, description NVARCHAR(1024), artifactsType NVARCHAR(32), createdBy NVARCHAR(256), createdOn DATETIME2(6) NOT NULL, modifiedBy NVARCHAR(256), modifiedOn DATETIME2(6), labels TEXT);
 ALTER TABLE groups ADD PRIMARY KEY (groupId);
 
-CREATE TABLE group_labels (groupId NVARCHAR(512) NOT NULL, pkey NVARCHAR(256) NOT NULL, pvalue NVARCHAR(512));
+CREATE TABLE group_labels (groupId NVARCHAR(512) NOT NULL, labelKey NVARCHAR(256) NOT NULL, labelValue NVARCHAR(512));
 ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
-CREATE INDEX IDX_glabels_1 ON group_labels(pkey);
-CREATE INDEX IDX_glabels_2 ON group_labels(pvalue);
+CREATE INDEX IDX_glabels_1 ON group_labels(labelKey);
+CREATE INDEX IDX_glabels_2 ON group_labels(labelValue);
 
 CREATE TABLE group_rules (groupId NVARCHAR(512) NOT NULL, type NVARCHAR(32) NOT NULL, configuration NVARCHAR(1024) NOT NULL);
 ALTER TABLE group_rules ADD PRIMARY KEY (groupId, type);
@@ -51,10 +51,10 @@ CREATE INDEX IDX_artifacts_0 ON artifacts(type);
 CREATE INDEX IDX_artifacts_1 ON artifacts(createdBy);
 CREATE INDEX IDX_artifacts_2 ON artifacts(createdOn);
 
-CREATE TABLE artifact_labels (groupId NVARCHAR(512) NOT NULL, artifactId NVARCHAR(512) NOT NULL, pkey NVARCHAR(256) NOT NULL, pvalue NVARCHAR(512));
+CREATE TABLE artifact_labels (groupId NVARCHAR(512) NOT NULL, artifactId NVARCHAR(512) NOT NULL, labelKey NVARCHAR(256) NOT NULL, labelValue NVARCHAR(512));
 ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
-CREATE INDEX IDX_alabels_1 ON artifact_labels(pkey);
-CREATE INDEX IDX_alabels_2 ON artifact_labels(pvalue);
+CREATE INDEX IDX_alabels_1 ON artifact_labels(labelKey);
+CREATE INDEX IDX_alabels_2 ON artifact_labels(labelValue);
 
 CREATE TABLE artifact_rules (groupId NVARCHAR(512) NOT NULL, artifactId NVARCHAR(512) NOT NULL, type NVARCHAR(32) NOT NULL, configuration NVARCHAR(1024) NOT NULL);
 ALTER TABLE artifact_rules ADD PRIMARY KEY (groupId, artifactId, type);
@@ -78,10 +78,10 @@ CREATE INDEX IDX_versions_5 ON versions(createdBy);
 CREATE INDEX IDX_versions_6 ON versions(createdOn);
 CREATE INDEX IDX_versions_7 ON versions(contentId);
 
-CREATE TABLE version_labels (globalId BIGINT NOT NULL, pkey NVARCHAR(256) NOT NULL, pvalue NVARCHAR(512));
+CREATE TABLE version_labels (globalId BIGINT NOT NULL, labelKey NVARCHAR(256) NOT NULL, labelValue NVARCHAR(512));
 ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
-CREATE INDEX IDX_vlabels_1 ON version_labels(pkey);
-CREATE INDEX IDX_vlabels_2 ON version_labels(pvalue);
+CREATE INDEX IDX_vlabels_1 ON version_labels(labelKey);
+CREATE INDEX IDX_vlabels_2 ON version_labels(labelValue);
 
 CREATE TABLE version_comments (commentId NVARCHAR(128) NOT NULL, globalId BIGINT NOT NULL, createdBy NVARCHAR(256), createdOn DATETIME2(6) NOT NULL, cvalue NVARCHAR(1024) NOT NULL);
 ALTER TABLE version_comments ADD PRIMARY KEY (commentId);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/mssql.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/mssql.ddl
@@ -6,12 +6,44 @@ CREATE TABLE apicurio (prop_name NVARCHAR(255) NOT NULL, prop_value NVARCHAR(255
 ALTER TABLE apicurio ADD PRIMARY KEY (prop_name);
 INSERT INTO apicurio (prop_name, prop_value) VALUES ('db_version', 100);
 
--- TODO: Different column name in h2
-CREATE TABLE sequences (name NVARCHAR(32) NOT NULL, value BIGINT NOT NULL);
-ALTER TABLE sequences ADD PRIMARY KEY (name);
+CREATE TABLE sequences (seq_name NVARCHAR(32) NOT NULL, seq_value BIGINT NOT NULL);
+ALTER TABLE sequences ADD PRIMARY KEY (seq_name);
 
-CREATE TABLE globalrules (type NVARCHAR(32) NOT NULL, configuration TEXT NOT NULL);
-ALTER TABLE globalrules ADD PRIMARY KEY (type);
+CREATE TABLE config (pname NVARCHAR(255) NOT NULL, pvalue NVARCHAR(1024) NOT NULL, modifiedOn BIGINT NOT NULL);
+ALTER TABLE config ADD PRIMARY KEY (pname);
+CREATE INDEX IDX_config_1 ON config(modifiedOn);
+
+CREATE TABLE acls (principalId NVARCHAR(256) NOT NULL, role NVARCHAR(32) NOT NULL, principalName NVARCHAR(256));
+ALTER TABLE acls ADD PRIMARY KEY (principalId);
+
+CREATE TABLE downloads (downloadId NVARCHAR(128) NOT NULL, expires BIGINT NOT NULL, context NVARCHAR(1024));
+ALTER TABLE downloads ADD PRIMARY KEY (downloadId);
+CREATE INDEX IDX_down_1 ON downloads(expires);
+
+CREATE TABLE global_rules (type NVARCHAR(32) NOT NULL, configuration TEXT NOT NULL);
+ALTER TABLE global_rules ADD PRIMARY KEY (type);
+
+CREATE TABLE content (contentId BIGINT NOT NULL, canonicalHash NVARCHAR(64) NOT NULL, contentHash NVARCHAR(64) NOT NULL, content VARBINARY(MAX) NOT NULL, refs TEXT);
+ALTER TABLE content ADD PRIMARY KEY (contentId);
+ALTER TABLE content ADD CONSTRAINT UQ_content_1 UNIQUE (contentHash);
+CREATE INDEX IDX_content_1 ON content(canonicalHash);
+CREATE INDEX IDX_content_2 ON content(contentHash);
+
+CREATE TABLE content_references (contentId BIGINT NOT NULL, groupId NVARCHAR(512), artifactId NVARCHAR(512) NOT NULL, version NVARCHAR(256), name NVARCHAR(512) NOT NULL);
+ALTER TABLE content_references ADD PRIMARY KEY (contentId, name);
+ALTER TABLE content_references ADD CONSTRAINT FK_content_references_1 FOREIGN KEY (contentId) REFERENCES content(contentId) ON DELETE CASCADE;
+
+CREATE TABLE groups (groupId NVARCHAR(512) NOT NULL, description NVARCHAR(1024), artifactsType NVARCHAR(32), createdBy NVARCHAR(256), createdOn DATETIME2(6) NOT NULL, modifiedBy NVARCHAR(256), modifiedOn DATETIME2(6), labels TEXT);
+ALTER TABLE groups ADD PRIMARY KEY (groupId);
+
+CREATE TABLE group_labels (groupId NVARCHAR(512) NOT NULL, pkey NVARCHAR(256) NOT NULL, pvalue NVARCHAR(512));
+ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
+CREATE INDEX IDX_glabels_1 ON group_labels(pkey);
+CREATE INDEX IDX_glabels_2 ON group_labels(pvalue);
+
+CREATE TABLE group_rules (groupId NVARCHAR(512) NOT NULL, type NVARCHAR(32) NOT NULL, configuration NVARCHAR(1024) NOT NULL);
+ALTER TABLE group_rules ADD PRIMARY KEY (groupId, type);
+ALTER TABLE group_rules ADD CONSTRAINT FK_grules_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
 
 CREATE TABLE artifacts (groupId NVARCHAR(512) NOT NULL, artifactId NVARCHAR(512) NOT NULL, type NVARCHAR(32) NOT NULL, createdBy NVARCHAR(256), createdOn DATETIME2(6) NOT NULL, labels TEXT);
 ALTER TABLE artifacts ADD PRIMARY KEY (groupId, artifactId);
@@ -19,18 +51,15 @@ CREATE INDEX IDX_artifacts_0 ON artifacts(type);
 CREATE INDEX IDX_artifacts_1 ON artifacts(createdBy);
 CREATE INDEX IDX_artifacts_2 ON artifacts(createdOn);
 
-CREATE TABLE artifact_labels (groupId NVARCHAR(512) NOT NULL, artifactId NVARCHAR(512) NOT NULL, pkey NVARCHAR(256) NOT NULL, pvalue NVARCHAR(1024));
-ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId);
+CREATE TABLE artifact_labels (groupId NVARCHAR(512) NOT NULL, artifactId NVARCHAR(512) NOT NULL, pkey NVARCHAR(256) NOT NULL, pvalue NVARCHAR(512));
+ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
 CREATE INDEX IDX_alabels_1 ON artifact_labels(pkey);
+CREATE INDEX IDX_alabels_2 ON artifact_labels(pvalue);
 
-CREATE TABLE rules (groupId NVARCHAR(512) NOT NULL, artifactId NVARCHAR(512) NOT NULL, type NVARCHAR(32) NOT NULL, configuration NVARCHAR(1024) NOT NULL);
-ALTER TABLE rules ADD PRIMARY KEY (groupId, artifactId, type);
-
-CREATE TABLE content (contentId BIGINT NOT NULL, canonicalHash NVARCHAR(64) NOT NULL, contentHash NVARCHAR(64) NOT NULL, content VARBINARY(MAX) NOT NULL, artifactreferences TEXT);
-ALTER TABLE content ADD PRIMARY KEY (contentId);
-ALTER TABLE content ADD CONSTRAINT UQ_content_1 UNIQUE (contentHash);
-CREATE INDEX IDX_content_1 ON content(canonicalHash);
-CREATE INDEX IDX_content_2 ON content(contentHash);
+CREATE TABLE artifact_rules (groupId NVARCHAR(512) NOT NULL, artifactId NVARCHAR(512) NOT NULL, type NVARCHAR(32) NOT NULL, configuration NVARCHAR(1024) NOT NULL);
+ALTER TABLE artifact_rules ADD PRIMARY KEY (groupId, artifactId, type);
+-- Note: no FK constraint between artifact_rules and artifacts because the Confluent API allows
+--       rules to be configured for Artifacts that do not yet exist.
 
 -- The "versionOrder" field is needed to generate "version" when it is not provided.
 -- It contains the same information as the "branchOrder" in the "latest" branch, but we cannot use it because of a chicken-and-egg problem.
@@ -39,7 +68,7 @@ CREATE TABLE versions (globalId BIGINT NOT NULL, groupId NVARCHAR(512) NOT NULL,
 ALTER TABLE versions ADD PRIMARY KEY (globalId);
 ALTER TABLE versions ADD CONSTRAINT UQ_versions_1 UNIQUE (groupId, artifactId, version);
 ALTER TABLE versions ADD CONSTRAINT UQ_versions_2 UNIQUE (globalId, versionOrder);
-ALTER TABLE versions ADD CONSTRAINT FK_versions_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId);
+ALTER TABLE versions ADD CONSTRAINT FK_versions_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
 ALTER TABLE versions ADD CONSTRAINT FK_versions_2 FOREIGN KEY (contentId) REFERENCES content(contentId);
 CREATE INDEX IDX_versions_1 ON versions(version);
 CREATE INDEX IDX_versions_2 ON versions(state);
@@ -49,42 +78,19 @@ CREATE INDEX IDX_versions_5 ON versions(createdBy);
 CREATE INDEX IDX_versions_6 ON versions(createdOn);
 CREATE INDEX IDX_versions_7 ON versions(contentId);
 
+CREATE TABLE version_labels (globalId BIGINT NOT NULL, pkey NVARCHAR(256) NOT NULL, pvalue NVARCHAR(512));
+ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
+CREATE INDEX IDX_vlabels_1 ON version_labels(pkey);
+CREATE INDEX IDX_vlabels_2 ON version_labels(pvalue);
+
+CREATE TABLE version_comments (commentId NVARCHAR(128) NOT NULL, globalId BIGINT NOT NULL, createdBy NVARCHAR(256), createdOn DATETIME2(6) NOT NULL, cvalue NVARCHAR(1024) NOT NULL);
+ALTER TABLE version_comments ADD PRIMARY KEY (commentId);
+ALTER TABLE version_comments ADD CONSTRAINT FK_version_comments_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
+CREATE INDEX IDX_version_comments_1 ON version_comments(createdBy);
+
+-- This table is defined way down here because it has a FK to the artifacts table *and* the versions table
 CREATE TABLE artifact_branches (groupId NVARCHAR(512) NOT NULL, artifactId NVARCHAR(512) NOT NULL, branchId NVARCHAR(256) NOT NULL, branchOrder INT NOT NULL, version NVARCHAR(256) NOT NULL);
 ALTER TABLE artifact_branches ADD PRIMARY KEY (groupId, artifactId, branchId, branchOrder);
-ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId, version) REFERENCES versions(groupId, artifactId, version);
+ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId);
+ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_2 FOREIGN KEY (groupId, artifactId, version) REFERENCES versions(groupId, artifactId, version) ON DELETE CASCADE;
 CREATE INDEX IDX_artifact_branches_1 ON artifact_branches(groupId, artifactId, branchId, branchOrder);
-
-CREATE TABLE version_labels (globalId BIGINT NOT NULL, pkey NVARCHAR(256) NOT NULL, pvalue NVARCHAR(1024));
-ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId);
-CREATE INDEX IDX_vlabels_1 ON version_labels(pkey);
--- MSSQL may have a limit on the size of indexed value:
--- com.microsoft.sqlserver.jdbc.SQLServerException: Operation failed. The index entry of length 2048 bytes for the index 'IDX_props_2' exceeds the maximum length of 1700 bytes for nonclustered indexes.
--- CREATE INDEX IDX_vlabels_2 ON version_labels(pvalue);
-
-CREATE TABLE comments (commentId NVARCHAR(128) NOT NULL, globalId BIGINT NOT NULL, createdBy NVARCHAR(256), createdOn DATETIME2(6) NOT NULL, cvalue NVARCHAR(1024) NOT NULL);
-ALTER TABLE comments ADD PRIMARY KEY (commentId);
-ALTER TABLE comments ADD CONSTRAINT FK_comments_1 FOREIGN KEY (globalId) REFERENCES versions(globalId);
-CREATE INDEX IDX_comments_1 ON comments(createdBy);
-
-CREATE TABLE groups (groupId NVARCHAR(512) NOT NULL, description NVARCHAR(1024), artifactsType NVARCHAR(32), createdBy NVARCHAR(256), createdOn DATETIME2(6) NOT NULL, modifiedBy NVARCHAR(256), modifiedOn DATETIME2(6), labels TEXT);
-ALTER TABLE groups ADD PRIMARY KEY (groupId);
-
-CREATE TABLE group_labels (groupId NVARCHAR(512) NOT NULL, pkey NVARCHAR(256) NOT NULL, pvalue NVARCHAR(1024));
-ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId);
-CREATE INDEX IDX_glabels_1 ON group_labels(pkey);
-
-CREATE TABLE acls (principalId NVARCHAR(256) NOT NULL, role NVARCHAR(32) NOT NULL, principalName NVARCHAR(256));
-ALTER TABLE acls ADD PRIMARY KEY (principalId);
-
-CREATE TABLE downloads (downloadId NVARCHAR(128) NOT NULL, expires BIGINT NOT NULL, context NVARCHAR(1024));
-ALTER TABLE downloads ADD PRIMARY KEY (downloadId);
-CREATE INDEX IDX_down_1 ON downloads(expires);
-
--- TODO: Missing NOT NULL in h2
-CREATE TABLE config (pname NVARCHAR(255) NOT NULL, pvalue NVARCHAR(1024) NOT NULL, modifiedOn BIGINT NOT NULL);
-ALTER TABLE config ADD PRIMARY KEY (pname);
-CREATE INDEX IDX_config_1 ON config(modifiedOn);
-
-CREATE TABLE artifactreferences (contentId BIGINT NOT NULL, groupId NVARCHAR(512), artifactId NVARCHAR(512) NOT NULL, version NVARCHAR(256), name NVARCHAR(512) NOT NULL);
-ALTER TABLE artifactreferences ADD PRIMARY KEY (contentId, name);
-ALTER TABLE artifactreferences ADD CONSTRAINT FK_artifactreferences_1 FOREIGN KEY (contentId) REFERENCES content(contentId) ON DELETE CASCADE;

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
@@ -2,15 +2,15 @@
 -- DDL for the Apicurio Registry - Database: PostgreSQL 10+
 -- *********************************************************************
 
-CREATE TABLE apicurio (prop_name VARCHAR(255) NOT NULL, prop_value VARCHAR(255));
-ALTER TABLE apicurio ADD PRIMARY KEY (prop_name);
-INSERT INTO apicurio (prop_name, prop_value) VALUES ('db_version', 100);
+CREATE TABLE apicurio (propName VARCHAR(255) NOT NULL, propValue VARCHAR(255));
+ALTER TABLE apicurio ADD PRIMARY KEY (propName);
+INSERT INTO apicurio (propName, propValue) VALUES ('db_version', 100);
 
-CREATE TABLE sequences (seq_name VARCHAR(32) NOT NULL, seq_value BIGINT NOT NULL);
-ALTER TABLE sequences ADD PRIMARY KEY (seq_name);
+CREATE TABLE sequences (seqName VARCHAR(32) NOT NULL, seqValue BIGINT NOT NULL);
+ALTER TABLE sequences ADD PRIMARY KEY (seqName);
 
-CREATE TABLE config (pname VARCHAR(255) NOT NULL, pvalue VARCHAR(1024) NOT NULL, modifiedOn BIGINT NOT NULL);
-ALTER TABLE config ADD PRIMARY KEY (pname);
+CREATE TABLE config (propName VARCHAR(255) NOT NULL, propValue VARCHAR(1024) NOT NULL, modifiedOn BIGINT NOT NULL);
+ALTER TABLE config ADD PRIMARY KEY (propName);
 CREATE INDEX IDX_config_1 ON config(modifiedOn);
 
 CREATE TABLE acls (principalId VARCHAR(256) NOT NULL, role VARCHAR(32) NOT NULL, principalName VARCHAR(256));
@@ -36,10 +36,10 @@ ALTER TABLE content_references ADD CONSTRAINT FK_content_references_1 FOREIGN KE
 CREATE TABLE groups (groupId VARCHAR(512) NOT NULL, description VARCHAR(1024), artifactsType VARCHAR(32), createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, modifiedBy VARCHAR(256), modifiedOn TIMESTAMP WITHOUT TIME ZONE, labels TEXT);
 ALTER TABLE groups ADD PRIMARY KEY (groupId);
 
-CREATE TABLE group_labels (groupId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+CREATE TABLE group_labels (groupId VARCHAR(512) NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
 ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
-CREATE INDEX IDX_glabels_1 ON group_labels(pkey);
-CREATE INDEX IDX_glabels_2 ON group_labels(pvalue);
+CREATE INDEX IDX_glabels_1 ON group_labels(labelKey);
+CREATE INDEX IDX_glabels_2 ON group_labels(labelValue);
 
 CREATE TABLE group_rules (groupId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, configuration VARCHAR(1024) NOT NULL);
 ALTER TABLE group_rules ADD PRIMARY KEY (groupId, type);
@@ -51,10 +51,10 @@ CREATE INDEX IDX_artifacts_0 ON artifacts USING HASH (type);
 CREATE INDEX IDX_artifacts_1 ON artifacts USING HASH (createdBy);
 CREATE INDEX IDX_artifacts_2 ON artifacts(createdOn);
 
-CREATE TABLE artifact_labels (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+CREATE TABLE artifact_labels (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
 ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
-CREATE INDEX IDX_alabels_1 ON artifact_labels(pkey);
-CREATE INDEX IDX_alabels_2 ON artifact_labels(pvalue);
+CREATE INDEX IDX_alabels_1 ON artifact_labels(labelKey);
+CREATE INDEX IDX_alabels_2 ON artifact_labels(labelValue);
 
 CREATE TABLE artifact_rules (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, configuration VARCHAR(1024) NOT NULL);
 ALTER TABLE artifact_rules ADD PRIMARY KEY (groupId, artifactId, type);
@@ -78,10 +78,10 @@ CREATE INDEX IDX_versions_5 ON versions USING HASH (createdBy);
 CREATE INDEX IDX_versions_6 ON versions(createdOn);
 CREATE INDEX IDX_versions_7 ON versions USING HASH (contentId);
 
-CREATE TABLE version_labels (globalId BIGINT NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+CREATE TABLE version_labels (globalId BIGINT NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
 ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
-CREATE INDEX IDX_vlabels_1 ON version_labels(pkey);
-CREATE INDEX IDX_vlabels_2 ON version_labels(pvalue);
+CREATE INDEX IDX_vlabels_1 ON version_labels(labelKey);
+CREATE INDEX IDX_vlabels_2 ON version_labels(labelValue);
 
 CREATE TABLE version_comments (commentId VARCHAR(128) NOT NULL, globalId BIGINT NOT NULL, createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, cvalue VARCHAR(1024) NOT NULL);
 ALTER TABLE version_comments ADD PRIMARY KEY (commentId);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
@@ -6,12 +6,44 @@ CREATE TABLE apicurio (prop_name VARCHAR(255) NOT NULL, prop_value VARCHAR(255))
 ALTER TABLE apicurio ADD PRIMARY KEY (prop_name);
 INSERT INTO apicurio (prop_name, prop_value) VALUES ('db_version', 100);
 
--- TODO: Different column name in h2
-CREATE TABLE sequences (name VARCHAR(32) NOT NULL, value BIGINT NOT NULL);
-ALTER TABLE sequences ADD PRIMARY KEY (name);
+CREATE TABLE sequences (seq_name VARCHAR(32) NOT NULL, seq_value BIGINT NOT NULL);
+ALTER TABLE sequences ADD PRIMARY KEY (seq_name);
 
-CREATE TABLE globalrules (type VARCHAR(32) NOT NULL, configuration TEXT NOT NULL);
-ALTER TABLE globalrules ADD PRIMARY KEY (type);
+CREATE TABLE config (pname VARCHAR(255) NOT NULL, pvalue VARCHAR(1024) NOT NULL, modifiedOn BIGINT NOT NULL);
+ALTER TABLE config ADD PRIMARY KEY (pname);
+CREATE INDEX IDX_config_1 ON config(modifiedOn);
+
+CREATE TABLE acls (principalId VARCHAR(256) NOT NULL, role VARCHAR(32) NOT NULL, principalName VARCHAR(256));
+ALTER TABLE acls ADD PRIMARY KEY (principalId);
+
+CREATE TABLE downloads (downloadId VARCHAR(128) NOT NULL, expires BIGINT NOT NULL, context VARCHAR(1024));
+ALTER TABLE downloads ADD PRIMARY KEY (downloadId);
+CREATE INDEX IDX_down_1 ON downloads USING HASH (expires);
+
+CREATE TABLE global_rules (type VARCHAR(32) NOT NULL, configuration TEXT NOT NULL);
+ALTER TABLE global_rules ADD PRIMARY KEY (type);
+
+CREATE TABLE content (contentId BIGINT NOT NULL, canonicalHash VARCHAR(64) NOT NULL, contentHash VARCHAR(64) NOT NULL, content BYTEA NOT NULL, refs TEXT);
+ALTER TABLE content ADD PRIMARY KEY (contentId);
+ALTER TABLE content ADD CONSTRAINT UQ_content_1 UNIQUE (contentHash);
+CREATE INDEX IDX_content_1 ON content USING HASH (canonicalHash);
+CREATE INDEX IDX_content_2 ON content USING HASH (contentHash);
+
+CREATE TABLE content_references (contentId BIGINT NOT NULL, groupId VARCHAR(512), artifactId VARCHAR(512) NOT NULL, version VARCHAR(256), name VARCHAR(512) NOT NULL);
+ALTER TABLE content_references ADD PRIMARY KEY (contentId, name);
+ALTER TABLE content_references ADD CONSTRAINT FK_content_references_1 FOREIGN KEY (contentId) REFERENCES content(contentId) ON DELETE CASCADE;
+
+CREATE TABLE groups (groupId VARCHAR(512) NOT NULL, description VARCHAR(1024), artifactsType VARCHAR(32), createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, modifiedBy VARCHAR(256), modifiedOn TIMESTAMP WITHOUT TIME ZONE, labels TEXT);
+ALTER TABLE groups ADD PRIMARY KEY (groupId);
+
+CREATE TABLE group_labels (groupId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
+CREATE INDEX IDX_glabels_1 ON group_labels(pkey);
+CREATE INDEX IDX_glabels_2 ON group_labels(pvalue);
+
+CREATE TABLE group_rules (groupId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, configuration VARCHAR(1024) NOT NULL);
+ALTER TABLE group_rules ADD PRIMARY KEY (groupId, type);
+ALTER TABLE group_rules ADD CONSTRAINT FK_grules_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
 
 CREATE TABLE artifacts (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, labels TEXT);
 ALTER TABLE artifacts ADD PRIMARY KEY (groupId, artifactId);
@@ -19,19 +51,15 @@ CREATE INDEX IDX_artifacts_0 ON artifacts USING HASH (type);
 CREATE INDEX IDX_artifacts_1 ON artifacts USING HASH (createdBy);
 CREATE INDEX IDX_artifacts_2 ON artifacts(createdOn);
 
-CREATE TABLE artifact_labels (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(1024));
-ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId);
+CREATE TABLE artifact_labels (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
 CREATE INDEX IDX_alabels_1 ON artifact_labels(pkey);
 CREATE INDEX IDX_alabels_2 ON artifact_labels(pvalue);
 
-CREATE TABLE rules (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, configuration VARCHAR(1024) NOT NULL);
-ALTER TABLE rules ADD PRIMARY KEY (groupId, artifactId, type);
-
-CREATE TABLE content (contentId BIGINT NOT NULL, canonicalHash VARCHAR(64) NOT NULL, contentHash VARCHAR(64) NOT NULL, content BYTEA NOT NULL, artifactreferences TEXT);
-ALTER TABLE content ADD PRIMARY KEY (contentId);
-ALTER TABLE content ADD CONSTRAINT UQ_content_1 UNIQUE (contentHash);
-CREATE INDEX IDX_content_1 ON content USING HASH (canonicalHash);
-CREATE INDEX IDX_content_2 ON content USING HASH (contentHash);
+CREATE TABLE artifact_rules (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, type VARCHAR(32) NOT NULL, configuration VARCHAR(1024) NOT NULL);
+ALTER TABLE artifact_rules ADD PRIMARY KEY (groupId, artifactId, type);
+-- Note: no FK constraint between artifact_rules and artifacts because the Confluent API allows
+--       rules to be configured for Artifacts that do not yet exist.
 
 -- The "versionOrder" field is needed to generate "version" when it is not provided.
 -- It contains the same information as the "branchOrder" in the "latest" branch, but we cannot use it because of a chicken-and-egg problem.
@@ -40,7 +68,7 @@ CREATE TABLE versions (globalId BIGINT NOT NULL, groupId VARCHAR(512) NOT NULL, 
 ALTER TABLE versions ADD PRIMARY KEY (globalId);
 ALTER TABLE versions ADD CONSTRAINT UQ_versions_1 UNIQUE (groupId, artifactId, version);
 ALTER TABLE versions ADD CONSTRAINT UQ_versions_2 UNIQUE (globalId, versionOrder);
-ALTER TABLE versions ADD CONSTRAINT FK_versions_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId);
+ALTER TABLE versions ADD CONSTRAINT FK_versions_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
 ALTER TABLE versions ADD CONSTRAINT FK_versions_2 FOREIGN KEY (contentId) REFERENCES content(contentId);
 CREATE INDEX IDX_versions_1 ON versions(version);
 CREATE INDEX IDX_versions_2 ON versions USING HASH (state);
@@ -50,41 +78,19 @@ CREATE INDEX IDX_versions_5 ON versions USING HASH (createdBy);
 CREATE INDEX IDX_versions_6 ON versions(createdOn);
 CREATE INDEX IDX_versions_7 ON versions USING HASH (contentId);
 
-CREATE TABLE artifact_branches (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, branchId VARCHAR(256) NOT NULL, branchOrder INT NOT NULL, version VARCHAR(256) NOT NULL);
-ALTER TABLE artifact_branches ADD PRIMARY KEY (groupId, artifactId, branchId, branchOrder);
-ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId, version) REFERENCES versions(groupId, artifactId, version);
-CREATE INDEX IDX_artifact_branches_1 ON artifact_branches(groupId, artifactId, branchId, branchOrder);
-
-CREATE TABLE version_labels (globalId BIGINT NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(1024));
-ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId);
+CREATE TABLE version_labels (globalId BIGINT NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(512));
+ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
 CREATE INDEX IDX_vlabels_1 ON version_labels(pkey);
 CREATE INDEX IDX_vlabels_2 ON version_labels(pvalue);
 
-CREATE TABLE comments (commentId VARCHAR(128) NOT NULL, globalId BIGINT NOT NULL, createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, cvalue VARCHAR(1024) NOT NULL);
-ALTER TABLE comments ADD PRIMARY KEY (commentId);
-ALTER TABLE comments ADD CONSTRAINT FK_comments_1 FOREIGN KEY (globalId) REFERENCES versions(globalId);
-CREATE INDEX IDX_comments_1 ON comments(createdBy);
+CREATE TABLE version_comments (commentId VARCHAR(128) NOT NULL, globalId BIGINT NOT NULL, createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, cvalue VARCHAR(1024) NOT NULL);
+ALTER TABLE version_comments ADD PRIMARY KEY (commentId);
+ALTER TABLE version_comments ADD CONSTRAINT FK_version_comments_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
+CREATE INDEX IDX_version_comments_1 ON version_comments(createdBy);
 
-CREATE TABLE groups (groupId VARCHAR(512) NOT NULL, description VARCHAR(1024), artifactsType VARCHAR(32), createdBy VARCHAR(256), createdOn TIMESTAMP WITHOUT TIME ZONE NOT NULL, modifiedBy VARCHAR(256), modifiedOn TIMESTAMP WITHOUT TIME ZONE, labels TEXT);
-ALTER TABLE groups ADD PRIMARY KEY (groupId);
-
-CREATE TABLE group_labels (groupId VARCHAR(512) NOT NULL, pkey VARCHAR(256) NOT NULL, pvalue VARCHAR(1024));
-ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId);
-CREATE INDEX IDX_glabels_1 ON group_labels(pkey);
-CREATE INDEX IDX_glabels_2 ON group_labels(pvalue);
-
-CREATE TABLE acls (principalId VARCHAR(256) NOT NULL, role VARCHAR(32) NOT NULL, principalName VARCHAR(256));
-ALTER TABLE acls ADD PRIMARY KEY (principalId);
-
-CREATE TABLE downloads (downloadId VARCHAR(128) NOT NULL, expires BIGINT NOT NULL, context VARCHAR(1024));
-ALTER TABLE downloads ADD PRIMARY KEY (downloadId);
-CREATE INDEX IDX_down_1 ON downloads USING HASH (expires);
-
--- TODO: Missing NOT NULL in h2
-CREATE TABLE config (pname VARCHAR(255) NOT NULL, pvalue VARCHAR(1024) NOT NULL, modifiedOn BIGINT NOT NULL);
-ALTER TABLE config ADD PRIMARY KEY (pname);
-CREATE INDEX IDX_config_1 ON config(modifiedOn);
-
-CREATE TABLE artifactreferences (contentId BIGINT NOT NULL, groupId VARCHAR(512), artifactId VARCHAR(512) NOT NULL, version VARCHAR(256), name VARCHAR(512) NOT NULL);
-ALTER TABLE artifactreferences ADD PRIMARY KEY (contentId, name);
-ALTER TABLE artifactreferences ADD CONSTRAINT FK_artifactreferences_1 FOREIGN KEY (contentId) REFERENCES content(contentId) ON DELETE CASCADE;
+-- This table is defined way down here because it has a FK to the artifacts table *and* the versions table
+CREATE TABLE artifact_branches (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, branchId VARCHAR(256) NOT NULL, branchOrder INT NOT NULL, version VARCHAR(256) NOT NULL);
+ALTER TABLE artifact_branches ADD PRIMARY KEY (groupId, artifactId, branchId, branchOrder);
+ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
+ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_2 FOREIGN KEY (groupId, artifactId, version) REFERENCES versions(groupId, artifactId, version) ON DELETE CASCADE;
+CREATE INDEX IDX_artifact_branches_1 ON artifact_branches(groupId, artifactId, branchId, branchOrder);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
@@ -91,6 +91,6 @@ CREATE INDEX IDX_version_comments_1 ON version_comments(createdBy);
 -- This table is defined way down here because it has a FK to the artifacts table *and* the versions table
 CREATE TABLE artifact_branches (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, branchId VARCHAR(256) NOT NULL, branchOrder INT NOT NULL, version VARCHAR(256) NOT NULL);
 ALTER TABLE artifact_branches ADD PRIMARY KEY (groupId, artifactId, branchId, branchOrder);
-ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId);
+ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
 ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_2 FOREIGN KEY (groupId, artifactId, version) REFERENCES versions(groupId, artifactId, version) ON DELETE CASCADE;
 CREATE INDEX IDX_artifact_branches_1 ON artifact_branches(groupId, artifactId, branchId, branchOrder);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
@@ -91,6 +91,6 @@ CREATE INDEX IDX_version_comments_1 ON version_comments(createdBy);
 -- This table is defined way down here because it has a FK to the artifacts table *and* the versions table
 CREATE TABLE artifact_branches (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, branchId VARCHAR(256) NOT NULL, branchOrder INT NOT NULL, version VARCHAR(256) NOT NULL);
 ALTER TABLE artifact_branches ADD PRIMARY KEY (groupId, artifactId, branchId, branchOrder);
-ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
+ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId);
 ALTER TABLE artifact_branches ADD CONSTRAINT FK_artifact_branches_2 FOREIGN KEY (groupId, artifactId, version) REFERENCES versions(groupId, artifactId, version) ON DELETE CASCADE;
 CREATE INDEX IDX_artifact_branches_1 ON artifact_branches(groupId, artifactId, branchId, branchOrder);

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
@@ -986,15 +986,50 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .statusCode(204);
 
         // Verify that all 3 artifacts were deleted
-        TestUtils.retry(() -> {
-            given()
-                    .when()
-                    .queryParam("group", group)
-                    .get("/registry/v3/search/artifacts")
-                    .then()
-                    .statusCode(200)
-                    .body("count", equalTo(0));
-        });
+        given()
+                .when()
+                .queryParam("group", group)
+                .get("/registry/v3/search/artifacts")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(0));
+    }
+
+    @Test
+    public void testDeleteGroupWithArtifacts() throws Exception {
+        String group = "testDeleteGroupWithArtifacts";
+        String artifactContent = resourceToString("openapi-empty.json");
+
+        // Create several artifacts in the group.
+        createArtifact(group, "EmptyAPI-1", ArtifactType.OPENAPI, artifactContent);
+        createArtifact(group, "EmptyAPI-2", ArtifactType.OPENAPI, artifactContent);
+        createArtifact(group, "EmptyAPI-3", ArtifactType.OPENAPI, artifactContent);
+
+        // Make sure we can search for all three artifacts in the group.
+        given()
+                .when()
+                .queryParam("group", group)
+                .get("/registry/v3/search/artifacts")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(3));
+
+        // Delete the *group* (should delete all artifacts)
+        given()
+                .when()
+                .pathParam("groupId", group)
+                .delete("/registry/v3/groups/{groupId}")
+                .then()
+                .statusCode(204);
+
+        // Verify that all 3 artifacts were deleted
+        given()
+                .when()
+                .queryParam("group", group)
+                .get("/registry/v3/search/artifacts")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(0));
     }
 
     @Test

--- a/scripts/validate-files.sh
+++ b/scripts/validate-files.sh
@@ -8,7 +8,7 @@ DDLS="app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.dd
 for ddl in $DDLS 
 do
     echo "Processing DDL $ddl"
-    DB_VERSION_INSERT=$(grep "INSERT INTO apicurio (prop_name, prop_value) VALUES ('db_version'" $ddl)
+    DB_VERSION_INSERT=$(grep "INSERT INTO apicurio (propName, propValue) VALUES ('db_version'" $ddl)
     DB_VERSION_IN_DDL=$(echo $DB_VERSION_INSERT | awk '{ print $8 }' - | awk -F ")" '{ print $1}' -)
     echo "DB version in DDL is $DB_VERSION_IN_DDL"
 


### PR DESCRIPTION
This PR includes the following DB changes:

* Add `ON DELETE CASCADE` where appropriate to FKs
* Add FK from `artifact_branches` to `artifacts` table
* Rename `globalrules` to `global_rules`
* Rename `rules` table to `artifact_rules`
* Rename `artifactreferences` table to `content_references`
* Rename `artifactreferences` column on `content` table to `refs`
* Rename `comments` table to `version_comments`
* Organize/group table definitions within DDL file
* Create new `group_rules` table (future need)
* Standardize on `seq_name` and `seq_value` for column names in `sequences` table
* Reduce max label value column size to 512
* Add INDEX on label value columns for mssql DB flavor
