### PR TITLE
fix: race condition in a test

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/proxy/ProxySdkClientTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/proxy/ProxySdkClientTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URL;
 
+import static io.apicurio.registry.utils.ConcurrentUtil.blockOn;
+
 /**
  * Tests the proxy configuration options in the Java SDK clients.
  */
@@ -38,7 +40,7 @@ public class ProxySdkClientTest extends AbstractResourceTestBase {
             port = 8081;
         }
         proxy = new SimpleTestProxy(PROXY_PORT, host, port);
-        proxy.start().get();
+        blockOn(proxy.start());
         proxy.resetRequestCount();
     }
 

--- a/common/src/main/java/io/apicurio/registry/utils/ConcurrentUtil.java
+++ b/common/src/main/java/io/apicurio/registry/utils/ConcurrentUtil.java
@@ -50,6 +50,12 @@ public final class ConcurrentUtil {
         T get() throws InterruptedException, ExecutionException;
     }
 
+    public static <T> CompletableFuture<T> toJavaFuture(io.vertx.core.Future<T> vf) {
+        var cf = new CompletableFuture<T>();
+        vf.onComplete(cf::complete, cf::completeExceptionally);
+        return cf;
+    }
+
     private ConcurrentUtil() {
     }
 }

--- a/common/src/main/java/io/apicurio/registry/utils/RandomUtil.java
+++ b/common/src/main/java/io/apicurio/registry/utils/RandomUtil.java
@@ -6,6 +6,11 @@ public final class RandomUtil {
 
     public static final Random RANDOM = new Random();
 
+    public static int randomPort() {
+        // See https://www.rfc-editor.org/rfc/rfc6335#section-6
+        return RANDOM.nextInt(0xC000, 0xFFFF + 1);
+    }
+
     private RandomUtil() {
     }
 }


### PR DESCRIPTION
https://github.com/Apicurio/apicurio-registry/actions/runs/19637100015/job/56230445219

```
2025-11-24T14:15:15.4856524Z [ERROR] io.apicurio.registry.noprofile.proxy.ProxySdkClientTest.testProxyConfigurationValidation -- Time elapsed: 0.009 s <<< ERROR!
    2025-11-24T14:15:15.4858151Z java.util.concurrent.ExecutionException: java.net.BindException: Address already in use
    2025-11-24T14:15:15.4859254Z 	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
    2025-11-24T14:15:15.4860305Z 	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
    2025-11-24T14:15:15.4861454Z 	at io.apicurio.registry.noprofile.proxy.ProxySdkClientTest.setupProxy(ProxySdkClientTest.java:41)
    2025-11-24T14:15:15.4862427Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
    2025-11-24T14:15:15.4863377Z 	at io.quarkus.test.junit.QuarkusTestExtension.runExtensionMethod(QuarkusTestExtension.java:960)
    2025-11-24T14:15:15.4864627Z 	at io.quarkus.test.junit.QuarkusTestExtension.interceptBeforeEachMethod(QuarkusTestExtension.java:791)
    [...]
    2025-11-24T14:15:15.4866972Z Caused by: java.net.BindException: Address already in use
    2025-11-24T14:15:15.4867556Z 	at java.base/sun.nio.ch.Net.bind0(Native Method)
    2025-11-24T14:15:15.4868264Z 	at java.base/sun.nio.ch.Net.bind(Net.java:555)
    [...]
```