### PR TITLE
fix: Correct UnauthorizedException response status mapping

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/AuthenticationFailedExceptionMapper.java
+++ b/app/src/main/java/io/apicurio/registry/rest/AuthenticationFailedExceptionMapper.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.rest;
 
+import io.apicurio.registry.rest.v3.beans.ProblemDetails;
 import io.quarkus.security.UnauthorizedException;
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
@@ -18,6 +19,8 @@ public class AuthenticationFailedExceptionMapper implements ExceptionMapper<Unau
     @Override
     public Response toResponse(UnauthorizedException exception) {
         Response errorHttpResponse = exceptionMapperService.toResponse(exception);
-        return Response.status(401).entity(errorHttpResponse).build();
+        ProblemDetails problemDetails = (ProblemDetails) errorHttpResponse.getEntity();
+        problemDetails.setStatus(401);
+        return Response.status(401).entity(problemDetails).type(errorHttpResponse.getMediaType()).build();
     }
 }

--- a/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
@@ -59,6 +59,7 @@ import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 
 @Singleton
@@ -105,6 +106,8 @@ public class HttpStatusCodeMap {
         // latter for authx only.
         map.put(NotAuthorizedException.class, HTTP_FORBIDDEN);
         map.put(NotFoundException.class, HTTP_NOT_FOUND);
+        map.put(io.quarkus.security.UnauthorizedException.class, HTTP_UNAUTHORIZED);
+        map.put(io.quarkus.security.ForbiddenException.class, HTTP_FORBIDDEN);
         map.put(ParametersConflictException.class, HTTP_CONFLICT);
         map.put(ReadOnlyStorageException.class, HTTP_CONFLICT);
         map.put(ReferenceExistsException.class, HTTP_UNPROCESSABLE_ENTITY);


### PR DESCRIPTION
## Summary

Fixes #6047 - Corrects the error response structure when `UnauthorizedException` is thrown during authentication.

**Problem**: When an unauthenticated user accessed a protected V3 API endpoint, the HTTP response correctly returned status 401, but the JSON response body contained incorrect data:
- The entire JAX-RS `Response` object was serialized as the entity (including metadata like `statusInfo`, `cookies`, `headers`, etc.)
- Both `entity.status` and `status` fields showed 500 instead of 401

**Root Cause**: Two issues were identified:
1. `AuthenticationFailedExceptionMapper` was incorrectly using the entire `Response` object as the entity instead of extracting the `ProblemDetails`
2. `io.quarkus.security.UnauthorizedException` was not mapped in `HttpStatusCodeMap`, causing it to default to HTTP 500

## Changes

### 1. Fixed `AuthenticationFailedExceptionMapper.java`
- Now properly extracts the `ProblemDetails` entity from the response
- Updates the status field to 401 before building the final response
- Preserves the correct media type from the original response

### 2. Updated `HttpStatusCodeMap.java`
- Added mapping for `io.quarkus.security.UnauthorizedException` → HTTP 401
- Added mapping for `io.quarkus.security.ForbiddenException` → HTTP 403
- Ensures correct status codes are generated from the start

## Test plan

- [ ] Verify that unauthenticated requests to protected V3 API endpoints return clean `ProblemDetails` JSON with `status: 401`
- [ ] Confirm the response no longer includes JAX-RS Response metadata fields
- [ ] Test with the exact curl command from issue #6047
- [ ] Verify V2 and ccompat API endpoints are not affected