### PR TITLE
feat(UI): The UI now has better support for being served from a context path

### DIFF
--- a/ui/.docker-scripts/entrypoint.sh
+++ b/ui/.docker-scripts/entrypoint.sh
@@ -8,6 +8,11 @@ echo "---------------------------------------------"
 node /usr/local/bin/create-config.cjs
 
 echo "---------------------------------------------"
+echo "Patching base hrefs..."
+echo "---------------------------------------------"
+node /usr/local/bin/update-base-href.cjs
+
+echo "---------------------------------------------"
 echo "Config Complete. Nginx Server Started....."
 echo "---------------------------------------------"
 source /usr/libexec/s2i/run

--- a/ui/.docker-scripts/update-base-href.cjs
+++ b/ui/.docker-scripts/update-base-href.cjs
@@ -1,0 +1,34 @@
+#! /usr/bin/env node
+
+const fs = require("fs");
+
+const INDEXHTML_PATH=process.env["REGISTRY_INDEXHTML_PATH"] || "/opt/app-root/src/index.html";
+
+console.info("Updating base href in index.html file at:", INDEXHTML_PATH);
+
+const CONTEXT_PATH=process.env["REGISTRY_CONTEXT_PATH"] || "/";
+
+// Read the index.html file
+fs.readFile(INDEXHTML_PATH, "utf8", (err, data) => {
+    if (err) {
+        console.error("Error reading index.html:", err);
+        return;
+    }
+
+    var newBaseHref = `<base href="${CONTEXT_PATH}">`;
+
+    // Use a regular expression to match the <base> tag and replace the href attribute
+    const updatedHtml = data.replace(
+        /<base.href=...>/i,
+        newBaseHref
+    );
+
+    // Write the updated HTML back to the file
+    fs.writeFile(INDEXHTML_PATH, updatedHtml, "utf8", (err) => {
+        if (err) {
+            console.error("Error writing the index.html file:", err);
+        } else {
+            console.log("Successfully updated the base href value.");
+        }
+    });
+});

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -18,6 +18,7 @@ RUN chmod -R g+w /opt/app-root/src /usr/local/bin/
 
 # Copy configuration scripts
 COPY --chown=1001:0 .docker-scripts/create-config.cjs /usr/local/bin/create-config.cjs
+COPY --chown=1001:0 .docker-scripts/update-base-href.cjs /usr/local/bin/update-base-href.cjs
 COPY --chown=1001:0 .docker-scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Copy nginx config
@@ -26,6 +27,7 @@ COPY --chown=1001:0 .docker-scripts/nginx.conf /etc/nginx/nginx.conf
 # To avoid docker-scripts failure in windows, convert text files from DOS line
 # endings (carriage return + line feed) to Unix line endings (line feed).
 RUN dos2unix /usr/local/bin/create-config.cjs && \
+    dos2unix /usr/local/bin/update-base-href.cjs && \
     dos2unix /usr/local/bin/entrypoint.sh && \
     dos2unix /etc/nginx/nginx.conf
 

--- a/ui/deploy-examples/build-container-image.sh
+++ b/ui/deploy-examples/build-container-image.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+UI_DIR="$(dirname "$(dirname "$(realpath "$0")")")"
+echo "Building all using base directory: $UI_DIR"
+
+cd $UI_DIR
+npm install
+npm run clean
+npm run build
+npm run package
+
+cd $UI_DIR
+docker build -t apicurio/apicurio-registry-ui:latest-snapshot .

--- a/ui/deploy-examples/getting-started-context-path/docker-compose.yml
+++ b/ui/deploy-examples/getting-started-context-path/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  # Define the Apicurio Registry API service
+  apicurio-registry:
+    image: apicurio/apicurio-registry:latest-snapshot
+    container_name: apicurio-registry-getting-started-context-path_api
+    environment:
+      - apicurio.rest.deletion.group.enabled=true
+      - apicurio.rest.deletion.artifact.enabled=true
+      - apicurio.rest.deletion.artifact-version.enabled=true
+      - QUARKUS_HTTP_CORS_ORIGINS=*
+
+  # Define the Apicurio Registry UI service
+  apicurio-registry-ui:
+    image: apicurio/apicurio-registry-ui:latest-snapshot
+    container_name: apicurio-registry-getting-started-context-path_ui
+    environment:
+      - REGISTRY_CONTEXT_PATH=/ui/
+    depends_on:
+      - apicurio-registry
+
+  # Define the Nginx reverse proxy service
+  nginx:
+    image: nginx
+    container_name: apicurio-registry-getting-started-context-path_proxy
+    ports:
+      - "8080:8080" # Expose the reverse proxy on port 8080
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro # Mount custom Nginx config
+    depends_on:
+      - apicurio-registry
+      - apicurio-registry-ui

--- a/ui/deploy-examples/getting-started-context-path/nginx.conf
+++ b/ui/deploy-examples/getting-started-context-path/nginx.conf
@@ -1,0 +1,53 @@
+events { }
+
+http {
+    server {
+        listen 8080;
+
+        location = / {
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+            return 301 $scheme://$http_host/ui/;
+        }
+
+        location = /ui {
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+            return 301 $scheme://$http_host/ui/;
+        }
+
+        location /ui/ {
+            proxy_pass http://apicurio-registry-ui:8080/; # Proxy to the Apicurio Registry UI service
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /apis/ {
+            proxy_pass http://apicurio-registry:8080/apis/; # Proxy to the Apicurio Registry API service
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /api-specifications/ {
+            proxy_pass http://apicurio-registry:8080/api-specifications/; # Proxy to the Apicurio Registry API service
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /resources/ {
+            proxy_pass http://apicurio-registry:8080/resources/; # Proxy to the Apicurio Registry API service
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/ui/deploy-examples/getting-started/docker-compose.yml
+++ b/ui/deploy-examples/getting-started/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  # Define the Apicurio Registry API service
+  apicurio-registry:
+    image: apicurio/apicurio-registry:latest-snapshot
+    container_name: apicurio-registry-getting-started_api
+    environment:
+      - apicurio.rest.deletion.group.enabled=true
+      - apicurio.rest.deletion.artifact.enabled=true
+      - apicurio.rest.deletion.artifact-version.enabled=true
+      - QUARKUS_HTTP_CORS_ORIGINS=*
+    ports:
+      - "8080:8080"
+
+  # Define the Apicurio Registry UI service
+  apicurio-registry-ui:
+    image: apicurio/apicurio-registry-ui:latest-snapshot
+    container_name: apicurio-registry-getting-started_ui
+    ports:
+      - "8888:8080"
+    depends_on:
+      - apicurio-registry

--- a/ui/ui-app/index.html
+++ b/ui/ui-app/index.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <head>
+    <base href="/">
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-    <link rel="icon" type="image/png" href="/favicon.png">
+    <link rel="icon" type="image/svg+xml" href="./public/favicon.svg">
+    <link rel="icon" type="image/png" href="./public/favicon.png">
     <meta id="appName" name="application-name" content="Apicurio Registry">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Apicurio Registry</title>
-    <script type="text/javascript" src="/version.js"></script>
-    <script type="text/javascript" src="/config.js"></script>
+    <script type="text/javascript" src="./version.js"></script>
+    <script type="text/javascript" src="./config.js"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/ui/ui-app/package-lock.json
+++ b/ui/ui-app/package-lock.json
@@ -60,6 +60,7 @@
       }
     },
     "../../typescript-sdk": {
+      "name": "@apicurio/apicurio-registry-sdk",
       "version": "3.0.4-Dev",
       "devDependencies": {
         "@apicurio/eslint-config": "0.3.0",

--- a/ui/ui-app/src/app/components/header/AppHeader.tsx
+++ b/ui/ui-app/src/app/components/header/AppHeader.tsx
@@ -19,11 +19,13 @@ export const AppHeader: FunctionComponent<AppHeaderProps> = () => {
         return <></>;
     }
 
+    const logoSrc: string = `${config.uiContextPath() || "/"}apicurio_registry_logo_reverse.svg`;
+
     return (
         <Masthead id="icon-router-link">
             <MastheadMain>
                 <MastheadBrand component={props => <Link {...props} to={ appNavigation.createLink("/explore") } />}>
-                    <Brand src="/apicurio_registry_logo_reverse.svg" alt="Apicurio Registry" heights={{ default: "36px" }} />
+                    <Brand src={logoSrc} alt="Apicurio Registry" heights={{ default: "36px" }} />
                 </MastheadBrand>
             </MastheadMain>
             <MastheadContent>

--- a/ui/ui-app/src/app/components/header/AppHeaderToolbar.tsx
+++ b/ui/ui-app/src/app/components/header/AppHeaderToolbar.tsx
@@ -5,6 +5,7 @@ import { AvatarDropdown, IfAuth } from "@app/components";
 import { AppAboutModal, BackendInfo, FrontendInfo } from "@apicurio/common-ui-components";
 import { useVersionService, VersionService } from "@services/useVersionService.ts";
 import { SystemService, useSystemService } from "@services/useSystemService.ts";
+import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 
 
 export type AppHeaderToolbarProps = {
@@ -16,6 +17,7 @@ export const AppHeaderToolbar: FunctionComponent<AppHeaderToolbarProps> = () => 
     const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
     const version: VersionService = useVersionService();
     const system: SystemService = useSystemService();
+    const config: ConfigService = useConfigService();
 
     const frontendInfo: FrontendInfo = {
         ...version.getVersion()
@@ -33,13 +35,15 @@ export const AppHeaderToolbar: FunctionComponent<AppHeaderToolbarProps> = () => 
         });
     };
 
+    const logoSrc: string = `${config.uiContextPath() || "/"}apicurio_registry_logo_reverse.svg`;
+
     return (
         <>
             <AppAboutModal
                 frontendInfo={frontendInfo}
                 backendInfo={fetchBackendInfo}
                 backendLabel="Registry API info"
-                brandImageSrc="/apicurio_registry_logo_reverse.svg"
+                brandImageSrc={logoSrc}
                 brandImageAlt={version.getVersion().name}
                 isOpen={isAboutModalOpen}
                 onClose={() => setIsAboutModalOpen(false)} />

--- a/ui/ui-app/src/app/components/header/AvatarDropdown.tsx
+++ b/ui/ui-app/src/app/components/header/AvatarDropdown.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, useState } from "react";
 import { Avatar, Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement } from "@patternfly/react-core";
 import { AuthService, useAuth } from "@apicurio/common-ui-components";
 import { UserService, useUserService } from "@services/useUserService.ts";
+import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 
 
 export type AvatarDropdownProps = {
@@ -12,8 +13,11 @@ export type AvatarDropdownProps = {
 export const AvatarDropdown: FunctionComponent<AvatarDropdownProps> = () => {
     const [isOpen, setIsOpen] = useState(false);
 
+    const config: ConfigService = useConfigService();
     const auth: AuthService = useAuth();
     const user: UserService = useUserService();
+
+    const avatarSrc: string = `${config.uiContextPath() || "/"}avatar.png`;
 
     const onSelect = (): void => {
         setIsOpen(!isOpen);
@@ -24,7 +28,7 @@ export const AvatarDropdown: FunctionComponent<AvatarDropdownProps> = () => {
     };
 
     const icon = (
-        <Avatar src="/avatar.png" alt="User" />
+        <Avatar src={avatarSrc} alt="User" />
     );
 
     return (

--- a/ui/ui-app/src/app/components/modals/GenerateClientModal.tsx
+++ b/ui/ui-app/src/app/components/modals/GenerateClientModal.tsx
@@ -14,6 +14,7 @@ import { ClientGeneration } from "@services/useGroupsService.ts";
 import { DownloadService, useDownloadService } from "@services/useDownloadService.ts";
 import { CheckCircleIcon } from "@patternfly/react-icons";
 import { CodeEditor } from "@patternfly/react-code-editor";
+import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 
 
 /**
@@ -44,6 +45,7 @@ export const GenerateClientModal: FunctionComponent<GenerateClientModalProps> = 
     const [isGenerated, setIsGenerated] = useState(false);
     const [isExpanded, setIsExpanded] = useState(false);
 
+    const config: ConfigService = useConfigService();
     const download: DownloadService = useDownloadService();
 
     useEffect(() => {
@@ -72,8 +74,8 @@ export const GenerateClientModal: FunctionComponent<GenerateClientModalProps> = 
         setIsGenerating(true);
         setIsGenerated(false);
 
-        // @ts-expect-error unsafe inclusion of the wasm assets
-        const { generate } = await import("/kiota-wasm/main.js?url");
+        const kiotaWasmUrl: string = `${config.uiContextPath() || "/"}kiota-wasm/main.js?url`;
+        const { generate } = await import(kiotaWasmUrl);
 
         try {
             console.debug("GENERATING USING KIOTA:");

--- a/ui/ui-app/vite.config.mts
+++ b/ui/ui-app/vite.config.mts
@@ -2,9 +2,12 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import react from "@vitejs/plugin-react-swc";
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
 const PORT: number = parseInt(process.env.SERVER_PORT || "8888");
 
 export default defineConfig({
+    base: "./",
     plugins: [react(), tsconfigPaths()],
     server: {
         port: PORT


### PR DESCRIPTION
This should support various k8s/OpenShift and Docker Compose configurations, specifically when you want the Registry API and Registry UI to be served from the same domain.

This PR includes a nice example of how to test this using a docker compose file.