### PR TITLE
fix: Add primary keys to label tables for MySQL InnoDB Cluster compatibility

### DIFF
--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/h2.ddl
@@ -37,6 +37,7 @@ CREATE TABLE groups (groupId VARCHAR(512) NOT NULL, description VARCHAR(1024), a
 ALTER TABLE groups ADD PRIMARY KEY (groupId);
 
 CREATE TABLE group_labels (groupId VARCHAR(512) NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
+ALTER TABLE group_labels ADD PRIMARY KEY (groupId, labelKey);
 ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
 CREATE INDEX IDX_glabels_1 ON group_labels(labelKey);
 CREATE INDEX IDX_glabels_2 ON group_labels(labelValue);
@@ -54,6 +55,7 @@ CREATE INDEX IDX_artifacts_3 ON artifacts(name);
 CREATE INDEX IDX_artifacts_4 ON artifacts(description);
 
 CREATE TABLE artifact_labels (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
+ALTER TABLE artifact_labels ADD PRIMARY KEY (groupId, artifactId, labelKey);
 ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
 CREATE INDEX IDX_alabels_1 ON artifact_labels(labelKey);
 CREATE INDEX IDX_alabels_2 ON artifact_labels(labelValue);
@@ -81,6 +83,7 @@ CREATE INDEX IDX_versions_6 ON versions(createdOn);
 CREATE HASH INDEX IDX_versions_7 ON versions(contentId);
 
 CREATE TABLE version_labels (globalId BIGINT NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
+ALTER TABLE version_labels ADD PRIMARY KEY (globalId, labelKey);
 ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
 CREATE INDEX IDX_vlabels_1 ON version_labels(labelKey);
 CREATE INDEX IDX_vlabels_2 ON version_labels(labelValue);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/mssql.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/mssql.ddl
@@ -37,6 +37,7 @@ CREATE TABLE groups (groupId NVARCHAR(512) NOT NULL, description NVARCHAR(1024),
 ALTER TABLE groups ADD PRIMARY KEY (groupId);
 
 CREATE TABLE group_labels (groupId NVARCHAR(512) NOT NULL, labelKey NVARCHAR(256) NOT NULL, labelValue NVARCHAR(512));
+ALTER TABLE group_labels ADD PRIMARY KEY (groupId, labelKey);
 ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
 CREATE INDEX IDX_glabels_1 ON group_labels(labelKey);
 CREATE INDEX IDX_glabels_2 ON group_labels(labelValue);
@@ -54,6 +55,7 @@ CREATE INDEX IDX_artifacts_3 ON artifacts(name);
 -- CREATE INDEX IDX_artifacts_4 ON artifacts(description);
 
 CREATE TABLE artifact_labels (groupId NVARCHAR(512) NOT NULL, artifactId NVARCHAR(512) NOT NULL, labelKey NVARCHAR(256) NOT NULL, labelValue NVARCHAR(512));
+ALTER TABLE artifact_labels ADD PRIMARY KEY (groupId, artifactId, labelKey);
 ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
 CREATE INDEX IDX_alabels_1 ON artifact_labels(labelKey);
 CREATE INDEX IDX_alabels_2 ON artifact_labels(labelValue);
@@ -81,6 +83,7 @@ CREATE INDEX IDX_versions_6 ON versions(createdOn);
 CREATE INDEX IDX_versions_7 ON versions(contentId);
 
 CREATE TABLE version_labels (globalId BIGINT NOT NULL, labelKey NVARCHAR(256) NOT NULL, labelValue NVARCHAR(512));
+ALTER TABLE version_labels ADD PRIMARY KEY (globalId, labelKey);
 ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
 CREATE INDEX IDX_vlabels_1 ON version_labels(labelKey);
 CREATE INDEX IDX_vlabels_2 ON version_labels(labelValue);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/mysql.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/mysql.ddl
@@ -84,6 +84,7 @@ CREATE TABLE group_labels (
     labelKey   VARCHAR(256) NOT NULL,
     labelValue VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
+ALTER TABLE group_labels ADD PRIMARY KEY (groupId, labelKey);
 ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES `groups` (groupId) ON DELETE CASCADE;
 CREATE INDEX IDX_glabels_1 ON group_labels (labelKey);
 CREATE INDEX IDX_glabels_2 ON group_labels (labelValue);
@@ -121,6 +122,7 @@ CREATE TABLE artifact_labels (
     labelKey   VARCHAR(256) NOT NULL,
     labelValue VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
+ALTER TABLE artifact_labels ADD PRIMARY KEY (groupId, artifactId, labelKey);
 ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts (groupId, artifactId) ON DELETE CASCADE;
 CREATE INDEX IDX_alabels_1 ON artifact_labels (labelKey);
 CREATE INDEX IDX_alabels_2 ON artifact_labels (labelValue);
@@ -167,6 +169,7 @@ CREATE TABLE version_labels (
     labelKey   VARCHAR(256) NOT NULL,
     labelValue VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
+ALTER TABLE version_labels ADD PRIMARY KEY (globalId, labelKey);
 ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions (globalId) ON DELETE CASCADE;
 CREATE INDEX IDX_vlabels_1 ON version_labels (labelKey);
 CREATE INDEX IDX_vlabels_2 ON version_labels (labelValue);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/postgresql.ddl
@@ -37,6 +37,7 @@ CREATE TABLE groups (groupId VARCHAR(512) NOT NULL, description VARCHAR(1024), a
 ALTER TABLE groups ADD PRIMARY KEY (groupId);
 
 CREATE TABLE group_labels (groupId VARCHAR(512) NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
+ALTER TABLE group_labels ADD PRIMARY KEY (groupId, labelKey);
 ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES groups(groupId) ON DELETE CASCADE;
 CREATE INDEX IDX_glabels_1 ON group_labels(labelKey);
 CREATE INDEX IDX_glabels_2 ON group_labels(labelValue);
@@ -54,6 +55,7 @@ CREATE INDEX IDX_artifacts_3 ON artifacts(name);
 CREATE INDEX IDX_artifacts_4 ON artifacts(description);
 
 CREATE TABLE artifact_labels (groupId VARCHAR(512) NOT NULL, artifactId VARCHAR(512) NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
+ALTER TABLE artifact_labels ADD PRIMARY KEY (groupId, artifactId, labelKey);
 ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts(groupId, artifactId) ON DELETE CASCADE;
 CREATE INDEX IDX_alabels_1 ON artifact_labels(labelKey);
 CREATE INDEX IDX_alabels_2 ON artifact_labels(labelValue);
@@ -81,6 +83,7 @@ CREATE INDEX IDX_versions_6 ON versions(createdOn);
 CREATE INDEX IDX_versions_7 ON versions USING HASH (contentId);
 
 CREATE TABLE version_labels (globalId BIGINT NOT NULL, labelKey VARCHAR(256) NOT NULL, labelValue VARCHAR(512));
+ALTER TABLE version_labels ADD PRIMARY KEY (globalId, labelKey);
 ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions(globalId) ON DELETE CASCADE;
 CREATE INDEX IDX_vlabels_1 ON version_labels(labelKey);
 CREATE INDEX IDX_vlabels_2 ON version_labels(labelValue);


### PR DESCRIPTION
## Summary

Adds composite primary keys to three label tables (`group_labels`, `artifact_labels`, and `version_labels`) across all database types (MySQL, PostgreSQL, H2, and MSSQL) to enable MySQL InnoDB Cluster compatibility.

## Changes

- **group_labels**: Added PK on `(groupId, labelKey)`
- **artifact_labels**: Added PK on `(groupId, artifactId, labelKey)`  
- **version_labels**: Added PK on `(globalId, labelKey)`

## Rationale

MySQL InnoDB Cluster requires all tables to have primary keys defined. The missing primary keys on these three label tables prevented cluster initialization from completing successfully.

The chosen composite keys are based on the natural keys of each table - the foreign key column(s) plus `labelKey` - which prevents duplicate label keys for the same entity (group/artifact/version) as expected by the application logic.

## Impact

- **New installations**: Will automatically have primary keys defined on these tables
- **Existing installations**: Will continue to work without issues (PKs are not functionally required by the application)
- **MySQL InnoDB Cluster**: Will now initialize successfully with new deployments
- **No breaking changes**: Application logic remains unchanged

## Testing

The primary keys enforce the existing application behavior where each entity can only have one value per label key, which is already enforced by the `DELETE` + `INSERT` pattern used in the code.

Fixes #6865