### PR TITLE
XSD Validation level SYNTAX_ONLY does nothing

### DIFF
--- a/schema-util/xsd/src/main/java/io/apicurio/registry/rules/validity/XsdContentValidator.java
+++ b/schema-util/xsd/src/main/java/io/apicurio/registry/rules/validity/XsdContentValidator.java
@@ -27,7 +27,7 @@ public class XsdContentValidator extends XmlContentValidator {
             Map<String, TypedContent> resolvedReferences) throws RuleViolationException {
         super.validate(level, content, resolvedReferences);
 
-        if (level == ValidityLevel.FULL) {
+        if (level == ValidityLevel.SYNTAX_ONLY || level == ValidityLevel.FULL) {
             try (InputStream semanticStream = content.getContent().stream()) {
                 // validate that its a valid schema
                 Source source = new StreamSource(semanticStream);


### PR DESCRIPTION
I believe this is an oversight - other types (AVRO, PROTOBUF, GRAPHQL, KCONN) where there is only one level of validation possible, will also perform the check when the level SYNTAX_ONLY is set.