### PR TITLE
Fix config documentation generation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+dependency-reduced-pom.xml
 .project
 .settings
 .classpath

--- a/docs/config-generator/pom.xml
+++ b/docs/config-generator/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.apicurio</groupId>
+        <artifactId>apicurio-registry-docs</artifactId>
+        <version>3.1.2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>apicurio-registry-config-generator</artifactId>
+    <packaging>jar</packaging>
+    <name>apicurio-registry-config-generator</name>
+    <description>Configuration documentation generator</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-config-definitions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <version>3.1.7</version>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>docs-generation</id>
+            <activation>
+                <property>
+                    <name>!skipDocsGen</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-config-docs</id>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                                <phase>process-classes</phase>
+                                <configuration>
+                                    <mainClass>io.apicurio.registry.docs.GenerateAllConfigPartial</mainClass>
+                                    <arguments>
+                                        <argument>${project.version}</argument>
+                                        <argument>${project.basedir}/..</argument>
+                                        <argument>${project.version}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
+++ b/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
@@ -1,6 +1,4 @@
-///usr/bin/env jbang "$0" "$@" ; exit $?
-//DEPS org.jboss:jandex:3.1.7
-
+package io.apicurio.registry.docs;
 
 import io.apicurio.common.apps.config.ConfigPropertyCategory;
 import org.jboss.jandex.AnnotationInstance;
@@ -27,7 +25,31 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class generateAllConfigPartial {
+/**
+ * Generates AsciiDoc documentation for all Apicurio Registry configuration properties.
+ *
+ * This tool scans the compiled registry application JAR using Jandex to extract configuration
+ * properties annotated with @ConfigProperty and @Info annotations. It also reads the
+ * application.properties file to capture additional default values and Quarkus properties.
+ * The extracted configuration is then organized by category (e.g., api, auth, storage,
+ * observability) and written to an AsciiDoc file suitable for inclusion in the project
+ * documentation.
+ *
+ * The generated documentation includes:
+ * <ul>
+ *   <li>Property name</li>
+ *   <li>Property type (with support for parameterized types)</li>
+ *   <li>Default value</li>
+ *   <li>Version when the property became available</li>
+ *   <li>Description</li>
+ * </ul>
+ *
+ * Usage: java -jar config-generator.jar &lt;version&gt; &lt;baseDir&gt; &lt;commonComponentsVersion&gt;
+ *
+ * @see io.apicurio.common.apps.config.Info
+ * @see io.apicurio.common.apps.config.ConfigPropertyCategory
+ */
+public class GenerateAllConfigPartial {
 
     private static Map<String, Option> allConfiguration = new HashMap();
     private static Set<String> skipProperties = Set.of("quarkus.oidc.auth-server-url");
@@ -122,7 +144,7 @@ public class generateAllConfigPartial {
                 return prefix + t.asParameterizedType()
                         .arguments()
                         .stream()
-                        .map(p -> resolveTypeName(p))
+                        .map((Type arg) -> resolveTypeName(arg))
                         .collect(Collectors.joining(", ", "<", ">"));
             }
         } catch (IllegalArgumentException e) {
@@ -196,10 +218,10 @@ public class generateAllConfigPartial {
                     var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString()).orElse("");
 
                     var availableSince = Optional.ofNullable(info.get().value("registryAvailableSince"))
-                            .map(v -> v.value().toString()).
-                            orElse(Optional.ofNullable(info.get().value("availableSince"))
-                                    .map(v -> v.value().toString()).
-                                    orElse(""));
+                            .map(v -> v.value().toString())
+                            .orElse(Optional.ofNullable(info.get().value("availableSince"))
+                                    .map(v -> v.value().toString())
+                                    .orElse(""));
 
                     allConfiguration.put(configName, new Option(
                             configName,

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -170,7 +170,7 @@ The following {registry} configuration options are available for each component 
 |Enable auth
 |`quarkus.oidc.token-path`
 |`string`
-|
+|`/protocol/openid-connect/token/`
 |`2.1.0.Final`
 |Authentication server token endpoint.
 |===
@@ -487,6 +487,68 @@ The following {registry} configuration options are available for each component 
 |Storage metrics cache max size.
 |===
 
+== log
+.log configuration options
+[.table-expandable,width="100%",cols="6,3,2,3,5",options="header"]
+|===
+|Name
+|Type
+|Default
+|Available from
+|Description
+|`apicurio.log.level`
+|`string [dynamic]`
+|`WARN`
+|`3.1.0`
+|Dynamic log level for Apicurio Registry
+|===
+
+== observability
+.observability configuration options
+[.table-expandable,width="100%",cols="6,3,2,3,5",options="header"]
+|===
+|Name
+|Type
+|Default
+|Available from
+|Description
+|`apicurio.metrics.rest.enabled`
+|`boolean`
+|`true`
+|`3.1.1`
+|        Enable collecting metrics about REST API requests.
+
+|`apicurio.metrics.rest.explicit-status-codes-list`
+|`list<string>`
+|`401`
+|`3.1.1`
+|        Only the general category of the HTTP status code is added as a tag/label on REST API request metrics,
+        e.g. `1xx`, `2xx`, ...         If you are interested in metrics for a specific status code, e.g. 401 for authentication errors,
+        this property allows you to specify a list of such codes.         Each request will be counted only once, i.e. either as the specific status code or in the general category. 
+|`apicurio.metrics.rest.method-tag-enabled`
+|`boolean`
+|`true`
+|`3.1.1`
+|        Add the HTTP method tag/label on REST API request metrics.         You might disable this tag to reduce metrics cardinality.
+
+|`apicurio.metrics.rest.path-filter-pattern`
+|`string`
+|`/apis/.*`
+|`3.1.1`
+|        Only requests with a path matching this pattern (Java syntax) will be considered for metrics collection.         The pattern is applied to the request path only,
+        e.g. `curl 'http://localhost:8080/apis/registry/v3/groups/default/artifacts?offset=42&limit=10'`
+        will be matched against `/apis/registry/v3/groups/default/artifacts`.
+
+|`apicurio.metrics.rest.path-tag-enabled`
+|`boolean`
+|`true`
+|`3.1.1`
+|        Add the unsubstituted path tag/label on REST API request metrics,
+        e.g. `/apis/registry/v3/groups/{groupId}/artifacts/{artifactId}`.         You might disable this tag to reduce metrics cardinality.         When an unsubstituted REST API resource path could not be determined,
+        the tag value will be `(unspecified)`.
+
+|===
+
 == redirects
 .redirects configuration options
 [.table-expandable,width="100%",cols="6,3,2,3,5",options="header"]
@@ -794,6 +856,11 @@ The following {registry} configuration options are available for each component 
 |`true`
 |`2.0.0.Final`
 |SQL init
+|`apicurio.storage.enable-automatic-group-creation`
+|`boolean`
+|`true`
+|`3.0.15`
+|Enable automatic creation of group when creating an artifact
 |`apicurio.storage.kind`
 |`string`
 |
@@ -802,7 +869,7 @@ The following {registry} configuration options are available for each component 
 |`apicurio.storage.read-only.enabled`
 |`boolean [dynamic]`
 |`false`
-|`2.5.0.Final`
+|`3.0.0`
 |Enable Registry storage read-only mode
 |`apicurio.storage.snapshot.location`
 |`string`
@@ -877,6 +944,11 @@ The following {registry} configuration options are available for each component 
 |Default
 |Available from
 |Description
+|`apicurio.app.context-path`
+|`string`
+|`/`
+|`3.1.0`
+|Context path for application (useful when behind a proxy)
 |`apicurio.ui.auth.oidc.client-id`
 |`string`
 |`apicurio-registry-ui`
@@ -907,6 +979,11 @@ The following {registry} configuration options are available for each component 
 |`/docs/`
 |`3.0.0`
 |URL of the Documentation component
+|`apicurio.ui.editorsUrl`
+|`string`
+|`/editors/`
+|`3.1.0`
+|URL of the Editors component
 |`apicurio.ui.features.breadcrumbs`
 |`string`
 |`true`
@@ -1056,6 +1133,11 @@ The following {registry} configuration options are available for each component 
 |`apicurio.limits.config.cache.check-period`
 |`unknown`
 |`30000`
+|
+|
+|`apicurio.log.level.dynamic.allow`
+|`unknown`
+|`${apicurio.config.dynamic.allow-all}`
 |
 |
 |`apicurio.logconfigjob.delayed`

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -64,6 +64,7 @@
   </developers>
 
   <modules>
+    <module>config-generator</module>
     <module>rest-api</module>
   </modules>
 
@@ -91,43 +92,5 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>docs-generation</id>
-      <activation>
-        <property>
-          <name>!skipDocsGen</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>dev.jbang</groupId>
-            <artifactId>jbang-maven-plugin</artifactId>
-            <version>0.0.8</version>
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <id>run</id>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <phase>process-resources</phase>
-                <configuration>
-                  <jbangargs>-cp "${projectRoot}/config-index/definitions/target/classes"</jbangargs>
-                  <script>${project.basedir}/generateAllConfigPartial.java</script>
-                  <args>
-                    <arg>${project.version}</arg>
-                    <arg>${project.basedir}</arg>
-                    <arg>${project.version}</arg>
-                  </args>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
 </project>


### PR DESCRIPTION
## Summary

Fixes #6734 by refactoring the configuration documentation generator from a JBang script into a proper Maven module.  With this change, if the java code fails to compile then the build will fail during the compile phase.  Previously if there was a problem, the jbang exec could fail with logging info but without failing the build.

## Issues Fixed

1. **Compilation Error**: The JBang script had syntax errors (orphaned periods on lines 199-201) causing compilation failures
2. **Missing Documentation**: New observability configuration properties from PR #6713 were not appearing in generated docs

## Changes

### Created `docs/config-generator` Maven Module
- New JAR module at `docs/config-generator`
- Proper package structure: `io.apicurio.registry.docs`
- Added comprehensive Javadoc explaining the tool's purpose and usage
- Dependencies: `apicurio-registry-config-definitions` and `jandex`

### Refactored Build Process
- Uses `exec-maven-plugin` with `exec:java` goal (no shade plugin needed)
- Runs in `process-classes` phase after compilation
- Maven automatically handles classpath dependencies
- Simpler and more maintainable than JBang approach
- Works better in the IDE

### Generated Documentation
The generated documentation now correctly includes all configuration properties, including:
- `apicurio.metrics.rest.enabled`
- `apicurio.metrics.rest.path-filter-pattern`
- `apicurio.metrics.rest.method-tag-enabled`
- `apicurio.metrics.rest.path-tag-enabled`
- `apicurio.metrics.rest.explicit-status-codes-list`

### Additional Changes
- Added `dependency-reduced-pom.xml` to `.gitignore` for future use
- Fixed syntax errors in the generator code

## Testing

Verified that:
- ✅ Module builds successfully
- ✅ Documentation is generated without errors
- ✅ Observability section appears in generated docs
- ✅ All five new REST metrics properties are documented
- ✅ Build works correctly from clean state

## Migration Notes

The config generator is now built and executed as part of the `docs/config-generator` module. To generate documentation:

```bash
mvn clean install -pl :apicurio-registry-config-generator -DskipTests
```

To skip documentation generation:
```bash
mvn clean install -pl :apicurio-registry-config-generator -DskipTests -DskipDocsGen
```