### PR TITLE
Fixed some of the "available since" info for our config properties (for 3.0.0) config

### DIFF
--- a/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
@@ -96,7 +96,7 @@ public class AuthConfig {
     String adminOverrideClaimValue;
 
     @ConfigProperty(name = "apicurio.auth.admin-override.user", defaultValue = "admin")
-    @Info(category = "auth", description = "Auth admin override user name", availableSince = "3.0.0.Final")
+    @Info(category = "auth", description = "Auth admin override user name", availableSince = "3.0.0")
     String adminOverrideUser;
 
     @PostConstruct

--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorageProducer.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorageProducer.java
@@ -29,7 +29,7 @@ public class RegistryStorageProducer {
     Instance<RegistryStorageDecorator> decorators;
 
     @ConfigProperty(name = "apicurio.storage.kind")
-    @Info(category = "storage", description = "Application storage variant, for example, sql, kafkasql, or gitops", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Application storage variant, for example, sql, kafkasql, or gitops", availableSince = "3.0.0")
     String registryStorageType;
 
     private RegistryStorage cachedCurrent;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/BlueDatasourceProducer.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/BlueDatasourceProducer.java
@@ -16,31 +16,31 @@ import java.util.Map;
 public class BlueDatasourceProducer {
 
     @ConfigProperty(name = "apicurio.datasource.blue.db-kind", defaultValue = "h2")
-    @Info(category = "storage", description = "Gitops blue datasource db kind", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops blue datasource db kind", availableSince = "3.0.0")
     String databaseType;
 
     @ConfigProperty(name = "apicurio.datasource.blue.jdbc.url", defaultValue = "jdbc:h2:mem:registry_db")
-    @Info(category = "storage", description = "Gitops blue datasource jdbc url", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops blue datasource jdbc url", availableSince = "3.0.0")
     String jdbcUrl;
 
     @ConfigProperty(name = "apicurio.datasource.blue.username", defaultValue = "sa")
-    @Info(category = "storage", description = "Gitops blue datasource username", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops blue datasource username", availableSince = "3.0.0")
     String username;
 
     @ConfigProperty(name = "apicurio.datasource.blue.password", defaultValue = "sa")
-    @Info(category = "storage", description = "Gitops blue datasource password", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops blue datasource password", availableSince = "3.0.0")
     String password;
 
     @ConfigProperty(name = "apicurio.datasource.blue.jdbc.initial-size", defaultValue = "20")
-    @Info(category = "storage", description = "Gitops blue datasource pool initial size", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops blue datasource pool initial size", availableSince = "3.0.0")
     String initialSize;
 
     @ConfigProperty(name = "apicurio.datasource.blue.jdbc.min-size", defaultValue = "20")
-    @Info(category = "storage", description = "Gitops blue datasource pool minimum size", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops blue datasource pool minimum size", availableSince = "3.0.0")
     String minSize;
 
     @ConfigProperty(name = "apicurio.datasource.blue.jdbc.max-size", defaultValue = "100")
-    @Info(category = "storage", description = "Gitops blue datasource pool max size", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops blue datasource pool max size", availableSince = "3.0.0")
     String maxSize;
 
     @Produces

--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsRegistryStorage.java
@@ -53,7 +53,7 @@ public class GitOpsRegistryStorage extends AbstractReadOnlyRegistryStorage {
     GitManager gitManager;
 
     @ConfigProperty(name = "apicurio.storage.kind")
-    @Info(category = "storage", description = "Application storage variant, for example, sql, kafkasql, or gitops", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Application storage variant, for example, sql, kafkasql, or gitops", availableSince = "3.0.0")
     String registryStorageType;
 
     // Fair lock, so we ensure the writer does not wait indefinitely under high throughput.

--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GreenDatasourceProducer.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GreenDatasourceProducer.java
@@ -16,31 +16,31 @@ import java.util.Map;
 public class GreenDatasourceProducer {
 
     @ConfigProperty(name = "apicurio.datasource.green.db-kind", defaultValue = "h2")
-    @Info(category = "storage", description = "Gitops green datasource db kind", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops green datasource db kind", availableSince = "3.0.0")
     String databaseType;
 
     @ConfigProperty(name = "apicurio.datasource.green.jdbc.url", defaultValue = "jdbc:h2:mem:registry_db")
-    @Info(category = "storage", description = "Gitops green datasource jdbc url", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops green datasource jdbc url", availableSince = "3.0.0")
     String jdbcUrl;
 
     @ConfigProperty(name = "apicurio.datasource.green.username", defaultValue = "sa")
-    @Info(category = "storage", description = "Gitops green datasource username", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops green datasource username", availableSince = "3.0.0")
     String username;
 
     @ConfigProperty(name = "apicurio.datasource.green.password", defaultValue = "sa")
-    @Info(category = "storage", description = "Gitops green datasource password", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops green datasource password", availableSince = "3.0.0")
     String password;
 
     @ConfigProperty(name = "apicurio.datasource.green.jdbc.initial-size", defaultValue = "20")
-    @Info(category = "storage", description = "Gitops green datasource pool initial size", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops green datasource pool initial size", availableSince = "3.0.0")
     String initialSize;
 
     @ConfigProperty(name = "apicurio.datasource.green.jdbc.min-size", defaultValue = "20")
-    @Info(category = "storage", description = "Gitops green datasource pool minimum size", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops green datasource pool minimum size", availableSince = "3.0.0")
     String minSize;
 
     @ConfigProperty(name = "apicurio.datasource.green.jdbc.max-size", defaultValue = "100")
-    @Info(category = "storage", description = "Gitops green datasource pool max size", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Gitops green datasource pool max size", availableSince = "3.0.0")
     String maxSize;
 
     @Produces

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryDatasourceProducer.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryDatasourceProducer.java
@@ -22,31 +22,31 @@ public class RegistryDatasourceProducer {
     Logger log;
 
     @ConfigProperty(name = "apicurio.storage.sql.kind", defaultValue = "h2")
-    @Info(category = "storage", description = "Application datasource database type", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Application datasource database type", availableSince = "3.0.0")
     String databaseType;
 
     @ConfigProperty(name = "apicurio.datasource.url", defaultValue = "jdbc:h2:mem:registry_db")
-    @Info(category = "storage", description = "Application datasource jdbc url", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Application datasource jdbc url", availableSince = "3.0.0")
     String jdbcUrl;
 
     @ConfigProperty(name = "apicurio.datasource.username", defaultValue = "sa")
-    @Info(category = "storage", description = "Application datasource username", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Application datasource username", availableSince = "3.0.0")
     String username;
 
     @ConfigProperty(name = "apicurio.datasource.password", defaultValue = "sa")
-    @Info(category = "storage", description = "Application datasource password", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Application datasource password", availableSince = "3.0.0")
     String password;
 
     @ConfigProperty(name = "apicurio.datasource.jdbc.initial-size", defaultValue = "20")
-    @Info(category = "storage", description = "Application datasource pool initial size", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Application datasource pool initial size", availableSince = "3.0.0")
     String initialSize;
 
     @ConfigProperty(name = "apicurio.datasource.jdbc.min-size", defaultValue = "20")
-    @Info(category = "storage", description = "Application datasource pool minimum size", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Application datasource pool minimum size", availableSince = "3.0.0")
     String minSize;
 
     @ConfigProperty(name = "apicurio.datasource.jdbc.max-size", defaultValue = "100")
-    @Info(category = "storage", description = "Application datasource pool maximum size", availableSince = "3.0.0.Final")
+    @Info(category = "storage", description = "Application datasource pool maximum size", availableSince = "3.0.0")
     String maxSize;
 
     @Produces

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -71,7 +71,7 @@ The following {registry} configuration options are available for each component 
 |`apicurio.auth.admin-override.user`
 |`string`
 |`admin`
-|`3.0.0.Final`
+|`3.0.0`
 |Auth admin override user name
 |`apicurio.auth.anonymous-read-access.enabled`
 |`boolean [dynamic]`
@@ -592,102 +592,102 @@ The following {registry} configuration options are available for each component 
 |`apicurio.datasource.blue.db-kind`
 |`string`
 |`h2`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops blue datasource db kind
 |`apicurio.datasource.blue.jdbc.initial-size`
 |`string`
 |`20`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops blue datasource pool initial size
 |`apicurio.datasource.blue.jdbc.max-size`
 |`string`
 |`100`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops blue datasource pool max size
 |`apicurio.datasource.blue.jdbc.min-size`
 |`string`
 |`20`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops blue datasource pool minimum size
 |`apicurio.datasource.blue.jdbc.url`
 |`string`
 |`jdbc:h2:mem:registry_db`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops blue datasource jdbc url
 |`apicurio.datasource.blue.password`
 |`string`
 |`sa`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops blue datasource password
 |`apicurio.datasource.blue.username`
 |`string`
 |`sa`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops blue datasource username
 |`apicurio.datasource.green.db-kind`
 |`string`
 |`h2`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops green datasource db kind
 |`apicurio.datasource.green.jdbc.initial-size`
 |`string`
 |`20`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops green datasource pool initial size
 |`apicurio.datasource.green.jdbc.max-size`
 |`string`
 |`100`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops green datasource pool max size
 |`apicurio.datasource.green.jdbc.min-size`
 |`string`
 |`20`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops green datasource pool minimum size
 |`apicurio.datasource.green.jdbc.url`
 |`string`
 |`jdbc:h2:mem:registry_db`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops green datasource jdbc url
 |`apicurio.datasource.green.password`
 |`string`
 |`sa`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops green datasource password
 |`apicurio.datasource.green.username`
 |`string`
 |`sa`
-|`3.0.0.Final`
+|`3.0.0`
 |Gitops green datasource username
 |`apicurio.datasource.jdbc.initial-size`
 |`string`
 |`20`
-|`3.0.0.Final`
+|`3.0.0`
 |Application datasource pool initial size
 |`apicurio.datasource.jdbc.max-size`
 |`string`
 |`100`
-|`3.0.0.Final`
+|`3.0.0`
 |Application datasource pool maximum size
 |`apicurio.datasource.jdbc.min-size`
 |`string`
 |`20`
-|`3.0.0.Final`
+|`3.0.0`
 |Application datasource pool minimum size
 |`apicurio.datasource.password`
 |`string`
 |`sa`
-|`3.0.0.Final`
+|`3.0.0`
 |Application datasource password
 |`apicurio.datasource.url`
 |`string`
 |`jdbc:h2:mem:registry_db`
-|`3.0.0.Final`
+|`3.0.0`
 |Application datasource jdbc url
 |`apicurio.datasource.username`
 |`string`
 |`sa`
-|`3.0.0.Final`
+|`3.0.0`
 |Application datasource username
 |`apicurio.events.kafka.topic`
 |`string`
@@ -807,7 +807,7 @@ The following {registry} configuration options are available for each component 
 |`apicurio.storage.kind`
 |`string`
 |
-|`3.0.0.Final`
+|`3.0.0`
 |Application storage variant, for example, sql, kafkasql, or gitops
 |`apicurio.storage.read-only.enabled`
 |`boolean [dynamic]`
@@ -822,7 +822,7 @@ The following {registry} configuration options are available for each component 
 |`apicurio.storage.sql.kind`
 |`string`
 |`h2`
-|`3.0.0.Final`
+|`3.0.0`
 |Application datasource database type
 |`artifacts.skip.disabled.latest`
 |`boolean`


### PR DESCRIPTION
We dropped the `.Final` convention, but some of our config properties were still documented as "available since 3.0.0.Final".