### PR TITLE
fix: Wrong groupid registering referenced avro schema with apicurio-registry-maven-plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.2.5</version>
+    </extension>
+</extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,0 @@
-<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
-    <extension>
-        <groupId>com.google.cloud.artifactregistry</groupId>
-        <artifactId>artifactregistry-maven-wagon</artifactId>
-        <version>2.2.5</version>
-    </extension>
-</extensions>

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/refs/AbstractReferenceArtifactIdentifierExtractor.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/refs/AbstractReferenceArtifactIdentifierExtractor.java
@@ -1,0 +1,13 @@
+package io.apicurio.registry.content.refs;
+
+public class AbstractReferenceArtifactIdentifierExtractor implements ReferenceArtifactIdentifierExtractor {
+    @Override
+    public String extractArtifactId(String fullReference) {
+        return fullReference;
+    }
+
+    @Override
+    public String extractGroupId(String fullReference) {
+        return null;
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/refs/AvroReferenceArtifactIdentifierExtractor.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/refs/AvroReferenceArtifactIdentifierExtractor.java
@@ -1,0 +1,21 @@
+package io.apicurio.registry.content.refs;
+
+public class AvroReferenceArtifactIdentifierExtractor extends AbstractReferenceArtifactIdentifierExtractor {
+    @Override
+    public String extractArtifactId(String fullReference) {
+        if (fullReference == null || fullReference.isEmpty()) {
+            return null;
+        }
+        int lastDot = fullReference.lastIndexOf(".");
+        return fullReference.substring(lastDot + 1);
+    }
+
+    @Override
+    public String extractGroupId(String fullReference) {
+        if (fullReference == null || fullReference.isEmpty()) {
+            return null;
+        }
+        int lastDot = fullReference.lastIndexOf(".");
+        return lastDot < 0 ? null : fullReference.substring(0, lastDot);
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/refs/DefaultReferenceArtifactIdentifierExtractor.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/refs/DefaultReferenceArtifactIdentifierExtractor.java
@@ -1,0 +1,4 @@
+package io.apicurio.registry.content.refs;
+
+public class DefaultReferenceArtifactIdentifierExtractor extends AbstractReferenceArtifactIdentifierExtractor {
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/refs/ReferenceArtifactIdentifierExtractor.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/refs/ReferenceArtifactIdentifierExtractor.java
@@ -1,0 +1,7 @@
+package io.apicurio.registry.content.refs;
+
+public interface ReferenceArtifactIdentifierExtractor {
+    String extractArtifactId(String fullReference);
+
+    String extractGroupId(String fullReference);
+}

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/AbstractArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/AbstractArtifactTypeUtilProvider.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.types.provider;
 
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
 import io.apicurio.registry.content.extract.ContentExtractor;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
 import io.apicurio.registry.rules.validity.ContentValidator;
 
@@ -11,6 +12,7 @@ public abstract class AbstractArtifactTypeUtilProvider implements ArtifactTypeUt
     private volatile ContentCanonicalizer canonicalizer;
     private volatile ContentValidator validator;
     private volatile ContentExtractor extractor;
+    private volatile ReferenceArtifactIdentifierExtractor referenceArtifactIdentifierExtractor;
 
     @Override
     public CompatibilityChecker getCompatibilityChecker() {
@@ -51,4 +53,14 @@ public abstract class AbstractArtifactTypeUtilProvider implements ArtifactTypeUt
     }
 
     protected abstract ContentExtractor createContentExtractor();
+
+    protected abstract ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor();
+
+    @Override
+    public ReferenceArtifactIdentifierExtractor getReferenceArtifactIdentifierExtractor() {
+        if (referenceArtifactIdentifierExtractor == null) {
+            referenceArtifactIdentifierExtractor = createReferenceArtifactIdentifierExtractor();
+        }
+        return referenceArtifactIdentifierExtractor;
+    }
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ArtifactTypeUtilProvider.java
@@ -4,6 +4,7 @@ import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
 import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.extract.ContentExtractor;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
 import io.apicurio.registry.rules.validity.ContentValidator;
@@ -36,4 +37,6 @@ public interface ArtifactTypeUtilProvider {
     ReferenceFinder getReferenceFinder();
 
     boolean supportsReferencesWithContext();
+
+    ReferenceArtifactIdentifierExtractor getReferenceArtifactIdentifierExtractor();
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/AsyncApiArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/AsyncApiArtifactTypeUtilProvider.java
@@ -9,6 +9,8 @@ import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.extract.AsyncApiContentExtractor;
 import io.apicurio.registry.content.extract.ContentExtractor;
 import io.apicurio.registry.content.refs.AsyncApiReferenceFinder;
+import io.apicurio.registry.content.refs.DefaultReferenceArtifactIdentifierExtractor;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.content.util.ContentTypeUtil;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
@@ -65,6 +67,11 @@ public class AsyncApiArtifactTypeUtilProvider extends AbstractArtifactTypeUtilPr
     @Override
     protected ContentExtractor createContentExtractor() {
         return new AsyncApiContentExtractor();
+    }
+
+    @Override
+    protected ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor() {
+        return new DefaultReferenceArtifactIdentifierExtractor();
     }
 
     @Override

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/AvroArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/AvroArtifactTypeUtilProvider.java
@@ -7,7 +7,9 @@ import io.apicurio.registry.content.dereference.AvroDereferencer;
 import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.extract.AvroContentExtractor;
 import io.apicurio.registry.content.extract.ContentExtractor;
+import io.apicurio.registry.content.refs.AvroReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.AvroReferenceFinder;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.content.util.ContentTypeUtil;
 import io.apicurio.registry.rules.compatibility.AvroCompatibilityChecker;
@@ -97,6 +99,11 @@ public class AvroArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvid
     @Override
     public boolean supportsReferencesWithContext() {
         return false;
+    }
+
+    @Override
+    protected ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor() {
+        return new AvroReferenceArtifactIdentifierExtractor();
     }
 
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/DefaultArtifactTypeUtilProviderImpl.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/DefaultArtifactTypeUtilProviderImpl.java
@@ -54,4 +54,5 @@ public class DefaultArtifactTypeUtilProviderImpl implements ArtifactTypeUtilProv
 
         return contentType;
     }
+
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/GraphQLArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/GraphQLArtifactTypeUtilProvider.java
@@ -8,7 +8,9 @@ import io.apicurio.registry.content.canon.GraphQLContentCanonicalizer;
 import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.extract.ContentExtractor;
 import io.apicurio.registry.content.extract.NoopContentExtractor;
+import io.apicurio.registry.content.refs.DefaultReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.NoOpReferenceFinder;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
 import io.apicurio.registry.rules.compatibility.NoopCompatibilityChecker;
@@ -78,6 +80,11 @@ public class GraphQLArtifactTypeUtilProvider extends AbstractArtifactTypeUtilPro
     @Override
     public boolean supportsReferencesWithContext() {
         return false;
+    }
+
+    @Override
+    protected ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor() {
+        return new DefaultReferenceArtifactIdentifierExtractor();
     }
 
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/JsonArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/JsonArtifactTypeUtilProvider.java
@@ -8,7 +8,9 @@ import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.dereference.JsonSchemaDereferencer;
 import io.apicurio.registry.content.extract.ContentExtractor;
 import io.apicurio.registry.content.extract.JsonContentExtractor;
+import io.apicurio.registry.content.refs.DefaultReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.JsonSchemaReferenceFinder;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.content.util.ContentTypeUtil;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
@@ -77,6 +79,11 @@ public class JsonArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvid
     @Override
     public boolean supportsReferencesWithContext() {
         return true;
+    }
+
+    @Override
+    protected ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor() {
+        return new DefaultReferenceArtifactIdentifierExtractor();
     }
 
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/KConnectArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/KConnectArtifactTypeUtilProvider.java
@@ -6,7 +6,9 @@ import io.apicurio.registry.content.canon.KafkaConnectContentCanonicalizer;
 import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.extract.ContentExtractor;
 import io.apicurio.registry.content.extract.NoopContentExtractor;
+import io.apicurio.registry.content.refs.DefaultReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.NoOpReferenceFinder;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
 import io.apicurio.registry.rules.compatibility.NoopCompatibilityChecker;
@@ -63,6 +65,11 @@ public class KConnectArtifactTypeUtilProvider extends AbstractArtifactTypeUtilPr
     @Override
     public boolean supportsReferencesWithContext() {
         return false;
+    }
+
+    @Override
+    protected ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor() {
+        return new DefaultReferenceArtifactIdentifierExtractor();
     }
 
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/OpenApiArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/OpenApiArtifactTypeUtilProvider.java
@@ -8,7 +8,9 @@ import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.dereference.OpenApiDereferencer;
 import io.apicurio.registry.content.extract.ContentExtractor;
 import io.apicurio.registry.content.extract.OpenApiContentExtractor;
+import io.apicurio.registry.content.refs.DefaultReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.OpenApiReferenceFinder;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.content.util.ContentTypeUtil;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
@@ -80,6 +82,11 @@ public class OpenApiArtifactTypeUtilProvider extends AbstractArtifactTypeUtilPro
     @Override
     public boolean supportsReferencesWithContext() {
         return true;
+    }
+
+    @Override
+    protected ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor() {
+        return new DefaultReferenceArtifactIdentifierExtractor();
     }
 
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ProtobufArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ProtobufArtifactTypeUtilProvider.java
@@ -8,7 +8,9 @@ import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.dereference.ProtobufDereferencer;
 import io.apicurio.registry.content.extract.ContentExtractor;
 import io.apicurio.registry.content.extract.NoopContentExtractor;
+import io.apicurio.registry.content.refs.DefaultReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ProtobufReferenceFinder;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
 import io.apicurio.registry.rules.compatibility.ProtobufCompatibilityChecker;
@@ -83,6 +85,11 @@ public class ProtobufArtifactTypeUtilProvider extends AbstractArtifactTypeUtilPr
     @Override
     public boolean supportsReferencesWithContext() {
         return false;
+    }
+
+    @Override
+    protected ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor() {
+        return new DefaultReferenceArtifactIdentifierExtractor();
     }
 
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/WsdlArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/WsdlArtifactTypeUtilProvider.java
@@ -6,7 +6,9 @@ import io.apicurio.registry.content.canon.XmlContentCanonicalizer;
 import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.extract.ContentExtractor;
 import io.apicurio.registry.content.extract.WsdlOrXsdContentExtractor;
+import io.apicurio.registry.content.refs.DefaultReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.NoOpReferenceFinder;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.content.util.ContentTypeUtil;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
@@ -98,6 +100,11 @@ public class WsdlArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvid
     @Override
     public boolean supportsReferencesWithContext() {
         return false;
+    }
+
+    @Override
+    protected ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor() {
+        return new DefaultReferenceArtifactIdentifierExtractor();
     }
 
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/XmlArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/XmlArtifactTypeUtilProvider.java
@@ -6,7 +6,9 @@ import io.apicurio.registry.content.canon.XmlContentCanonicalizer;
 import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.extract.ContentExtractor;
 import io.apicurio.registry.content.extract.NoopContentExtractor;
+import io.apicurio.registry.content.refs.DefaultReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.NoOpReferenceFinder;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.content.util.ContentTypeUtil;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
@@ -102,6 +104,11 @@ public class XmlArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvide
     @Override
     public boolean supportsReferencesWithContext() {
         return false;
+    }
+
+    @Override
+    protected ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor() {
+        return new DefaultReferenceArtifactIdentifierExtractor();
     }
 
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/XsdArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/XsdArtifactTypeUtilProvider.java
@@ -6,7 +6,9 @@ import io.apicurio.registry.content.canon.XmlContentCanonicalizer;
 import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.extract.ContentExtractor;
 import io.apicurio.registry.content.extract.WsdlOrXsdContentExtractor;
+import io.apicurio.registry.content.refs.DefaultReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.NoOpReferenceFinder;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
 import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.content.util.ContentTypeUtil;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
@@ -97,6 +99,11 @@ public class XsdArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvide
     @Override
     public boolean supportsReferencesWithContext() {
         return false;
+    }
+
+    @Override
+    protected ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor() {
+        return new DefaultReferenceArtifactIdentifierExtractor();
     }
 
 }


### PR DESCRIPTION
Currently when defining a schema that references another schema, the apicurio-registry-maven-plugin registers the referenced schema using the parent groupid and set the referenced schema artifactid to its fullname (`groupid.artifactid`).
This issue defeats the very purpose of having separate schemas to put some avro object definition in common.

The proposed solution is to create a `ReferenceArtifactIdentifierExtractor` util that is in charge of parsing the artifact id and group id from the external reference `resource` string. An AVRO implementation just break down the resource and separate the artifact id from the group id depending on the position of the last existing `.` according to AVRO 1.12.0 specification. Other implementations are just a default one mimicking the current behavior : groupid = null, artifactid = resource.