### PR TITLE
fix(validity-rule): Test and fix for issue #6530

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/Issue6530Test.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/Issue6530Test.java
@@ -1,0 +1,129 @@
+package io.apicurio.registry.noprofile;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+
+import io.apicurio.registry.rest.v3.beans.ArtifactReference;
+import io.apicurio.registry.rest.client.models.CreateArtifactResponse;
+import io.apicurio.registry.rest.client.models.CreateGroup;
+import io.apicurio.registry.rest.client.models.CreateRule;
+import io.apicurio.registry.rest.client.models.RuleType;
+import io.apicurio.registry.rules.integrity.IntegrityLevel;
+import io.apicurio.registry.rules.validity.ValidityLevel;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Test for GitHub issue #6530: Registering protobuf schemas with references results in error when Validity rule is enabled.
+ * 
+ * This test reproduces the bug where attempting to register a protobuf schema that imports/references another 
+ * protobuf schema fails with a RuleViolationException when the Validity rule is enabled at FULL level.
+ * 
+ * The test scenario:
+ * 1. Creates a test group with FULL Validity rule enabled
+ * 2. Registers a base protobuf schema (UserCreated.proto) - should succeed
+ * 3. Registers a second protobuf schema (UserCreatedEvent.proto) that imports the first schema - should succeed but currently fails
+ * 
+ * Expected behavior: Both schemas should register successfully
+ * Actual behavior: The second schema registration fails with RuleViolationException: "Syntax violation for Protobuf artifact."
+ * 
+ * @see <a href="https://github.com/Apicurio/apicurio-registry/issues/6530">GitHub Issue #6530</a>
+ */
+@QuarkusTest
+public class Issue6530Test extends AbstractResourceTestBase {
+
+    private static final String USER_CREATED_PROTO = """
+syntax = "proto3";
+package demo;
+
+message UserCreated {
+  string user_id = 1;
+  string name = 2;
+  int32 age = 3;
+  string email = 4;
+}
+""";
+
+    private static final String USER_CREATED_EVENT_PROTO = """
+syntax = "proto3";
+package demo;
+
+import "demo/UserCreated.proto";
+
+message UserCreatedEvent {
+  UserCreated user = 1;
+  string source = 2;
+  int64 timestamp = 3;
+}
+""";
+
+    @Test
+    public void testIssue6530() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String referencedArtifactId = "UserCreated.proto";
+        String referencingArtifactId = "UserCreatedEvent.proto";
+
+        // Create a group
+        CreateGroup createGroup = new CreateGroup();
+        createGroup.setGroupId(groupId);
+        clientV3.groups().post(createGroup);
+
+        // Enable FULL Validity rule at the Group level
+        CreateRule createRule = new CreateRule();
+        createRule.setRuleType(RuleType.VALIDITY);
+        createRule.setConfig(ValidityLevel.FULL.name());
+        clientV3.groups().byGroupId(groupId).rules().post(createRule);
+
+        // Enable FULL Integrity rule at the Group level
+        createRule = new CreateRule();
+        createRule.setRuleType(RuleType.INTEGRITY);
+        createRule.setConfig(IntegrityLevel.FULL.name());
+        clientV3.groups().byGroupId(groupId).rules().post(createRule);
+
+        // Create the first artifact (UserCreated.proto) - this should succeed
+        CreateArtifactResponse response1 = createArtifact(groupId, referencedArtifactId, 
+                ArtifactType.PROTOBUF, USER_CREATED_PROTO, ContentTypes.APPLICATION_PROTOBUF);
+        
+        Assertions.assertNotNull(response1);
+        Assertions.assertEquals(groupId, response1.getArtifact().getGroupId());
+        Assertions.assertEquals(referencedArtifactId, response1.getArtifact().getArtifactId());
+        Assertions.assertEquals(ArtifactType.PROTOBUF, response1.getArtifact().getArtifactType());
+        Assertions.assertEquals("1", response1.getVersion().getVersion());
+
+        // Create reference to the first artifact
+        ArtifactReference reference = ArtifactReference.builder()
+                .groupId(groupId)
+                .artifactId(referencedArtifactId)
+                .version("1")
+                .name("demo/UserCreated.proto")
+                .build();
+
+        // Create the second artifact (UserCreatedEvent.proto) with reference
+        CreateArtifactResponse response2 = createArtifactWithReferences(groupId, referencingArtifactId,
+                ArtifactType.PROTOBUF, USER_CREATED_EVENT_PROTO, ContentTypes.APPLICATION_PROTOBUF,
+                List.of(reference));
+
+        Assertions.assertNotNull(response2);
+        Assertions.assertEquals(groupId, response2.getArtifact().getGroupId());
+        Assertions.assertEquals(referencingArtifactId, response2.getArtifact().getArtifactId());
+        Assertions.assertEquals(ArtifactType.PROTOBUF, response2.getArtifact().getArtifactType());
+        Assertions.assertEquals("1", response2.getVersion().getVersion());
+
+        // Verify the references are properly stored
+        var actualReferences = clientV3.groups().byGroupId(groupId)
+                .artifacts().byArtifactId(referencingArtifactId)
+                .versions().byVersionExpression("1")
+                .references().get();
+        
+        Assertions.assertEquals(1, actualReferences.size());
+        Assertions.assertEquals(reference.getName(), actualReferences.get(0).getName());
+        Assertions.assertEquals(reference.getVersion(), actualReferences.get(0).getVersion());
+        Assertions.assertEquals(reference.getArtifactId(), actualReferences.get(0).getArtifactId());
+        Assertions.assertEquals(reference.getGroupId(), actualReferences.get(0).getGroupId());
+    }
+}

--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
@@ -140,20 +140,17 @@ public class ProtobufSchemaLoader {
             okio.Path path = writeFile(schemaDefinition, fileName, dirPath, inMemoryFileSystem);
 
             for (Map.Entry<String, String> schema : deps.entrySet()) {
+                String depDirPath = "/";
                 final String depKey = schema.getKey();
                 final String depSchema = schema.getValue();
                 int beforeFileName = depKey.lastIndexOf('/');
                 if (beforeFileName != -1) {
                     final String packageNameDep = depKey.substring(0, beforeFileName);
-                    String depDirPath = dirPath;
-                    if (!packageName.isPresent() || !packageName.get().equals(packageNameDep)) {
-                        // apply the same logic used for dirs of the root one
-                        depDirPath = createDirectory(packageNameDep.split("\\."), inMemoryFileSystem);
-                    }
+                    depDirPath = createDirectory(packageNameDep.split("\\."), inMemoryFileSystem);
                     writeFile(depSchema, depKey.substring(beforeFileName + 1), depDirPath,
                             inMemoryFileSystem);
                 } else {
-                    writeFile(depSchema, depKey, dirPath, inMemoryFileSystem);
+                    writeFile(depSchema, depKey, depDirPath, inMemoryFileSystem);
                 }
             }
 


### PR DESCRIPTION
Fix for issue:
* https://github.com/Apicurio/apicurio-registry/issues/6530

I think we were not properly writing the various .proto files to the correct locations in the virtual filesystem, prior to loading them.  This caused the validity rule to fail.

The original issue did highlight this problem, although the test .proto files in the issue are not quite right.  The `UserCreated.proto` import should be `demo/UserCreated.proto` for everything to work as expected.