### PR TITLE
chore(ci): replace ghrc.io with a temporary quay.io repository (alternative)

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build temporary Application image
         run: |
-          docker build -f ./distro/docker/target/docker/Dockerfile.jvm -t ghcr.io/apicurio/apicurio-registry:${{ github.sha }} ./distro/docker/target/docker
+          docker build -f ./distro/docker/target/docker/Dockerfile.jvm -t quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }} ./distro/docker/target/docker
 
       - name: Push Temporary image for testing
         uses: nick-fields/retry@v3
@@ -62,8 +62,8 @@ jobs:
           retry_on: error
           retry_wait_seconds: 60
           command: |
-            echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
-            docker push ghcr.io/apicurio/apicurio-registry:${{ github.sha }}
+            echo ${{ vars.QUAY_TMP_ONLY_PASSWORD }} | docker login quay.io -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} --password-stdin
+            docker push quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}
 
   prepare-ui-tests:
     name: Prepare for UI Integration Tests
@@ -102,7 +102,7 @@ jobs:
       - name: Build UI container image
         working-directory: ui
         run: |
-          docker build -t ghcr.io/apicurio/apicurio-registry-ui:${{ github.sha }} .
+          docker build -t quay.io/apicurio-ci/apicurio-registry-ui:$(date --rfc-3339=date)_${{ github.sha }} .
 
       - name: Push Temporary UI image for testing
         uses: nick-fields/retry@v3
@@ -113,8 +113,8 @@ jobs:
           retry_wait_seconds: 60
           command: |
             cd ui
-            echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
-            docker push ghcr.io/apicurio/apicurio-registry-ui:${{ github.sha }}
+            echo ${{ vars.QUAY_TMP_ONLY_PASSWORD }} | docker login quay.io -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} --password-stdin
+            docker push quay.io/apicurio-ci/apicurio-registry-ui:$(date --rfc-3339=date)_${{ github.sha }}
 
   integration-tests-h2:
     name: Integration Tests H2
@@ -141,17 +141,17 @@ jobs:
       - name: Prepare minikube tunnel
         run: minikube tunnel &> /dev/null &
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Login to quay.io TMP ONLY
+        run: echo ${{ vars.QUAY_TMP_ONLY_PASSWORD }} | docker login quay.io -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} --password-stdin
 
       - name: Run Integration Tests - H2
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-in-memory-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-in-memory-image=quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - auth - H2
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-in-memory-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-in-memory-image=quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - migration - H2
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-in-memory-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-in-memory-image=quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}  -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
@@ -189,17 +189,17 @@ jobs:
       - name: Prepare minikube tunnel
         run: minikube tunnel &> /dev/null &
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Login to quay.io TMP ONLY
+        run: echo ${{ vars.QUAY_TMP_ONLY_PASSWORD }} | docker login quay.io -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} --password-stdin
 
       - name: Run Integration Tests - Postgresql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-sql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-sql-image=quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - auth - Postgresql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-sql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-sql-image=quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - migration - Postgresql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-sql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-sql-image=quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}  -Premote-sql -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
@@ -238,20 +238,20 @@ jobs:
       - name: Prepare minikube tunnel
         run: minikube tunnel &> /dev/null &
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Login to quay.io TMP ONLY
+        run: echo ${{ vars.QUAY_TMP_ONLY_PASSWORD }} | docker login quay.io -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} --password-stdin
 
       - name: Run Integration Tests - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pci -Dregistry-kafkasql-image=quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - auth - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-kafkasql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pauth -Dregistry-kafkasql-image=quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - migration - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-kafkasql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pmigration -Dregistry-kafkasql-image=quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - snapshotting - Kafkasql
-        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pkafkasql-snapshotting -Dregistry-kafkasql-image=ghcr.io/apicurio/apicurio-registry:${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am --no-transfer-progress -Pintegration-tests -Pkafkasql-snapshotting -Dregistry-kafkasql-image=quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}  -Premote-kafka -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()
@@ -279,15 +279,15 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'ui/tests/package-lock.json'
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Login to quay.io TMP ONLY
+        run: echo ${{ vars.QUAY_TMP_ONLY_PASSWORD }} | docker login quay.io -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} --password-stdin
 
       - name: Run UI tests
         run: |
           echo "Starting Registry App (In Memory)"
-          docker run -it -p 8080:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ghcr.io/apicurio/apicurio-registry:${{ github.sha }}
+          docker run -it -p 8080:8080 -e apicurio.rest.deletion.artifact.enabled=true -d quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}
           echo "Starting Registry UI"
-          docker run -it -p 8888:8080 -d ghcr.io/apicurio/apicurio-registry-ui:${{ github.sha }}
+          docker run -it -p 8888:8080 -d quay.io/apicurio-ci/apicurio-registry-ui:$(date --rfc-3339=date)_${{ github.sha }}
 
           cd ui/tests
           npm install
@@ -347,13 +347,13 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Login to quay.io TMP ONLY
+        run: echo ${{ vars.QUAY_TMP_ONLY_PASSWORD }} | docker login quay.io -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} --password-stdin
 
       - name: Run Legacy Integration Tests (Core API v2)
         run: |
           echo "Starting Registry App (In Memory)"
-          docker run -it -p 8181:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ghcr.io/apicurio/apicurio-registry:${{ github.sha }}
+          docker run -it -p 8181:8080 -e apicurio.rest.deletion.artifact.enabled=true -d quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}
           cd registry-v2
           ./mvnw -Pintegration-tests clean install -DskipTests=true -DskipUiBuild=true -Dmaven.javadoc.skip=true
           cd integration-tests
@@ -378,13 +378,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Login to quay.io TMP ONLY
+        run: echo ${{ vars.QUAY_TMP_ONLY_PASSWORD }} | docker login quay.io -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} --password-stdin
 
       - name: Run SDK tests
         run: |
           echo "Starting Registry App (In Memory)"
-          docker run -it -p 8080:8080 -e apicurio.rest.deletion.artifact.enabled=true -d ghcr.io/apicurio/apicurio-registry:${{ github.sha }}
+          docker run -it -p 8080:8080 -e apicurio.rest.deletion.artifact.enabled=true -d quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}
 
           cd typescript-sdk
           npm install
@@ -408,11 +408,11 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Login to ghcr.io
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
+      - name: Login to quay.io TMP ONLY
+        run: echo ${{ vars.QUAY_TMP_ONLY_PASSWORD }} | docker login quay.io -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} --password-stdin
 
       - name: Run Apicurio Registry application
-        run: docker run -d -p 8080:8080 -it ghcr.io/apicurio/apicurio-registry:${{ github.sha }}
+        run: docker run -d -p 8080:8080 -it quay.io/apicurio-ci/apicurio-registry:$(date --rfc-3339=date)_${{ github.sha }}
 
       - name: Build Apicurio Registry with Examples
         run: cd apicurio-registry && mvn clean install -DskipTests -Pexamples

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -23,17 +23,16 @@ jobs:
     if: github.repository_owner == 'Apicurio' && !contains(github.event.*.labels.*.name, 'DO NOT MERGE')
     steps:
 
-      - name: Configure env. variables 1
-        run: |
-          echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+      - name: Login to quay.io TMP ONLY
+        run: echo ${{ vars.QUAY_TMP_ONLY_PASSWORD }} | docker login quay.io -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} --password-stdin
 
       # We need tho push the bundle image because opm always pulls; the catalog image because OLM
       # deploys it with `imagePullPolicy: Always`; and also the operator image itself for the same reason.
-      - name: Configure env. variables 2
+      - name: Configure env. variables
         run: |
-          echo "IMAGE=ttl.sh/apicurio-registry-3-operator-$UUID:8h" >> $GITHUB_ENV
-          echo "BUNDLE_IMAGE=ttl.sh/apicurio-registry-3-operator-bundle-$UUID:8h" >> $GITHUB_ENV
-          echo "CATALOG_IMAGE=ttl.sh/apicurio-registry-3-operator-catalog-$UUID:8h" >> $GITHUB_ENV
+          echo "IMAGE=quay.io/apicurio-ci/apicurio-registry-3-operator:$(date --rfc-3339=date)_${{ github.sha }}" >> $GITHUB_ENV
+          echo "BUNDLE_IMAGE=quay.io/apicurio-ci/apicurio-registry-3-operator-bundle:$(date --rfc-3339=date)_${{ github.sha }}" >> $GITHUB_ENV
+          echo "CATALOG_IMAGE=quay.io/apicurio-ci/apicurio-registry-3-operator-catalog:$(date --rfc-3339=date)_${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v4
@@ -106,24 +105,24 @@ jobs:
 
       # Uncomment if you need to debug the tests:
 
-#      - name: Install debug tools on failure
-#        if: failure()
-#        run: |
-#          NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-#          echo >> /home/runner/.bashrc
-#          echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/runner/.bashrc
-#          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-#          brew install derailed/k9s/k9s
-#          . ~/.bashrc
-#          # Run tests e.g.:
-#          # make BUILD_OPTS=--no-transfer-progress test-remote-all &> 1.log &
-#          # tail -f 1.log
-#
-#      - name: Setup tmate session on failure
-#        if: failure()
-#        uses: mxschmitt/action-tmate@v3
-#        with:
-#          limit-access-to-actor: true
+  #      - name: Install debug tools on failure
+  #        if: failure()
+  #        run: |
+  #          NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  #          echo >> /home/runner/.bashrc
+  #          echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/runner/.bashrc
+  #          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+  #          brew install derailed/k9s/k9s
+  #          . ~/.bashrc
+  #          # Run tests e.g.:
+  #          # make BUILD_OPTS=--no-transfer-progress test-remote-all &> 1.log &
+  #          # tail -f 1.log
+  #
+  #      - name: Setup tmate session on failure
+  #        if: failure()
+  #        uses: mxschmitt/action-tmate@v3
+  #        with:
+  #          limit-access-to-actor: true
 
   operator-publish:
     name: Publish Operator

--- a/.github/workflows/quay-clean.yaml
+++ b/.github/workflows/quay-clean.yaml
@@ -1,0 +1,45 @@
+name: Clean quay.io/apicurio-ci
+on:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+
+  quay-clean:
+    name: Clean quay.io/apicurio-ci
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Apicurio'
+    steps:
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Clean
+        run: |
+          crane auth login -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} -p ${{ vars.QUAY_TMP_ONLY_PASSWORD }} quay.io
+          for REGISTRY in apicurio-registry apicurio-registry-native apicurio-registry-ui apicurio-registry-3-operator apicurio-registry-3-operator-bundle apicurio-registry-3-operator-catalog; do
+            crane ls quay.io/apicurio-ci/$REGISTRY | grep -v "^$(date --rfc-3339=date)_.*" | grep -v "^$(date --rfc-3339=date -d '1 day ago')_.*" | xargs -I{} crane delete quay.io/apicurio-ci/$REGISTRY:{}
+          done
+
+      - name: Slack Notification (Always)
+        if: always()
+        run: |
+          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job completed with status: ${{ job.status }}"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}"
+
+      - name: Slack Notification (Error)
+        if: failure()
+        run: |
+          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job FAILED!"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "${{ secrets.SLACK_ERROR_WEBHOOK }}"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -238,7 +238,7 @@ jobs:
 
       - name: Build Temporary image for testing
         run: |
-          docker build -f ./distro/docker/target/docker/Dockerfile.native -t ghcr.io/apicurio/apicurio-registry-native:${{ github.sha }} app/
+          docker build -f ./distro/docker/target/docker/Dockerfile.native -t quay.io/apicurio-ci/apicurio-registry-native:$(date --rfc-3339=date)_${{ github.sha }} app/
 
       - name: Push Temporary image for testing
         uses: nick-fields/retry@v3
@@ -248,8 +248,8 @@ jobs:
           retry_on: error
           retry_wait_seconds: 60
           command: |
-            echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u apicurio-ci --password-stdin
-            docker push ghcr.io/apicurio/apicurio-registry-native:${{ github.sha }}
+            echo ${{ vars.QUAY_TMP_ONLY_PASSWORD }} | docker login quay.io -u ${{ vars.QUAY_TMP_ONLY_USERNAME }} --password-stdin
+            docker push quay.io/apicurio-ci/apicurio-registry-native:$(date --rfc-3339=date)_${{ github.sha }}
 
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.13.0
@@ -263,10 +263,10 @@ jobs:
         run: minikube tunnel &> /dev/null &
 
       - name: Run Integration Tests - Native
-        run: ./mvnw verify -am -Pci --no-transfer-progress -Pintegration-tests -Dregistry-in-memory-image=ghcr.io/apicurio/apicurio-registry-native:${{ github.sha }} -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am -Pci --no-transfer-progress -Pintegration-tests -Dregistry-in-memory-image=quay.io/apicurio-ci/apicurio-registry-native:$(date --rfc-3339=date)_${{ github.sha }} -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Run Integration Tests - Native - Auth
-        run: ./mvnw verify -am -Pauth --no-transfer-progress -Pintegration-tests -Dregistry-in-memory-image=ghcr.io/apicurio/apicurio-registry-native:${{ github.sha }} -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
+        run: ./mvnw verify -am -Pauth --no-transfer-progress -Pintegration-tests -Dregistry-in-memory-image=quay.io/apicurio-ci/apicurio-registry-native:$(date --rfc-3339=date)_${{ github.sha }} -Premote-mem -pl integration-tests -Dmaven.javadoc.skip=true
 
       - name: Collect logs
         if: failure()


### PR DESCRIPTION
Possible alternative to https://github.com/Apicurio/apicurio-registry/pull/6420