### PR TITLE
Update jandex-maven-plugin to 3.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     -->
 
     <!-- Jandex -->
-    <jandex.version>3.5.0</jandex.version>
+    <jandex.version>3.5.1</jandex.version>
 
     <!-- Schema types -->
     <avro.version>1.12.1</avro.version>


### PR DESCRIPTION
## Summary
- Update io.smallrye:jandex-maven-plugin from 3.5.0 to 3.5.1

## Context
This dependency upgrade was split from Renovate PR #6629 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected