### PR TITLE
Switch groovy-maven-plugin to gmavenplus-plugin

### DIFF
--- a/java-sdk-v2/pom.xml
+++ b/java-sdk-v2/pom.xml
@@ -62,12 +62,18 @@
   </dependencies>
   <build>
     <plugins>
-      <!-- Filter OpenAPI spec before Kiota code generation -->
+      <!-- GMavenPlus plugin for Groovy script execution -->
       <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>groovy-maven-plugin</artifactId>
-        <version>2.1.1</version>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>${version.gmavenplus-plugin}</version>
         <dependencies>
+          <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+            <scope>runtime</scope>
+          </dependency>
           <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -75,6 +81,7 @@
           </dependency>
         </dependencies>
         <executions>
+          <!-- Filter OpenAPI spec before Kiota code generation -->
           <execution>
             <id>filter-openapi-spec</id>
             <phase>initialize</phase>
@@ -82,62 +89,112 @@
               <goal>execute</goal>
             </goals>
             <configuration>
-              <source><![CDATA[
-                import com.fasterxml.jackson.databind.ObjectMapper
-                import com.fasterxml.jackson.databind.SerializationFeature
+              <scripts>
+                <script><![CDATA[
+                  import com.fasterxml.jackson.databind.ObjectMapper
+                  import com.fasterxml.jackson.databind.SerializationFeature
 
-                def inputFile = new File(project.basedir, '../common/src/main/resources/META-INF/openapi-v2.json')
-                def outputFile = new File(project.build.directory, 'openapi-v2-filtered.json')
+                  def inputFile = new File(project.basedir, '../common/src/main/resources/META-INF/openapi-v2.json')
+                  def outputFile = new File(project.build.directory, 'openapi-v2-filtered.json')
 
-                // Paths to process
-                def pathsToFilter = [
-                    '/groups/{groupId}/artifacts',
-                    '/groups/{groupId}/artifacts/{artifactId}',
-                    '/groups/{groupId}/artifacts/{artifactId}/versions'
-                ] as Set
+                  // Paths to process
+                  def pathsToFilter = [
+                      '/groups/{groupId}/artifacts',
+                      '/groups/{groupId}/artifacts/{artifactId}',
+                      '/groups/{groupId}/artifacts/{artifactId}/versions'
+                  ] as Set
 
-                // Content types to remove
-                def contentTypesToRemove = ['*/*', 'application/create.extended+json'] as Set
+                  // Content types to remove
+                  def contentTypesToRemove = ['*/*', 'application/create.extended+json'] as Set
 
-                log.info("Filtering OpenAPI spec from: ${inputFile}")
-                log.info("Output will be written to: ${outputFile}")
+                  log.info("Filtering OpenAPI spec from: ${inputFile}")
+                  log.info("Output will be written to: ${outputFile}")
 
-                // Use Jackson to preserve order
-                def mapper = new ObjectMapper()
-                def json = mapper.readValue(inputFile, LinkedHashMap.class)
+                  // Use Jackson to preserve order
+                  def mapper = new ObjectMapper()
+                  def json = mapper.readValue(inputFile, LinkedHashMap.class)
 
-                // Process only the specified paths
-                json.paths.each { pathKey, pathItem ->
-                    if (pathsToFilter.contains(pathKey)) {
-                        log.info("Processing path: ${pathKey}")
+                  // Process only the specified paths
+                  json.paths.each { pathKey, pathItem ->
+                      if (pathsToFilter.contains(pathKey)) {
+                          log.info("Processing path: ${pathKey}")
 
-                        // Check if POST operation exists
-                        if (pathItem.post?.requestBody?.content) {
-                            def content = pathItem.post.requestBody.content
+                          // Check if POST operation exists
+                          if (pathItem.post?.requestBody?.content) {
+                              def content = pathItem.post.requestBody.content
 
-                            // Remove unwanted content types
-                            contentTypesToRemove.each { contentType ->
-                                if (content.containsKey(contentType)) {
-                                    content.remove(contentType)
-                                    log.info("  Removed content-type: ${contentType}")
-                                }
-                            }
+                              // Remove unwanted content types
+                              contentTypesToRemove.each { contentType ->
+                                  if (content.containsKey(contentType)) {
+                                      content.remove(contentType)
+                                      log.info("  Removed content-type: ${contentType}")
+                                  }
+                              }
 
-                            def remainingKeys = content.keySet() as List
-                            log.info("  Remaining content-types: ${remainingKeys}")
-                        }
+                              def remainingKeys = content.keySet() as List
+                              log.info("  Remaining content-types: ${remainingKeys}")
+                          }
+                      }
+                  }
+
+                  // Ensure output directory exists
+                  outputFile.parentFile.mkdirs()
+
+                  // Write with pretty printing while preserving order
+                  mapper.enable(SerializationFeature.INDENT_OUTPUT)
+                  mapper.writeValue(outputFile, json)
+
+                  log.info("Filtered OpenAPI spec written successfully")
+                ]]></script>
+              </scripts>
+            </configuration>
+          </execution>
+          <!-- Post-process Kiota-generated files to support legacy date formats -->
+          <execution>
+            <id>post-process-kiota</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script><![CDATA[
+                  // Post-process Kiota-generated files to support legacy date formats
+                  // See: https://github.com/Apicurio/apicurio-registry/issues/6799
+
+                  def generatedDir = new File(project.build.directory, 'generated-sources/kiota')
+                  if (!generatedDir.exists()) {
+                    log.info('Generated sources directory not found, skipping Kiota post-processing')
+                    return
+                  }
+
+                  log.info('Post-processing Kiota-generated files in ' + generatedDir)
+
+                  def oldPattern = 'n.getOffsetDateTimeValue()'
+                  def newPattern = 'io.apicurio.registry.client.util.DateTimeUtil.getOffsetDateTimeValue(n)'
+
+                  def modifiedCount = 0
+
+                  generatedDir.eachFileRecurse { file ->
+                    if (file.name.endsWith('.java')) {
+                      def content = file.text
+
+                      // Check if file contains the pattern to replace
+                      if (content.contains(oldPattern)) {
+                        // Replace the pattern with fully qualified method call
+                        content = content.replace(oldPattern, newPattern)
+
+                        // Write modified content back to file
+                        file.text = content
+                        modifiedCount++
+                        log.info('  Modified: ' + file.name)
+                      }
                     }
-                }
+                  }
 
-                // Ensure output directory exists
-                outputFile.parentFile.mkdirs()
-
-                // Write with pretty printing while preserving order
-                mapper.enable(SerializationFeature.INDENT_OUTPUT)
-                mapper.writeValue(outputFile, json)
-
-                log.info("Filtered OpenAPI spec written successfully")
-              ]]></source>
+                  log.info('Post-processing complete. Modified ' + modifiedCount + ' files.')
+                ]]></script>
+              </scripts>
             </configuration>
           </execution>
         </executions>
@@ -178,58 +235,6 @@
               <sources>
                 <source>${project.build.directory}/generated-sources/kiota/</source>
               </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>groovy-maven-plugin</artifactId>
-        <version>2.1.1</version>
-        <executions>
-          <execution>
-            <id>post-process-kiota</id>
-            <phase>process-sources</phase>
-            <goals>
-              <goal>execute</goal>
-            </goals>
-            <configuration>
-              <source><![CDATA[
-                // Post-process Kiota-generated files to support legacy date formats
-                // See: https://github.com/Apicurio/apicurio-registry/issues/6799
-
-                def generatedDir = new File(project.build.directory, 'generated-sources/kiota')
-                if (!generatedDir.exists()) {
-                  log.info('Generated sources directory not found, skipping Kiota post-processing')
-                  return
-                }
-
-                log.info('Post-processing Kiota-generated files in ' + generatedDir)
-
-                def oldPattern = 'n.getOffsetDateTimeValue()'
-                def newPattern = 'io.apicurio.registry.client.util.DateTimeUtil.getOffsetDateTimeValue(n)'
-
-                def modifiedCount = 0
-
-                generatedDir.eachFileRecurse { file ->
-                  if (file.name.endsWith('.java')) {
-                    def content = file.text
-
-                    // Check if file contains the pattern to replace
-                    if (content.contains(oldPattern)) {
-                      // Replace the pattern with fully qualified method call
-                      content = content.replace(oldPattern, newPattern)
-
-                      // Write modified content back to file
-                      file.text = content
-                      modifiedCount++
-                      log.info('  Modified: ' + file.name)
-                    }
-                  }
-                }
-
-                log.info('Post-processing complete. Modified ' + modifiedCount + ' files.')
-              ]]></source>
             </configuration>
           </execution>
         </executions>

--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -95,9 +95,17 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>groovy-maven-plugin</artifactId>
-        <version>2.1.1</version>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>${version.gmavenplus-plugin}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>post-process-kiota</id>
@@ -106,42 +114,44 @@
               <goal>execute</goal>
             </goals>
             <configuration>
-              <source><![CDATA[
-                // Post-process Kiota-generated files to support legacy date formats
-                // See: https://github.com/Apicurio/apicurio-registry/issues/6799
+              <scripts>
+                <script><![CDATA[
+                  // Post-process Kiota-generated files to support legacy date formats
+                  // See: https://github.com/Apicurio/apicurio-registry/issues/6799
 
-                def generatedDir = new File(project.build.directory, 'generated-sources/kiota')
-                if (!generatedDir.exists()) {
-                  log.info('Generated sources directory not found, skipping Kiota post-processing')
-                  return
-                }
+                  def generatedDir = new File(project.build.directory, 'generated-sources/kiota')
+                  if (!generatedDir.exists()) {
+                    log.info('Generated sources directory not found, skipping Kiota post-processing')
+                    return
+                  }
 
-                log.info('Post-processing Kiota-generated files in ' + generatedDir)
+                  log.info('Post-processing Kiota-generated files in ' + generatedDir)
 
-                def oldPattern = 'n.getOffsetDateTimeValue()'
-                def newPattern = 'io.apicurio.registry.client.util.DateTimeUtil.getOffsetDateTimeValue(n)'
+                  def oldPattern = 'n.getOffsetDateTimeValue()'
+                  def newPattern = 'io.apicurio.registry.client.util.DateTimeUtil.getOffsetDateTimeValue(n)'
 
-                def modifiedCount = 0
+                  def modifiedCount = 0
 
-                generatedDir.eachFileRecurse { file ->
-                  if (file.name.endsWith('.java')) {
-                    def content = file.text
+                  generatedDir.eachFileRecurse { file ->
+                    if (file.name.endsWith('.java')) {
+                      def content = file.text
 
-                    // Check if file contains the pattern to replace
-                    if (content.contains(oldPattern)) {
-                      // Replace the pattern with fully qualified method call
-                      content = content.replace(oldPattern, newPattern)
+                      // Check if file contains the pattern to replace
+                      if (content.contains(oldPattern)) {
+                        // Replace the pattern with fully qualified method call
+                        content = content.replace(oldPattern, newPattern)
 
-                      // Write modified content back to file
-                      file.text = content
-                      modifiedCount++
-                      log.info('  Modified: ' + file.name)
+                        // Write modified content back to file
+                        file.text = content
+                        modifiedCount++
+                        log.info('  Modified: ' + file.name)
+                      }
                     }
                   }
-                }
 
-                log.info('Post-processing complete. Modified ' + modifiedCount + ' files.')
-              ]]></source>
+                  log.info('Post-processing complete. Modified ' + modifiedCount + ' files.')
+                ]]></script>
+              </scripts>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@
     <version.license-maven-plugin>2.7.0</version.license-maven-plugin>
     <version.exec-maven-plugin>3.6.2</version.exec-maven-plugin>
     <version.apicurio-codegen-plugin>1.2.6.Final</version.apicurio-codegen-plugin>
+    <version.gmavenplus-plugin>4.2.1</version.gmavenplus-plugin>
 
     <!-- Central-Publishing-Maven-Plugin -->
     <version.org.sonatype.central-publishing-maven-plugin>0.9.0</version.org.sonatype.central-publishing-maven-plugin>
@@ -301,6 +302,9 @@
     <kiota.version>1.28.0</kiota.version>
     <kiota.timeout>60</kiota.timeout>
     <kiota.base.url>https://github.com/microsoft/kiota/releases/download</kiota.base.url>
+
+    <!-- Groovy scripting -->
+    <groovy.version>4.0.24</groovy.version>
 
     <!-- Test containers version, should be aligned with version used in Quarkus -->
     <pulsar.testcontainers.version>1.21.3</pulsar.testcontainers.version>


### PR DESCRIPTION
## Summary

Migrated from the unmaintained `groovy-maven-plugin` to the actively maintained `gmavenplus-plugin` across all modules that use Groovy scripting in their build process.

### Changes Made

- **Plugin Update**: Replaced `org.codehaus.gmaven:groovy-maven-plugin:2.1.1` with `org.codehaus.gmavenplus:gmavenplus-plugin:4.2.1`
- **Groovy Dependency**: Added required Groovy runtime dependency (`org.apache.groovy:groovy:4.0.24`) to all plugin configurations
- **Configuration Syntax**: Updated from `<source>` wrapper to `<scripts><script>` wrapper for Groovy scripts
- **Consolidation**: Merged two separate plugin declarations in `java-sdk-v2/pom.xml` into a single plugin with multiple executions
- **Version Management**: Centralized version properties in root `pom.xml` for easier maintenance

### Affected Modules

1. **java-sdk/pom.xml**: Updated Kiota post-processing script execution
2. **java-sdk-v2/pom.xml**: Updated OpenAPI filtering and Kiota post-processing script executions
3. **pom.xml**: Added centralized version properties

### Functional Equivalence

All Groovy scripts remain functionally unchanged:
- OpenAPI spec filtering with Jackson (removes unwanted content types)
- Kiota-generated file post-processing (date format compatibility fix)

## Test Plan

- [x] Build succeeds with the new plugin
- [ ] Verify OpenAPI spec filtering works correctly in java-sdk-v2
- [ ] Verify Kiota post-processing modifies generated files as expected
- [ ] Run full build and test suite to ensure no regressions

Fixes #6826