### PR TITLE
fix(6693): Validate version state filter in search

### DIFF
--- a/ui/ui-editors/angular.json
+++ b/ui/ui-editors/angular.json
@@ -68,18 +68,18 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "editors:build"
+            "buildTarget": "editors:build"
           },
           "configurations": {
             "production": {
-              "browserTarget": "editors:build:production"
+              "buildTarget": "editors:build:production"
             }
           }
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "editors:build"
+            "buildTarget": "editors:build"
           }
         },
         "test": {


### PR DESCRIPTION
- Added validation for version state filter values
- Coerce state filter to uppercase before sending to API
- Default to "DISABLED" if invalid state value provided
- Fixed Angular deprecation warnings (browserTarget -> buildTarget)

This prevents API errors when users enter invalid state values in the version search filter.