### PR TITLE
feat(operator): add release workflow

### DIFF
--- a/.github/workflows/composite/setup-minikube/action.yaml
+++ b/.github/workflows/composite/setup-minikube/action.yaml
@@ -1,0 +1,34 @@
+name: Setup Minikube
+description: Setup Minikube
+inputs:
+  github_token:
+    description: GitHub token
+    required: true
+
+runs:
+  using: composite
+  steps:
+
+    - name: Enable port-forwarding
+      shell: bash
+      run: |
+        sudo apt-get -y install socat
+
+    - name: Setup Minikube
+      uses: manusa/actions-setup-minikube@v2.13.0
+      with:
+        'minikube version': v1.33.1
+        'kubernetes version': v1.25.0
+        'github token': ${{ inputs.github_token }}
+        'start args': --force
+
+    - name: Enable Minikube features
+      shell: bash
+      run: |
+        minikube addons enable ingress
+        minikube addons enable olm
+
+    - name: Setup Minikube tunnel
+      shell: bash
+      run: |
+        minikube tunnel &

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -4,13 +4,12 @@ on:
     branches:
       - main
     paths:
-      - 'operator/**'
-
+      - operator/**
   pull_request:
     branches:
       - main
     paths:
-      - 'operator/**'
+      - operator/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,10 +31,9 @@ jobs:
       # deploys it with `imagePullPolicy: Always`; and also the operator image itself for the same reason.
       - name: Configure env. variables 2
         run: |
-          echo "IMAGE=ttl.sh/apicurio-registry-operator-$UUID:8h" >> $GITHUB_ENV
-          echo "BUNDLE_IMAGE=ttl.sh/apicurio-registry-operator-bundle-$UUID:8h" >> $GITHUB_ENV
-          echo "CATALOG_IMAGE=ttl.sh/apicurio-registry-operator-catalog-$UUID:8h" >> $GITHUB_ENV
-          echo "ADDITIONAL_CATALOG_IMAGE=" >> $GITHUB_ENV
+          echo "IMAGE=ttl.sh/apicurio-registry-3-operator-$UUID:8h" >> $GITHUB_ENV
+          echo "BUNDLE_IMAGE=ttl.sh/apicurio-registry-3-operator-bundle-$UUID:8h" >> $GITHUB_ENV
+          echo "CATALOG_IMAGE=ttl.sh/apicurio-registry-3-operator-catalog-$UUID:8h" >> $GITHUB_ENV
 
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v4
@@ -47,31 +45,24 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - name: Enable port-forwarding
-        run: |
-          sudo apt-get -y install socat
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.13.0
+      - uses: ./.github/workflows/composite/setup-minikube
         with:
-          'minikube version': v1.33.1
-          'kubernetes version': v1.25.0
-          'github token': ${{ secrets.GITHUB_TOKEN }}
-          'start args': '--force'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable minikube features
-        run: |
-          minikube addons enable ingress
-          minikube addons enable olm
-
-      - name: Setup minikube tunnel
-        run: |
-          minikube tunnel &   
-
-      - name: Build and run local tests on Minikube
+      - name: Build only
+        if: github.event_name != 'push'
         working-directory: operator
         run: |
-          make BUILD_OPTS="--no-transfer-progress" build
+          make BUILD_OPTS=--no-transfer-progress SKIP_TESTS=true build
+
+      - name: Build and run local tests on Minikube
+        # Speed up the PR check by running both local and remote tests on push to main,
+        # and only run remote tests against a PR.
+        # TODO: Is this ok?
+        if: github.event_name == 'push'
+        working-directory: operator
+        run: |
+          make BUILD_OPTS=--no-transfer-progress build
 
       - name: Build temporary operator image
         working-directory: operator
@@ -91,13 +82,13 @@ jobs:
       - name: Run remote and OLM tests on Minikube
         working-directory: operator
         run: |
-          make BUILD_OPTS="--no-transfer-progress" remote-tests-all
+          make BUILD_OPTS=--no-transfer-progress remote-tests-all
 
       - name: Update install file
         working-directory: operator
         run: |
           # We need to remove unset the variables to generate a clean install file.
-          # See https://stackoverflow.com/questions/70137245/how-to-remove-an-environment-variable-on-github-actions
+          # See https://github.com/actions/runner/issues/1126
           unset IMAGE
           unset BUNDLE_IMAGE
           unset CATALOG_IMAGE
@@ -110,7 +101,7 @@ jobs:
             echo 'Install file needs to be updated. Please run "cd operator; make SKIP_TESTS=true build IMAGE_TAG=latest-snapshot INSTALL_FILE=install/install.yaml dist-install-file" and commit the result.';
             exit 1;
           else
-            echo "No changes to the install file.";            
+            echo "No changes to the install file.";
           fi
 
   operator-publish:
@@ -120,11 +111,12 @@ jobs:
     if: github.event_name == 'push'
     steps:
 
-      # Do not publish (version)-snapshot tag, instead use `latest-snapshot`.
       - name: Configure env. variables
         run: |
+          # We want to use latest-snapshot instead of x.y.z-snapshot
           echo "IMAGE_TAG=latest-snapshot" >> $GITHUB_ENV
           echo "BUNDLE_IMAGE_TAG=latest-snapshot" >> $GITHUB_ENV
+          echo "CATALOG_IMAGE_TAG=latest-snapshot" >> $GITHUB_ENV
 
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v4
@@ -139,13 +131,14 @@ jobs:
       - name: Build
         working-directory: operator
         run: |
-          make BUILD_OPTS="--no-transfer-progress" SKIP_TESTS=true build
+          make BUILD_OPTS=--no-transfer-progress SKIP_TESTS=true build
 
       - name: Login to quay.io registry
         run: |
           docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
 
-      - name: Build and publish operator image # TODO: Also push to DockerHub Registry
+      # TODO: Also push to DockerHub Registry
+      - name: Build and publish operator image
         working-directory: operator
         run: |
           make image-build image-push
@@ -154,3 +147,26 @@ jobs:
         working-directory: operator
         run: |
           make bundle
+
+      - name: Build and publish operator catalog
+        working-directory: operator
+        run: |
+          make catalog
+
+      - name: Slack Notification (Always)
+        if: always()
+        run: |
+          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job completed with status: ${{ job.status }}"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}"
+
+      - name: Slack Notification (Error)
+        if: failure()
+        run: |
+          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job FAILED!"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "${{ secrets.SLACK_ERROR_WEBHOOK }}"

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -1,0 +1,265 @@
+name: Release Operator
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag name
+        required: true
+      run_tests:
+        description: Run tests using the release artifacts
+        type: boolean
+        default: true
+
+  release:
+    types: [ released, prereleased ] # TODO: What to do with pre-release?
+
+env:
+  RELEASE_VERSION: ${{ github.event.release.name }}
+  BRANCH: ${{ github.event.release.target_commitish }}
+  RUN_TESTS: 'true'
+
+jobs:
+  release-operator:
+    if: github.repository_owner == 'Apicurio' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '3.'))
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    steps:
+
+      - name: Fetch Release Details
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          touch release.json && curl "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/${{ github.event.inputs.tag }}" > release.json
+          echo "RELEASE_VERSION=$(cat release.json | jq -r '.name')" >> $GITHUB_ENV
+          echo "BRANCH=$(cat release.json | jq -r '.target_commitish')" >> $GITHUB_ENV
+          echo "RUN_TESTS=${{ github.event.inputs.run_tests }}" >> $GITHUB_ENV
+
+      - name: Check release type
+        if: contains(env.RELEASE_VERSION, 'RC')
+        run: |
+          # TODO: Figure out what pre-release operator looks like. Maybe just skip OperatorHub?
+          # We we would have to remove the pre-release version from standard-release catalog.
+          echo "Operator cannot be released as part of a pre-release version yet."
+          exit 1
+
+      - name: Download Source Code
+        run: |
+          git config --global user.name apicurio-ci
+          git config --global user.email apicurio.ci@gmail.com
+          git clone "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git" registry
+          cd registry && git checkout "$RELEASE_VERSION"
+
+      - name: Verify Project Version
+        working-directory: registry
+        run: |
+          PROJECT_VERSION="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          if [[ "$PROJECT_VERSION" != "$RELEASE_VERSION" ]]
+          then
+              echo "ERROR: Project version $PROJECT_VERSION does not match released version $RELEASE_VERSION"
+              exit 1
+          fi
+
+      - name: Configure env. variables 1
+        working-directory: registry/operator
+        run: |
+          echo "GH_TOKEN=${{ secrets.ACCESS_TOKEN }}" >> "$GITHUB_ENV"
+          echo "CUSTOM_ENV=$(pwd)/custom_env" >> "$GITHUB_ENV"
+          echo "PACKAGE_VERSION=$(make VAR=LC_VERSION get-variable)" >> "$GITHUB_ENV"
+
+      - name: Configure env. variables 2
+        run: |
+          echo "RELEASE_BRANCH=release-$PACKAGE_VERSION" >> "$GITHUB_ENV"
+
+      - name: Configure custom env. variables 1
+        # See https://github.com/actions/runner/issues/1126
+        run: |
+          echo "export OPERAND_IMAGE_TAG=$RELEASE_VERSION" >> "$CUSTOM_ENV"
+
+      - name: Show make configuration
+        working-directory: registry/operator
+        run: |
+          source "$CUSTOM_ENV"
+          make config-show
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: temurin
+          cache: maven
+
+      - name: Build the operator
+        working-directory: registry/operator
+        run: |
+          source "$CUSTOM_ENV"
+          make BUILD_OPTS=--no-transfer-progress SKIP_TESTS=true build
+
+      - name: Login to Quay.io Registry
+        run: docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+
+      - name: Build and push operator image
+        working-directory: registry/operator
+        run: |
+          source "$CUSTOM_ENV"
+          make ADDITIONAL_IMAGE_TAG=latest image-build image-push
+
+      - name: Wait on operand images
+        working-directory: registry/operator
+        run: |
+          source "$CUSTOM_ENV"
+          export REGISTRY_APP_IMAGE="$(make VAR=REGISTRY_APP_IMAGE get-variable)"
+          until docker manifest inspect "$REGISTRY_APP_IMAGE" >& /dev/null; do echo "Waiting on $REGISTRY_APP_IMAGE"; sleep 10; done
+          export REGISTRY_UI_IMAGE="$(make VAR=REGISTRY_UI_IMAGE get-variable)"
+          until docker manifest inspect "$REGISTRY_UI_IMAGE" >& /dev/null; do echo "Waiting on $REGISTRY_UI_IMAGE"; sleep 10; done
+          export STUDIO_UI_IMAGE="$(make VAR=STUDIO_UI_IMAGE get-variable)"
+          until docker manifest inspect "$STUDIO_UI_IMAGE" >& /dev/null; do echo "Waiting on $STUDIO_UI_IMAGE"; sleep 10; done
+
+      - name: Build operator bundle
+        working-directory: registry/operator
+        run: |
+          source "$CUSTOM_ENV"
+          make bundle
+
+      - name: Build operator catalog
+        working-directory: registry/operator
+        run: |
+          source "$CUSTOM_ENV"
+          make ADDITIONAL_CATALOG_IMAGE_TAG=latest catalog
+
+      - uses: ./registry/.github/workflows/composite/setup-minikube
+        if: env.RUN_TESTS == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tests
+        if: env.RUN_TESTS == 'true'
+        working-directory: registry/operator
+        run: |
+          source "$CUSTOM_ENV"
+          make REMOTE_TESTS_ALL_INSTALL_FILE=install/install.yaml BUILD_OPTS=--no-transfer-progress remote-tests-all
+
+      - name: Build dist archive and attach to the release
+        working-directory: registry/operator
+        run: |
+          source "$CUSTOM_ENV"
+          make dist
+          DIST_FILE="target/apicurio-registry-operator-$RELEASE_VERSION.tar.gz"
+          gh release upload "$RELEASE_VERSION" "$DIST_FILE"
+
+      - name: Checkout the Community Operators repository
+        run: |
+          mkdir community-operators
+          cd community-operators
+          git init
+          git remote add origin https://github.com/k8s-operatorhub/community-operators.git
+          git remote add source "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/community-operators.git"
+          git fetch
+          git checkout --track origin/main
+          git push -f source main
+
+      - name: Create the Community Operators PR
+        working-directory: community-operators
+        run: |
+          git checkout -b "$RELEASE_BRANCH"
+          TITLE="Release Apicurio Registry Operator $PACKAGE_VERSION"
+          BODY="$(curl -s https://raw.githubusercontent.com/k8s-operatorhub/community-operators/main/docs/pull_request_template.md)"
+          # TODO: Remove after first release
+          mkdir operators/apicurio-registry-3
+          # TODO: Remove after first release
+          echo -e "---\nupdateGraph: replaces-mode\nreviewers:\n  - apicurio-ci\n  - carlesarnal\n  - EricWittmann  - jsenko\n" > operators/apicurio-registry-3/ci.yaml
+          cp -r "../registry/operator/target/bundle/apicurio-registry-3/$PACKAGE_VERSION" operators/apicurio-registry-3
+          git add .
+          git commit -s -m "$TITLE"
+          git push -f source "$RELEASE_BRANCH"
+          gh repo set-default k8s-operatorhub/community-operators
+          gh pr create --title "$TITLE" --body "$BODY" --base main --head "Apicurio:$RELEASE_BRANCH"
+
+      - name: Checkout the Openshift Community Operators repository
+        run: |
+          mkdir openshift-community-operators
+          cd openshift-community-operators
+          git init
+          git remote add origin https://github.com/redhat-openshift-ecosystem/community-operators-prod.git
+          git remote add source "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/community-operators-prod.git"
+          git fetch
+          git checkout --track origin/main
+          git push -f source main
+
+      - name: Create the Openshift Community Operators PR
+        working-directory: openshift-community-operators
+        run: |
+          git checkout -b "$RELEASE_BRANCH"
+          TITLE="Release Apicurio Registry Operator $PACKAGE_VERSION"
+          BODY="$(curl -s https://raw.githubusercontent.com/redhat-openshift-ecosystem/community-operators-prod/main/docs/pull_request_template.md)"
+          # TODO: Remove after first release
+          mkdir operators/apicurio-registry-3
+          # TODO: Remove after first release
+          echo -e "---\nupdateGraph: replaces-mode\nreviewers:\n  - apicurio-ci\n  - carlesarnal\n  - EricWittmann  - jsenko\n" > operators/apicurio-registry-3/ci.yaml
+          cp -r "../registry/operator/target/bundle/apicurio-registry-3/$PACKAGE_VERSION" operators/apicurio-registry-3
+          git add .
+          git commit -s -m "$TITLE"
+          git push -f source "$RELEASE_BRANCH"
+          gh repo set-default redhat-openshift-ecosystem/community-operators-prod
+          gh pr create --title "$TITLE" --body "$BODY" --base main --head "Apicurio:$RELEASE_BRANCH"
+
+      - name: Configure custom env. variables 2
+        run: |
+          # We want to use latest-snapshot instead of x.y.z-snapshot
+          echo "export IMAGE_TAG=latest-snapshot" >> "$CUSTOM_ENV"
+
+      - name: Prepare post-release changes
+        working-directory: registry/operator
+        run: |
+          git checkout "$BRANCH"
+
+      - name: Update Makefile
+        working-directory: registry/operator
+        run: |
+          make VAR=PREVIOUS_PACKAGE_VERSION "VAL=$PACKAGE_VERSION" set-variable
+          make VAR=STUDIO_UI_IMAGE_TAG VAL=latest-snapshot set-variable
+          git add Makefile
+
+      - name: Update catalog template
+        working-directory: registry/operator
+        run: |
+          make release-catalog-template-update
+          git add "$(make VAR=CATALOG_DIR get-variable)"
+
+      - name: Update install file
+        working-directory: registry/operator
+        run: |
+          source "$CUSTOM_ENV"
+          make INSTALL_FILE=install/install.yaml dist-install-file
+          git add install/*
+
+      - name: Commit & push post-release changes
+        working-directory: registry/operator
+        run: |
+          git commit -m "ci(operator): post-release changes for $RELEASE_VERSION"
+          # Rebase in case somebody else pushed to the branch
+          git fetch origin
+          git rebase "origin/$BRANCH"
+          git push origin "$BRANCH"
+
+      - name: Slack Notification (Always)
+        if: always()
+        run: |
+          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job completed with status: ${{ job.status }}"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}"
+
+      - name: Slack Notification (Error)
+        if: failure()
+        run: |
+          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job FAILED!"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "${{ secrets.SLACK_ERROR_WEBHOOK }}"
+
+      - name: Setup tmate session on failure
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,15 +3,18 @@ on:
   workflow_dispatch:
     inputs:
       release-version:
-        description: 'Version being released'
+        description: Version being released
+        required: true
+      apicurio-studio-version:
+        description: Apicurio Studio version being used in this release. Must correspond to an image tag.
         required: true
       snapshot-version:
-        description: 'Next snapshot version'
+        description: Next snapshot version
         required: true
       branch:
-        description: 'Branch to release from'
+        description: Branch to release from
         required: true
-        default: 'main'
+        default: main
 jobs:
   release:
     runs-on: ubuntu-22.04
@@ -30,10 +33,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Set up Node.js v18
+      - name: Set up Node.js v20
         uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Set up json CLI
         run: npm install -g json
@@ -71,6 +74,8 @@ jobs:
           sed -i  "s/version\:\s.*/version: \'${DOCS_VERSION}\'/g" docs/antora.yml
           sed -i  "5s/\"version\"\:\s\".*\"/\"version\": \"${DOCS_VERSION}\"/g" app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v3/openapi.json
 
+          # TODO: Operator docs
+
           # take only the major, minor and patch
           PYTHON_SDK_VERSION=$(echo "${{ github.event.inputs.release-version}}" | awk -F '[.-]' '{print $1"."$2"."$3}')
           sed -i "s/^version.*/version \= \"${PYTHON_SDK_VERSION}\"/" python-sdk/pyproject.toml
@@ -101,6 +106,28 @@ jobs:
           npm run lint
           npm run build
           npm run package
+
+      - name: (Operator) Configure env. variables
+        run: |
+          echo "OPERAND_IMAGE_TAG=${{ github.event.inputs.release-version }}" >> $GITHUB_ENV
+
+      - name: (Operator) Update Makefile
+        working-directory: registry/operator
+        run: |
+          make VAR=STUDIO_UI_IMAGE_TAG "VAL=${{ github.event.inputs.apicurio-studio-version }}" set-variable
+          git add Makefile
+
+      - name: (Operator) Update install file
+        working-directory: registry/operator
+        run: |
+          make dist-install-file
+          cp "$(make VAR=INSTALL_FILE get-variable)" install/install.yaml
+          git add install/*
+
+      - name: (Operator) Commit pre-release changes
+        working-directory: registry/operator
+        run: |
+          git commit -m "ci(operator): pre-release changes for ${{ github.event.inputs.release-version }}"
 
       - name: Commit Release Version Change
         run: |
@@ -141,6 +168,8 @@ jobs:
 
           sed -i  "s/version\:\s.*/version: \'${DOCS_VERSION}\'/g" docs/antora.yml
           sed -i  "5s/\"version\"\:\s\".*\"/\"version\": \"${DOCS_VERSION}\"/g" app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v3/openapi.json
+
+          # TODO: Operator docs
 
           # take only the major, minor and patch
           PYTHON_SDK_VERSION=$(echo "${{ github.event.inputs.snapshot-version}}" | awk -F '[.-]' '{print $1"."$2"."$3}')
@@ -184,3 +213,9 @@ jobs:
           LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
           PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
           curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_ERROR_WEBHOOK }}
+
+      - name: Setup tmate session on failure
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -19,15 +19,18 @@ ifneq ($(SKIP_TESTS),true)
 endif
 
 IMAGE_REGISTRY ?= quay.io/apicurio
-IMAGE_NAME ?= apicurio-registry-operator
+IMAGE_NAME ?= apicurio-registry-3-operator
 IMAGE_TAG ?= $(LC_VERSION)
 
 IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 ADDITIONAL_IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(ADDITIONAL_IMAGE_TAG)
 
-REGISTRY_APP_IMAGE ?= quay.io/apicurio/apicurio-registry:latest-snapshot
-REGISTRY_UI_IMAGE ?= quay.io/apicurio/apicurio-registry-ui:latest-snapshot
-STUDIO_UI_IMAGE ?= quay.io/apicurio/apicurio-studio-ui:latest-snapshot
+OPERAND_IMAGE_TAG ?= latest-snapshot
+STUDIO_UI_IMAGE_TAG ?= latest-snapshot
+
+REGISTRY_APP_IMAGE ?= quay.io/apicurio/apicurio-registry:$(OPERAND_IMAGE_TAG)
+REGISTRY_UI_IMAGE ?= quay.io/apicurio/apicurio-registry-ui:$(OPERAND_IMAGE_TAG)
+STUDIO_UI_IMAGE ?= quay.io/apicurio/apicurio-studio-ui:$(STUDIO_UI_IMAGE_TAG)
 
 NAMESPACE ?= default
 
@@ -35,9 +38,10 @@ NAMESPACE ?= default
 
 PACKAGE_NAME ?= apicurio-registry-3
 PACKAGE ?= $(PACKAGE_NAME).v$(LC_VERSION)
-# TODO Replaces:
-# PREVIOUS_PACKAGE_VERSION =
-# REPLACES = $(PACKAGE_NAME).v$(PREVIOUS_PACKAGE_VERSION)
+
+PREVIOUS_PACKAGE_VERSION ?=
+PREVIOUS_PACKAGE ?= $(PACKAGE_NAME).v$(PREVIOUS_PACKAGE_VERSION)
+# TODO: Handle `replaces` after first release
 
 CHANNELS ?= 3.x
 DEFAULT_CHANNEL ?= $(CHANNELS)
@@ -72,7 +76,6 @@ CATALOG_TARGET_DIR ?= target/catalog
 CATALOG_IMAGE_NAME ?= $(IMAGE_NAME)-catalog
 CATALOG_IMAGE_TAG ?= $(LC_VERSION)
 CATALOG_IMAGE ?= $(IMAGE_REGISTRY)/$(CATALOG_IMAGE_NAME):$(CATALOG_IMAGE_TAG)
-ADDITIONAL_CATALOG_IMAGE_TAG ?= latest$(LC_VERSION_SUFFIX)
 ADDITIONAL_CATALOG_IMAGE ?= $(IMAGE_REGISTRY)/$(CATALOG_IMAGE_NAME):$(ADDITIONAL_CATALOG_IMAGE_TAG)
 
 AC_CATALOG_DIR ?= olm-tests/src/test/deploy/api-controller-catalog
@@ -261,10 +264,13 @@ build: ## TODO
 
 .PHONY: remote-tests-all
 remote-tests-all: ## TODO
-	mvn clean # Running `mvn clean` will delete controller/target/test-install.yaml, so it has to be run first, if needed.
+	# Do not run `mvn clean` when not necessary.
+ifeq ($(REMOTE_TESTS_ALL_INSTALL_FILE),)
 	$(MAKE) INSTALL_FILE=controller/target/test-install.yaml dist-install-file
-	$(eval BUILD_OPTS_EXT := $(subst "-pl controller -am",,$(BUILD_OPTS_EXT)))
-	mvn verify $(BUILD_OPTS_EXT) -Dtest.operator.deployment=remote -Dtest.operator.catalog-image=$(CATALOG_IMAGE)
+else
+	cp $(REMOTE_TESTS_ALL_INSTALL_FILE) controller/target/test-install.yaml
+endif
+	mvn verify $(subst -pl controller -am,,$(BUILD_OPTS_EXT)) -Dtest.operator.deployment=remote -Dtest.operator.catalog-image=$(CATALOG_IMAGE)
 
 
 .PHONY: image-build
@@ -461,11 +467,6 @@ ac-catalog-image-push: ## TODO
 	docker push $(AC_CATALOG_IMAGE)
 
 
-.PHONY: catalog-image-get
-catalog-image-get: ## TODO
-	@echo -n $(CATALOG_IMAGE)
-
-
 .PHONY: ac-catalog
 ac-catalog: ac-catalog-build ac-catalog-image-build ac-catalog-image-push ## TODO
 
@@ -510,6 +511,22 @@ catalog-subscription-undeploy: ## TODO
 	kubectl -n $(NAMESPACE) delete clusterserviceversion $(PACKAGE) || true
 
 
+.PHONY: release-catalog-template-update
+release-catalog-template-update: install-yq
+	$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name = "3.x") | .entries[] | select(.name = "$${PLACEHOLDER_PACKAGE}")).name = "$(PREVIOUS_PACKAGE)"' -i $(CATALOG_DIR)/catalog.template.yaml
+	$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name = "3.x") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}", "replaces": "$(PREVIOUS_PACKAGE)"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml
+
+
 .PHONY: dev
 dev:
 	mvn quarkus:dev
+
+
+.PHONY: set-variable
+set-variable:
+	sed -i 's|^\( *$(VAR) *\??=\) *\([^ ]*\)\(.*\)$$|\1 $(VAL)\3|g' Makefile
+
+
+.PHONY: get-variable
+get-variable:
+	@echo $($(VAR))

--- a/operator/README.md
+++ b/operator/README.md
@@ -267,7 +267,7 @@ OLM tests are similar to the remote tests in that the operator is deployed into 
 4. Run:
    ```shell
    make INSTALL_FILE=controller/target/test-install.yaml dist-install-file
-   mvn clean verify -DskipOperatorTests=false -Dtest.operator.deployment=remote -Dtest.operator.catalog-image=$(make catalog-image-get)
+   mvn verify -DskipOperatorTests=false -Dtest.operator.deployment=remote -Dtest.operator.catalog-image=$(make VAR=CATALOG_IMAGE get-variable)
    ```
    or
    ```shell
@@ -277,9 +277,9 @@ OLM tests are similar to the remote tests in that the operator is deployed into 
 
 Configuration options for the remote + OLM tests are same as those for the remote tests, but the following options are additionally available:
 
-| Option                      | Type             | Default value                                                         | Description                                                             |
-|-----------------------------|------------------|-----------------------------------------------------------------------|-------------------------------------------------------------------------|
-| test.operator.catalog-image | string           | `quay.io/apicurio/apicurio-registry-operator-catalog:latest-snapshot` | Catalog image that is used to deploy the operator for testing with OLM. |
+| Option                      | Type             | Default value | Description                                                             |
+|-----------------------------|------------------|---------------|-------------------------------------------------------------------------|
+| test.operator.catalog-image | string           | -             | Catalog image that is used to deploy the operator for testing with OLM. |
 
 ## Distribution and Release
 

--- a/operator/controller/src/main/resources/application.properties
+++ b/operator/controller/src/main/resources/application.properties
@@ -69,5 +69,3 @@ registry.version=${project.version}
 %test.test.operator.deployment-target=kubernetes
 # Maven property
 %test.test.operator.install-file=${build.directory}/test-install.yaml
-%test.test.operator.olm-skip=false
-%test.test.operator.catalog-image=quay.io/apicurio/apicurio-registry-operator-catalog:latest-snapshot

--- a/operator/install/install.yaml
+++ b/operator/install/install.yaml
@@ -9609,7 +9609,7 @@ spec:
           value: quay.io/apicurio/apicurio-registry-ui:latest-snapshot
         - name: STUDIO_UI_IMAGE
           value: quay.io/apicurio/apicurio-studio-ui:latest-snapshot
-        image: quay.io/apicurio/apicurio-registry-operator:latest-snapshot
+        image: quay.io/apicurio/apicurio-registry-3-operator:latest-snapshot
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
+++ b/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
@@ -8,6 +8,5 @@ entries:
     name: 3.x
     entries:
       - name: ${PLACEHOLDER_PACKAGE}
-      # TODO: Replaces
   - schema: olm.bundle
     image: ${PLACEHOLDER_BUNDLE_IMAGE}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
@@ -39,7 +39,7 @@ public abstract class OLMITBase {
         cleanup = ConfigProvider.getConfig().getValue(ITBase.CLEANUP, Boolean.class);
 
         if (client.apiextensions().v1().customResourceDefinitions()
-                .withName("catalogsources.operators.coreos.com").get() == null) {
+                    .withName("catalogsources.operators.coreos.com").get() == null) {
             throw new OperatorException("CatalogSource CRD is not available. Please install OLM.");
         }
 
@@ -47,7 +47,7 @@ public abstract class OLMITBase {
         var projectRoot = ConfigProvider.getConfig().getValue(PROJECT_ROOT_PROP, String.class);
         var catalogImage = ConfigProvider.getConfig().getValue(CATALOG_IMAGE_PROP, String.class);
 
-        var testDeployDir = Paths.get(projectRoot, "operator/controller/src/test/deploy");
+        var testDeployDir = Paths.get(projectRoot, "operator/olm-tests/src/test/deploy");
 
         // Catalog Source
 
@@ -55,11 +55,12 @@ public abstract class OLMITBase {
         catalogSourceRaw = catalogSourceRaw.replace("${PLACEHOLDER_CATALOG_NAMESPACE}", namespace);
         catalogSourceRaw = catalogSourceRaw.replace("${PLACEHOLDER_CATALOG_IMAGE}", catalogImage);
         var catalogSource = client.resource(catalogSourceRaw);
+
         catalogSource.create();
 
         Awaitility.await().ignoreExceptions().until(() -> {
             return client.pods().inNamespace(namespace).list().getItems().stream().filter(
-                    pod -> pod.getMetadata().getName().startsWith("apicurio-registry-operator-catalog"))
+                            pod -> pod.getMetadata().getName().startsWith("apicurio-registry-operator-catalog"))
                     .anyMatch(pod -> pod.getStatus().getConditions().stream()
                             .anyMatch(c -> "Ready".equals(c.getType()) && "True".equals(c.getStatus())));
         });
@@ -76,8 +77,9 @@ public abstract class OLMITBase {
         var subscriptionRaw = Files.readString(testDeployDir.resolve("catalog/subscription.yaml"));
         subscriptionRaw = subscriptionRaw.replace("${PLACEHOLDER_NAMESPACE}", namespace);
         subscriptionRaw = subscriptionRaw.replace("${PLACEHOLDER_CATALOG_NAMESPACE}", namespace);
+        subscriptionRaw = subscriptionRaw.replace("${PLACEHOLDER_PACKAGE_NAME}", "apicurio-registry-3");
         subscriptionRaw = subscriptionRaw.replace("${PLACEHOLDER_PACKAGE}",
-                "apicurio-registry.v" + projectVersion.toLowerCase());
+                "apicurio-registry-3.v" + projectVersion.toLowerCase());
         var subscription = client.resource(subscriptionRaw);
         subscription.create();
     }


### PR DESCRIPTION
- This workflow automates all tasks for the operator release, including creating PRs to the OperatorHub and Operator Marketplace repos, however manual intervention might be needed for those PRs to be merged.
- Since I could not fully test the workflow in an actual release, some supervision will be needed when first running this for real.
- After the first release is done, some changes have to be made since the subsequent releases have to reference the previous bundle in the channel. There is a couple of TODOs for this task.
- I've also modified the PR check workflow to improve the run time by skipping local test mode, which will only run on push.
- I've refactored Minikube setup steps into a composite action. We might use this approach in the future for e.g. Slack notifications.
- I found out that the operator check workflow was not running he OLM tests by mistake, and I had to fix a few things we missed as a result.
- I've also changed the image repository names for operator-related images (operator, bundle, and catalog) to `apicurio-registry-3-operator-*` to differentiate them from the legacy images.