### PR TITLE
Revert "build(deps): bump io.quarkiverse.operatorsdk:quarkus-operator-sdk-bom from 6.3.3 to 6.6.8"

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -31,7 +31,7 @@
         <!-- ATTENTION! The Quarkus version needs to be aligned with the Quarkus Operator SDK -->
         <!-- TODO: possibly stabilize on something shared with the rest of the repo -->
         <quarkus.version>3.4.2</quarkus.version>
-        <quarkus.operator.sdk.version>6.6.8</quarkus.operator.sdk.version>
+        <quarkus.operator.sdk.version>6.3.3</quarkus.operator.sdk.version>
         <quarkus.container-image.group>apicurio</quarkus.container-image.group>
     </properties>
 


### PR DESCRIPTION
Reverts Apicurio/apicurio-registry#4628