### PR TITLE
fix: Set infinite retention for KafkaSQL journal topic

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -174,12 +174,18 @@ public class KafkaSqlRegistryStorage extends RegistryStorageDecoratorReadOnlyBas
      * Automatically create the Kafka topics.
      */
     private void autoCreateTopics() {
+        Map<String, String> topicProperties = new HashMap<>();
+
+        // Set default retention policy for journal topic to ensure messages are never deleted
+        topicProperties.putIfAbsent("retention.ms", "-1");
+        topicProperties.putIfAbsent("cleanup.policy", "delete");
+
+        configuration.topicProperties()
+                .forEach((key, value) -> topicProperties.put(key.toString(), value.toString()));
+
         Set<String> topicNames = Set.of(configuration.topic(), configuration.snapshotsTopic(),
                 configuration.eventsTopic());
 
-        Map<String, String> topicProperties = new HashMap<>();
-        configuration.topicProperties()
-                .forEach((key, value) -> topicProperties.put(key.toString(), value.toString()));
         Properties adminProperties = configuration.adminProperties();
         adminProperties.putIfAbsent(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
                 configuration.bootstrapServers());


### PR DESCRIPTION
## Summary
- Configure default Kafka topic properties to ensure journal topic messages are never deleted
- Set `retention.ms=-1` for infinite retention
- Set `cleanup.policy=delete` as explicit default policy

## Problem
The KafkaSQL storage implementation uses a Kafka topic as a persistent journal. Previously, when auto-creating this topic, no explicit retention or cleanup policy was configured. This caused the topic to use Kafka's default settings (typically 7-day retention with delete policy), which could lead to data loss as old messages would be automatically deleted.

## Solution
Modified the `autoCreateTopics()` method to set sensible defaults:
- `retention.ms=-1`: Messages are retained indefinitely
- `cleanup.policy=delete`: Explicit delete policy (no compaction)

These are applied as defaults using `putIfAbsent()`, so users can still override them via `apicurio.kafkasql.topic.*` configuration properties if needed.

## Test plan
- [ ] Verify that newly created KafkaSQL journal topics have `retention.ms=-1` configured
- [ ] Verify that the `cleanup.policy=delete` is set on created topics
- [ ] Verify that existing topics are not affected
- [ ] Verify that users can still override these defaults via configuration