### PR TITLE
Created an option in the CCompat API to support groups via subject naming convention

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/CCompatConfig.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/CCompatConfig.java
@@ -46,6 +46,13 @@ public class CCompatConfig {
     @Info(category = "ccompat", description = "Maximum number of Subjects returned (compatibility API)", availableSince = "2.4.2.Final")
     Supplier<Integer> maxSubjects;
 
+    @ConfigProperty(name = "registry.ccompat.group-concat.enabled", defaultValue = "false")
+    @Info(category = "ccompat", description = "Enable group support via concatenation in subject (compatibility API)", availableSince = "2.6.2.Final")
+    public boolean groupConcatEnabled;
+
+    @ConfigProperty(name = "registry.ccompat.group-concat.separator", defaultValue = ":")
+    @Info(category = "ccompat", description = "Separator to use when group concatenation is enabled (compatibility API)", availableSince = "2.6.2.Final")
+    public String groupConcatSeparator;
 
     public Supplier<Boolean> getCanonicalHashModeEnabled() {
         return canonicalHashModeEnabled;

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
@@ -26,7 +26,6 @@ import io.apicurio.registry.ccompat.rest.v7.SchemasResource;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
-import io.apicurio.registry.model.GA;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
@@ -26,6 +26,7 @@ import io.apicurio.registry.ccompat.rest.v7.SchemasResource;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
+import io.apicurio.registry.model.GA;
 import io.apicurio.registry.storage.ArtifactNotFoundException;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectVersionsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectVersionsResourceImpl.java
@@ -18,6 +18,7 @@ package io.apicurio.registry.ccompat.rest.v7.impl;
 
 import io.apicurio.common.apps.logging.Logged;
 import io.apicurio.common.apps.logging.audit.Audited;
+import io.apicurio.common.apps.util.Pair;
 import io.apicurio.registry.auth.Authorized;
 import io.apicurio.registry.auth.AuthorizedLevel;
 import io.apicurio.registry.auth.AuthorizedStyle;
@@ -32,6 +33,7 @@ import io.apicurio.registry.ccompat.rest.v7.SubjectVersionsResource;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
+import io.apicurio.registry.model.GA;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.dto.StoredArtifactDto;
@@ -64,22 +66,27 @@ public class SubjectVersionsResourceImpl extends AbstractResource implements Sub
     @Inject
     ApiConverter converter;
 
+    // GET /apis/ccompat/v7/subjects/{subject}/versions
     @Override
     @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Read)
     public List<Integer> listVersions(String subject, String groupId, Boolean deleted) throws Exception {
         final boolean fdeleted = deleted == null ? Boolean.FALSE : deleted;
+        final GA ga = getGA(groupId, subject);
+
         if (fdeleted) {
-            return storage.getArtifactVersions(groupId, subject, DEFAULT).stream().map(VersionUtil::toLong).map(converter::convertUnsigned).sorted().collect(Collectors.toList());
+            return storage.getArtifactVersions(ga.getGroupId(), ga.getArtifactId(), DEFAULT).stream().map(VersionUtil::toLong).map(converter::convertUnsigned).sorted().collect(Collectors.toList());
         } else {
-            return storage.getArtifactVersions(groupId, subject, SKIP_DISABLED_LATEST).stream().map(VersionUtil::toLong).map(converter::convertUnsigned).sorted().collect(Collectors.toList());
+            return storage.getArtifactVersions(ga.getGroupId(), ga.getArtifactId(), SKIP_DISABLED_LATEST).stream().map(VersionUtil::toLong).map(converter::convertUnsigned).sorted().collect(Collectors.toList());
         }
     }
 
+    // POST /apis/ccompat/v7/subjects/{subject}/versions
     @Override
     @Audited(extractParameters = {"0", KEY_ARTIFACT_ID})
     @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Write)
     public SchemaId register(String subject, SchemaInfo request, Boolean normalize, String groupId) throws Exception {
         final boolean fnormalize = normalize == null ? Boolean.FALSE : normalize;
+        final GA ga = getGA(groupId, subject);
 
         // Check to see if this content is already registered - return the global ID of that content
         // if it exists.  If not, then register the new content.
@@ -92,9 +99,9 @@ public class SubjectVersionsResourceImpl extends AbstractResource implements Sub
         final Map<String, ContentHandle> resolvedReferences = resolveReferences(request.getReferences());
 
         try {
-            ArtifactVersionMetaDataDto dto = lookupSchema(groupId, subject, request.getSchema(), request.getReferences(), request.getSchemaType(), fnormalize);
+            ArtifactVersionMetaDataDto dto = lookupSchema(ga.getGroupId(), ga.getArtifactId(), request.getSchema(), request.getReferences(), request.getSchemaType(), fnormalize);
             if (dto.getState().equals(ArtifactState.DISABLED)) {
-                throw new ArtifactNotFoundException(groupId, subject);
+                throw new ArtifactNotFoundException(ga.getGroupId(), ga.getArtifactId());
             }
             sid = cconfig.legacyIdModeEnabled.get() ? dto.getGlobalId() : dto.getContentId();
             idFound = true;
@@ -110,7 +117,7 @@ public class SubjectVersionsResourceImpl extends AbstractResource implements Sub
                     throw new UnprocessableEntityException(String.format("Given schema is not from type: %s", request.getSchemaType()));
                 }
 
-                ArtifactMetaDataDto artifactMeta = createOrUpdateArtifact(subject, request.getSchema(), artifactType, request.getReferences(), groupId);
+                ArtifactMetaDataDto artifactMeta = createOrUpdateArtifact(ga.getArtifactId(), request.getSchema(), artifactType, request.getReferences(), ga.getGroupId());
                 sid = cconfig.legacyIdModeEnabled.get() ? artifactMeta.getGlobalId() : artifactMeta.getContentId();
             } catch (InvalidArtifactTypeException ex) {
                 //If no artifact type can be inferred, throw invalid schema ex
@@ -122,87 +129,95 @@ public class SubjectVersionsResourceImpl extends AbstractResource implements Sub
         return new SchemaId(id);
     }
 
+    // GET /apis/ccompat/v7/subjects/{subject}/versions/{version}
     @Override
     @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Read)
     public Schema getSchemaByVersion(String subject, String version, String groupId, Boolean deleted) throws Exception {
         final boolean fdeleted = deleted == null ? Boolean.FALSE : deleted;
-        return getSchema(groupId, subject, version, fdeleted);
+        final GA ga = getGA(groupId, subject);
+        return getSchema(ga.getGroupId(), ga.getArtifactId(), version, fdeleted);
     }
 
+    // DELETE /apis/ccompat/v7/subjects/{subject}/versions/{version}
     @Override
     @Audited(extractParameters = {"0", KEY_ARTIFACT_ID, "1", KEY_VERSION})
     @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Write)
     public int deleteSchemaVersion(String subject, String versionString, Boolean permanent, String groupId) throws Exception {
+        final GA ga = getGA(groupId, subject);
         try {
-            if (doesArtifactExist(subject, groupId)) {
+            if (doesArtifactExist(ga.getArtifactId(), ga.getGroupId())) {
                 final boolean fpermanent = permanent == null ? Boolean.FALSE : permanent;
 
-                return VersionUtil.toInteger(parseVersionString(subject, versionString, groupId, version -> {
-                    List<Long> globalIdsReferencingSchema = storage.getGlobalIdsReferencingArtifact(groupId, subject, version);
-                    ArtifactVersionMetaDataDto avmd = storage.getArtifactVersionMetaData(groupId, subject, version);
+                return VersionUtil.toInteger(parseVersionString(ga.getArtifactId(), versionString, ga.getGroupId(), version -> {
+                    List<Long> globalIdsReferencingSchema = storage.getGlobalIdsReferencingArtifact(ga.getGroupId(), ga.getArtifactId(), version);
+                    ArtifactVersionMetaDataDto avmd = storage.getArtifactVersionMetaData(ga.getGroupId(), ga.getArtifactId(), version);
                     if (globalIdsReferencingSchema.isEmpty() || areAllSchemasDisabled(globalIdsReferencingSchema)) {
-                        return processDeleteVersion(subject, versionString, groupId, version, fpermanent, avmd);
+                        return processDeleteVersion(ga.getArtifactId(), versionString, ga.getGroupId(), version, fpermanent, avmd);
                     } else {
                         //There are other schemas referencing this one, it cannot be deleted.
                         throw new ReferenceExistsException(String.format("There are subjects referencing %s", subject));
                     }
-
                 }));
             } else {
-                throw new ArtifactNotFoundException(groupId, subject);
+                throw new ArtifactNotFoundException(ga.getGroupId(), ga.getArtifactId());
             }
         } catch (IllegalArgumentException ex) {
             throw new BadRequestException(ex);
         }
     }
 
-    private String processDeleteVersion(String subject, String versionString, String groupId, String version, boolean fpermanent, ArtifactVersionMetaDataDto avmd) {
+    private String processDeleteVersion(String artifactId, String versionString, String groupId, String version, boolean fpermanent, ArtifactVersionMetaDataDto avmd) {
         if (fpermanent) {
             if (avmd.getState().equals(ArtifactState.ENABLED) || avmd.getState().equals(ArtifactState.DEPRECATED)) {
-                throw new SchemaNotSoftDeletedException(String.format("Subject %s version %s must be soft deleted first", subject, versionString));
+                throw new SchemaNotSoftDeletedException(String.format("Subject %s version %s must be soft deleted first", artifactId, versionString));
             } else if (avmd.getState().equals(ArtifactState.DISABLED)) {
-                storage.deleteArtifactVersion(groupId, subject, version);
+                storage.deleteArtifactVersion(groupId, artifactId, version);
             }
         } else {
             if (avmd.getState().equals(ArtifactState.DISABLED)) {
                 throw new SchemaSoftDeletedException("Schema is already soft deleted");
             } else {
-                storage.updateArtifactState(groupId, subject, version, ArtifactState.DISABLED);
+                storage.updateArtifactState(groupId, artifactId, version, ArtifactState.DISABLED);
             }
         }
         return version;
     }
 
+    // GET /apis/ccompat/v7/subjects/{subject}/versions/{version}/schema
     @Override
     @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Read)
     public String getSchemaOnly(String subject, String version, String groupId, Boolean deleted) throws Exception {
+        final GA ga = getGA(groupId, subject);
         final boolean fdeleted = deleted == null ? Boolean.FALSE : deleted;
-        return getSchema(groupId, subject, version, fdeleted).getSchema();
+        return getSchema(ga.getGroupId(), ga.getArtifactId(), version, fdeleted).getSchema();
     }
 
+    // GET /apis/ccompat/v7/subjects/{subject}/versions/{version}/referencedBy
     @Override
     @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Read)
     public List<Long> getSchemasReferencedBy(String subject, String versionString, String groupId) throws Exception {
+        final GA ga = getGA(groupId, subject);
+
         if (cconfig.legacyIdModeEnabled.get()) {
-            return parseVersionString(subject, versionString, groupId, version -> storage.getGlobalIdsReferencingArtifact(groupId, subject, version));
+            return parseVersionString(ga.getArtifactId(), versionString, ga.getGroupId(), version -> storage.getGlobalIdsReferencingArtifact(ga.getGroupId(), ga.getArtifactId(), version));
         }
 
-        return parseVersionString(subject, versionString, groupId, version -> storage.getContentIdsReferencingArtifact(groupId, subject, version));
+        return parseVersionString(ga.getArtifactId(), versionString, ga.getGroupId(), version -> storage.getContentIdsReferencingArtifact(ga.getGroupId(), ga.getArtifactId(), version));
     }
 
-    protected Schema getSchema(String groupId, String subject, String versionString, boolean deleted) {
-        if (doesArtifactExist(subject, groupId) && isArtifactActive(subject, groupId, SKIP_DISABLED_LATEST)) {
-            return parseVersionString(subject, versionString, groupId, version -> {
-                ArtifactVersionMetaDataDto amd = storage.getArtifactVersionMetaData(groupId, subject, version);
+    protected Schema getSchema(String groupId, String artifactId, String versionString, boolean deleted) {
+        if (doesArtifactExist(artifactId, groupId) && isArtifactActive(artifactId, groupId, SKIP_DISABLED_LATEST)) {
+            return parseVersionString(artifactId, versionString, groupId, version -> {
+                ArtifactVersionMetaDataDto amd = storage.getArtifactVersionMetaData(groupId, artifactId, version);
                 if (amd.getState() != ArtifactState.DISABLED || deleted) {
-                    StoredArtifactDto storedArtifact = storage.getArtifactVersion(groupId, subject, amd.getVersion());
-                    return converter.convert(subject, storedArtifact, amd.getType());
+                    StoredArtifactDto storedArtifact = storage.getArtifactVersion(groupId, artifactId, amd.getVersion());
+                    return converter.convert(artifactId, storedArtifact, amd.getType());
                 } else {
-                    throw new VersionNotFoundException(groupId, subject, version);
+                    throw new VersionNotFoundException(groupId, artifactId, version);
                 }
             });
         } else {
-            throw new ArtifactNotFoundException(groupId, subject);
+            throw new ArtifactNotFoundException(groupId, artifactId);
         }
     }
 }

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectVersionsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectVersionsResourceImpl.java
@@ -18,7 +18,6 @@ package io.apicurio.registry.ccompat.rest.v7.impl;
 
 import io.apicurio.common.apps.logging.Logged;
 import io.apicurio.common.apps.logging.audit.Audited;
-import io.apicurio.common.apps.util.Pair;
 import io.apicurio.registry.auth.Authorized;
 import io.apicurio.registry.auth.AuthorizedLevel;
 import io.apicurio.registry.auth.AuthorizedStyle;

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -45,7 +45,6 @@ import io.apicurio.registry.util.VersionUtil;
 import jakarta.interceptor.Interceptors;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -19,7 +19,6 @@ package io.apicurio.registry.ccompat.rest.v7.impl;
 import com.google.common.base.Function;
 import io.apicurio.common.apps.logging.Logged;
 import io.apicurio.common.apps.logging.audit.Audited;
-import io.apicurio.common.apps.util.Pair;
 import io.apicurio.registry.auth.Authorized;
 import io.apicurio.registry.auth.AuthorizedLevel;
 import io.apicurio.registry.auth.AuthorizedStyle;

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -16,8 +16,10 @@
 
 package io.apicurio.registry.ccompat.rest.v7.impl;
 
+import com.google.common.base.Function;
 import io.apicurio.common.apps.logging.Logged;
 import io.apicurio.common.apps.logging.audit.Audited;
+import io.apicurio.common.apps.util.Pair;
 import io.apicurio.registry.auth.Authorized;
 import io.apicurio.registry.auth.AuthorizedLevel;
 import io.apicurio.registry.auth.AuthorizedStyle;
@@ -29,6 +31,8 @@ import io.apicurio.registry.ccompat.rest.error.SubjectSoftDeletedException;
 import io.apicurio.registry.ccompat.rest.v7.SubjectsResource;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
+import io.apicurio.registry.model.GA;
+import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
@@ -61,22 +65,37 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
     public List<String> listSubjects(String subjectPrefix, Boolean deleted, String groupId) {
         //Since contexts are not supported, subjectPrefix is not used
         final boolean fdeleted = deleted == null ? Boolean.FALSE : deleted;
-        return storage.searchArtifacts(Set.of(SearchFilter.ofGroup(groupId)), OrderBy.createdOn, OrderDirection.asc, 0, cconfig.maxSubjects.get()).getArtifacts().stream().filter(searchedArtifactDto -> isCcompatManagedType(searchedArtifactDto.getType()) && shouldFilterState(fdeleted, searchedArtifactDto.getState())).map(SearchedArtifactDto::getId).collect(Collectors.toList());
+        Set<SearchFilter> filters = Set.of();
+        if (groupId != null) {
+            filters.add(SearchFilter.ofGroup(groupId));
+        }
+        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, OrderBy.createdOn,
+                OrderDirection.asc, 0, cconfig.maxSubjects.get());
+        Function<SearchedArtifactDto, String> toSubject = SearchedArtifactDto::getId;
+        if (cconfig.groupConcatEnabled) {
+            toSubject = (dto) -> toSubjectWithGroupConcat(dto);
+        }
+        return results.getArtifacts().stream().filter(searchedArtifactDto ->
+                isCcompatManagedType(searchedArtifactDto.getType()) &&
+                shouldFilterState(fdeleted, searchedArtifactDto.getState())
+        ).map(toSubject).collect(Collectors.toList());
     }
 
     @Override
     @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Read)
     public Schema findSchemaByContent(String subject, SchemaInfo request, Boolean normalize, String groupId, Boolean deleted) throws Exception {
-        if (doesArtifactExist(subject, groupId)) {
+        GA ga = getGA(groupId, subject);
+
+        if (doesArtifactExist(ga.getArtifactId(), ga.getGroupId())) {
             final boolean fnormalize = normalize == null ? Boolean.FALSE : normalize;
             final boolean fdeleted = deleted == null ? Boolean.FALSE : deleted;
 
             try {
                 ArtifactVersionMetaDataDto amd;
-                amd = lookupSchema(groupId, subject, request.getSchema(), request.getReferences(), request.getSchemaType(), fnormalize);
+                amd = lookupSchema(ga.getGroupId(), ga.getArtifactId(), request.getSchema(), request.getReferences(), request.getSchemaType(), fnormalize);
                 if (amd.getState() != ArtifactState.DISABLED || fdeleted) {
-                    StoredArtifactDto storedArtifact = storage.getArtifactVersion(groupId, subject, amd.getVersion());
-                    return converter.convert(subject, storedArtifact);
+                    StoredArtifactDto storedArtifact = storage.getArtifactVersion(ga.getGroupId(), ga.getArtifactId(), amd.getVersion());
+                    return converter.convert(ga.getArtifactId(), storedArtifact);
                 } else {
                     throw new SchemaNotFoundException(String.format("The given schema does not match any schema under the subject %s", subject));
                 }
@@ -85,7 +104,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
             }
         } else {
             //If the artifact does not exist there is no need for looking up the schema, just fail.
-            throw new ArtifactNotFoundException(groupId, subject);
+            throw new ArtifactNotFoundException(ga.getGroupId(), ga.getArtifactId());
         }
     }
 
@@ -93,13 +112,15 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
     @Audited(extractParameters = {"0", KEY_ARTIFACT_ID})
     @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Write)
     public List<Integer> deleteSubject(String subject, Boolean permanent, String groupId) throws Exception {
+        GA ga = getGA(groupId, subject);
+
         final boolean fpermanent = permanent == null ? Boolean.FALSE : permanent;
         if (fpermanent) {
-            return deleteSubjectPermanent(groupId, subject);
-        } else if (isArtifactActive(subject, groupId, DEFAULT)) {
-            return deleteSubjectVersions(groupId, subject);
+            return deleteSubjectPermanent(ga.getGroupId(), ga.getArtifactId());
+        } else if (isArtifactActive(ga.getArtifactId(), ga.getGroupId(), DEFAULT)) {
+            return deleteSubjectVersions(ga.getGroupId(), ga.getArtifactId());
         } else {
-            if (storage.isArtifactExists(groupId, subject)) {
+            if (storage.isArtifactExists(ga.getGroupId(), ga.getArtifactId())) {
                 //The artifact exist, it's in DISABLED state but the delete request is set to not permanent, throw ex.
                 throw new SubjectSoftDeletedException(String.format("Subject %s is in soft deleted state.", subject));
             } else {
@@ -108,19 +129,20 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
         }
     }
 
-    private List<Integer> deleteSubjectPermanent(String groupId, String subject) {
-        if (isArtifactActive(subject, groupId, DEFAULT)) {
+    private List<Integer> deleteSubjectPermanent(String groupId, String artifactId) {
+        if (isArtifactActive(artifactId, groupId, DEFAULT)) {
+            String subject = toSubjectWithGroupConcat(groupId, artifactId);
             throw new SubjectNotSoftDeletedException(String.format("Subject %s must be soft deleted first", subject));
         } else {
-            return storage.deleteArtifact(groupId, subject).stream().map(VersionUtil::toInteger).map(converter::convertUnsigned).collect(Collectors.toList());
+            return storage.deleteArtifact(groupId, artifactId).stream().map(VersionUtil::toInteger).map(converter::convertUnsigned).collect(Collectors.toList());
         }
     }
 
     //Deleting artifact versions means updating all the versions status to DISABLED.
-    private List<Integer> deleteSubjectVersions(String groupId, String subject) {
-        List<String> deletedVersions = storage.getArtifactVersions(groupId, subject);
+    private List<Integer> deleteSubjectVersions(String groupId, String artifactId) {
+        List<String> deletedVersions = storage.getArtifactVersions(groupId, artifactId);
         try {
-            deletedVersions.forEach(version -> storage.updateArtifactState(groupId, subject, version, ArtifactState.DISABLED));
+            deletedVersions.forEach(version -> storage.updateArtifactState(groupId, artifactId, version, ArtifactState.DISABLED));
         } catch (InvalidArtifactStateException ignored) {
             log.warn("Invalid artifact state transition", ignored);
         }

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/ConfluentCompatApiWithGroupsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/ConfluentCompatApiWithGroupsTest.java
@@ -24,7 +24,6 @@ import io.apicurio.registry.utils.IoUtil;
 import io.apicurio.registry.utils.tests.CCompatWithGroupsTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.restassured.response.ResponseBodyExtractionOptions;
 import io.restassured.response.ValidatableResponse;
 import jakarta.enterprise.inject.Typed;
 import org.hamcrest.Matchers;

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/ConfluentCompatApiWithGroupsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/ConfluentCompatApiWithGroupsTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2022 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.noprofile.ccompat.rest.v7;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ccompat.rest.ContentTypes;
+import io.apicurio.registry.rest.v2.beans.ArtifactMetaData;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.utils.IoUtil;
+import io.apicurio.registry.utils.tests.CCompatWithGroupsTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.response.ResponseBodyExtractionOptions;
+import io.restassured.response.ValidatableResponse;
+import jakarta.enterprise.inject.Typed;
+import org.hamcrest.Matchers;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.apicurio.registry.noprofile.ccompat.rest.CCompatTestConstants.SCHEMA_SIMPLE_WRAPPED;
+import static io.restassured.RestAssured.given;
+
+/**
+ * Tests that the REST API exposed at endpoint "/ccompat/v7" follows the
+ * <a href="https://docs.confluent.io/7.2.1/schema-registry/develop/api.html">Confluent API specification</a>,
+ * unless otherwise stated.
+ *
+ * @author Carles Arnal
+ */
+@QuarkusTest
+@Typed(ConfluentCompatApiWithGroupsTest.class)
+@TestProfile(CCompatWithGroupsTestProfile.class)
+public class ConfluentCompatApiWithGroupsTest extends AbstractResourceTestBase {
+
+    public static final String BASE_PATH = "/ccompat/v7";
+
+    private static String toSubject(String groupId, String artifactId) {
+        return groupId + ":" + artifactId;
+    }
+
+    @NotNull
+    public String getBasePath() {
+        return BASE_PATH;
+    }
+
+    @Test
+    public void testCreateSubject() throws Exception {
+        final String groupId = "g_testCreateSubject";
+        final String artifactId = "a_testCreateSubject";
+        final String subject = toSubject(groupId, artifactId);
+
+        // POST
+        ValidatableResponse res = given()
+                .when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(SCHEMA_SIMPLE_WRAPPED)
+                .post(getBasePath() + "/subjects/{subject}/versions", subject)
+                .then()
+                .statusCode(200)
+                .body("id", Matchers.allOf(Matchers.isA(Integer.class), Matchers.greaterThanOrEqualTo(0)));
+        /*int id = */
+        res.extract().jsonPath().getInt("id");
+
+        // Verify with ccompat
+        given()
+                .when()
+                .get(getBasePath() + "/subjects/").then().body(Matchers.containsString(subject));
+        // Verify with core
+        ArtifactMetaData amd = clientV2.getArtifactMetaData(groupId, artifactId);
+        Assertions.assertNotNull(amd);
+
+        // Invalid subject format
+        given()
+                .when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(SCHEMA_SIMPLE_WRAPPED)
+                .post(getBasePath() + "/subjects/{subject}/versions", "invalid-subject-format")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void testDeleteSubject() throws Exception {
+        final String groupId = "g_testDeleteSubject";
+        final String artifactId = "a_testDeleteSubject";
+        final String subject = toSubject(groupId, artifactId);
+
+        // Create using core API
+        clientV2.createArtifact(groupId, artifactId, ArtifactType.AVRO, IoUtil.toStream(SCHEMA_SIMPLE_WRAPPED));
+
+        // Verify using ccompat
+        given()
+                .when()
+                .get(getBasePath() + "/subjects/").then().body(Matchers.containsString(subject));
+
+        // DELETE
+        given()
+                .when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .delete(getBasePath() + "/subjects/{subject}", subject)
+                .then()
+                .statusCode(200)
+                .body(Matchers.anything());
+
+        // Verify with ccompat
+        given()
+                .when()
+                .get(getBasePath() + "/subjects/").then().body(Matchers.not(Matchers.containsString(subject)));
+        // Verify with core
+        Exception e = Assertions.assertThrows(Exception.class, () -> {
+            clientV2.getArtifactMetaData(groupId, artifactId);
+        });
+        Assertions.assertEquals("No artifact with ID 'a_testDeleteSubject' in group 'g_testDeleteSubject' was found.", e.getMessage());
+    }
+
+    @Test
+    public void testListSubjects() throws Exception {
+        final String groupId1 = "g_testListSubjects1";
+        final String groupId2 = "g_testListSubjects2";
+        final String artifactId1 = "a_testListSubjects1";
+        final String artifactId2 = "a_testListSubjects2";
+        final String artifactId3 = "a_testListSubjects3";
+        final String subject1_1 = toSubject(groupId1, artifactId1);
+        final String subject1_2 = toSubject(groupId1, artifactId2);
+        final String subject1_3 = toSubject(groupId1, artifactId3);
+        final String subject2_1 = toSubject(groupId2, artifactId1);
+        final String subject2_2 = toSubject(groupId2, artifactId2);
+
+        // Create using core API
+        // Group 1
+        clientV2.createArtifact(groupId1, artifactId1, ArtifactType.AVRO, IoUtil.toStream(SCHEMA_SIMPLE_WRAPPED));
+        clientV2.createArtifact(groupId1, artifactId2, ArtifactType.AVRO, IoUtil.toStream(SCHEMA_SIMPLE_WRAPPED));
+        clientV2.createArtifact(groupId1, artifactId3, ArtifactType.AVRO, IoUtil.toStream(SCHEMA_SIMPLE_WRAPPED));
+        // Group 2
+        clientV2.createArtifact(groupId2, artifactId1, ArtifactType.AVRO, IoUtil.toStream(SCHEMA_SIMPLE_WRAPPED));
+        clientV2.createArtifact(groupId2, artifactId2, ArtifactType.AVRO, IoUtil.toStream(SCHEMA_SIMPLE_WRAPPED));
+
+        // Verify with ccompat
+        List<?> subjects = given()
+                .when()
+                .get(getBasePath() + "/subjects/")
+                .then()
+                .statusCode(200)
+                .extract().body().as(List.class);
+
+        Assertions.assertTrue(subjects.contains(subject1_1));
+        Assertions.assertTrue(subjects.contains(subject1_2));
+        Assertions.assertTrue(subjects.contains(subject1_3));
+        Assertions.assertTrue(subjects.contains(subject2_1));
+        Assertions.assertTrue(subjects.contains(subject2_2));
+
+        // Get versions
+        List<?> versions = given()
+                .when()
+                .get(getBasePath() + "/subjects/{subject}/versions", subject1_1)
+                .then()
+                .statusCode(200)
+                .extract().body().as(List.class);
+        Assertions.assertEquals(1, versions.size());
+        Assertions.assertTrue(versions.contains(1));
+
+        // Get one version
+        given()
+                .when()
+                .get(getBasePath() + "/subjects/{subject}/versions/{version}", subject1_1, "1")
+                .then()
+                .statusCode(200)
+                .body(Matchers.anything());
+        given()
+                .when()
+                .get(getBasePath() + "/subjects/{subject}/versions/{version}/schema", subject1_1, "1")
+                .then()
+                .statusCode(200)
+                .body(Matchers.anything());
+        given()
+                .when()
+                .get(getBasePath() + "/subjects/{subject}/versions/{version}/referencedby", subject1_1, "1")
+                .then()
+                .statusCode(200)
+                .body(Matchers.anything());
+    }
+
+}

--- a/common/src/main/java/io/apicurio/registry/model/GA.java
+++ b/common/src/main/java/io/apicurio/registry/model/GA.java
@@ -1,0 +1,15 @@
+package io.apicurio.registry.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GA {
+
+    private final String groupId;
+    private final String artifactId;
+
+}

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -190,6 +190,16 @@ The following {registry} configuration options are available for each component 
 |Default
 |Available from
 |Description
+|`registry.ccompat.group-concat.enabled`
+|`boolean`
+|`false`
+|`2.6.2.Final`
+|Enable group support via concatenation in subject (compatibility API)
+|`registry.ccompat.group-concat.separator`
+|`string`
+|`:`
+|`2.6.2.Final`
+|Separator to use when group concatenation is enabled (compatibility API)
 |`registry.ccompat.legacy-id-mode.enabled`
 |`boolean [dynamic]`
 |`false`

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/CCompatWithGroupsTestProfile.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/CCompatWithGroupsTestProfile.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.utils.tests;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class CCompatWithGroupsTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("registry.ccompat.group-concat.enabled", "true");
+    }
+}


### PR DESCRIPTION
This change introduces a config option that, when enabled, will allow the ccompat API to support groups via a subject naming convention:

`subject` `=` `groupId` `:separator:` `artifactId`

When enabled all CCompat operations will support this new `subject` naming convention.  This allows the ccompat API to read and write artifacts in groups.