### PR TITLE
fix(example): update simple protobuf example proto version

### DIFF
--- a/examples/simple-protobuf/pom.xml
+++ b/examples/simple-protobuf/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>
     <proto-plugin.version>0.6.1</proto-plugin.version>
+    <protobuf.version>3.21.12</protobuf.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
On the tag `v3.0.9` the `SimpleProtobufExample` fails due to improperly-compiled `AddressBook` protobuf:

```
Producing (2) messages.
Closing the producer.
[WARNING] 
java.lang.UnsupportedOperationException: This is supposed to be overridden by subclasses.
    at com.google.protobuf.GeneratedMessageV3.getUnknownFields (GeneratedMessageV3.java:302)
    at io.apicurio.registry.serde.protobuf.ref.RefOuterClass$Ref.getSerializedSize (RefOuterClass.java:138)
    at com.google.protobuf.AbstractMessageLite.writeDelimitedTo (AbstractMessageLite.java:89)
    at io.apicurio.registry.serde.protobuf.ProtobufSerializer.serializeData (ProtobufSerializer.java:95)
    at io.apicurio.registry.serde.protobuf.ProtobufSerializer.serializeData (ProtobufSerializer.java:21)
    at io.apicurio.registry.serde.AbstractSerializer.serializeData (AbstractSerializer.java:67)
    at io.apicurio.registry.serde.KafkaSerializer.serialize (KafkaSerializer.java:77)
    at org.apache.kafka.clients.producer.KafkaProducer.doSend (KafkaProducer.java:1015)
    at org.apache.kafka.clients.producer.KafkaProducer.send (KafkaProducer.java:962)
    at org.apache.kafka.clients.producer.KafkaProducer.send (KafkaProducer.java:847)
    at io.apicurio.registry.examples.simple.protobuf.SimpleProtobufExample.main (SimpleProtobufExample.java:89)
    at org.codehaus.mojo.exec.ExecJavaMojo.doMain (ExecJavaMojo.java:375)
    at org.codehaus.mojo.exec.ExecJavaMojo.doExec (ExecJavaMojo.java:364)
    at org.codehaus.mojo.exec.ExecJavaMojo.lambda$execute$0 (ExecJavaMojo.java:286)
    at java.lang.Thread.run (Thread.java:1583)

```