### PR TITLE
fix: Set provided scope for Kafka Connect dependencies

### DIFF
--- a/distro/connect-converter/pom.xml
+++ b/distro/connect-converter/pom.xml
@@ -26,6 +26,7 @@
         <groupId>org.apache.kafka</groupId>
         <artifactId>connect-json</artifactId>
         <version>${distro.version.kafka}</version>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/distro/connect-converter/src/assembly/converter-distribution.xml
+++ b/distro/connect-converter/src/assembly/converter-distribution.xml
@@ -16,10 +16,7 @@
       <useTransitiveFiltering>true</useTransitiveFiltering>
       <excludes>
         <!-- Exclude dependencies of Kafka APIs, since they will be available in the runtime -->
-        <exclude>org.apache.kafka:kafka-clients:*</exclude>
-        <exclude>org.apache.kafka:connect-api:*</exclude>
-        <exclude>org.apache.kafka:connect-json:*</exclude>
-        <exclude>com.fasterxml.jackson:*</exclude>
+
         <exclude>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:*</exclude>
       </excludes>
     </dependencySet>
@@ -31,12 +28,7 @@
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <excludes>
         <!-- Exclude dependencies of Kafka APIs, since they will be available in the runtime -->
-        <exclude>org.apache.kafka:kafka-clients:*</exclude>
-        <exclude>org.apache.kafka:connect-api:*</exclude>
-        <!-- Connect JSON needs to be kept due to classloading conflicts of Jackson data mapper
-        <exclude>org.apache.kafka:connect-json:*</exclude>
-        <exclude>com.fasterxml.jackson:*:*</exclude>
-        -->
+
         <exclude>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:*</exclude>
       </excludes>
     </dependencySet>

--- a/utils/converter/pom.xml
+++ b/utils/converter/pom.xml
@@ -36,11 +36,13 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-api</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-json</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Set provided scope for Kafka Connect dependencies and use the dependencies from the Kafka Connect runtime.

The dependency graph before this change:
```
io.apicurio:apicurio-registry-utils-converter:jar:3.0.15-SNAPSHOT
+- io.apicurio:apicurio-registry-avro-serde-kafka:jar:3.0.15-SNAPSHOT:compile
+- io.apicurio:apicurio-registry-jsonschema-serde-kafka:jar:3.0.15-SNAPSHOT:compile
+- io.apicurio:apicurio-registry-schema-resolver:jar:3.0.15-SNAPSHOT:compile
+- org.apache.kafka:connect-api:jar:3.9.1:compile
|  +- org.apache.kafka:kafka-clients:jar:3.9.1:compile
|  |  +- com.github.luben:zstd-jni:jar:1.5.6-4:runtime
|  |  +- org.lz4:lz4-java:jar:1.8.0:runtime
|  |  \- org.xerial.snappy:snappy-java:jar:1.1.10.5:runtime
|  +- org.slf4j:slf4j-api:jar:2.0.6:runtime
|  \- javax.ws.rs:javax.ws.rs-api:jar:2.1.1:runtime
+- org.apache.kafka:connect-json:jar:3.9.1:compile
|  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.2:compile
|  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.2:compile
|  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.18.2:compile
|  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.18.2:compile
|  \- com.fasterxml.jackson.module:jackson-module-afterburner:jar:2.18.2:compile
\- org.junit.jupiter:junit-jupiter:jar:5.12.1:test
   +- org.junit.jupiter:junit-jupiter-api:jar:5.12.1:test
   |  +- org.opentest4j:opentest4j:jar:1.3.0:test
   |  +- org.junit.platform:junit-platform-commons:jar:1.12.1:test
   |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
   +- org.junit.jupiter:junit-jupiter-params:jar:5.12.1:test
   \- org.junit.jupiter:junit-jupiter-engine:jar:5.12.1:test
      \- org.junit.platform:junit-platform-engine:jar:1.12.1:test
```

The dependency graph after this change:
```
io.apicurio:apicurio-registry-utils-converter:jar:3.1.0-SNAPSHOT
+- io.apicurio:apicurio-registry-avro-serde-kafka:jar:3.1.0-SNAPSHOT:compile
+- io.apicurio:apicurio-registry-jsonschema-serde-kafka:jar:3.1.0-SNAPSHOT:compile
+- io.apicurio:apicurio-registry-schema-resolver:jar:3.1.0-SNAPSHOT:compile
+- org.apache.kafka:connect-api:jar:3.9.1:provided
|  +- org.apache.kafka:kafka-clients:jar:3.9.1:provided
|  |  +- com.github.luben:zstd-jni:jar:1.5.6-4:provided
|  |  +- org.lz4:lz4-java:jar:1.8.0:provided
|  |  \- org.xerial.snappy:snappy-java:jar:1.1.10.5:provided
|  +- org.slf4j:slf4j-api:jar:2.0.6:provided
|  \- javax.ws.rs:javax.ws.rs-api:jar:2.1.1:provided
+- org.apache.kafka:connect-json:jar:3.9.1:provided
|  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.2:provided
|  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.2:provided
|  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.18.2:provided
|  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.18.2:provided
|  \- com.fasterxml.jackson.module:jackson-module-afterburner:jar:2.18.2:provided
\- org.junit.jupiter:junit-jupiter:jar:5.12.1:test
   +- org.junit.jupiter:junit-jupiter-api:jar:5.12.1:test
   |  +- org.opentest4j:opentest4j:jar:1.3.0:test
   |  +- org.junit.platform:junit-platform-commons:jar:1.12.1:test
   |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
   +- org.junit.jupiter:junit-jupiter-params:jar:5.12.1:test
   \- org.junit.jupiter:junit-jupiter-engine:jar:5.12.1:test
      \- org.junit.platform:junit-platform-engine:jar:1.12.1:test
```