### PR TITLE
Fix double-slash bug in API docs spec URL generation

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ui/servlets/ApiDocsFilter.java
+++ b/app/src/main/java/io/apicurio/registry/ui/servlets/ApiDocsFilter.java
@@ -118,7 +118,8 @@ public class ApiDocsFilter implements Filter {
     private String generateSpecUrl(HttpServletRequest request) {
         String servletPath = request.getServletPath();
         String contextPath = normalizeContextPath(config.contextPath);
-        String apiSpec = servletPath.replace("/apis/", contextPath + "/api-specifications/");
+        String apiSpecPath = contextPath.equals("/") ? "/api-specifications/" : contextPath + "/api-specifications/";
+        String apiSpec = servletPath.replace("/apis/", apiSpecPath);
         if (!apiSpec.endsWith("/")) {
             apiSpec += "/";
         }

--- a/app/src/test/java/io/apicurio/registry/ui/servlets/ApiDocsFilterTest.java
+++ b/app/src/test/java/io/apicurio/registry/ui/servlets/ApiDocsFilterTest.java
@@ -1,0 +1,165 @@
+package io.apicurio.registry.ui.servlets;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for ApiDocsFilter to verify correct URL generation and context path handling.
+ */
+@QuarkusTest
+class ApiDocsFilterTest extends AbstractResourceTestBase {
+
+    /**
+     * Tests that spec URL generation does not create double slashes when context path is root ("/").
+     * This is the fix for issue #6791.
+     */
+    @Test
+    void testSpecUrlWithRootContextPath_NoDoubleSlash() {
+        // When: fetching the Registry v3 API docs page
+        String html = given()
+                .when()
+                .get("http://localhost:" + testPort + "/apis/registry/v3")
+                .then()
+                .statusCode(200)
+                .contentType("text/html")
+                .extract()
+                .asString();
+
+        // Then: generated spec URL should not have double slashes
+        String expectedSpecUrl = "/api-specifications/registry/v3/openapi.json";
+        assertTrue(html.contains("spec-url=\"" + expectedSpecUrl + "\""),
+                "Spec URL should be: " + expectedSpecUrl + ", but got: " + extractSpecUrl(html));
+        assertFalse(html.contains("spec-url=\"//api-specifications"),
+                "Spec URL should not start with double slashes");
+    }
+
+    /**
+     * Tests spec URL generation for Registry v2 API.
+     */
+    @Test
+    void testSpecUrlForRegistryV2() {
+        // When: fetching the Registry v2 API docs page
+        String html = given()
+                .when()
+                .get("http://localhost:" + testPort + "/apis/registry/v2")
+                .then()
+                .statusCode(200)
+                .contentType("text/html")
+                .extract()
+                .asString();
+
+        // Then: generated spec URL should be for v2 and not have double slashes
+        String expectedSpecUrl = "/api-specifications/registry/v2/openapi.json";
+        assertTrue(html.contains("spec-url=\"" + expectedSpecUrl + "\""),
+                "Spec URL should be: " + expectedSpecUrl + ", but got: " + extractSpecUrl(html));
+        assertFalse(html.contains("//api-specifications"),
+                "Spec URL should not have double slashes");
+    }
+
+    /**
+     * Tests spec URL generation for Confluent Schema Registry compatibility API.
+     */
+    @Test
+    void testSpecUrlForCcompat() {
+        // When: fetching the CCompat v7 API docs page
+        String html = given()
+                .when()
+                .get("http://localhost:" + testPort + "/apis/ccompat/v7")
+                .then()
+                .statusCode(200)
+                .contentType("text/html")
+                .extract()
+                .asString();
+
+        // Then: generated spec URL should be for ccompat and not have double slashes
+        String expectedSpecUrl = "/api-specifications/ccompat/v7/openapi.json";
+        assertTrue(html.contains("spec-url=\"" + expectedSpecUrl + "\""),
+                "Spec URL should be: " + expectedSpecUrl + ", but got: " + extractSpecUrl(html));
+        assertFalse(html.contains("//api-specifications"),
+                "Spec URL should not have double slashes");
+    }
+
+    /**
+     * Tests that API title is correctly set for Registry v3.
+     */
+    @Test
+    void testApiTitleForRegistryV3() {
+        // When: fetching the Registry v3 API docs page
+        String html = given()
+                .when()
+                .get("http://localhost:" + testPort + "/apis/registry/v3")
+                .then()
+                .statusCode(200)
+                .contentType("text/html")
+                .extract()
+                .asString();
+
+        // Then: API title should be correct
+        assertTrue(html.contains("Core Registry API (v3)"),
+                "API title should be 'Core Registry API (v3)'");
+    }
+
+    /**
+     * Tests that API title is correctly set for Registry v2.
+     */
+    @Test
+    void testApiTitleForRegistryV2() {
+        // When: fetching the Registry v2 API docs page
+        String html = given()
+                .when()
+                .get("http://localhost:" + testPort + "/apis/registry/v2")
+                .then()
+                .statusCode(200)
+                .contentType("text/html")
+                .extract()
+                .asString();
+
+        // Then: API title should be correct
+        assertTrue(html.contains("Core Registry API (v2)"),
+                "API title should be 'Core Registry API (v2)'");
+    }
+
+    /**
+     * Tests that API title is correctly set for CCompat API.
+     */
+    @Test
+    void testApiTitleForCcompat() {
+        // When: fetching the CCompat v7 API docs page
+        String html = given()
+                .when()
+                .get("http://localhost:" + testPort + "/apis/ccompat/v7")
+                .then()
+                .statusCode(200)
+                .contentType("text/html")
+                .extract()
+                .asString();
+
+        // Then: API title should be correct
+        assertTrue(html.contains("Confluent Schema Registry API"),
+                "API title should be 'Confluent Schema Registry API'");
+    }
+
+    /**
+     * Extracts the spec-url value from the HTML result for debugging.
+     *
+     * @param html the HTML content
+     * @return the extracted spec URL or "not found"
+     */
+    private String extractSpecUrl(String html) {
+        int start = html.indexOf("spec-url=\"");
+        if (start == -1) {
+            return "not found";
+        }
+        start += "spec-url=\"".length();
+        int end = html.indexOf("\"", start);
+        if (end == -1) {
+            return "not found";
+        }
+        return html.substring(start, end);
+    }
+}


### PR DESCRIPTION
## Summary

- Fixed bug where API docs spec URL was generated with double slashes (`//api-specifications/...`) when using root context path
- Added conditional check to prevent double-slash when concatenating root context path with API specification path
- Created comprehensive integration tests for API docs filter covering v2, v3, and ccompat APIs

## Related Issue

Fixes #6791

## Test Plan

- [x] Review the code changes in `ApiDocsFilter.java:121`
- [x] Run the new integration tests in `ApiDocsFilterTest`
- [x] Verify that `/apis/registry/v3` generates correct spec URL without double slashes
- [x] Verify that `/apis/registry/v2` generates correct spec URL
- [x] Verify that `/apis/ccompat/v7` generates correct spec URL
- [x] Confirm API titles are displayed correctly for each endpoint