### PR TITLE
[2.6.x] Update keycloakjs and use access_token instead of id_token for oidc code path

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@rhoas/app-services-ui-components": "2.30.0",
         "ace-builds": "1.18.0",
         "axios": "0.27.2",
-        "keycloak-js": "21.1.1",
+        "keycloak-js": "26.0.0",
         "mobx": "6.9.0",
         "moment": "2.29.4",
         "oidc-client-ts": "2.2.3",
@@ -4706,6 +4706,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14038,12 +14039,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14286,13 +14281,9 @@
       "license": "MIT"
     },
     "node_modules/keycloak-js": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-21.1.1.tgz",
-      "integrity": "sha512-Viyhf0SOpu2jM/A33vpigSCFLo8l4yg8lqzaGyxXoZ3nGO9lo68B2LwJBDtgpzqDUh8DK//yCOzdWuR2CT4keA==",
-      "dependencies": {
-        "base64-js": "^1.5.1",
-        "js-sha256": "^0.9.0"
-      }
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.0.0.tgz",
+      "integrity": "sha512-uUvoc6luDuAOQ74i4/wKm1tGduYcJ/2jSh29Krekkt+ytn1mLL+mHug27FfpwgxcTb6yx+uL0OcehXwl3WIRMQ=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -24905,7 +24896,8 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
     },
     "basic-auth": {
       "version": "1.1.0",
@@ -31856,11 +31848,6 @@
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
     },
-    "js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -32068,13 +32055,9 @@
       "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "keycloak-js": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-21.1.1.tgz",
-      "integrity": "sha512-Viyhf0SOpu2jM/A33vpigSCFLo8l4yg8lqzaGyxXoZ3nGO9lo68B2LwJBDtgpzqDUh8DK//yCOzdWuR2CT4keA==",
-      "requires": {
-        "base64-js": "^1.5.1",
-        "js-sha256": "^0.9.0"
-      }
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.0.0.tgz",
+      "integrity": "sha512-uUvoc6luDuAOQ74i4/wKm1tGduYcJ/2jSh29Krekkt+ytn1mLL+mHug27FfpwgxcTb6yx+uL0OcehXwl3WIRMQ=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -69,7 +69,7 @@
     "@rhoas/app-services-ui-components": "2.30.0",
     "ace-builds": "1.18.0",
     "axios": "0.27.2",
-    "keycloak-js": "21.1.1",
+    "keycloak-js": "26.0.0",
     "mobx": "6.9.0",
     "moment": "2.29.4",
     "oidc-client-ts": "2.2.3",

--- a/ui/src/services/auth/auth.service.ts
+++ b/ui/src/services/auth/auth.service.ts
@@ -182,7 +182,7 @@ export class AuthService implements Service {
     public getToken = () => this.keycloak.token;
 
     public getOidcToken = () => {
-        return this.oidcUser.id_token;
+        return this.oidcUser.access_token;
     };
 
     public isAuthenticationEnabled(): boolean {

--- a/ui/src/services/auth/auth.service.ts
+++ b/ui/src/services/auth/auth.service.ts
@@ -76,7 +76,7 @@ export class AuthService implements Service {
         const configOptions: any = only(KC_CONFIG_OPTIONS, this.config.authOptions());
         const initOptions: any = only(KC_INIT_OPTIONS, this.config.authOptions());
 
-        this.keycloak = Keycloak(configOptions);
+        this.keycloak = new Keycloak(configOptions);
 
         const addRoles: ((user: AuthenticatedUser) => void) = (user) => {
             if (this.keycloak.resourceAccess) {


### PR DESCRIPTION
Fixes: #5085
