### PR TITLE
Fix typo with AsyncAPI version from 2.0.6 to 2.6.0

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-artifact-reference.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-artifact-reference.adoc
@@ -38,7 +38,7 @@ You can store and manage a wide range of schema and API artifact types in {regis
 |Supported versions
 |`ASYNCAPI`
 |AsyncAPI specification
-|`2.0.0` -> `2.0.6`, `3.0.0`
+|`2.0.0` -> `2.6.0`, `3.0.0`
 |`AVRO`
 |Apache Avro schema
 |`1.0` -> `1.12`,


### PR DESCRIPTION
This pull request updates the documentation to correct a typo in the supported AsyncAPI specification versions.

Documentation update:

* In `docs/modules/ROOT/pages/getting-started/assembly-artifact-reference.adoc`, the supported AsyncAPI versions were updated from `2.0.0`–`2.0.6` to `2.0.0`–`2.6.0`, fixing a typo with AsyncAPI version from 2.0.6 to 2.6.0