### PR TITLE
fix(serde): Added some options to the protobuf serde config

### DIFF
--- a/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufDeserializer.java
+++ b/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufDeserializer.java
@@ -36,6 +36,8 @@ public class ProtobufDeserializer<U extends Message> extends AbstractDeserialize
     private Method specificReturnClassParseMethod;
     private boolean deriveClass;
     private String messageTypeName;
+    private boolean readTypeRef = true;
+    private boolean readIndexes = false;
 
     private final Map<String, Method> parseMethodsCache = new ConcurrentHashMap<>();
 
@@ -84,7 +86,8 @@ public class ProtobufDeserializer<U extends Message> extends AbstractDeserialize
         }
 
         deriveClass = config.deriveClass();
-
+        readTypeRef = config.readTypeRef();
+        readIndexes = config.readIndexes();
     }
 
     @Override
@@ -118,7 +121,13 @@ public class ProtobufDeserializer<U extends Message> extends AbstractDeserialize
 
             }
 
-            if (descriptor == null) {
+            if (readIndexes) {
+                // Read the message index list from the buffer.  Currently we do not use it for anything,
+                // but this may be necessary for interoperability with Confluent.
+                MessageIndexesUtil.readFrom(is);
+            }
+
+            if (readTypeRef && descriptor == null) {
                 try {
                     Ref ref = Ref.parseDelimitedFrom(is);
                     descriptor = schema.getParsedSchema().getFileDescriptor()

--- a/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufDeserializerConfig.java
+++ b/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufDeserializerConfig.java
@@ -2,7 +2,6 @@ package io.apicurio.registry.serde.protobuf;
 
 import io.apicurio.registry.serde.config.SerdeConfig;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,5 +45,16 @@ public class ProtobufDeserializerConfig extends SerdeConfig {
         return joint;
     }
 
-    private static final Map<String, ?> DEFAULTS = Collections.emptyMap();
+    public boolean readTypeRef() {
+        return this.getBoolean(READ_TYPE_REF);
+    }
+
+    public boolean readIndexes() {
+        return this.getBoolean(READ_INDEXES);
+    }
+
+    private static final Map<String, ?> DEFAULTS = Map.of(
+            READ_TYPE_REF, READ_TYPE_REF_DEFAULT,
+            READ_INDEXES, READ_INDEXES_DEFAULT
+    );
 }

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/config/SerdeConfig.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/config/SerdeConfig.java
@@ -96,11 +96,26 @@ public class SerdeConfig extends SchemaResolverConfig {
     public static final boolean SEND_TYPE_REF_DEFAULT = true;
 
     /**
+     * Boolean used to enable or disable reading the type ref (either in message headers or payload)
+     * when deserializing a Protobuf message.
+     */
+    public static final String READ_TYPE_REF = "apicurio.registry.serde.read-type-ref";
+    public static final boolean READ_TYPE_REF_DEFAULT = true;
+
+    /**
      * Boolean used to enable or disable sending the protobuf schema message indexes when writing
      * the proto message as a payload.
      */
     public static final String SEND_INDEXES = "apicurio.registry.serde.send-indexes";
     public static final boolean SEND_INDEXES_DEFAULT = false;
+
+    /**
+     * Boolean used to enable or disable reading the protobuf schema message indexes when reading
+     * the proto message as a payload.  When enabled, the deserializer will assume that the
+     * message indexes (array) is present in the payload buffer before the serialized message data.
+     */
+    public static final String READ_INDEXES = "apicurio.registry.serde.read-indexes";
+    public static final boolean READ_INDEXES_DEFAULT = false;
 
     /**
      * Only applicable for deserializers Optional, set explicitly the groupId used as fallback for resolving


### PR DESCRIPTION
New deserializer options for reading message indexes and type ref.  These new options mirror the ones recently added in the serializer.

This is protobuf specific.