### PR TITLE
refactor: Extract release notes generation to separate workflow

### DIFF
--- a/.github/workflows/release-maven-artifacts.yaml
+++ b/.github/workflows/release-maven-artifacts.yaml
@@ -104,9 +104,3 @@ jobs:
           LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
           PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
           curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_ERROR_WEBHOOK }}
-
-      - name: Setup tmate session on failure
-        if: failure()
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true

--- a/.github/workflows/release-release-notes.yaml
+++ b/.github/workflows/release-release-notes.yaml
@@ -1,0 +1,88 @@
+name: Release Release Notes
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag name'
+        required: true
+  release:
+    types: [ released, prereleased ]
+
+
+env:
+  # The values are extracted from the github.event context,
+  # which is only available when the workflow gets triggered by a release event.
+  RELEASE_VERSION: ${{ github.event.release.name }}
+  BRANCH: ${{ github.event.release.target_commitish }}
+
+
+jobs:
+  generate-release-notes:
+    if: github.repository_owner == 'Apicurio' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '3.'))
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fetch Release Details
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          touch release.json && curl https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${{ github.event.inputs.tag }} > release.json
+          echo "RELEASE_VERSION=$(cat release.json | jq -r '.name')" >> $GITHUB_ENV
+          echo "BRANCH=$(cat release.json | jq -r '.target_commitish')" >> $GITHUB_ENV
+
+      - name: Generate Release Notes from Milestone Issues
+        run: |
+          MILESTONE="${RELEASE_VERSION}"
+
+          # Get all closed issues for this milestone
+          gh issue list \
+            --repo ${GITHUB_REPOSITORY} \
+            --milestone "${MILESTONE}" \
+            --state closed \
+            --limit 1000 \
+            --json number,title,labels \
+            > issues.json
+
+          # Generate release notes
+          cat > release_notes.md << 'EOF'
+          ## What's Changed
+
+          EOF
+
+          # Extract bugs
+          echo "### Bug Fixes" >> release_notes.md
+          jq -r '.[] | select(.labels[]?.name == "type/bug") | "* \(.title) (#\(.number))"' issues.json >> release_notes.md
+          echo "" >> release_notes.md
+
+          # Extract enhancements
+          echo "### Enhancements" >> release_notes.md
+          jq -r '.[] | select(.labels[]?.name == "type/enhancement") | "* \(.title) (#\(.number))"' issues.json >> release_notes.md
+          echo "" >> release_notes.md
+
+          # Extract other issues (not tagged as bug or enhancement)
+          echo "### Other Changes" >> release_notes.md
+          jq -r '.[] | select(all(.labels[]?.name; . != "type/bug" and . != "type/enhancement")) | "* \(.title) (#\(.number))"' issues.json >> release_notes.md
+          echo "" >> release_notes.md
+
+          # Update the GitHub release with the generated notes
+          gh release edit ${RELEASE_VERSION} \
+            --repo ${GITHUB_REPOSITORY} \
+            --notes-file release_notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Slack Notification (Always)
+        if: always()
+        run: |
+          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job completed with status: ${{ job.status }}"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+
+      - name: Slack Notification (Error)
+        if: failure()
+        run: |
+          MESSAGE="'${{ github.workflow }}/${{ github.job }}' job FAILED!"
+          REPO="${{ github.repository }}"
+          LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
+          PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_ERROR_WEBHOOK }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,9 +70,6 @@ jobs:
       - name: Set up json CLI
         run: npm install -g json
 
-      - name: Set up Gren
-        run: npm install -g github-release-notes
-
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@f6f458f535f4ccdf100400ee0755c0e857226a66
         env:
@@ -171,11 +168,6 @@ jobs:
           files: |
             registry/distro/docker/target/docker/app-files/apicurio-registry-app-${{ github.event.inputs.release-version }}-all.*
 
-      - name: Generate Release Notes
-        run: |
-          cd registry
-          gren release --token=${{ secrets.GITHUB_TOKEN }} --override
-
       - name: Update Snapshot Version ${{ env.SNAPSHOT_VERSION }}
         run: |
           cd registry
@@ -226,9 +218,3 @@ jobs:
           LINK="https://github.com/$REPO/actions/runs/${{ github.run_id }}"
           PAYLOAD="{\"workflow\": \"${{ github.workflow }}\", \"status\": \"${{ job.status }}\", \"message\": \"$MESSAGE\", \"link\": \"$LINK\", \"repository\": \"$REPO\"}"
           curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" ${{ secrets.SLACK_ERROR_WEBHOOK }}
-
-      - name: Setup tmate session on failure
-        if: failure()
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true


### PR DESCRIPTION
## Summary
- Moves release notes generation from main `release.yaml` workflow into a new dedicated `release-release-notes.yaml` workflow
- Replaces gren-based release notes with milestone-based approach using GitHub CLI
- Removes tmate debugging sessions from multiple workflows

## Changes

### New Workflow: `release-release-notes.yaml`
- Triggers automatically when a release is created (or manually via workflow_dispatch)
- Queries GitHub issues closed in the milestone matching the release version
- Categorizes issues into sections:
  - **Bug Fixes**: Issues labeled `type/bug`
  - **Enhancements**: Issues labeled `type/enhancement`
  - **Other Changes**: Issues without those labels
- Updates the GitHub release body with generated notes using `gh release edit`

### Modified: `release.yaml`
- Removed gren setup step
- Removed release notes generation step (now handled by separate workflow)
- Removed tmate debugging session

### Modified: `release-maven-artifacts.yaml`
- Removed tmate debugging session

## Benefits
- Follows existing pattern of separate `release-*` workflows for different release tasks
- Simpler and more maintainable than gren
- Automatically organizes release notes by issue type
- Can be re-run independently if release notes need updating