### PR TITLE
Upgrade proto-google-common-protos to 2.62.0

### DIFF
--- a/examples/serdes-with-references/pom.xml
+++ b/examples/serdes-with-references/pom.xml
@@ -14,7 +14,7 @@
     <projectRoot>${project.basedir}/../..</projectRoot>
     <protobuf.version>4.30.2</protobuf.version>
     <proto-plugin.version>0.6.1</proto-plugin.version>
-    <protobuf.googleapi.types.version>2.51.0</protobuf.googleapi.types.version>
+    <protobuf.googleapi.types.version>2.62.0</protobuf.googleapi.types.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
     <icu4j.version>76.1</icu4j.version>
     <protobuf.version>4.33.0</protobuf.version>
     <xmlsec.version>4.0.4</xmlsec.version>
-    <protobuf.googleapi.types.version>2.52.0</protobuf.googleapi.types.version>
+    <protobuf.googleapi.types.version>2.62.0</protobuf.googleapi.types.version>
     <wsdl4j.version>1.6.3</wsdl4j.version>
     <google.truth.extension.version>1.4.5</google.truth.extension.version>
 


### PR DESCRIPTION
## Summary
- Upgraded `proto-google-common-protos` from 2.52.0 to 2.62.0 in root pom.xml
- Upgraded `proto-google-common-protos` from 2.51.0 to 2.62.0 in examples/serdes-with-references/pom.xml

## Test plan
- [x] Build completed successfully with `mvn clean install -DskipTests`
- [x] All tests pass with `mvn clean install`
- [x] No compilation errors
- [x] No test failures