### PR TITLE
fix(tls): Add TLS/SSL configuration support to SerDe layer

### DIFF
--- a/app/src/test/java/io/apicurio/registry/tls/TlsSerdeTest.java
+++ b/app/src/test/java/io/apicurio/registry/tls/TlsSerdeTest.java
@@ -1,0 +1,290 @@
+package io.apicurio.registry.tls;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.client.RegistryClientFactory;
+import io.apicurio.registry.client.RegistryClientOptions;
+import io.apicurio.registry.resolver.config.SchemaResolverConfig;
+import io.apicurio.registry.serde.config.KafkaSerdeConfig;
+import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaDeserializer;
+import io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaSerializer;
+import io.apicurio.registry.serde.strategy.SimpleTopicIdStrategy;
+import io.apicurio.registry.support.Person;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.IoUtil;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.Vertx;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLHandshakeException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests that SerDe classes (serializers/deserializers) work with TLS/SSL configuration
+ * when connecting to an HTTPS-enabled registry with self-signed certificates.
+ */
+@QuarkusTest
+@TestProfile(TlsTestProfile.class)
+public class TlsSerdeTest extends AbstractResourceTestBase {
+
+    @TestHTTPResource(value = "/apis", tls = true)
+    URL httpsUrl;
+
+    @Override
+    protected void deleteGlobalRules(int expectedDefaultRulesCount) throws Exception {
+        // Don't bother with this test
+    }
+
+    @Override
+    @BeforeAll
+    protected void beforeAll() throws Exception {
+        vertx = Vertx.vertx();
+
+        // Override base URL to use HTTPS
+        registryApiBaseUrl = httpsUrl.toExternalForm();
+        registryV2ApiUrl = registryApiBaseUrl + "/registry/v2";
+        registryV3ApiUrl = registryApiBaseUrl + "/registry/v3";
+
+        clientV3 = RegistryClientFactory.create(RegistryClientOptions.create()
+                .registryUrl(registryV3ApiUrl)
+                .trustAll(true)
+                .vertx(vertx));
+    }
+
+    /**
+     * Test JsonSchema SerDe with JKS trust store
+     */
+    @Test
+    public void testJsonSchemaSerdeWithJksTrustStore() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-truststore.jks");
+        Assertions.assertNotNull(truststoreUrl, "Truststore file not found");
+
+        InputStream jsonSchema = getClass()
+                .getResourceAsStream("/io/apicurio/registry/util/json-schema.json");
+        Assertions.assertNotNull(jsonSchema);
+
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = generateArtifactId();
+
+        createArtifact(groupId, artifactId, ArtifactType.JSON, IoUtil.toString(jsonSchema),
+                ContentTypes.APPLICATION_JSON);
+
+        Person person = new Person("Alice", "Smith", 25);
+
+        try (JsonSchemaKafkaSerializer<Person> serializer = new JsonSchemaKafkaSerializer<>();
+            Deserializer<Person> deserializer = new JsonSchemaKafkaDeserializer<>()) {
+
+            // Common SerDe configuration
+            Map<String, Object> commonConfig = new HashMap<>();
+            commonConfig.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+            // TLS configuration with JKS trust store
+            commonConfig.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+            commonConfig.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "registrytest");
+            commonConfig.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "JKS");
+
+            // Configure the serializer
+            Map<String, Object> serializerConfig = new HashMap<>();
+            serializerConfig.putAll(commonConfig);
+            serializerConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+            serializerConfig.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, SimpleTopicIdStrategy.class.getName());
+            serializerConfig.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+            serializerConfig.put(SerdeConfig.VALIDATION_ENABLED, "true");
+            serializer.configure(serializerConfig, false);
+
+            // Configure the deserializer
+            Map<String, Object> deserializerConfig = new HashMap<>();
+            deserializerConfig.putAll(commonConfig);
+            deserializerConfig.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+            deserializer.configure(deserializerConfig, false);
+
+            // Serialize/deserialize the message
+            Headers headers = new RecordHeaders();
+            byte[] bytes = serializer.serialize(artifactId, headers, person);
+            person = deserializer.deserialize(artifactId, headers, bytes);
+
+            Assertions.assertEquals("Alice", person.getFirstName());
+            Assertions.assertEquals("Smith", person.getLastName());
+            Assertions.assertEquals(25, person.getAge());
+        }
+    }
+
+    /**
+     * Test JsonSchema SerDe with PEM certificate
+     */
+    @Test
+    public void testJsonSchemaSerdeWithPemCertificate() throws Exception {
+        URL certUrl = getClass().getClassLoader().getResource("tls/registry-cert.pem");
+        Assertions.assertNotNull(certUrl, "PEM certificate file not found");
+
+        InputStream jsonSchema = getClass()
+                .getResourceAsStream("/io/apicurio/registry/util/json-schema.json");
+        Assertions.assertNotNull(jsonSchema);
+
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = generateArtifactId();
+
+        createArtifact(groupId, artifactId, ArtifactType.JSON, IoUtil.toString(jsonSchema),
+                ContentTypes.APPLICATION_JSON);
+
+        Person person = new Person("Bob", "Jones", 30);
+
+        try (JsonSchemaKafkaSerializer<Person> serializer = new JsonSchemaKafkaSerializer<>();
+            Deserializer<Person> deserializer = new JsonSchemaKafkaDeserializer<>()) {
+
+            // Common SerDe configuration
+            Map<String, Object> commonConfig = new HashMap<>();
+            commonConfig.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+            // TLS configuration with PEM certificate
+            commonConfig.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PEM");
+            commonConfig.put(SchemaResolverConfig.TLS_CERTIFICATES, certUrl.getPath());
+
+            // Configure the serializer
+            Map<String, Object> serializerConfig = new HashMap<>();
+            serializerConfig.putAll(commonConfig);
+            serializerConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+            serializerConfig.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, SimpleTopicIdStrategy.class.getName());
+            serializerConfig.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+            serializerConfig.put(SerdeConfig.VALIDATION_ENABLED, "true");
+            serializer.configure(serializerConfig, false);
+
+            // Configure the deserializer
+            Map<String, Object> deserializerConfig = new HashMap<>();
+            deserializerConfig.putAll(commonConfig);
+            deserializerConfig.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+            deserializer.configure(deserializerConfig, false);
+
+            Headers headers = new RecordHeaders();
+            byte[] bytes = serializer.serialize(artifactId, headers, person);
+
+            person = deserializer.deserialize(artifactId, headers, bytes);
+
+            Assertions.assertEquals("Bob", person.getFirstName());
+            Assertions.assertEquals("Jones", person.getLastName());
+            Assertions.assertEquals(30, person.getAge());
+        }
+    }
+
+    /**
+     * Test JsonSchema SerDe with trust-all enabled (development mode)
+     */
+    @Test
+    public void testJsonSchemaSerdeWithTrustAll() throws Exception {
+        InputStream jsonSchema = getClass()
+                .getResourceAsStream("/io/apicurio/registry/util/json-schema.json");
+        Assertions.assertNotNull(jsonSchema);
+
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = generateArtifactId();
+
+        createArtifact(groupId, artifactId, ArtifactType.JSON, IoUtil.toString(jsonSchema),
+                ContentTypes.APPLICATION_JSON);
+
+        Person person = new Person("Charlie", "Brown", 35);
+
+        try (JsonSchemaKafkaSerializer<Person> serializer = new JsonSchemaKafkaSerializer<>();
+            Deserializer<Person> deserializer = new JsonSchemaKafkaDeserializer<>()) {
+
+            // Common SerDe configuration
+            Map<String, Object> commonConfig = new HashMap<>();
+            commonConfig.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+            // TLS configuration with trust-all enabled
+            commonConfig.put(SchemaResolverConfig.TLS_TRUST_ALL, "true");
+
+            // Configure the serializer
+            Map<String, Object> serializerConfig = new HashMap<>();
+            serializerConfig.putAll(commonConfig);
+            serializerConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+            serializerConfig.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, SimpleTopicIdStrategy.class.getName());
+            serializerConfig.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+            serializerConfig.put(SerdeConfig.VALIDATION_ENABLED, "true");
+            serializer.configure(serializerConfig, false);
+
+            // Configure the deserializer
+            Map<String, Object> deserializerConfig = new HashMap<>();
+            deserializerConfig.putAll(commonConfig);
+            deserializerConfig.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+            deserializer.configure(deserializerConfig, false);
+
+            Headers headers = new RecordHeaders();
+            byte[] bytes = serializer.serialize(artifactId, headers, person);
+
+            person = deserializer.deserialize(artifactId, headers, bytes);
+
+            Assertions.assertEquals("Charlie", person.getFirstName());
+            Assertions.assertEquals("Brown", person.getLastName());
+            Assertions.assertEquals(35, person.getAge());
+        }
+    }
+
+    /**
+     * Test that SerDe fails without TLS configuration when server uses HTTPS
+     */
+    @Test
+    public void testJsonSchemaSerdeWithoutTlsConfigFails() throws Exception {
+        InputStream jsonSchema = getClass()
+                .getResourceAsStream("/io/apicurio/registry/util/json-schema.json");
+        Assertions.assertNotNull(jsonSchema);
+
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = generateArtifactId();
+
+        createArtifact(groupId, artifactId, ArtifactType.JSON, IoUtil.toString(jsonSchema),
+                ContentTypes.APPLICATION_JSON);
+
+        Person person = new Person("Eve", "Adams", 40);
+
+        try (JsonSchemaKafkaSerializer<Person> serializer = new JsonSchemaKafkaSerializer<>()) {
+            // Common SerDe configuration
+            Map<String, Object> commonConfig = new HashMap<>();
+            commonConfig.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+            // No TLS configuration - should fail
+
+            // Configure the serializer
+            Map<String, Object> serializerConfig = new HashMap<>();
+            serializerConfig.putAll(commonConfig);
+            serializerConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+            serializerConfig.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, SimpleTopicIdStrategy.class.getName());
+            serializerConfig.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+            serializerConfig.put(SerdeConfig.VALIDATION_ENABLED, "true");
+            serializer.configure(serializerConfig, false);
+
+            Headers headers = new RecordHeaders();
+            // This (serialize) should fail with an SSL-related error
+            Exception exception = Assertions.assertThrows(Exception.class, () -> {
+                serializer.serialize(artifactId, headers, person);
+            });
+
+            // Verify it's an SSL-related error
+            boolean isSslError = isSslException(exception);
+            if (!isSslError) {
+                Assertions.fail("Expected SSL-related error, but got something else.", exception);
+            }
+        }
+    }
+
+    /**
+     * Helper method to check if the exception thrown was an SSL related error.
+     */
+    private boolean isSslException(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause.getCause() != null && cause.getCause() != cause) {
+            if (cause instanceof SSLHandshakeException) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+}

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -91,6 +91,35 @@ public class RegistryClientFacadeFactory {
             clientOptions.retry();
         }
 
+        // Configure TLS/SSL
+        String truststoreLocation = config.getTlsTruststoreLocation();
+        String truststorePassword = config.getTlsTruststorePassword();
+        String truststoreType = config.getTlsTruststoreType();
+        String certificates = config.getTlsCertificates();
+        boolean trustAll = config.getTlsTrustAll();
+        boolean verifyHost = config.getTlsVerifyHost();
+
+        if (trustAll) {
+            clientOptions.trustAll(true);
+        } else if (truststoreLocation != null) {
+            if ("JKS".equalsIgnoreCase(truststoreType)) {
+                clientOptions.trustStoreJks(truststoreLocation, truststorePassword);
+            } else if ("PEM".equalsIgnoreCase(truststoreType)) {
+                clientOptions.trustStorePem(truststoreLocation);
+            }
+        } else if (certificates != null) {
+            // Support comma-separated list of PEM certificate paths
+            String[] certPaths = certificates.split(",");
+            for (int i = 0; i < certPaths.length; i++) {
+                certPaths[i] = certPaths[i].trim();
+            }
+            clientOptions.trustStorePem(certPaths);
+        }
+
+        if (!verifyHost) {
+            clientOptions.verifyHost(false);
+        }
+
         return clientOptions;
     }
 

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -192,6 +192,45 @@ public class SchemaResolverConfig extends AbstractConfig {
     public static final String CANONICALIZE = "apicurio.registry.canonicalize";
     public static final boolean CANONICALIZE_DEFAULT = false;
 
+    /**
+     * The location of the trust store file for TLS/SSL connections. Can be a file path or a resource
+     * on the classpath. Used when connecting to a registry over HTTPS with custom certificates.
+     */
+    public static final String TLS_TRUSTSTORE_LOCATION = "apicurio.registry.tls.truststore.location";
+
+    /**
+     * The password for the trust store file specified by {@link #TLS_TRUSTSTORE_LOCATION}.
+     * Only required when using JKS trust stores.
+     */
+    public static final String TLS_TRUSTSTORE_PASSWORD = "apicurio.registry.tls.truststore.password";
+
+    /**
+     * The type of trust store. Valid values are "JKS" and "PEM". Defaults to "JKS".
+     */
+    public static final String TLS_TRUSTSTORE_TYPE = "apicurio.registry.tls.truststore.type";
+    public static final String TLS_TRUSTSTORE_TYPE_DEFAULT = "JKS";
+
+    /**
+     * Comma-separated list of PEM certificate file paths to trust. An alternative to using
+     * {@link #TLS_TRUSTSTORE_LOCATION} with a JKS file. When using this option, set
+     * {@link #TLS_TRUSTSTORE_TYPE} to "PEM".
+     */
+    public static final String TLS_CERTIFICATES = "apicurio.registry.tls.certificates";
+
+    /**
+     * If true, disables all SSL/TLS certificate verification. This is insecure and should only be used
+     * in development/testing environments. Defaults to false.
+     */
+    public static final String TLS_TRUST_ALL = "apicurio.registry.tls.trust-all";
+    public static final boolean TLS_TRUST_ALL_DEFAULT = false;
+
+    /**
+     * If true, verifies that the hostname in the server certificate matches the server hostname.
+     * Defaults to true. Set to false only when necessary (e.g., when using IP addresses instead of hostnames).
+     */
+    public static final String TLS_VERIFY_HOST = "apicurio.registry.tls.verify-host";
+    public static final boolean TLS_VERIFY_HOST_DEFAULT = true;
+
     public String getRegistryUrl() {
         String registryUrl = getString(REGISTRY_URL);
         if (registryUrl != null) {
@@ -306,6 +345,30 @@ public class SchemaResolverConfig extends AbstractConfig {
         return getBooleanOrFalse(CANONICALIZE);
     }
 
+    public String getTlsTruststoreLocation() {
+        return getString(TLS_TRUSTSTORE_LOCATION);
+    }
+
+    public String getTlsTruststorePassword() {
+        return getString(TLS_TRUSTSTORE_PASSWORD);
+    }
+
+    public String getTlsTruststoreType() {
+        return getString(TLS_TRUSTSTORE_TYPE);
+    }
+
+    public String getTlsCertificates() {
+        return getString(TLS_CERTIFICATES);
+    }
+
+    public boolean getTlsTrustAll() {
+        return getBooleanOrFalse(TLS_TRUST_ALL);
+    }
+
+    public boolean getTlsVerifyHost() {
+        return getBoolean(TLS_VERIFY_HOST);
+    }
+
     @Override
     protected Map<String, ?> getDefaults() {
         return DEFAULTS;
@@ -321,5 +384,8 @@ public class SchemaResolverConfig extends AbstractConfig {
             entry(FIND_LATEST_ARTIFACT, FIND_LATEST_ARTIFACT_DEFAULT),
             entry(CHECK_PERIOD_MS, CHECK_PERIOD_MS_DEFAULT), entry(RETRY_COUNT, RETRY_COUNT_DEFAULT),
             entry(RETRY_BACKOFF_MS, RETRY_BACKOFF_MS_DEFAULT),
-            entry(DEREFERENCE_SCHEMA, DEREFERENCE_DEFAULT));
+            entry(DEREFERENCE_SCHEMA, DEREFERENCE_DEFAULT),
+            entry(TLS_TRUSTSTORE_TYPE, TLS_TRUSTSTORE_TYPE_DEFAULT),
+            entry(TLS_TRUST_ALL, TLS_TRUST_ALL_DEFAULT),
+            entry(TLS_VERIFY_HOST, TLS_VERIFY_HOST_DEFAULT));
 }


### PR DESCRIPTION
- Added TLS configuration properties to SchemaResolverConfig:
  * TLS_TRUSTSTORE_LOCATION, TLS_TRUSTSTORE_PASSWORD, TLS_TRUSTSTORE_TYPE
  * TLS_CERTIFICATES (comma-separated PEM files)
  * TLS_TRUST_ALL, TLS_VERIFY_HOST
- Updated RegistryClientFacadeFactory to apply TLS configuration
- Created TlsSerdeTest to verify SerDe works with TLS
- Supports JKS trust stores, PEM certificates, and trust-all mode
- Enables Kafka/Pulsar serializers to connect to HTTPS registries