### PR TITLE
Change serdes use content id and 4 byte identifier

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/JsonSerdeTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/JsonSerdeTest.java
@@ -43,7 +43,8 @@ public class JsonSerdeTest extends AbstractResourceTestBase {
             JsonSchemaKafkaDeserializer<Person> deserializer = new JsonSchemaKafkaDeserializer<>(clientV3,
                     true)) {
 
-            Map<String, String> configs = Map.of(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+            Map<String, String> configs = Map.of(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId,
+                    SerdeConfig.ENABLE_HEADERS, "true");
             serializer.configure(configs, false);
 
             deserializer.configure(configs, false);

--- a/app/src/test/java/io/apicurio/registry/noprofile/serde/AvroSerdeTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/serde/AvroSerdeTest.java
@@ -65,6 +65,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 import static io.apicurio.registry.utils.tests.TestUtils.waitForSchema;
+import static io.apicurio.registry.utils.tests.TestUtils.waitForSchemaLongId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
@@ -168,7 +169,6 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             Map<String, Object> config = new HashMap<>();
             config.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, strategy);
             config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
-            config.put(SerdeConfig.ENABLE_HEADERS, "false");
             serializer.configure(config, false);
 
             config = new HashMap<>();
@@ -182,11 +182,12 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             byte[] bytes = serializer.serialize(topic, record);
 
             // some impl details ...
-            waitForSchema(globalId -> {
+            waitForSchema(contentId -> {
                 try {
-                    if (restClient.ids().globalIds().byGlobalId(globalId).get().readAllBytes().length > 0) {
+                    if (restClient.ids().contentIds().byContentId(contentId.longValue()).get()
+                            .readAllBytes().length > 0) {
                         VersionMetaData artifactMetadata = artifactFinder.get();
-                        assertEquals(globalId, artifactMetadata.getGlobalId());
+                        assertEquals(contentId.longValue(), artifactMetadata.getContentId());
                         return true;
                     }
                 } catch (IOException e) {
@@ -214,7 +215,6 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             Map<String, String> config = new HashMap<>();
             config.put(AvroKafkaSerdeConfig.AVRO_ENCODING, AvroKafkaSerdeConfig.AVRO_ENCODING_JSON);
             config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
-            config.put(SerdeConfig.ENABLE_HEADERS, "false");
             serializer.configure(config, false);
 
             config = new HashMap<>();
@@ -228,14 +228,15 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
 
             byte[] bytes = serializer.serialize(artifactId, record);
 
-            // Test msg is stored as json, take 1st 9 bytes off (magic byte and long)
-            JSONObject msgAsJson = new JSONObject(new String(Arrays.copyOfRange(bytes, 9, bytes.length)));
+            // Test msg is stored as json, take 1st 5 bytes off (magic byte and long)
+            JSONObject msgAsJson = new JSONObject(new String(Arrays.copyOfRange(bytes, 5, bytes.length)));
             Assertions.assertEquals("somebar", msgAsJson.getString("bar"));
 
             // some impl details ...
-            waitForSchema(globalId -> {
+            waitForSchema(contentId -> {
                 try {
-                    return restClient.ids().globalIds().byGlobalId(globalId).get().readAllBytes().length > 0;
+                    return restClient.ids().contentIds().byContentId(contentId.longValue()).get()
+                            .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -256,7 +257,6 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             Map<String, String> config = new HashMap<>();
             config.put(AvroKafkaSerdeConfig.AVRO_ENCODING, AvroKafkaSerdeConfig.AVRO_ENCODING_JSON);
             config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
-            config.put(SerdeConfig.ENABLE_HEADERS, "false");
             serializer.configure(config, false);
 
             config = new HashMap<>();
@@ -298,14 +298,15 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
 
             byte[] bytes = serializer.serialize(artifactId, avroSchemaB);
 
-            // Test msg is stored as json, take 1st 9 bytes off (magic byte and long)
-            JSONObject msgAsJson = new JSONObject(new String(Arrays.copyOfRange(bytes, 9, bytes.length)));
+            // Test msg is stored as json, take 1st 5 bytes off (magic byte and long)
+            JSONObject msgAsJson = new JSONObject(new String(Arrays.copyOfRange(bytes, 5, bytes.length)));
             Assertions.assertEquals("CSymbol", msgAsJson.getJSONObject("schemaC").getString("symbol"));
 
             // some impl details ...
-            waitForSchema(globalId -> {
+            waitForSchema(contentId -> {
                 try {
-                    return restClient.ids().globalIds().byGlobalId(globalId).get().readAllBytes().length > 0;
+                    return restClient.ids().contentIds().byContentId(contentId.longValue()).get()
+                            .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -331,7 +332,6 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             Map<String, String> config = new HashMap<>();
             config.put(AvroKafkaSerdeConfig.AVRO_ENCODING, AvroKafkaSerdeConfig.AVRO_ENCODING_JSON);
             config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
-            config.put(SerdeConfig.ENABLE_HEADERS, "false");
             config.put(SchemaResolverConfig.DEREFERENCE_SCHEMA, "true");
             serializer.configure(config, false);
 
@@ -375,14 +375,15 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
 
             byte[] bytes = serializer.serialize(artifactId, avroSchemaB);
 
-            // Test msg is stored as json, take 1st 9 bytes off (magic byte and long)
-            JSONObject msgAsJson = new JSONObject(new String(Arrays.copyOfRange(bytes, 9, bytes.length)));
+            // Test msg is stored as json, take 1st 5 bytes off (magic byte and long)
+            JSONObject msgAsJson = new JSONObject(new String(Arrays.copyOfRange(bytes, 5, bytes.length)));
             Assertions.assertEquals("CSymbol", msgAsJson.getJSONObject("schemaC").getString("symbol"));
 
             // some impl details ...
-            waitForSchema(globalId -> {
+            waitForSchema(contentId -> {
                 try {
-                    return restClient.ids().globalIds().byGlobalId(globalId).get().readAllBytes().length > 0;
+                    return restClient.ids().contentIds().byContentId(contentId.longValue()).get()
+                            .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -408,7 +409,6 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             Map<String, String> config = new HashMap<>();
             config.put(AvroKafkaSerdeConfig.AVRO_ENCODING, AvroKafkaSerdeConfig.AVRO_ENCODING_JSON);
             config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
-            config.put(SerdeConfig.ENABLE_HEADERS, "false");
             serializer.configure(config, false);
 
             config = new HashMap<>();
@@ -452,13 +452,14 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
 
             byte[] bytes = serializer.serialize(artifactId, avroSchemaB);
 
-            // Test msg is stored as json, take 1st 9 bytes off (magic byte and long)
-            JSONObject msgAsJson = new JSONObject(new String(Arrays.copyOfRange(bytes, 9, bytes.length)));
+            // Test msg is stored as json, take 1st 5 bytes off (magic byte and long)
+            JSONObject msgAsJson = new JSONObject(new String(Arrays.copyOfRange(bytes, 5, bytes.length)));
             Assertions.assertEquals("CSymbol", msgAsJson.getJSONObject("schemaC").getString("symbol"));
 
-            waitForSchema(globalId -> {
+            waitForSchema(contentId -> {
                 try {
-                    return restClient.ids().globalIds().byGlobalId(globalId).get().readAllBytes().length > 0;
+                    return restClient.ids().contentIds().byContentId(contentId.longValue()).get()
+                            .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -481,7 +482,6 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             Map<String, String> config = new HashMap<>();
             config.put(AvroKafkaSerdeConfig.AVRO_ENCODING, AvroKafkaSerdeConfig.AVRO_ENCODING_JSON);
             config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
-            config.put(SerdeConfig.ENABLE_HEADERS, "false");
             serializer.configure(config, false);
 
             config = new HashMap<>();
@@ -503,7 +503,8 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
 
             waitForSchema(id -> {
                 try {
-                    return restClient.ids().globalIds().byGlobalId(id).get().readAllBytes().length > 0;
+                    return restClient.ids().contentIds().byContentId(id.longValue()).get()
+                            .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -540,8 +541,8 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             Headers headers = new RecordHeaders();
             byte[] bytes = serializer.serialize(artifactId, headers, record);
 
-            Assertions.assertNotNull(headers.lastHeader(SerdeHeaders.HEADER_VALUE_GLOBAL_ID));
-            headers.lastHeader(SerdeHeaders.HEADER_VALUE_GLOBAL_ID);
+            Assertions.assertNotNull(headers.lastHeader(SerdeHeaders.HEADER_VALUE_CONTENT_ID));
+            headers.lastHeader(SerdeHeaders.HEADER_VALUE_CONTENT_ID);
 
             GenericData.Record ir = deserializer.deserialize(artifactId, headers, bytes);
 
@@ -578,17 +579,18 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             Headers headers = new RecordHeaders();
             byte[] bytes = serializer.serialize(artifactId, headers, record);
 
-            Assertions.assertNotNull(headers.lastHeader(SerdeHeaders.HEADER_VALUE_GLOBAL_ID));
-            Header globalId = headers.lastHeader(SerdeHeaders.HEADER_VALUE_GLOBAL_ID);
-            long globalIdkey = ByteBuffer.wrap(globalId.value()).getLong();
+            Assertions.assertNotNull(headers.lastHeader(SerdeHeaders.HEADER_VALUE_CONTENT_ID));
+            Header contentId = headers.lastHeader(SerdeHeaders.HEADER_VALUE_CONTENT_ID);
+            long contentIdKey = ByteBuffer.wrap(contentId.value()).getLong();
 
-            waitForSchema(id -> {
+            waitForSchemaLongId(id -> {
                 try {
-                    return restClient.ids().globalIds().byGlobalId(id).get().readAllBytes().length > 0;
+                    return restClient.ids().contentIds().byContentId(contentIdKey).get()
+                            .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
-            }, bytes, byteBuffer -> globalIdkey);
+            }, bytes, byteBuffer -> contentIdKey);
 
             GenericData.EnumSymbol ir = deserializer.deserialize(artifactId, headers, bytes);
 
@@ -623,7 +625,6 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
 
             Map<String, String> config = new HashMap<>();
             config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
-            config.put(SerdeConfig.ENABLE_HEADERS, "false");
             config.put(AvroKafkaSerdeConfig.AVRO_DATUM_PROVIDER, datumProvider.getName());
             config.put(SchemaResolverConfig.ARTIFACT_RESOLVER_STRATEGY,
                     artifactResolverStrategyClass.getName());
@@ -638,9 +639,10 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             Tester tester = testerFactory.get();
             byte[] bytes = serializer.serialize(artifactId, tester);
 
-            waitForSchema(globalId -> {
+            waitForSchema(contentId -> {
                 try {
-                    return restClient.ids().globalIds().byGlobalId(globalId).get().readAllBytes().length > 0;
+                    return restClient.ids().contentIds().byContentId(contentId.longValue()).get()
+                            .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -677,14 +679,14 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
 
             TestUtils.retry(() -> TestUtils.waitForSchema(contentId -> {
                 try {
-                    return restClient.ids().contentIds().byContentId(contentId).get()
+                    return restClient.ids().contentIds().byContentId(contentId.longValue()).get()
                             .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
-            }, bytes, bb -> (long) bb.getInt()));
+            }, bytes, ByteBuffer::getInt));
 
-            deserializer1.asLegacyId();
+            deserializer1.as4ByteId();
             Map<String, String> config = new HashMap<>();
             config.put(SerdeConfig.USE_ID, IdOption.contentId.name());
             deserializer1.configure(config, false);
@@ -699,7 +701,7 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             Map<String, String> config = new HashMap<>();
             config.put(SerdeConfig.USE_ID, IdOption.contentId.name());
 
-            serializer2.asLegacyId();
+            serializer2.as4ByteId();
             serializer2.configure(config, false);
             byte[] bytes = serializer2.serialize(subject, record);
 

--- a/app/src/test/java/io/apicurio/registry/noprofile/serde/ProtobufSerdeTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/serde/ProtobufSerdeTest.java
@@ -62,12 +62,13 @@ public class ProtobufSerdeTest extends AbstractResourceTestBase {
 
             byte[] bytes = serializer.serialize(topic, record);
 
-            waitForSchema(globalId -> {
+            waitForSchema(contentId -> {
                 try {
-                    if (restClient.ids().globalIds().byGlobalId(globalId).get().readAllBytes().length > 0) {
+                    if (restClient.ids().contentIds().byContentId(contentId.longValue()).get()
+                            .readAllBytes().length > 0) {
                         VersionMetaData artifactMetadata = restClient.groups().byGroupId(groupId).artifacts()
                                 .byArtifactId(topic).versions().byVersionExpression("branch=latest").get();
-                        assertEquals(globalId, artifactMetadata.getGlobalId());
+                        assertEquals(contentId.longValue(), artifactMetadata.getContentId());
                         return true;
                     }
                 } catch (IOException e) {

--- a/docs/modules/ROOT/partials/getting-started/con-registry-serdes-avro.adoc
+++ b/docs/modules/ROOT/partials/getting-started/con-registry-serdes-avro.adoc
@@ -33,8 +33,8 @@ The property name is `apicurio.registry.headers.enabled`.
 .ID encoding
 You can customize how the schema ID is encoded when passing it in the Kafka message body. Set the `apicurio.registry.id-handler` configuration property to a class that implements the `io.apicurio.registry.serde.IdHandler` interface. {registry} provides the following implementations:
 
-* `io.apicurio.registry.serde.DefaultIdHandler`: Stores the ID as an 8-byte long
-* `io.apicurio.registry.serde.Legacy4ByteIdHandler`:  Stores the ID as an 4-byte integer
+* `io.apicurio.registry.serde.Default4ByteIdHandler`: Stores the ID as an 4-byte long
+* `io.apicurio.registry.serde.Legacy8ByteIdHandler`:  Stores the ID as an 8-byte integer
 
 {registry} represents the schema ID as a long, but for legacy reasons, or for compatibility with other registries or SerDe classes, you might want to use 4 bytes when sending the ID.
 

--- a/docs/modules/ROOT/partials/getting-started/con-registry-serdes-constants.adoc
+++ b/docs/modules/ROOT/partials/getting-started/con-registry-serdes-constants.adoc
@@ -19,13 +19,10 @@ public class SerdeConfig {
 
    public static final String REGISTRY_URL = "apicurio.registry.url"; <1>
    public static final String ID_HANDLER = "apicurio.registry.id-handler"; <2>
-   public static final String ENABLE_CONFLUENT_ID_HANDLER = "apicurio.registry.as-confluent"; <3>
 ----
 . The required URL of {registry}.
 . Extends ID handling to support other ID formats and make them compatible with {registry} SerDes services.
-For example, changing the default ID format from `Long` to `Integer` supports the Confluent ID format.
-. Simplifies the handling of Confluent IDs. If set to `true`, an `Integer` is used for the global ID lookup.
-The setting should not be used with the `ID_HANDLER` option.
+For example, you may change it from the default ID format `Integer` that's also compatible with Confluent's ID format to `Long`.
 
 [role="_additional-resources"]
 .Additional resources

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-serdes-config-props.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-serdes-config-props.adoc
@@ -162,7 +162,7 @@ The `DefaultSchemaResolver` uses the following properties to configure how to lo
 |`apicurio.registry.use-id`
 |Used by serializers and deserializers. Configures to use the specified `IdOption` as the identifier for artifacts. Options are `globalId` and `contentId`. Instructs the serializer to write the specified ID to Kafka, and instructs the deserializer to use this ID to find the schema.
 |`String`
-|`globalId`
+|`contentId`
 |===
 
 [discrete]
@@ -182,7 +182,7 @@ The `DefaultSchemaResolver` uses the following properties to configure how artif
 |`apicurio.registry.headers.enabled`
 |Used by serializers and deserializers. Configures to read/write the artifact identifier to Kafka message headers instead of in the message payload.
 |`boolean`
-|`true`
+|`false`
 |`HEADERS_HANDLER`
 |`apicurio.registry.headers.handler`
 |Used by serializers and deserializers. Fully-qualified Java classname that implements `HeadersHandler` and writes/reads the artifact identifier to/from the Kafka message headers.
@@ -190,14 +190,9 @@ The `DefaultSchemaResolver` uses the following properties to configure how artif
 |`io.apicurio.registry.serde.headers.DefaultHeadersHandler`
 |`ID_HANDLER`
 |`apicurio.registry.id-handler`
-|Used by serializers and deserializers. Fully-qualified Java classname of a class that implements `IdHandler` and writes/reads the artifact identifier to/from the message payload. Only used if `apicurio.registry.headers.enabled` is set to `false`.
+|Used by serializers and deserializers. Fully-qualified Java classname of a class that implements `IdHandler` and writes/reads the artifact identifier to/from the message payload. Default to a 4 byte format that includes the contentId in the message payload.
 |`String`
-|`io.apicurio.registry.serde.DefaultIdHandler`
-|`ENABLE_CONFLUENT_ID_HANDLER`
-|`apicurio.registry.as-confluent`
-|Used by serializers and deserializers. Shortcut for enabling the legacy Confluent-compatible implementation of `IdHandler`. Only used if `apicurio.registry.headers.enabled` is set to `false`.
-|`boolean`
-|`false`
+|`io.apicurio.registry.serde.Default4ByteIdHandler`
 |===
 
 [discrete]

--- a/examples/confluent-serdes/src/main/java/io/apicurio/registry/examples/confluent/serdes/ConfluentSerdesExample.java
+++ b/examples/confluent-serdes/src/main/java/io/apicurio/registry/examples/confluent/serdes/ConfluentSerdesExample.java
@@ -201,9 +201,7 @@ public class ConfluentSerdesExample {
 
         // Configure Service Registry location
         props.putIfAbsent(SerdeConfig.REGISTRY_URL, REGISTRY_URL);
-        // Enable "Confluent Compatible API" mode in the Apicurio Registry deserializer
-        props.putIfAbsent(SerdeConfig.ENABLE_CONFLUENT_ID_HANDLER, Boolean.TRUE);
-        // No other configuration needed for the deserializer, because the globalId of the schema
+        // No other configuration needed for the deserializer, because the contentId of the schema
         // the deserializer should use is sent as part of the payload. So the deserializer simply
         // extracts that globalId and uses it to look up the Schema from the registry.
 

--- a/examples/event-driven-architecture/README.md
+++ b/examples/event-driven-architecture/README.md
@@ -77,9 +77,7 @@ and their respective registry configurations:
   "key.converter.apicurio.registry.url": "http://schema-registry:8080/apis/registry/v2",
   "value.converter": "io.apicurio.registry.utils.converter.AvroConverter",
   "key.converter.apicurio.registry.auto-register": "true",
-  "key.converter": "io.apicurio.registry.utils.converter.AvroConverter",
-  "value.converter.apicurio.registry.as-confluent": "true",
-  "value.converter.apicurio.registry.use-id": "contentId"
+  "key.converter": "io.apicurio.registry.utils.converter.AvroConverter"
 }
 ```
 

--- a/examples/event-driven-architecture/studio-connector.json
+++ b/examples/event-driven-architecture/studio-connector.json
@@ -8,19 +8,15 @@
   "database.server.name": "apicuriodb",
   "schema.include.list": "public",
   "value.converter.apicurio.registry.auto-register": "true",
-  "key.converter.apicurio.registry.as-confluent": "true",
   "database.port": "5432",
   "plugin.name": "pgoutput",
   "topic.prefix": "postgre-changes",
   "database.hostname": "apicurio-db",
   "database.password": "postgres",
-  "key.converter.apicurio.registry.use-id": "contentId",
   "name": "Test",
   "value.converter.apicurio.registry.url": "http://schema-registry:8080/apis/registry/v2",
   "key.converter.apicurio.registry.url": "http://schema-registry:8080/apis/registry/v2",
   "value.converter": "io.apicurio.registry.utils.converter.AvroConverter",
   "key.converter.apicurio.registry.auto-register": "true",
-  "key.converter": "io.apicurio.registry.utils.converter.AvroConverter",
-  "value.converter.apicurio.registry.as-confluent": "true",
-  "value.converter.apicurio.registry.use-id": "contentId"
+  "key.converter": "io.apicurio.registry.utils.converter.AvroConverter"
 }

--- a/integration-tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
@@ -108,9 +108,9 @@ public class RegistryConverterIT extends ApicurioRegistryBaseIT {
             byte[] bytes = converter.fromConnectData(subject, sc, struct);
 
             // some impl details ...
-            TestUtils.waitForSchema(globalId -> {
+            TestUtils.waitForSchema(contentId -> {
                 try {
-                    return registryClient.ids().globalIds().byGlobalId(globalId).get()
+                    return registryClient.ids().contentIds().byContentId(contentId.longValue()).get()
                             .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -153,9 +153,9 @@ public class RegistryConverterIT extends ApicurioRegistryBaseIT {
             byte[] bytes = converter.fromConnectData(subject, sc, struct);
 
             // some impl details ...
-            TestUtils.waitForSchema(globalId -> {
+            TestUtils.waitForSchema(contentId -> {
                 try {
-                    return registryClient.ids().globalIds().byGlobalId(globalId).get()
+                    return registryClient.ids().contentIds().byContentId(contentId.longValue()).get()
                             .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -187,9 +187,9 @@ public class RegistryConverterIT extends ApicurioRegistryBaseIT {
             byte[] bytes = converter.fromConnectData(subject, sc, struct);
 
             // some impl details ...
-            TestUtils.waitForSchema(globalId -> {
+            TestUtils.waitForSchema(contentId -> {
                 try {
-                    return registryClient.ids().globalIds().byGlobalId(globalId).get()
+                    return registryClient.ids().contentIds().byContentId(contentId.longValue()).get()
                             .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -207,7 +207,7 @@ public class RegistryConverterIT extends ApicurioRegistryBaseIT {
             try {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode root = mapper.readTree(input);
-                return root.get("schemaId").asLong();
+                return root.get("schemaId").asInt();
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
@@ -242,9 +242,9 @@ public class RegistryConverterIT extends ApicurioRegistryBaseIT {
             byte[] bytes = converter.fromConnectData(subject, envelopeSchema, envelopeStruct);
 
             // some impl details ...
-            TestUtils.waitForSchema(globalId -> {
+            TestUtils.waitForSchema(contentId -> {
                 try {
-                    return registryClient.ids().globalIds().byGlobalId(globalId).get()
+                    return registryClient.ids().contentIds().byContentId(contentId.longValue()).get()
                             .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -319,12 +319,12 @@ public class RegistryConverterIT extends ApicurioRegistryBaseIT {
     public void testCompactJson() throws Exception {
         testJson(createRegistryClient(), new CompactFormatStrategy(), input -> {
             ByteBuffer buffer = AbstractKafkaSerDe.getByteBuffer(input);
-            return buffer.getLong();
+            return buffer.getInt();
         });
     }
 
-    private void testJson(RegistryClient restClient, FormatStrategy formatStrategy, Function<byte[], Long> fn)
-            throws Exception {
+    private void testJson(RegistryClient restClient, FormatStrategy formatStrategy,
+            Function<byte[], Integer> fn) throws Exception {
         try (ExtJsonConverter converter = new ExtJsonConverter(restClient)) {
             converter.setFormatStrategy(formatStrategy);
             Map<String, Object> config = new HashMap<>();
@@ -339,9 +339,10 @@ public class RegistryConverterIT extends ApicurioRegistryBaseIT {
             byte[] bytes = converter.fromConnectData("extjson", sc, struct);
 
             // some impl details ...
-            TestUtils.waitForSchemaCustom(globalId -> {
+            TestUtils.waitForSchemaCustom(contentId -> {
                 try {
-                    return restClient.ids().globalIds().byGlobalId(globalId).get().readAllBytes().length > 0;
+                    return restClient.ids().contentIds().byContentId(contentId.longValue()).get()
+                            .readAllBytes().length > 0;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
@@ -499,7 +499,6 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withDataGenerator(avroSchema::generateRecord).withDataValidator(avroSchema::validateRecord)
                 .withProducerProperty(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true")
-                .withProducerProperty(SerdeConfig.ENABLE_HEADERS, "false")
                 .withProducerProperty(AvroKafkaSerdeConfig.AVRO_ENCODING,
                         AvroKafkaSerdeConfig.AVRO_ENCODING_JSON)
                 .withConsumerProperty(AvroKafkaSerdeConfig.AVRO_ENCODING,
@@ -546,9 +545,9 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
 
     }
 
-    // test use contentId headers
+    // test use globalId headers
     @Test
-    void testContentIdInHeaders() throws Exception {
+    void testGlobalIdInHeaders() throws Exception {
         String topicName = TestUtils.generateTopic();
         // because of using TopicIdStrategy
         String artifactId = topicName + "-value";
@@ -561,23 +560,23 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withDataGenerator(avroSchema::generateRecord).withDataValidator(avroSchema::validateRecord)
                 .withProducerProperty(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true")
-                .withProducerProperty(SerdeConfig.USE_ID, IdOption.contentId.name())
-                .withConsumerProperty(SerdeConfig.USE_ID, IdOption.contentId.name())
+                .withProducerProperty(SerdeConfig.USE_ID, IdOption.globalId.name())
+                .withConsumerProperty(SerdeConfig.USE_ID, IdOption.globalId.name())
                 .withAfterProduceValidator(() -> {
                     return TestUtils.retry(() -> {
                         VersionMetaData meta = registryClient.groups().byGroupId("default").artifacts()
                                 .byArtifactId(artifactId).versions().byVersionExpression("branch=latest")
                                 .get();
-                        registryClient.ids().globalIds().byGlobalId(meta.getGlobalId()).get();
+                        registryClient.ids().contentIds().byContentId(meta.getContentId()).get();
                         return true;
                     });
                 }).build().test();
 
     }
 
-    // test use contentId magic byte
+    // test use globalId magic byte
     @Test
-    void testContentIdInBody() throws Exception {
+    void testGlobalIdInBody() throws Exception {
         String topicName = TestUtils.generateTopic();
         // because of using TopicIdStrategy
         String artifactId = topicName + "-value";
@@ -590,9 +589,8 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withDataGenerator(avroSchema::generateRecord).withDataValidator(avroSchema::validateRecord)
                 .withProducerProperty(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true")
-                .withProducerProperty(SerdeConfig.ENABLE_HEADERS, "false")
-                .withProducerProperty(SerdeConfig.USE_ID, IdOption.contentId.name())
-                .withConsumerProperty(SerdeConfig.USE_ID, IdOption.contentId.name())
+                .withProducerProperty(SerdeConfig.USE_ID, IdOption.globalId.name())
+                .withConsumerProperty(SerdeConfig.USE_ID, IdOption.globalId.name())
                 .withAfterProduceValidator(() -> {
                     return TestUtils.retry(() -> {
                         VersionMetaData meta = registryClient.groups().byGroupId("default").artifacts()
@@ -608,9 +606,9 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
     // disabled because the setup process to have an artifact with different globalId/contentId is not
     // reliable
     @Disabled
-    // test producer use contentId, consumer default
+    // test producer use globalId, consumer default
     @Test
-    void testProducerUsesContentIdConsumerUsesDefault() throws Exception {
+    void testProducerUsesGlobalIdConsumerUsesDefault() throws Exception {
         String topicName = TestUtils.generateTopic();
         // because of using TopicIdStrategy
         String artifactId = topicName + "-value";
@@ -632,15 +630,14 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         new WrongConfiguredConsumerTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withDataGenerator(avroSchema::generateRecord).withDataValidator(avroSchema::validateRecord)
-                .withProducerProperty(SerdeConfig.ENABLE_HEADERS, "false")
                 .withProducerProperty(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true")
-                .withProducerProperty(SerdeConfig.USE_ID, IdOption.contentId.name())
+                .withProducerProperty(SerdeConfig.USE_ID, IdOption.globalId.name())
                 .withAfterProduceValidator(() -> {
                     return TestUtils.retry(() -> {
                         VersionMetaData meta = registryClient.groups().byGroupId("default").artifacts()
                                 .byArtifactId(artifactId).versions().byVersionExpression("branch=latest")
                                 .get();
-                        registryClient.ids().globalIds().byGlobalId(meta.getGlobalId()).get();
+                        registryClient.ids().contentIds().byContentId(meta.getContentId()).get();
                         return true;
                     });
                 }).build().test();
@@ -650,9 +647,9 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
     // disabled because the setup process to have an artifact with different globalId/contentId is not
     // reliable
     @Disabled
-    // test producer use default, consumer use contentId
+    // test producer use default, consumer use globalId
     @Test
-    void testProducerUsesDefaultConsumerUsesContentId() throws Exception {
+    void testProducerUsesDefaultConsumerUsesGlobalId() throws Exception {
         String topicName = TestUtils.generateTopic();
         // because of using TopicIdStrategy
         String artifactId = topicName + "-value";
@@ -673,15 +670,14 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
         new WrongConfiguredConsumerTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withDataGenerator(avroSchema::generateRecord).withDataValidator(avroSchema::validateRecord)
-                .withProducerProperty(SerdeConfig.ENABLE_HEADERS, "false")
                 .withProducerProperty(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true")
-                .withConsumerProperty(SerdeConfig.USE_ID, IdOption.contentId.name())
+                .withConsumerProperty(SerdeConfig.USE_ID, IdOption.globalId.name())
                 .withAfterProduceValidator(() -> {
                     return TestUtils.retry(() -> {
                         VersionMetaData meta = registryClient.groups().byGroupId("default").artifacts()
                                 .byArtifactId(artifactId).versions().byVersionExpression("branch=latest")
                                 .get();
-                        registryClient.ids().globalIds().byGlobalId(meta.getGlobalId()).get();
+                        registryClient.ids().contentIds().byContentId(meta.getContentId()).get();
                         return true;
                     });
                 }).build().test();

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/JsonSchemaSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/JsonSchemaSerdeIT.java
@@ -54,7 +54,8 @@ public class JsonSchemaSerdeIT extends ApicurioRegistryBaseIT {
                 ContentTypes.APPLICATION_JSON, null, null);
 
         new SimpleSerdesTesterBuilder<ValidMessage, ValidMessage>().withTopic(topicName)
-                .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
+                .withCommonProperty(SerdeConfig.ENABLE_HEADERS, "true").withSerializer(serializer)
+                .withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withDataGenerator(schema::generateMessage).withDataValidator(schema::validateMessage).build()
                 .test();
     }
@@ -71,9 +72,10 @@ public class JsonSchemaSerdeIT extends ApicurioRegistryBaseIT {
                 ContentTypes.APPLICATION_JSON, null, null);
 
         new SimpleSerdesTesterBuilder<ValidMessage, ValidMessage>().withTopic(topicName)
-                .withSerializer(serializer).withDeserializer(deserializer)
-                .withStrategy(SimpleTopicIdStrategy.class).withDataGenerator(schema::generateMessage)
-                .withDataValidator(schema::validateMessage).build().test();
+                .withCommonProperty(SerdeConfig.ENABLE_HEADERS, "true").withSerializer(serializer)
+                .withDeserializer(deserializer).withStrategy(SimpleTopicIdStrategy.class)
+                .withDataGenerator(schema::generateMessage).withDataValidator(schema::validateMessage).build()
+                .test();
     }
 
     // there is no mechanism for json serdes to auto register a schema, yet

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/ProtobufSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/ProtobufSerdeIT.java
@@ -57,9 +57,9 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
 
         logRestClientError(() -> {
             new SimpleSerdesTesterBuilder<ProtobufTestMessage, ProtobufTestMessage>().withTopic(topicName)
-                    .withSerializer(serializer).withDeserializer(deserializer)
-                    .withStrategy(TopicIdStrategy.class).withDataGenerator(schema::generateMessage)
-                    .withDataValidator(schema::validateMessage)
+                    .withCommonProperty(SerdeConfig.ENABLE_HEADERS, "true").withSerializer(serializer)
+                    .withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
+                    .withDataGenerator(schema::generateMessage).withDataValidator(schema::validateMessage)
                     .withProducerProperty(SerdeConfig.FIND_LATEST_ARTIFACT, "true").build();
         });
     }
@@ -77,9 +77,9 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
 
         logRestClientError(() -> {
             new SimpleSerdesTesterBuilder<ProtobufTestMessage, ProtobufTestMessage>().withTopic(topicName)
-                    .withSerializer(serializer).withDeserializer(deserializer)
-                    .withStrategy(SimpleTopicIdStrategy.class).withDataGenerator(schema::generateMessage)
-                    .withDataValidator(schema::validateMessage)
+                    .withCommonProperty(SerdeConfig.ENABLE_HEADERS, "true").withSerializer(serializer)
+                    .withDeserializer(deserializer).withStrategy(SimpleTopicIdStrategy.class)
+                    .withDataGenerator(schema::generateMessage).withDataValidator(schema::validateMessage)
                     .withProducerProperty(SerdeConfig.FIND_LATEST_ARTIFACT, "true").build();
         });
     }
@@ -168,18 +168,21 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
         // by default the artifact is found by content so this should work by finding the version 1 of the
         // artifact
         new SimpleSerdesTesterBuilder<ProtobufTestMessage, ProtobufTestMessage>().withTopic(topicName)
-                .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
+                .withCommonProperty(SerdeConfig.ENABLE_HEADERS, "true").withSerializer(serializer)
+                .withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withProducerProperty(SerdeConfig.FIND_LATEST_ARTIFACT, "false")
                 .withProducerProperty(SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1")
                 .withDataGenerator(schemaV1::generateMessage).withDataValidator(schemaV1::validateMessage)
                 .build().test();
         new SimpleSerdesTesterBuilder<ProtobufTestMessage, ProtobufTestMessage>().withTopic(topicName)
-                .withSerializer(serializer).withProducerProperty(SerdeConfig.FIND_LATEST_ARTIFACT, "false")
+                .withCommonProperty(SerdeConfig.ENABLE_HEADERS, "true").withSerializer(serializer)
+                .withProducerProperty(SerdeConfig.FIND_LATEST_ARTIFACT, "false")
                 .withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withDataGenerator(schemaV1::generateMessage).withDataValidator(schemaV1::validateMessage)
                 .build().test();
         new SimpleSerdesTesterBuilder<TestCmmn.UUID, TestCmmn.UUID>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
+                .withCommonProperty(SerdeConfig.ENABLE_HEADERS, "true")
                 .withDataGenerator(schemaV2::generateMessage).withDataValidator(schemaV2::validateTypeMessage)
                 .build().test();
 
@@ -193,12 +196,14 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
 
         // if find latest is enabled and we use the v2 schema it should work. Validation is enabled by default
         new SimpleSerdesTesterBuilder<TestCmmn.UUID, TestCmmn.UUID>().withTopic(topicName)
-                .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
+                .withCommonProperty(SerdeConfig.ENABLE_HEADERS, "true").withSerializer(serializer)
+                .withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withProducerProperty(SerdeConfig.FIND_LATEST_ARTIFACT, "true")
                 .withDataGenerator(schemaV2::generateMessage).withDataValidator(schemaV2::validateTypeMessage)
                 .build().test();
         new SimpleSerdesTesterBuilder<TestCmmn.UUID, TestCmmn.UUID>().withTopic(topicName)
-                .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
+                .withCommonProperty(SerdeConfig.ENABLE_HEADERS, "true").withSerializer(serializer)
+                .withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withProducerProperty(SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "2")
                 .withDataGenerator(schemaV2::generateMessage).withDataValidator(schemaV2::validateTypeMessage)
                 .build().test();
@@ -307,6 +312,7 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
         logRestClientError(() -> {
             new SimpleSerdesTesterBuilder<ProtobufTestMessage, ProtobufTestMessage>().withTopic(topicName)
                     .withSerializer(serializer).withDeserializer(deserializer)
+                    .withCommonProperty(SerdeConfig.ENABLE_HEADERS, "true")
                     .withStrategy(SimpleTopicIdStrategy.class).withDataGenerator(schema::generateMessage)
                     .withDataValidator(schema::validateMessage)
                     .withProducerProperty(SerdeConfig.FIND_LATEST_ARTIFACT, "true")
@@ -363,6 +369,7 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
         new SimpleSerdesTesterBuilder<ProtobufTestMessage, ProtobufTestMessage>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withDataGenerator(schema::generateMessage).withDataValidator(schema::validateMessage)
+                .withCommonProperty(SerdeConfig.ENABLE_HEADERS, "true")
                 .withProducerProperty(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true")
                 .withAfterProduceValidator(() -> {
                     return TestUtils.retry(() -> {
@@ -461,7 +468,6 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withDataGenerator(schema::generateMessage).withDataValidator(schema::validateMessage)
                 .withProducerProperty(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true")
-                .withProducerProperty(SerdeConfig.ENABLE_HEADERS, "false")
                 .withConsumerProperty(ProtobufKafkaDeserializerConfig.DERIVE_CLASS_FROM_SCHEMA, "true")
                 .withAfterProduceValidator(() -> {
                     return TestUtils.retry(() -> {
@@ -489,8 +495,7 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
         new SimpleSerdesTesterBuilder<ProtobufTestMessage, DynamicMessage>().withTopic(topicName)
                 .withSerializer(serializer).withDeserializer(deserializer).withStrategy(TopicIdStrategy.class)
                 .withDataGenerator(schema::generateMessage).withDataValidator(schema::validateDynamicMessage)
-                .withProducerProperty(SerdeConfig.FIND_LATEST_ARTIFACT, "true")
-                .withProducerProperty(SerdeConfig.ENABLE_HEADERS, "false").build().test();
+                .withProducerProperty(SerdeConfig.FIND_LATEST_ARTIFACT, "true").build().test();
     }
 
 }

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
@@ -1,10 +1,8 @@
 package io.apicurio.tests.serdes.confluent;
 
-import io.apicurio.registry.serde.SerdeConfig;
 import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
 import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
 import io.apicurio.registry.serde.avro.strategy.RecordIdStrategy;
-import io.apicurio.registry.serde.config.IdOption;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.IoUtil;
@@ -89,8 +87,6 @@ public class BasicConfluentSerDesIT extends ConfluentBaseIT {
 
         new SimpleSerdesTesterBuilder<GenericRecord, GenericRecord>().withTopic(topicName)
                 .withSerializer(KafkaAvroSerializer.class).withDeserializer(AvroKafkaDeserializer.class)
-                .withConsumerProperty(SerdeConfig.ENABLE_CONFLUENT_ID_HANDLER, "true")
-                .withConsumerProperty(SerdeConfig.USE_ID, IdOption.contentId.name())
                 .withStrategy(TopicNameStrategy.class).withDataGenerator(avroSchema::generateRecord)
                 .withDataValidator(avroSchema::validateRecord).build().test();
     }
@@ -111,10 +107,6 @@ public class BasicConfluentSerDesIT extends ConfluentBaseIT {
                 .withSerializer(AvroKafkaSerializer.class)
 
                 // very important
-                .withProducerProperty(SerdeConfig.ENABLE_HEADERS, "false")
-
-                .withProducerProperty(SerdeConfig.ENABLE_CONFLUENT_ID_HANDLER, "true")
-                .withProducerProperty(SerdeConfig.USE_ID, IdOption.contentId.name())
                 .withDeserializer(KafkaAvroDeserializer.class)
                 .withStrategy(io.apicurio.registry.serde.strategy.TopicIdStrategy.class)
                 .withDataGenerator(avroSchema::generateRecord).withDataValidator(avroSchema::validateRecord)

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/strategy/ArtifactReference.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/strategy/ArtifactReference.java
@@ -62,6 +62,10 @@ public interface ArtifactReference {
         return builder().globalId(globalId).build();
     }
 
+    public static ArtifactReference fromContentId(Long contentId) {
+        return builder().contentId(contentId).build();
+    }
+
     public static ArtifactReferenceBuilder builder() {
         return new ArtifactReferenceBuilder();
     }

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/AbstractKafkaSerDe.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/AbstractKafkaSerDe.java
@@ -51,14 +51,6 @@ public abstract class AbstractKafkaSerDe<T, U> extends SchemaResolverConfigurer<
         if (idHandler == null) {
             Object idh = config.getIdHandler();
             Utils.instantiate(IdHandler.class, idh, this::setIdHandler);
-
-            if (config.enableConfluentIdHandler()) {
-                if (idHandler != null && !(idHandler instanceof Legacy4ByteIdHandler)) {
-                    log.warn(String.format("Duplicate id-handler configuration: %s vs. %s", idh,
-                            "as-confluent"));
-                }
-                setIdHandler(new Legacy4ByteIdHandler());
-            }
         }
         idHandler.configure(config.originals(), isKey);
 
@@ -84,8 +76,8 @@ public abstract class AbstractKafkaSerDe<T, U> extends SchemaResolverConfigurer<
         this.idHandler = Objects.requireNonNull(idHandler);
     }
 
-    public void asLegacyId() {
-        setIdHandler(new Legacy4ByteIdHandler());
+    public void as4ByteId() {
+        setIdHandler(new Default4ByteIdHandler());
     }
 
     public void reset() {

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/Default4ByteIdHandler.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/Default4ByteIdHandler.java
@@ -13,10 +13,10 @@ import java.util.Map;
 /**
  * IdHandler that assumes 4 bytes for the magic number (the ID).
  */
-public class Legacy4ByteIdHandler implements IdHandler {
+public class Default4ByteIdHandler implements IdHandler {
     static final int idSize = 4; // e.g. Confluent uses 4 / int
 
-    private IdOption idOption;
+    private IdOption idOption = IdOption.contentId;
 
     /**
      * @see io.apicurio.registry.serde.IdHandler#configure(java.util.Map, boolean)
@@ -30,14 +30,14 @@ public class Legacy4ByteIdHandler implements IdHandler {
     @Override
     public void writeId(ArtifactReference reference, OutputStream out) throws IOException {
         long id;
-        if (idOption == IdOption.contentId) {
-            if (reference.getContentId() == null) {
+        if (idOption == IdOption.globalId) {
+            if (reference.getGlobalId() == null) {
                 throw new SerializationException(
-                        "Missing contentId. IdOption is contentId but there is no contentId in the ArtifactReference");
+                        "Missing globalId. IdOption is globalId but there is no contentId in the ArtifactReference");
             }
-            id = reference.getContentId();
-        } else {
             id = reference.getGlobalId();
+        } else {
+            id = reference.getContentId();
         }
         out.write(ByteBuffer.allocate(idSize).putInt((int) id).array());
     }
@@ -45,14 +45,14 @@ public class Legacy4ByteIdHandler implements IdHandler {
     @Override
     public void writeId(ArtifactReference reference, ByteBuffer buffer) {
         long id;
-        if (idOption == IdOption.contentId) {
-            if (reference.getContentId() == null) {
+        if (idOption == IdOption.globalId) {
+            if (reference.getGlobalId() == null) {
                 throw new SerializationException(
-                        "Missing contentId. IdOption is contentId but there is no contentId in the ArtifactReference");
+                        "Missing globalId. IdOption is globalId but there is no globalId in the ArtifactReference");
             }
-            id = reference.getContentId();
-        } else {
             id = reference.getGlobalId();
+        } else {
+            id = reference.getContentId();
         }
         buffer.putInt((int) id);
     }
@@ -62,10 +62,10 @@ public class Legacy4ByteIdHandler implements IdHandler {
      */
     @Override
     public ArtifactReference readId(ByteBuffer buffer) {
-        if (idOption == IdOption.contentId) {
-            return ArtifactReference.builder().contentId(Long.valueOf(buffer.getInt())).build();
-        } else {
+        if (idOption == IdOption.globalId) {
             return ArtifactReference.builder().globalId(Long.valueOf(buffer.getInt())).build();
+        } else {
+            return ArtifactReference.builder().contentId(Long.valueOf(buffer.getInt())).build();
         }
     }
 

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/Legacy8ByteIdHandler.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/Legacy8ByteIdHandler.java
@@ -10,10 +10,10 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
-public class DefaultIdHandler implements IdHandler {
+public class Legacy8ByteIdHandler implements IdHandler {
     static final int idSize = 8; // we use 8 / long
 
-    private IdOption idOption = IdOption.globalId;
+    private IdOption idOption = IdOption.contentId;
 
     @Override
     public void configure(Map<String, Object> configs, boolean isKey) {
@@ -24,14 +24,14 @@ public class DefaultIdHandler implements IdHandler {
     @Override
     public void writeId(ArtifactReference reference, OutputStream out) throws IOException {
         long id;
-        if (idOption == IdOption.contentId) {
-            if (reference.getContentId() == null) {
+        if (idOption == IdOption.globalId) {
+            if (reference.getGlobalId() == null) {
                 throw new SerializationException(
-                        "Missing contentId. IdOption is contentId but there is no contentId in the ArtifactReference");
+                        "Missing globalId. IdOption is globalId but there is no contentId in the ArtifactReference");
             }
-            id = reference.getContentId();
-        } else {
             id = reference.getGlobalId();
+        } else {
+            id = reference.getContentId();
         }
         out.write(ByteBuffer.allocate(idSize).putLong(id).array());
     }
@@ -39,24 +39,24 @@ public class DefaultIdHandler implements IdHandler {
     @Override
     public void writeId(ArtifactReference reference, ByteBuffer buffer) {
         long id;
-        if (idOption == IdOption.contentId) {
-            if (reference.getContentId() == null) {
+        if (idOption == IdOption.globalId) {
+            if (reference.getGlobalId() == null) {
                 throw new SerializationException(
-                        "Missing contentId. IdOption is contentId but there is no contentId in the ArtifactReference");
+                        "Missing globalId. IdOption is globalId but there is no globalId in the ArtifactReference");
             }
-            id = reference.getContentId();
-        } else {
             id = reference.getGlobalId();
+        } else {
+            id = reference.getContentId();
         }
         buffer.putLong(id);
     }
 
     @Override
     public ArtifactReference readId(ByteBuffer buffer) {
-        if (idOption == IdOption.contentId) {
-            return ArtifactReference.builder().contentId(buffer.getLong()).build();
-        } else {
+        if (idOption == IdOption.globalId) {
             return ArtifactReference.builder().globalId(buffer.getLong()).build();
+        } else {
+            return ArtifactReference.builder().contentId(buffer.getLong()).build();
         }
     }
 

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/SerdeConfig.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/SerdeConfig.java
@@ -137,20 +137,14 @@ public class SerdeConfig {
      * {@link SerdeConfig#ENABLE_HEADERS} is missing or 'false'.
      */
     public static final String ID_HANDLER = "apicurio.registry.id-handler";
-    public static final String ID_HANDLER_DEFAULT = DefaultIdHandler.class.getName();
-
-    /**
-     * Shortcut for enabling the Legacy (Confluent compatible) implementation of {@link IdHandler}. Should not
-     * be used with "ID_HANDLER". The value should be 'true' or 'false'.
-     */
-    public static final String ENABLE_CONFLUENT_ID_HANDLER = "apicurio.registry.as-confluent";
+    public static final String ID_HANDLER_DEFAULT = Default4ByteIdHandler.class.getName();
 
     /**
      * Boolean to indicate whether serde classes should pass Global Id information via message headers instead
      * of in the message payload.
      */
     public static final String ENABLE_HEADERS = "apicurio.registry.headers.enabled";
-    public static final boolean ENABLE_HEADERS_DEFAULT = true;
+    public static final boolean ENABLE_HEADERS_DEFAULT = false;
 
     /**
      * Fully qualified Java classname of a class that implements {@link HeadersHandler} and is responsible for
@@ -189,7 +183,7 @@ public class SerdeConfig {
      * deserializer to read and use the specified id from the kafka records (to find the schema).
      */
     public static final String USE_ID = "apicurio.registry.use-id";
-    public static final String USE_ID_DEFAULT = IdOption.globalId.name();
+    public static final String USE_ID_DEFAULT = IdOption.contentId.name();
 
     /**
      * Boolean used to enable or disable validation. Not applicable to all serde classes. For example, the

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/config/BaseKafkaSerDeConfig.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/config/BaseKafkaSerDeConfig.java
@@ -14,7 +14,6 @@ public class BaseKafkaSerDeConfig extends AbstractConfig {
     private static ConfigDef buildConfigDef(ConfigDef base) {
         ConfigDef configDef = new ConfigDef(base)
                 .define(ID_HANDLER, Type.CLASS, ID_HANDLER_DEFAULT, Importance.MEDIUM, "TODO docs")
-                .define(ENABLE_CONFLUENT_ID_HANDLER, Type.BOOLEAN, false, Importance.LOW, "TODO docs")
                 .define(ENABLE_HEADERS, Type.BOOLEAN, ENABLE_HEADERS_DEFAULT, Importance.MEDIUM, "TODO docs")
                 .define(HEADERS_HANDLER, Type.CLASS, HEADERS_HANDLER_DEFAULT, Importance.MEDIUM, "TODO docs")
                 .define(USE_ID, Type.STRING, USE_ID_DEFAULT, Importance.MEDIUM, "TODO docs");
@@ -31,10 +30,6 @@ public class BaseKafkaSerDeConfig extends AbstractConfig {
 
     public Object getIdHandler() {
         return this.get(ID_HANDLER);
-    }
-
-    public boolean enableConfluentIdHandler() {
-        return this.getBoolean(ENABLE_CONFLUENT_ID_HANDLER);
     }
 
     public boolean enableHeaders() {

--- a/serdes/serde-common/src/main/java/io/apicurio/registry/serde/headers/DefaultHeadersHandler.java
+++ b/serdes/serde-common/src/main/java/io/apicurio/registry/serde/headers/DefaultHeadersHandler.java
@@ -50,21 +50,21 @@ public class DefaultHeadersHandler implements HeadersHandler {
      */
     @Override
     public void writeHeaders(Headers headers, ArtifactReference reference) {
-        if (idOption == IdOption.contentId) {
-            if (reference.getContentId() == null) {
+        if (idOption == IdOption.globalId) {
+            if (reference.getGlobalId() == null) {
                 throw new SerializationException(
-                        "Missing contentId. IdOption is contentId but there is no contentId in the ArtifactReference");
+                        "Missing globalId. IdOption is globalId but there is no contentId in the ArtifactReference");
             }
-            ByteBuffer buff = ByteBuffer.allocate(8);
-            buff.putLong(reference.getContentId());
-            headers.add(contentIdHeaderName, buff.array());
-            return;
-        }
-
-        if (reference.getGlobalId() != null) {
             ByteBuffer buff = ByteBuffer.allocate(8);
             buff.putLong(reference.getGlobalId());
             headers.add(globalIdHeaderName, buff.array());
+            return;
+        }
+
+        if (reference.getContentId() != null) {
+            ByteBuffer buff = ByteBuffer.allocate(8);
+            buff.putLong(reference.getContentId());
+            headers.add(contentIdHeaderName, buff.array());
         } else {
             if (reference.getContentHash() != null) {
                 headers.add(contentHashHeaderName, IoUtil.toBytes(reference.getContentHash()));

--- a/serdes/serde-common/src/test/java/io/apicurio/registry/serde/headers/DefaultHeadersHandlerTest.java
+++ b/serdes/serde-common/src/test/java/io/apicurio/registry/serde/headers/DefaultHeadersHandlerTest.java
@@ -126,8 +126,8 @@ public class DefaultHeadersHandlerTest {
     @Test
     void testWriteValueHeadersHandlesMissingContentHash() {
         String contentHashHeaderName = "another write key header name";
-        Map<String, Object> configs = Collections
-                .singletonMap(SerdeConfig.HEADER_VALUE_CONTENT_HASH_OVERRIDE_NAME, contentHashHeaderName);
+        Map<String, Object> configs = Map.of(SerdeConfig.HEADER_VALUE_CONTENT_HASH_OVERRIDE_NAME,
+                contentHashHeaderName);
         RecordHeaders headers = new RecordHeaders();
         DefaultHeadersHandler handler = new DefaultHeadersHandler();
         handler.configure(configs, false);

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/ExtJsonConverter.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/ExtJsonConverter.java
@@ -92,7 +92,7 @@ public class ExtJsonConverter extends SchemaResolverConfigurer<JsonNode, Object>
 
         byte[] payload = jsonConverter.fromConnectData(topic, schema, value);
 
-        return formatStrategy.fromConnectData(schemaLookupResult.getGlobalId(), payload);
+        return formatStrategy.fromConnectData(schemaLookupResult.getContentId(), payload);
 
     }
 
@@ -100,10 +100,10 @@ public class ExtJsonConverter extends SchemaResolverConfigurer<JsonNode, Object>
     public SchemaAndValue toConnectData(String topic, byte[] value) {
         FormatStrategy.IdPayload ip = formatStrategy.toConnectData(value);
 
-        long globalId = ip.getGlobalId();
+        long contentId = ip.getContentId();
 
         SchemaLookupResult<JsonNode> schemaLookupResult = getSchemaResolver()
-                .resolveSchemaByArtifactReference(ArtifactReference.builder().globalId(globalId).build());
+                .resolveSchemaByArtifactReference(ArtifactReference.builder().contentId(contentId).build());
 
         JsonNode parsedSchema = schemaLookupResult.getParsedSchema().getParsedSchema();
         JsonNode dataDeserialized = jsonDeserializer.deserialize(topic, ip.getPayload());

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/json/CompactFormatStrategy.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/json/CompactFormatStrategy.java
@@ -2,7 +2,7 @@ package io.apicurio.registry.utils.converter.json;
 
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
 import io.apicurio.registry.serde.AbstractKafkaSerDe;
-import io.apicurio.registry.serde.DefaultIdHandler;
+import io.apicurio.registry.serde.Default4ByteIdHandler;
 import io.apicurio.registry.serde.IdHandler;
 
 import java.nio.ByteBuffer;
@@ -13,7 +13,7 @@ public class CompactFormatStrategy implements FormatStrategy {
     private IdHandler idHandler;
 
     public CompactFormatStrategy() {
-        this(new DefaultIdHandler());
+        this(new Default4ByteIdHandler());
     }
 
     public CompactFormatStrategy(IdHandler idHandler) {
@@ -25,10 +25,10 @@ public class CompactFormatStrategy implements FormatStrategy {
     }
 
     @Override
-    public byte[] fromConnectData(long globalId, byte[] bytes) {
+    public byte[] fromConnectData(long contentId, byte[] bytes) {
         ByteBuffer buffer = ByteBuffer.allocate(1 + idHandler.idSize() + bytes.length);
         buffer.put(AbstractKafkaSerDe.MAGIC_BYTE);
-        idHandler.writeId(ArtifactReference.fromGlobalId(globalId), buffer);
+        idHandler.writeId(ArtifactReference.fromContentId(contentId), buffer);
         buffer.put(bytes);
         return buffer.array();
     }
@@ -37,9 +37,9 @@ public class CompactFormatStrategy implements FormatStrategy {
     public IdPayload toConnectData(byte[] bytes) {
         ByteBuffer buffer = AbstractKafkaSerDe.getByteBuffer(bytes);
         ArtifactReference reference = idHandler.readId(buffer);
-        long globalId = reference.getGlobalId();
+        long contentId = reference.getContentId();
         byte[] payload = new byte[bytes.length - idHandler.idSize() - 1];
         buffer.get(payload);
-        return new IdPayload(globalId, payload);
+        return new IdPayload(contentId, payload);
     }
 }

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/json/FormatStrategy.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/json/FormatStrategy.java
@@ -1,21 +1,21 @@
 package io.apicurio.registry.utils.converter.json;
 
 public interface FormatStrategy {
-    byte[] fromConnectData(long globalId, byte[] payload);
+    byte[] fromConnectData(long contentId, byte[] payload);
 
     IdPayload toConnectData(byte[] bytes);
 
     class IdPayload {
-        private long globalId;
+        private long contentId;
         private byte[] payload;
 
-        public IdPayload(long globalId, byte[] payload) {
-            this.globalId = globalId;
+        public IdPayload(long contentId, byte[] payload) {
+            this.contentId = contentId;
             this.payload = payload;
         }
 
-        public long getGlobalId() {
-            return globalId;
+        public long getContentId() {
+            return contentId;
         }
 
         public byte[] getPayload() {

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/json/PrettyFormatStrategy.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/json/PrettyFormatStrategy.java
@@ -43,10 +43,10 @@ public class PrettyFormatStrategy implements FormatStrategy {
     public IdPayload toConnectData(byte[] bytes) {
         try {
             JsonNode root = mapper.readTree(bytes);
-            long globalId = root.get(idName).asLong();
+            long contentId = root.get(idName).asLong();
             String payload = root.get(payloadName).toString();
             byte[] payloadBytes = IoUtil.toBytes(payload);
-            return new IdPayload(globalId, payloadBytes);
+            return new IdPayload(contentId, payloadBytes);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
@@ -420,25 +420,46 @@ public class TestUtils {
 
     // some impl details ...
 
-    public static void waitForSchema(Predicate<Long> schemaFinder, byte[] bytes) throws Exception {
-        waitForSchema(schemaFinder, bytes, ByteBuffer::getLong);
+    public static void waitForSchema(Predicate<Integer> schemaFinder, byte[] bytes) throws Exception {
+        waitForSchema(schemaFinder, bytes, ByteBuffer::getInt);
     }
 
-    public static void waitForSchema(Predicate<Long> schemaFinder, byte[] bytes,
-            Function<ByteBuffer, Long> globalIdExtractor) throws Exception {
+    public static void waitForSchemaLongId(Predicate<Long> schemaFinder, byte[] bytes) throws Exception {
+        waitForSchemaLongId(schemaFinder, bytes, ByteBuffer::getLong);
+    }
+
+    public static void waitForSchema(Predicate<Integer> schemaFinder, byte[] bytes,
+            Function<ByteBuffer, Integer> idExtractor) throws Exception {
         waitForSchemaCustom(schemaFinder, bytes, input -> {
             ByteBuffer buffer = ByteBuffer.wrap(input);
             buffer.get(); // magic byte
-            return globalIdExtractor.apply(buffer);
+            return idExtractor.apply(buffer);
+        });
+    }
+
+    public static void waitForSchemaLongId(Predicate<Long> schemaFinder, byte[] bytes,
+            Function<ByteBuffer, Long> idExtractor) throws Exception {
+        waitForSchemaCustomLongId(schemaFinder, bytes, input -> {
+            ByteBuffer buffer = ByteBuffer.wrap(input);
+            buffer.get(); // magic byte
+            return idExtractor.apply(buffer);
         });
     }
 
     // we can have non-default Apicurio serialization; e.g. ExtJsonConverter
-    public static void waitForSchemaCustom(Predicate<Long> schemaFinder, byte[] bytes,
-            Function<byte[], Long> globalIdExtractor) throws Exception {
-        long id = globalIdExtractor.apply(bytes);
+    public static void waitForSchemaCustom(Predicate<Integer> schemaFinder, byte[] bytes,
+            Function<byte[], Integer> idExtractor) throws Exception {
+        int id = idExtractor.apply(bytes);
         boolean schemaExists = retry(() -> schemaFinder.test(id));
-        Assertions.assertTrue(schemaExists); // wait for global id to populate
+        Assertions.assertTrue(schemaExists); // wait for id to populate
+    }
+
+    // we can have non-default Apicurio serialization; e.g. ExtJsonConverter
+    public static void waitForSchemaCustomLongId(Predicate<Long> schemaFinder, byte[] bytes,
+            Function<byte[], Long> idExtractor) throws Exception {
+        long id = idExtractor.apply(bytes);
+        boolean schemaExists = retry(() -> schemaFinder.test(id));
+        Assertions.assertTrue(schemaExists); // wait for id to populate
     }
 
     public static final String normalizeMultiLineString(String value) throws Exception {


### PR DESCRIPTION
This PR changes the following default configuration and behaviour in the serdes:

- Make the serdes use a 4 bytes identifier by default (8 bytes is still possible, but with a configuration).
- Make serdes use the contentId by default to better align them with other existing 3rd party serializers.
- Headers are disabled by default, so the schemaId is added to the message body by default. This was wrongly set in 2.x, and now has the correct value.