### PR TITLE
Default debug and test log level for Quarkus is now `INFO` instead of `DEBUG`

### DIFF
--- a/operator/controller/src/main/resources/application.properties
+++ b/operator/controller/src/main/resources/application.properties
@@ -4,8 +4,8 @@
 # Logging
 
 quarkus.log.level=info
-%dev.quarkus.log.level=debug
-%test.quarkus.log.level=debug
+%dev.quarkus.log.level=info
+%test.quarkus.log.level=info
 
 apicurio.log.level=info
 %dev.apicurio.log.level=debug


### PR DESCRIPTION
Having `DEBUG` logs enabled for Quarkus is producing enormous log files.  Changing the default to `INFO`.