### PR TITLE
refactor(operator): replace use of CoreDNS (not supported by OCP) with host aliases

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/AuthITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/AuthITTest.java
@@ -40,6 +40,8 @@ public class AuthITTest extends BaseAuthTest {
 
         client.resource(registry).create();
 
+        hostAliasManager.defineHostAlias(registry);
+
         // Assertions, checks registry deployments exist
         checkDeploymentExists(registry, COMPONENT_APP, 1);
         checkDeploymentExists(registry, COMPONENT_UI, 1);
@@ -60,13 +62,13 @@ public class AuthITTest extends BaseAuthTest {
                 .contains(EnvironmentVariables.APICURIO_REGISTRY_UI_CLIENT_ID + "=" + "apicurio-registry");
         assertThat(appEnv).map(ev -> ev.getName() + "=" + ev.getValue())
                 .contains(EnvironmentVariables.APICURIO_REGISTRY_AUTH_SERVER_URL + "="
-                        + "https://simple-keycloak.apps.cluster.example/realms/registry");
+                          + "https://simple-keycloak.apps.cluster.example/realms/registry");
         assertThat(appEnv).map(ev -> ev.getName() + "=" + ev.getValue())
                 .contains(EnvironmentVariables.APICURIO_UI_AUTH_OIDC_REDIRECT_URI + "="
-                        + "https://simple-ui.apps.cluster.example");
+                          + "https://simple-ui.apps.cluster.example");
         assertThat(appEnv).map(ev -> ev.getName() + "=" + ev.getValue())
                 .contains(EnvironmentVariables.APICURIO_UI_AUTH_OIDC_LOGOUT_URL + "="
-                        + "https://simple-ui.apps.cluster.example");
+                          + "https://simple-ui.apps.cluster.example");
         assertThat(appEnv).map(ev -> ev.getName() + "=" + ev.getValue())
                 .contains(EnvironmentVariables.OIDC_TLS_VERIFICATION + "=" + "none");
 
@@ -76,5 +78,20 @@ public class AuthITTest extends BaseAuthTest {
                 EnvironmentVariables.APICURIO_AUTHN_BASIC_CLIENT_CREDENTIALS_CACHE_EXPIRATION + "=" + "25");
         assertThat(appEnv).map(ev -> ev.getName() + "=" + ev.getValue())
                 .contains(EnvironmentVariables.APICURIO_AUTH_ANONYMOUS_READ_ACCESS_ENABLED + "=" + "true");
+
+        try (var job = jobManager.runJob("""
+                #/bin/bash
+                CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+                    -X POST -H 'content-type: application/json' \
+                    --data '{"ruleType": "VALIDITY", "config": "FULL"}' \
+                    http://simple-app.apps.cluster.example:8080/apis/registry/v3/admin/rules\
+                  )
+                if [[ "$CODE" != "401" ]]; then
+                  echo "Authorization error expected, but got: $CODE";
+                  exit 1;
+                fi;
+                """)) {
+            assertThat(job.waitAndIsSuccessful()).isTrue();
+        }
     }
 }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/BaseAuthTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/BaseAuthTest.java
@@ -31,11 +31,11 @@ public abstract class BaseAuthTest extends ITBase {
                     .isEqualTo(1);
         });
 
-        createKeycloakDNSResolution("simple-keycloak.apps.cluster.example",
-                "keycloak." + namespace + ".svc.cluster.local");
-
         // Deploy Registry
         var registry = deserialize(apicurioResource, ApicurioRegistry3.class);
+
+        hostAliasManager.defineHostAlias("simple-keycloak.apps.cluster.example", "keycloak");
+        hostAliasManager.inject(registry);
 
         registry.getMetadata().setNamespace(namespace);
 

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/HostAliasManager.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/HostAliasManager.java
@@ -1,0 +1,111 @@
+package io.apicurio.registry.operator.it;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Spec;
+import io.apicurio.registry.operator.api.v1.spec.AppSpec;
+import io.apicurio.registry.operator.api.v1.spec.IngressSpec;
+import io.apicurio.registry.operator.api.v1.spec.UiSpec;
+import io.fabric8.kubernetes.api.model.HostAlias;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.util.*;
+import java.util.Map.Entry;
+
+import static java.util.Optional.ofNullable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class HostAliasManager {
+
+    private final KubernetesClient client;
+
+    // IP -> {host alias}
+    private final Map<String, Set<String>> hostAliasesMap = new HashMap<>();
+
+    public HostAliasManager(KubernetesClient client) {
+        this.client = client;
+    }
+
+    /**
+     * Define a host alias based on ApicurioRegistry3 ingress values.
+     */
+    public void defineHostAlias(ApicurioRegistry3 source) {
+        ofNullable(source.getSpec())
+                .map(ApicurioRegistry3Spec::getApp)
+                .map(AppSpec::getIngress)
+                .map(IngressSpec::getHost)
+                .ifPresent(h -> defineHostAlias(h, source.getMetadata().getName() + "-app-service"));
+        ofNullable(source.getSpec())
+                .map(ApicurioRegistry3Spec::getUi)
+                .map(UiSpec::getIngress)
+                .map(IngressSpec::getHost)
+                .ifPresent(h -> defineHostAlias(h, source.getMetadata().getName() + "-ui-service"));
+    }
+
+    /**
+     * Define a host alias to the target service.
+     */
+    public void defineHostAlias(String host, String serviceName) {
+        await().ignoreExceptions().until(() -> client.services().withName(serviceName).get() != null);
+        var clusterIP = client.services().withName(serviceName).get().getSpec().getClusterIP();
+        assertThat(clusterIP).isNotBlank();
+        hostAliasesMap.compute(clusterIP, (_ignored, v) -> {
+            if (v == null) {
+                v = new HashSet<>();
+            }
+            v.add(host);
+            return v;
+        });
+    }
+
+    /**
+     * Inject host aliases that have been defined into the resource.
+     */
+    public void inject(PodTemplateSpec target) {
+        if (hostAliasesMap.isEmpty()) {
+            return;
+        }
+        var spec = target.getSpec();
+        if (spec == null) {
+            spec = new PodSpec();
+            target.setSpec(spec);
+        }
+        var hostAliases = spec.getHostAliases();
+        if (hostAliases == null) {
+            hostAliases = new ArrayList<>();
+            spec.setHostAliases(hostAliases);
+        }
+        for (Entry<String, Set<String>> entry : hostAliasesMap.entrySet()) {
+            var hostAlias = hostAliases.stream().filter(ha -> ha.getIp().equals(entry.getKey())).findFirst().orElse(null);
+            if (hostAlias == null) {
+                hostAlias = new HostAlias(new ArrayList<>(), entry.getKey());
+                hostAliases.add(hostAlias);
+            }
+            hostAlias.getHostnames().addAll(entry.getValue());
+        }
+    }
+
+    /**
+     * Inject host aliases that have been defined into the resource.
+     */
+    public void inject(ApicurioRegistry3 target) {
+        var pts = ofNullable(target.getSpec()).map(ApicurioRegistry3Spec::getApp).map(AppSpec::getPodTemplateSpec).orElse(null);
+        if (pts == null) {
+            pts = new PodTemplateSpec();
+            target.getSpec().withApp().setPodTemplateSpec(pts);
+        }
+        inject(pts);
+        pts = ofNullable(target.getSpec()).map(ApicurioRegistry3Spec::getUi).map(UiSpec::getPodTemplateSpec).orElse(null);
+        if (pts == null) {
+            pts = new PodTemplateSpec();
+            target.getSpec().withUi().setPodTemplateSpec(pts);
+        }
+        inject(pts);
+    }
+
+    public void clear() {
+        hostAliasesMap.clear();
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -2,8 +2,6 @@ package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.Constants;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
-import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -24,15 +22,12 @@ import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.util.TypeLiteral;
 import org.awaitility.Awaitility;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -72,6 +67,8 @@ public abstract class ITBase {
     protected static String namespace;
     protected static boolean cleanup;
     private static Operator operator;
+    protected static JobManager jobManager;
+    protected static HostAliasManager hostAliasManager;
 
     @BeforeAll
     public static void before() throws Exception {
@@ -92,6 +89,8 @@ public abstract class ITBase {
         portForwardManager = new PortForwardManager(client, namespace);
         ingressManager = new IngressManager(client, namespace);
         podLogManager = new PodLogManager(client);
+        hostAliasManager = new HostAliasManager(client);
+        jobManager = new JobManager(client, hostAliasManager);
 
         if (operatorDeployment == OperatorDeployment.remote) {
             createTestResources();
@@ -164,7 +163,7 @@ public abstract class ITBase {
     }
 
     protected static PodDisruptionBudget checkPodDisruptionBudgetExists(ApicurioRegistry3 primary,
-            String component) {
+                                                                        String component) {
         final ValueOrNull<PodDisruptionBudget> rval = new ValueOrNull<>();
 
         await().ignoreExceptions().untilAsserted(() -> {
@@ -272,46 +271,11 @@ public abstract class ITBase {
         });
     }
 
-    static void createKeycloakDNSResolution(String ingressHostname, String keycloakService) {
-        String configMapName = "coredns";
-        String systemNamespace = "kube-system";
-
-        // Step 1: Fetch the existing CoreDNS ConfigMap
-        ConfigMap existingConfigMap = client.configMaps().inNamespace(systemNamespace).withName(configMapName)
-                .get();
-
-        if (existingConfigMap == null) {
-            throw new IllegalStateException("Error: CoreDNS ConfigMap not found!");
-        }
-
-        // Step 2: Modify the CoreDNS configuration
-        String corefile = existingConfigMap.getData().get("Corefile");
-
-        // Step 3: Append the rewrite rule to Corefile
-        String newCorefile = corefile.replaceFirst("\\.:53 \\{",
-                ".:53 {\n    rewrite name " + ingressHostname + " " + keycloakService);
-
-        // Step 4: Create the updated ConfigMap, ensuring resourceVersion is included
-        ConfigMap updatedConfigMap = new ConfigMapBuilder().withMetadata(existingConfigMap.getMetadata()) // Preserve
-                                                                                                          // metadata
-                                                                                                          // (including
-                                                                                                          // UID)
-                .addToData("Corefile", newCorefile).build();
-
-        // Step 5: Apply the updated ConfigMap
-        client.configMaps().inNamespace(systemNamespace).resource(updatedConfigMap).update();
-
-        log.info("CoreDNS ConfigMap updated successfully!");
-
-        // Step 6: Restart CoreDNS to apply changes
-        client.apps().deployments().inNamespace(systemNamespace).withName("coredns").rolling().restart();
-    }
-
     static void createNamespace(KubernetesClient client, String namespace) {
         log.info("Creating Namespace {}", namespace);
         client.resource(
-                new NamespaceBuilder().withNewMetadata().addToLabels("app", "apicurio-registry-operator-test")
-                        .withName(namespace).endMetadata().build())
+                        new NamespaceBuilder().withNewMetadata().addToLabels("app", "apicurio-registry-operator-test")
+                                .withName(namespace).endMetadata().build())
                 .create();
     }
 

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/JobManager.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/JobManager.java
@@ -1,0 +1,113 @@
+package io.apicurio.registry.operator.it;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.util.UUID;
+
+import static org.awaitility.Awaitility.await;
+
+public class JobManager {
+
+    private final KubernetesClient client;
+    private final HostAliasManager hostAliasManager;
+
+    public JobManager(KubernetesClient client, HostAliasManager hostAliasManager) {
+        this.client = client;
+        this.hostAliasManager = hostAliasManager;
+    }
+
+    /**
+     * Run a job in the cluster, with the given bash script as an input.
+     */
+    public JobHandle runJob(String bashScript) {
+        var suffix = UUID.randomUUID().toString().substring(0, 7);
+
+        // @formatter:off
+        var data = new ConfigMapBuilder()
+                .withNewMetadata()
+                    .withName("data-" + suffix)
+                .endMetadata()
+                .addToData("script.sh", bashScript)
+                .build();
+        // @formatter:on
+
+        // @formatter:off
+        var job = new JobBuilder()
+                .withNewMetadata()
+                    .withName("job-" + suffix)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewTemplate()
+                        .withNewMetadata()
+                            .withName("worker-" + suffix)
+                        .endMetadata()
+                        .withNewSpec()
+                            .addNewContainer()
+                                .withName("worker")
+                                .withImage("registry.access.redhat.com/ubi9/ubi:latest") // Fedora?
+                                .withCommand("/bin/bash", "/mnt/data/script.sh")
+                                .addNewVolumeMount()
+                                    .withName("data")
+                                    .withMountPath("/mnt/data")
+                                .endVolumeMount()
+                            .endContainer()
+                            .addNewVolume()
+                                .withName("data")
+                                .withNewConfigMap()
+                                    .withName("data-" + suffix)
+                                .endConfigMap()
+                            .endVolume()
+                            .withRestartPolicy("Never")
+                        .endSpec()
+                    .endTemplate()
+                    .withBackoffLimit(0)
+                .endSpec()
+                .build();
+        // @formatter:on
+
+        hostAliasManager.inject(job.getSpec().getTemplate());
+
+        client.resource(data).create();
+        client.resource(job).create();
+
+        return new JobHandle(client, suffix);
+    }
+
+    public static class JobHandle implements AutoCloseable {
+
+        private final KubernetesClient client;
+
+        private final String suffix;
+
+        JobHandle(KubernetesClient client, String suffix) {
+            this.client = client;
+            this.suffix = suffix;
+        }
+
+        /**
+         * Wait until the job finishes.
+         *
+         * @return true if the job has been successful (script returned code 0).
+         */
+        public boolean waitAndIsSuccessful() {
+            await().ignoreExceptions().until(() -> {
+                var status = client.batch().v1().jobs().withName("job-" + suffix).get().getStatus();
+                return status.getSucceeded() == 1 || status.getFailed() == 1;
+            });
+            return isSuccessful();
+        }
+
+        public boolean isSuccessful() {
+            var status = client.batch().v1().jobs().withName("job-" + suffix).get().getStatus();
+            return status.getSucceeded() == 1;
+        }
+
+        @Override
+        public void close() {
+            client.configMaps().withName("data-" + suffix).delete();
+            client.batch().v1().jobs().withName("job-" + suffix).delete();
+        }
+    }
+}


### PR DESCRIPTION
I've been using OCP for development and testing for some time, and I can't do it with CoreDNS, so I found an alternative. 