### PR TITLE
[Protobuf] Fix generation of "optional" labels in proto3 schema outW

### DIFF
--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/MessageDefinition.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/MessageDefinition.java
@@ -136,6 +136,11 @@ public class MessageDefinition {
             // Note: changed
             if (label != null) {
                 fieldBuilder.setLabel(label);
+                // If this field is a regular optional field, then force the "optional" keyword in the schema output.
+                // Ignore if the field is part of a oneOf.
+                if (oneofBuilder == null && label.equals(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)) {
+                    fieldBuilder.setProto3Optional(true);
+                }
             }
             DescriptorProtos.FieldDescriptorProto.Type primType = sTypeMap.get(type);
             if (primType != null) {


### PR DESCRIPTION
When parsing a Protobuf schema, and then generating it back, fields marked with "optional" don't get the same label in the generated output. Instead, they become required. This patch checks per field if it needs to set the "proto3Optional" flag (ignored for oneOf fields). The flag is set if the field is optional, rendering the expected "optional" keyword in fileElement.toSchema().