### PR TITLE
feat(auth): Add an option to choose which OIDC token (id or access) to use in the UI [2.6.x]

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
+++ b/app/src/main/java/io/apicurio/registry/ui/config/UiConfigProperties.java
@@ -98,6 +98,11 @@ public class UiConfigProperties {
     @Info(category = "ui", description = "UI auth OIDC scope value", availableSince = "2.6.8.Final")
     String scope;
 
+    @Inject
+    @ConfigProperty(name = "registry.ui.config.auth.oidc.token-type", defaultValue = "access")
+    @Info(category = "ui", description = "OIDC token type to use ('id' or 'access') when invoking REST API endpoints.", availableSince = "2.2.12.Final")
+    String oidcTokenType;
+
     private final Map<String, Object> keycloakConfig;
 
     /**
@@ -166,6 +171,10 @@ public class UiConfigProperties {
 
     public String getOidcRedirectUrl() {
         return oidcRedirectUri;
+    }
+
+    public String getOidcTokenType() {
+        return oidcTokenType;
     }
 
     public String getScope() {

--- a/app/src/main/java/io/apicurio/registry/ui/servlets/ConfigJsServlet.java
+++ b/app/src/main/java/io/apicurio/registry/ui/servlets/ConfigJsServlet.java
@@ -114,6 +114,7 @@ public class ConfigJsServlet extends HttpServlet {
                 config.auth.options.put("url", uiConfig.getOidcUrl());
                 config.auth.options.put("redirectUri", uiConfig.getOidcRedirectUrl());
                 config.auth.options.put("scope", uiConfig.getScope());
+                config.auth.options.put("tokenType", uiConfig.getOidcTokenType());
             }
 
             config.auth.rbacEnabled = authConfig.isRbacEnabled();

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -742,6 +742,11 @@ The following {registry} configuration options are available for each component 
 |`openid profile email`
 |`2.6.8.Final`
 |UI auth OIDC scope value
+|`registry.ui.config.auth.oidc.token-type`
+|`string`
+|`access`
+|`2.2.12.Final`
+|OIDC token type to use ('id' or 'access') when invoking REST API endpoints.
 |`registry.ui.config.auth.oidc.url`
 |`string`
 |`none`

--- a/ui/config/config-oidcjs.js
+++ b/ui/config/config-oidcjs.js
@@ -14,7 +14,7 @@ var ApicurioRegistryConfig = {
         options: {
             url: "http://localhost:8090",
             redirectUri: "http://localhost:8888",
-            clientId:"apicurio-registry",
+            clientId: "apicurio-registry",
         }
     },
     features: {

--- a/ui/src/services/auth/auth.service.ts
+++ b/ui/src/services/auth/auth.service.ts
@@ -180,8 +180,12 @@ export class AuthService implements Service {
 
     public getToken = () => this.keycloak.token;
 
-    public getOidcToken = () => {
+    public getOidcAccessToken = () => {
         return this.oidcUser.access_token;
+    };
+
+    public getOidcIdToken = () => {
+        return this.oidcUser.id_token;
     };
 
     public isAuthenticationEnabled(): boolean {
@@ -270,7 +274,8 @@ export class AuthService implements Service {
                     return Promise.reject(error);
                 });
             } else if (self.config.authType() === "oidc") {
-                config.headers.Authorization = `Bearer ${this.getOidcToken()}`;
+                const token: string | undefined = self.config.authOptions().tokenType === "id" ? this.getOidcIdToken() : this.getOidcAccessToken();
+                config.headers.Authorization = `Bearer ${token}`;
                 return Promise.resolve(config);
             } else {
                 return Promise.resolve(config);

--- a/ui/src/services/config/config.type.ts
+++ b/ui/src/services/config/config.type.ts
@@ -96,7 +96,7 @@ export interface AuthConfig {
     obacEnabled: boolean;
 }
 
-// Used when `type=keycloakjs`
+// Used when `type=keycloakjs` or `type=oidc`
 export interface OidcJsAuthConfig extends AuthConfig {
     options?: any;
 }


### PR DESCRIPTION
Backporting the id/access token option from 3.0 to 2.6.