### PR TITLE
fix(6560) : The client facade factory now properly detects the configured endpoint version from the URL

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/serde/AvroSerdeFacadeV2Test.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/serde/AvroSerdeFacadeV2Test.java
@@ -1,0 +1,87 @@
+package io.apicurio.registry.noprofile.serde;
+
+import io.apicurio.registry.AbstractClientFacadeTestBase;
+import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
+import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
+import io.apicurio.registry.serde.avro.AvroSerdeConfig;
+import io.apicurio.registry.serde.avro.DefaultAvroDatumProvider;
+import io.apicurio.registry.serde.avro.strategy.TopicRecordIdStrategy;
+import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@QuarkusTest
+public class AvroSerdeFacadeV2Test extends AbstractClientFacadeTestBase {
+
+    @Test
+    public void testConfiguration() throws Exception {
+        String recordName = "myrecord3";
+        Schema schema = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"" + recordName
+                + "\",\"fields\":[{\"name\":\"bar\",\"type\":\"string\"}]}");
+
+        String groupId = TestUtils.generateGroupId();
+        String topic = generateArtifactId();
+
+        /* final Integer globalId = */
+        createArtifact(groupId, topic + "-" + recordName, ArtifactType.AVRO, schema.toString(),
+                ContentTypes.APPLICATION_JSON);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, TestUtils.getRegistryV2ApiUrl(testPort));
+        config.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+        config.put(SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1");
+        config.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, TopicRecordIdStrategy.class.getName());
+        config.put(AvroSerdeConfig.AVRO_DATUM_PROVIDER, DefaultAvroDatumProvider.class.getName());
+        Serializer<GenericData.Record> serializer = new AvroKafkaSerializer<GenericData.Record>();
+        serializer.configure(config, true);
+
+        Deserializer<GenericData.Record> deserializer = new AvroKafkaDeserializer<GenericData.Record>();
+
+        TestUtils.retry(() -> {
+
+            GenericData.Record record = new GenericData.Record(schema);
+            record.put("bar", "somebar");
+            byte[] bytes = serializer.serialize(topic, record);
+
+            Map<String, Object> deserializerConfig = new HashMap<>();
+            deserializerConfig.put(SerdeConfig.REGISTRY_URL, TestUtils.getRegistryV2ApiUrl(testPort));
+            deserializer.configure(deserializerConfig, true);
+
+            GenericData.Record deserializedRecord = deserializer.deserialize(topic, bytes);
+            Assertions.assertEquals(record, deserializedRecord);
+            Assertions.assertEquals("somebar", record.get("bar").toString());
+
+            config.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, TopicRecordIdStrategy.class.getName());
+            config.put(AvroSerdeConfig.AVRO_DATUM_PROVIDER, DefaultAvroDatumProvider.class.getName());
+            serializer.configure(config, true);
+            bytes = serializer.serialize(topic, record);
+
+            deserializer.configure(deserializerConfig, true);
+            record = deserializer.deserialize(topic, bytes);
+            Assertions.assertEquals("somebar", record.get("bar").toString());
+
+            config.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, TopicRecordIdStrategy.class.getName());
+            config.put(AvroSerdeConfig.AVRO_DATUM_PROVIDER, DefaultAvroDatumProvider.class.getName());
+            serializer.configure(config, true);
+            bytes = serializer.serialize(topic, record);
+            deserializer.configure(deserializerConfig, true);
+            record = deserializer.deserialize(topic, bytes);
+            Assertions.assertEquals("somebar", record.get("bar").toString());
+
+        });
+
+        serializer.close();
+        deserializer.close();
+    }
+}

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -34,10 +34,22 @@ public class RegistryClientFacadeFactory {
         Vertx ivertx = vertx == null ? Vertx.vertx() : vertx;
         boolean shouldCloseVertx = vertx == null;
 
-        if (baseUrl.contains("/apis/v2/")) {
-            return create_v2(config, ivertx, shouldCloseVertx);
+        String endpointVersion = null;
+        if (config.getRegistryUrlVersion() != null) {
+            endpointVersion = config.getRegistryUrlVersion();
+        }
+        if (endpointVersion == null && baseUrl.contains("/apis/registry/v2")) {
+            endpointVersion = "2";
         } else {
-            return create_v3(config, ivertx, shouldCloseVertx);
+            endpointVersion = "3";
+        }
+
+        switch  (endpointVersion) {
+            case "2":
+                return create_v2(config, ivertx, shouldCloseVertx);
+            case "3":
+            default:
+                return create_v3(config, ivertx, shouldCloseVertx);
         }
     }
 

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -115,6 +115,15 @@ public class SchemaResolverConfig extends AbstractConfig {
     public static final String REGISTRY_URL = "apicurio.registry.url";
 
     /**
+     * The API version implemented by the URL endpoint indicated by the 'apicurio.registry.url' property.
+     * This is typically not required because the Registry Client will auto-detect the endpoint version
+     * based on the URL itself.  However, in case the URL is non-standard or being rewritten by a proxy,
+     * or some other odd circumstance, set the property to the API version such as "2" or "3".  Use the
+     * major version only.
+     */
+    public static final String REGISTRY_URL_VERSION = "apicurio.registry.url.version";
+
+    /**
      * The URL of the Token Endpoint.
      */
     public static final String AUTH_TOKEN_ENDPOINT = "apicurio.registry.auth.service.token.endpoint";
@@ -197,6 +206,10 @@ public class SchemaResolverConfig extends AbstractConfig {
             }
         }
         return registryUrl;
+    }
+
+    public String getRegistryUrlVersion() {
+        return getString(REGISTRY_URL_VERSION);
     }
 
     public String getTokenEndpoint() {


### PR DESCRIPTION
Fix for:
* https://github.com/Apicurio/apicurio-registry/issues/6560
