### PR TITLE
docs: fix config properties with no category or wrong category

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorageProducer.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorageProducer.java
@@ -29,7 +29,7 @@ public class RegistryStorageProducer {
     Instance<RegistryStorageDecorator> decorators;
 
     @ConfigProperty(name = "registry.storage.kind")
-    @Info
+    @Info(category = "storage", description = "Application storage variant, for example, sql, kafkasql, or gitops", availableSince = "3.0.0.Final")
     String registryStorageType;
 
     private RegistryStorage cachedCurrent;

--- a/app/src/main/java/io/apicurio/registry/storage/StorageBehaviorProperties.java
+++ b/app/src/main/java/io/apicurio/registry/storage/StorageBehaviorProperties.java
@@ -10,7 +10,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 public class StorageBehaviorProperties {
 
     @ConfigProperty(name = "artifacts.skip.disabled.latest", defaultValue = "true")
-    @Info(category = "store", description = "Skip artifact versions with DISABLED state when retrieving latest artifact version", availableSince = "2.4.2-SNAPSHOT")
+    @Info(category = "storage", description = "Skip artifact versions with DISABLED state when retrieving latest artifact version", availableSince = "2.4.2-SNAPSHOT")
     boolean skipLatestDisabledArtifacts;
 
     public ArtifactRetrievalBehavior getDefaultArtifactRetrievalBehavior() {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsRegistryStorage.java
@@ -53,7 +53,7 @@ public class GitOpsRegistryStorage extends AbstractReadOnlyRegistryStorage {
     GitManager gitManager;
 
     @ConfigProperty(name = "registry.storage.kind")
-    @Info
+    @Info(category = "storage", description = "Application storage variant, for example, sql, kafkasql, or gitops", availableSince = "3.0.0.Final")
     String registryStorageType;
 
     // Fair lock, so we ensure the writer does not wait indefinitely under high throughput.

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -3,22 +3,6 @@
 
 The following {registry} configuration options are available for each component category:
 
-== 
-. configuration options
-[.table-expandable,width="100%",cols="6,3,2,3,5",options="header"]
-|===
-|Name
-|Type
-|Default
-|Available from
-|Description
-|`registry.storage.kind`
-|`string`
-|
-|
-|
-|===
-
 == api
 .api configuration options
 [.table-expandable,width="100%",cols="6,3,2,3,5",options="header"]
@@ -571,6 +555,11 @@ The following {registry} configuration options are available for each component 
 |Default
 |Available from
 |Description
+|`artifacts.skip.disabled.latest`
+|`boolean`
+|`true`
+|`2.4.2-SNAPSHOT`
+|Skip artifact versions with DISABLED state when retrieving latest artifact version
 |`registry.datasource.blue.db-kind`
 |`string`
 |`h2`
@@ -776,27 +765,16 @@ The following {registry} configuration options are available for each component 
 |`h2`
 |`3.0.0.Final`
 |Application datasource database type
+|`registry.storage.kind`
+|`string`
+|
+|`3.0.0.Final`
+|Application storage variant, for example, sql, kafkasql, or gitops
 |`registry.storage.read-only`
 |`boolean [dynamic]`
 |`false`
 |`2.5.0.Final`
 |Enable Registry storage read-only mode
-|===
-
-== store
-.store configuration options
-[.table-expandable,width="100%",cols="6,3,2,3,5",options="header"]
-|===
-|Name
-|Type
-|Default
-|Available from
-|Description
-|`artifacts.skip.disabled.latest`
-|`boolean`
-|`true`
-|`2.4.2-SNAPSHOT`
-|Skip artifact versions with DISABLED state when retrieving latest artifact version
 |===
 
 == ui


### PR DESCRIPTION
Removes properties from empty category and duplicate `store` category, and assigns both properties to `storage` category.

For example, see broken auto-generated doc output of property in empty category:

![Screenshot from 2024-02-09 12-32-37](https://github.com/Apicurio/apicurio-registry/assets/29098561/9705850a-ba97-472e-ada8-dafea3178691)
