### PR TITLE
fix(db): New config property to set the name of the db schema

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -233,7 +233,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     @Info(category = "storage", description = "SQL init", availableSince = "2.0.0.Final")
     boolean initDB;
 
-    @ConfigProperty(name = "apicurio.sql.db-schema", defaultValue = "")
+    @ConfigProperty(name = "apicurio.sql.db-schema", defaultValue = "*")
     @Info(category = "storage", description = "Database schema name (only needed when running two instances of Registry against the same database, in multiple schemas)", availableSince = "3.0.6")
     String dbSchema;
 
@@ -330,7 +330,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
      */
     private boolean isDatabaseInitializedRaw(Handle handle) {
         log.info("Checking to see if the DB is initialized.");
-        if ("".equals(dbSchema)) {
+        if ("*".equals(dbSchema)) {
             int count = handle.createQuery(this.sqlStatements.isDatabaseInitialized()).mapTo(Integer.class)
                     .one();
             return count > 0;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -234,8 +234,8 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     boolean initDB;
 
     @ConfigProperty(name = "apicurio.sql.db-schema", defaultValue = "")
-    @Info(category = "storage", description = "Database schema", availableSince = "3.0.6")
-    boolean dbSchema;
+    @Info(category = "storage", description = "Database schema name (only needed when running two instances of Registry against the same database, in multiple schemas)", availableSince = "3.0.6")
+    String dbSchema;
 
     @Inject
     @ConfigProperty(name = "apicurio.events.kafka.topic", defaultValue = "registry-events")

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -17,6 +17,19 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     /**
+     * @see SqlStatements#isDatabaseInitialized()
+     */
+    @Override
+    public String isDatabaseInitialized() {
+        return "SELECT count(*) AS count FROM information_schema.tables WHERE table_name = 'apicurio'";
+    }
+
+    @Override
+    public String isDatabaseSchemaInitialized() {
+        return "SELECT count(*) AS count FROM information_schema.tables WHERE table_schema = ? AND table_name = 'apicurio'";
+    }
+
+    /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#databaseInitialization()
      */
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/H2SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/H2SqlStatements.java
@@ -45,6 +45,11 @@ public class H2SqlStatements extends CommonSqlStatements {
         return "SELECT COUNT(*) AS count FROM information_schema.tables WHERE table_name = 'APICURIO'";
     }
 
+    @Override
+    public String isDatabaseSchemaInitialized() {
+        return "SELECT COUNT(*) AS count FROM information_schema.tables WHERE table_schema = ? AND table_name = 'APICURIO'";
+    }
+
     /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#getNextSequenceValue()
      */

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/MySQLSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/MySQLSqlStatements.java
@@ -37,14 +37,6 @@ public class MySQLSqlStatements extends CommonSqlStatements {
     }
 
     /**
-     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#isDatabaseInitialized()
-     */
-    @Override
-    public String isDatabaseInitialized() {
-        return "SELECT count(*) AS count FROM information_schema.tables WHERE table_name = 'artifacts'";
-    }
-
-    /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#getNextSequenceValue()
      */
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
@@ -37,14 +37,6 @@ public class PostgreSQLSqlStatements extends CommonSqlStatements {
     }
 
     /**
-     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#isDatabaseInitialized()
-     */
-    @Override
-    public String isDatabaseInitialized() {
-        return "SELECT count(*) AS count FROM information_schema.tables WHERE table_name = 'artifacts'";
-    }
-
-    /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#getNextSequenceValue()
      */
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SQLServerSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SQLServerSqlStatements.java
@@ -37,14 +37,6 @@ public class SQLServerSqlStatements extends CommonSqlStatements {
         return error.getMessage().contains("conflicted with the FOREIGN KEY constraint");
     }
 
-    /**
-     * @see SqlStatements#isDatabaseInitialized()
-     */
-    @Override
-    public String isDatabaseInitialized() {
-        return "SELECT count(*) AS count FROM information_schema.tables WHERE table_name = 'artifacts'";
-    }
-
     @Override
     public String upsertBranch() {
         return """

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -29,6 +29,11 @@ public interface SqlStatements {
     public String isDatabaseInitialized();
 
     /**
+     * A statement that returns 'true' if the database (with schema) has already been initialized.
+     */
+    public String isDatabaseSchemaInitialized();
+
+    /**
      * A sequence of statements needed to initialize the database.
      */
     public List<String> databaseInitialization();

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -163,7 +163,6 @@ apicurio.import.work-dir=${java.io.tmpdir}
 ## SQL Storage
 apicurio.storage.sql.kind=h2
 apicurio.sql.init=true
-apicurio.sql.db-schema=
 
 apicurio.datasource.url=jdbc:h2:mem:db_${quarkus.uuid}
 apicurio.datasource.username=sa

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -163,6 +163,7 @@ apicurio.import.work-dir=${java.io.tmpdir}
 ## SQL Storage
 apicurio.storage.sql.kind=h2
 apicurio.sql.init=true
+apicurio.sql.db-schema=*
 
 apicurio.datasource.url=jdbc:h2:mem:db_${quarkus.uuid}
 apicurio.datasource.username=sa

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -163,6 +163,7 @@ apicurio.import.work-dir=${java.io.tmpdir}
 ## SQL Storage
 apicurio.storage.sql.kind=h2
 apicurio.sql.init=true
+apicurio.sql.db-schema=
 
 apicurio.datasource.url=jdbc:h2:mem:db_${quarkus.uuid}
 apicurio.datasource.username=sa

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -816,10 +816,10 @@ The following {registry} configuration options are available for each component 
 |
 |Kafka sql storage topic auto create
 |`apicurio.sql.db-schema`
-|`boolean`
+|`string`
 |
 |`3.0.6`
-|Database schema
+|Database schema name (only needed when running two instances of Registry against the same database, in multiple schemas)
 |`apicurio.sql.init`
 |`boolean`
 |`true`

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -815,6 +815,11 @@ The following {registry} configuration options are available for each component 
 |`true`
 |
 |Kafka sql storage topic auto create
+|`apicurio.sql.db-schema`
+|`boolean`
+|
+|`3.0.6`
+|Database schema
 |`apicurio.sql.init`
 |`boolean`
 |`true`


### PR DESCRIPTION
The information is only used during dbinit and only necessary when installing two Registry instances in the same database but different db schemas.