### PR TITLE
Fix a possible regresion where serializers were not putting required info in message headers

### DIFF
--- a/serdes/kafka/avro-serde/src/main/java/io/apicurio/registry/serde/avro/AvroKafkaSerializer.java
+++ b/serdes/kafka/avro-serde/src/main/java/io/apicurio/registry/serde/avro/AvroKafkaSerializer.java
@@ -1,6 +1,5 @@
 package io.apicurio.registry.serde.avro;
 
-import io.apicurio.registry.resolver.ParsedSchema;
 import io.apicurio.registry.resolver.SchemaResolver;
 import io.apicurio.registry.resolver.strategy.ArtifactReferenceResolverStrategy;
 import io.apicurio.registry.rest.client.RegistryClient;
@@ -8,8 +7,6 @@ import io.apicurio.registry.serde.KafkaSerializer;
 import org.apache.avro.Schema;
 import org.apache.kafka.common.header.Headers;
 
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Map;
 
 public class AvroKafkaSerializer<U> extends KafkaSerializer<Schema, U> {
@@ -43,18 +40,13 @@ public class AvroKafkaSerializer<U> extends KafkaSerializer<Schema, U> {
         avroHeaders = new AvroSerdeHeaders(isKey);
     }
 
-    /**
-     * @see KafkaSerializer#serializeData(org.apache.kafka.common.header.Headers,
-     *      io.apicurio.registry.resolver.ParsedSchema, java.lang.Object, java.io.OutputStream)
-     */
     @Override
-    protected void serializeData(Headers headers, ParsedSchema<Schema> schema, U data, OutputStream out)
-            throws IOException {
+    public byte[] serialize(String topic, Headers headers, U data) {
         if (headers != null) {
             avroHeaders.addEncodingHeader(headers,
                     ((AvroSerializer<U>) delegatedSerializer).getEncoding().name());
         }
 
-        super.serializeData(headers, schema, data, out);
+        return super.serialize(topic, headers, data);
     }
 }

--- a/serdes/kafka/jsonschema-serde/src/main/java/io/apicurio/registry/serde/jsonschema/JsonSchemaKafkaSerializer.java
+++ b/serdes/kafka/jsonschema-serde/src/main/java/io/apicurio/registry/serde/jsonschema/JsonSchemaKafkaSerializer.java
@@ -1,7 +1,6 @@
 package io.apicurio.registry.serde.jsonschema;
 
 import com.networknt.schema.JsonSchema;
-import io.apicurio.registry.resolver.ParsedSchema;
 import io.apicurio.registry.resolver.SchemaResolver;
 import io.apicurio.registry.resolver.strategy.ArtifactReferenceResolverStrategy;
 import io.apicurio.registry.rest.client.RegistryClient;
@@ -9,8 +8,6 @@ import io.apicurio.registry.serde.KafkaSerializer;
 import io.apicurio.registry.serde.headers.MessageTypeSerdeHeaders;
 import org.apache.kafka.common.header.Headers;
 
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -61,18 +58,12 @@ public class JsonSchemaKafkaSerializer<T> extends KafkaSerializer<JsonSchema, T>
         ((JsonSchemaSerializer<T>) delegatedSerializer).setValidationEnabled(validationEnabled);
     }
 
-    /**
-     * @see KafkaSerializer#serializeData(org.apache.kafka.common.header.Headers,
-     *      io.apicurio.registry.resolver.ParsedSchema, java.lang.Object, java.io.OutputStream)
-     */
     @Override
-    protected void serializeData(Headers headers, ParsedSchema<JsonSchema> schema, T data, OutputStream out)
-            throws IOException {
-
+    public byte[] serialize(String topic, Headers headers, T data) {
         if (headers != null) {
             serdeHeaders.addMessageTypeHeader(headers, data.getClass().getName());
         }
 
-        delegatedSerializer.serializeData(schema, data, out);
+        return super.serialize(topic, headers, data);
     }
 }

--- a/serdes/kafka/protobuf-serde/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufKafkaSerializer.java
+++ b/serdes/kafka/protobuf-serde/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufKafkaSerializer.java
@@ -1,7 +1,6 @@
 package io.apicurio.registry.serde.protobuf;
 
 import com.google.protobuf.Message;
-import io.apicurio.registry.resolver.ParsedSchema;
 import io.apicurio.registry.resolver.SchemaResolver;
 import io.apicurio.registry.resolver.strategy.ArtifactReferenceResolverStrategy;
 import io.apicurio.registry.rest.client.RegistryClient;
@@ -9,8 +8,6 @@ import io.apicurio.registry.serde.KafkaSerializer;
 import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
 import org.apache.kafka.common.header.Headers;
 
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,13 +43,8 @@ public class ProtobufKafkaSerializer<U extends Message> extends KafkaSerializer<
         serdeHeaders = new ProtobufSerdeHeaders(new HashMap<>(configs), isKey);
     }
 
-    /**
-     * @see KafkaSerializer#serializeData(org.apache.kafka.common.header.Headers,
-     *      io.apicurio.registry.resolver.ParsedSchema, java.lang.Object, java.io.OutputStream)
-     */
     @Override
-    protected void serializeData(Headers headers, ParsedSchema<ProtobufSchema> schema, U data,
-            OutputStream out) throws IOException {
+    public byte[] serialize(String topic, Headers headers, U data) {
         if (headers != null) {
             serdeHeaders.addMessageTypeHeader(headers, data.getClass().getName());
             serdeHeaders.addProtobufTypeNameHeader(headers, data.getDescriptorForType().getName());
@@ -60,6 +52,6 @@ public class ProtobufKafkaSerializer<U extends Message> extends KafkaSerializer<
             ((ProtobufSerializer<U>) delegatedSerializer).setWriteRef(false);
         }
 
-        delegatedSerializer.serializeData(schema, data, out);
+        return super.serialize(topic, headers, data);
     }
 }

--- a/serdes/kafka/serde-kafka-common/src/main/java/io/apicurio/registry/serde/KafkaSerializer.java
+++ b/serdes/kafka/serde-kafka-common/src/main/java/io/apicurio/registry/serde/KafkaSerializer.java
@@ -1,6 +1,5 @@
 package io.apicurio.registry.serde;
 
-import io.apicurio.registry.resolver.ParsedSchema;
 import io.apicurio.registry.resolver.SchemaLookupResult;
 import io.apicurio.registry.resolver.SchemaResolver;
 import io.apicurio.registry.resolver.utils.Utils;
@@ -14,7 +13,6 @@ import org.apache.kafka.common.serialization.Serializer;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.util.Map;
 
@@ -47,11 +45,6 @@ public class KafkaSerializer<T, U> implements Serializer<U> {
         this.headersHandler = headersHandler;
     }
 
-    protected void serializeData(Headers headers, ParsedSchema<T> schema, U data, OutputStream out)
-            throws IOException {
-        delegatedSerializer.serializeData(schema, data, out);
-    }
-
     @Override
     public byte[] serialize(String topic, U data) {
         return delegatedSerializer.serializeData(topic, data);
@@ -71,7 +64,7 @@ public class KafkaSerializer<T, U> implements Serializer<U> {
                         .resolveSchema(new SerdeRecord<>(resolverMetadata, data));
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                 headersHandler.writeHeaders(headers, schema.toArtifactReference());
-                this.serializeData(headers, schema.getParsedSchema(), data, out);
+                delegatedSerializer.serializeData(schema.getParsedSchema(), data, out);
                 return out.toByteArray();
             } else {
                 return delegatedSerializer.serializeData(topic, data);


### PR DESCRIPTION
It seems like the serializers were failing to store some needed metadata in the message headers.  For example, the JsonSchema serializer was not storing the bean type, resulting in `SimpleJsonSchemaExample` not working.