### PR TITLE
fix: Add client scope support for OAuth2 authentication for maven plugin

### DIFF
--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/AbstractRegistryMojo.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/AbstractRegistryMojo.java
@@ -77,9 +77,18 @@ public abstract class AbstractRegistryMojo extends AbstractMojo {
     protected RegistryClient createClient(Vertx vertx) {
         RegistryClientOptions clientOptions = RegistryClientOptions.create(registryUrl, vertx);
         if (authServerUrl != null && clientId != null && clientSecret != null) {
-            clientOptions.oauth2(authServerUrl, clientId, clientSecret);
+            if (clientScope != null && !clientScope.isEmpty()) {
+                getLog().info("Creating registry client with OAuth2 authentication with scope.");
+                clientOptions.oauth2(authServerUrl, clientId, clientSecret, clientScope);
+            } else {
+                getLog().info("Creating registry client with OAuth2 authentication.");
+                clientOptions.oauth2(authServerUrl, clientId, clientSecret);
+            }
         } else if (username != null && password != null) {
+            getLog().info("Creating registry client with Basic authentication.");
             clientOptions.basicAuth(username, password);
+        } else {
+            getLog().info("Creating registry client without authentication.");
         }
         return RegistryClientFactory.create(clientOptions.retry());
     }


### PR DESCRIPTION
Authentication to Entra-enabled apicurio-registry was failing with an exception, when using the maven plugin:
```
[ERROR] Exception while registering artifact [default] / [com.example.package.v1.Model]
java.lang.RuntimeException: java.util.concurrent.ExecutionException: io.vertx.core.impl.NoStackTraceThrowable: invalid_request: AADSTS90014: The required field 'scope' is missing from the credential. Ensure that you have all the necessary parameters for the login request. Trace ID: 4dfc2eb8-cffb-447c-8806-7a127b7a1200 Correlation ID: e72690ec-ffcf-49c9-b080-b657ad905b26 Timestamp: 2025-09-30 19:28:17Z
```

After some digging around, I discovered, that the plugin was reading the `clientScope` parameter, but it is not being used.

I have also added additional logging, to see which auth, if any, is being used when executing plugin actions.