### PR TITLE
fix: override version of io.strimzi:kafka-oauth-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -696,6 +696,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.strimzi</groupId>
+                <artifactId>kafka-oauth-common</artifactId>
+                <version>${kafka-oauth-client.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>


### PR DESCRIPTION
For some reason, the dependency tree was:

+- io.strimzi:kafka-oauth-client:jar:0.15.0:compile |  \- io.strimzi:kafka-oauth-common:jar:0.14.0:compile

I couldn't find out why.