### PR TITLE
feat: Log warning when max retry attempts exceeded in Java SDK

### DIFF
--- a/java-sdk-common/src/main/java/io/apicurio/registry/client/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk-common/src/main/java/io/apicurio/registry/client/RegistryClientRequestAdapterFactory.java
@@ -203,6 +203,11 @@ public class RegistryClientRequestAdapterFactory {
                             throw new RuntimeException("Retry interrupted", interruptedException);
                         }
                     } else {
+                        // Log when max retries exceeded
+                        if (isRetryable(cause) && attempt >= maxRetryAttempts) {
+                            log.log(Level.WARNING, "Maximum retry attempts ({0}) exceeded for {1}: {2}",
+                                    new Object[]{maxRetryAttempts, cause.getClass().getName(), cause.getMessage()});
+                        }
                         // Re-throw the original cause
                         throw originalCause;
                     }


### PR DESCRIPTION
## Summary
- Added warning log message in `RetryInvocationHandler` when maximum retry attempts are exceeded
- Improves observability for retry exhaustion scenarios

## Details
When the Java SDK retry mechanism exhausts all retry attempts for a retryable exception (`HttpClosedException`), it now logs a warning message before re-throwing the exception. 

The log message includes:
- The maximum number of retry attempts that were configured
- The exception class name
- The exception message

Example log output:
```
WARNING: Maximum retry attempts (3) exceeded for io.vertx.core.http.HttpClosedException: Connection was closed
```

This helps developers debug scenarios where the SDK is experiencing persistent connectivity issues that cannot be resolved through retries.

## Changes
- Modified `RegistryClientRequestAdapterFactory.java` - added logging in the `RetryInvocationHandler.invoke()` method (lines 206-210)