### PR TITLE
fix(ccompat): Fixed an issue with owner only auth and the ccompat api

### DIFF
--- a/app/src/main/java/io/apicurio/registry/auth/AppAuthenticationMechanism.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AppAuthenticationMechanism.java
@@ -322,7 +322,8 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
         OidcAuth oidcAuth = new OidcAuth(httpClient, clientCredentials.getLeft(),
                 clientCredentials.getRight(), Duration.ofSeconds(1), scope.orElse(null));
         try {
-            String jwtToken = oidcAuth.authenticate();// If we manage to get a token from basic credentials,
+            String jwtToken = oidcAuth.authenticate();
+            // If we manage to get a token from basic credentials,
             // try to authenticate it using the fetched token using
             // the identity provider manager
             cachedAccessTokens.put(credentialsHash,

--- a/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
+++ b/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
@@ -12,6 +12,7 @@ import io.apicurio.registry.rest.client.models.CreateGroup;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.GroupMetaData;
 import io.apicurio.registry.rest.client.models.Labels;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.rest.client.models.VersionMetaData;
 import io.apicurio.registry.rest.v3.V3ApiUtil;
@@ -369,8 +370,8 @@ public abstract class AbstractResourceTestBase extends AbstractRegistryTestBase 
     }
 
     protected void assertNotFound(Exception exception) {
-        if (exception.getClass().equals(ApiException.class)) {
-            Assertions.assertEquals(404, ((ApiException) exception).getResponseStatusCode());
+        if (exception.getClass().equals(ProblemDetails.class)) {
+            Assertions.assertEquals(404, ((ProblemDetails) exception).getResponseStatusCode());
         } else if (exception.getClass().equals(RestClientException.class)) {
             Assertions.assertEquals(404, ((RestClientException) exception).getStatus());
         } else {

--- a/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
+++ b/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
@@ -12,7 +12,6 @@ import io.apicurio.registry.rest.client.models.CreateGroup;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.GroupMetaData;
 import io.apicurio.registry.rest.client.models.Labels;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.rest.client.models.VersionMetaData;
 import io.apicurio.registry.rest.v3.V3ApiUtil;
@@ -24,6 +23,7 @@ import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.rest.client.auth.exception.NotAuthorizedException;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.kiota.http.vertx.VertXRequestAdapter;
 import io.restassured.RestAssured;
 import io.restassured.parsing.Parser;
@@ -369,13 +369,23 @@ public abstract class AbstractResourceTestBase extends AbstractRegistryTestBase 
     }
 
     protected void assertNotFound(Exception exception) {
-        Assertions.assertEquals(ProblemDetails.class, exception.getClass());
-        Assertions.assertEquals(404, ((ApiException) exception).getResponseStatusCode());
+        if (exception.getClass().equals(ApiException.class)) {
+            Assertions.assertEquals(404, ((ApiException) exception).getResponseStatusCode());
+        } else if (exception.getClass().equals(RestClientException.class)) {
+            Assertions.assertEquals(404, ((RestClientException) exception).getStatus());
+        } else {
+            Assertions.fail("Unexpected exception type.", exception);
+        }
     }
 
     protected void assertForbidden(Exception exception) {
-        Assertions.assertEquals(ApiException.class, exception.getClass());
-        Assertions.assertEquals(403, ((ApiException) exception).getResponseStatusCode());
+        if (exception.getClass().equals(ApiException.class)) {
+            Assertions.assertEquals(403, ((ApiException) exception).getResponseStatusCode());
+        } else if (exception.getClass().equals(RestClientException.class)) {
+            Assertions.assertEquals(403, ((RestClientException) exception).getStatus());
+        } else {
+            Assertions.fail("Unexpected exception type.", exception);
+        }
     }
 
     protected void assertNotAuthorized(Exception exception) {

--- a/app/src/test/java/io/apicurio/registry/auth/CCompatAuthTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/CCompatAuthTest.java
@@ -1,0 +1,166 @@
+package io.apicurio.registry.auth;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.client.RegistryClientFactory;
+import io.apicurio.registry.client.RegistryClientOptions;
+import io.apicurio.registry.rest.Headers;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.utils.tests.ApicurioTestTags;
+import io.apicurio.registry.utils.tests.AuthTestProfile;
+import io.apicurio.registry.utils.tests.KeycloakTestContainerManager;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.SchemaProvider;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.Vertx;
+import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.auth.oauth2.OAuth2FlowType;
+import io.vertx.ext.auth.oauth2.OAuth2Options;
+import io.vertx.ext.auth.oauth2.Oauth2Credentials;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@QuarkusTest
+@TestProfile(AuthTestProfile.class)
+@Tag(ApicurioTestTags.SLOW)
+public class CCompatAuthTest extends AbstractResourceTestBase {
+
+    private final String AVRO_SCHEMA = "{\"type\":\"record\",\"name\":\"TestRecord\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}";
+    private final String AVRO_SCHEMA_V2 = "{\"type\":\"record\",\"name\":\"TestRecord\",\"fields\":[{\"name\":\"name\",\"type\":\"string\",\"description\":\"string\"}]}";
+
+    @ConfigProperty(name = "quarkus.oidc.token-path")
+    String authServerUrlConfigured;
+
+    /**
+     * Override to create a client with admin auth creds.
+     */
+    @Override
+    protected RegistryClient createRestClientV3(Vertx vertx) {
+        return RegistryClientFactory.create(RegistryClientOptions.create(registryV3ApiUrl, vertx)
+                .oauth2(authServerUrlConfigured, KeycloakTestContainerManager.ADMIN_CLIENT_ID, "test1"));
+    }
+
+    /**
+     * Builds a confluent schema registry client.  Use the given auth token and put it into the
+     * Authorization HTTP header (to make authenticated calls to /ccompat).
+     * @param authToken
+     */
+    public SchemaRegistryClient buildClient(String authToken) {
+        final List<SchemaProvider> schemaProviders = Arrays.asList(new JsonSchemaProvider(),
+                new AvroSchemaProvider(), new ProtobufSchemaProvider());
+        RestService restService = new RestService("http://localhost:" + testPort + "/apis/ccompat/v7");
+        Map<String, String> headers = Map.of(
+                Headers.GROUP_ID, "confluentV7-test-group",
+                "Authorization", "Bearer " + authToken
+        );
+        return new CachedSchemaRegistryClient(
+                restService, 3, schemaProviders,
+                null, headers);
+    }
+
+    /**
+     * Acquires an authentication token using OIDC Client Credentials flow.
+     *
+     * @param clientId the client ID for authentication
+     * @param clientSecret the client secret for authentication
+     * @return the access token
+     * @throws Exception if token acquisition fails
+     */
+    public String acquireAuthToken(String clientId, String clientSecret) throws Exception {
+        OAuth2Options oauth2Options = new OAuth2Options()
+                .setFlow(OAuth2FlowType.CLIENT)
+                .setClientId(clientId)
+                .setClientSecret(clientSecret)
+                .setTokenPath(authServerUrlConfigured);
+
+        OAuth2Auth oauth2Auth = OAuth2Auth.create(vertx, oauth2Options);
+
+        Oauth2Credentials credentials = new Oauth2Credentials();
+
+        CompletableFuture<String> tokenFuture = new CompletableFuture<>();
+
+        oauth2Auth.authenticate(credentials)
+                .onSuccess(user -> {
+                    String accessToken = user.principal().getString("access_token");
+                    tokenFuture.complete(accessToken);
+                })
+                .onFailure(tokenFuture::completeExceptionally);
+
+        return tokenFuture.get();
+    }
+
+    @Test
+    public void testReadOnly() throws Exception {
+        String readOnlyToken = acquireAuthToken(KeycloakTestContainerManager.READONLY_CLIENT_ID, "test1");
+        try (var schemaRegistryClient = buildClient(readOnlyToken)) {
+            // Get all subjects should work
+            schemaRegistryClient.getAllSubjects();
+
+            // Try to create a subject (should fail - read only)
+            Assertions.assertThrows(Exception.class, () -> {
+                String subject = TestUtils.generateSubject();
+                ParsedSchema schema = new AvroSchemaProvider().parseSchema(AVRO_SCHEMA, null, false)
+                    .orElseThrow(() -> new RuntimeException("Failed to parse Avro schema"));
+                schemaRegistryClient.register(subject, schema);
+            });
+        }
+    }
+
+    @Test
+    public void testOwnerOnlyAuthorization() throws Exception {
+        String devToken = acquireAuthToken(KeycloakTestContainerManager.DEVELOPER_CLIENT_ID, "test1");
+        String adminToken = acquireAuthToken(KeycloakTestContainerManager.ADMIN_CLIENT_ID, "test1");
+        ParsedSchema avroSchema_v1 = new AvroSchemaProvider().parseSchema(AVRO_SCHEMA, null, false)
+                .orElseThrow(() -> new RuntimeException("Failed to parse Avro schema"));
+        ParsedSchema avroSchema_v2 = new AvroSchemaProvider().parseSchema(AVRO_SCHEMA_V2, null, false)
+                .orElseThrow(() -> new RuntimeException("Failed to parse Avro schema"));
+
+        try (var adminClient = buildClient(adminToken); var devClient = buildClient(devToken)) {
+            // Admin user will create an artifact
+            String subject1 = TestUtils.generateSubject();
+            adminClient.register(subject1, avroSchema_v1);
+
+            // Dev user cannot delete the subject because Dev user is not the owner
+            RestClientException exception = Assertions.assertThrows(RestClientException.class, () -> {
+                devClient.deleteSubject(subject1);
+            });
+            assertForbidden(exception);
+
+            // But the admin user CAN delete the subject
+            adminClient.deleteSubject(subject1);
+
+            // Now the Dev user will create an artifact
+            String subject2 = TestUtils.generateSubject();
+            devClient.register(subject2, avroSchema_v1);
+
+            // And the Admin user will delete it (allowed because it's the Admin user)
+            adminClient.deleteSubject(subject2);
+
+            // Admin user will create an artifact
+            String subject3 = TestUtils.generateSubject();
+            adminClient.register(subject3, avroSchema_v1);
+
+            // Dev user cannot update with ifExists the same artifact because Dev user is not the owner
+            exception = Assertions.assertThrows(RestClientException.class, () -> {
+                devClient.register(subject3, avroSchema_v2);
+            });
+            assertForbidden(exception);
+        }
+    }
+
+}


### PR DESCRIPTION
Fix for issue:

* https://issues.redhat.com/browse/IPT-1186

I believe the root cause was the auth layer not checking the HTTP request for a groupId that should be used when making ccompat API calls.  Because the ccompat API does not support groups, it is possible for a request to include the groupId to use as a http header.  This override the default groupId for ccompat operations.  The auth layer was not checking that http header, so it failed to find the artifact when checking ownership.