### PR TITLE
fix: Complete fix for Protobuf validation with reserved fields (#6697)

### DIFF
--- a/schema-util/protobuf/src/main/java/io/apicurio/registry/rules/compatibility/protobuf/ProtobufCompatibilityCheckerLibrary.java
+++ b/schema-util/protobuf/src/main/java/io/apicurio/registry/rules/compatibility/protobuf/ProtobufCompatibilityCheckerLibrary.java
@@ -52,17 +52,20 @@ public class ProtobufCompatibilityCheckerLibrary {
 
     /**
      * Find differences between two protobuf schemas.
-     * @param includeNoUsingReservedFieldsCheck whether to check for removed reserved fields.
-     *        Set to false e.g. when comparing registry schemas against compiled protobuf classes,
+     * @param includeReservedFieldsChecks whether to check for reserved field violations.
+     *        Set to false when comparing registry schemas against compiled protobuf classes,
      *        since the protobuf compiler strips reserved field information from generated code.
+     *        When false, skips both checkNoRemovingReservedFields() and
+     *        checkNoRemovingFieldsWithoutReserve() since both require reserved field information
+     *        to be present in the "after" schema.
      */
-    public List<ProtobufDifference> findDifferences(boolean includeNoUsingReservedFieldsCheck) {
+    public List<ProtobufDifference> findDifferences(boolean includeReservedFieldsChecks) {
         List<ProtobufDifference> totalIssues = new ArrayList<>();
         totalIssues.addAll(checkNoUsingReservedFields());
-        if (includeNoUsingReservedFieldsCheck) {
+        if (includeReservedFieldsChecks) {
             totalIssues.addAll(checkNoRemovingReservedFields());
+            totalIssues.addAll(checkNoRemovingFieldsWithoutReserve());
         }
-        totalIssues.addAll(checkNoRemovingFieldsWithoutReserve());
         totalIssues.addAll(checkNoChangingFieldIDs());
         totalIssues.addAll(checkNoChangingFieldTypes());
         totalIssues.addAll(checkNoChangingFieldNames());


### PR DESCRIPTION
## Summary

This PR completes the fix for GitHub issue #6697 by addressing a follow-up issue where `checkNoRemovingFieldsWithoutReserve()` was still running even when comparing registry schemas against compiled protobuf classes.

## Background

The original fix in PR #6747 addressed the issue where `checkNoRemovingReservedFields()` would fail when validating protobuf data with reserved fields. However, it only skipped that one check, leaving `checkNoRemovingFieldsWithoutReserve()` still running, which caused a different false positive.

## Root Cause

When comparing:
- **Registry schema**: Contains field #2 marked as `reserved`
- **Compiled Java class**: Field #2 doesn't exist at all (not even as reserved, because `protoc` strips this metadata)

The `checkNoRemovingFieldsWithoutReserve()` method would:
1. See field #2 exists in "before" (registry) but not in "after" (compiled class)
2. Check if field #2 is reserved in "after" schema - it's NOT (because compiled classes have no reserved info)
3. Incorrectly report: "fields removed without reservation, message Person"

## Solution

Modified `findDifferences(boolean)` to skip **BOTH** reserved field checks when the parameter is `false`:
1. `checkNoRemovingReservedFields()` - expects reserved declarations to remain in "after" schema
2. `checkNoRemovingFieldsWithoutReserve()` - expects removed fields to be marked as reserved in "after" schema

Both checks assume the "after" schema contains reserved field information, which is never true for compiled protobuf classes since the compiler strips this metadata (reserved fields are only needed at compile-time).

## Changes

### ProtobufCompatibilityCheckerLibrary.java
- Renamed parameter from `includeNoUsingReservedFieldsCheck` to `includeReservedFieldsChecks` for clarity
- Moved `checkNoRemovingFieldsWithoutReserve()` inside the conditional block
- Updated Javadoc to explain why both checks must be skipped

### ProtobufSerdeTest.java
- Enhanced test documentation to explain that TWO different errors would occur without the complete fix
- Clarified why both checks must be skipped
- Updated inline comments to reflect both error scenarios

## Testing

The existing test `testProtobufWithReservedFields` already covers this scenario:
- Uses `person_with_reserved.proto` which has field #2 reserved
- Without this fix, the test would fail with "fields removed without reservation"
- With this fix, validation properly skips both reserved field checks

## Related Issues

- Fixes #6697
- Completes PR #6747

## Checklist

- [x] Code changes are complete
- [x] Test documentation updated
- [x] Existing tests cover the scenario
- [x] No breaking changes