### PR TITLE
Nginx returns SPA when trying to access an API version containing a period

### DIFF
--- a/ui/.docker-scripts/nginx.conf
+++ b/ui/.docker-scripts/nginx.conf
@@ -44,6 +44,11 @@ http {
         # Load configuration files for the default server block.
         include /opt/app-root/etc/nginx.default.d/*.conf;
 
+        # Location for routing requests for the API-version page to the SPA. API versions can contain periods, so might otherwise be matched by the file-extension expression
+        location ~ ^.*/explore/[^/]+/[^/]+/[^/]+$ {
+            try_files $uri $uri/ /index.html;
+        }
+
         # Any route containing a file extension (e.g. /devicesfile.js)
         location ~ ^.+\..+$ {
           try_files $uri =404;
@@ -78,6 +83,11 @@ http {
 
         # Load configuration files for the default server block.
         include /opt/app-root/etc/nginx.default.d/*.conf;
+
+        # Location for routing requests for the API-version page to the SPA. API versions can contain periods, so might otherwise be matched by the file-extension expression
+        location ~ ^.*/explore/[^/]+/[^/]+/[^/]+$ {
+            try_files $uri $uri/ /index.html;
+        }
 
         # Any route containing a file extension (e.g. /devicesfile.js)
         location ~ ^.+\..+$ {


### PR DESCRIPTION
Fix for #4846 

The current Nginx configuration included in the UI container image returns 404 when directly trying to access an API version containing a period (e.g. semantic versions such as 1.0.0) due to the first location in the configuration that matches file extensions.

