### PR TITLE
fix: Upgrade apicurio-data-models to fix OpenAPI 3.1 security validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <skipCommitIdPlugin>true</skipCommitIdPlugin>
 
     <!-- Apicurio Data Models (OpenAPI and AsyncAPI support) -->
-    <apicurio-data-models.version>2.2.4</apicurio-data-models.version>
+    <apicurio-data-models.version>2.2.6</apicurio-data-models.version>
 
     <!-- GraphQL -->
     <graphql.version>22.4</graphql.version>

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/OpenApiContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/OpenApiContentValidatorTest.java
@@ -54,6 +54,18 @@ public class OpenApiContentValidatorTest extends ArtifactUtilProviderTestBase {
         });
     }
 
+    /**
+     * Test for issue #6864 - OpenAPI 3.1 with endpoint security fails to validate.
+     * This test validates an OpenAPI 3.1 document with security requirements on endpoints.
+     * Before the fix in apicurio-data-models, this would throw a ClassCastException.
+     */
+    @Test
+    public void testValidateOpenApi31WithSecurityRequirements() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("openapi-3.1-security-requirements.json");
+        OpenApiContentValidator validator = new OpenApiContentValidator();
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+    }
+
     @Test
     public void testValidateRefs() throws Exception {
         TypedContent content = resourceToTypedContentHandle("openapi-valid-with-refs.json");

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/openapi-3.1-security-requirements.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/openapi-3.1-security-requirements.json
@@ -1,0 +1,40 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "My Simplest API",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/hello": {
+            "get": {
+                "summary": "Returns a greeting",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string",
+                                    "example": "Hello, World!"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "HTTPBearer": {
+                "type": "http",
+                "scheme": "bearer"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Upgraded apicurio-data-models dependency from 2.2.4 to 2.2.6
- Added test case for OpenAPI 3.1 documents with security requirements
- Resolves ClassCastException when validating OpenAPI 3.1 schemas with endpoint security

## Related Issue

Fixes #6864

## Background

The issue was caused by a bug in the apicurio-data-models library where the `OasSecurityRequirementScopesMustBeEmptyRule` validation rule incorrectly cast all non-OpenAPI 2.0 documents to `OpenApi30Document`. When processing OpenAPI 3.1 documents with security requirements, this resulted in a ClassCastException.

The fix was implemented upstream in apicurio-data-models 2.2.6, which now properly handles OpenAPI 3.0 and 3.1 documents separately.

## Test Plan

- [x] Added test `testValidateOpenApi31WithSecurityRequirements()` that validates an OpenAPI 3.1 document with HTTP Bearer security
- [x] Test uses the exact schema from the bug report
- [x] Verified test passes with apicurio-data-models 2.2.6
- [ ] Run full test suite to ensure no regressions
- [ ] Manual testing with the original reported schema