### PR TITLE
[3.0] fix(1323) : Fixed issue with ccompat API when getting invalid schema by contentId

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/Ticket1323Test.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/Ticket1323Test.java
@@ -1,0 +1,70 @@
+package io.apicurio.registry.noprofile;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateArtifactResponse;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproducer for:  https://issues.redhat.com/browse/IPT-1323
+ */
+@QuarkusTest
+public class Ticket1323Test extends AbstractResourceTestBase {
+
+    private static final String INVALID_AVRO_CONTENT = "{\n" +
+            "  \"type\": \"record\",\n" +
+            "  \"name\": \"Key\",\n" +
+            "  \"namespace\": \"cpr-jdz-private-sltrs_isu-dbo-ISU_EPROFVAL15-rt\",\n" +
+            "  \"fields\": [\n" +
+            "    {\n" +
+            "      \"name\": \"MANDT\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"name\": \"PROFILE\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"name\": \"VALUEDAY\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"name\": \"__dbz__physicalTableIdentifier\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"connect.name\": \"cpr-jdz-private-sltrs_isu-dbo-ISU_EPROFVAL15-rt.Key\"\n" +
+            "}";
+
+    @Test
+    public void testInvalidAvroContent() throws Exception {
+        String groupId = "default";
+        String artifactId = TestUtils.generateArtifactId();
+
+        // Create the invalid schema using the core v3 api
+        CreateArtifact createAddress = new CreateArtifact();
+        createAddress.setArtifactId(artifactId);
+        createAddress.setArtifactType("AVRO");
+        createAddress.setFirstVersion(new CreateVersion());
+        createAddress.getFirstVersion().setVersion("1");
+        createAddress.getFirstVersion().setContent(new VersionContent());
+        createAddress.getFirstVersion().getContent().setContent(INVALID_AVRO_CONTENT);
+        createAddress.getFirstVersion().getContent().setContentType(ContentTypes.APPLICATION_JSON);
+        CreateArtifactResponse car = clientV3.groups().byGroupId(groupId).artifacts().post(createAddress);
+
+        long contentId = car.getVersion().getContentId();
+
+        // Try to get the schema by its contentId via the ccompat API
+        SchemaString schemaString = confluentClient.getId((int) contentId);
+        Assertions.assertNotNull(schemaString);
+        Assertions.assertTrue(schemaString.getSchemaString().contains("ISU_EPROFVAL15"));
+    }
+
+}


### PR DESCRIPTION
Reference:  
* https://issues.redhat.com/browse/IPT-1323

Changed the logic of this so that the artifact type is figured out based on the artifact type of the first artifact that references the content.  We need to do this because we do not store the artifact type with the content.

Technically this means that if you upload the same content for two different artifacts with **different artifact types**, then you may get the wrong response from the ccompat API when getting the schema by ID.  You'll still get the right content, but you **might** get the wrong artifact type, because there would be multiple artifacts with different types referencing the same content.