### PR TITLE
 Fix for JIRA ticket 1062: deleting subjects that have inbound refs using the ccompat API [3.0.x]

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
@@ -832,6 +832,14 @@ public interface RegistryStorage extends DynamicConfigStorage {
     List<Long> getGlobalIdsReferencingArtifactVersion(String groupId, String artifactId, String version);
 
     /**
+     * Gets a list of global IDs that have at least one reference to any version of the given artifact.
+     * @param groupId
+     * @param artifactId
+     * @return list of global IDs of artifact verions that reference any version of the artifact
+     */
+    List<Long> getGlobalIdsReferencingArtifact(String groupId, String artifactId);
+
+    /**
      * Gets a list of inbound references for a given artifact version.
      * 
      * @param groupId

--- a/app/src/main/java/io/apicurio/registry/storage/decorator/RegistryStorageDecoratorReadOnlyBase.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/RegistryStorageDecoratorReadOnlyBase.java
@@ -306,6 +306,11 @@ public abstract class RegistryStorageDecoratorReadOnlyBase implements RegistrySt
     }
 
     @Override
+    public List<Long> getGlobalIdsReferencingArtifact(String groupId, String artifactId) {
+        return delegate.getGlobalIdsReferencingArtifact(groupId, artifactId);
+    }
+
+    @Override
     public List<ArtifactReferenceDto> getInboundArtifactReferences(String groupId, String artifactId,
             String version) {
         return delegate.getInboundArtifactReferences(groupId, artifactId, version);

--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsRegistryStorage.java
@@ -433,6 +433,11 @@ public class GitOpsRegistryStorage extends AbstractReadOnlyRegistryStorage {
     }
 
     @Override
+    public List<Long> getGlobalIdsReferencingArtifact(String groupId, String artifactId) {
+        return proxy(storage -> storage.getGlobalIdsReferencingArtifact(groupId, artifactId));
+    }
+
+    @Override
     public List<ArtifactReferenceDto> getInboundArtifactReferences(String groupId, String artifactId,
             String version) {
         return proxy(storage -> storage.getInboundArtifactReferences(groupId, artifactId, version));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -2782,8 +2782,17 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     public List<Long> getGlobalIdsReferencingArtifactVersion(String groupId, String artifactId,
             String version) {
         return handles.withHandleNoException(handle -> {
-            return handle.createQuery(sqlStatements().selectGlobalIdsReferencingArtifactBy())
+            return handle.createQuery(sqlStatements().selectGlobalIdsReferencingArtifactVersionBy())
                     .bind(0, normalizeGroupId(groupId)).bind(1, artifactId).bind(2, version).mapTo(Long.class)
+                    .list();
+        });
+    }
+
+    @Override
+    public List<Long> getGlobalIdsReferencingArtifact(String groupId, String artifactId) {
+        return handles.withHandleNoException(handle -> {
+            return handle.createQuery(sqlStatements().selectGlobalIdsReferencingArtifactBy())
+                    .bind(0, normalizeGroupId(groupId)).bind(1, artifactId).mapTo(Long.class)
                     .list();
         });
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -1046,8 +1046,13 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     @Override
-    public String selectGlobalIdsReferencingArtifactBy() {
+    public String selectGlobalIdsReferencingArtifactVersionBy() {
         return "SELECT DISTINCT v.globalId FROM versions v JOIN content_references ar ON v.contentId=ar.contentId WHERE ar.groupId=? AND ar.artifactId=? AND ar.version=?";
+    }
+
+    @Override
+    public String selectGlobalIdsReferencingArtifactBy() {
+        return "SELECT DISTINCT v.globalId FROM versions v JOIN content_references ar ON v.contentId=ar.contentId WHERE ar.groupId=? AND ar.artifactId=?";
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -371,6 +371,11 @@ public interface SqlStatements {
     public String selectContentIdsReferencingArtifactBy();
 
     /**
+     * A statement to select global ids of artifact versions with content referencing an artifact version
+     */
+    public String selectGlobalIdsReferencingArtifactVersionBy();
+
+    /**
      * A statement to select global ids of artifact versions with content referencing an artifact
      */
     public String selectGlobalIdsReferencingArtifactBy();

--- a/app/src/test/java/io/apicurio/registry/noprofile/Ticket1062Test.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/Ticket1062Test.java
@@ -1,0 +1,187 @@
+package io.apicurio.registry.noprofile;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.client.models.ArtifactReference;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import io.apicurio.registry.rest.client.models.VersionMetaData;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.MutabilityEnabledProfile;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reproducer for:  https://issues.redhat.com/browse/IPT-1062
+ */
+@QuarkusTest
+@TestProfile(MutabilityEnabledProfile.class)
+public class Ticket1062Test extends AbstractResourceTestBase {
+
+    private static final String PERSON_SCHEMA = """
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "$id": "person.schema.json",
+          "title": "Person",
+          "description": "Schema for a person",
+          "type": "object",
+          "properties": {
+            "firstName": {
+              "type": "string",
+              "description": "The person's first name."
+            },
+            "lastName": {
+              "type": "string",
+              "description": "The person's last name."
+            },
+            "age": {
+              "type": "integer",
+              "description": "The person's age in years.",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "firstName",
+            "lastName"
+          ]
+        }""";
+
+    private static final String ADDRESS_SCHEMA = """
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "$id": "address.schema.json",
+          "title": "Address",
+          "description": "Schema for an address",
+          "type": "object",
+          "properties": {
+            "streetAddress": {
+              "type": "string",
+              "description": "The street address."
+            },
+            "city": {
+              "type": "string",
+              "description": "The city."
+            },
+            "state": {
+              "type": "string",
+              "description": "The state."
+            },
+            "postalCode": {
+              "type": "string",
+              "description": "The postal code."
+            }
+          },
+          "required": [
+            "streetAddress",
+            "city",
+            "state",
+            "postalCode"
+          ]
+        }""";
+
+    private static final String CONTACT_SCHEMA = """
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "$id": "contact.schema.json",
+          "title": "Contact",
+          "description": "Schema for a contact",
+          "type": "object",
+          "properties": {
+            "person": {
+              "$ref": "./person.schema.json"
+            },
+            "address": {
+              "$ref": "./address.schema.json"
+            },
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The contact's email address."
+            }
+          },
+          "required": [
+            "person",
+            "address",
+            "email"
+          ]
+        }""";
+
+    @Test
+    public void testDeleteArtifactWithInboundRefs() throws Exception {
+        String groupId = "default";
+        String addressId = TestUtils.generateArtifactId();
+        String personId = TestUtils.generateArtifactId();
+        String contactId = TestUtils.generateArtifactId();
+
+        // Create the address schema
+        CreateArtifact createAddress = new CreateArtifact();
+        createAddress.setArtifactId(addressId);
+        createAddress.setArtifactType("JSON");
+        createAddress.setFirstVersion(new CreateVersion());
+        createAddress.getFirstVersion().setVersion("1");
+        createAddress.getFirstVersion().setContent(new VersionContent());
+        createAddress.getFirstVersion().getContent().setContent(ADDRESS_SCHEMA);
+        createAddress.getFirstVersion().getContent().setContentType(ContentTypes.APPLICATION_JSON);
+        clientV3.groups().byGroupId(groupId).artifacts().post(createAddress);
+
+        // Create the person schema
+        CreateArtifact createPerson = new CreateArtifact();
+        createPerson.setArtifactId(personId);
+        createPerson.setArtifactType("JSON");
+        createPerson.setFirstVersion(new CreateVersion());
+        createPerson.getFirstVersion().setVersion("1");
+        createPerson.getFirstVersion().setContent(new VersionContent());
+        createPerson.getFirstVersion().getContent().setContent(PERSON_SCHEMA);
+        createPerson.getFirstVersion().getContent().setContentType(ContentTypes.APPLICATION_JSON);
+        clientV3.groups().byGroupId(groupId).artifacts().post(createPerson);
+
+        // Create the contact schema (with references)
+        CreateArtifact createContact = new CreateArtifact();
+        createContact.setArtifactId(contactId);
+        createContact.setArtifactType("JSON");
+        createContact.setFirstVersion(new CreateVersion());
+        createContact.getFirstVersion().setVersion("1");
+        createContact.getFirstVersion().setContent(new VersionContent());
+        createContact.getFirstVersion().getContent().setContent(CONTACT_SCHEMA);
+        createContact.getFirstVersion().getContent().setContentType(ContentTypes.APPLICATION_JSON);
+        createContact.getFirstVersion().getContent().setReferences(List.of(
+                ref("./person.schema.json", groupId, personId, "1"),
+                ref("./address.schema.json", groupId, addressId, "1")
+        ));
+        clientV3.groups().byGroupId(groupId).artifacts().post(createContact);
+
+        // Try to delete the "address" artifact, version 1 - using the ccompat API - should fail
+        Assertions.assertThrows(RestClientException.class, () -> {
+            confluentClient.deleteSchemaVersion(Map.of(), addressId, "1");
+        });
+        VersionMetaData addressVMD = clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(addressId).versions().byVersionExpression("1").get();
+        Assertions.assertNotNull(addressVMD);
+        Assertions.assertEquals(addressId, addressVMD.getArtifactId());
+
+        // Try to delete the "contact" artifact itself - using the ccompat API - should fail
+        Assertions.assertThrows(RestClientException.class, () -> {
+            confluentClient.deleteSubject(Map.of(), addressId);
+        });
+        addressVMD = clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(addressId).versions().byVersionExpression("1").get();
+        Assertions.assertNotNull(addressVMD);
+        Assertions.assertEquals(addressId, addressVMD.getArtifactId());
+
+    }
+
+    private ArtifactReference ref(String name, String groupId, String artifactId, String version) {
+        ArtifactReference ref = new ArtifactReference();
+        ref.setName(name);
+        ref.setGroupId(groupId);
+        ref.setArtifactId(artifactId);
+        ref.setVersion(version);
+        return ref;
+    }
+
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/Ticket1062Test.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/Ticket1062Test.java
@@ -165,7 +165,7 @@ public class Ticket1062Test extends AbstractResourceTestBase {
         Assertions.assertNotNull(addressVMD);
         Assertions.assertEquals(addressId, addressVMD.getArtifactId());
 
-        // Try to delete the "contact" artifact itself - using the ccompat API - should fail
+        // Try to delete the "address" artifact itself - using the ccompat API - should fail
         Assertions.assertThrows(RestClientException.class, () -> {
             confluentClient.deleteSubject(Map.of(), addressId);
         });

--- a/app/src/test/java/io/apicurio/registry/storage/impl/readonly/ReadOnlyRegistryStorageTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/readonly/ReadOnlyRegistryStorageTest.java
@@ -117,6 +117,8 @@ public class ReadOnlyRegistryStorageTest {
                 entry("getConfigProperty1", new State(false, s -> s.getConfigProperty(null))),
                 entry("getContentIdsReferencingArtifactVersion3",
                         new State(false, s -> s.getContentIdsReferencingArtifactVersion(null, null, null))),
+                entry("getGlobalIdsReferencingArtifactVersion2",
+                        new State(false, s -> s.getGlobalIdsReferencingArtifact(null, null))),
                 entry("getGlobalIdsReferencingArtifactVersion3",
                         new State(false, s -> s.getGlobalIdsReferencingArtifactVersion(null, null, null))),
                 entry("getGlobalRule1", new State(false, s -> s.getGlobalRule(null))),

--- a/app/src/test/java/io/apicurio/registry/storage/impl/readonly/ReadOnlyRegistryStorageTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/readonly/ReadOnlyRegistryStorageTest.java
@@ -117,7 +117,7 @@ public class ReadOnlyRegistryStorageTest {
                 entry("getConfigProperty1", new State(false, s -> s.getConfigProperty(null))),
                 entry("getContentIdsReferencingArtifactVersion3",
                         new State(false, s -> s.getContentIdsReferencingArtifactVersion(null, null, null))),
-                entry("getGlobalIdsReferencingArtifactVersion2",
+                entry("getGlobalIdsReferencingArtifact2",
                         new State(false, s -> s.getGlobalIdsReferencingArtifact(null, null))),
                 entry("getGlobalIdsReferencingArtifactVersion3",
                         new State(false, s -> s.getGlobalIdsReferencingArtifactVersion(null, null, null))),

--- a/integration-tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
@@ -57,31 +57,18 @@ public abstract class ConfluentBaseIT extends ApicurioRegistryBaseIT {
     }
 
     protected void clearAllConfluentSubjects() throws IOException, RestClientException {
-        int breakerCount = 0;
-        boolean broken = false;
-        while (confluentService != null && !confluentService.getAllSubjects().isEmpty()) {
-            if (breakerCount > 5) {
-                broken = true;
-                break;
-            }
+        if (confluentService != null && !confluentService.getAllSubjects().isEmpty()) {
             for (String confluentSubject : confluentService.getAllSubjects()) {
                 if (confluentSubject != null) {
                     logger.info("Deleting confluent schema {}", confluentSubject);
                     try {
-                        confluentService.deleteSubject(confluentSubject);
-                    } catch (RestClientException e) {
-                        if (e.getStatus() == 404 || e.getStatus() == 422) {
-                            // subject may be already deleted or have references
-                            continue;
-                        }
-                        throw e;
+                        registryClient.groups().byGroupId("default").artifacts().byArtifactId(confluentSubject).delete();
+                    } catch (Exception e) {
+                        System.out.println("WARNING>> Failed to delete confluent schema " + confluentSubject);
+                        System.out.println("WARNING>>    " + e.getMessage());
                     }
                 }
             }
-            breakerCount++;
-        }
-        if (broken) {
-            throw new IOException("Failed to delete ALL confluent schemas.");
         }
     }
 

--- a/integration-tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
@@ -59,7 +59,7 @@ public abstract class ConfluentBaseIT extends ApicurioRegistryBaseIT {
     protected void clearAllConfluentSubjects() throws IOException, RestClientException {
         int breakerCount = 0;
         boolean broken = false;
-        while (confluentService != null && confluentService.getAllSubjects() != null) {
+        while (confluentService != null && !confluentService.getAllSubjects().isEmpty()) {
             if (breakerCount > 5) {
                 broken = true;
                 break;


### PR DESCRIPTION
* https://issues.redhat.com/browse/IPT-1062

```
If schema A contains a reference to schema B, then it should be less easy
than it is, to delete schema B whilst A still exists. Schema A will be left with
a dangling reference to a non-existent schema.

I imagine that there will be times when it is necessary to delete a schema
that is referenced by others. However, at present it seems to make no
difference whether the reference exists or not, and the API does not (so far
as I can tell) allow for any control over the way references are interpreted.
```