### PR TITLE
(fix) Improve support for OBAC in UI and REST API

### DIFF
--- a/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
@@ -126,10 +126,14 @@ public class AuthorizedInterceptor {
         }
 
         // If Owner-only is enabled, apply ownership rules
-        if (authConfig.ownerOnlyAuthorizationEnabled.get() && !obac.isAuthorized(context)) {
-            log.warn("OBAC enabled and operation not permitted due to wrong owner.");
-            throw new ForbiddenException("User " + securityIdentity.getPrincipal().getName()
-                    + " is not authorized to perform the requested operation.");
+        if (authConfig.ownerOnlyAuthorizationEnabled.get()) {
+            if (authConfig.roleBasedAuthorizationEnabled && rbac.isAdmin()) {
+                // User is admin, that's good enough.
+            } else if (!obac.isAuthorized(context)) {
+                log.warn("OBAC enabled and operation not permitted due to wrong owner.");
+                throw new ForbiddenException("User " + securityIdentity.getPrincipal().getName()
+                        + " is not authorized to perform the requested operation.");
+            }
         }
 
         return context.proceed();

--- a/app/src/main/java/io/apicurio/registry/rest/v3/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/GroupsResourceImpl.java
@@ -730,7 +730,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
      */
     @Override
     @Audited(extractParameters = { "0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION })
-    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public Comment addArtifactVersionComment(String groupId, String artifactId, String versionExpression,
             NewComment data) {
         requireParameter("groupId", groupId);
@@ -752,7 +752,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Override
     @Audited(extractParameters = { "0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION, "3",
             "comment_id" })
-    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void deleteArtifactVersionComment(String groupId, String artifactId, String versionExpression,
             String commentId) {
         requireParameter("groupId", groupId);
@@ -793,7 +793,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Override
     @Audited(extractParameters = { "0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION, "3",
             "comment_id" })
-    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void updateArtifactVersionComment(String groupId, String artifactId, String versionExpression,
             String commentId, NewComment data) {
         requireParameter("groupId", groupId);

--- a/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
+++ b/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
@@ -10,6 +10,7 @@ import io.apicurio.registry.rest.client.models.CreateGroup;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.GroupMetaData;
 import io.apicurio.registry.rest.client.models.Labels;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.rest.client.models.VersionMetaData;
 import io.apicurio.registry.rest.v3.V3ApiUtil;
@@ -345,6 +346,11 @@ public abstract class AbstractResourceTestBase extends AbstractRegistryTestBase 
         return references.stream()
                 .peek(r -> r.setGroupId(new GroupId(r.getGroupId()).getRawGroupIdWithNull()))
                 .map(V3ApiUtil::referenceToDto).collect(Collectors.toList());
+    }
+
+    protected void assertNotFound(Exception exception) {
+        Assertions.assertEquals(ProblemDetails.class, exception.getClass());
+        Assertions.assertEquals(404, ((ApiException) exception).getResponseStatusCode());
     }
 
     protected void assertForbidden(Exception exception) {

--- a/distro/docker-compose/config/realm.json
+++ b/distro/docker-compose/config/realm.json
@@ -517,6 +517,37 @@
       "groups": []
     },
     {
+      "id": "91058f32-3c88-11f0-ba59-083a885f86ce",
+      "username": "developer2",
+      "enabled": true,
+      "email": "developer2@example.org",
+      "emailVerified": true,
+      "firstName": "Devtwo",
+      "lastName": "Eloper",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "developer",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "sr-developer",
+        "offline_access",
+        "uma_authorization",
+        "User"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-applications",
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "requiredActions": [],
+      "groups": []
+    },
+    {
       "id": "cb42baf4-041a-11f0-9cd7-aab64c422d44",
       "username": "user",
       "enabled": true,

--- a/distro/docker-compose/in-memory-with-rbac-owneronly/docker-compose.yml
+++ b/distro/docker-compose/in-memory-with-rbac-owneronly/docker-compose.yml
@@ -1,0 +1,52 @@
+services:
+  keycloak:
+    container_name: keycloak-inmemorywithrbac
+    image: quay.io/keycloak/keycloak:23.0.7
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HOSTNAME: "localhost"
+      KC_HOSTNAME_PORT: "8080"
+      KC_HOSTNAME_STRICT_BACKCHANNEL: "false"
+    command:
+      - start-dev
+      - --import-realm
+    ports:
+      - 8080:8080
+    volumes:
+      - ../config/realm.json:/opt/keycloak/data/import/realm.json
+
+  apicurio-registry:
+    image: apicurio/apicurio-registry:latest-snapshot
+    container_name: apicurio-registry-api-inmemorywithrbac
+    environment:
+      apicurio.rest.deletion.group.enabled: "true"
+      apicurio.rest.deletion.artifact.enabled: "true"
+      apicurio.rest.deletion.artifact-version.enabled: "true"
+      QUARKUS_OIDC_TENANT_ENABLED: "true"
+      QUARKUS_OIDC_AUTH_SERVER_URL: "http://keycloak:8080/realms/registry"
+      apicurio.ui.auth.oidc.redirect-uri: "http://localhost:8888/"
+      QUARKUS_OIDC_CLIENT_ID: "registry-api"
+      APICURIO_UI_AUTH_OIDC_CLIENT_ID: "apicurio-registry"
+      apicurio.auth.role-based-authorization: "true"
+      apicurio.auth.owner-only-authorization: "true"
+      QUARKUS_OIDC_TLS_VERIFICATION: "none"
+      QUARKUS_HTTP_CORS_ORIGINS: "*"
+      QUARKUS_PROFILE: "prod"
+    ports:
+      - "8081:8080"
+    depends_on:
+      - keycloak
+
+  apicurio-registry-ui:
+    image: apicurio/apicurio-registry-ui:latest-snapshot
+    container_name: apicurio-registry-ui-inmemorywithrbac
+    environment:
+      REGISTRY_API_URL: "http://localhost:8081/apis/registry/v3"
+      REGISTRY_AUTH_TYPE: "oidc"
+      REGISTRY_AUTH_URL: "http://localhost:8080/realms/registry"
+    ports:
+      - "8888:8080"
+    depends_on:
+      - apicurio-registry
+      - keycloak

--- a/distro/docker-compose/in-memory-with-rbac-owneronly/docker-compose.yml
+++ b/distro/docker-compose/in-memory-with-rbac-owneronly/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   keycloak:
-    container_name: keycloak-inmemorywithrbac
+    container_name: keycloak-inmemorywithrbac-owneronly
     image: quay.io/keycloak/keycloak:23.0.7
     environment:
       KEYCLOAK_ADMIN: admin
@@ -18,7 +18,7 @@ services:
 
   apicurio-registry:
     image: apicurio/apicurio-registry:latest-snapshot
-    container_name: apicurio-registry-api-inmemorywithrbac
+    container_name: apicurio-registry-api-inmemorywithrbac-owneronly
     environment:
       apicurio.rest.deletion.group.enabled: "true"
       apicurio.rest.deletion.artifact.enabled: "true"
@@ -40,7 +40,7 @@ services:
 
   apicurio-registry-ui:
     image: apicurio/apicurio-registry-ui:latest-snapshot
-    container_name: apicurio-registry-ui-inmemorywithrbac
+    container_name: apicurio-registry-ui-inmemorywithrbac-owneronly
     environment:
       REGISTRY_API_URL: "http://localhost:8081/apis/registry/v3"
       REGISTRY_AUTH_TYPE: "oidc"

--- a/ui/ui-app/src/app/components/auth/IfAuth.tsx
+++ b/ui/ui-app/src/app/components/auth/IfAuth.tsx
@@ -42,6 +42,7 @@ export const IfAuth: FunctionComponent<IfAuthProps> = (props: IfAuthProps) => {
             rval = rval && (user.isUserAdmin() === props.isAdmin);
         }
         if (props.isDeveloper !== undefined) {
+            console.info(">>> checking if user is developer: " + props.owner);
             rval = rval && (user.isUserDeveloper(props.owner) === props.isDeveloper);
         }
         if (props.isOwner !== undefined && props.owner) {

--- a/ui/ui-app/src/app/components/errorPage/ErrorPage.css
+++ b/ui/ui-app/src/app/components/errorPage/ErrorPage.css
@@ -15,3 +15,6 @@
     border: 1px solid #ccc;
 }
 
+.pf-v5-c-code-editor__code {
+    background: #fff;
+}

--- a/ui/ui-app/src/app/components/errorPage/ErrorPage.tsx
+++ b/ui/ui-app/src/app/components/errorPage/ErrorPage.tsx
@@ -2,10 +2,6 @@ import React, { FunctionComponent, useState } from "react";
 import "./ErrorPage.css";
 import {
     Button,
-    ClipboardCopyButton,
-    CodeBlock,
-    CodeBlockAction,
-    CodeBlockCode,
     EmptyState,
     EmptyStateActions,
     EmptyStateBody,
@@ -18,6 +14,7 @@ import {
 import { ExclamationTriangleIcon } from "@patternfly/react-icons";
 import { PageError } from "@app/pages";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
 
 
 export type ErrorPageProps = {
@@ -59,27 +56,6 @@ export const ErrorPage: FunctionComponent<ErrorPageProps> = (props: ErrorPagePro
         window.location.reload();
     };
 
-    const actions = (
-        <React.Fragment>
-            <CodeBlockAction>
-                <ClipboardCopyButton
-                    id="basic-copy-button"
-                    textId="code-content"
-                    aria-label="Copy to clipboard"
-                    onClick={() => {}}
-                    // onClick={(e) => onClick(e, code)}
-                    // exitDelay={copied ? 1500 : 600}
-                    maxWidth="110px"
-                    variant="plain"
-                    // onTooltipHidden={() => setCopied(false)}
-                >
-                    {/*{copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}*/}
-                    Copy to clipboard
-                </ClipboardCopyButton>
-            </CodeBlockAction>
-        </React.Fragment>
-    );
-
     return (
         <React.Fragment>
             <PageSection className="ps_error" variant={PageSectionVariants.light}>
@@ -111,9 +87,20 @@ export const ErrorPage: FunctionComponent<ErrorPageProps> = (props: ErrorPagePro
                     <div className="separator">&nbsp;</div>
                     {
                         isShowDetails ?
-                            <CodeBlock actions={actions}>
-                                <CodeBlockCode id="code-content">{errorDetail()}</CodeBlockCode>
-                            </CodeBlock>
+                            <CodeEditor
+                                code={errorDetail()}
+                                width="700px"
+                                isReadOnly={true}
+                                isLineNumbersVisible={false}
+                                isMinimapVisible={false}
+                                onChange={() => {}}
+                                language={Language.json}
+                                onEditorDidMount={(editor, monaco) => {
+                                    editor.layout();
+                                    monaco.editor.getModels()[0].updateOptions({ tabSize: 4 });
+                                }}
+                                height="sizeToFit"
+                            />
                             :
                             <div/>
                     }

--- a/ui/ui-app/src/app/components/ruleList/RuleList.tsx
+++ b/ui/ui-app/src/app/components/ruleList/RuleList.tsx
@@ -20,6 +20,7 @@ export type RuleListProps = {
     onConfigureRule: (ruleType: string, config: string) => void;
     rules: Rule[];
     type: RuleListType;
+    resourceOwner?: string | null;
 };
 
 const NAME_COLUMN_WIDTH: string = "250px";
@@ -176,7 +177,7 @@ export const RuleList: FunctionComponent<RuleListProps> = (props: RuleListProps)
                         </Tooltip>
                     </FlexItem>
                     <FlexItem className="rule-actions">
-                        <RuleValue type={props.type} actions={validityRuleActions} label={validityRuleLabel} />
+                        <RuleValue type={props.type} resourceOwner={props.resourceOwner} actions={validityRuleActions} label={validityRuleLabel} />
                     </FlexItem>
                 </Flex>
             </GridItem>
@@ -194,7 +195,7 @@ export const RuleList: FunctionComponent<RuleListProps> = (props: RuleListProps)
                         </Tooltip>
                     </FlexItem>
                     <FlexItem className="rule-actions">
-                        <RuleValue type={props.type} actions={compatibilityRuleActions} label={compatibilityRuleLabel} />
+                        <RuleValue type={props.type} resourceOwner={props.resourceOwner} actions={compatibilityRuleActions} label={compatibilityRuleLabel} />
                     </FlexItem>
                 </Flex>
             </GridItem>
@@ -212,7 +213,7 @@ export const RuleList: FunctionComponent<RuleListProps> = (props: RuleListProps)
                         </Tooltip>
                     </FlexItem>
                     <FlexItem className="rule-actions">
-                        <RuleValue type={props.type} actions={integrityRuleActions} label={integrityRuleLabel} />
+                        <RuleValue type={props.type} resourceOwner={props.resourceOwner} actions={integrityRuleActions} label={integrityRuleLabel} />
                     </FlexItem>
                 </Flex>
             </GridItem>

--- a/ui/ui-app/src/app/components/ruleList/RuleValue.tsx
+++ b/ui/ui-app/src/app/components/ruleList/RuleValue.tsx
@@ -9,6 +9,7 @@ export type RuleValueProps = {
     type: RuleListType;
     actions: React.ReactElement;
     label: React.ReactElement;
+    resourceOwner?: string;
 };
 
 export const RuleValue: FunctionComponent<RuleValueProps> = (props: RuleValueProps) => {
@@ -16,7 +17,7 @@ export const RuleValue: FunctionComponent<RuleValueProps> = (props: RuleValuePro
     const user = useUserService();
     const readOnly: boolean = config.featureReadOnly();
     const userIsAdmin: boolean = user.isUserAdmin();
-    const userIsDev: boolean = user.isUserDeveloper();
+    const userIsDev: boolean = user.isUserDeveloper(props.resourceOwner);
 
     const isEditable: boolean = !readOnly && (props.type === RuleListType.Global ? userIsAdmin : userIsDev);
 

--- a/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
+++ b/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
@@ -163,6 +163,8 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
         groups.deleteArtifact(groupId as string, artifactId as string).then( () => {
             pleaseWait(false, "");
             appNavigation.navigateTo("/explore");
+        }).catch(error => {
+            setPageError(toPageError(error, "Error deleting an artifact."));
         });
     };
 

--- a/ui/ui-app/src/app/pages/artifact/components/pageheader/ArtifactPageHeader.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/pageheader/ArtifactPageHeader.tsx
@@ -32,7 +32,7 @@ export const ArtifactPageHeader: FunctionComponent<ArtifactPageHeaderProps> = (p
                 </TextContent>
             </FlexItem>
             <FlexItem align={{ default: "alignRight" }}>
-                <IfAuth isDeveloper={true}>
+                <IfAuth isDeveloper={true} owner={props.artifact.owner}>
                     <IfFeature feature="readOnly" isNot={true}>
                         <IfFeature feature="deleteArtifact" is={true}>
                             <Button id="delete-artifact-button" variant="danger"

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactInfoTabContent.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactInfoTabContent.tsx
@@ -61,7 +61,7 @@ export const ArtifactInfoTabContent: FunctionComponent<ArtifactInfoTabContentPro
                                 <FlexItem className="type"><ArtifactTypeIcon artifactType={props.artifact.artifactType!} /></FlexItem>
                                 <FlexItem className="title">Artifact metadata</FlexItem>
                                 <FlexItem className="actions" align={{ default: "alignRight" }}>
-                                    <IfAuth isDeveloper={true}>
+                                    <IfAuth isDeveloper={true} owner={props.artifact.owner}>
                                         <IfFeature feature="readOnly" isNot={true}>
                                             <Button id="edit-action"
                                                 data-testid="artifact-btn-edit"
@@ -153,6 +153,7 @@ export const ArtifactInfoTabContent: FunctionComponent<ArtifactInfoTabContentPro
                         </p>
                         <RuleList
                             type={RuleListType.Artifact}
+                            resourceOwner={props.artifact.owner}
                             rules={props.rules}
                             onEnableRule={props.onEnableRule}
                             onDisableRule={props.onDisableRule}

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/BranchesTabContent.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/BranchesTabContent.tsx
@@ -72,7 +72,7 @@ export const BranchesTabContent: FunctionComponent<BranchesTabContentProps> = (p
     }, [props.artifact, paging]);
 
     const toolbar = (
-        <BranchesTabToolbar results={results} paging={paging} onPageChange={setPaging} onCreateBranch={props.onCreateBranch} />
+        <BranchesTabToolbar artifact={props.artifact} results={results} paging={paging} onPageChange={setPaging} onCreateBranch={props.onCreateBranch} />
     );
 
     const emptyState = (

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/BranchesTabToolbar.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/BranchesTabToolbar.tsx
@@ -3,13 +3,14 @@ import "./BranchesTabToolbar.css";
 import { Button, Pagination, Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import { Paging } from "@models/paging.model.ts";
 import { IfAuth, IfFeature } from "@app/components";
-import { BranchSearchResults } from "@sdk/lib/generated-client/models";
+import {ArtifactMetaData, BranchSearchResults} from "@sdk/lib/generated-client/models";
 
 
 /**
  * Properties
  */
 export type BranchesToolbarProps = {
+    artifact: ArtifactMetaData;
     results: BranchSearchResults;
     paging: Paging;
     onPageChange: (paging: Paging) => void;
@@ -42,7 +43,7 @@ export const BranchesTabToolbar: FunctionComponent<BranchesToolbarProps> = (prop
         <Toolbar id="branches-toolbar-1" className="branches-toolbar">
             <ToolbarContent>
                 <ToolbarItem className="create-branch-item">
-                    <IfAuth isDeveloper={true}>
+                    <IfAuth isDeveloper={true} owner={props.artifact.owner}>
                         <IfFeature feature="readOnly" isNot={true}>
                             <Button className="btn-header-create-branch" data-testid="btn-toolbar-create-branch"
                                 variant="primary" onClick={props.onCreateBranch}>Create branch</Button>

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/BranchesTable.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/BranchesTable.tsx
@@ -8,6 +8,7 @@ import { ArtifactMetaData, SearchedBranch } from "@sdk/lib/generated-client/mode
 import { DesktopIcon } from "@patternfly/react-icons";
 import { Tooltip } from "@patternfly/react-core";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
+import { UserService, useUserService } from "@services/useUserService.ts";
 
 export type BranchesTableProps = {
     artifact: ArtifactMetaData;
@@ -31,6 +32,7 @@ type BranchActionSeparator = {
 export const BranchesTable: FunctionComponent<BranchesTableProps> = (props: BranchesTableProps) => {
     const appNavigation: AppNavigation = useAppNavigation();
     const config: ConfigService = useConfigService();
+    const user: UserService = useUserService();
 
     const columns: any[] = [
         { index: 0, id: "branch", label: "Branch", width: 50, sortable: false },
@@ -76,8 +78,7 @@ export const BranchesTable: FunctionComponent<BranchesTableProps> = (props: Bran
 
     const actionsFor = (branch: SearchedBranch): (BranchAction | BranchActionSeparator)[] => {
         const vhash: number = shash(branch.branchId!);
-        // TODO hide/show actions based on user role
-        return config.featureReadOnly() ? [
+        return config.featureReadOnly() || !user.isUserDeveloper(props.artifact.owner) ? [
             { label: "View branch", onClick: () => props.onView(branch), testId: `view-branch-${vhash}` },
         ] : [
             { label: "View branch", onClick: () => props.onView(branch), testId: `view-branch-${vhash}` },

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTabContent.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTabContent.tsx
@@ -88,7 +88,7 @@ export const VersionsTabContent: FunctionComponent<VersionsTabContentProps> = (p
     }, [props.artifact, paging, sortBy, sortOrder]);
 
     const toolbar = (
-        <VersionsTabToolbar results={results} paging={paging} onPageChange={setPaging} onCreateVersion={props.onCreateVersion} />
+        <VersionsTabToolbar artifact={props.artifact} results={results} paging={paging} onPageChange={setPaging} onCreateVersion={props.onCreateVersion} />
     );
 
     const emptyState = (

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTabToolbar.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTabToolbar.tsx
@@ -3,13 +3,14 @@ import "./VersionsTabToolbar.css";
 import { Button, Pagination, Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import { Paging } from "@models/paging.model.ts";
 import { IfAuth, IfFeature } from "@app/components";
-import { VersionSearchResults } from "@sdk/lib/generated-client/models";
+import { ArtifactMetaData, VersionSearchResults } from "@sdk/lib/generated-client/models";
 
 
 /**
  * Properties
  */
 export type VersionsToolbarProps = {
+    artifact: ArtifactMetaData;
     results: VersionSearchResults;
     paging: Paging;
     onPageChange: (paging: Paging) => void;
@@ -42,7 +43,7 @@ export const VersionsTabToolbar: FunctionComponent<VersionsToolbarProps> = (prop
         <Toolbar id="versions-toolbar-1" className="versions-toolbar">
             <ToolbarContent>
                 <ToolbarItem className="create-version-item">
-                    <IfAuth isDeveloper={true}>
+                    <IfAuth isDeveloper={true} owner={props.artifact.owner}>
                         <IfFeature feature="readOnly" isNot={true}>
                             <Button className="btn-header-create-version" data-testid="btn-toolbar-create-version"
                                 variant="primary" onClick={props.onCreateVersion}>Create version</Button>

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTable.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTable.tsx
@@ -15,6 +15,7 @@ import {
 } from "@sdk/lib/generated-client/models";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { Flex, FlexItem, Label } from "@patternfly/react-core";
+import { UserService, useUserService } from "@services/useUserService.ts";
 
 export type VersionsTableProps = {
     artifact: ArtifactMetaData;
@@ -41,6 +42,7 @@ export const VersionsTable: FunctionComponent<VersionsTableProps> = (props: Vers
 
     const appNavigation: AppNavigation = useAppNavigation();
     const config: ConfigService = useConfigService();
+    const user: UserService = useUserService();
 
     const columns: any[] = [
         { index: 0, id: "version", label: "Version", width: 40, sortable: true, sortBy: VersionSortByObject.Version },
@@ -113,7 +115,7 @@ export const VersionsTable: FunctionComponent<VersionsTableProps> = (props: Vers
         const actions: (VersionAction | VersionActionSeparator)[] = [
             { label: "View version", onClick: () => props.onView(version), testId: `view-version-${vhash}` },
         ];
-        if (!config.featureReadOnly()) {
+        if (!config.featureReadOnly() && user.isUserDeveloper(props.artifact.owner)) {
             actions.push(
                 { label: "Add to branch", onClick: () => props.onAddToBranch(version), testId: `add-to-branch-version-${vhash}` },
             );

--- a/ui/ui-app/src/app/pages/branch/BranchPage.tsx
+++ b/ui/ui-app/src/app/pages/branch/BranchPage.tsx
@@ -187,6 +187,7 @@ export const BranchPage: FunctionComponent<PageProperties> = () => {
                 </IfFeature>
                 <PageSection className="ps_artifact-branch-header" variant={PageSectionVariants.light}>
                     <BranchPageHeader
+                        artifact={artifact}
                         onDelete={onDeleteBranch}
                         branch={branch as BranchMetaData}
                         groupId={gid}

--- a/ui/ui-app/src/app/pages/branch/components/pageheader/BranchPageHeader.tsx
+++ b/ui/ui-app/src/app/pages/branch/components/pageheader/BranchPageHeader.tsx
@@ -3,13 +3,14 @@ import "./BranchPageHeader.css";
 import { Button, Flex, FlexItem, Text, TextContent, TextVariants } from "@patternfly/react-core";
 import { IfAuth, IfFeature } from "@app/components";
 import { If } from "@apicurio/common-ui-components";
-import { BranchMetaData } from "@sdk/lib/generated-client/models";
+import { ArtifactMetaData, BranchMetaData } from "@sdk/lib/generated-client/models";
 
 
 /**
  * Properties
  */
 export type ArtifactBranchPageHeaderProps = {
+    artifact: ArtifactMetaData | undefined;
     groupId: string;
     artifactId: string;
     branch: BranchMetaData;
@@ -37,7 +38,7 @@ export const BranchPageHeader: FunctionComponent<ArtifactBranchPageHeaderProps> 
             </FlexItem>
             <FlexItem align={{ default: "alignRight" }}>
                 <If condition={!(props.branch.systemDefined || false)}>
-                    <IfAuth isDeveloper={true}>
+                    <IfAuth isDeveloper={true} owner={props.artifact?.owner}>
                         <IfFeature feature="readOnly" isNot={true}>
                             <Button id="delete-branch-button" variant="danger"
                                 data-testid="header-btn-delete" onClick={props.onDelete}>Delete branch</Button>

--- a/ui/ui-app/src/app/pages/branch/components/tabs/BranchInfoTabContent.tsx
+++ b/ui/ui-app/src/app/pages/branch/components/tabs/BranchInfoTabContent.tsx
@@ -49,7 +49,7 @@ export const BranchInfoTabContent: FunctionComponent<BranchInfoTabContentProps> 
                                 <FlexItem className="title">Branch metadata</FlexItem>
                                 <FlexItem className="actions" align={{ default: "alignRight" }}>
                                     <If condition={!(props.branch.systemDefined || false)}>
-                                        <IfAuth isDeveloper={true}>
+                                        <IfAuth isDeveloper={true} owner={props.artifact.owner}>
                                             <IfFeature feature="readOnly" isNot={true}>
                                                 <Button id="edit-action"
                                                     data-testid="version-btn-edit"

--- a/ui/ui-app/src/app/pages/version/VersionPage.tsx
+++ b/ui/ui-app/src/app/pages/version/VersionPage.tsx
@@ -272,6 +272,7 @@ export const VersionPage: FunctionComponent<PageProperties> = () => {
                     <VersionPageHeader
                         onDelete={onDeleteVersion}
                         onDownload={doDownloadVersion}
+                        artifact={artifact}
                         version={version as string}
                         groupId={gid}
                         artifactId={artifactId as string} />

--- a/ui/ui-app/src/app/pages/version/components/pageheader/VersionPageHeader.tsx
+++ b/ui/ui-app/src/app/pages/version/components/pageheader/VersionPageHeader.tsx
@@ -3,12 +3,14 @@ import "./VersionPageHeader.css";
 import { Button, Flex, FlexItem, Text, TextContent, TextVariants } from "@patternfly/react-core";
 import { IfAuth, IfFeature } from "@app/components";
 import { If } from "@apicurio/common-ui-components";
+import { ArtifactMetaData } from "@sdk/lib/generated-client/models";
 
 
 /**
  * Properties
  */
-export type ArtifactVersionPageHeaderProps = {
+export type VersionPageHeaderProps = {
+    artifact: ArtifactMetaData | undefined;
     groupId: string;
     artifactId: string;
     version: string;
@@ -19,7 +21,7 @@ export type ArtifactVersionPageHeaderProps = {
 /**
  * Models the page header for the Artifact page.
  */
-export const VersionPageHeader: FunctionComponent<ArtifactVersionPageHeaderProps> = (props: ArtifactVersionPageHeaderProps) => {
+export const VersionPageHeader: FunctionComponent<VersionPageHeaderProps> = (props: VersionPageHeaderProps) => {
     return (
         <Flex className="example-border">
             <FlexItem>
@@ -38,7 +40,7 @@ export const VersionPageHeader: FunctionComponent<ArtifactVersionPageHeaderProps
             <FlexItem align={{ default: "alignRight" }}>
                 <Button id="download-artifact-button" variant="primary"
                     data-testid="header-btn-download" onClick={props.onDownload}>Download</Button>
-                <IfAuth isDeveloper={true}>
+                <IfAuth isDeveloper={true} owner={props.artifact?.owner}>
                     <IfFeature feature="readOnly" isNot={true}>
                         <IfFeature feature="deleteVersion" is={true}>
                             <Button id="delete-artifact-button" variant="danger"

--- a/ui/ui-app/src/app/pages/version/components/tabs/VersionInfoTabContent.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/VersionInfoTabContent.tsx
@@ -67,7 +67,7 @@ export const VersionInfoTabContent: FunctionComponent<VersionInfoTabContentProps
                                             onClick={props.onGenerateClient}
                                             variant="link">Generate client SDK</Button>
                                     </If>
-                                    <IfAuth isDeveloper={true}>
+                                    <IfAuth isDeveloper={true} owner={props.artifact.owner}>
                                         <IfFeature feature="readOnly" isNot={true}>
                                             <Button id="edit-action"
                                                 data-testid="version-btn-edit"


### PR DESCRIPTION
This PR does the following:

1. Improve the UI to hide/show actions appropriately when OBAC is enabled (e.g. when OBAC is enabled and the user is a Developer but NOT the owner of an artifact, hide the "Delete" button)
2. Fix an issue where Admin users could not perform operations when OBAC was enabled (the owner based auth logic was overriding the RBAC logic for admins)

So now the UI should better reflect what the user can actually do.  And also Admins can now perform operations on artifacts even when they do not own the artifact (as intended).