### PR TITLE
fix: Add comprehensive semantic validation for Protobuf schemas

### DIFF
--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/ProtobufContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/ProtobufContentValidatorTest.java
@@ -80,4 +80,80 @@ public class ProtobufContentValidatorTest extends ArtifactUtilProviderTestBase {
         });
     }
 
+    /**
+     * Test that schemas with duplicate field tag numbers are accepted with SYNTAX_ONLY
+     * but rejected with FULL validation.
+     * Case 1 from GitHub issue #6209.
+     */
+    @Test
+    public void testProtobufWithDuplicateTagNumbers() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("protobuf-duplicate-tags.proto");
+        ProtobufContentValidator validator = new ProtobufContentValidator();
+
+        // SYNTAX_ONLY should pass (Wire parser doesn't catch duplicate tags)
+        validator.validate(ValidityLevel.SYNTAX_ONLY, content, Collections.emptyMap());
+
+        // FULL validation should fail (Google Protobuf catches duplicate tags)
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+    }
+
+    /**
+     * Test that schemas with negative field tag numbers are accepted with SYNTAX_ONLY
+     * but rejected with FULL validation.
+     * Case 2 from GitHub issue #6209.
+     */
+    @Test
+    public void testProtobufWithNegativeTagNumber() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("protobuf-negative-tag.proto");
+        ProtobufContentValidator validator = new ProtobufContentValidator();
+
+        // SYNTAX_ONLY should pass (Wire parser doesn't catch negative tags)
+        validator.validate(ValidityLevel.SYNTAX_ONLY, content, Collections.emptyMap());
+
+        // FULL validation should fail (Google Protobuf catches negative tags)
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+    }
+
+    /**
+     * Test that schemas with invalid field types are accepted with SYNTAX_ONLY
+     * but rejected with FULL validation.
+     * Case 3 from GitHub issue #6209.
+     */
+    @Test
+    public void testProtobufWithInvalidType() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("protobuf-invalid-type.proto");
+        ProtobufContentValidator validator = new ProtobufContentValidator();
+
+        // SYNTAX_ONLY should pass (Wire parser doesn't catch undefined types at parse time)
+        validator.validate(ValidityLevel.SYNTAX_ONLY, content, Collections.emptyMap());
+
+        // FULL validation should fail (Google Protobuf catches undefined types)
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+    }
+
+    /**
+     * Test that schemas with invalid option values are accepted with SYNTAX_ONLY
+     * but rejected with FULL validation.
+     * Case 4 from GitHub issue #6209.
+     */
+    @Test
+    public void testProtobufWithInvalidOptionValue() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("protobuf-invalid-option.proto");
+        ProtobufContentValidator validator = new ProtobufContentValidator();
+
+        // SYNTAX_ONLY should pass (Wire parser doesn't validate option types)
+        validator.validate(ValidityLevel.SYNTAX_ONLY, content, Collections.emptyMap());
+
+        // FULL validation should fail (Google Protobuf catches invalid option types)
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+    }
+
 }

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/protobuf-duplicate-tags.proto
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/protobuf-duplicate-tags.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package schema;
+
+message TestSchema {
+    string field1 = 1;
+    string field2 = 1;
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/protobuf-invalid-option.proto
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/protobuf-invalid-option.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package schema;
+
+// The 'java_package' option must be a string, not a number
+option java_package = 123;
+
+message TestSchema {
+    string field1 = 1;
+    string field2 = 2;
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/protobuf-invalid-type.proto
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/protobuf-invalid-type.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package schema;
+
+message TestSchema {
+    string field1 = 1;
+    lakjsd field2 = 2;
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/protobuf-negative-tag.proto
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/protobuf-negative-tag.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package schema;
+
+message TestSchema {
+    string field1 = 1;
+    string field2 = -11;
+}


### PR DESCRIPTION
## Summary

Fixes #6209 by implementing proper semantic validation for Protobuf schemas. The Apicurio Registry now correctly rejects Protobuf schemas with semantic errors when using FULL validation level.

## Problem

The existing `ProtobufContentValidator` only used the Wire library's parser, which performs basic syntax parsing but does not validate semantic correctness. This allowed schemas with the following issues to be incorrectly registered:

- Duplicate field tag numbers
- Negative field tag numbers
- Invalid field types
- Invalid option values

Users with all validation rules configured to `FULL` (as reported in the issue) were not receiving proper validation.

## Solution

Enhanced `ProtobufContentValidator` to properly distinguish between `SYNTAX_ONLY` and `FULL` validation levels:

### `SYNTAX_ONLY`
- Uses Wire library parser for basic syntax validation
- Validates that content can be parsed as a Protobuf schema
- Does NOT catch semantic errors (faster, lightweight validation)

### `FULL`
- Uses Wire library parser + Google Protobuf's `FileDescriptor.buildFrom()`
- Performs comprehensive semantic validation including:
  - Duplicate field tag numbers
  - Negative or zero field tag numbers
  - Invalid field types
  - Invalid option values
  - Other semantic violations

This approach follows the pattern established by `JsonSchemaContentValidator`:
- `SYNTAX_ONLY` = valid JSON
- `FULL` = valid JSON Schema

For Protobuf:
- `SYNTAX_ONLY` = valid .proto syntax
- `FULL` = valid and semantically correct Protobuf schema

## Changes

**Implementation:**
- Modified `ProtobufContentValidator.validate()` to use separate code paths for `SYNTAX_ONLY` vs `FULL`
- Added comprehensive Javadoc explaining validation behavior at each level
- Updated error messages to distinguish "Syntax violation" from "Syntax or semantic violation"

**Tests:**
- Added 4 new test cases covering all scenarios from issue #6209
- Each test validates both `SYNTAX_ONLY` (should pass) and `FULL` (should fail) behavior
- Created test resources for each validation scenario

## Test Plan

- [x] All existing tests pass
- [x] New tests verify SYNTAX_ONLY accepts schemas with semantic errors
- [x] New tests verify FULL rejects schemas with semantic errors
- [x] Covers all 4 cases from the issue:
  - Duplicate field tag numbers
  - Negative field tag numbers
  - Invalid field types
  - Invalid option values

## Files Changed

- `schema-util/protobuf/src/main/java/io/apicurio/registry/rules/validity/ProtobufContentValidator.java` (+31/-3)
- `schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/ProtobufContentValidatorTest.java` (+76)
- Added 4 new test resource files with invalid Protobuf schemas