### PR TITLE
chore(deps): update to Quarkus 3.20.3, resolving 2 CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,12 +147,12 @@
     <!--
     WARNING: The following group of dependencies has to be aligned with the best corresponding Quarkus version.
     -->
-    <quarkus.version>3.20.2.2</quarkus.version>
+    <quarkus.version>3.20.3</quarkus.version>
     <!--
     # QOSDK
 
     Go to the extension parent POM, e.g. https://repo1.maven.org/maven2/io/quarkiverse/operatorsdk/quarkus-operator-sdk-parent/7.1.4/quarkus-operator-sdk-parent-7.1.4.pom
-    to check that the versions match:
+    to check that the versions match as best as possible:
 
     - QOSDK 7.2.1 -> Quarkus 3.27.0
     - QOSDK 7.2.0 -> Quarkus 3.23.2
@@ -165,14 +165,13 @@
     # Quarkus MCP Server
 
     Go to the extension parent POM, e.g. https://repo1.maven.org/maven2/io/quarkiverse/mcp/quarkus-mcp-server-parent/1.6.0/quarkus-mcp-server-parent-1.6.0.pom
-    to check that the versions match:
+    to check that the versions match as best as possible:
 
+    - MCP Server 1.7.0 -> Quarkus 3.27.0
+    - MCP Server 1.6.1 -> Quarkus 3.20.2.2
     - MCP Server 1.6.0 -> Quarkus 3.20.2.2
-    - MCP Server 1.5.1 ... 1.5.3 -> Quarkus 3.20.2.2
-    - MCP Server 1.5.0 -> Quarkus 3.20.2.1
-    - MCP Server 1.4.1 -> Quarkus 3.20.2
     -->
-    <quarkus-mcp-server.version>1.6.0</quarkus-mcp-server.version>
+    <quarkus-mcp-server.version>1.6.1</quarkus-mcp-server.version>
     <!--
     /WARNING
     -->


### PR DESCRIPTION
See  https://access.redhat.com/errata/RHSA-2025:17563

I've asked about compatibility of QOSDK and QMCPS:

- https://github.com/quarkiverse/quarkus-operator-sdk/issues/1189
- https://github.com/quarkiverse/quarkus-mcp-servers/issues/82

But I think the chance of issues is low, so we can merge this if the tests pass and in the worst case scenario revert.
