### PR TITLE
Check MicroProfile Config provider for date format property

### DIFF
--- a/java-sdk-common/pom.xml
+++ b/java-sdk-common/pom.xml
@@ -34,5 +34,22 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-oauth2</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.config</groupId>
+      <artifactId>microprofile-config-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <!-- Test only -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.kiota</groupId>
+      <artifactId>kiota-serialization-jackson</artifactId>
+      <version>${kiota.community.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/java-sdk-common/src/test/java/io/apicurio/registry/client/util/DateTimeUtilTest.java
+++ b/java-sdk-common/src/test/java/io/apicurio/registry/client/util/DateTimeUtilTest.java
@@ -1,0 +1,64 @@
+package io.apicurio.registry.client.util;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.microsoft.kiota.serialization.ParseNode;
+
+import io.kiota.serialization.json.JsonParseNode;
+import io.kiota.serialization.json.JsonParseNodeFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DateTimeUtilTest {
+
+    final JsonParseNodeFactory nodeFactory = new JsonParseNodeFactory();
+
+    @Test
+    void testNullInput() {
+        var parsedValue = DateTimeUtil.getOffsetDateTimeValue(null);
+        assertNull(parsedValue);
+    }
+
+    @Test
+    void testNullInputNode() {
+        ParseNode node = new JsonParseNode(nodeFactory, NullNode.instance);
+        var parsedValue = DateTimeUtil.getOffsetDateTimeValue(node);
+        assertNull(parsedValue);
+    }
+
+    @Test
+    void testStandardFormat() {
+        Instant now = Instant.now();
+        ParseNode node = new JsonParseNode(nodeFactory, new TextNode(now.toString()));
+        var parsedValue = DateTimeUtil.getOffsetDateTimeValue(node);
+        assertEquals(now.atOffset(ZoneOffset.UTC), parsedValue);
+    }
+
+    @Test
+    void testLegacyFormat() {
+        DateTimeFormatter format = DateTimeFormatter.ofPattern(DateTimeUtil.DEFAULT_LEGACY_FORMAT);
+        TemporalAccessor now = OffsetDateTime.now()
+                .withOffsetSameInstant(ZoneOffset.UTC)
+                .withNano(0);
+        ParseNode node = new JsonParseNode(nodeFactory, new TextNode(format.format(now)));
+        var parsedValue = DateTimeUtil.getOffsetDateTimeValue(node);
+        assertEquals(now, parsedValue);
+    }
+
+    @Test
+    void testLegacyFormatBadValue() {
+        ParseNode node = new JsonParseNode(nodeFactory, new TextNode("Not A Valid Date"));
+        assertThrows(DateTimeParseException.class, () -> DateTimeUtil.getOffsetDateTimeValue(node));
+    }
+}


### PR DESCRIPTION
As discussed on #6823 . The existing tests in the app module hit the MP config path, so the new tests in the sdk simply make sure the absence of config on the classpath doesn't result in some unexpected exceptions, etc.