### PR TITLE
Update quarkus dependency to patched version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <!--
     WARNING: The following group of dependencies has to be aligned with the corresponding Quarkus version.
     -->
-    <quarkus.version>3.15.4</quarkus.version>
+    <quarkus.version>3.15.3.1</quarkus.version>
     <!--
     Go to `io.quarkiverse.operatorsdk:quarkus-operator-sdk-bom` and then to the parent `io.quarkiverse.operatorsdk:quarkus-operator-sdk-parent`,
     e.g. https://repo1.maven.org/maven2/io/quarkiverse/operatorsdk/quarkus-operator-sdk-parent/6.8.4/quarkus-operator-sdk-parent-6.8.4.pom


### PR DESCRIPTION
Update quarkus dependency to patched version to fix CVE-2025-1634
https://nvd.nist.gov/vuln/detail/CVE-2025-1634



