### PR TITLE
Update custom-artifact-type example to use @apicurio/artifact-type-builtins npm package

### DIFF
--- a/examples/custom-artifact-type/README.md
+++ b/examples/custom-artifact-type/README.md
@@ -12,7 +12,7 @@ Apicurio Registry can be extended to support custom artifact types by:
 3. Deploying the registry with the custom configuration
 
 This example includes:
-- A TypeScript implementation of a TOML artifact type
+- A TypeScript implementation of a TOML artifact type using the `@apicurio/artifact-type-builtins` npm package
 - Configuration file for enabling the custom artifact type
 - Docker Compose setup for running the registry with the custom type
 - Demo script showing the custom artifact type in action
@@ -44,6 +44,20 @@ Identifies external references in TOML content.
 - Node.js 18+ and npm (for building the TypeScript implementation)
 - Docker and Docker Compose
 - curl and jq (for running the demo script)
+
+## TypeScript Types and Utilities
+
+This example uses the `@apicurio/artifact-type-builtins` npm package, which provides:
+- TypeScript type definitions for all artifact type function interfaces
+- Built-in utility functions like `info()` and `debug()` for logging
+- IDE autocomplete support for developing custom artifact types
+
+The package is published on npm and can be installed with:
+```bash
+npm install @apicurio/artifact-type-builtins
+```
+
+For more information, see: https://www.npmjs.com/package/@apicurio/artifact-type-builtins
 
 ## Quick Start
 

--- a/examples/custom-artifact-type/toml-artifact-type/TomlArtifactType.ts
+++ b/examples/custom-artifact-type/toml-artifact-type/TomlArtifactType.ts
@@ -1,3 +1,16 @@
+import type {
+    ContentAccepterRequest,
+    CompatibilityCheckerRequest,
+    CompatibilityCheckerResponse,
+    ContentCanonicalizerRequest,
+    ContentCanonicalizerResponse,
+    ContentDereferencerRequest,
+    ContentDereferencerResponse,
+    ContentValidatorRequest,
+    ContentValidatorResponse,
+    ReferenceFinderRequest,
+    ReferenceFinderResponse
+} from '@apicurio/artifact-type-builtins';
 
 type TypedContent = {
     contentType: string;
@@ -34,7 +47,7 @@ function isValidToml(content: string): boolean {
 /**
  * Check if the content is TOML format
  */
-export function acceptsContent(request: any): boolean {
+export function acceptsContent(request: ContentAccepterRequest): boolean {
     let accepted: boolean = false;
     if (request.typedContent.contentType === "application/toml") {
         const content: string = request.typedContent.content;
@@ -47,7 +60,7 @@ export function acceptsContent(request: any): boolean {
  * Test compatibility between existing and proposed artifacts
  * For this simple example, we just ensure section names haven't been removed
  */
-export function testCompatibility(request: any): any {
+export function testCompatibility(request: CompatibilityCheckerRequest): CompatibilityCheckerResponse {
     const existingArtifacts: TypedContent[] = request.existingArtifacts;
     const proposedArtifact: TypedContent = request.proposedArtifact;
 
@@ -106,7 +119,7 @@ function extractSections(content: string): string[] {
 /**
  * Canonicalize TOML content by normalizing whitespace and sorting sections
  */
-export function canonicalize(request: any): any {
+export function canonicalize(request: ContentCanonicalizerRequest): ContentCanonicalizerResponse {
     const originalContent: string = request.content.content;
 
     // Simple canonicalization: uppercase all keys
@@ -133,7 +146,7 @@ export function canonicalize(request: any): any {
 /**
  * Validate TOML content structure
  */
-export function validate(request: any): any {
+export function validate(request: ContentValidatorRequest): ContentValidatorResponse {
     const violations: any[] = [];
     const content: string = request.content.content;
     const contentType: string = request.content.contentType;
@@ -164,7 +177,7 @@ export function validate(request: any): any {
 /**
  * Dereference content by replacing references with actual content
  */
-export function dereference(request: any): any {
+export function dereference(request: ContentDereferencerRequest): ContentDereferencerResponse {
     const content: string = request.content.content;
     const indexedResolvedRefs: any = {};
 
@@ -201,7 +214,7 @@ export function dereference(request: any): any {
 /**
  * Rewrite references to use URLs instead of file paths
  */
-export function rewriteReferences(request: any): any {
+export function rewriteReferences(request: ContentDereferencerRequest): ContentDereferencerResponse {
     const content: string = request.content.content;
     const indexedResolvedReferenceUrls: any = {};
 
@@ -235,8 +248,8 @@ export function rewriteReferences(request: any): any {
 /**
  * Find external references in the content
  */
-export function findExternalReferences(request: any): any {
-    const content: string = request.content.content;
+export function findExternalReferences(request: ReferenceFinderRequest): ReferenceFinderResponse {
+    const content: string = request.typedContent.content;
     const references: string[] = [];
 
     const lines = content.split('\n');
@@ -255,10 +268,12 @@ export function findExternalReferences(request: any): any {
 /**
  * Validate that all references are properly mapped
  */
-export function validateReferences(request: any): any {
+export function validateReferences(request: ContentValidatorRequest): ContentValidatorResponse {
     const violations: any[] = [];
-    const mappedReferences: string[] = request.mappedReferences || [];
-    const foundReferences = findExternalReferences(request);
+    const mappedReferences: string[] = request.resolvedReferences || [];
+    const foundReferences = findExternalReferences({
+        typedContent: request.content
+    });
 
     for (const ref of foundReferences.externalReferences) {
         if (!mappedReferences.includes(ref)) {

--- a/examples/custom-artifact-type/toml-artifact-type/package.json
+++ b/examples/custom-artifact-type/toml-artifact-type/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.0",
   "type": "module",
   "description": "Custom TOML artifact type for Apicurio Registry",
+  "dependencies": {
+    "@apicurio/artifact-type-builtins": "^3.1.0"
+  },
   "devDependencies": {
     "cp": "0.2.0",
     "esbuild": "0.25.11",


### PR DESCRIPTION
## Summary

Updates the custom-artifact-type example to use the newly published `@apicurio/artifact-type-builtins` npm package (v3.1.0+), providing TypeScript type definitions and built-in utilities for creating custom artifact types.

## Changes

- Added `@apicurio/artifact-type-builtins` dependency to `package.json`
- Imported TypeScript type definitions from the npm package in `TomlArtifactType.ts`
- Updated all exported function signatures to use proper typed interfaces:
  - `ContentAccepterRequest` / `ContentAccepterResponse`
  - `CompatibilityCheckerRequest` / `CompatibilityCheckerResponse`
  - `ContentCanonicalizerRequest` / `ContentCanonicalizerResponse`
  - `ContentDereferencerRequest` / `ContentDereferencerResponse`
  - `ContentValidatorRequest` / `ContentValidatorResponse`
  - `ReferenceFinderRequest` / `ReferenceFinderResponse`
- Added documentation section in README explaining the npm package and its benefits
- Fixed property access to use correct interface members (e.g., `request.typedContent.content` in `findExternalReferences`)

## Benefits

- **Type Safety**: Full TypeScript type checking catches errors at compile time
- **Better IDE Support**: Autocomplete and inline documentation for all interfaces
- **Improved Developer Experience**: Clear interface contracts for custom artifact type implementations
- **Future-Proofing**: Using official type definitions ensures compatibility with Apicurio Registry

## Test Plan

- [ ] Verify the example builds successfully: `cd examples/custom-artifact-type/toml-artifact-type && npm install && npm run build`
- [ ] Run the demo script to ensure the custom artifact type works: `./demo.sh`
- [ ] Verify Docker Compose setup still works correctly

## Related Issues

Related to #6778