### PR TITLE
Address kafkasql minor problems

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
@@ -159,7 +159,11 @@ public class KafkaSqlConfiguration {
         // So we convert them as soon as possible.
         var props = toMap(eventsTopicProperties);
 
-        // TODO: Check if the events topic can support multiple partitions. Currently all events are explicitly sent to partition 0.
+        // Events topic is configured with a single partition to guarantee total ordering of all events.
+        // This ensures consumers see events in the exact order they occurred. If per-aggregate ordering
+        // is sufficient (rather than global ordering), multiple partitions could be supported by removing
+        // the explicit partition assignment in KafkaSqlEventsProcessor and using the aggregateId as the
+        // partition key. This would enable better scalability while maintaining ordering per aggregate.
         props.put(TOPIC_PARTITIONS_CONFIG, "1");
         props.putIfAbsent(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE);
         props.putIfAbsent(TopicConfig.RETENTION_MS_CONFIG, "-1");

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlCoordinator.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlCoordinator.java
@@ -49,8 +49,10 @@ public class KafkaSqlCoordinator {
             Object rval = returnValues.remove(uuid);
             if (rval == NULL) {
                 return null;
-            } else if (rval instanceof RegistryException) {
-                throw (RegistryException) rval; // TODO: Any exception
+            } else if (rval instanceof RuntimeException) {
+                // Rethrow any RuntimeException to preserve the original exception type
+                // for proper handling by exception mappers.
+                throw (RuntimeException) rval;
             }
             return rval;
         } catch (InterruptedException e) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlEventsProcessor.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlEventsProcessor.java
@@ -24,7 +24,8 @@ public class KafkaSqlEventsProcessor {
 
     public void processEvent(@Observes KafkaSqlOutboxEvent event) {
         OutboxEvent outboxEvent = event.getOutboxEvent();
-        // TODO: Are we only allowing a single partition?
+        // Explicitly send to partition 0 to guarantee total ordering of all events.
+        // See KafkaSqlConfiguration.getEventsTopicProperties() for details on this design decision.
         ProducerRecord<String, String> record = new ProducerRecord<>(configuration.getEventsTopic(), 0,
                 outboxEvent.getAggregateId(), outboxEvent.getPayload().toString(), Collections.emptyList());
         blockOnResult(eventsProducer.apply(record));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlSink.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/sql/KafkaSqlSink.java
@@ -55,13 +55,15 @@ public class KafkaSqlSink {
                     result != null ? result.toString() : "");
             log.debug("Kafka message successfully processed. Notifying listeners of response.");
             coordinator.notifyResponse(requestId, result);
-        } catch (RegistryException e) {
-            log.debug("Registry exception detected: {}", e.getMessage());
+        } catch (RuntimeException e) {
+            // Pass RuntimeException (including RegistryException) directly without wrapping
+            // to preserve the original exception type for proper handling by exception mappers.
+            log.debug("Runtime exception detected: {}", e.getMessage());
             coordinator.notifyResponse(requestId, e);
         } catch (Throwable e) {
+            // Wrap checked exceptions and Errors in RegistryException
             log.debug("Unexpected exception detected: {}", e.getMessage());
-            coordinator.notifyResponse(requestId, new RegistryException(e)); // TODO: Any exception (no
-                                                                             // wrapping)
+            coordinator.notifyResponse(requestId, new RegistryException(e));
         }
     }
 


### PR DESCRIPTION
Summary

This PR addresses all TODO comments in the KafkaSQL storage implementation, improving code quality, reliability, and documentation.

Changes

  Health Check Improvements (KafkaSqlRegistryStorage.java)
  - Enhanced isAlive() to verify the Kafka consumer thread is still running, providing better detection of Kafka connectivity issues

  Snapshot Consumption Fix (KafkaSqlRegistryStorage.java)
  - Fixed consumeSnapshotsTopic() to poll in a loop until the topic is exhausted, rather than a single poll that could miss messages
  - Added logging for total snapshots found

  Unnecessary Sleep Removal (KafkaSqlRegistryStorage.java)
  - Removed 2-second sleep in importData() and upgradeData() methods
  - Since all messages use the same partition key (__GLOBAL_PARTITION__), Kafka guarantees ordering within the partition, making the sleep redundant

  Exception Handling (KafkaSqlSink.java, KafkaSqlCoordinator.java)
  - Changed exception handling to preserve original exception types instead of wrapping everything in RegistryException
  - RuntimeException (including RegistryException subclasses) are now passed through directly
  - This ensures proper handling by exception mappers and better error reporting

  Documentation (KafkaSqlRegistryStorage.java, KafkaSqlConfiguration.java, KafkaSqlEventsProcessor.java)
  - Replaced TODOs with clear documentation explaining design decisions
  - Documented why journal records are processed on the consumer thread (single partition guarantees ordering)
  - Documented why the events topic uses a single partition (total ordering guarantee for consumers)

Test plan

  - Verify KafkaSQL storage starts correctly and isAlive() returns true
  - Verify snapshot restoration works with multiple snapshots in the topic
  - Verify data import/upgrade operations complete successfully without the sleep delay
  - Verify exceptions are properly propagated with correct types (e.g., ArtifactNotFoundException is not wrapped)
  - Run existing KafkaSQL integration tests: ./mvnw verify -Pintegration-tests -pl integration-tests -Plocal-tests -Pkafkasqlit
