### PR TITLE
feat(oidc): add token refresh and safe retry logic for 401 responses

### DIFF
--- a/ui/ui-app/package-lock.json
+++ b/ui/ui-app/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "@apicurio/apicurio-registry-sdk": "3.1.3-Dev",
-        "@apicurio/common-ui-components": "2.0.13",
+        "@apicurio/common-ui-components": "2.0.15",
         "@apicurio/data-models": "1.1.33",
         "@microsoft/kiota-abstractions": "1.0.0-preview.99",
         "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.99",
@@ -100,9 +100,9 @@
       "link": true
     },
     "node_modules/@apicurio/common-ui-components": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@apicurio/common-ui-components/-/common-ui-components-2.0.13.tgz",
-      "integrity": "sha512-HNcMDWSvSzDZjawI0pWT3RXm6/m8IPz2k0f8EAyhTk16vibxS88+Yg58NTJHjLb1A3wWQGrgAiWyvwhPeMkczQ==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@apicurio/common-ui-components/-/common-ui-components-2.0.15.tgz",
+      "integrity": "sha512-YhEIdv6OdWADbqjRsgSwyvCNeHtVGZY1oFlk6WD9cj5LUxjotZgiGHYDSeXmHBDeIIcolRq2kXYlik23LIStNg==",
       "peerDependencies": {
         "@patternfly/patternfly": "~5",
         "@patternfly/react-core": "~5",

--- a/ui/ui-app/package.json
+++ b/ui/ui-app/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@apicurio/apicurio-registry-sdk": "3.1.3-Dev",
-    "@apicurio/common-ui-components": "2.0.13",
+    "@apicurio/common-ui-components": "2.0.15",
     "@apicurio/data-models": "1.1.33",
     "@microsoft/kiota-abstractions": "1.0.0-preview.99",
     "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.99",


### PR DESCRIPTION
### Summary

This PR fixes a critical issue where the UI becomes permanently unauthorized when the user goes offline (or the OIDC provider becomes unreachable) and the OIDC `silentRenew` mechanism fails.

After 2 failed attempts, `oidc-client-ts` stops renewing tokens.  Apicurio UI never attempts a manual refresh, so the user becomes stuck:
- Access token expires
- Refresh token is still valid
- UI fails with 401
- User must log out
- Unsaved edits are lost

This PR implements:
- Manual token refresh via the new `auth.refresh()` API
- A 401 middleware that refreshes tokens before retrying
- Shared refresh promise (to avoid storm of refresh requests)

---

### What this PR adds

✔ `RefreshOn401Handler` middleware  
✔ Token refresh when 401 is received  
✔ Safe retry of the original request  
✔ Proper debug logging  
✔ No UX disruption  
✔ No breaking changes  

---

### Why this is needed

**Silent renew fails permanently** after 2 network errors:

- Browser goes offline
- Laptop sleeps
- VPN drops
- Keycloak temporarily down

Without this fix:
- Users cannot save artifacts
- Refresh token is never used
- Only option: logout → lose work

With this fix:
- Tokens are refreshed correctly
- UI recovers automatically
- Users do not lose changes

---

### Implementation Notes

- Uses a static promise to dedupe token refresh
- Retries a failed request only once
- Second 401 returns normally (permissions, real expired session, etc)
- Works with Kiota + RegistryClientFactory
- No changes required to backend APIs

---

### Testing

Scenarios tested:

- Disconnect network
- Wait for silent renew to fail twice
- Reconnect
- Save changes
- Token refresh succeeds
- Request is retried
- Save completes successfully
- No data loss

Also tested:
- No double refresh
- No infinite retry loops
- Refresh token truly expired → expected 401 shown

---

### No impact to:

- Basic Auth mode
- Non-OIDC deployments

---

### ⚠️ Merge Order & Version Update

This PR depends on the following change in **`apicurio-common-ui-components`**:

➡️ https://github.com/Apicurio/apicurio-common-ui-components/pull/237

**Required merge flow:**

~~1. Merge the `apicurio-common-ui-components` PR~~
~~2. Update `package.json` here to reference that version~~
3. Then merge this PR

~~CI will fail until the updated version is available, because `auth.refresh()` is not yet part of the published package.~~

---

### ⚠️ Additional Note: Token refresh in useAdminService

One more place in the UI may still require token refresh handling:

> ui/ui-app/src/services/useAdminService.ts

Specifically in - **importFrom**

There is already a TODO in the source: **"// TODO convert to using the SDK?"**
So this may not require immediate changes if that migration is planned,
but I wanted to document it for completeness.

If needed, I can:
- update importFrom to use the same token refresh logic
- or help migrate it to SDK usage
- or provide a follow-up PR after this one is merged