### PR TITLE
Fixes AUTH_CLIENT_ID typo

### DIFF
--- a/ui/.docker-scripts/create-config.cjs
+++ b/ui/.docker-scripts/create-config.cjs
@@ -72,7 +72,7 @@ if (AUTH_TYPE === "oidc") {
         CONFIG.auth.options.redirectUri = AUTH_REDIRECT_URL;
     }
     if (AUTH_CLIENT_ID) {
-        CONFIG.auth.options.clientId = AUTH_CLIENT_ID_URL;
+        CONFIG.auth.options.clientId = AUTH_CLIENT_ID;
     }
     if (AUTH_CLIENT_SCOPES) {
         CONFIG.auth.options.scope = AUTH_CLIENT_SCOPES;


### PR DESCRIPTION
Caught this when trying to spin up apicurio-api-lifecycle-hub (undefined variable). This is a pure gut feeling fix :)