### PR TITLE
Add ability to create drafts from the maven plugin

### DIFF
--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterArtifact.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterArtifact.java
@@ -17,6 +17,7 @@ public class RegisterArtifact {
     private Boolean minify;
     private Boolean analyzeDirectory;
     private Boolean autoRefs;
+    private Boolean isDraft;
     private String contentType;
     private List<RegisterArtifactReference> references;
     private List<ExistingReference> existingReferences;
@@ -181,6 +182,14 @@ public class RegisterArtifact {
 
     public void setAutoRefs(Boolean autoRefs) {
         this.autoRefs = autoRefs;
+    }
+
+    public Boolean getIsDraft() {
+        return isDraft;
+    }
+
+    public void setIsDraft(Boolean isDraft) {
+       this.isDraft = isDraft;
     }
 
     public List<ExistingReference> getExistingReferences() {

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
@@ -312,6 +312,7 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
         String version = artifact.getVersion();
         String type = artifact.getArtifactType();
         Boolean canonicalize = artifact.getCanonicalize();
+        Boolean isDraft = artifact.getIsDraft();
         String ct = artifact.getContentType() == null ? ContentTypes.APPLICATION_JSON
                 : artifact.getContentType();
         String data = null;
@@ -333,6 +334,7 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
 
         CreateVersion createVersion = new CreateVersion();
         createVersion.setVersion(version);
+        createVersion.setIsDraft(isDraft);
         createArtifact.setFirstVersion(createVersion);
 
         VersionContent content = new VersionContent();


### PR DESCRIPTION
Adding draft versions using the maven plugin is currently not possible. This adds this ability by extending the configuration of the plugin. 