### PR TITLE
(fix) Allow admins to perform operations when OBAC is enabled

### DIFF
--- a/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
@@ -167,9 +167,14 @@ public class AuthorizedInterceptor {
         }
 
         // If Owner-only is enabled, apply ownership rules
-        if (authConfig.ownerOnlyAuthorizationEnabled.get() && !obac.isAuthorized(context)) {
-            log.warn("OBAC enabled and operation not permitted due to wrong owner.");
-            throw new ForbiddenException("User " + securityIdentity.getPrincipal().getName() + " is not authorized to perform the requested operation.");
+        if (authConfig.ownerOnlyAuthorizationEnabled.get()) {
+            if (authConfig.roleBasedAuthorizationEnabled && rbac.isAdmin()) {
+                // User is admin, that's good enough.
+            } else if (!obac.isAuthorized(context)) {
+                log.warn("OBAC enabled and operation not permitted due to wrong owner.");
+                throw new ForbiddenException("User " + securityIdentity.getPrincipal().getName()
+                        + " is not authorized to perform the requested operation.");
+            }
         }
 
         return context.proceed();

--- a/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/GroupsResourceImpl.java
@@ -671,7 +671,7 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION})
-    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public Comment addArtifactVersionComment(String groupId, String artifactId, String version, NewComment data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
@@ -686,7 +686,7 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION, "3", "comment_id"})
-    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void deleteArtifactVersionComment(String groupId, String artifactId, String version, String commentId) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);
@@ -716,7 +716,7 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     @Override
     @Audited(extractParameters = {"0", KEY_GROUP_ID, "1", KEY_ARTIFACT_ID, "2", KEY_VERSION, "3", "comment_id"})
-    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void updateArtifactVersionComment(String groupId, String artifactId, String version, String commentId, NewComment data) {
         requireParameter("groupId", groupId);
         requireParameter("artifactId", artifactId);


### PR DESCRIPTION
Fix an issue where Admin users could not perform operations when OBAC was enabled (the owner based auth logic was overriding the RBAC logic for admins).