### PR TITLE
Fix serializer dereference

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/serde/AvroSerdeTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/serde/AvroSerdeTest.java
@@ -332,7 +332,7 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             Map<String, String> config = new HashMap<>();
             config.put(AvroSerdeConfig.AVRO_ENCODING, AvroSerdeConfig.AVRO_ENCODING_JSON);
             config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
-            config.put(SerdeConfig.DEREFERENCE_SCHEMA, "true");
+            config.put(SerdeConfig.REGISTER_DEREFERENCED, "true");
             serializer.configure(config, false);
 
             config = new HashMap<>();
@@ -464,6 +464,21 @@ public class AvroSerdeTest extends AbstractResourceTestBase {
             }, bytes);
 
             AvroSchemaB ir = deserializer.deserialize(artifactId, bytes);
+
+            Assertions.assertEquals(avroSchemaB, ir);
+            Assertions.assertEquals(AvroSchemaA.GEMINI, ir.getSchemaA());
+
+            // Create new serializer, the schema already exists in Registry
+            config = new HashMap<>();
+            config.put(AvroSerdeConfig.AVRO_ENCODING, AvroSerdeConfig.AVRO_ENCODING_JSON);
+            config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "false");
+            config.put(SerdeConfig.SERIALIZER_DEREFERENCE_SCHEMA, "true");
+            serializer.configure(config, false);
+
+            bytes = serializer.serialize(artifactId, avroSchemaB);
+
+            // No need to wait, the schema has been previously registered in Registry
+            ir = deserializer.deserialize(artifactId, bytes);
 
             Assertions.assertEquals(avroSchemaB, ir);
             Assertions.assertEquals(AvroSchemaA.GEMINI, ir.getSchemaA());

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
@@ -41,9 +41,10 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
     protected String explicitArtifactGroupId;
     protected String explicitArtifactId;
     protected String explicitArtifactVersion;
-    protected boolean deserializerDereference;
 
     protected Vertx vertx;
+
+    protected boolean dereference;
 
     @Override
     public void configure(Map<String, ?> configs, SchemaParser<S, T> schemaParser) {
@@ -114,7 +115,7 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
             this.explicitArtifactVersion = artifactVersionOverride;
         }
 
-        this.deserializerDereference = config.deserializerDereference();
+        this.dereference = config.deserializerDereference() || config.serializerDereference();
     }
 
     /**
@@ -177,7 +178,7 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
 
     protected SchemaLookupResult<S> resolveSchemaByGlobalId(long globalId) {
         return schemaCache.getByGlobalId(globalId, globalIdKey -> {
-            if (deserializerDereference) {
+            if (dereference) {
                 return resolveSchemaDereferenced(globalIdKey);
             } else {
                 return resolveSchemaWithReferences(globalIdKey);

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
@@ -3,15 +3,7 @@ package io.apicurio.registry.resolver;
 import io.apicurio.registry.resolver.data.Record;
 import io.apicurio.registry.resolver.strategy.ArtifactCoordinates;
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
-import io.apicurio.registry.rest.client.models.CreateArtifact;
-import io.apicurio.registry.rest.client.models.CreateArtifactResponse;
-import io.apicurio.registry.rest.client.models.CreateVersion;
-import io.apicurio.registry.rest.client.models.IfArtifactExists;
-import io.apicurio.registry.rest.client.models.SortOrder;
-import io.apicurio.registry.rest.client.models.VersionContent;
-import io.apicurio.registry.rest.client.models.VersionMetaData;
-import io.apicurio.registry.rest.client.models.VersionSearchResults;
-import io.apicurio.registry.rest.client.models.VersionSortBy;
+import io.apicurio.registry.rest.client.models.*;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.IoUtil;
@@ -21,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,7 +28,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
     private boolean autoCreateArtifact;
     private String autoCreateBehavior;
     private boolean findLatest;
-    private boolean dereference;
+    private boolean registerDereferenced;
 
     private static final Logger logger = Logger.getLogger(DefaultSchemaResolver.class.getSimpleName());
 
@@ -60,7 +53,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
         }
 
         this.autoCreateArtifact = config.autoRegisterArtifact();
-        this.dereference = config.serializerDereference();
+        this.registerDereferenced = config.registerDereferenced();
         this.autoCreateBehavior = config.autoRegisterArtifactIfExists();
         this.findLatest = config.findLatest();
     }
@@ -75,7 +68,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
 
         ParsedSchema<S> parsedSchema;
         if (artifactResolverStrategy.loadSchema() && schemaParser.supportsExtractSchemaFromData()) {
-            parsedSchema = schemaParser.getSchemaFromData(data, dereference);
+            parsedSchema = schemaParser.getSchemaFromData(data, registerDereferenced);
         } else {
             parsedSchema = null;
         }
@@ -112,7 +105,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
             if (schemaParser.supportsExtractSchemaFromData()) {
 
                 if (parsedSchema == null) {
-                    parsedSchema = schemaParser.getSchemaFromData(data, dereference);
+                    parsedSchema = schemaParser.getSchemaFromData(data, registerDereferenced);
                 }
 
                 if (parsedSchema.hasReferences()) {
@@ -137,7 +130,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
 
         if (schemaParser.supportsExtractSchemaFromData()) {
             if (parsedSchema == null) {
-                parsedSchema = schemaParser.getSchemaFromData(data);
+                parsedSchema = schemaParser.getSchemaFromData(data, dereference);
             }
             return handleResolveSchemaByContent(parsedSchema, artifactReference);
         }
@@ -284,6 +277,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
             });
 
             if (results.getCount() == 0) {
+                is = new ByteArrayInputStream(contentKey.getBytes(StandardCharsets.UTF_8));
                 results = client.search().versions().post(is, ct, config -> {
                     config.queryParameters.groupId = artifactReference.getGroupId() == null ? "default"
                         : artifactReference.getGroupId();
@@ -469,13 +463,21 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
         loadFromMetaData(metadata, result);
         gid = metadata.getGlobalId();
 
-        InputStream rawSchema = client.ids().globalIds().byGlobalId(gid).get();
-
-        // Get the artifact references
-        final List<io.apicurio.registry.rest.client.models.ArtifactReference> artifactReferences = client
-                .ids().globalIds().byGlobalId(gid).references().get();
-        // If there are any references for the schema being parsed, resolve them before parsing the schema
-        final Map<String, ParsedSchema<S>> resolvedReferences = resolveReferences(artifactReferences);
+        InputStream rawSchema;
+        Map<String, ParsedSchema<S>> resolvedReferences = new HashMap<>();
+        if (dereference) {
+            rawSchema = client.ids().globalIds().byGlobalId(gid).get(config -> {
+                assert config.queryParameters != null;
+                config.queryParameters.references = HandleReferencesType.DEREFERENCE;
+            });
+        } else {
+            rawSchema = client.ids().globalIds().byGlobalId(gid).get();
+            // Get the artifact references
+            final List<io.apicurio.registry.rest.client.models.ArtifactReference> artifactReferences = client
+                    .ids().globalIds().byGlobalId(gid).references().get();
+            // If there are any references for the schema being parsed, resolve them before parsing the schema
+            resolvedReferences = resolveReferences(artifactReferences);
+        }
 
         schema = IoUtil.toBytes(rawSchema);
         parsed = schemaParser.parseSchema(schema, resolvedReferences);

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/SchemaResolverConfig.java
@@ -165,12 +165,19 @@ public class SchemaResolverConfig {
      * Registry. Only supported for Avro. Only applicable when
      * {@link SchemaResolverConfig#AUTO_REGISTER_ARTIFACT} is enabled.
      */
-    public static final String DEREFERENCE_SCHEMA = "apicurio.registry.dereference-schema";
-    public static final boolean DEREFERENCE_SCHEMA_DEFAULT = true;
+    public static final String REGISTER_DEREFERENCED = "apicurio.registry.dereference-schema";
+    public static final boolean REGISTER_DEREFERENCED_DEFAULT = true;
+
+    /**
+     * Used to indicate the serializer to ask Registry to return the schema dereferenced. This is useful to
+     * reduce the number of http requests to the server.
+     */
+    public static final String SERIALIZER_DEREFERENCE_SCHEMA = "apicurio.registry.serializer.dereference-schema";
+    public static final boolean SERIALIZER_DEREFERENCE_SCHEMA_DEFAULT = false;
 
     /**
      * Used to indicate the deserializer to ask Registry to return the schema dereferenced. This is useful to
-     * reduce the number of http requests to the server. Only applicable to Avro schemas.
+     * reduce the number of http requests to the server.
      */
     public static final String DESERIALIZER_DEREFERENCE_SCHEMA = "apicurio.registry.deserializer.dereference-schema";
     public static final boolean DESERIALIZER_DEREFERENCE_SCHEMA_DEFAULT = false;

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/DefaultSchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/DefaultSchemaResolverConfig.java
@@ -17,8 +17,9 @@ public class DefaultSchemaResolverConfig extends AbstractConfig {
             entry(FIND_LATEST_ARTIFACT, FIND_LATEST_ARTIFACT_DEFAULT),
             entry(CHECK_PERIOD_MS, CHECK_PERIOD_MS_DEFAULT), entry(RETRY_COUNT, RETRY_COUNT_DEFAULT),
             entry(RETRY_BACKOFF_MS, RETRY_BACKOFF_MS_DEFAULT),
-            entry(DEREFERENCE_SCHEMA, DEREFERENCE_SCHEMA_DEFAULT),
-            entry(DESERIALIZER_DEREFERENCE_SCHEMA, DESERIALIZER_DEREFERENCE_SCHEMA_DEFAULT));
+            entry(REGISTER_DEREFERENCED, REGISTER_DEREFERENCED_DEFAULT),
+            entry(DESERIALIZER_DEREFERENCE_SCHEMA, DESERIALIZER_DEREFERENCE_SCHEMA_DEFAULT),
+            entry(SERIALIZER_DEREFERENCE_SCHEMA, SERIALIZER_DEREFERENCE_SCHEMA_DEFAULT));
 
     public DefaultSchemaResolverConfig(Map<String, ?> originals) {
         this.originals = originals;
@@ -115,8 +116,12 @@ public class DefaultSchemaResolverConfig extends AbstractConfig {
         return getString(EXPLICIT_ARTIFACT_VERSION);
     }
 
+    public boolean registerDereferenced() {
+        return getBooleanOrFalse(REGISTER_DEREFERENCED);
+    }
+
     public boolean serializerDereference() {
-        return getBooleanOrFalse(DEREFERENCE_SCHEMA);
+        return getBooleanOrFalse(SERIALIZER_DEREFERENCE_SCHEMA);
     }
 
     public boolean deserializerDereference() {

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/config/SerdeConfig.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/config/SerdeConfig.java
@@ -90,8 +90,15 @@ public class SerdeConfig extends AbstractConfig {
     public static final String AUTO_REGISTER_ARTIFACT_IF_EXISTS = SchemaResolverConfig.AUTO_REGISTER_ARTIFACT_IF_EXISTS;
     public static final String AUTO_REGISTER_ARTIFACT_IF_EXISTS_DEFAULT = SchemaResolverConfig.AUTO_REGISTER_ARTIFACT_IF_EXISTS_DEFAULT;
 
-    public static final String DEREFERENCE_SCHEMA = SchemaResolverConfig.DEREFERENCE_SCHEMA;
-    public static final boolean DEREFERENCE_SCHEMA_DEFAULT = SchemaResolverConfig.DEREFERENCE_SCHEMA_DEFAULT;
+    /**
+     * Used to indicate the serializer to ask Registry to return the schema dereferenced. This is useful to
+     * reduce the number of http requests to the server.
+     */
+    public static final String SERIALIZER_DEREFERENCE_SCHEMA = SchemaResolverConfig.SERIALIZER_DEREFERENCE_SCHEMA;
+    public static final boolean SERIALIZER_DEREFERENCE_SCHEMA_DEFAULT = SchemaResolverConfig.SERIALIZER_DEREFERENCE_SCHEMA_DEFAULT;
+
+    public static final String REGISTER_DEREFERENCED = SchemaResolverConfig.REGISTER_DEREFERENCED;
+    public static final boolean REGISTER_DEREFERENCED_DEFAULT = SchemaResolverConfig.REGISTER_DEREFERENCED_DEFAULT;
 
     /**
      * Used to indicate the deserializer to ask Registry to return the schema dereferenced. This is useful to


### PR DESCRIPTION
Fixes a problem where creating a second serializer would fail when it's trying to use an artifact that was previously registered dereferenced by adding a new configuration option to instruct the serializer to dereference the artifact when searching by content.