### PR TITLE
chore(ci): Remove ghcr due to issues with secrets

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -148,7 +148,10 @@ jobs:
           docker load -i apicurio-registry-${{ github.sha }}.tar
 
       - name: Load temporary Docker image into Minikube
-        run: minikube image load apicurio-registry-${{ github.sha }}.tar
+        run: |
+          minikube image load apicurio-registry-${{ github.sha }}.tar
+          echo "Verifying image in minikube..."
+          minikube image ls | grep apicurio-registry || echo "Image not found in minikube!"
 
       - name: Run Integration Tests - H2
         run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-in-memory-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
@@ -204,7 +207,10 @@ jobs:
         run: docker load -i apicurio-registry-${{ github.sha }}.tar
 
       - name: Load temporary Docker image into Minikube
-        run: minikube image load apicurio-registry-${{ github.sha }}.tar
+        run: |
+          minikube image load apicurio-registry-${{ github.sha }}.tar
+          echo "Verifying image in minikube..."
+          minikube image ls | grep apicurio-registry || echo "Image not found in minikube!"
 
       - name: Run Integration Tests - Postgresql
         run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-sql-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
@@ -261,7 +267,10 @@ jobs:
         run: docker load -i apicurio-registry-${{ github.sha }}.tar
 
       - name: Load temporary Docker image into Minikube
-        run: minikube image load apicurio-registry-${{ github.sha }}.tar
+        run: |
+          minikube image load apicurio-registry-${{ github.sha }}.tar
+          echo "Verifying image in minikube..."
+          minikube image ls | grep apicurio-registry || echo "Image not found in minikube!"
 
       - name: Run Integration Tests - Kafkasql
         run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -144,7 +144,9 @@ jobs:
           name: apicurio-registry-${{ github.sha }}.tar
 
       - name: Load temporary Docker image
-        run: docker load -i apicurio-registry-${{ github.sha }}.tar
+        run: |
+          docker load -i apicurio-registry-${{ github.sha }}.tar
+          docker images apicurio/*
 
       - name: Load temporary Docker image into Minikube
         run: minikube image load apicurio/apicurio-registry:${{ github.sha }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -146,10 +146,9 @@ jobs:
       - name: Load temporary Docker image
         run: |
           docker load -i apicurio-registry-${{ github.sha }}.tar
-          docker images apicurio/*
 
       - name: Load temporary Docker image into Minikube
-        run: minikube image load apicurio/apicurio-registry:${{ github.sha }}
+        run: minikube image load apicurio-registry-${{ github.sha }}.tar
 
       - name: Run Integration Tests - H2
         run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-in-memory-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
@@ -205,7 +204,7 @@ jobs:
         run: docker load -i apicurio-registry-${{ github.sha }}.tar
 
       - name: Load temporary Docker image into Minikube
-        run: minikube image load apicurio/apicurio-registry:${{ github.sha }}
+        run: minikube image load apicurio-registry-${{ github.sha }}.tar
 
       - name: Run Integration Tests - Postgresql
         run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-sql-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
@@ -262,7 +261,7 @@ jobs:
         run: docker load -i apicurio-registry-${{ github.sha }}.tar
 
       - name: Load temporary Docker image into Minikube
-        run: minikube image load apicurio/apicurio-registry:${{ github.sha }}
+        run: minikube image load apicurio-registry-${{ github.sha }}.tar
 
       - name: Run Integration Tests - Kafkasql
         run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -52,18 +52,17 @@ jobs:
 
       - name: Build temporary Application image
         run: |
-          docker build -f ./distro/docker/target/docker/Dockerfile.jvm -t ghcr.io/apicurio/apicurio-registry:${{ github.sha }} ./distro/docker/target/docker
+          docker build -f ./distro/docker/target/docker/Dockerfile.jvm -t apicurio/apicurio-registry:${{ github.sha }} ./distro/docker/target/docker
 
-      - name: Push Temporary image for testing
-        uses: nick-fields/retry@v3
+      - name: Save Temporary image for testing
+        run: |
+          docker save apicurio/apicurio-registry:${{ github.sha }} -o apicurio-registry-${{ github.sha }}.tar
+
+      - name: Upload temporary image as artifact
+        uses: actions/upload-artifact@v4
         with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_on: error
-          retry_wait_seconds: 60
-          command: |
-            echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
-            docker push ghcr.io/apicurio/apicurio-registry:${{ github.sha }}
+          name: apicurio-registry-${{ github.sha }}.tar
+          path: apicurio-registry-${{ github.sha }}.tar
 
   prepare-ui-tests:
     name: Prepare for UI Integration Tests
@@ -102,19 +101,17 @@ jobs:
       - name: Build UI container image
         working-directory: ui
         run: |
-          docker build -t ghcr.io/apicurio/apicurio-registry-ui:${{ github.sha }} .
+          docker build -t apicurio/apicurio-registry-ui:${{ github.sha }} .
 
-      - name: Push Temporary UI image for testing
-        uses: nick-fields/retry@v3
+      - name: Save Temporary image for testing
+        run: |
+          docker save apicurio/apicurio-registry-ui:${{ github.sha }} -o apicurio-registry-ui-${{ github.sha }}.tar
+
+      - name: Upload temporary image as artifact
+        uses: actions/upload-artifact@v4
         with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_on: error
-          retry_wait_seconds: 60
-          command: |
-            cd ui
-            echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
-            docker push ghcr.io/apicurio/apicurio-registry-ui:${{ github.sha }}
+          name: apicurio-registry-ui-${{ github.sha }}.tar
+          path: apicurio-registry-ui-${{ github.sha }}.tar
 
   integration-tests-h2:
     name: Integration Tests H2
@@ -141,17 +138,25 @@ jobs:
       - name: Prepare minikube tunnel
         run: minikube tunnel &> /dev/null &
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Download temporary Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: apicurio-registry-${{ github.sha }}.tar
+
+      - name: Load temporary Docker image
+        run: docker load -i apicurio-registry-${{ github.sha }}.tar
+
+      - name: Load temporary Docker image into Minikube
+        run: minikube image load apicurio/apicurio-registry:${{ github.sha }}
 
       - name: Run Integration Tests - H2
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-in-memory-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-in-memory-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - auth - H2
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-in-memory-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-in-memory-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - migration - H2
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-in-memory-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-in-memory-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
@@ -189,17 +194,25 @@ jobs:
       - name: Prepare minikube tunnel
         run: minikube tunnel &> /dev/null &
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Download temporary Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: apicurio-registry-${{ github.sha }}.tar
+
+      - name: Load temporary Docker image
+        run: docker load -i apicurio-registry-${{ github.sha }}.tar
+
+      - name: Load temporary Docker image into Minikube
+        run: minikube image load apicurio/apicurio-registry:${{ github.sha }}
 
       - name: Run Integration Tests - Postgresql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-sql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-sql-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - auth - Postgresql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-sql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-sql-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - migration - Postgresql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-sql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-sql-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
@@ -238,20 +251,28 @@ jobs:
       - name: Prepare minikube tunnel
         run: minikube tunnel &> /dev/null &
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Download temporary Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: apicurio-registry-${{ github.sha }}.tar
+
+      - name: Load temporary Docker image
+        run: docker load -i apicurio-registry-${{ github.sha }}.tar
+
+      - name: Load temporary Docker image into Minikube
+        run: minikube image load apicurio/apicurio-registry:${{ github.sha }}
 
       - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - auth - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-kafkasql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-kafkasql-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - migration - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-kafkasql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-kafkasql-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - snapshotting - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pkafkasql-snapshotting -Dregistry-kafkasql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pkafkasql-snapshotting -Dregistry-kafkasql-image=apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
@@ -279,15 +300,27 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'ui/tests/package-lock.json'
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Download temporary Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: apicurio-registry-${{ github.sha }}.tar
+
+      - name: Download temporary Docker image (UI)
+        uses: actions/download-artifact@v4
+        with:
+          name: apicurio-registry-ui-${{ github.sha }}.tar
+
+      - name: Load temporary Docker images
+        run: |
+          docker load -i apicurio-registry-${{ github.sha }}.tar
+          docker load -i apicurio-registry-ui-${{ github.sha }}.tar
 
       - name: Run UI tests
         run: |
           echo "Starting Registry App (In Memory)"
-          docker run -it -p 8080:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ghcr.io/apicurio/apicurio-registry:${{ github.sha }}
+          docker run -it -p 8080:8080 -e apicurio.rest.deletion.artifact.enabled=true -d apicurio/apicurio-registry:${{ github.sha }}
           echo "Starting Registry UI"
-          docker run -it -p 8888:8080 -d ghcr.io/apicurio/apicurio-registry-ui:${{ github.sha }}
+          docker run -it -p 8888:8080 -d apicurio/apicurio-registry-ui:${{ github.sha }}
 
           cd ui/tests
           npm install
@@ -347,13 +380,18 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Download temporary Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: apicurio-registry-${{ github.sha }}.tar
+
+      - name: Load temporary Docker image
+        run: docker load -i apicurio-registry-${{ github.sha }}.tar
 
       - name: Run Legacy Integration Tests (Core API v2)
         run: |
           echo "Starting Registry App (In Memory)"
-          docker run -it -p 8181:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ghcr.io/apicurio/apicurio-registry:${{ github.sha }}
+          docker run -it -p 8181:8080 -e apicurio.rest.deletion.artifact.enabled=true -d apicurio/apicurio-registry:${{ github.sha }}
           cd registry-v2
           ./mvnw -Pintegration-tests clean install -DskipTests=true -DskipUiBuild=true -Dmaven.javadoc.skip=true
           cd integration-tests
@@ -378,13 +416,18 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Download temporary Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: apicurio-registry-${{ github.sha }}.tar
+
+      - name: Load temporary Docker image
+        run: docker load -i apicurio-registry-${{ github.sha }}.tar
 
       - name: Run SDK tests
         run: |
           echo "Starting Registry App (In Memory)"
-          docker run -it -p 8080:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ghcr.io/apicurio/apicurio-registry:${{ github.sha }}
+          docker run -it -p 8080:8080 -e apicurio.rest.deletion.artifact.enabled=true -d apicurio/apicurio-registry:${{ github.sha }}
 
           cd typescript-sdk
           npm install
@@ -408,11 +451,16 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Download temporary Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: apicurio-registry-${{ github.sha }}.tar
+
+      - name: Load temporary Docker image
+        run: docker load -i apicurio-registry-${{ github.sha }}.tar
 
       - name: Run Apicurio Registry application
-        run: docker run -d -p 8080:8080 -it ghcr.io/apicurio/apicurio-registry:${{ github.sha }}
+        run: docker run -d -p 8080:8080 -it apicurio/apicurio-registry:${{ github.sha }}
 
       - name: Build Apicurio Registry with Examples
         run: cd apicurio-registry && mvn clean install -DskipTests -Pexamples

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -238,18 +238,7 @@ jobs:
 
       - name: Build Temporary image for testing
         run: |
-          docker build -f ./distro/docker/target/docker/Dockerfile.native -t ghcr.io/apicurio/apicurio-registry-native:${{ github.sha }} app/
-
-      - name: Push Temporary image for testing
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_on: error
-          retry_wait_seconds: 60
-          command: |
-            echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
-            docker push ghcr.io/apicurio/apicurio-registry-native:${{ github.sha }}
+          docker build -f ./distro/docker/target/docker/Dockerfile.native -t apicurio/apicurio-registry-native:${{ github.sha }} app/
 
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.13.0
@@ -262,15 +251,19 @@ jobs:
       - name: Prepare minikube tunnel
         run: minikube tunnel &> /dev/null &
 
+      - name: Load temporary Docker image into Minikube
+        run: minikube image load apicurio/apicurio-registry-native:${{ github.sha }}
+
       - name: Run Integration Tests - Native
-        run: ./mvnw verify -am -Pci --no-transfer-progress -Pintegration-tests -Dregistry-in-memory-image=ghcr.io/apicurio/apicurio-registry-native:${{ github.sha }} -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am -Pci --no-transfer-progress -Pintegration-tests -Dregistry-in-memory-image=apicurio/apicurio-registry-native:${{ github.sha }} -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - Native - Auth
-        run: ./mvnw verify -am -Pauth --no-transfer-progress -Pintegration-tests -Dregistry-in-memory-image=ghcr.io/apicurio/apicurio-registry-native:${{ github.sha }} -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am -Pauth --no-transfer-progress -Pintegration-tests -Dregistry-in-memory-image=apicurio/apicurio-registry-native:${{ github.sha }} -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
         run: ./.github/scripts/collect_logs.sh
+
       - name: Upload tests logs artifacts
         if: failure()
         uses: actions/upload-artifact@v4.0.0

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -239,6 +239,7 @@ jobs:
       - name: Build Temporary image for testing
         run: |
           docker build -f ./distro/docker/target/docker/Dockerfile.native -t apicurio/apicurio-registry-native:${{ github.sha }} app/
+          docker save apicurio/apicurio-registry-native:${{ github.sha }} -o apicurio-registry-native-${{ github.sha }}.tar
 
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.13.0
@@ -252,7 +253,7 @@ jobs:
         run: minikube tunnel &> /dev/null &
 
       - name: Load temporary Docker image into Minikube
-        run: minikube image load apicurio/apicurio-registry-native:${{ github.sha }}
+        run: minikube image load apicurio-registry-native-${{ github.sha }}.tar
 
       - name: Run Integration Tests - Native
         run: ./mvnw verify -am -Pci --no-transfer-progress -Pintegration-tests -Dregistry-in-memory-image=apicurio/apicurio-registry-native:${{ github.sha }} -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true

--- a/integration-tests/src/test/resources/infra/in-memory/registry-in-memory-secured.yml
+++ b/integration-tests/src/test/resources/infra/in-memory/registry-in-memory-secured.yml
@@ -50,7 +50,7 @@ spec:
             - name: APICURIO_REST_DELETION_GROUP_ENABLED
               value: "true"
           image: registry-image
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/integration-tests/src/test/resources/infra/in-memory/registry-in-memory.yml
+++ b/integration-tests/src/test/resources/infra/in-memory/registry-in-memory.yml
@@ -28,7 +28,7 @@ spec:
             - name: APICURIO_REST_DELETION_GROUP_ENABLED
               value: "true"
           image: registry-image
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/integration-tests/src/test/resources/infra/kafka/registry-kafka-old.yml
+++ b/integration-tests/src/test/resources/infra/kafka/registry-kafka-old.yml
@@ -24,7 +24,7 @@ spec:
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: kafka-service:9092
           image: quay.io/apicurio/apicurio-registry-kafkasql:2.1.2.Final
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/integration-tests/src/test/resources/infra/kafka/registry-kafka-secured.yml
+++ b/integration-tests/src/test/resources/infra/kafka/registry-kafka-secured.yml
@@ -54,7 +54,7 @@ spec:
             - name: APICURIO_REST_DELETION_GROUP_ENABLED
               value: "true"
           image: registry-image
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/integration-tests/src/test/resources/infra/kafka/registry-kafka.yml
+++ b/integration-tests/src/test/resources/infra/kafka/registry-kafka.yml
@@ -35,7 +35,7 @@ spec:
             - name: APICURIO_REST_DELETION_GROUP_ENABLED
               value: "true"
           image: registry-image
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/integration-tests/src/test/resources/infra/sql/registry-sql-secured.yml
+++ b/integration-tests/src/test/resources/infra/sql/registry-sql-secured.yml
@@ -58,7 +58,7 @@ spec:
             - name: APICURIO_REST_DELETION_GROUP_ENABLED
               value: "true"
           image: registry-image
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/integration-tests/src/test/resources/infra/sql/registry-sql.yml
+++ b/integration-tests/src/test/resources/infra/sql/registry-sql.yml
@@ -36,7 +36,7 @@ spec:
             - name: APICURIO_REST_DELETION_GROUP_ENABLED
               value: "true"
           image: registry-image
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
Stop using GHCR.  Even though it works well, it only works for PRs opened from the original repository.  PRs from forks do not work because the GHCR secret is not available.

Summary of changes:
1. Stop using GHCR for temporary docker images
2. Use `docker save` to export docker image to a .tar file
3. Upload the saved docker image as an artifact to the workflow run
4. When needed by other jobs, download the saved docker image and load it into docker & minikube
5. Update the `imagePullPolicy` on all integration test Deployment resources so minikube does not attempt to pull the temporary docker image (which would not work)
