### PR TITLE
fix: remove unnecessary metrics, fix initialization

### DIFF
--- a/app/src/main/java/io/apicurio/registry/metrics/MetricsConstants.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/MetricsConstants.java
@@ -14,14 +14,11 @@ public interface MetricsConstants {
     String REST_REQUESTS = REST_PREFIX + "requests";
     String REST_REQUESTS_DESCRIPTION = "Timing and results of REST endpoints calls";
 
-    String REST_REQUESTS_COUNTER = REST_REQUESTS + ".count";
-    String REST_REQUESTS_COUNTER_DESCRIPTION = "Count and results of REST endpoints calls";
-
     // REST tags/labels
 
     String REST_REQUESTS_TAG_PATH = "path";
     String REST_REQUESTS_TAG_METHOD = "method";
-    String REST_REQUESTS_TAG_STATUS_CODE_FAMILY = "status_code_group";
+    String REST_REQUESTS_TAG_STATUS_CODE_GROUP = "status.code.group";
 
     // Storage
 

--- a/app/src/test/java/io/apicurio/registry/metrics/RestMetricsResponseFilterTest.java
+++ b/app/src/test/java/io/apicurio/registry/metrics/RestMetricsResponseFilterTest.java
@@ -1,13 +1,13 @@
 package io.apicurio.registry.metrics;
 
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
-import static io.apicurio.registry.metrics.MetricsConstants.REST_REQUESTS_COUNTER;
-import static io.apicurio.registry.metrics.MetricsConstants.REST_REQUESTS_TAG_STATUS_CODE_FAMILY;
+import static io.apicurio.registry.metrics.MetricsConstants.REST_REQUESTS;
+import static io.apicurio.registry.metrics.MetricsConstants.REST_REQUESTS_TAG_STATUS_CODE_GROUP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Thomas Thornton
@@ -21,15 +21,14 @@ public class RestMetricsResponseFilterTest {
         filter.registry = registry;
         filter.initializeCounters();
         String[] expectedStatusGroups = {"1xx", "2xx", "3xx", "4xx", "5xx"};
-        for (String statusGroup: expectedStatusGroups) {
-            Counter counter = registry.find(REST_REQUESTS_COUNTER)
-                    .tags(REST_REQUESTS_TAG_STATUS_CODE_FAMILY, statusGroup)
-                    .counter();
-            Assertions.assertNotNull(counter);
-            double value = counter.count();
-            Assertions.assertEquals(0, value);
+        for (String statusGroup : expectedStatusGroups) {
+            var timer = registry.find(REST_REQUESTS)
+                    .tags(REST_REQUESTS_TAG_STATUS_CODE_GROUP, statusGroup)
+                    .timer();
+            Assertions.assertNotNull(timer);
+            double value = timer.count();
+            assertEquals(0, value);
         }
-        Assertions.assertEquals(registry.find(REST_REQUESTS_COUNTER).counters().size(), expectedStatusGroups.length);
+        assertEquals(registry.find(REST_REQUESTS).timers().size(), expectedStatusGroups.length);
     }
-
 }


### PR DESCRIPTION
Removing `rest_requests_count`, because `rest_requests_seconds_count` can be used instead. The former was initialized to zero as a result of https://github.com/Apicurio/apicurio-registry/pull/6297, however it was never incremented because of a possible Micrometer issue. It looks like if a meter is initialized with a subset of the tags, and then a measurement is recorded later with full set of tags, the measurement is ignored. As a result, I'm adding empty tag values during initialization of `rest_requests_seconds_count`, even though that specific tag combination in later never used. I've also cleaned the code up a bit.

See also [#general > metrics](https://apicurio.zulipchat.com/#narrow/channel/345336-general/topic/metrics/with/539726574) on Zulip.