### PR TITLE
ci: make sure node version in workflows is 20

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Build Registry
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Set up Node.js v20
+      - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 20


### PR DESCRIPTION
I've encountered a Kiota-related build error with node 18.