### PR TITLE
Switch npm publishing to trusted publishing using OIDC

### DIFF
--- a/.github/workflows/release-artifact-type-builtins.yaml
+++ b/.github/workflows/release-artifact-type-builtins.yaml
@@ -9,6 +9,11 @@ on:
     types: [released, prereleased]
 
 
+permissions:
+  id-token: write
+  contents: read
+
+
 env:
   # The values are extracted from the github.event context,
   # which is only available when the workflow gets triggered by a release event.
@@ -81,6 +86,9 @@ jobs:
       - name: Check Node Version
         run: node --version
 
+      - name: Check npm Version
+        run: npm --version
+
       - name: Build Artifact Type Builtins Package
         working-directory: registry/artifact-type-builtins
         run: |
@@ -89,8 +97,6 @@ jobs:
 
       - name: Publish to npmjs.com
         working-directory: registry/artifact-type-builtins
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
 
       - name: Slack Notification (Always)

--- a/.github/workflows/release-sdk-typescript.yaml
+++ b/.github/workflows/release-sdk-typescript.yaml
@@ -9,6 +9,11 @@ on:
     types: [released, prereleased]
 
 
+permissions:
+  id-token: write
+  contents: read
+
+
 env:
   # The values are extracted from the github.event context,
   # which is only available when the workflow gets triggered by a release event.
@@ -58,6 +63,9 @@ jobs:
       - name: Check Node Version
         run: node --version
 
+      - name: Check npm Version
+        run: npm --version
+
       # Needs special tagging to use submodules: https://stackoverflow.com/a/64705638/7898052
       - name: Release Typescript SDK
         working-directory: registry/typescript-sdk
@@ -68,8 +76,6 @@ jobs:
 
       - name: Publish to npmjs.com
         working-directory: registry/typescript-sdk
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
 
       - name: Slack Notification (Always)


### PR DESCRIPTION
## Summary

This PR migrates our npm publishing workflows to use npm's [trusted publishing](https://docs.npmjs.com/trusted-publishers) feature, which uses OpenID Connect (OIDC) for authentication instead of long-lived API tokens.

## Changes

- Added `id-token: write` and `contents: read` permissions to both npm release workflows
- Removed `NODE_AUTH_TOKEN` secret references from npm publish steps
- Added npm version check step for better visibility in workflow logs

## Benefits

- **Improved security**: Eliminates the need to store and rotate `NPM_TOKEN` secrets
- **Simplified maintenance**: No more token expiration issues
- **Better audit trail**: OIDC provides better tracking of publish events

## Testing

The changes will be validated on the next npm package release.

## Related

- [npm Trusted Publishers documentation](https://docs.npmjs.com/trusted-publishers)