### PR TITLE
Update quickjs4j to 0.0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
     <pulsar-clients.version>3.3.9</pulsar-clients.version>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
     <quarkus-quickjs4j.version>0.0.2</quarkus-quickjs4j.version>
-    <quickjs4j.version>0.0.10</quickjs4j.version>
+    <quickjs4j.version>0.0.11</quickjs4j.version>
 
     <nats.version>2.23.0</nats.version>
     <snakeyaml.version>2.5</snakeyaml.version>


### PR DESCRIPTION
## Summary
- Update quickjs4j from 0.0.10 to 0.0.11

This update includes all quickjs4j artifacts:
- io.roastedroot:quickjs4j
- io.roastedroot:quickjs4j-processor
- io.roastedroot:quickjs4j-annotations

These artifacts share the same version property (`quickjs4j.version`) and must be updated together.

## Context
This dependency upgrade was split from Renovate PR #6629 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected