### PR TITLE
Ignore disabled artifact version when searching artifact by content 

### DIFF
--- a/schema-resolver/pom.xml
+++ b/schema-resolver/pom.xml
@@ -36,6 +36,16 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeImpl.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeImpl.java
@@ -11,6 +11,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import static io.apicurio.registry.rest.client.models.VersionState.DISABLED;
+
 /**
  * An implementation of @{@link RegistryClientFacade} that uses version 3 of the
  * Apicurio Registry Core API.
@@ -110,7 +112,9 @@ public class RegistryClientFacadeImpl implements RegistryClientFacade {
             config.queryParameters.order = SortOrder.Desc;
         });
 
-        return results.getVersions().stream().map(v ->
+        return results.getVersions().stream()
+                .filter(version -> DISABLED != version.getState())
+                .map(v ->
                 RegistryVersionCoordinates.create(v.getGlobalId(), v.getContentId(), v.getGroupId(), v.getArtifactId(), v.getVersion())).toList();
     }
 

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeImpl_v2.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeImpl_v2.java
@@ -13,6 +13,8 @@ import io.vertx.core.Vertx;
 import java.io.InputStream;
 import java.util.List;
 
+import static io.apicurio.registry.rest.client.v2.models.ArtifactState.DISABLED;
+
 /**
  * An implementation of @{@link RegistryClientFacade} that uses version 2 of the
  * Apicurio Registry Core API.
@@ -111,6 +113,9 @@ public class RegistryClientFacadeImpl_v2 implements RegistryClientFacade {
                     config.queryParameters.canonical = canonical;
                 });
 
+        if(DISABLED == vmd.getState()) {
+            return List.of();
+        }
         return List.of(RegistryVersionCoordinates.create(
                 vmd.getGlobalId(), vmd.getContentId(), vmd.getGroupId(), vmd.getId(), vmd.getVersion()));
     }

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeImplTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeImplTest.java
@@ -1,0 +1,124 @@
+package io.apicurio.registry.resolver.client;
+
+import com.microsoft.kiota.RequestAdapter;
+import io.apicurio.registry.resolver.strategy.ArtifactReference;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.models.SearchedVersion;
+import io.apicurio.registry.rest.client.models.VersionSearchResults;
+import io.apicurio.registry.rest.client.models.VersionState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static io.apicurio.registry.rest.client.models.VersionState.DISABLED;
+import static io.apicurio.registry.rest.client.models.VersionState.ENABLED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class RegistryClientFacadeImplTest {
+    public static final String SCHEMA_CONTENT = """
+            {
+              "type": "record",
+              "name": "artifactTestId",
+              "namespace": "test.group.id",
+              "fields": [
+                {
+                  "name": "userId",
+                  "type": {
+                    "type": "string",
+                    "logicalType": "uuid"
+                  }
+                }
+              ]
+            }
+            """;
+    RequestAdapter requestAdapter = mock(RequestAdapter.class);
+    RegistryClient client;
+    RegistryClientFacade schemaByContentResolverClient;
+
+    @BeforeEach
+    public void init() {
+        client = new RegistryClient(requestAdapter);
+        schemaByContentResolverClient = new RegistryClientFacadeImpl(client);
+    }
+
+    @Test
+    void should_fetch_version_using_content() {
+        // Given
+        ArtifactReference reference = ArtifactReference.builder().artifactId("artifactTestId").groupId("test.group.id").build();
+        VersionSearchResults response = createVersionSearchResults(createSearchedVersion(ENABLED, "1"));
+
+        doReturn(response).when(requestAdapter).send(any(), any(), any());
+
+        // When
+        var coordinates = schemaByContentResolverClient.searchVersionsByContent(SCHEMA_CONTENT, "AVRO", reference,  true);
+
+        // Then
+        assertThat(coordinates).singleElement().
+        satisfies(artifact -> {
+            assertThat(artifact.getArtifactId()).isEqualTo("artifactTestId");
+            assertThat(artifact.getGroupId()).isEqualTo("test.group.id");
+            assertThat(artifact.getVersion()).isEqualTo("1");
+        });
+    }
+
+    @Test
+    void should_return_empty_coordinates_when_version_is_disabled() {
+        // Given
+
+        ArtifactReference reference = ArtifactReference.builder().artifactId("artifactTestId").groupId("test.group.id").build();
+        VersionSearchResults response = createVersionSearchResults(createSearchedVersion(DISABLED, "1"));
+
+        doReturn(response).when(requestAdapter).send(any(), any(), any());
+
+        // When / Then
+        assertThat(schemaByContentResolverClient.searchVersionsByContent(SCHEMA_CONTENT, "AVRO", reference, true)).isEmpty();
+    }
+
+    @Test
+    void should_to_fetch_version_when_one_artifact_is_not_disabled_in_search_results() {
+        // Given
+
+        ArtifactReference reference = ArtifactReference.builder().artifactId("artifactTestId").groupId("test.group.id").build();
+        VersionSearchResults response =
+                createVersionSearchResults(
+                        createSearchedVersion(ENABLED, "2"),
+                        createSearchedVersion(DISABLED, "1")
+                );
+
+        doReturn(response).when(requestAdapter).send(any(), any(), any());
+
+        // When / Then
+        // When
+        var coordinates = schemaByContentResolverClient.searchVersionsByContent(SCHEMA_CONTENT, "AVRO", reference, true);
+
+        // Then
+        assertThat(coordinates).singleElement()
+                .satisfies( artifact -> assertThat(artifact.getVersion()).isEqualTo("2"));
+    }
+
+    private static VersionSearchResults createVersionSearchResults(SearchedVersion... versions) {
+        VersionSearchResults results = new VersionSearchResults();
+        results.setCount(1);
+        results.setVersions(List.of(versions));
+        return results;
+    }
+
+    private static SearchedVersion createSearchedVersion(VersionState state, String version) {
+        SearchedVersion searchedVersion = new SearchedVersion();
+        searchedVersion.setName("artifactTest");
+        searchedVersion.setGlobalId(1L);
+        searchedVersion.setArtifactId("artifactTestId");
+        searchedVersion.setGroupId("test.group.id");
+        searchedVersion.setVersion(version);
+        searchedVersion.setState(state);
+        searchedVersion.setArtifactType("AVRO");
+        return searchedVersion;
+    }
+}


### PR DESCRIPTION
fixes https://github.com/Apicurio/apicurio-registry/issues/877

In the registry facade impl, add a check on the artifact state to filter out DISABLED artifacts.
Add unit tests dependencies (mockito + assertj) in schema resolver module
Add test case for the v3 registry client facade around ignoreing disabled artifacts versions