### PR TITLE
fix: prioritize configured redirectUri coming from app-backend over window.location.href

### DIFF
--- a/ui/ui-app/src/app/App.tsx
+++ b/ui/ui-app/src/app/App.tsx
@@ -30,7 +30,8 @@ export const App: FunctionComponent<AppProps> = () => {
         options: config.authOptions()
     };
     if (authConfig.type === "oidc") {
-        if (window.location?.href) {
+        // Only set redirectUri as fallback if not already configured
+        if (!authConfig.options.redirectUri && window.location?.href) {
             authConfig.options.redirectUri = window.location.href;
         } else if (authConfig.options.redirectUri && authConfig.options.redirectUri.startsWith("/")) {
             authConfig.options.redirectUri = window.location.origin + authConfig.options.redirectUri;


### PR DESCRIPTION
- Modified authConfig logic to only use window.location.href as fallback
- Prevents overwriting of explicitly configured redirectUri values coming from app-backend as uiConfig
- Maintains backward compatibility for cases with no configured redirectUri

```
    "auth": {
        "type": "oidc",
        "rbacEnabled": true,
        "obacEnabled": false,
        "options": {
            "redirectUri": "http://localhost:8080",
            ... ... 
        }
    },
```