### PR TITLE
Upgrade quarkus to 3.15

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/DatabaseConfigInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/services/DatabaseConfigInterceptor.java
@@ -1,0 +1,51 @@
+package io.apicurio.registry.services;
+
+import io.apicurio.registry.storage.impl.sql.RegistryDatabaseKind;
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+import jakarta.annotation.Priority;
+
+@Priority(100)
+public class DatabaseConfigInterceptor implements ConfigSourceInterceptor {
+
+    @Override
+    public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
+        ConfigValue storageKind = context.proceed("apicurio.storage.sql.kind");
+        RegistryDatabaseKind databaseKind = RegistryDatabaseKind.valueOf(storageKind.getValue());
+
+        switch (name) {
+            case "quarkus.datasource.postgresql.active" -> {
+                if (databaseKind.equals(RegistryDatabaseKind.postgresql)) {
+                    return ConfigValue.builder().withName(name).withValue("true").build();
+                } else {
+                    return ConfigValue.builder().withName(name).withValue("false").build();
+                }
+            }
+            case "quarkus.datasource.mssql.active" -> {
+                if (databaseKind.equals(RegistryDatabaseKind.mssql)) {
+                    return ConfigValue.builder().withName(name).withValue("true").build();
+                } else {
+                    return ConfigValue.builder().withName(name).withValue("false").build();
+                }
+            }
+            case "quarkus.datasource.mysql.active" -> {
+                if (databaseKind.equals(RegistryDatabaseKind.mysql)) {
+                    return ConfigValue.builder().withName(name).withValue("true").build();
+                } else {
+                    return ConfigValue.builder().withName(name).withValue("false").build();
+                }
+            }
+            case "quarkus.datasource.h2.active" -> {
+                if (databaseKind.equals(RegistryDatabaseKind.h2)) {
+                    return ConfigValue.builder().withName(name).withValue("true").build();
+                } else {
+                    return ConfigValue.builder().withName(name).withValue("false").build();
+                }
+            }
+        }
+
+        return context.proceed(name);
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/services/RegistryConfigSource.java
+++ b/app/src/main/java/io/apicurio/registry/services/RegistryConfigSource.java
@@ -1,6 +1,6 @@
 package io.apicurio.registry.services;
 
-import io.quarkus.runtime.configuration.ProfileManager;
+import io.quarkus.runtime.LaunchMode;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
 import java.util.HashMap;
@@ -21,7 +21,7 @@ public class RegistryConfigSource implements ConfigSource {
             properties = new HashMap<>();
             String prefix = System.getenv("REGISTRY_PROPERTIES_PREFIX");
             if (prefix != null) {
-                String profile = ProfileManager.getLaunchMode().getProfileKey();
+                String profile = LaunchMode.current().getProfileKey();
                 String profilePrefix = "%" + profile + ".";
                 Map<String, String> envMap = System.getenv();
                 for (Map.Entry<String, String> entry : envMap.entrySet()) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractHandleFactory.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractHandleFactory.java
@@ -7,6 +7,7 @@ import io.apicurio.registry.storage.impl.sql.jdb.HandleCallback;
 import io.apicurio.registry.storage.impl.sql.jdb.HandleImpl;
 import org.slf4j.Logger;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,7 +35,10 @@ public abstract class AbstractHandleFactory implements HandleFactory {
         try {
             // Create a new handle if necessary. Increment the "level" if a handle already exists.
             if (state.handle == null) {
-                state.handle = new HandleImpl(dataSource.getConnection());
+                Connection connection = dataSource.getConnection();
+                // We must disable autocommit since we're managing the transactions ourselves.
+                connection.setAutoCommit(false);
+                state.handle = new HandleImpl(connection);
                 state.level = 0;
             } else {
                 state.level++;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -134,7 +134,6 @@ import io.apicurio.registry.utils.impexp.v3.GroupRuleEntity;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 import jakarta.validation.ValidationException;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -2905,7 +2904,6 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     }
 
     @Override
-    @Transactional
     public ContentWrapperDto getContentByReference(ArtifactReferenceDto reference) {
         try {
             var meta = getArtifactVersionMetaData(reference.getGroupId(), reference.getArtifactId(),

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlRegistryStorage.java
@@ -7,7 +7,6 @@ import io.apicurio.registry.metrics.health.readiness.PersistenceTimeoutReadiness
 import io.apicurio.registry.storage.RegistryStorage;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 
 /**
  * An in-memory SQL implementation of the {@link RegistryStorage} interface.
@@ -40,7 +39,6 @@ public class SqlRegistryStorage extends AbstractSqlRegistryStorage {
                 .bind(0, snapshotLocation).execute());
     }
 
-    @Transactional
     public void executeSqlStatement(String sqlStatement) {
         handleFactory.withHandle(handle -> handle.createUpdate(sqlStatement).execute());
     }

--- a/app/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/app/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,0 +1,1 @@
+io.apicurio.registry.services.DatabaseConfigInterceptor

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -162,13 +162,50 @@ apicurio.import.work-dir=${java.io.tmpdir}
 
 ## SQL Storage
 apicurio.storage.sql.kind=h2
+apicurio.sql.init=true
+
 apicurio.datasource.url=jdbc:h2:mem:db_${quarkus.uuid}
 apicurio.datasource.username=sa
 apicurio.datasource.password=sa
 apicurio.datasource.jdbc.initial-size=20
 apicurio.datasource.jdbc.min-size=20
 apicurio.datasource.jdbc.max-size=100
-apicurio.sql.init=true
+
+## H2
+quarkus.datasource.h2.db-kind=h2
+quarkus.datasource.h2.jdbc.url=${apicurio.datasource.url}
+quarkus.datasource.h2.username=${apicurio.datasource.username}
+quarkus.datasource.h2.password=${apicurio.datasource.password}
+quarkus.datasource.h2.jdbc.initial-size=${apicurio.datasource.jdbc.initial-size}
+quarkus.datasource.h2.jdbc.min-size=${apicurio.datasource.jdbc.min-size}
+quarkus.datasource.h2.jdbc.max-size=${apicurio.datasource.jdbc.max-size}
+
+## Postgresql
+quarkus.datasource.postgresql.db-kind=postgresql
+quarkus.datasource.postgresql.jdbc.url=${apicurio.datasource.url}
+quarkus.datasource.postgresql.username=${apicurio.datasource.username}
+quarkus.datasource.postgresql.password=${apicurio.datasource.password}
+quarkus.datasource.postgresql.jdbc.initial-size=${apicurio.datasource.jdbc.initial-size}
+quarkus.datasource.postgresql.jdbc.min-size=${apicurio.datasource.jdbc.min-size}
+quarkus.datasource.postgresql.jdbc.max-size=${apicurio.datasource.jdbc.max-size}
+
+## Mysql
+quarkus.datasource.mysql.db-kind=mysql
+quarkus.datasource.mysql.jdbc.url=${apicurio.datasource.url}
+quarkus.datasource.mysql.username=${apicurio.datasource.username}
+quarkus.datasource.mysql.password=${apicurio.datasource.password}
+quarkus.datasource.mysql.jdbc.initial-size=${apicurio.datasource.jdbc.initial-size}
+quarkus.datasource.mysql.jdbc.min-size=${apicurio.datasource.jdbc.min-size}
+quarkus.datasource.mysql.jdbc.max-size=${apicurio.datasource.jdbc.max-size}
+
+## Mssql
+quarkus.datasource.mssql.db-kind=mssql
+quarkus.datasource.mssql.jdbc.url=${apicurio.datasource.url}
+quarkus.datasource.mssql.username=${apicurio.datasource.username}
+quarkus.datasource.mssql.password=${apicurio.datasource.password}
+quarkus.datasource.mssql.jdbc.initial-size=${apicurio.datasource.jdbc.initial-size}
+quarkus.datasource.mssql.jdbc.min-size=${apicurio.datasource.jdbc.min-size}
+quarkus.datasource.mssql.jdbc.max-size=${apicurio.datasource.jdbc.max-size}
 
 ## Kafka SQL storage
 apicurio.kafkasql.bootstrap.servers=localhost:9092

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -53,7 +53,7 @@ quarkus.native.additional-build-args=--initialize-at-run-time=org.apache.kafka.c
   --allow-incomplete-classpath
 
 # Package
-quarkus.package.type=legacy-jar
+quarkus.package.jar.type=legacy-jar
 quarkus.index-dependency.jaxrs.group-id=jakarta.ws.rs
 quarkus.index-dependency.jaxrs.artifact-id=jakarta.ws.rs-api
 

--- a/app/src/test/java/io/apicurio/registry/storage/util/MssqlTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/storage/util/MssqlTestProfile.java
@@ -11,7 +11,7 @@ public class MssqlTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Collections.singletonMap("apicurio.storage.sql.kind", "mssql");
+        return Map.of("apicurio.storage.sql.kind", "mssql");
     }
 
     @Override

--- a/app/src/test/java/io/apicurio/registry/storage/util/MysqlTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/storage/util/MysqlTestProfile.java
@@ -11,7 +11,7 @@ public class MysqlTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Collections.singletonMap("apicurio.storage.sql.kind", "mysql");
+        return Map.of("apicurio.storage.sql.kind", "mysql");
     }
 
     @Override

--- a/app/src/test/java/io/apicurio/registry/storage/util/PostgresqlTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/storage/util/PostgresqlTestProfile.java
@@ -11,7 +11,7 @@ public class PostgresqlTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Collections.singletonMap("apicurio.storage.sql.kind", "postgresql");
+        return Map.of("apicurio.storage.sql.kind", "postgresql");
     }
 
     @Override

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -709,6 +709,11 @@ The following {registry} configuration options are available for each component 
 |
 |
 |Kafka sql storage bootstrap servers
+|`apicurio.kafkasql.consumer.group-prefix`
+|`string`
+|`apicurio-`
+|
+|Kafka sql storage prefix for consumer group name
 |`apicurio.kafkasql.consumer.poll.timeout`
 |`integer`
 |`5000`

--- a/examples/confluent-serdes/pom.xml
+++ b/examples/confluent-serdes/pom.xml
@@ -59,10 +59,6 @@
       <name>Confluent</name>
       <url>https://packages.confluent.io/maven/</url>
     </repository>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
   </repositories>
 
 </project>

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/Conditions.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/Conditions.java
@@ -1,7 +1,6 @@
 package io.apicurio.registry.operator.api.v1.status;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -39,7 +38,7 @@ public class Conditions implements KubernetesResource {
     @Required()
     @JsonPropertyDescription("lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.")
     @JsonSetter(nulls = Nulls.SKIP)
-    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
     @SchemaFrom(type = String.class)
     private Instant lastTransitionTime;
 

--- a/pom.xml
+++ b/pom.xml
@@ -688,8 +688,8 @@
       </dependency>
 
       <dependency>
-        <groupId>com.github.everit-org.json-schema</groupId>
-        <artifactId>org.everit.json.schema</artifactId>
+        <groupId>com.github.erosb</groupId>
+        <artifactId>everit-json-schema</artifactId>
         <version>${org.everit.json.schema.version}</version>
       </dependency>
       <dependency>
@@ -1326,6 +1326,11 @@
         <repository>
           <id>jgit-repository</id>
           <url>https://repo.eclipse.org/content/groups/releases/</url>
+        </repository>
+        <repository>
+          <id>confluent</id>
+          <name>Confluent</name>
+          <url>https://packages.confluent.io/maven/</url>
         </repository>
       </repositories>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     WARNING: The following group of dependencies has to be aligned with the corresponding Quarkus version.
     See notes for each entry.
     -->
-    <quarkus.version>3.11.1</quarkus.version>
+    <quarkus.version>3.15.1</quarkus.version>
     <!-- Go to `io.quarkiverse.operatorsdk:quarkus-operator-sdk-bom` and then to the parent `io.quarkiverse.operatorsdk:quarkus-operator-sdk-parent`. -->
     <!-- TODO: Fix: Currently, versions are not aligned exactly (3.11.1 vs 3.11.0), because there is no closer version supported by QOSDK. -->
     <quarkus-operator-sdk.version>6.7.1</quarkus-operator-sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1324,15 +1324,6 @@
       </activation>
       <repositories>
         <repository>
-          <id>confluent</id>
-          <name>Confluent</name>
-          <url>https://packages.confluent.io/maven/</url>
-        </repository>
-        <repository>
-          <id>jitpack.io</id>
-          <url>https://jitpack.io</url>
-        </repository>
-        <repository>
           <id>jgit-repository</id>
           <url>https://repo.eclipse.org/content/groups/releases/</url>
         </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -147,8 +147,8 @@
     <quarkus.version>3.15.1</quarkus.version>
     <!-- Go to `io.quarkiverse.operatorsdk:quarkus-operator-sdk-bom` and then to the parent `io.quarkiverse.operatorsdk:quarkus-operator-sdk-parent`. -->
     <!-- TODO: Fix: Currently, versions are not aligned exactly (3.11.1 vs 3.11.0), because there is no closer version supported by QOSDK. -->
-    <quarkus-operator-sdk.version>6.7.1</quarkus-operator-sdk.version>
-    <java-operator-sdk.version>4.9.6</java-operator-sdk.version>
+    <quarkus-operator-sdk.version>6.8.4</quarkus-operator-sdk.version>
+    <java-operator-sdk.version>4.9.5</java-operator-sdk.version>
     <!-- /WARNING -->
 
     <!-- Jandex -->

--- a/schema-util/json/pom.xml
+++ b/schema-util/json/pom.xml
@@ -41,8 +41,8 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.everit-org.json-schema</groupId>
-      <artifactId>org.everit.json.schema</artifactId>
+      <groupId>com.github.erosb</groupId>
+      <artifactId>everit-json-schema</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/utils/exportConfluent/src/main/resources/application.properties
+++ b/utils/exportConfluent/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 quarkus.package.main-class=ConfluentExport
 
 quarkus.log.level=WARN
-quarkus.package.type=uber-jar
+quarkus.package.jar.type=legacy-jar

--- a/utils/exportConfluent/src/main/resources/application.properties
+++ b/utils/exportConfluent/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 quarkus.package.main-class=ConfluentExport
 
 quarkus.log.level=WARN
-quarkus.package.jar.type=uber-jar
+quarkus.package.type=uber-jar


### PR DESCRIPTION
This PR upgrades Quarkus with the following additions:

- We get back to use the datasources created by Quarkus, so any other jdbc property can be configured using standard Quarkus config values.
- The appropriate datasource is activated at application startup, using the configured storage.
- It keeps the existing properties for configuring the Apicurio datasource for backwards compatibility, so we technically have two different ways of configuring the same thing, using the apicurio property and using the quarkus one (just one documented). The Apicurio property could be removed, but that would be a breaking change.