### PR TITLE
[2.5.x] Set default log level for OIDC provider to DEBUG

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -86,6 +86,7 @@ quarkus.http.non-application-root-path=/
 quarkus.log.console.format=%d{YYYY-MM-dd HH:mm:ss} %p <%X{tenantId}> [%C] (%t) %m%n
 quarkus.log.console.color=false
 quarkus.log.min-level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".level=DEBUG
 
 ## Max HTTP request body size (large files needed to support Import functionality)
 ## (Set to 50MB)


### PR DESCRIPTION
Set the default log level for the Quarkus `OidcProvider` to `DEBUG` so that issues with authentication show up in the logs without any additional configuration.