### PR TITLE
Add custom-artifact-type example

### DIFF
--- a/examples/custom-artifact-type/.gitignore
+++ b/examples/custom-artifact-type/.gitignore
@@ -1,0 +1,15 @@
+# Node modules
+toml-artifact-type/node_modules/
+toml-artifact-type/package-lock.json
+
+# Build output
+toml-artifact-type/dist/
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# OS
+.DS_Store
+Thumbs.db

--- a/examples/custom-artifact-type/README.md
+++ b/examples/custom-artifact-type/README.md
@@ -1,0 +1,218 @@
+# Custom Artifact Type Example
+
+This example demonstrates how to extend Apicurio Registry with support for a custom artifact type at
+deployment time. The example implements a simple TOML (Tom's Obvious, Minimal Language) configuration
+file artifact type.
+
+## Overview
+
+Apicurio Registry can be extended to support custom artifact types by:
+1. Implementing artifact type functions in JavaScript/TypeScript
+2. Configuring the registry to load your custom artifact type
+3. Deploying the registry with the custom configuration
+
+This example includes:
+- A TypeScript implementation of a TOML artifact type
+- Configuration file for enabling the custom artifact type
+- Docker Compose setup for running the registry with the custom type
+- Demo script showing the custom artifact type in action
+
+## Custom Artifact Type Components
+
+The TOML artifact type implements the following components:
+
+### Content Accepter
+Automatically detects if content is TOML format based on content analysis.
+
+### Content Validator
+Validates that TOML content follows proper syntax rules.
+
+### Content Canonicalizer
+Normalizes TOML content for consistent comparison (uppercases keys).
+
+### Compatibility Checker
+Ensures backward compatibility by checking that sections haven't been removed.
+
+### Content Dereferencer
+Resolves `@include "filename"` references by replacing them with actual content.
+
+### Reference Finder
+Identifies external references in TOML content.
+
+## Prerequisites
+
+- Node.js 18+ and npm (for building the TypeScript implementation)
+- Docker and Docker Compose
+- curl and jq (for running the demo script)
+
+## Quick Start
+
+### 1. Build the Custom Artifact Type
+
+First, build the JavaScript library from the TypeScript source:
+
+```bash
+cd toml-artifact-type
+npm install
+npm run build
+cd ..
+```
+
+This will create `toml-artifact-type/dist/toml-artifact-type.js` which contains the bundled artifact
+type implementation.
+
+### 2. Start the Registry
+
+Start Apicurio Registry with the custom artifact type configuration:
+
+```bash
+docker compose up
+```
+
+The Docker Compose file:
+- Starts Apicurio Registry with custom artifact type support (using in-memory storage)
+- Starts Apicurio Registry UI for web-based management
+- Mounts the configuration file and JavaScript library into the registry container
+
+Wait for the services to be ready (check with `docker compose logs -f`).
+
+**Note**: This example uses in-memory storage for simplicity. Data will be lost when the container
+stops. For production use, configure persistent storage (PostgreSQL, Kafka, etc.).
+
+### 3. Run the Demo
+
+Execute the demo script to see the custom artifact type in action:
+
+```bash
+./demo.sh
+```
+
+The demo script demonstrates:
+- Listing available artifact types (including TOML)
+- Creating TOML artifacts
+- Auto-detection of artifact type from content
+- Creating new versions with compatibility checking
+- Content validation
+- Handling incompatible changes
+
+### 4. Explore the Registry
+
+You can also explore the registry using:
+- **Web UI**: http://localhost:8888
+- **REST API**: http://localhost:8080/apis/registry/v3
+
+## Configuration Details
+
+### artifact-types-config.json
+
+This file configures the custom artifact type:
+
+```json
+{
+  "includeStandardArtifactTypes": true,
+  "artifactTypes": [
+    {
+      "artifactType": "TOML",
+      "name": "TOML",
+      "description": "Tom's Obvious, Minimal Language - A config file format",
+      "contentTypes": ["application/toml"],
+      "scriptLocation": "/custom-artifact-types/dist/toml-artifact-type.js",
+      "contentAccepter": { "type": "script" },
+      "contentCanonicalizer": { "type": "script" },
+      "contentValidator": { "type": "script" },
+      "compatibilityChecker": { "type": "script" },
+      "contentDereferencer": { "type": "script" },
+      "referenceFinder": { "type": "script" }
+    }
+  ]
+}
+```
+
+Key fields:
+- `includeStandardArtifactTypes`: Set to `true` to keep built-in types (Avro, Protobuf, etc.)
+- `artifactType`: Unique identifier for your custom type
+- `contentTypes`: MIME types associated with this artifact type
+- `scriptLocation`: Path to the JavaScript implementation (inside the container)
+- Component configurations: Each set to `"type": "script"` to use the JavaScript implementation
+
+### Docker Compose Configuration
+
+The Docker Compose file mounts two important paths:
+
+```yaml
+volumes:
+  - ./artifact-types-config.json:/custom-artifact-types/artifact-types-config.json:ro
+  - ./toml-artifact-type/dist:/custom-artifact-types/dist:ro
+```
+
+And sets the environment variable:
+
+```yaml
+environment:
+  APICURIO_ARTIFACT_TYPES_CONFIG_FILE: "/custom-artifact-types/artifact-types-config.json"
+```
+
+**Note**: The example uses in-memory storage (the default). To use persistent storage, add database
+configuration environment variables.
+
+## Cleanup
+
+To stop and remove the containers:
+
+```bash
+docker compose down
+```
+
+Since this example uses in-memory storage, all data is automatically removed when the containers
+stop.
+
+## Advanced Topics
+
+### Using with Kubernetes
+
+To deploy with Kubernetes:
+1. Build the JavaScript library
+2. Create a ConfigMap from `artifact-types-config.json` and the JavaScript library
+3. Mount the ConfigMap into the registry pod
+4. Set the `APICURIO_ARTIFACT_TYPES_CONFIG_FILE` environment variable
+
+### Disabling Standard Artifact Types
+
+If you want only your custom types (no Avro, Protobuf, etc.):
+
+```json
+{
+  "includeStandardArtifactTypes": false,
+  "artifactTypes": []
+}
+```
+
+### Multiple Custom Artifact Types
+
+You can define multiple custom types in the same configuration file:
+
+```json
+{
+  "includeStandardArtifactTypes": true,
+  "artifactTypes": [
+    {},
+    {},
+    {}
+  ]
+}
+```
+
+## References
+
+- [Apicurio Registry Documentation](https://www.apicur.io/registry/)
+- [Custom Artifact Types Test](../../app/src/test/java/io/apicurio/registry/customTypes/)
+- [TOML Specification](https://toml.io/)
+
+## Notes
+
+This example keeps the TOML parsing and validation intentionally simple to focus on demonstrating
+the custom artifact type mechanism. In a production implementation, you would:
+- Use a proper TOML parsing library
+- Implement comprehensive validation
+- Add sophisticated compatibility checking logic
+- Handle edge cases and error conditions more robustly

--- a/examples/custom-artifact-type/artifact-types-config.json
+++ b/examples/custom-artifact-type/artifact-types-config.json
@@ -1,0 +1,32 @@
+{
+  "includeStandardArtifactTypes": true,
+  "artifactTypes": [
+    {
+      "artifactType": "TOML",
+      "name": "TOML",
+      "description": "Tom's Obvious, Minimal Language - A config file format that's easy to read and write",
+      "contentTypes": [
+        "application/toml"
+      ],
+      "scriptLocation": "/custom-artifact-types/dist/toml-artifact-type.js",
+      "contentAccepter": {
+        "type": "script"
+      },
+      "contentCanonicalizer": {
+        "type": "script"
+      },
+      "contentValidator": {
+        "type": "script"
+      },
+      "compatibilityChecker": {
+        "type": "script"
+      },
+      "contentDereferencer": {
+        "type": "script"
+      },
+      "referenceFinder": {
+        "type": "script"
+      }
+    }
+  ]
+}

--- a/examples/custom-artifact-type/demo.sh
+++ b/examples/custom-artifact-type/demo.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+
+# Demo script for custom TOML artifact type in Apicurio Registry
+# This script demonstrates the various capabilities of the custom artifact type
+
+REGISTRY_URL="http://localhost:8080/apis/registry/v3"
+GROUP_ID="example-group"
+ARTIFACT_ID="app-config"
+
+echo "=================================================="
+echo "Custom TOML Artifact Type Demo"
+echo "=================================================="
+echo ""
+
+# Step 1: List available artifact types
+echo "1. Listing available artifact types..."
+echo "   Command: curl -s $REGISTRY_URL/admin/config/artifactTypes"
+curl -s "$REGISTRY_URL/admin/config/artifactTypes" | jq '.'
+echo ""
+echo "   Note: You should see TOML in the list above"
+echo ""
+read -p "Press Enter to continue..."
+echo ""
+
+# Step 2: Create a TOML artifact
+echo "2. Creating a TOML artifact..."
+TOML_CONTENT='[database]
+host = "localhost"
+port = 5432
+database = "myapp"
+
+[server]
+host = "0.0.0.0"
+port = 8080
+debug = true'
+
+echo "   TOML Content:"
+echo "$TOML_CONTENT"
+echo ""
+
+CREATE_RESPONSE=$(curl -s -X POST "$REGISTRY_URL/groups/$GROUP_ID/artifacts" \
+  -H "Content-Type: application/json" \
+  -H "X-Registry-ArtifactId: $ARTIFACT_ID" \
+  -H "X-Registry-ArtifactType: TOML" \
+  -d "{
+    \"artifactId\": \"$ARTIFACT_ID\",
+    \"artifactType\": \"TOML\",
+    \"firstVersion\": {
+      \"version\": \"1.0.0\",
+      \"content\": {
+        \"content\": $(echo "$TOML_CONTENT" | jq -Rs .),
+        \"contentType\": \"application/toml\"
+      }
+    }
+  }")
+
+echo "   Response:"
+echo "$CREATE_RESPONSE" | jq '.'
+echo ""
+read -p "Press Enter to continue..."
+echo ""
+
+# Step 3: Get the artifact content
+echo "3. Retrieving the artifact content..."
+echo "   Command: curl -s $REGISTRY_URL/groups/$GROUP_ID/artifacts/$ARTIFACT_ID/versions/1.0.0/content"
+curl -s "$REGISTRY_URL/groups/$GROUP_ID/artifacts/$ARTIFACT_ID/versions/1.0.0/content"
+echo ""
+echo ""
+read -p "Press Enter to continue..."
+echo ""
+
+# Step 4: Test content auto-detection (ContentAccepter)
+echo "4. Creating artifact without specifying type (auto-detection)..."
+AUTO_ARTIFACT_ID="auto-detected-config"
+AUTO_RESPONSE=$(curl -s -X POST "$REGISTRY_URL/groups/$GROUP_ID/artifacts" \
+  -H "Content-Type: application/json" \
+  -H "X-Registry-ArtifactId: $AUTO_ARTIFACT_ID" \
+  -d "{
+    \"artifactId\": \"$AUTO_ARTIFACT_ID\",
+    \"firstVersion\": {
+      \"version\": \"1.0.0\",
+      \"content\": {
+        \"content\": $(echo "$TOML_CONTENT" | jq -Rs .),
+        \"contentType\": \"application/toml\"
+      }
+    }
+  }")
+
+echo "   Response (note the artifactType field):"
+echo "$AUTO_RESPONSE" | jq '.'
+echo ""
+read -p "Press Enter to continue..."
+echo ""
+
+# Step 5: Create a new version with compatibility check
+echo "5. Creating a new version (compatible - adds new section)..."
+TOML_V2_CONTENT='[database]
+host = "localhost"
+port = 5432
+database = "myapp"
+
+[server]
+host = "0.0.0.0"
+port = 8080
+debug = false
+
+[cache]
+enabled = true
+ttl = 3600'
+
+echo "   New TOML Content (added [cache] section):"
+echo "$TOML_V2_CONTENT"
+echo ""
+
+V2_RESPONSE=$(curl -s -X POST "$REGISTRY_URL/groups/$GROUP_ID/artifacts/$ARTIFACT_ID/versions" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"version\": \"2.0.0\",
+    \"content\": {
+      \"content\": $(echo "$TOML_V2_CONTENT" | jq -Rs .),
+      \"contentType\": \"application/toml\"
+    }
+  }")
+
+echo "   Response:"
+echo "$V2_RESPONSE" | jq '.'
+echo ""
+read -p "Press Enter to continue..."
+echo ""
+
+# Step 6: Enable compatibility rule and test
+echo "6. Enabling compatibility rule (BACKWARD)..."
+RULE_RESPONSE=$(curl -s -X POST "$REGISTRY_URL/groups/$GROUP_ID/rules" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ruleType": "COMPATIBILITY",
+    "config": "BACKWARD"
+  }')
+
+echo "   Compatibility rule enabled."
+echo ""
+
+echo "   Attempting to create incompatible version (removes [database] section)..."
+INCOMPATIBLE_CONTENT='[server]
+host = "0.0.0.0"
+port = 9090
+debug = false'
+
+INCOMPATIBLE_RESPONSE=$(curl -s -X POST "$REGISTRY_URL/groups/$GROUP_ID/artifacts/$ARTIFACT_ID/versions" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"version\": \"3.0.0\",
+    \"content\": {
+      \"content\": $(echo "$INCOMPATIBLE_CONTENT" | jq -Rs .),
+      \"contentType\": \"application/toml\"
+    }
+  }" || echo "Expected to fail")
+
+echo "   Response (should show error):"
+echo "$INCOMPATIBLE_RESPONSE" | jq '.'
+echo ""
+read -p "Press Enter to continue..."
+echo ""
+
+# Step 7: Test validation
+echo "7. Testing content validation..."
+echo "   Enabling validity rule (FULL)..."
+VALIDITY_RULE_RESPONSE=$(curl -s -X POST "$REGISTRY_URL/groups/$GROUP_ID/rules" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ruleType": "VALIDITY",
+    "config": "FULL"
+  }')
+
+echo "   Validity rule enabled."
+echo ""
+
+echo "   Attempting to create artifact with invalid TOML..."
+INVALID_TOML='This is not valid TOML
+random text here
+no structure'
+
+INVALID_RESPONSE=$(curl -s -X POST "$REGISTRY_URL/groups/$GROUP_ID/artifacts" \
+  -H "Content-Type: application/json" \
+  -H "X-Registry-ArtifactId: invalid-toml" \
+  -H "X-Registry-ArtifactType: TOML" \
+  -d "{
+    \"artifactId\": \"invalid-toml\",
+    \"artifactType\": \"TOML\",
+    \"firstVersion\": {
+      \"version\": \"1.0.0\",
+      \"content\": {
+        \"content\": $(echo "$INVALID_TOML" | jq -Rs .),
+        \"contentType\": \"application/toml\"
+      }
+    }
+  }" 2>&1)
+
+echo "   Response (should indicate validation failure):"
+echo "$INVALID_RESPONSE" | jq '.' 2>/dev/null || echo "$INVALID_RESPONSE"
+echo ""
+read -p "Press Enter to continue..."
+echo ""
+
+# Step 8: List all versions
+echo "8. Listing all versions of the artifact..."
+echo "   Command: curl -s $REGISTRY_URL/groups/$GROUP_ID/artifacts/$ARTIFACT_ID/versions"
+curl -s "$REGISTRY_URL/groups/$GROUP_ID/artifacts/$ARTIFACT_ID/versions" | jq '.'
+echo ""
+read -p "Press Enter to continue..."
+echo ""
+
+# Summary
+echo "=================================================="
+echo "Demo Complete!"
+echo "=================================================="
+echo ""
+echo "This demo demonstrated:"
+echo "  ✓ Custom artifact type registration (TOML)"
+echo "  ✓ Artifact creation with explicit type"
+echo "  ✓ Content auto-detection (ContentAccepter)"
+echo "  ✓ Compatibility checking"
+echo "  ✓ Content validation"
+echo "  ✓ Version management"
+echo ""
+echo "You can explore the registry using:"
+echo "  - Web UI:  http://localhost:8888"
+echo "  - API:     http://localhost:8080/apis/registry/v3"
+echo ""

--- a/examples/custom-artifact-type/docker-compose.yml
+++ b/examples/custom-artifact-type/docker-compose.yml
@@ -1,0 +1,40 @@
+---
+version: '3.8'
+
+services:
+  # Apicurio Registry with custom artifact type support
+  # Uses in-memory storage (default) for simplicity
+  apicurio-registry:
+    image: apicurio/apicurio-registry:latest-snapshot
+    container_name: custom-artifact-type-registry
+    ports:
+      - "8080:8080"
+    environment:
+      # Custom artifact types configuration
+      APICURIO_ARTIFACT_TYPES_CONFIG_FILE: "/custom-artifact-types/artifact-types-config.json"
+
+      # Logging
+      QUARKUS_LOG_LEVEL: "INFO"
+      APICURIO_LOG_LEVEL: "DEBUG"
+    volumes:
+      # Mount the custom artifact types configuration and JavaScript library
+      - ./artifact-types-config.json:/custom-artifact-types/artifact-types-config.json:ro
+      - ./toml-artifact-type/dist:/custom-artifact-types/dist:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  # Apicurio Registry UI
+  apicurio-registry-ui:
+    image: quay.io/apicurio/apicurio-registry-ui:latest-snapshot
+    container_name: custom-artifact-type-registry-ui
+    ports:
+      - "8888:8080"
+    environment:
+      REGISTRY_API_URL: "http://localhost:8080/apis/registry/v3"
+    depends_on:
+      apicurio-registry:
+        condition: service_healthy

--- a/examples/custom-artifact-type/sample-configs/app-config.toml
+++ b/examples/custom-artifact-type/sample-configs/app-config.toml
@@ -1,0 +1,30 @@
+# Sample application configuration in TOML format
+# This file demonstrates a typical use case for the custom TOML artifact type
+
+[database]
+host = "localhost"
+port = 5432
+database = "myapp"
+username = "dbuser"
+max_connections = 100
+
+[server]
+host = "0.0.0.0"
+port = 8080
+debug = true
+workers = 4
+
+[logging]
+level = "INFO"
+format = "json"
+output = "/var/log/app.log"
+
+[cache]
+enabled = true
+ttl = 3600
+provider = "redis"
+
+[cache.redis]
+host = "localhost"
+port = 6379
+db = 0

--- a/examples/custom-artifact-type/sample-configs/microservice-config.toml
+++ b/examples/custom-artifact-type/sample-configs/microservice-config.toml
@@ -1,0 +1,22 @@
+# Microservice configuration example with references
+# This demonstrates the reference resolution feature
+
+[service]
+name = "user-service"
+version = "2.0.0"
+environment = "production"
+
+[endpoints]
+api = "/api/v2/users"
+health = "/health"
+metrics = "/metrics"
+
+# Example of external reference (would be resolved by the ContentDereferencer)
+[secrets]
+# @include "secrets/db-credentials.toml"
+database_password = "placeholder"
+
+[features]
+rate_limiting = true
+authentication = true
+audit_logging = true

--- a/examples/custom-artifact-type/toml-artifact-type/TomlArtifactType.ts
+++ b/examples/custom-artifact-type/toml-artifact-type/TomlArtifactType.ts
@@ -1,0 +1,275 @@
+
+type TypedContent = {
+    contentType: string;
+    content: string;
+}
+
+/**
+ * Simple TOML parser for basic validation
+ * This is a minimal implementation just to demonstrate the concept
+ */
+function isValidToml(content: string): boolean {
+    const lines = content.split('\n');
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed === '' || trimmed.startsWith('#')) {
+            continue;
+        }
+        // Check for section headers [section]
+        if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+            continue;
+        }
+        // Check for key-value pairs
+        if (trimmed.includes('=')) {
+            continue;
+        }
+        // If line is not empty, comment, section, or key-value, it's invalid
+        if (trimmed.length > 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Check if the content is TOML format
+ */
+export function acceptsContent(request: any): boolean {
+    let accepted: boolean = false;
+    if (request.typedContent.contentType === "application/toml") {
+        const content: string = request.typedContent.content;
+        accepted = isValidToml(content);
+    }
+    return accepted;
+}
+
+/**
+ * Test compatibility between existing and proposed artifacts
+ * For this simple example, we just ensure section names haven't been removed
+ */
+export function testCompatibility(request: any): any {
+    const existingArtifacts: TypedContent[] = request.existingArtifacts;
+    const proposedArtifact: TypedContent = request.proposedArtifact;
+
+    if (existingArtifacts == null || existingArtifacts == undefined || existingArtifacts.length === 0) {
+        return {
+            incompatibleDifferences: []
+        }
+    }
+
+    try {
+        const proposedSections = extractSections(proposedArtifact.content);
+        const existingSections = extractSections(existingArtifacts[0].content);
+
+        const incompatibleDifferences: any[] = [];
+
+        // Check if any sections were removed
+        for (const section of existingSections) {
+            if (!proposedSections.includes(section)) {
+                incompatibleDifferences.push({
+                    description: "Section '" + section + "' was removed",
+                    context: "/" + section
+                });
+            }
+        }
+
+        return {
+            incompatibleDifferences: incompatibleDifferences
+        }
+    } catch (e) {
+        return {
+            incompatibleDifferences: [
+                {
+                    description: "Error during compatibility check: " + e,
+                    context: "/"
+                }
+            ]
+        }
+    }
+}
+
+/**
+ * Extract section names from TOML content
+ */
+function extractSections(content: string): string[] {
+    const sections: string[] = [];
+    const lines = content.split('\n');
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+            sections.push(trimmed.substring(1, trimmed.length - 1));
+        }
+    }
+    return sections;
+}
+
+/**
+ * Canonicalize TOML content by normalizing whitespace and sorting sections
+ */
+export function canonicalize(request: any): any {
+    const originalContent: string = request.content.content;
+
+    // Simple canonicalization: uppercase all keys
+    const convertedContent: string = originalContent
+        .split('\n')
+        .map(line => {
+            const trimmed = line.trim();
+            if (trimmed.includes('=') && !trimmed.startsWith('#')) {
+                const parts = line.split('=');
+                return parts[0].toUpperCase() + '=' + parts.slice(1).join('=');
+            }
+            return line;
+        })
+        .join('\n');
+
+    return {
+        typedContent: {
+            contentType: request.content.contentType,
+            content: convertedContent
+        }
+    };
+}
+
+/**
+ * Validate TOML content structure
+ */
+export function validate(request: any): any {
+    const violations: any[] = [];
+    const content: string = request.content.content;
+    const contentType: string = request.content.contentType;
+
+    if (contentType !== "application/toml") {
+        violations.push(
+            {
+                description: "Incorrect content type.  Expected 'application/toml' but found '" + contentType + "'.",
+                context: null
+            }
+        );
+    } else {
+        if (!isValidToml(content)) {
+            violations.push(
+                {
+                    description: "Invalid TOML format detected.",
+                    context: null
+                }
+            );
+        }
+    }
+
+    return {
+        ruleViolations: violations
+    };
+}
+
+/**
+ * Dereference content by replacing references with actual content
+ */
+export function dereference(request: any): any {
+    const content: string = request.content.content;
+    const indexedResolvedRefs: any = {};
+
+    request.resolvedReferences.forEach((resolvedRef: any) => {
+        indexedResolvedRefs[resolvedRef.name] = {
+            contentType: resolvedRef.contentType,
+            content: resolvedRef.content
+        }
+    });
+
+    let dereferencedContent = content;
+
+    // Replace references in format: @include "filename"
+    const lines = content.split('\n');
+    const resultLines = lines.map(line => {
+        const includeMatch = line.match(/@include\s+"([^"]+)"/);
+        if (includeMatch && indexedResolvedRefs[includeMatch[1]]) {
+            const includeContent: TypedContent = indexedResolvedRefs[includeMatch[1]];
+            return "# Included from " + includeMatch[1] + "\n" + includeContent.content;
+        }
+        return line;
+    });
+
+    dereferencedContent = resultLines.join('\n');
+
+    return {
+        typedContent: {
+            contentType: request.content.contentType,
+            content: dereferencedContent
+        }
+    }
+}
+
+/**
+ * Rewrite references to use URLs instead of file paths
+ */
+export function rewriteReferences(request: any): any {
+    const content: string = request.content.content;
+    const indexedResolvedReferenceUrls: any = {};
+
+    request.resolvedReferenceUrls.forEach((resolvedRefUrl: any) => {
+        indexedResolvedReferenceUrls[resolvedRefUrl.name] = resolvedRefUrl.url;
+    });
+
+    let rewrittenContent = content;
+
+    // Replace references with URLs
+    const lines = content.split('\n');
+    const resultLines = lines.map(line => {
+        const includeMatch = line.match(/@include\s+"([^"]+)"/);
+        if (includeMatch && indexedResolvedReferenceUrls[includeMatch[1]]) {
+            const refUrl: string = indexedResolvedReferenceUrls[includeMatch[1]];
+            return '@include "' + refUrl + '"';
+        }
+        return line;
+    });
+
+    rewrittenContent = resultLines.join('\n');
+
+    return {
+        typedContent: {
+            contentType: request.content.contentType,
+            content: rewrittenContent
+        }
+    }
+}
+
+/**
+ * Find external references in the content
+ */
+export function findExternalReferences(request: any): any {
+    const content: string = request.content.content;
+    const references: string[] = [];
+
+    const lines = content.split('\n');
+    for (const line of lines) {
+        const includeMatch = line.match(/@include\s+"([^"]+)"/);
+        if (includeMatch) {
+            references.push(includeMatch[1]);
+        }
+    }
+
+    return {
+        externalReferences: references
+    };
+}
+
+/**
+ * Validate that all references are properly mapped
+ */
+export function validateReferences(request: any): any {
+    const violations: any[] = [];
+    const mappedReferences: string[] = request.mappedReferences || [];
+    const foundReferences = findExternalReferences(request);
+
+    for (const ref of foundReferences.externalReferences) {
+        if (!mappedReferences.includes(ref)) {
+            violations.push({
+                description: "Reference '" + ref + "' is not mapped",
+                context: null
+            });
+        }
+    }
+
+    return {
+        ruleViolations: violations
+    };
+}

--- a/examples/custom-artifact-type/toml-artifact-type/package.json
+++ b/examples/custom-artifact-type/toml-artifact-type/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "toml-artifact-type",
+  "private": false,
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Custom TOML artifact type for Apicurio Registry",
+  "devDependencies": {
+    "cp": "0.2.0",
+    "esbuild": "0.25.11",
+    "rimraf": "6.0.1",
+    "typescript": "5.9.3"
+  },
+  "scripts": {
+    "clean": "rimraf dist",
+    "transpile": "tsc --p ./tsconfig-build.json",
+    "build-library": "esbuild dist/TomlArtifactType.js --bundle --outfile=dist/toml-artifact-type.js --format=esm",
+    "build": "npm run transpile && npm run build-library"
+  }
+}

--- a/examples/custom-artifact-type/toml-artifact-type/tsconfig-build.json
+++ b/examples/custom-artifact-type/toml-artifact-type/tsconfig-build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false
+  }
+}

--- a/examples/custom-artifact-type/toml-artifact-type/tsconfig.json
+++ b/examples/custom-artifact-type/toml-artifact-type/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "lib": ["ES2020"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist"
+  },
+  "include": [
+    "*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds a comprehensive example demonstrating how to extend Apicurio Registry with custom artifact types at deployment time.

## What's included

- **TOML Artifact Type Implementation**: Complete TypeScript implementation showing all required components:
  - Content Accepter (auto-detection)
  - Content Validator
  - Content Canonicalizer
  - Compatibility Checker
  - Content Dereferencer
  - Reference Finder

- **Configuration**: JSON configuration file for enabling custom artifact types

- **Docker Compose Setup**: Simple deployment with in-memory storage plus separate UI service

- **Interactive Demo**: Bash script with curl commands demonstrating:
  - Artifact type registration and listing
  - Creating artifacts with explicit and auto-detected types
  - Version management with compatibility checking
  - Content validation with rule enforcement
  
- **Documentation**: Comprehensive README with:
  - Quick start guide
  - Configuration details
  - Instructions for implementing custom artifact types
  - Advanced topics (Kubernetes deployment, multiple types, etc.)

## Notes

The TOML implementation is intentionally kept simple to focus on demonstrating the custom artifact type mechanism rather than building a production TOML parser.

The example uses in-memory storage for simplicity, making it easy for users to quickly test custom artifact type functionality.