### PR TITLE
Remove incorrect response example in OpenAPI specification

### DIFF
--- a/common/src/main/resources/META-INF/openapi-v2.json
+++ b/common/src/main/resources/META-INF/openapi-v2.json
@@ -2233,16 +2233,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/VersionSearchResults"
-                                },
-                                "examples": {
-                                    "All Versions": {
-                                        "value": [
-                                            5,
-                                            6,
-                                            10,
-                                            103
-                                        ]
-                                    }
                                 }
                             }
                         },

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -1942,16 +1942,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/VersionSearchResults"
-                },
-                "examples": {
-                  "All Versions": {
-                    "value": [
-                      5,
-                      6,
-                      10,
-                      103
-                    ]
-                  }
                 }
               }
             },


### PR DESCRIPTION
The "List artifact versions" response example was incorrect for both the v2 and v3 API specifications.

By removing the examples the OpenAPI UI will render a default example response based on `#/components/schemas/VersionSearchResults`.