### PR TITLE
Stabilize CI pipelines

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -64,7 +64,149 @@ jobs:
       - name: Build and Push Application image
         run: |
           docker buildx build --push -f ./distro/docker/target/docker/Dockerfile.jvm -t ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le ./distro/docker/target/docker
-  
+
+  prepare-ui-tests:
+    name: Prepare for UI Integration Tests
+    runs-on: ubuntu-20.04
+    if: github.repository_owner == 'Apicurio' && !contains(github.event.*.labels.*.name, 'DO NOT MERGE')
+    steps:
+      - name: Show Actor
+        run: echo ${{github.actor}}
+
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+          cache-dependency-path: 'ui/**/package-lock.json'
+
+      - name: Build and verify the typescript-sdk
+        working-directory: typescript-sdk
+        run: |
+          npm install
+          npm run generate-registry-sdk
+          npm run lint
+          npm run build
+
+      - name: Install UI Dependencies
+        run: |
+          cd ui
+          npm install
+
+      - name: Lint UI Code
+        run: |
+          cd ui
+          npm run lint
+
+      - name: Build and Package UI
+        run: |
+          cd ui
+          npm run build
+          npm run package
+
+      - name: Build and Push UI image
+        env:
+          IMAGE_REPO: ttl.sh/${{ github.sha }}
+          # maximum allowed
+          IMAGE_TAG: 1d
+        run: |
+          cd ui
+          docker build -t $IMAGE_REPO/apicurio/apicurio-registry-ui:$IMAGE_TAG .
+          docker push $IMAGE_REPO/apicurio/apicurio-registry-ui:$IMAGE_TAG
+
+  integration-tests-h2:
+    name: Integration Tests H2
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - H2
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Run Integration Tests - auth - H2
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Run Integration Tests - migration - H2
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          name: tests-logs-h2
+          path: artifacts
+
+  integration-tests-postgresql:
+    name: Integration Tests Postgresql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Postgresql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Run Integration Tests - auth - Postgresql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Run Integration Tests - migration - Postgresql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          name: tests-logs-postgresql
+          path: artifacts
+
 
   integration-tests-kafkasql:
     name: Integration Tests KafkaSql
@@ -94,6 +236,15 @@ jobs:
       - name: Run Integration Tests - Kafkasql
         run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
+      - name: Run Integration Tests - auth - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Run Integration Tests - migration - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Run Integration Tests - snapshotting - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pkafkasql-snapshotting -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
       - name: Collect logs
         if: failure()
         run: sh ./.github/scripts/collect_logs.sh
@@ -105,13 +256,90 @@ jobs:
           name: tests-logs-kafkasql
           path: artifacts
 
-  integration-tests-kafkasql1:
-    name: Integration Tests KafkaSql
+  integration-tests-ui:
+    name: Integration Tests UI
     runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
+    needs: [prepare-ui-tests, prepare-integration-tests]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+          cache-dependency-path: 'ui/tests/package-lock.json'
+
+      - name: Run UI tests
+        run: |
+          echo "Starting Registry App (In Memory)"
+          docker run -it -p 8080:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d
+          echo "Starting Registry UI"
+          docker run -it -p 8888:8080 -d ttl.sh/${{ github.sha }}/apicurio/apicurio-registry-ui:1d
+
+          cd ui/tests
+          npm install
+          npx playwright install --with-deps
+
+          echo "App System Info:"
+          echo "--"
+          curl -s http://localhost:8080/apis/registry/v3/system/info
+          echo "--"
+          echo ""
+          echo "UI Config Info (Local):"
+          echo "--"
+          curl -s http://localhost:8888/config.js
+          echo "--"
+          echo ""
+          echo "UI Config Info (Remote):"
+          echo "--"
+          curl -s http://localhost:8080/apis/registry/v3/system/uiConfig
+          echo "--"
+          echo ""
+          echo "UI Version Info:"
+          curl -s http://localhost:8888/version.js
+          echo "--"
+          echo "UI index.html:"
+          echo "--"
+          curl -s http://localhost:8888
+          echo "--"
+          echo ""
+          echo "-------------------------"
+          echo "Running Playwright tests!"
+          echo "-------------------------"
+          npm run test
+
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: ui/tests/playwright-report/
+          retention-days: 30
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: tests-logs-ui
+          path: artifacts
+
+  integration-tests-legacy-v2:
+    name: Integration Tests Legacy V2
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Registry 2.5
+        uses: actions/checkout@v4
+        with:
+          ref: '2.5.x'
+          path: registry-v2
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -119,19 +347,14 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+      - name: Run Legacy Integration Tests (Core API v2)
+        run: |
+          echo "Starting Registry App (In Memory)"
+          docker run -it -p 8181:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d
+          cd registry-v2
+          ./mvnw -Pintegration-tests clean install -DskipTests=true -DskipUiBuild=true -Dmaven.javadoc.skip=true
+          cd integration-tests
+          ../mvnw verify -Pregression -Dmaven.javadoc.skip=true -Dquarkus.http.test-host=localhost -Dquarkus.http.test-port=8181
 
       - name: Collect logs
         if: failure()
@@ -141,16 +364,19 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4.0.0
         with:
-          name: tests-logs-kafkasql
+          name: tests-logs-legacy-v2
           path: artifacts
 
-  integration-tests-kafkasql2:
-    name: Integration Tests KafkaSql
+  build-examples:
+    name: Build and Run Application examples
     runs-on: ubuntu-20.04
     needs: prepare-integration-tests
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
+      - name: Checkout Code with Ref '${{ github.ref }}'
+        uses: actions/checkout@v2
+        with:
+          path: apicurio-registry
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -158,1545 +384,8 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql3:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-
-  integration-tests-kafkasql4:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql5:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql6:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql7:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-
-  integration-tests-kafkasql8:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql9:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql10:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql11:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-
-  integration-tests-kafkasql12:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql13:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql14:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql15:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-
-  integration-tests-kafkasql16:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql17:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql18:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql19:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-
-  integration-tests-kafkasql20:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql21:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql22:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql23:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-
-  integration-tests-kafkasql24:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql25:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql26:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql27:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-
-  integration-tests-kafkasql28:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql29:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql30:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql31:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-
-  integration-tests-kafkasql32:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql33:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql34:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql35:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-
-  integration-tests-kafkasql36:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql37:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-  integration-tests-kafkasql38:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-  integration-tests-kafkasql39:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
-
-
-
-  integration-tests-kafkasql40:
-    name: Integration Tests KafkaSql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: tests-logs-kafkasql
-          path: artifacts
+      - name: Run Apicurio Registry application
+        run: docker run -d -p 8080:8080 -it ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d
+
+      - name: Build Apicurio Registry with Examples
+        run: cd apicurio-registry && mvn clean install -DskipTests -Pexamples

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -59,7 +59,7 @@ jobs:
         run: mvn -N io.takari:maven:wrapper -Dmaven=3.8.2
 
       - name: Build Application
-        run: ./mvnw -T 4C clean package -pl app -am --no-transfer-progress -Pprod -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
+        run: ./mvnw clean package -pl app,distro/docker -am --no-transfer-progress -Pprod -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 
       - name: Build and Push Application image
         run: |
@@ -143,13 +143,13 @@ jobs:
         run: minikube tunnel &> /dev/null &
 
       - name: Run Integration Tests - H2
-        run: ./mvnw -T 1.5C verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - auth - H2
-        run: ./mvnw -T 1.5C verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - migration - H2
-        run: ./mvnw -T 1.5C verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
@@ -188,13 +188,13 @@ jobs:
         run: minikube tunnel &> /dev/null &
 
       - name: Run Integration Tests - Postgresql
-        run: ./mvnw -T 1.5C verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - auth - Postgresql
-        run: ./mvnw -T 1.5C verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - migration - Postgresql
-        run: ./mvnw -T 1.5C verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
@@ -234,16 +234,16 @@ jobs:
         run: minikube tunnel &> /dev/null &
 
       - name: Run Integration Tests - Kafkasql
-        run: ./mvnw -T 1.5C verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - auth - Kafkasql
-        run: ./mvnw -T 1.5C verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - migration - Kafkasql
-        run: ./mvnw -T 1.5C verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - snapshotting - Kafkasql
-        run: ./mvnw -T 1.5C verify -am --no-transfer-progress -Pintegration-tests -Pkafkasql-snapshotting -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pkafkasql-snapshotting -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
@@ -352,9 +352,9 @@ jobs:
           echo "Starting Registry App (In Memory)"
           docker run -it -p 8181:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d
           cd registry-v2
-          ./mvnw -T 1.5C -Pintegration-tests clean compile -DskipTests=true -DskipUiBuild=true -Dmaven.javadoc.skip=true
+          ./mvnw -Pintegration-tests clean package -DskipTests=true -DskipUiBuild=true -Dmaven.javadoc.skip=true
           cd integration-tests
-          ../mvnw -T 1.5C verify -Pregression -Dmaven.javadoc.skip=true -Dquarkus.http.test-host=localhost -Dquarkus.http.test-port=8181
+          ../mvnw verify -Pregression -Dmaven.javadoc.skip=true -Dquarkus.http.test-host=localhost -Dquarkus.http.test-port=8181
 
       - name: Collect logs
         if: failure()
@@ -388,4 +388,4 @@ jobs:
         run: docker run -d -p 8080:8080 -it ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d
 
       - name: Build Apicurio Registry with Examples
-        run: cd apicurio-registry && mvn -T 4C clean package -pl examples -am
+        run: cd apicurio-registry && mvn clean package -Pexamples -DskipTests

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -64,149 +64,7 @@ jobs:
       - name: Build and Push Application image
         run: |
           docker buildx build --push -f ./distro/docker/target/docker/Dockerfile.jvm -t ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le ./distro/docker/target/docker
-
-  prepare-ui-tests:
-    name: Prepare for UI Integration Tests
-    runs-on: ubuntu-20.04
-    if: github.repository_owner == 'Apicurio' && !contains(github.event.*.labels.*.name, 'DO NOT MERGE')
-    steps:
-      - name: Show Actor
-        run: echo ${{github.actor}}
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'npm'
-          cache-dependency-path: 'ui/**/package-lock.json'
-
-      - name: Build and verify the typescript-sdk
-        working-directory: typescript-sdk
-        run: |
-          npm install
-          npm run generate-registry-sdk
-          npm run lint
-          npm run build
-
-      - name: Install UI Dependencies
-        run: |
-          cd ui
-          npm install
-
-      - name: Lint UI Code
-        run: |
-          cd ui
-          npm run lint
-
-      - name: Build and Package UI
-        run: |
-          cd ui
-          npm run build
-          npm run package
-
-      - name: Build and Push UI image
-        env:
-          IMAGE_REPO: ttl.sh/${{ github.sha }}
-          # maximum allowed
-          IMAGE_TAG: 1d
-        run: |
-          cd ui
-          docker build -t $IMAGE_REPO/apicurio/apicurio-registry-ui:$IMAGE_TAG .
-          docker push $IMAGE_REPO/apicurio/apicurio-registry-ui:$IMAGE_TAG
-
-  integration-tests-h2:
-    name: Integration Tests H2
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - H2
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Run Integration Tests - auth - H2
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Run Integration Tests - migration - H2
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-in-memory-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v1.0.0
-        with:
-          name: tests-logs-h2
-          path: artifacts
-
-  integration-tests-postgresql:
-    name: Integration Tests Postgresql
-    runs-on: ubuntu-20.04
-    needs: prepare-integration-tests
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.9.0
-        with:
-          minikube version: 'v1.31.1'
-          kubernetes version: 'v1.26.3'
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
-      - name: Prepare minikube tunnel
-        run: minikube tunnel &> /dev/null &
-
-      - name: Run Integration Tests - Postgresql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Run Integration Tests - auth - Postgresql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Run Integration Tests - migration - Postgresql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-sql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v1.0.0
-        with:
-          name: tests-logs-postgresql
-          path: artifacts
-
+  
 
   integration-tests-kafkasql:
     name: Integration Tests KafkaSql
@@ -236,14 +94,44 @@ jobs:
       - name: Run Integration Tests - Kafkasql
         run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
-      - name: Run Integration Tests - auth - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
 
-      - name: Run Integration Tests - migration - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
 
-      - name: Run Integration Tests - snapshotting - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pkafkasql-snapshotting -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+  integration-tests-kafkasql1:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
@@ -256,90 +144,13 @@ jobs:
           name: tests-logs-kafkasql
           path: artifacts
 
-  integration-tests-ui:
-    name: Integration Tests UI
-    runs-on: ubuntu-20.04
-    needs: [prepare-ui-tests, prepare-integration-tests]
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'npm'
-          cache-dependency-path: 'ui/tests/package-lock.json'
-
-      - name: Run UI tests
-        run: |
-          echo "Starting Registry App (In Memory)"
-          docker run -it -p 8080:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d
-          echo "Starting Registry UI"
-          docker run -it -p 8888:8080 -d ttl.sh/${{ github.sha }}/apicurio/apicurio-registry-ui:1d
-
-          cd ui/tests
-          npm install
-          npx playwright install --with-deps
-
-          echo "App System Info:"
-          echo "--"
-          curl -s http://localhost:8080/apis/registry/v3/system/info
-          echo "--"
-          echo ""
-          echo "UI Config Info (Local):"
-          echo "--"
-          curl -s http://localhost:8888/config.js
-          echo "--"
-          echo ""
-          echo "UI Config Info (Remote):"
-          echo "--"
-          curl -s http://localhost:8080/apis/registry/v3/system/uiConfig
-          echo "--"
-          echo ""
-          echo "UI Version Info:"
-          curl -s http://localhost:8888/version.js
-          echo "--"
-          echo "UI index.html:"
-          echo "--"
-          curl -s http://localhost:8888
-          echo "--"
-          echo ""
-          echo "-------------------------"
-          echo "Running Playwright tests!"
-          echo "-------------------------"
-          npm run test
-
-      - name: Upload Test Report
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report
-          path: ui/tests/playwright-report/
-          retention-days: 30
-
-      - name: Collect logs
-        if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
-
-      - name: Upload tests logs artifacts
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: tests-logs-ui
-          path: artifacts
-
-  integration-tests-legacy-v2:
-    name: Integration Tests Legacy V2
+  integration-tests-kafkasql2:
+    name: Integration Tests KafkaSql
     runs-on: ubuntu-20.04
     needs: prepare-integration-tests
     steps:
-      - name: Checkout Registry 2.5
-        uses: actions/checkout@v4
-        with:
-          ref: '2.5.x'
-          path: registry-v2
-
+      - name: Checkout Code
+        uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -347,14 +158,19 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Run Legacy Integration Tests (Core API v2)
-        run: |
-          echo "Starting Registry App (In Memory)"
-          docker run -it -p 8181:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d
-          cd registry-v2
-          ./mvnw -Pintegration-tests clean package -DskipTests=true -DskipUiBuild=true -Dmaven.javadoc.skip=true
-          cd integration-tests
-          ../mvnw verify -Pregression -Dmaven.javadoc.skip=true -Dquarkus.http.test-host=localhost -Dquarkus.http.test-port=8181
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
@@ -364,19 +180,17 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v1.0.0
         with:
-          name: tests-logs-legacy-v2
+          name: tests-logs-kafkasql
           path: artifacts
 
-  build-examples:
-    name: Build and Run Application examples
+
+  integration-tests-kafkasql3:
+    name: Integration Tests KafkaSql
     runs-on: ubuntu-20.04
     needs: prepare-integration-tests
     steps:
-      - name: Checkout Code with Ref '${{ github.ref }}'
-        uses: actions/checkout@v2
-        with:
-          path: apicurio-registry
-
+      - name: Checkout Code
+        uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -384,8 +198,1505 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Run Apicurio Registry application
-        run: docker run -d -p 8080:8080 -it ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
 
-      - name: Build Apicurio Registry with Examples
-        run: cd apicurio-registry && mvn clean package -Pexamples -DskipTests
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+
+  integration-tests-kafkasql4:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql5:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql6:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql7:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+
+  integration-tests-kafkasql8:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql9:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql10:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql11:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+
+  integration-tests-kafkasql12:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql13:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql14:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql15:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+
+  integration-tests-kafkasql16:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql17:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql18:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql19:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+
+  integration-tests-kafkasql20:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql21:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql22:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql23:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+
+  integration-tests-kafkasql24:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql25:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql26:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql27:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+
+  integration-tests-kafkasql28:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql29:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql30:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql31:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+
+  integration-tests-kafkasql32:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql33:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql34:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql35:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+
+  integration-tests-kafkasql36:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql37:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+  integration-tests-kafkasql38:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+  integration-tests-kafkasql39:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts
+
+
+
+  integration-tests-kafkasql40:
+    name: Integration Tests KafkaSql
+    runs-on: ubuntu-20.04
+    needs: prepare-integration-tests
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          minikube version: 'v1.31.1'
+          kubernetes version: 'v1.26.3'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Prepare minikube tunnel
+        run: minikube tunnel &> /dev/null &
+
+      - name: Run Integration Tests - Kafkasql
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+
+      - name: Collect logs
+        if: failure()
+        run: sh ./.github/scripts/collect_logs.sh
+
+      - name: Upload tests logs artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: tests-logs-kafkasql
+          path: artifacts

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -59,7 +59,7 @@ jobs:
         run: mvn -N io.takari:maven:wrapper -Dmaven=3.8.2
 
       - name: Build Application
-        run: ./mvnw -T 1.5C clean install --no-transfer-progress -Pprod -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
+        run: ./mvnw -T 4C clean package -pl app -am --no-transfer-progress -Pprod -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 
       - name: Build and Push Application image
         run: |
@@ -352,7 +352,7 @@ jobs:
           echo "Starting Registry App (In Memory)"
           docker run -it -p 8181:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d
           cd registry-v2
-          ./mvnw -T 1.5C -Pintegration-tests clean install -DskipTests=true -DskipUiBuild=true -Dmaven.javadoc.skip=true
+          ./mvnw -T 1.5C -Pintegration-tests clean compile -DskipTests=true -DskipUiBuild=true -Dmaven.javadoc.skip=true
           cd integration-tests
           ../mvnw -T 1.5C verify -Pregression -Dmaven.javadoc.skip=true -Dquarkus.http.test-host=localhost -Dquarkus.http.test-port=8181
 
@@ -388,4 +388,4 @@ jobs:
         run: docker run -d -p 8080:8080 -it ttl.sh/${{ github.sha }}/apicurio/apicurio-registry:1d
 
       - name: Build Apicurio Registry with Examples
-        run: cd apicurio-registry && mvn clean install -DskipTests -Pexamples
+        run: cd apicurio-registry && mvn -T 4C clean package -pl examples -am

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -218,7 +218,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -259,7 +259,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -298,7 +298,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -337,7 +337,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -377,7 +377,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -418,7 +418,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -458,7 +458,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -497,7 +497,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -537,7 +537,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -578,7 +578,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -618,7 +618,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -657,7 +657,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -697,7 +697,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -738,7 +738,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -778,7 +778,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -817,7 +817,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -857,7 +857,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -898,7 +898,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -937,7 +937,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -976,7 +976,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1016,7 +1016,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1057,7 +1057,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1096,7 +1096,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1135,7 +1135,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1175,7 +1175,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1216,7 +1216,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1256,7 +1256,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1295,7 +1295,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1335,7 +1335,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1376,7 +1376,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1416,7 +1416,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1455,7 +1455,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1495,7 +1495,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1536,7 +1536,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1576,7 +1576,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1615,7 +1615,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1655,7 +1655,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts
@@ -1696,7 +1696,7 @@ jobs:
 
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs-kafkasql
           path: artifacts

--- a/.github/workflows/registry-rhbq-build.yaml
+++ b/.github/workflows/registry-rhbq-build.yaml
@@ -95,7 +95,7 @@ jobs:
 
         - name: Upload tests logs artifacts
           if: failure()
-          uses: actions/upload-artifact@v1.0.0
+          uses: actions/upload-artifact@v4.0.0
           with:
             name: tests-logs
             path: artifacts

--- a/.github/workflows/registry-rhbq-build.yaml
+++ b/.github/workflows/registry-rhbq-build.yaml
@@ -68,7 +68,7 @@ jobs:
           run: cd registry && java -jar /home/runner/.m2/pom-manipulation-cli.jar -DgroovyScripts=${{ github.event.inputs.script-url }}
 
         - name: Build Registry
-          run: pwd && cd registry && ./mvnw clean install -P${{ github.event.inputs.maven-profiles }} -DskipTests=${{ github.event.inputs.skip-tests }} ${{ github.event.inputs.extra-params }}
+          run: pwd && cd registry && ./mvnw clean compile -P${{ github.event.inputs.maven-profiles }} -DskipTests=${{ github.event.inputs.skip-tests }} ${{ github.event.inputs.extra-params }}
 
         - name: Set test profile to all
           run: echo "test_profile=all" >> $GITHUB_ENV

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Build Registry
         run: |
           cd registry
-          ./mvnw -T 1.5C clean install --no-transfer-progress -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
+          ./mvnw -T 4C clean package -pl app -am --no-transfer-progress -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 
       - name: Build the typescript-sdk
         run: |

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Build Registry
         run: |
           cd registry
-          ./mvnw -T 4C clean package -pl app -am --no-transfer-progress -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
+          ./mvnw  clean package -pl app,distro/docker -am --no-transfer-progress -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 
       - name: Build the typescript-sdk
         run: |
@@ -154,7 +154,7 @@ jobs:
           SKIP_TESTS: "true"
         run: |
           cd registry
-          ./mvnw -T 1.5C package --no-transfer-progress -Pnative -Dquarkus.native.container-build=true -Pprod -DskipTests=true
+          ./mvnw  package --no-transfer-progress -Pnative -Dquarkus.native.container-build=true -Pprod -DskipTests=true
 
       - name: Build and Push Native image for testing
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Build Registry (All Variants)
         run: |
           cd registry
-          ./mvnw -T 1.5C clean install --no-transfer-progress -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
+          ./mvnw -T 4C clean package -pl app -am --no-transfer-progress -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 
       - name: Build the typescript-sdk
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Build Registry (All Variants)
         run: |
           cd registry
-          ./mvnw -T 4C clean package -pl app -am --no-transfer-progress -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
+          ./mvnw clean package -pl app -am --no-transfer-progress -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 
       - name: Build the typescript-sdk
         run: |

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Build and Test Application
-        run: ./mvnw -T 4C clean package -pl app -am --no-transfer-progress -Pprod -DskipTests=false -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
+        run: ./mvnw clean package -pl app,distro/docker -am --no-transfer-progress -Pprod -DskipTests=false -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 
       - name: Login to DockerHub Registry
         if: github.event_name == 'push'
@@ -224,13 +224,13 @@ jobs:
           ( cd /tmp/coreutils-workaround && mvn dependency:get -DremoteRepositories=https://repo1.maven.org/maven2 -Dartifact=com.github.java-json-tools:jackson-coreutils:2.0 )
 
       - name: Build Application
-        run: ./mvnw -T 4C clean package -pl app -am -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5 --no-transfer-progress
+        run: ./mvnw  clean package -pl app,distro/docker -am -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5 --no-transfer-progress
 
       - name: Build Native executables
         env:
           SKIP_TESTS: "true"
         run: |
-          ./mvnw -T 1.5C package --no-transfer-progress -Pnative -Dquarkus.native.container-build=true -Pprod -DskipTests=true
+          ./mvnw package --no-transfer-progress -Pnative -Dquarkus.native.container-build=true -Pprod -DskipTests=true
 
       - name: Build and Push Temporary image for testing
         env:
@@ -336,7 +336,7 @@ jobs:
         run: make lint-check
 
       - name: Build Registry
-        run: -T 4C clean package -pl app -am-Dskip.npm -DskipTests=true --no-transfer-progress
+        run: mvn clean package -pl app -am -Dskip.npm -DskipTests=true --no-transfer-progress
 
       - name: Run the tests
         working-directory: python-sdk
@@ -363,7 +363,7 @@ jobs:
           go-version: '1.20'
 
       - name: Build Registry
-        run: mvn -T 4C clean package -pl app -am -Dskip.npm -DskipTests=true --no-transfer-progress
+        run: mvn clean package -pl app -am -Dskip.npm -DskipTests=true --no-transfer-progress
 
       - name: Run the tests
         working-directory: go-sdk

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -262,7 +262,7 @@ jobs:
         run: ./.github/scripts/collect_logs.sh
       - name: Upload tests logs artifacts
         if: failure()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: tests-logs
           path: artifacts

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Build and Test Application
-        run: ./mvnw clean package -pl app,distro/docker -am --no-transfer-progress -Pprod -DskipTests=false -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
+        run: ./mvnw clean package --no-transfer-progress -Pprod -DskipTests=false -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 
       - name: Login to DockerHub Registry
         if: github.event_name == 'push'

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Build and Test Application
-        run: ./mvnw -T 1.5C clean install --no-transfer-progress -Pprod -DskipTests=false -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
+        run: ./mvnw -T 4C clean package -pl app -am --no-transfer-progress -Pprod -DskipTests=false -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 
       - name: Login to DockerHub Registry
         if: github.event_name == 'push'
@@ -224,7 +224,7 @@ jobs:
           ( cd /tmp/coreutils-workaround && mvn dependency:get -DremoteRepositories=https://repo1.maven.org/maven2 -Dartifact=com.github.java-json-tools:jackson-coreutils:2.0 )
 
       - name: Build Application
-        run: ./mvnw -T 1.5C clean install -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5 --no-transfer-progress
+        run: ./mvnw -T 4C clean package -pl app -am -Pprod -DskipTests=true -DskipCommitIdPlugin=false -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5 --no-transfer-progress
 
       - name: Build Native executables
         env:
@@ -336,7 +336,7 @@ jobs:
         run: make lint-check
 
       - name: Build Registry
-        run: mvn clean install -am -pl app -Dskip.npm -DskipTests=true --no-transfer-progress
+        run: -T 4C clean package -pl app -am-Dskip.npm -DskipTests=true --no-transfer-progress
 
       - name: Run the tests
         working-directory: python-sdk
@@ -363,7 +363,7 @@ jobs:
           go-version: '1.20'
 
       - name: Build Registry
-        run: mvn clean install -am -pl app -Dskip.npm -DskipTests=true --no-transfer-progress
+        run: mvn -T 4C clean package -pl app -am -Dskip.npm -DskipTests=true --no-transfer-progress
 
       - name: Run the tests
         working-directory: go-sdk

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -164,7 +164,7 @@ apicurio.import.workDir=${java.io.tmpdir}
 
 ## SQL Storage
 apicurio.storage.sql.kind=h2
-apicurio.datasource.url=jdbc:h2:mem:registry_db
+apicurio.datasource.url=jdbc:h2:mem:${quarkus.uuid}
 apicurio.datasource.username=sa
 apicurio.datasource.password=sa
 apicurio.datasource.jdbc.initial-size=20

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>kafka-avro-serializer</artifactId>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.confluent</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -158,6 +158,8 @@
             <maven.home>${maven.home}</maven.home>
             <groups>${groups}</groups>
           </systemPropertyVariables>
+          <forkCount>2C</forkCount>
+          <reuseForks>true</reuseForks>
         </configuration>
         <executions>
           <execution>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -158,8 +158,6 @@
             <maven.home>${maven.home}</maven.home>
             <groups>${groups}</groups>
           </systemPropertyVariables>
-          <forkCount>2C</forkCount>
-          <reuseForks>true</reuseForks>
         </configuration>
         <executions>
           <execution>

--- a/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
@@ -81,7 +81,7 @@ public class RegistryDeploymentManager implements TestExecutionListener {
 
     private void handleInfraDeployment() throws Exception {
         // First, create the namespace used for the test.
-        kubernetesClient.load(getClass().getResourceAsStream(E2E_NAMESPACE_RESOURCE)).create();
+        kubernetesClient.load(getClass().getResourceAsStream(E2E_NAMESPACE_RESOURCE)).serverSideApply();
 
         // Based on the configuration, deploy the appropriate variant
         if (Boolean.parseBoolean(System.getProperty("deployInMemory"))) {
@@ -133,7 +133,7 @@ public class RegistryDeploymentManager implements TestExecutionListener {
             // Deploy all the resources associated to the registry variant
             kubernetesClient
                     .load(IOUtils.toInputStream(registryLoadedResources, StandardCharsets.UTF_8.name()))
-                    .create();
+                    .serverSideApply();
         } catch (Exception ex) {
             LOGGER.debug("Error creating registry resources:", ex);
         }
@@ -153,7 +153,7 @@ public class RegistryDeploymentManager implements TestExecutionListener {
             try {
                 final Route registryRoute = openShiftClient.routes()
                         .load(RegistryDeploymentManager.class.getResourceAsStream(REGISTRY_OPENSHIFT_ROUTE))
-                        .create();
+                        .serverSideApply();
 
                 System.setProperty("quarkus.http.test-host", registryRoute.getSpec().getHost());
                 System.setProperty("quarkus.http.test-port", "80");
@@ -176,7 +176,8 @@ public class RegistryDeploymentManager implements TestExecutionListener {
 
     private static void deployResource(String resource) {
         // Deploy all the resources associated to the external requirements
-        kubernetesClient.load(RegistryDeploymentManager.class.getResourceAsStream(resource)).create();
+        kubernetesClient.load(RegistryDeploymentManager.class.getResourceAsStream(resource))
+                .serverSideApply();
 
         // Wait for all the external resources pods to be ready
         kubernetesClient.pods().inNamespace(TEST_NAMESPACE).waitUntilReady(360, TimeUnit.SECONDS);

--- a/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
@@ -10,7 +10,6 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,11 +32,6 @@ public class RegistryDeploymentManager implements TestExecutionListener {
     static KubernetesClient kubernetesClient;
 
     static List<LogWatch> logWatch;
-
-    @Override
-    public void executionStarted(TestIdentifier testIdentifier) {
-        TestExecutionListener.super.executionStarted(testIdentifier);
-    }
 
     @Override
     public void testPlanExecutionStarted(TestPlan testPlan) {

--- a/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
@@ -10,6 +10,7 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +33,11 @@ public class RegistryDeploymentManager implements TestExecutionListener {
     static KubernetesClient kubernetesClient;
 
     static List<LogWatch> logWatch;
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        TestExecutionListener.super.executionStarted(testIdentifier);
+    }
 
     @Override
     public void testPlanExecutionStarted(TestPlan testPlan) {

--- a/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
@@ -9,7 +9,9 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +34,23 @@ public class RegistryDeploymentManager implements TestExecutionListener {
     static KubernetesClient kubernetesClient;
 
     static List<LogWatch> logWatch;
+
+    static String testLogsIdentifier;
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        TestExecutionListener.super.executionStarted(testIdentifier);
+        logWatch = streamPodLogs(testLogsIdentifier);
+    }
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+        TestExecutionListener.super.executionFinished(testIdentifier, testExecutionResult);
+
+        if (logWatch != null && !logWatch.isEmpty()) {
+            logWatch.forEach(LogWatch::close);
+        }
+    }
 
     @Override
     public void testPlanExecutionStarted(TestPlan testPlan) {
@@ -89,19 +108,19 @@ public class RegistryDeploymentManager implements TestExecutionListener {
                     "Deploying In Memory Registry Variant with image: {} ##################################################",
                     System.getProperty("registry-in-memory-image"));
             InMemoryDeploymentManager.deployInMemoryApp(System.getProperty("registry-in-memory-image"));
-            logWatch = streamPodLogs("apicurio-registry-memory");
+            testLogsIdentifier = "apicurio-registry-memory";
         } else if (Boolean.parseBoolean(System.getProperty("deploySql"))) {
             LOGGER.info(
                     "Deploying SQL Registry Variant with image: {} ##################################################",
                     System.getProperty("registry-sql-image"));
             SqlDeploymentManager.deploySqlApp(System.getProperty("registry-sql-image"));
-            logWatch = streamPodLogs("apicurio-registry-sql");
+            testLogsIdentifier = "apicurio-registry-sql";
         } else if (Boolean.parseBoolean(System.getProperty("deployKafka"))) {
             LOGGER.info(
                     "Deploying Kafka SQL Registry Variant with image: {} ##################################################",
                     System.getProperty("registry-kafkasql-image"));
             KafkaSqlDeploymentManager.deployKafkaApp(System.getProperty("registry-kafkasql-image"));
-            logWatch = streamPodLogs("apicurio-registry-kafka");
+            testLogsIdentifier = "apicurio-registry-kafka";
         }
     }
 

--- a/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
@@ -129,6 +129,9 @@ public class ApicurioRegistryBaseIT implements TestSeparator, Constants {
         // make sure content is available
         ensureClusterSyncContentId(response.getVersion().getContentId());
 
+        // Wait for the artifact version to be available across all replicas.
+        Thread.sleep(1000);
+
         return response;
     }
 
@@ -146,6 +149,9 @@ public class ApicurioRegistryBaseIT implements TestSeparator, Constants {
         ensureClusterSync(normalizeGroupId(meta.getGroupId()), meta.getArtifactId(),
                 String.valueOf(meta.getVersion()));
         ensureClusterSyncContentId(meta.getContentId());
+
+        // Wait for the artifact version to be available across all replicas.
+        Thread.sleep(1000);
 
         return meta;
     }

--- a/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
@@ -126,6 +126,9 @@ public class ApicurioRegistryBaseIT implements TestSeparator, Constants {
         ensureClusterSync(normalizeGroupId(response.getArtifact().getGroupId()),
                 response.getArtifact().getArtifactId(), String.valueOf(response.getVersion().getVersion()));
 
+        // make sure content is available
+        ensureClusterSyncContentId(response.getVersion().getContentId());
+
         return response;
     }
 
@@ -142,6 +145,7 @@ public class ApicurioRegistryBaseIT implements TestSeparator, Constants {
         ensureClusterSync(meta.getGlobalId());
         ensureClusterSync(normalizeGroupId(meta.getGroupId()), meta.getArtifactId(),
                 String.valueOf(meta.getVersion()));
+        ensureClusterSyncContentId(meta.getContentId());
 
         return meta;
     }
@@ -162,6 +166,10 @@ public class ApicurioRegistryBaseIT implements TestSeparator, Constants {
 
     private void ensureClusterSync(Long globalId) throws Exception {
         retry(() -> registryClient.ids().globalIds().byGlobalId(globalId));
+    }
+
+    private void ensureClusterSyncContentId(Long contentId) throws Exception {
+        retry(() -> registryClient.ids().contentIds().byContentId(contentId));
     }
 
     private void ensureClusterSync(String groupId, String artifactId, String version) throws Exception {

--- a/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
@@ -3,14 +3,11 @@ package io.apicurio.tests;
 import com.microsoft.kiota.ApiException;
 import io.apicurio.deployment.PortForwardManager;
 import io.apicurio.registry.client.auth.VertXAuthFactory;
-import io.apicurio.registry.model.GroupId;
 import io.apicurio.registry.rest.client.RegistryClient;
-import io.apicurio.registry.rest.client.models.ArtifactSearchResults;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateArtifactResponse;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.IfArtifactExists;
-import io.apicurio.registry.rest.client.models.SearchedArtifact;
 import io.apicurio.registry.rest.client.models.SearchedVersion;
 import io.apicurio.registry.rest.client.models.VersionMetaData;
 import io.apicurio.registry.utils.tests.SimpleDisplayName;
@@ -25,7 +22,6 @@ import io.restassured.RestAssured;
 import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -64,7 +60,6 @@ import java.util.stream.Collectors;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Base class for all base classes for integration tests or for integration tests directly. This class must
@@ -105,33 +100,6 @@ public class ApicurioRegistryBaseIT implements TestSeparator, Constants {
         logger.info("RestAssured configured with {}", RestAssured.baseURI);
         RestAssured.defaultParser = Parser.JSON;
         RestAssured.urlEncodingEnabled = false;
-    }
-
-    @AfterEach
-    public void cleanArtifacts() throws Exception {
-        logger.info("Removing all artifacts");
-        // Retrying to delete artifacts can solve the problem with bad order caused by artifacts references
-        // TODO: Solve problem with artifact references circle - maybe use of deleteAllUserData for cleaning
-        // artifacts after IT
-        retry(() -> {
-            ArtifactSearchResults artifacts = registryClient.search().artifacts().get();
-            for (SearchedArtifact artifact : artifacts.getArtifacts()) {
-                try {
-                    registryClient.groups().byGroupId(normalizeGroupId(artifact.getGroupId())).artifacts()
-                            .byArtifactId(artifact.getArtifactId()).delete();
-                    registryClient.groups().byGroupId(GroupId.DEFAULT.getRawGroupIdWithDefaultString())
-                            .artifacts().delete();
-                } catch (ApiException e) {
-                    // because of async storage artifact may be already deleted but listed anyway
-                    logger.info(e.getMessage());
-                } catch (Exception e) {
-                    logger.error("", e);
-                }
-            }
-            ensureClusterSync(client -> {
-                assertTrue(client.search().artifacts().get().getCount() == 0);
-            });
-        }, "CleanArtifacts", 5);
     }
 
     private static String normalizeGroupId(String groupId) {

--- a/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
@@ -3,11 +3,14 @@ package io.apicurio.tests;
 import com.microsoft.kiota.ApiException;
 import io.apicurio.deployment.PortForwardManager;
 import io.apicurio.registry.client.auth.VertXAuthFactory;
+import io.apicurio.registry.model.GroupId;
 import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.models.ArtifactSearchResults;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateArtifactResponse;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.IfArtifactExists;
+import io.apicurio.registry.rest.client.models.SearchedArtifact;
 import io.apicurio.registry.rest.client.models.SearchedVersion;
 import io.apicurio.registry.rest.client.models.VersionMetaData;
 import io.apicurio.registry.utils.tests.SimpleDisplayName;
@@ -22,6 +25,7 @@ import io.restassured.RestAssured;
 import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -60,6 +64,7 @@ import java.util.stream.Collectors;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Base class for all base classes for integration tests or for integration tests directly. This class must
@@ -100,6 +105,33 @@ public class ApicurioRegistryBaseIT implements TestSeparator, Constants {
         logger.info("RestAssured configured with {}", RestAssured.baseURI);
         RestAssured.defaultParser = Parser.JSON;
         RestAssured.urlEncodingEnabled = false;
+    }
+
+    @AfterEach
+    public void cleanArtifacts() throws Exception {
+        logger.info("Removing all artifacts");
+        // Retrying to delete artifacts can solve the problem with bad order caused by artifacts references
+        // TODO: Solve problem with artifact references circle - maybe use of deleteAllUserData for cleaning
+        // artifacts after IT
+        retry(() -> {
+            ArtifactSearchResults artifacts = registryClient.search().artifacts().get();
+            for (SearchedArtifact artifact : artifacts.getArtifacts()) {
+                try {
+                    registryClient.groups().byGroupId(normalizeGroupId(artifact.getGroupId())).artifacts()
+                            .byArtifactId(artifact.getArtifactId()).delete();
+                    registryClient.groups().byGroupId(GroupId.DEFAULT.getRawGroupIdWithDefaultString())
+                            .artifacts().delete();
+                } catch (ApiException e) {
+                    // because of async storage artifact may be already deleted but listed anyway
+                    logger.info(e.getMessage());
+                } catch (Exception e) {
+                    logger.error("", e);
+                }
+            }
+            ensureClusterSync(client -> {
+                assertTrue(client.search().artifacts().get().getCount() == 0);
+            });
+        }, "CleanArtifacts", 5);
     }
 
     private static String normalizeGroupId(String groupId) {

--- a/integration-tests/src/test/java/io/apicurio/tests/auth/SimpleAuthIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/auth/SimpleAuthIT.java
@@ -45,11 +45,6 @@ public class SimpleAuthIT extends ApicurioRegistryBaseIT {
     }
 
     @Override
-    public void cleanArtifacts() throws Exception {
-        // Don't clean
-    }
-
-    @Override
     protected RegistryClient createRegistryClient() {
         var auth = buildOIDCWebClient(authServerUrlConfigured, JWKSMockServer.ADMIN_CLIENT_ID, "test1");
         return createClient(auth);

--- a/integration-tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
@@ -45,11 +45,6 @@ import java.util.function.Function;
 @QuarkusIntegrationTest
 public class RegistryConverterIT extends ApicurioRegistryBaseIT {
 
-    @Override
-    public void cleanArtifacts() throws Exception {
-        // Don't clean up
-    }
-
     @Test
     public void testConfiguration() throws Exception {
         String groupId = "ns_" + TestUtils.generateGroupId().replace("-", "_");

--- a/integration-tests/src/test/java/io/apicurio/tests/kafkasql/KafkaSqlSnapshottingIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/kafkasql/KafkaSqlSnapshottingIT.java
@@ -4,7 +4,6 @@ import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.utils.Constants;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -13,11 +12,6 @@ import org.junit.jupiter.api.Test;
 public class KafkaSqlSnapshottingIT extends ApicurioRegistryBaseIT {
 
     private static final String NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID = "SNAPSHOT_TEST_GROUP_ID";
-
-    @Override
-    @BeforeEach
-    public void cleanArtifacts() throws Exception {
-    }
 
     @Test
     public void testRecoverFromSnapshot() throws InterruptedException {

--- a/integration-tests/src/test/java/io/apicurio/tests/migration/DoNotPreserveIdsImportIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/migration/DoNotPreserveIdsImportIT.java
@@ -37,16 +37,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @Tag(Constants.MIGRATION)
 @Disabled
 public class DoNotPreserveIdsImportIT extends ApicurioRegistryBaseIT {
-
     private static final Logger log = LoggerFactory.getLogger(DataMigrationIT.class);
     public static InputStream doNotPreserveIdsImportDataToImport;
     public static JsonSchemaMsgFactory jsonSchema;
     public static Map<String, String> doNotPreserveIdsImportArtifacts = new HashMap<>();
-
-    @Override
-    public void cleanArtifacts() throws Exception {
-        // Don't clean up
-    }
 
     @Test
     public void testDoNotPreserveIdsImport() throws Exception {

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
@@ -270,7 +270,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
 
         String recordNamespace = TestUtils.generateAvroNS();
         String recordName = TestUtils.generateSubject();
-        String schemaKey = "key1";
+        String schemaKey = "key1" + System.currentTimeMillis();
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(recordNamespace,
                 recordName, List.of(schemaKey));
 

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
@@ -322,7 +322,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
                 AvroKafkaDeserializer.class, topicName);
 
         // Produce and consume messages for the first version of the schema.
-        tester.produceMessages(producer, topicName, avroSchema::generateRecord, messageCount);
+        tester.produceMessages(producer, topicName, avroSchema::generateRecord, messageCount, true);
         tester.consumeMessages(consumer, topicName, messageCount, avroSchema::validateRecord);
 
         // Prepare the second version of the schema, for it to be different, a new field is added.
@@ -429,7 +429,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
             producer = tester.createProducer(StringSerializer.class, AvroKafkaSerializer.class, topicName,
                     strategy);
         }
-        tester.produceMessages(producer, topicName, avroSchema::generateRecord, messageCount);
+        tester.produceMessages(producer, topicName, avroSchema::generateRecord, messageCount, true);
 
         return producer;
     }
@@ -475,9 +475,9 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         Consumer<String, GenericRecord> consumer3 = tester.createConsumer(StringDeserializer.class,
                 AvroKafkaDeserializer.class, topicName3);
 
-        tester.produceMessages(producer1, topicName1, avroSchema::generateRecord, messageCount);
-        tester.produceMessages(producer2, topicName2, avroSchema::generateRecord, messageCount);
-        tester.produceMessages(producer3, topicName3, avroSchema::generateRecord, messageCount);
+        tester.produceMessages(producer1, topicName1, avroSchema::generateRecord, messageCount, true);
+        tester.produceMessages(producer2, topicName2, avroSchema::generateRecord, messageCount, true);
+        tester.produceMessages(producer3, topicName3, avroSchema::generateRecord, messageCount, true);
 
         tester.consumeMessages(consumer1, topicName1, messageCount, avroSchema::validateRecord);
         tester.consumeMessages(consumer2, topicName2, messageCount, avroSchema::validateRecord);

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -67,7 +66,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         kafkaCluster.createTopic(topicName, 1, 1);
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1" + UUID.randomUUID()));
+                List.of("key1" + System.currentTimeMillis()));
 
         String avroSchemaString = avroSchema.generateSchema().toString();
         logger.info("Registering Avro Schema: {}", avroSchemaString);
@@ -90,7 +89,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         kafkaCluster.createTopic(topicName, 1, 1);
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1" + UUID.randomUUID()));
+                List.of("key1" + System.currentTimeMillis()));
 
         String avroSchemaString = avroSchema.generateSchema().toString();
         logger.info("Registering Avro Schema: {}", avroSchemaString);
@@ -114,7 +113,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String groupId = TestUtils.generateSubject();
         String artifactId = TestUtils.generateSubject();
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(groupId, artifactId,
-                List.of("key1" + UUID.randomUUID()));
+                List.of("key1" + System.currentTimeMillis()));
 
         String avroSchemaString = avroSchema.generateSchema().toString();
         logger.info("Registering Avro Schema: {}", avroSchemaString);
@@ -139,7 +138,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String groupId = TestUtils.generateSubject();
         String recordName = TestUtils.generateSubject();
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(groupId, recordName,
-                List.of("key1" + UUID.randomUUID()));
+                List.of("key1" + System.currentTimeMillis()));
 
         String artifactId = topicName + "-" + recordName;
 
@@ -165,7 +164,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         kafkaCluster.createTopic(topicName, 1, 1);
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1" + UUID.randomUUID()));
+                List.of("key1" + System.currentTimeMillis()));
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
@@ -297,7 +296,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
 
         String recordNamespace = TestUtils.generateAvroNS();
         String recordName = TestUtils.generateSubject();
-        String schemaKey = "key1" + UUID.randomUUID();
+        String schemaKey = "key1" + System.currentTimeMillis();
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(recordNamespace,
                 recordName, List.of(schemaKey));
@@ -327,7 +326,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         tester.consumeMessages(consumer, topicName, messageCount, avroSchema::validateRecord);
 
         // Prepare the second version of the schema, for it to be different, a new field is added.
-        String schemaKey2 = "key2" + UUID.randomUUID();
+        String schemaKey2 = "key2" + System.currentTimeMillis();
         AvroGenericRecordSchemaFactory avroSchema2 = new AvroGenericRecordSchemaFactory(recordNamespace,
                 recordName, List.of(schemaKey, schemaKey2));
 
@@ -363,7 +362,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
             assertEquals(schema1Counter.get(), schema2Counter.get());
         }
 
-        String schemaKey3 = "key3" + UUID.randomUUID();
+        String schemaKey3 = "key3" + System.currentTimeMillis();
         AvroGenericRecordSchemaFactory avroSchema3 = new AvroGenericRecordSchemaFactory(recordNamespace,
                 recordName, List.of(schemaKey, schemaKey2, schemaKey3));
 
@@ -443,7 +442,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String topicName2 = TestUtils.generateTopic();
         String topicName3 = TestUtils.generateTopic();
         String subjectName = "myrecordconfluent";
-        String schemaKey = "key1" + UUID.randomUUID();
+        String schemaKey = "key1" + System.currentTimeMillis();
 
         kafkaCluster.createTopic(topicName1, 1, 1);
         kafkaCluster.createTopic(topicName2, 1, 1);
@@ -556,7 +555,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         kafkaCluster.createTopic(topicName, 1, 1);
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1" + UUID.randomUUID()));
+                List.of("key1" + System.currentTimeMillis()));
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
@@ -585,7 +584,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         kafkaCluster.createTopic(topicName, 1, 1);
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1" + UUID.randomUUID()));
+                List.of("key1" + System.currentTimeMillis()));
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
@@ -65,8 +65,9 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String artifactId = topicName + "-value";
         kafkaCluster.createTopic(topicName, 1, 1);
 
-        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1"));
+        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(
+                "myrecordapicurio1" + System.currentTimeMillis(),
+                List.of("key1" + System.currentTimeMillis()));
 
         createArtifact("default", artifactId, ArtifactType.AVRO, avroSchema.generateSchema().toString(),
                 ContentTypes.APPLICATION_JSON, null, null);
@@ -84,8 +85,9 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String artifactId = topicName;
         kafkaCluster.createTopic(topicName, 1, 1);
 
-        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1"));
+        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(
+                "myrecordapicurio1" + System.currentTimeMillis(),
+                List.of("key1" + System.currentTimeMillis()));
 
         createArtifact(topicName, artifactId, ArtifactType.AVRO, avroSchema.generateSchema().toString(),
                 ContentTypes.APPLICATION_JSON, null, null);
@@ -105,7 +107,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String groupId = TestUtils.generateSubject();
         String artifactId = TestUtils.generateSubject();
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(groupId, artifactId,
-                List.of("key1"));
+                List.of("key1" + System.currentTimeMillis()));
 
         createArtifact(groupId, artifactId, ArtifactType.AVRO, avroSchema.generateSchema().toString(),
                 ContentTypes.APPLICATION_JSON, null, null);
@@ -124,7 +126,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String groupId = TestUtils.generateSubject();
         String recordName = TestUtils.generateSubject();
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(groupId, recordName,
-                List.of("key1"));
+                List.of("key1" + System.currentTimeMillis()));
 
         String artifactId = topicName + "-" + recordName;
         createArtifact(groupId, artifactId, ArtifactType.AVRO, avroSchema.generateSchema().toString(),
@@ -144,8 +146,9 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String artifactId = topicName + "-value";
         kafkaCluster.createTopic(topicName, 1, 1);
 
-        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1"));
+        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(
+                "myrecordapicurio1" + System.currentTimeMillis(),
+                List.of("key1" + System.currentTimeMillis()));
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
@@ -385,7 +388,6 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
 
         IoUtil.closeIgnore(producer);
         IoUtil.closeIgnore(consumer);
-
     }
 
     @Test
@@ -396,7 +398,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String topicName2 = TestUtils.generateTopic();
         String topicName3 = TestUtils.generateTopic();
         String subjectName = "myrecordconfluent" + System.currentTimeMillis();
-        String schemaKey = "key1";
+        String schemaKey = "key1" + System.currentTimeMillis();
 
         kafkaCluster.createTopic(topicName1, 1, 1);
         kafkaCluster.createTopic(topicName2, 1, 1);
@@ -503,8 +505,9 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String artifactId = topicName + "-value";
         kafkaCluster.createTopic(topicName, 1, 1);
 
-        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1"));
+        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(
+                "myrecordapicurio1" + System.currentTimeMillis(),
+                List.of("key1" + System.currentTimeMillis()));
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
@@ -532,8 +535,9 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String artifactId = topicName + "-value";
         kafkaCluster.createTopic(topicName, 1, 1);
 
-        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1"));
+        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(
+                "myrecordapicurio1" + System.currentTimeMillis(),
+                List.of("key1" + System.currentTimeMillis()));
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
@@ -48,11 +48,6 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
     private final Class<AvroKafkaSerializer> serializer = AvroKafkaSerializer.class;
     private final Class<AvroKafkaDeserializer> deserializer = AvroKafkaDeserializer.class;
 
-    @Override
-    public void cleanArtifacts() throws Exception {
-        // Don't clean up
-    }
-
     @BeforeAll
     void setupEnvironment() {
         kafkaCluster.startIfNeeded();
@@ -400,7 +395,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String topicName1 = TestUtils.generateTopic();
         String topicName2 = TestUtils.generateTopic();
         String topicName3 = TestUtils.generateTopic();
-        String subjectName = "myrecordconfluent6";
+        String subjectName = "myrecordconfluent" + System.currentTimeMillis();
         String schemaKey = "key1";
 
         kafkaCluster.createTopic(topicName1, 1, 1);

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -66,7 +67,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         kafkaCluster.createTopic(topicName, 1, 1);
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1"));
+                List.of("key1" + UUID.randomUUID()));
 
         String avroSchemaString = avroSchema.generateSchema().toString();
         logger.info("Registering Avro Schema: {}", avroSchemaString);
@@ -89,7 +90,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         kafkaCluster.createTopic(topicName, 1, 1);
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1"));
+                List.of("key1" + UUID.randomUUID()));
 
         String avroSchemaString = avroSchema.generateSchema().toString();
         logger.info("Registering Avro Schema: {}", avroSchemaString);
@@ -113,7 +114,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String groupId = TestUtils.generateSubject();
         String artifactId = TestUtils.generateSubject();
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(groupId, artifactId,
-                List.of("key1"));
+                List.of("key1" + UUID.randomUUID()));
 
         String avroSchemaString = avroSchema.generateSchema().toString();
         logger.info("Registering Avro Schema: {}", avroSchemaString);
@@ -138,7 +139,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String groupId = TestUtils.generateSubject();
         String recordName = TestUtils.generateSubject();
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(groupId, recordName,
-                List.of("key1"));
+                List.of("key1" + UUID.randomUUID()));
 
         String artifactId = topicName + "-" + recordName;
 
@@ -164,7 +165,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         kafkaCluster.createTopic(topicName, 1, 1);
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1"));
+                List.of("key1" + UUID.randomUUID()));
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
@@ -296,7 +297,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
 
         String recordNamespace = TestUtils.generateAvroNS();
         String recordName = TestUtils.generateSubject();
-        String schemaKey = "key1";
+        String schemaKey = "key1" + UUID.randomUUID();
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(recordNamespace,
                 recordName, List.of(schemaKey));
@@ -326,7 +327,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         tester.consumeMessages(consumer, topicName, messageCount, avroSchema::validateRecord);
 
         // Prepare the second version of the schema, for it to be different, a new field is added.
-        String schemaKey2 = "key2";
+        String schemaKey2 = "key2" + UUID.randomUUID();
         AvroGenericRecordSchemaFactory avroSchema2 = new AvroGenericRecordSchemaFactory(recordNamespace,
                 recordName, List.of(schemaKey, schemaKey2));
 
@@ -362,7 +363,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
             assertEquals(schema1Counter.get(), schema2Counter.get());
         }
 
-        String schemaKey3 = "key3";
+        String schemaKey3 = "key3" + UUID.randomUUID();
         AvroGenericRecordSchemaFactory avroSchema3 = new AvroGenericRecordSchemaFactory(recordNamespace,
                 recordName, List.of(schemaKey, schemaKey2, schemaKey3));
 
@@ -442,7 +443,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String topicName2 = TestUtils.generateTopic();
         String topicName3 = TestUtils.generateTopic();
         String subjectName = "myrecordconfluent";
-        String schemaKey = "key1";
+        String schemaKey = "key1" + UUID.randomUUID();
 
         kafkaCluster.createTopic(topicName1, 1, 1);
         kafkaCluster.createTopic(topicName2, 1, 1);
@@ -555,7 +556,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         kafkaCluster.createTopic(topicName, 1, 1);
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1"));
+                List.of("key1" + UUID.randomUUID()));
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
@@ -584,7 +585,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         kafkaCluster.createTopic(topicName, 1, 1);
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
-                List.of("key1"));
+                List.of("key1" + UUID.randomUUID()));
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
@@ -345,6 +345,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
             producer = tester.createProducer(StringSerializer.class, AvroKafkaSerializer.class, topicName,
                     strategy);
         }
+
         tester.produceMessages(producer, topicName, avroSchema3::generateRecord, messageCount);
 
         if (!reuseClients) {

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
@@ -307,7 +307,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
 
         logger.info("Registering Avro Schema: {}", avroSchemaString);
 
-        // First we create a
+        // First we create the initial artifact
         createArtifact(recordNamespace, artifactId, ArtifactType.AVRO, avroSchemaString,
                 ContentTypes.APPLICATION_JSON, null, null);
 
@@ -330,8 +330,11 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         AvroGenericRecordSchemaFactory avroSchema2 = new AvroGenericRecordSchemaFactory(recordNamespace,
                 recordName, List.of(schemaKey, schemaKey2));
 
-        createArtifactVersion(recordNamespace, artifactId, avroSchema2.generateSchema().toString(),
-                ContentTypes.APPLICATION_JSON, null);
+        String avroSchemaString2 = avroSchema2.generateSchema().toString();
+        logger.info("Registering Avro Schema 2: {}", avroSchemaString2);
+
+        createArtifactVersion(recordNamespace, artifactId, avroSchemaString2, ContentTypes.APPLICATION_JSON,
+                null);
 
         // We produce messages for both, the old schema version, and the new one.
         produceForSchema(reuseClients, producer, tester, strategy, topicName, messageCount, avroSchema2);
@@ -362,8 +365,12 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         String schemaKey3 = "key3";
         AvroGenericRecordSchemaFactory avroSchema3 = new AvroGenericRecordSchemaFactory(recordNamespace,
                 recordName, List.of(schemaKey, schemaKey2, schemaKey3));
-        createArtifactVersion(recordNamespace, artifactId, avroSchema3.generateSchema().toString(),
-                ContentTypes.APPLICATION_JSON, null);
+
+        String avroSchemaString3 = avroSchema3.generateSchema().toString();
+        logger.info("Registering Avro Schema 3: {}", avroSchemaString3);
+
+        createArtifactVersion(recordNamespace, artifactId, avroSchemaString3, ContentTypes.APPLICATION_JSON,
+                null);
 
         produceForSchema(reuseClients, producer, tester, strategy, topicName, messageCount, avroSchema3);
         produceForSchema(reuseClients, producer, tester, strategy, topicName, messageCount, avroSchema2);

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
@@ -68,7 +68,10 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
                 List.of("key1"));
 
-        createArtifact("default", artifactId, ArtifactType.AVRO, avroSchema.generateSchema().toString(),
+        String avroSchemaString = avroSchema.generateSchema().toString();
+        logger.info("Registering Avro Schema: {}", avroSchemaString);
+
+        createArtifact("default", artifactId, ArtifactType.AVRO, avroSchemaString,
                 ContentTypes.APPLICATION_JSON, null, null);
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
@@ -88,7 +91,10 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("myrecordapicurio1",
                 List.of("key1"));
 
-        createArtifact(topicName, artifactId, ArtifactType.AVRO, avroSchema.generateSchema().toString(),
+        String avroSchemaString = avroSchema.generateSchema().toString();
+        logger.info("Registering Avro Schema: {}", avroSchemaString);
+
+        createArtifact(topicName, artifactId, ArtifactType.AVRO, avroSchemaString,
                 ContentTypes.APPLICATION_JSON, null, null);
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
@@ -109,7 +115,10 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(groupId, artifactId,
                 List.of("key1"));
 
-        createArtifact(groupId, artifactId, ArtifactType.AVRO, avroSchema.generateSchema().toString(),
+        String avroSchemaString = avroSchema.generateSchema().toString();
+        logger.info("Registering Avro Schema: {}", avroSchemaString);
+
+        createArtifact(groupId, artifactId, ArtifactType.AVRO, avroSchemaString,
                 ContentTypes.APPLICATION_JSON, null, null);
 
         SimpleSerdesTesterBuilder<GenericRecord, GenericRecord> tester = new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>()
@@ -133,7 +142,10 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
 
         String artifactId = topicName + "-" + recordName;
 
-        createArtifact(groupId, artifactId, ArtifactType.AVRO, avroSchema.generateSchema().toString(),
+        String avroSchemaString = avroSchema.generateSchema().toString();
+        logger.info("Registering Avro Schema: {}", avroSchemaString);
+
+        createArtifact(groupId, artifactId, ArtifactType.AVRO, avroSchemaString,
                 ContentTypes.APPLICATION_JSON, null, null);
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
@@ -291,8 +303,12 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
 
         String artifactId = topicName + "-" + recordName;
 
+        String avroSchemaString = avroSchema.generateSchema().toString();
+
+        logger.info("Registering Avro Schema: {}", avroSchemaString);
+
         // First we create a
-        createArtifact(recordNamespace, artifactId, ArtifactType.AVRO, avroSchema.generateSchema().toString(),
+        createArtifact(recordNamespace, artifactId, ArtifactType.AVRO, avroSchemaString,
                 ContentTypes.APPLICATION_JSON, null, null);
 
         if (reuseClients) {
@@ -427,7 +443,12 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
 
         AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory(subjectName,
                 List.of(schemaKey));
-        createArtifact("default", subjectName, ArtifactType.AVRO, avroSchema.generateSchema().toString(),
+
+        String avroSchemaString = avroSchema.generateSchema().toString();
+
+        logger.info("Registering Avro Schema: {}", avroSchemaString);
+
+        createArtifact("default", subjectName, ArtifactType.AVRO, avroSchemaString,
                 ContentTypes.APPLICATION_JSON, null, null);
 
         SerdesTester<String, GenericRecord, GenericRecord> tester = new SerdesTester<>();
@@ -593,8 +614,13 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
                 List.of("keyz"));
         // create a duplicated artifact beforehand with the same content to force the contentId and globalId
         // sequences to return different ids
-        createArtifact("default", TestUtils.generateArtifactId(), ArtifactType.AVRO,
-                avroSchema.generateSchema().toString(), ContentTypes.APPLICATION_JSON, null, null);
+
+        String avroSchemaString = avroSchema.generateSchema().toString();
+
+        logger.info("Registering Avro Schema: {}", avroSchemaString);
+
+        createArtifact("default", TestUtils.generateArtifactId(), ArtifactType.AVRO, avroSchemaString,
+                ContentTypes.APPLICATION_JSON, null, null);
 
         new WrongConfiguredConsumerTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
@@ -630,8 +656,12 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
                 List.of("keyz"));
         // create a duplicated artifact beforehand with the same content to force the contentId and globalId
         // sequences to return different ids
-        createArtifact("default", TestUtils.generateArtifactId(), ArtifactType.AVRO,
-                avroSchema.generateSchema().toString(), ContentTypes.APPLICATION_JSON, null, null);
+
+        String avroSchemaString = avroSchema.generateSchema().toString();
+        logger.info("Registering Avro Schema: {}", avroSchemaString);
+
+        createArtifact("default", TestUtils.generateArtifactId(), ArtifactType.AVRO, avroSchemaString,
+                ContentTypes.APPLICATION_JSON, null, null);
 
         new WrongConfiguredConsumerTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/JsonSchemaSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/JsonSchemaSerdeIT.java
@@ -28,14 +28,8 @@ import java.util.Map;
 public class JsonSchemaSerdeIT extends ApicurioRegistryBaseIT {
 
     private KafkaFacade kafkaCluster = KafkaFacade.getInstance();
-
     private Class<JsonSchemaKafkaSerializer> serializer = JsonSchemaKafkaSerializer.class;
     private Class<JsonSchemaKafkaDeserializer> deserializer = JsonSchemaKafkaDeserializer.class;
-
-    @Override
-    public void cleanArtifacts() throws Exception {
-        // Don't clean up
-    }
 
     @BeforeAll
     void setupEnvironment() {

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/ProtobufSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/ProtobufSerdeIT.java
@@ -169,11 +169,13 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
         // artifact
         new SimpleSerdesTesterBuilder<ProtobufTestMessage, ProtobufTestMessage>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
+                .withProducerProperty(SerdeConfig.FIND_LATEST_ARTIFACT, "false")
                 .withProducerProperty(SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1")
                 .withDataGenerator(schemaV1::generateMessage).withDataValidator(schemaV1::validateMessage)
                 .build().test();
         new SimpleSerdesTesterBuilder<ProtobufTestMessage, ProtobufTestMessage>().withTopic(topicName)
-                .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
+                .withSerializer(serializer).withProducerProperty(SerdeConfig.FIND_LATEST_ARTIFACT, "false")
+                .withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withDataGenerator(schemaV1::generateMessage).withDataValidator(schemaV1::validateMessage)
                 .build().test();
         new SimpleSerdesTesterBuilder<TestCmmn.UUID, TestCmmn.UUID>().withTopic(topicName)

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/ProtobufSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/ProtobufSerdeIT.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
 
     private KafkaFacade kafkaCluster = KafkaFacade.getInstance();
-
     private Class<ProtobufKafkaSerializer> serializer = ProtobufKafkaSerializer.class;
     private Class<ProtobufKafkaDeserializer> deserializer = ProtobufKafkaDeserializer.class;
 
@@ -42,11 +41,6 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
     @AfterAll
     void teardownEnvironment() throws Exception {
         kafkaCluster.stopIfPossible();
-    }
-
-    @Override
-    public void cleanArtifacts() throws Exception {
-        // Don't clean up
     }
 
     @Test

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SerdesTester.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SerdesTester.java
@@ -1,6 +1,7 @@
 package io.apicurio.tests.serdes.apicurio;
 
 import io.apicurio.registry.serde.SerdeConfig;
+import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.utils.KafkaFacade;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
@@ -114,7 +115,17 @@ public class SerdesTester<K, P, C> {
     }
 
     public void produceMessages(Producer<K, P> producer, String topicName, DataGenerator<P> dataGenerator,
-            int messageCount) throws Exception {
+            int messageCount, boolean retry) throws Exception {
+
+        if (retry) {
+            TestUtils.retry(() -> produceMessages(producer, topicName, dataGenerator, messageCount));
+        } else {
+            produceMessages(producer, topicName, dataGenerator, messageCount);
+        }
+    }
+
+    private void produceMessages(Producer<K, P> producer, String topicName, DataGenerator<P> dataGenerator,
+            int messageCount) throws ExecutionException, InterruptedException, TimeoutException {
         CompletableFuture<Integer> resultPromise = CompletableFuture.supplyAsync(() -> {
 
             int producedMessages = 0;
@@ -152,6 +163,7 @@ public class SerdesTester<K, P, C> {
         } catch (Exception e) {
             throw e;
         }
+
     }
 
     public void consumeMessages(Consumer<K, C> consumer, String topicName, int messageCount,

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SerdesTester.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SerdesTester.java
@@ -77,6 +77,7 @@ public class SerdesTester<K, P, C> {
             props.putIfAbsent(KafkaAvroSerializerConfig.VALUE_SUBJECT_NAME_STRATEGY,
                     artifactIdStrategy.getName());
         } else {
+            // props.putIfAbsent(SerdeConfig.FIND_LATEST_ARTIFACT, "true");
             props.putIfAbsent(SerdeConfig.REGISTRY_URL, ApicurioRegistryBaseIT.getRegistryV3ApiUrl());
             props.putIfAbsent(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, artifactIdStrategy.getName());
         }

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SimpleSerdesTesterBuilder.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SimpleSerdesTesterBuilder.java
@@ -136,7 +136,7 @@ public class SimpleSerdesTesterBuilder<P, C> implements TesterBuilder {
 
             try {
                 for (int i = 0; i < batchCount; i++) {
-                    this.produceMessages(producer, topic, dataGenerator, batchSize);
+                    this.produceMessages(producer, topic, dataGenerator, batchSize, false);
                 }
             } finally {
                 if (!autoCloseByProduceOrConsume) {

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SimpleSerdesTesterBuilder.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SimpleSerdesTesterBuilder.java
@@ -7,6 +7,8 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.Properties;
@@ -116,6 +118,8 @@ public class SimpleSerdesTesterBuilder<P, C> implements TesterBuilder {
 
     private class SimpleSerdesTester extends SerdesTester<String, P, C> implements Tester {
 
+        private final Logger logger = LoggerFactory.getLogger(SimpleSerdesTester.class);
+
         /**
          * @see Tester#test()
          */
@@ -123,6 +127,9 @@ public class SimpleSerdesTesterBuilder<P, C> implements TesterBuilder {
         public void test() throws Exception {
             Producer<String, P> producer = this.createProducer(producerProperties, StringSerializer.class,
                     serializer, topic, artifactResolverStrategy);
+
+            logger.info("Using producer configuration: {}", producerProperties);
+            logger.info("Using consumer configuration: {}", consumerProperties);
 
             boolean autoCloseByProduceOrConsume = batchCount == 1;
             setAutoClose(autoCloseByProduceOrConsume);

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/WrongConfiguredConsumerTesterBuilder.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/WrongConfiguredConsumerTesterBuilder.java
@@ -40,7 +40,7 @@ public class WrongConfiguredConsumerTesterBuilder<P, C> extends SimpleSerdesTest
                     serializer, topic, artifactResolverStrategy);
 
             int messageCount = 10;
-            this.produceMessages(producer, topic, dataGenerator, messageCount);
+            this.produceMessages(producer, topic, dataGenerator, messageCount, false);
 
             if (afterProduceValidator != null) {
                 assertTrue(afterProduceValidator.validate(), "After produce validation failed");

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/WrongConfiguredSerdesTesterBuilder.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/WrongConfiguredSerdesTesterBuilder.java
@@ -78,7 +78,7 @@ public class WrongConfiguredSerdesTesterBuilder<P> implements TesterBuilder {
                     serializer, topic, artifactResolverStrategy);
 
             assertThrows(ExecutionException.class,
-                    () -> this.produceMessages(producer, topic, dataGenerator, 10));
+                    () -> this.produceMessages(producer, topic, dataGenerator, 10, false));
 
         }
 

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
@@ -208,7 +208,7 @@ public class BasicConfluentSerDesIT extends ConfluentBaseIT {
         Consumer<String, GenericRecord> consumer = tester.createConsumer(StringDeserializer.class,
                 KafkaAvroDeserializer.class, topicName);
 
-        tester.produceMessages(producer, topicName, avroSchema::generateRecord, messageCount);
+        tester.produceMessages(producer, topicName, avroSchema::generateRecord, messageCount, true);
         tester.consumeMessages(consumer, topicName, messageCount, avroSchema::validateRecord);
 
         String schemaKey2 = "key2";
@@ -219,11 +219,11 @@ public class BasicConfluentSerDesIT extends ConfluentBaseIT {
 
         producer = tester.createProducer(StringSerializer.class, KafkaAvroSerializer.class, topicName,
                 strategy);
-        tester.produceMessages(producer, topicName, avroSchema2::generateRecord, messageCount);
+        tester.produceMessages(producer, topicName, avroSchema2::generateRecord, messageCount, true);
 
         producer = tester.createProducer(StringSerializer.class, KafkaAvroSerializer.class, topicName,
                 strategy);
-        tester.produceMessages(producer, topicName, avroSchema::generateRecord, messageCount);
+        tester.produceMessages(producer, topicName, avroSchema::generateRecord, messageCount, true);
 
         consumer = tester.createConsumer(StringDeserializer.class, KafkaAvroDeserializer.class, topicName);
         {
@@ -251,15 +251,15 @@ public class BasicConfluentSerDesIT extends ConfluentBaseIT {
 
         producer = tester.createProducer(StringSerializer.class, KafkaAvroSerializer.class, topicName,
                 strategy);
-        tester.produceMessages(producer, topicName, avroSchema3::generateRecord, messageCount);
+        tester.produceMessages(producer, topicName, avroSchema3::generateRecord, messageCount, true);
 
         producer = tester.createProducer(StringSerializer.class, KafkaAvroSerializer.class, topicName,
                 strategy);
-        tester.produceMessages(producer, topicName, avroSchema2::generateRecord, messageCount);
+        tester.produceMessages(producer, topicName, avroSchema2::generateRecord, messageCount, true);
 
         producer = tester.createProducer(StringSerializer.class, KafkaAvroSerializer.class, topicName,
                 strategy);
-        tester.produceMessages(producer, topicName, avroSchema::generateRecord, messageCount);
+        tester.produceMessages(producer, topicName, avroSchema::generateRecord, messageCount, true);
 
         consumer = tester.createConsumer(StringDeserializer.class, KafkaAvroDeserializer.class, topicName);
         {
@@ -325,9 +325,9 @@ public class BasicConfluentSerDesIT extends ConfluentBaseIT {
         Consumer<String, GenericRecord> consumer3 = tester.createConsumer(StringDeserializer.class,
                 AvroKafkaDeserializer.class, topicName3);
 
-        tester.produceMessages(producer1, topicName1, avroSchema::generateRecord, messageCount);
-        tester.produceMessages(producer2, topicName2, avroSchema::generateRecord, messageCount);
-        tester.produceMessages(producer3, topicName3, avroSchema::generateRecord, messageCount);
+        tester.produceMessages(producer1, topicName1, avroSchema::generateRecord, messageCount, true);
+        tester.produceMessages(producer2, topicName2, avroSchema::generateRecord, messageCount, true);
+        tester.produceMessages(producer3, topicName3, avroSchema::generateRecord, messageCount, true);
 
         tester.consumeMessages(consumer1, topicName1, messageCount, avroSchema::validateRecord);
         tester.consumeMessages(consumer2, topicName2, messageCount, avroSchema::validateRecord);

--- a/integration-tests/src/test/resources/infra/kafka/kafka.yml
+++ b/integration-tests/src/test/resources/infra/kafka/kafka.yml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
         - name: kafka-service
-          image: quay.io/strimzi/kafka:latest-kafka-3.5.0-amd64
+          image: quay.io/strimzi/kafka:latest-kafka-3.5.0-arm64
           command:
             - /bin/sh
             - -c

--- a/integration-tests/src/test/resources/infra/kafka/kafka.yml
+++ b/integration-tests/src/test/resources/infra/kafka/kafka.yml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
         - name: kafka-service
-          image: quay.io/strimzi/kafka:latest-kafka-3.5.0-amd64
+          image: quay.io/strimzi/kafka:latest-kafka-3.5.0
           command:
             - /bin/sh
             - -c

--- a/integration-tests/src/test/resources/infra/kafka/kafka.yml
+++ b/integration-tests/src/test/resources/infra/kafka/kafka.yml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
         - name: kafka-service
-          image: quay.io/strimzi/kafka:latest-kafka-3.5.0-arm64
+          image: quay.io/strimzi/kafka:latest-kafka-3.5.0-amd64
           command:
             - /bin/sh
             - -c

--- a/integration-tests/src/test/resources/infra/kafka/registry-kafka.yml
+++ b/integration-tests/src/test/resources/infra/kafka/registry-kafka.yml
@@ -7,7 +7,7 @@ metadata:
     app: apicurio-registry-kafka
   name: apicurio-registry-deployment
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: apicurio-registry-kafka

--- a/integration-tests/src/test/resources/infra/kafka/registry-kafka.yml
+++ b/integration-tests/src/test/resources/infra/kafka/registry-kafka.yml
@@ -7,7 +7,7 @@ metadata:
     app: apicurio-registry-kafka
   name: apicurio-registry-deployment
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: apicurio-registry-kafka

--- a/integration-tests/src/test/resources/infra/kafka/registry-kafka.yml
+++ b/integration-tests/src/test/resources/infra/kafka/registry-kafka.yml
@@ -27,7 +27,7 @@ spec:
             - name: APICURIO_STORAGE_KIND
               value: "kafkasql"
             - name: QUARKUS_LOG_CATEGORY__IO_APICURIO__LEVEL
-              value: "DEBUG"
+              value: "INFO"
             - name: APICURIO_REST_DELETION_ARTIFACT_ENABLED
               value: "true"
             - name: APICURIO_REST_DELETION_ARTIFACTVERSION_ENABLED

--- a/integration-tests/src/test/resources/junit-platform.properties
+++ b/integration-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=same_thread

--- a/integration-tests/src/test/resources/junit-platform.properties
+++ b/integration-tests/src/test/resources/junit-platform.properties
@@ -1,3 +1,0 @@
-junit.jupiter.execution.parallel.enabled=true
-junit.jupiter.execution.parallel.mode.default=concurrent
-junit.jupiter.execution.parallel.mode.classes.default=same_thread

--- a/java-sdk-v2/pom.xml
+++ b/java-sdk-v2/pom.xml
@@ -94,6 +94,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${version.build.helper.maven.plugin}</version>
         <executions>
           <execution>
             <id>add-source</id>

--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -93,6 +93,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${version.build.helper.maven.plugin}</version>
         <executions>
           <execution>
             <id>add-source</id>

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
     <scala.version>2.13.14</scala.version>
 
     <!-- Plugin Versions -->
+    <version.build.helper.maven.plugin>3.6.0</version.build.helper.maven.plugin>
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.deploy.plugin>3.1.3</version.deploy.plugin>
     <version.failsafe.plugin>3.5.0</version.failsafe.plugin>

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
@@ -278,8 +278,21 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
             });
 
             if (results.getCount() == 0) {
-                throw new RuntimeException(
-                        "Could not resolve artifact reference by content: " + artifactReference);
+                results = client.search().versions().post(is, ct, config -> {
+                    config.queryParameters.groupId = artifactReference.getGroupId() == null ? "default"
+                        : artifactReference.getGroupId();
+                    config.queryParameters.artifactId = artifactReference.getArtifactId();
+                    config.queryParameters.canonical = false;
+                    config.queryParameters.artifactType = at;
+                    config.queryParameters.orderby = VersionSortBy.GlobalId;
+                    config.queryParameters.order = SortOrder.Desc;
+                });
+
+                if (results.getCount() == 0) {
+                    throw new RuntimeException(
+                            String.format("Could not resolve artifact reference by content: %s",
+                                    rawSchemaString) + "&" + artifactReference);
+                }
             }
 
             SchemaLookupResult.SchemaLookupResultBuilder<S> result = SchemaLookupResult.builder();

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.logging.Logger;
 
 /**
  * Default implementation of {@link SchemaResolver}
@@ -35,6 +36,8 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
     private String autoCreateBehavior;
     private boolean findLatest;
     private boolean dereference;
+
+    private static final Logger logger = Logger.getLogger(DefaultSchemaResolver.class.getSimpleName());
 
     /**
      * @see io.apicurio.registry.resolver.AbstractSchemaResolver#reset()
@@ -264,6 +267,9 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
         String rawSchemaString = IoUtil.toString(parsedSchema.getRawSchema());
 
         return schemaCache.getByContent(rawSchemaString, contentKey -> {
+
+            logger.info(String.format("Retrieving schema content using string: %s", rawSchemaString));
+
             InputStream is = new ByteArrayInputStream(contentKey.getBytes(StandardCharsets.UTF_8));
             String at = schemaParser.artifactType();
             String ct = toContentType(at);

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/ERCache.java
@@ -244,8 +244,10 @@ public class ERCache<V> {
                 // && e.getCause().getCause() != null && e.getCause().getCause() instanceof ApiException
                 // && (((ApiException) e.getCause().getCause()).getResponseStatusCode() == 429)))
                 if (i == retries || !(e.getCause() != null && e.getCause() instanceof ApiException
-                        && (((ApiException) e.getCause()).getResponseStatusCode() == 429)))
+                        && (((ApiException) e.getCause()).getResponseStatusCode() == 429))) {
+                    e.printStackTrace();
                     return Result.error(new RuntimeException(e));
+                }
             }
             try {
                 Thread.sleep(backoff.toMillis());

--- a/utils/importexport/pom.xml
+++ b/utils/importexport/pom.xml
@@ -27,15 +27,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This PR introduces the following changes to address a few transient failures in CI:

- No more parallel build. The code generation phase is not thread safe and this was causing some build to fail. We no longer build the separe modules in parallel.
- Add a few required retries due to the nature of the kafkasql storage. All the tests are being executed in a clustered way, and this was causing a few eventual consistency issues. Added a few retries to address this problem.
- Applied a few minor improvements like not using the `install` goal to speed up the full process.


Before merging, this PR has to be squashed to prevent polluting the history.