### PR TITLE
Fix searchVersions Method when used in ApiCurio 3.0.0.M3 with mssql as storage layer

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -1444,8 +1444,15 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                 binder.bind(countQuery, idx);
                 idx++;
             }
-            versionsQuery.bind(idx++, limit);
-            versionsQuery.bind(idx++, offset);
+
+            // TODO find a better way to swap arguments
+            if ("mssql".equals(sqlStatements.dbType())) {
+                versionsQuery.bind(idx++, offset);
+                versionsQuery.bind(idx++, limit);
+            } else {
+                versionsQuery.bind(idx++, limit);
+                versionsQuery.bind(idx++, offset);
+            }
 
             // Execute query
             List<SearchedVersionDto> versions = versionsQuery.map(SearchedVersionMapper.instance).list();


### PR DESCRIPTION
Hey!

We came across an issue when we call the versions endpoint in ApiCurio 3.0.0.M3 using mssql as the underlying storage layer.

The limit and offset variables are not swapped for the searchVersions method (as it is done for the other ones), so the query throws an error.

See the query rewrite for mssql: https://github.com/Apicurio/apicurio-registry/blob/v3.0.0.M3/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java#L1551

where offset and limit have a different order for mssql

And see as a reference: https://github.com/Apicurio/apicurio-registry/blob/v3.0.0.M3/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java#L1058

where the variable bindings are swapped for mssql in one of the other methods

Currently the versions tab in the ui of ApiCurio with Version 3.0.0.M3 and mssql can't be used.

It would be really great if you could integrate that and release another version with this fix for 3.0.0.M3, since it currently blocks us from using ApiCurio 3

Thanks a lot for the great work and support!