### PR TITLE
fix(mcp): prevent null serialization of _meta fields in MCP responses

### DIFF
--- a/mcp/src/main/java/io/apicurio/registry/mcp/ObjectMapperCustomizerImpl.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/ObjectMapperCustomizerImpl.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.mcp;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.introspect.ClassIntrospector;
@@ -16,6 +17,10 @@ public class ObjectMapperCustomizerImpl implements ObjectMapperCustomizer {
         mapper.registerModule(new JavaTimeModule());
 
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // Fix for MCP SDK Zod validation: Don't serialize null fields (especially _meta)
+        // The MCP TypeScript SDK expects _meta to be either omitted or an object, never null
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         mapper.setMixInResolver(new ClassIntrospector.MixInResolver() {
             @Override

--- a/mcp/src/test/java/io/apicurio/registry/mcp/ObjectMapperNullSerializationTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/ObjectMapperNullSerializationTest.java
@@ -1,0 +1,111 @@
+package io.apicurio.registry.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test to verify that ObjectMapper doesn't serialize null fields.
+ * This is critical for MCP protocol compliance - the MCP TypeScript SDK
+ * expects fields like _meta to be either omitted or objects, never null.
+ */
+@QuarkusTest
+public class ObjectMapperNullSerializationTest {
+
+    @Inject
+    ObjectMapper mapper;
+
+    @Test
+    public void testNullFieldsAreNotSerialized() throws Exception {
+        // Create a test object with null fields
+        TestObject obj = new TestObject();
+        obj.setName("test");
+        obj.setDescription(null);  // This should NOT appear in JSON
+        obj.setMeta(null);          // This should NOT appear in JSON
+
+        // Serialize to JSON
+        String json = mapper.writeValueAsString(obj);
+
+        // Verify null fields are omitted
+        assertFalse(json.contains("\"description\""),
+            "JSON should not contain 'description' field when it's null");
+        assertFalse(json.contains("\"_meta\""),
+            "JSON should not contain '_meta' field when it's null");
+        assertFalse(json.contains("null"),
+            "JSON should not contain any null values");
+
+        // Verify non-null fields are present
+        assertTrue(json.contains("\"name\""),
+            "JSON should contain 'name' field");
+        assertTrue(json.contains("\"test\""),
+            "JSON should contain the value 'test'");
+    }
+
+    @Test
+    public void testNestedNullFieldsAreNotSerialized() throws Exception {
+        // Create nested object with null fields
+        TestObject outer = new TestObject();
+        outer.setName("outer");
+
+        TestObject inner = new TestObject();
+        inner.setName("inner");
+        inner.setDescription(null);  // Should not appear
+
+        outer.setNested(inner);
+
+        // Serialize to JSON
+        String json = mapper.writeValueAsString(outer);
+
+        // Verify nested null fields are omitted
+        assertFalse(json.contains("\"description\""),
+            "Nested null fields should be omitted");
+        assertTrue(json.contains("\"name\":\"inner\""),
+            "Nested non-null fields should be present");
+    }
+
+    /**
+     * Test object to verify serialization behavior.
+     * Intentionally uses _meta field name to match MCP protocol.
+     */
+    public static class TestObject {
+        private String name;
+        private String description;
+        private Object _meta;
+        private TestObject nested;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public Object get_meta() {
+            return _meta;
+        }
+
+        public void setMeta(Object meta) {
+            this._meta = meta;
+        }
+
+        public TestObject getNested() {
+            return nested;
+        }
+
+        public void setNested(TestObject nested) {
+            this.nested = nested;
+        }
+    }
+}


### PR DESCRIPTION
The MCP TypeScript SDK's Zod validation expects _meta fields to be either omitted entirely or to be objects. When the server serializes null values for _meta fields, the SDK fails validation with:

  ZodError: Expected object, received null at path ["result", "_meta"]

This breaks all MCP tool invocations via stdio transport, affecting Claude Code, MCP Inspector, and any client using the MCP TypeScript SDK.

Fix: Configure Jackson ObjectMapper to skip null fields during serialization by setting JsonInclude.Include.NON_NULL. This ensures _meta and other null fields are omitted from JSON output rather than being serialized as "field": null.

Testing: Added ObjectMapperNullSerializationTest to verify null fields (including _meta) are not present in serialized JSON output.