### PR TITLE
Fix bug where ccompat and core api would report different compatibility mode values

### DIFF
--- a/app/src/test/java/io/apicurio/registry/ccompat/rest/CCompatCompatibilityConfigTest.java
+++ b/app/src/test/java/io/apicurio/registry/ccompat/rest/CCompatCompatibilityConfigTest.java
@@ -1,0 +1,81 @@
+package io.apicurio.registry.ccompat.rest;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ccompat.dto.CompatibilityLevelDto;
+import io.apicurio.registry.ccompat.dto.CompatibilityLevelParamDto;
+import io.apicurio.registry.rest.v2.beans.Rule;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.enterprise.inject.Typed;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.noprofile.ccompat.rest.CCompatTestConstants.CONFIG_NONE;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@Typed(CCompatCompatibilityConfigTest.class)
+@TestProfile(ForwardCompatModeProfile.class)
+public class CCompatCompatibilityConfigTest extends AbstractResourceTestBase {
+
+    @NotNull
+    public String getCcompatBasePath() {
+        return "/ccompat/v7";
+    }
+
+    @NotNull
+    public String getCoreBasePath() {
+        return "/registry/v2";
+    }
+
+    CompatibilityLevelDto.Level getCompatibilityLevelFromCoreApi() {
+        var respCore = given()
+            .when()
+            .contentType(ContentTypes.JSON)
+            .get(getCoreBasePath() + "/admin/rules/COMPATIBILITY")
+            .then()
+            .statusCode(200)
+            .extract().as(Rule.class);
+        return CompatibilityLevelDto.Level.valueOf(respCore.getConfig());
+    }
+
+    CompatibilityLevelDto.Level getCompatibilityLevelFromCcompatApi() {
+        var respCcompat = given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .get(getCcompatBasePath() + "/config/")
+            .then()
+            .statusCode(200)
+            .extract().as(CompatibilityLevelParamDto.class);
+        return CompatibilityLevelDto.Level.valueOf(respCcompat.getCompatibilityLevel());
+    }
+
+    /**
+     * Test that the default global compatibility level is the same, no matter if we use
+     * the core or ccompat endpoint for retrieving its value.
+     */
+    @Test
+    public void testConfigEndpoints() {
+        // make sure that the default global "FORWARD" compatibility level is returned by both endpoints
+        assertEquals(CompatibilityLevelDto.Level.FORWARD, getCompatibilityLevelFromCoreApi());
+        assertEquals(getCompatibilityLevelFromCoreApi(), getCompatibilityLevelFromCcompatApi());
+
+        // change the compatibility level and check that it is the same in both endpoints
+        given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .body(CONFIG_NONE)
+            .put(getCcompatBasePath() + "/config")
+            .then()
+            .statusCode(200);
+
+        assertEquals(CompatibilityLevelDto.Level.NONE, getCompatibilityLevelFromCoreApi());
+        assertEquals(getCompatibilityLevelFromCoreApi(), getCompatibilityLevelFromCcompatApi());
+    }
+
+    @Override
+    protected void deleteGlobalRules(int expectedDefaultRulesCount) {
+        // Do nothing... (we want to keep the default global rules)
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/ccompat/rest/ForwardCompatModeProfile.java
+++ b/app/src/test/java/io/apicurio/registry/ccompat/rest/ForwardCompatModeProfile.java
@@ -1,0 +1,13 @@
+package io.apicurio.registry.ccompat.rest;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class ForwardCompatModeProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("registry.rules.global.compatibility", "FORWARD",
+            "registry.auth.enabled", "false");
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/CCompatTestConstants.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/CCompatTestConstants.java
@@ -48,6 +48,8 @@ public class CCompatTestConstants {
 
     public static final String CONFIG_BACKWARD = "{\"compatibility\": \"BACKWARD\"}";
 
+    public static final String CONFIG_NONE = "{\"compatibility\": \"NONE\"}";
+
     public static final String VALID_AVRO_SCHEMA = "{\"schema\": \"{\\\"type\\\": \\\"record\\\",\\\"name\\\": \\\"myrecord1\\\",\\\"fields\\\": [{\\\"name\\\": \\\"foo1\\\",\\\"type\\\": \\\"string\\\"}]}\"}";
 
     public static final String SCHEMA_INVALID_WRAPPED = "{\"schema\":\"{\\\"type\\\": \\\"bloop\\\"}\"}";


### PR DESCRIPTION
Hi everyone. This PR attempts to address a bug that we have recently found. The issue is the following: in various situations the `ccompat/v7` and the `core/v2` APIs may return different values when the user queries the global compatibility level setting. To reproduce this issue:

1. Configure default global compatibility level by setting the `REGISTRY_RULES_GLOBAL_COMPATIBILITY` environment variable to `BACKWARD`
2. Now getting the compatibility level by querying `/apis/ccompat/v7/config` returns `NONE` while GET'ing corresponding core-v2 API endpoint (`/apis/registry/v2/admin/rules/COMPATIBILITY`) returns `BACKWARD`. Here, I would have expected the ccompat API to also consult the global rule and return `BACKWARD`, but this is not the case.
3. Set compatibility to `NONE` using the `PUT /apis/registry/v2/admin/rules/COMPATIBILITY` endpoint.
4. Observe that the reported compatibility is `NONE` for both APIs. This works fine.
5. Now set compatibility to `NONE` using the `/apis/ccompat/v7/config` endpoint
6. Now querying for compatibility via `/apis/registry/v2/admin/rules/COMPATIBILITY` returns `BACKWARD` while doing the same via the confluent API returns `NONE`. Here, the API call from step 5. simply deletes the compatibility rule, which makes the core API default to the `REGISTRY_RULES_GLOBAL_COMPATIBILITY` value, which is not correct IMO.

