### PR TITLE
chore(operator):  Created a pre-commit hook for regenerating the operator install.yaml file

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Define the directory to monitor
+WATCHED_DIR="operator/model/"
+
+# Get the list of changed files in the staging area
+CHANGED_FILES=$(git diff --cached --name-only)
+
+# Check if any file in the watched directory has been modified
+FILES_TO_CHECK=$(echo "$CHANGED_FILES" | grep "^$WATCHED_DIR")
+
+# If no changes detected in the directory, exit successfully
+if [ -z "$FILES_TO_CHECK" ]; then
+    echo "No changes detected to Operator Model, skipping install.yaml regen."
+    exit 0
+fi
+
+# Run your custom command (e.g., linting, formatting, tests, etc.)
+echo "Changes detected to Operator Model. Generating install.yaml file..."
+
+# Update the install.yaml file (regenerate it)
+cd operator
+make SKIP_TESTS=true build INSTALL_FILE=install/install.yaml dist-install-file > /dev/null 2>&1
+
+# Capture the exit code of the command
+EXIT_CODE=$?
+
+# Exit with the appropriate status
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "Failed to regenerate install.yaml file."
+    exit 1
+fi
+
+echo "Successfully generated install.yaml."
+git add ./install/install.yaml
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -20,7 +20,7 @@ echo "Changes detected to Operator Model. Generating install.yaml file..."
 
 # Update the install.yaml file (regenerate it)
 cd operator
-make SKIP_TESTS=true build INSTALL_FILE=install/install.yaml dist-install-file > /dev/null 2>&1
+make SKIP_TESTS=true build IMAGE_TAG=latest-snapshot INSTALL_FILE=install/install.yaml dist-install-file > /dev/null 2>&1
 
 # Capture the exit code of the command
 EXIT_CODE=$?

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the directory to monitor
-WATCHED_DIR="operator/model/"
+WATCHED_DIR="operator/model/src/main/java"
 
 # Get the list of changed files in the staging area
 CHANGED_FILES=$(git diff --cached --name-only)

--- a/install-githooks.sh
+++ b/install-githooks.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cp .githooks/* .git/hooks/.


### PR DESCRIPTION
If you want to use the hook, all you need to do is:

```
./install-githooks.sh
```

That will copy the hook into `.git/hooks` and you're good to go.  Once installed, the `install.yaml` will automatically be regenerated whenever a change to the operator model is made.