### PR TITLE
Make it easier to change the kiota base url

### DIFF
--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <kiota.libs.version>0.12.1</kiota.libs.version>
         <kiota.community.version>0.0.13</kiota.community.version>
-        <kiota.base.url>https://github.com/microsoft/kiota/releases/download1</kiota.base.url>
+        <kiota.base.url>https://github.com/microsoft/kiota/releases/download</kiota.base.url>
     </properties>
     <dependencies>
         <dependency>

--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -28,6 +28,7 @@
     <properties>
         <kiota.libs.version>0.12.1</kiota.libs.version>
         <kiota.community.version>0.0.13</kiota.community.version>
+        <kiota.base.url>https://github.com/microsoft/kiota/releases/download1</kiota.base.url>
     </properties>
     <dependencies>
         <dependency>
@@ -84,6 +85,7 @@
                 </executions>
                 <configuration>
                     <kiotaVersion>1.10.1</kiotaVersion>
+                    <baseURL>${kiota.base.url}</baseURL>
                     <file>../common/src/main/resources/META-INF/openapi.json</file>
                     <namespace>io.apicurio.registry.rest.client</namespace>
                     <clientClass>RegistryClient</clientClass>


### PR DESCRIPTION
This allows for easy overriding of the property, e.g.:

```bash
mvn clean install -f java-sdk/pom.xml -Dkiota.base.url=<my-alternative-download-location>
```