### PR TITLE
chore(operator): updates after the first release

### DIFF
--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -195,6 +195,7 @@ jobs:
         run: |
           # We want to use latest-snapshot instead of x.y.z-snapshot
           echo "export IMAGE_TAG=latest-snapshot" >> "$CUSTOM_ENV"
+          echo "export OPERAND_IMAGE_TAG=latest-snapshot" >> "$CUSTOM_ENV"
 
       - name: Prepare post-release changes
         working-directory: registry/operator

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -159,11 +159,7 @@ jobs:
         run: |
           git checkout -b "$RELEASE_BRANCH"
           TITLE="Release Apicurio Registry Operator $PACKAGE_VERSION"
-          BODY="$(curl -s https://raw.githubusercontent.com/k8s-operatorhub/community-operators/main/docs/pull_request_template.md)"
-          # TODO: Remove after first release
-          mkdir operators/apicurio-registry-3
-          # TODO: Remove after first release
-          echo -e "---\nupdateGraph: replaces-mode\nreviewers:\n  - apicurio-ci\n  - carlesarnal\n  - EricWittmann  - jsenko\n" > operators/apicurio-registry-3/ci.yaml
+          BODY="$(curl -s https://raw.githubusercontent.com/k8s-operatorhub/community-operators/main/docs/pull_request_template.md)"          
           cp -r "../registry/operator/target/bundle/apicurio-registry-3/$PACKAGE_VERSION" operators/apicurio-registry-3
           git add .
           git commit -s -m "$TITLE"
@@ -188,10 +184,6 @@ jobs:
           git checkout -b "$RELEASE_BRANCH"
           TITLE="Release Apicurio Registry Operator $PACKAGE_VERSION"
           BODY="$(curl -s https://raw.githubusercontent.com/redhat-openshift-ecosystem/community-operators-prod/main/docs/pull_request_template.md)"
-          # TODO: Remove after first release
-          mkdir operators/apicurio-registry-3
-          # TODO: Remove after first release
-          echo -e "---\nupdateGraph: replaces-mode\nreviewers:\n  - apicurio-ci\n  - carlesarnal\n  - EricWittmann  - jsenko\n" > operators/apicurio-registry-3/ci.yaml
           cp -r "../registry/operator/target/bundle/apicurio-registry-3/$PACKAGE_VERSION" operators/apicurio-registry-3
           git add .
           git commit -s -m "$TITLE"

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -39,7 +39,6 @@ PACKAGE ?= $(PACKAGE_NAME).v$(LC_VERSION)
 
 PREVIOUS_PACKAGE_VERSION ?= 3.0.7
 PREVIOUS_PACKAGE ?= $(PACKAGE_NAME).v$(PREVIOUS_PACKAGE_VERSION)
-# TODO: Handle `replaces` after first release
 
 CHANNELS ?= 3.x
 DEFAULT_CHANNEL ?= $(CHANNELS)
@@ -100,6 +99,8 @@ export PLACEHOLDER_DATE := $(DATE)
 
 export PLACEHOLDER_PACKAGE_NAME := $(PACKAGE_NAME)
 export PLACEHOLDER_PACKAGE := $(PACKAGE)
+export PLACEHOLDER_PREVIOUS_PACKAGE := $(PREVIOUS_PACKAGE)
+
 export PLACEHOLDER_BUNDLE_IMAGE := $(BUNDLE_IMAGE)
 
 export PLACEHOLDER_CATALOG_NAMESPACE := $(CATALOG_NAMESPACE)
@@ -419,6 +420,7 @@ catalog-subscription-undeploy: ## TODO
 release-catalog-template-update: install-yq
 	$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name = "3.x") | .entries[] | select(.name = "$${PLACEHOLDER_PACKAGE}")).name = "$(PREVIOUS_PACKAGE)"' -i $(CATALOG_DIR)/catalog.template.yaml
 	$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name = "3.x") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}", "replaces": "$(PREVIOUS_PACKAGE)"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml
+	$(YQ) '.entries |= . + [{"schema": "olm.bundle", "image": "$(BUNDLE_IMAGE)"}]' -i $(CATALOG_DIR)/catalog.template.yaml
 
 
 .PHONY: dev

--- a/operator/controller/src/main/deploy/csv/apicurio-registry-3.clusterserviceversion.yaml
+++ b/operator/controller/src/main/deploy/csv/apicurio-registry-3.clusterserviceversion.yaml
@@ -102,4 +102,5 @@ spec:
     name: Apicurio
   selector: {}
   version: 0.0.0
+  replaces: ${PLACEHOLDER_PREVIOUS_PACKAGE}
   minKubeVersion: 1.25.0

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -290,8 +290,10 @@ public abstract class ITBase {
     }
 
     static void applyStrimziResources() throws IOException {
-        try (BufferedInputStream in = new BufferedInputStream(
-                new URL("https://strimzi.io/install/latest").openStream())) {
+        // TODO: IMPORTANT: Strimzi >0.45 only supports Kraft-based Kafka clusters. Migration needed.
+        // var strimziClusterOperatorURL = new URL("https://strimzi.io/install/latest");
+        var strimziClusterOperatorURL = new URL("https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.45.0/strimzi-cluster-operator-0.45.0.yaml");
+        try (BufferedInputStream in = new BufferedInputStream(strimziClusterOperatorURL.openStream())) {
             List<HasMetadata> resources = Serialization.unmarshal(in);
             resources.forEach(r -> {
                 if (r.getKind().equals("ClusterRoleBinding") && r instanceof ClusterRoleBinding) {

--- a/operator/install/install.yaml
+++ b/operator/install/install.yaml
@@ -6714,9 +6714,9 @@ spec:
         - name: QUARKUS_PROFILE
           value: prod
         - name: REGISTRY_APP_IMAGE
-          value: quay.io/apicurio/apicurio-registry:3.0.7
+          value: quay.io/apicurio/apicurio-registry:latest-snapshot
         - name: REGISTRY_UI_IMAGE
-          value: quay.io/apicurio/apicurio-registry-ui:3.0.7
+          value: quay.io/apicurio/apicurio-registry-ui:latest-snapshot
         image: quay.io/apicurio/apicurio-registry-3-operator:latest-snapshot
         imagePullPolicy: Always
         livenessProbe:

--- a/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
+++ b/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
@@ -12,3 +12,5 @@ entries:
       - name: apicurio-registry-3.v3.0.7
   - schema: olm.bundle
     image: ${PLACEHOLDER_BUNDLE_IMAGE}
+  - schema: olm.bundle
+    image: quay.io/apicurio/apicurio-registry-3-operator-bundle:3.0.7


### PR DESCRIPTION
Should resolve workflow failures in #6193 and #6195 