### PR TITLE
chore(deps): update OpenAPI compatibility check dependencies

### DIFF
--- a/go-sdk/generate.sh
+++ b/go-sdk/generate.sh
@@ -4,7 +4,7 @@
 
 RAW_ARCH="$(uname -m)"
 # See https://stackoverflow.com/a/45125525
-if  [[ "$RAW_ARCH" == aarch64* || "$RAW_ARCH" == armv8* ]]; then
+if  [[ "$RAW_ARCH" == aarch64* || "$RAW_ARCH" == armv8* || "$RAW_ARCH" == arm64* ]]; then
   ARCH=arm64
 elif [[ "$RAW_ARCH" == x86_64* ]]; then
   ARCH=x64

--- a/pom.xml
+++ b/pom.xml
@@ -207,9 +207,9 @@
     <jackson-dataformat-yaml.version>2.15.2</jackson-dataformat-yaml.version>
 
     <!-- OpenAPI -->
-    <openapi-diff.version>2.0.1</openapi-diff.version>
+    <openapi-diff.version>2.1.2</openapi-diff.version>
     <!-- We need to manually include the version because of dependency issues with snakeyaml -->
-    <swagger-parser-v3.version>2.1.25</swagger-parser-v3.version>
+    <swagger-parser-v3.version>2.1.30</swagger-parser-v3.version>
 
     <!-- Dependency versions -->
     <lombok.version>1.18.36</lombok.version>


### PR DESCRIPTION
Currently released version is 4 years old. This should hopefully improve the compatibility checks.

@EricWittmann Should this maybe picked up by the renovate bot?