### PR TITLE
Create @apicurio/artifact-type-builtins npm package

### DIFF
--- a/.github/workflows/release-artifact-type-builtins.yaml
+++ b/.github/workflows/release-artifact-type-builtins.yaml
@@ -1,0 +1,112 @@
+name: Release Artifact Type Builtins
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag name'
+        required: true
+  release:
+    types: [released, prereleased]
+
+
+env:
+  # The values are extracted from the github.event context,
+  # which is only available when the workflow gets triggered by a release event.
+  RELEASE_VERSION: ${{ github.event.release.name }}
+  BRANCH: ${{ github.event.release.target_commitish }}
+
+
+jobs:
+  release-artifact-type-builtins:
+    if: github.repository_owner == 'Apicurio' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '3.'))
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    env:
+      RELEASE_TYPE: release
+    steps:
+      - name: Fetch Release Details
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          touch release.json && curl https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${{ github.event.inputs.tag }} > release.json
+          echo "RELEASE_VERSION=$(cat release.json | jq -r '.name')" >> $GITHUB_ENV
+          echo "BRANCH=$(cat release.json | jq -r '.target_commitish')" >> $GITHUB_ENV
+
+      - name: Download Source Code
+        run: |
+          git config --global user.name "apicurio-ci"
+          git config --global user.email "apicurio.ci@gmail.com"
+          git clone --branch $RELEASE_VERSION --single-branch https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git registry
+
+      # We have faced issues in the past where a github release was created from a wrong commit
+      # This step will ensure that the release was created from the right commit
+      - name: Verify Project Version
+        run: |
+          cd registry
+          PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          if [[ $PROJECT_VERSION != $RELEASE_VERSION ]]
+          then
+              echo "ERROR: Project Version '${PROJECT_VERSION}' does not match with Released Version '${RELEASE_VERSION}'"
+              exit 1
+          fi
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Maven
+        working-directory: registry
+        run: |
+          mvn clean install -pl app -am -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress
+
+      - name: Verify Generated Files Exist
+        working-directory: registry
+        run: |
+          if [ ! -f app/target/classes/META-INF/quickjs4j/ArtifactTypeScriptProvider_Builtins.d.ts ]; then
+            echo "ERROR: Generated TypeScript definitions not found"
+            exit 1
+          fi
+          if [ ! -f app/target/classes/META-INF/quickjs4j/ArtifactTypeScriptProvider_Builtins.mjs ]; then
+            echo "ERROR: Generated JavaScript module not found"
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Check Node Version
+        run: node --version
+
+      - name: Build Artifact Type Builtins Package
+        working-directory: registry/artifact-type-builtins
+        run: |
+          npm install
+          npm run build
+
+      - name: Publish to npmjs.com
+        working-directory: registry/artifact-type-builtins
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+      - name: Slack Notification (Always)
+        if: always()
+        run: |
+          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job completed with status: ${{ job.status }}"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+
+      - name: Slack Notification (Error)
+        if: failure()
+        run: |
+          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job FAILED!"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_ERROR_WEBHOOK }}

--- a/artifact-type-builtins/.gitignore
+++ b/artifact-type-builtins/.gitignore
@@ -1,0 +1,21 @@
+# Dependencies
+node_modules/
+package-lock.json
+
+# Build output
+lib/
+
+# Logs
+*.log
+npm-debug.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~

--- a/artifact-type-builtins/.npmignore
+++ b/artifact-type-builtins/.npmignore
@@ -1,0 +1,30 @@
+# Development files
+node_modules/
+*.log
+.DS_Store
+
+# Source files (we only ship the lib/ directory)
+src/
+
+# IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Test files
+test/
+tests/
+*.test.ts
+*.spec.ts
+
+# Build configuration
+tsconfig.json
+.eslintrc*
+.prettierrc*
+
+# Git files
+.git/
+.gitignore
+.gitattributes

--- a/artifact-type-builtins/README.md
+++ b/artifact-type-builtins/README.md
@@ -1,0 +1,54 @@
+# @apicurio/artifact-type-builtins
+
+Built-in functions and TypeScript type definitions for creating custom artifact types in Apicurio
+Registry.
+
+## Overview
+
+This package provides the TypeScript type definitions and built-in utility functions needed to develop
+custom artifact types for [Apicurio Registry](https://www.apicur.io/registry/). It enables type safety
+and IDE autocomplete support when implementing custom artifact type handlers in JavaScript/TypeScript.
+
+## Installation
+
+```bash
+npm install @apicurio/artifact-type-builtins
+```
+
+## Usage
+
+Import the types and built-in functions in your custom artifact type implementation:
+
+```typescript
+import {
+    ArtifactTypeScriptProvider,
+    info,
+    debug
+} from '@apicurio/artifact-type-builtins';
+
+export function acceptsContent(request: any): boolean {
+    info('Checking if content is accepted');
+    // Your implementation here
+    return true;
+}
+
+export function validate(request: any): any {
+    debug('Validating artifact content');
+    // Your implementation here
+    return {
+        ruleViolations: []
+    };
+}
+
+// Implement other required functions...
+```
+
+## Example
+
+For a complete example of creating a custom artifact type, see the
+[TOML Artifact Type Example](https://github.com/Apicurio/apicurio-registry/tree/main/examples/custom-artifact-type)
+in the Apicurio Registry repository.
+
+## License
+
+Apache License 2.0

--- a/artifact-type-builtins/package.json
+++ b/artifact-type-builtins/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "@apicurio/artifact-type-builtins",
+    "private": false,
+    "version": "3.1.2",
+    "type": "module",
+    "description": "Built-in functions and TypeScript type definitions for creating custom artifact types in Apicurio Registry",
+    "main": "lib/ArtifactTypeScriptProvider_Builtins.mjs",
+    "types": "lib/ArtifactTypeScriptProvider_Builtins.d.ts",
+    "files": [
+        "lib"
+    ],
+    "scripts": {
+        "clean": "rimraf lib",
+        "copy-generated": "mkdir -p lib && cp ../app/target/classes/META-INF/quickjs4j/ArtifactTypeScriptProvider_Builtins.d.ts lib/ && cp ../app/target/classes/META-INF/quickjs4j/ArtifactTypeScriptProvider_Builtins.mjs lib/",
+        "build": "npm run clean && npm run copy-generated",
+        "prepublishOnly": "test -f lib/ArtifactTypeScriptProvider_Builtins.d.ts && test -f lib/ArtifactTypeScriptProvider_Builtins.mjs || (echo 'Error: Generated files not found. Run npm run build first.' && exit 1)"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Apicurio/apicurio-registry.git",
+        "directory": "artifact-type-builtins"
+    },
+    "keywords": [
+        "apicurio",
+        "registry",
+        "artifact-type",
+        "custom-artifact-type",
+        "typescript",
+        "quickjs"
+    ],
+    "author": "Apicurio",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "rimraf": "6.0.1"
+    }
+}


### PR DESCRIPTION
## Summary

- Created new npm package `@apicurio/artifact-type-builtins` for developers creating custom artifact types
- Package includes TypeScript type definitions and built-in functions (info, debug) generated by QuickJS4j
- Added GitHub Actions workflow `release-artifact-type-builtins.yaml` to automatically publish to npmjs.com after releases
- Configured build scripts to copy generated files from Maven output during release process
- Package version will always match Registry release version

## Related Issue

Fixes #6778

## Test Plan

- [ ] Verify package structure is correct (package.json, README.md, .gitignore, .npmignore)
- [ ] Test workflow can be triggered manually via workflow_dispatch
- [ ] Verify Maven build generates required files in app/target/classes/META-INF/quickjs4j/
- [ ] Test npm build script successfully copies generated files to lib/
- [ ] Validate package.json metadata and entry points are correct
- [ ] (After merge) Verify workflow publishes to npmjs.com during next release