### PR TITLE
 fix: exceptions in KafkaSqlStore do not trigger liveness checking #6021 

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/ImportException.java
+++ b/app/src/main/java/io/apicurio/registry/storage/ImportException.java
@@ -1,0 +1,28 @@
+package io.apicurio.registry.storage;
+
+import io.apicurio.registry.utils.impexp.Entity;
+import lombok.Getter;
+
+public class ImportException extends StorageException {
+
+    private static final long serialVersionUID = 8122199361950634285L;
+
+    @Getter
+    private final Entity entity;
+
+    public ImportException(String reason, Entity entity) {
+        super(reason);
+        this.entity = entity;
+    }
+
+    public ImportException(Entity entity, Throwable cause) {
+        super(cause);
+        this.entity = entity;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Import of entity '" + entity + "' has failed"
+               + (super.getMessage() != null ? ": " + super.getMessage() : ".");
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -29,11 +29,7 @@ import io.apicurio.registry.exception.UnreachableCodeException;
 import io.apicurio.registry.storage.*;
 import io.apicurio.registry.storage.dto.*;
 import io.apicurio.registry.storage.impexp.EntityInputStream;
-import io.apicurio.registry.storage.impl.sql.jdb.Handle;
-import io.apicurio.registry.storage.impl.sql.jdb.Query;
-import io.apicurio.registry.storage.impl.sql.jdb.RowMapper;
-import io.apicurio.registry.storage.impl.sql.jdb.RuntimeSqlException;
-import io.apicurio.registry.storage.impl.sql.jdb.Update;
+import io.apicurio.registry.storage.impl.sql.jdb.*;
 import io.apicurio.registry.storage.impl.sql.mappers.*;
 import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.RuleType;
@@ -92,6 +88,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
 
     // Sequence counters ** Note: only used for H2 in-memory **
     private static final Map<String, AtomicLong> sequenceCounters = new HashMap<>();
+
     static {
         sequenceCounters.put(GLOBAL_ID_SEQUENCE, new AtomicLong(0));
         sequenceCounters.put(CONTENT_ID_SEQUENCE, new AtomicLong(0));
@@ -3652,10 +3649,10 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                         .execute();
                 log.info("Artifact rule imported successfully.");
             } catch (Exception e) {
-                log.warn("Failed to import content entity (likely it already exists).", e);
+                throw new ImportException(entity, e);
             }
         } else {
-            log.warn("Artifact rule import failed: artifact not found.");
+            throw new ImportException("Artifact not found.", entity);
         }
     }
 
@@ -3673,9 +3670,8 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                         .execute();
                 log.info("Artifact entity imported successfully.");
             } catch (Exception e) {
-                log.warn("Failed to import artifact entity.", e);
+                throw new ImportException(entity, e);
             }
-
         }
 
         if (entity.globalId == -1 || !isGlobalIdExists(entity.globalId)) {
@@ -3763,10 +3759,10 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
 
                 log.info("Content entity imported successfully.");
             } else {
-                log.info("Duplicate content entity already exists, skipped.");
+                log.warn("Duplicate content entity already exists, skipped.");
             }
         } catch (Exception e) {
-            log.warn("Failed to import content entity.", e);
+            throw new ImportException(entity, e);
         }
     }
 
@@ -3780,7 +3776,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                     .execute();
             log.info("Global Rule entity imported successfully.");
         } catch (Exception e) {
-            log.warn("Failed to import content entity (likely it already exists).", e);
+            throw new ImportException(entity, e);
         }
     }
 
@@ -3800,7 +3796,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                     .execute();
             log.info("Group entity imported successfully.");
         } catch (Exception e) {
-            log.warn("Failed to import group entity (likely it already exists).", e);
+            throw new ImportException(entity, e);
         }
     }
 
@@ -3817,7 +3813,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                     .execute();
             log.info("Comment entity imported successfully.");
         } catch (Exception e) {
-            log.warn("Failed to import comment entity.", e);
+            throw new ImportException(entity, e);
         }
     }
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -300,7 +300,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
             @SuppressWarnings("unchecked")
             Class<IDbUpgrader> upgraderClass = (Class<IDbUpgrader>) Class.forName(cname);
             IDbUpgrader upgrader = upgraderClass.getConstructor().newInstance();
-            upgrader.upgrade( handle);
+            upgrader.upgrade(handle);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -638,7 +638,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
 
     @Transactional(Transactional.TxType.REQUIRES_NEW)
     protected void ensureContent(ContentHandle content, String contentHash, String canonicalContentHash,
-                               List<ArtifactReferenceDto> references, String referencesSerialized) {
+                                 List<ArtifactReferenceDto> references, String referencesSerialized) {
         this.handles.withHandle(handle -> {
             byte[] contentBytes = content.bytes();
 
@@ -1125,9 +1125,9 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
             // Formulate the SELECT clause for the artifacts query
             select.append(
                     "SELECT a.*, v.globalId, v.version, v.state, v.name, v.description, v.labels, v.properties, "
-                            + "v.createdBy AS modifiedBy, v.createdOn AS modifiedOn "
-                            + "FROM artifacts a "
-                            + "JOIN versions v ON a.tenantId = v.tenantId AND a.latest = v.globalId ");
+                    + "v.createdBy AS modifiedBy, v.createdOn AS modifiedOn "
+                    + "FROM artifacts a "
+                    + "JOIN versions v ON a.tenantId = v.tenantId AND a.latest = v.globalId ");
             if (joinContentTable) {
                 select.append("JOIN content c ON v.contentId = c.contentId AND v.tenantId = c.tenantId ");
             }
@@ -1149,13 +1149,13 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                         break;
                     case everything:
                         where.append("("
-                                + "v.name LIKE ? OR "
-                                + "v.groupId LIKE ? OR "
-                                + "a.artifactId LIKE ? OR "
-                                + "v.description LIKE ? OR "
-                                + "EXISTS(SELECT l.globalId FROM labels l WHERE l.label = ? AND l.globalId = v.globalId AND l.tenantId = v.tenantId) OR "
-                                + "EXISTS(SELECT p.globalId FROM properties p WHERE p.pkey = ? AND p.globalId = v.globalId AND p.tenantId = v.tenantId)"
-                                + ")");
+                                     + "v.name LIKE ? OR "
+                                     + "v.groupId LIKE ? OR "
+                                     + "a.artifactId LIKE ? OR "
+                                     + "v.description LIKE ? OR "
+                                     + "EXISTS(SELECT l.globalId FROM labels l WHERE l.label = ? AND l.globalId = v.globalId AND l.tenantId = v.tenantId) OR "
+                                     + "EXISTS(SELECT p.globalId FROM properties p WHERE p.pkey = ? AND p.globalId = v.globalId AND p.tenantId = v.tenantId)"
+                                     + ")");
                         binders.add((query, idx) -> {
                             query.bind(idx, "%" + filter.getStringValue() + "%");
                         });
@@ -1271,8 +1271,8 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
             Query artifactsQuery = handle.createQuery(artifactsQuerySql);
             // Query for the total row count
             String countSelect = "SELECT count(a.artifactId) "
-                    + "FROM artifacts a "
-                    + "JOIN versions v ON a.tenantId = v.tenantId AND a.latest = v.globalId ";
+                                 + "FROM artifacts a "
+                                 + "JOIN versions v ON a.tenantId = v.tenantId AND a.latest = v.globalId ";
             if (joinContentTable) {
                 countSelect += "JOIN content c ON v.contentId = c.contentId AND v.tenantId = c.tenantId ";
             }
@@ -3311,11 +3311,11 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
         return handles.withHandleNoException(handle -> {
             String sql = sqlStatements().selectArtifactCountById();
             return handle.createQuery(sql)
-                    .bind(0, tenantContext().tenantId())
-                    .bind(1, normalizeGroupId(groupId))
-                    .bind(2, artifactId)
-                    .mapTo(Integer.class)
-                    .one() > 0;
+                           .bind(0, tenantContext().tenantId())
+                           .bind(1, normalizeGroupId(groupId))
+                           .bind(2, artifactId)
+                           .mapTo(Integer.class)
+                           .one() > 0;
         });
     }
 
@@ -3327,10 +3327,10 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
         return handles.withHandleNoException(handle -> {
             String sql = sqlStatements().selectGroupCountById();
             return handle.createQuery(sql)
-                    .bind(0, tenantContext().tenantId())
-                    .bind(1, normalizeGroupId(groupId))
-                    .mapTo(Integer.class)
-                    .one() > 0;
+                           .bind(0, tenantContext().tenantId())
+                           .bind(1, normalizeGroupId(groupId))
+                           .mapTo(Integer.class)
+                           .one() > 0;
         });
     }
 
@@ -3429,9 +3429,9 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                         break;
                     case everything:
                         where.append("("
-                                + "g.groupId LIKE ? OR "
-                                + "g.description LIKE ? "
-                                + ")");
+                                     + "g.groupId LIKE ? OR "
+                                     + "g.description LIKE ? "
+                                     + ")");
                         binders.add((query, idx) -> {
                             query.bind(idx, "%" + filter.getStringValue() + "%");
                         });
@@ -3472,7 +3472,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
             Query groupsQuery = handle.createQuery(groupsQuerySql);
             // Query for the total row count
             String countSelect = "SELECT count(g.groupId) "
-                    + "FROM groups g ";
+                                 + "FROM groups g ";
 
             Query countQuery = handle.createQuery(countSelect + where.toString());
 
@@ -3822,10 +3822,10 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
         return handles.withHandleNoException(handle -> {
             String sql = sqlStatements().selectContentExists();
             return handle.createQuery(sql)
-                    .bind(0, contentId)
-                    .bind(1, tenantContext.tenantId())
-                    .mapTo(Integer.class)
-                    .one() > 0;
+                           .bind(0, contentId)
+                           .bind(1, tenantContext.tenantId())
+                           .mapTo(Integer.class)
+                           .one() > 0;
         });
     }
 
@@ -3833,10 +3833,10 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
         return handles.withHandleNoException(handle -> {
             String sql = sqlStatements().selectGlobalIdExists();
             return handle.createQuery(sql)
-                    .bind(0, globalId)
-                    .bind(1, tenantContext.tenantId())
-                    .mapTo(Integer.class)
-                    .one() > 0;
+                           .bind(0, globalId)
+                           .bind(1, tenantContext.tenantId())
+                           .mapTo(Integer.class)
+                           .one() > 0;
         });
     }
 

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
@@ -32,5 +32,5 @@ public interface KafkaSqlConfiguration {
     Properties producerProperties();
     Properties consumerProperties();
     Properties adminProperties();
-
+    boolean ignoreKafkaSqlTopicExceptions();
 }

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlFactory.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlFactory.java
@@ -145,6 +145,9 @@ public class KafkaSqlFactory {
     @ConfigProperty(name = "registry.kafkasql.ssl.key.password")
     Optional<String> keyPassword;
 
+    @ConfigProperty(name = "registry.kafkasql.ignore-topic-exceptions", defaultValue = "false")
+    boolean ignoreKafkaSqlTopicExceptions;
+
     @ApplicationScoped
     @Produces
     public KafkaSqlConfiguration createConfiguration() {
@@ -191,6 +194,10 @@ public class KafkaSqlFactory {
                 return adminProperties;
             }
 
+            @Override
+            public boolean ignoreKafkaSqlTopicExceptions() {
+                return ignoreKafkaSqlTopicExceptions;
+            }
         };
     }
 

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
@@ -63,7 +63,7 @@ public class KafkaSqlSubmitter {
      * @param value
      */
     public CompletableFuture<UUID> send(MessageKey key, MessageValue value) {
-        UUID requestId = coordinator.createUUID();
+        UUID requestId = coordinator.createUUID(key, value != null ? value.getAction() : null);
         RecordHeader header = new RecordHeader("req", requestId.toString().getBytes());
         ProducerRecord<MessageKey, MessageValue> record = new ProducerRecord<>(configuration.topic(), 0, key, value, Collections.singletonList(header));
         return producer.apply(record).thenApply(rm -> requestId);

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/WaitingOperation.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/WaitingOperation.java
@@ -1,0 +1,37 @@
+package io.apicurio.registry.storage.impl.kafkasql;
+
+import io.apicurio.registry.storage.impl.kafkasql.keys.MessageKey;
+import io.apicurio.registry.storage.impl.kafkasql.values.ActionType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+
+@Getter
+class WaitingOperation {
+
+    private final UUID uuid;
+    private final CountDownLatch latch;
+    private final Instant createdAt; // Protect against leaks
+
+    private final MessageKey key;
+
+    /**
+     * Might be null.
+     */
+    private final ActionType actionType;
+
+    @Setter
+    private volatile Object returnValue;
+
+    public WaitingOperation(MessageKey key, ActionType actionType) {
+        uuid = UUID.randomUUID();
+        latch = new CountDownLatch(1);
+        createdAt = Instant.now();
+
+        this.key = key;
+        this.actionType = actionType;
+    }
+}

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/AbstractMessageValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/AbstractMessageValue.java
@@ -27,6 +27,7 @@ public abstract class AbstractMessageValue implements MessageValue {
     /**
      * @return the action
      */
+    @Override
     public ActionType getAction() {
         return action;
     }
@@ -37,5 +38,4 @@ public abstract class AbstractMessageValue implements MessageValue {
     public void setAction(ActionType action) {
         this.action = action;
     }
-    
 }

--- a/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/MessageValue.java
+++ b/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/values/MessageValue.java
@@ -30,5 +30,6 @@ public interface MessageValue {
      */
     @JsonIgnore
     public MessageType getType();
-    
+
+    ActionType getAction();
 }


### PR DESCRIPTION
We have come across a case where after Registry (KafkaSQL) pod has started, h2 SQL exceptions were logged (probably because of topic corruption). The liveness check is expected to prevent the pod from running, but in this case the check was not triggered.

1. The initial hypothesis was that the `KafkaSqlStore` h2 DB was missing a liveness interceptor. However, I found out that [the exception was intentionally ignored](https://github.com/Apicurio/apicurio-registry/blob/2.4.x/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java#L3834). Since this might hide problems, I've created a new exception type and changed the code so it is thrown.
2. However, that change does not address the liveness part. Currently, all exceptions occurring when reading the topic are handled in [KafkaSqlSink](https://github.com/Apicurio/apicurio-registry/blob/2.4.x/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlSink.java#L121). There are two cases:

    1. The exception is caused by a message our node sent and should be handled by the HTTP thread (that code path includes liveness interceptor on `KafkaSqlRegistryStorage`)
    2. The exception is caused by a message from another node and is currently ignored. Instead of adding the interceptor to `KafkaSqlSink`, I've decided to add code here that triggers the liveness check under specific circumstances (see comment).

4. I also found out that despite liveness should be triggered in case 2 ii., that will happen only if the HTTP thread waits for the response, [which was not done for import operations](https://github.com/Apicurio/apicurio-registry/blob/2.4.x/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java#L1391). I've fixed this as well.
5. However, because there is no guarantee that an HTTP thread will wait on the response, we actually have a [slow memory leak in KafkaSqlCoordinator](https://github.com/Apicurio/apicurio-registry/blob/2.4.x/storage/kafkasql/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlCoordinator.java#L44-L45).
6. To address 3 and 4, I've added a code that would check for cases where the HTTP thread did not handle a return value or an exception, clean up, and determine if liveness check should be triggered.

I'll create a separate issue to investigate this for 3.x.