### PR TITLE
Add performance improvements to the serdes layer

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -121,6 +121,27 @@
     </dependency>
     <dependency>
       <groupId>io.confluent</groupId>
+      <artifactId>kafka-protobuf-serializer</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.confluent</groupId>
+      <artifactId>kafka-json-schema-serializer</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>2.0.1.Final</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.confluent</groupId>
       <artifactId>kafka-connect-avro-converter</artifactId>
       <scope>test</scope>
     </dependency>

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SerdesPerformanceIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SerdesPerformanceIT.java
@@ -1,0 +1,716 @@
+package io.apicurio.tests.serdes.apicurio;
+
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
+import io.apicurio.registry.rest.client.models.CreateRule;
+import io.apicurio.registry.rest.client.models.RuleType;
+import io.apicurio.registry.rest.client.models.VersionMetaData;
+import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
+import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
+import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaDeserializer;
+import io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaSerializer;
+import io.apicurio.registry.serde.protobuf.ProtobufKafkaDeserializer;
+import io.apicurio.registry.serde.protobuf.ProtobufKafkaSerializer;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.apicurio.tests.ApicurioRegistryBaseIT;
+import io.apicurio.tests.common.serdes.json.ValidMessage;
+import io.apicurio.tests.common.serdes.proto.TestCmmn;
+import io.apicurio.tests.utils.Constants;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializerConfig;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerConfig;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Performance comparison test: Measures and compares the serialization/deserialization
+ * performance between Apicurio and Confluent serializers for:
+ * - Avro
+ * - JSON Schema
+ * - Protobuf
+ */
+@Tag(Constants.SERDES)
+@QuarkusIntegrationTest
+public class SerdesPerformanceIT extends ApicurioRegistryBaseIT {
+
+    // Number of warmup iterations (not measured)
+    private static final int WARMUP_ITERATIONS = 100;
+
+    // Number of measured iterations
+    private static final int MEASURED_ITERATIONS = 1000;
+
+    @BeforeEach
+    void setupValidityRule() {
+        // Set up SYNTAX_ONLY validity rule for Confluent protobuf compatibility
+        try {
+            CreateRule rule = new CreateRule();
+            rule.setConfig("SYNTAX_ONLY");
+            rule.setRuleType(RuleType.VALIDITY);
+            registryClient.admin().rules().post(rule);
+        } catch (Exception e) {
+            // Rule may already exist, ignore
+        }
+    }
+
+    @AfterEach
+    void cleanupGlobalRules() {
+        // Clean up global rules to avoid affecting other tests
+        try {
+            registryClient.admin().rules().delete();
+        } catch (Exception e) {
+            // Ignore cleanup errors
+        }
+    }
+
+    // ==================== AVRO TESTS ====================
+
+    @Test
+    @Tag(Constants.ACCEPTANCE)
+    void testAvroSerializerPerformance() throws Exception {
+        String groupId = "avro-perf-test-serializer-" + UUID.randomUUID();
+        String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";
+
+        AvroGenericRecordSchemaFactory schemaFactory = new AvroGenericRecordSchemaFactory(
+                "io.apicurio.perf", "PerfTestRecord", List.of("field1", "field2", "field3"));
+        GenericRecord testRecord = schemaFactory.generateRecord(1);
+
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("AVRO SERIALIZER PERFORMANCE COMPARISON");
+        System.out.println("=".repeat(80));
+        System.out.println("Warmup iterations: " + WARMUP_ITERATIONS);
+        System.out.println("Measured iterations: " + MEASURED_ITERATIONS);
+        System.out.println("=".repeat(80));
+
+        testAvroSerializerWithMessage(groupId, apicurioArtifactId, schemaFactory, testRecord);
+
+        System.out.println("=".repeat(80));
+    }
+
+    @Test
+    @Tag(Constants.ACCEPTANCE)
+    void testAvroRoundTripPerformance() throws Exception {
+        String groupId = "avro-perf-test-roundtrip-" + UUID.randomUUID();
+        String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";
+
+        AvroGenericRecordSchemaFactory schemaFactory = new AvroGenericRecordSchemaFactory(
+                "io.apicurio.perf", "PerfTestRecord", List.of("field1", "field2", "field3"));
+        GenericRecord testRecord = schemaFactory.generateRecord(1);
+
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("AVRO ROUND-TRIP PERFORMANCE COMPARISON");
+        System.out.println("=".repeat(80));
+        System.out.println("Warmup iterations: " + WARMUP_ITERATIONS);
+        System.out.println("Measured iterations: " + MEASURED_ITERATIONS);
+        System.out.println("=".repeat(80));
+
+        testAvroRoundTripWithMessage(groupId, apicurioArtifactId, schemaFactory, testRecord);
+
+        System.out.println("=".repeat(80));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void testAvroSerializerWithMessage(String groupId, String apicurioArtifactId,
+            AvroGenericRecordSchemaFactory schemaFactory, GenericRecord testRecord) throws Exception {
+
+        System.out.println("\n--- Avro GenericRecord Serialization ---");
+
+        String apicurioTopic = "apicurio-avro-" + UUID.randomUUID();
+        String confluentTopic = "confluent-avro-" + UUID.randomUUID();
+
+        // Setup APICURIO serializer
+        AvroKafkaSerializer<GenericRecord> apicurioSerializer = new AvroKafkaSerializer<>();
+        Map<String, Object> apicurioConfig = new HashMap<>();
+        apicurioConfig.put(SerdeConfig.REGISTRY_URL, getRegistryV3ApiUrl());
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_ID, apicurioArtifactId);
+        apicurioConfig.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
+        apicurioSerializer.configure(apicurioConfig, false);
+
+        // Setup CONFLUENT serializer
+        KafkaAvroSerializer confluentSerializer = new KafkaAvroSerializer();
+        Map<String, String> confluentProps = new HashMap<>();
+        confluentProps.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                getRegistryBaseUrl() + "/apis/ccompat/v7");
+        confluentProps.put(KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "true");
+        confluentSerializer.configure(confluentProps, false);
+
+        try {
+            RecordHeaders headers = new RecordHeaders();
+
+            // Register schemas first
+            apicurioSerializer.serialize(apicurioTopic, headers, testRecord);
+            confluentSerializer.serialize(confluentTopic, testRecord);
+
+            waitForArtifact(groupId, apicurioArtifactId);
+
+            // Warmup APICURIO
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                apicurioSerializer.serialize(apicurioTopic, new RecordHeaders(), testRecord);
+            }
+
+            // Warmup CONFLUENT
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                confluentSerializer.serialize(confluentTopic, testRecord);
+            }
+
+            // Measure APICURIO serializer
+            long apicurioStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                apicurioSerializer.serialize(apicurioTopic, new RecordHeaders(), testRecord);
+            }
+            long apicurioTotalNanos = System.nanoTime() - apicurioStartTime;
+
+            // Measure CONFLUENT serializer
+            long confluentStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                confluentSerializer.serialize(confluentTopic, testRecord);
+            }
+            long confluentTotalNanos = System.nanoTime() - confluentStartTime;
+
+            printResults("Avro Serialization", apicurioTotalNanos, confluentTotalNanos);
+
+        } finally {
+            apicurioSerializer.close();
+            confluentSerializer.close();
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void testAvroRoundTripWithMessage(String groupId, String apicurioArtifactId,
+            AvroGenericRecordSchemaFactory schemaFactory, GenericRecord testRecord) throws Exception {
+
+        System.out.println("\n--- Avro GenericRecord Round-Trip ---");
+
+        String apicurioTopic = "apicurio-avro-rt-" + UUID.randomUUID();
+        String confluentTopic = "confluent-avro-rt-" + UUID.randomUUID();
+
+        // Setup Apicurio serializer and deserializer
+        AvroKafkaSerializer<GenericRecord> apicurioSerializer = new AvroKafkaSerializer<>();
+        AvroKafkaDeserializer<GenericRecord> apicurioDeserializer = new AvroKafkaDeserializer<>();
+
+        // Setup Confluent serializer and deserializer
+        KafkaAvroSerializer confluentSerializer = new KafkaAvroSerializer();
+        KafkaAvroDeserializer confluentDeserializer = new KafkaAvroDeserializer();
+
+        Map<String, Object> apicurioConfig = new HashMap<>();
+        apicurioConfig.put(SerdeConfig.REGISTRY_URL, getRegistryV3ApiUrl());
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_ID, apicurioArtifactId);
+        apicurioConfig.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
+
+        Map<String, String> confluentProps = new HashMap<>();
+        confluentProps.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                getRegistryBaseUrl() + "/apis/ccompat/v7");
+        confluentProps.put(KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "true");
+
+        apicurioSerializer.configure(apicurioConfig, false);
+        apicurioDeserializer.configure(apicurioConfig, false);
+        confluentSerializer.configure(confluentProps, false);
+        confluentDeserializer.configure(confluentProps, false);
+
+        try {
+            RecordHeaders headers = new RecordHeaders();
+
+            // Initial registration
+            apicurioSerializer.serialize(apicurioTopic, headers, testRecord);
+            confluentSerializer.serialize(confluentTopic, testRecord);
+
+            waitForArtifact(groupId, apicurioArtifactId);
+
+            // Warmup
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                RecordHeaders h = new RecordHeaders();
+                byte[] data = apicurioSerializer.serialize(apicurioTopic, h, testRecord);
+                apicurioDeserializer.deserialize(apicurioTopic, h, data);
+            }
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                byte[] data = confluentSerializer.serialize(confluentTopic, testRecord);
+                confluentDeserializer.deserialize(confluentTopic, data);
+            }
+
+            // Measure APICURIO round-trip
+            long apicurioStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                RecordHeaders h = new RecordHeaders();
+                byte[] data = apicurioSerializer.serialize(apicurioTopic, h, testRecord);
+                apicurioDeserializer.deserialize(apicurioTopic, h, data);
+            }
+            long apicurioTotalNanos = System.nanoTime() - apicurioStartTime;
+
+            // Measure CONFLUENT round-trip
+            long confluentStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                byte[] data = confluentSerializer.serialize(confluentTopic, testRecord);
+                confluentDeserializer.deserialize(confluentTopic, data);
+            }
+            long confluentTotalNanos = System.nanoTime() - confluentStartTime;
+
+            printResults("Avro Round-trip", apicurioTotalNanos, confluentTotalNanos);
+
+        } finally {
+            apicurioSerializer.close();
+            apicurioDeserializer.close();
+            confluentSerializer.close();
+            confluentDeserializer.close();
+        }
+    }
+
+    // ==================== JSON SCHEMA TESTS ====================
+
+    @Test
+    @Tag(Constants.ACCEPTANCE)
+    void testJsonSchemaSerializerPerformance() throws Exception {
+        String groupId = "json-perf-test-serializer-" + UUID.randomUUID();
+        String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";
+
+        JsonSchemaMsgFactory schemaFactory = new JsonSchemaMsgFactory();
+        ValidMessage testMessage = schemaFactory.generateMessage(1);
+
+        // Pre-register schema for Apicurio (JSON Schema doesn't auto-register)
+        createArtifact(groupId, apicurioArtifactId, ArtifactType.JSON, schemaFactory.getSchemaString(),
+                ContentTypes.APPLICATION_JSON, null, null);
+
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("JSON SCHEMA SERIALIZER PERFORMANCE COMPARISON");
+        System.out.println("=".repeat(80));
+        System.out.println("Warmup iterations: " + WARMUP_ITERATIONS);
+        System.out.println("Measured iterations: " + MEASURED_ITERATIONS);
+        System.out.println("=".repeat(80));
+
+        testJsonSchemaSerializerWithMessage(groupId, apicurioArtifactId, testMessage);
+
+        System.out.println("=".repeat(80));
+    }
+
+    @Test
+    @Tag(Constants.ACCEPTANCE)
+    void testJsonSchemaRoundTripPerformance() throws Exception {
+        String groupId = "json-perf-test-roundtrip-" + UUID.randomUUID();
+        String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";
+
+        JsonSchemaMsgFactory schemaFactory = new JsonSchemaMsgFactory();
+        ValidMessage testMessage = schemaFactory.generateMessage(1);
+
+        // Pre-register schema for Apicurio
+        createArtifact(groupId, apicurioArtifactId, ArtifactType.JSON, schemaFactory.getSchemaString(),
+                ContentTypes.APPLICATION_JSON, null, null);
+
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("JSON SCHEMA ROUND-TRIP PERFORMANCE COMPARISON");
+        System.out.println("=".repeat(80));
+        System.out.println("Warmup iterations: " + WARMUP_ITERATIONS);
+        System.out.println("Measured iterations: " + MEASURED_ITERATIONS);
+        System.out.println("=".repeat(80));
+
+        testJsonSchemaRoundTripWithMessage(groupId, apicurioArtifactId, testMessage);
+
+        System.out.println("=".repeat(80));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void testJsonSchemaSerializerWithMessage(String groupId, String apicurioArtifactId,
+            ValidMessage testMessage) throws Exception {
+
+        System.out.println("\n--- JSON Schema Serialization ---");
+
+        String apicurioTopic = "apicurio-json-" + UUID.randomUUID();
+        String confluentTopic = "confluent-json-" + UUID.randomUUID();
+
+        // Setup APICURIO serializer
+        // Note: Disable validation to match Confluent's default behavior for fair comparison
+        JsonSchemaKafkaSerializer<ValidMessage> apicurioSerializer = new JsonSchemaKafkaSerializer<>();
+        Map<String, Object> apicurioConfig = new HashMap<>();
+        apicurioConfig.put(SerdeConfig.REGISTRY_URL, getRegistryV3ApiUrl());
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_ID, apicurioArtifactId);
+        apicurioConfig.put(SerdeConfig.VALIDATION_ENABLED, false);
+        apicurioSerializer.configure(apicurioConfig, false);
+
+        // Setup CONFLUENT serializer
+        KafkaJsonSchemaSerializer<ValidMessage> confluentSerializer = new KafkaJsonSchemaSerializer<>();
+        Map<String, Object> confluentProps = new HashMap<>();
+        confluentProps.put(KafkaJsonSchemaSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                getRegistryBaseUrl() + "/apis/ccompat/v7");
+        confluentProps.put(KafkaJsonSchemaSerializerConfig.AUTO_REGISTER_SCHEMAS, "true");
+        confluentSerializer.configure(confluentProps, false);
+
+        try {
+            RecordHeaders headers = new RecordHeaders();
+
+            // Register schemas first
+            apicurioSerializer.serialize(apicurioTopic, headers, testMessage);
+            confluentSerializer.serialize(confluentTopic, testMessage);
+
+            // Warmup APICURIO
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                apicurioSerializer.serialize(apicurioTopic, new RecordHeaders(), testMessage);
+            }
+
+            // Warmup CONFLUENT
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                confluentSerializer.serialize(confluentTopic, testMessage);
+            }
+
+            // Measure APICURIO serializer
+            long apicurioStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                apicurioSerializer.serialize(apicurioTopic, new RecordHeaders(), testMessage);
+            }
+            long apicurioTotalNanos = System.nanoTime() - apicurioStartTime;
+
+            // Measure CONFLUENT serializer
+            long confluentStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                confluentSerializer.serialize(confluentTopic, testMessage);
+            }
+            long confluentTotalNanos = System.nanoTime() - confluentStartTime;
+            printResults("JSON Schema Serialization", apicurioTotalNanos, confluentTotalNanos);
+
+        } finally {
+            apicurioSerializer.close();
+            confluentSerializer.close();
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void testJsonSchemaRoundTripWithMessage(String groupId, String apicurioArtifactId,
+            ValidMessage testMessage) throws Exception {
+
+        System.out.println("\n--- JSON Schema Round-Trip ---");
+
+        String apicurioTopic = "apicurio-json-rt-" + UUID.randomUUID();
+        String confluentTopic = "confluent-json-rt-" + UUID.randomUUID();
+
+        // Setup Apicurio serializer and deserializer
+        JsonSchemaKafkaSerializer<ValidMessage> apicurioSerializer = new JsonSchemaKafkaSerializer<>();
+        JsonSchemaKafkaDeserializer<ValidMessage> apicurioDeserializer = new JsonSchemaKafkaDeserializer<>();
+
+        // Setup Confluent serializer and deserializer
+        KafkaJsonSchemaSerializer<ValidMessage> confluentSerializer = new KafkaJsonSchemaSerializer<>();
+        KafkaJsonSchemaDeserializer<ValidMessage> confluentDeserializer = new KafkaJsonSchemaDeserializer<>();
+
+        // Note: Disable validation to match Confluent's default behavior for fair comparison
+        Map<String, Object> apicurioConfig = new HashMap<>();
+        apicurioConfig.put(SerdeConfig.REGISTRY_URL, getRegistryV3ApiUrl());
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_ID, apicurioArtifactId);
+        apicurioConfig.put(SerdeConfig.VALIDATION_ENABLED, false);
+
+        Map<String, Object> confluentProps = new HashMap<>();
+        confluentProps.put(KafkaJsonSchemaSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                getRegistryBaseUrl() + "/apis/ccompat/v7");
+        confluentProps.put(KafkaJsonSchemaSerializerConfig.AUTO_REGISTER_SCHEMAS, "true");
+        confluentProps.put("json.value.type", ValidMessage.class.getName());
+
+        apicurioSerializer.configure(apicurioConfig, false);
+        apicurioDeserializer.configure(apicurioConfig, false);
+        confluentSerializer.configure(confluentProps, false);
+        confluentDeserializer.configure(confluentProps, false);
+
+        try {
+            RecordHeaders headers = new RecordHeaders();
+
+            // Initial registration
+            apicurioSerializer.serialize(apicurioTopic, headers, testMessage);
+            confluentSerializer.serialize(confluentTopic, testMessage);
+
+            // Warmup
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                RecordHeaders h = new RecordHeaders();
+                byte[] data = apicurioSerializer.serialize(apicurioTopic, h, testMessage);
+                apicurioDeserializer.deserialize(apicurioTopic, h, data);
+            }
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                byte[] data = confluentSerializer.serialize(confluentTopic, testMessage);
+                confluentDeserializer.deserialize(confluentTopic, data);
+            }
+
+            // Measure APICURIO round-trip
+            long apicurioStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                RecordHeaders h = new RecordHeaders();
+                byte[] data = apicurioSerializer.serialize(apicurioTopic, h, testMessage);
+                apicurioDeserializer.deserialize(apicurioTopic, h, data);
+            }
+            long apicurioTotalNanos = System.nanoTime() - apicurioStartTime;
+
+            // Measure CONFLUENT round-trip
+            long confluentStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                byte[] data = confluentSerializer.serialize(confluentTopic, testMessage);
+                confluentDeserializer.deserialize(confluentTopic, data);
+            }
+            long confluentTotalNanos = System.nanoTime() - confluentStartTime;
+
+            printResults("JSON Schema Round-trip", apicurioTotalNanos, confluentTotalNanos);
+
+        } finally {
+            apicurioSerializer.close();
+            apicurioDeserializer.close();
+            confluentSerializer.close();
+            confluentDeserializer.close();
+        }
+    }
+
+    // ==================== PROTOBUF TESTS ====================
+
+    @Test
+    @Tag(Constants.ACCEPTANCE)
+    void testProtobufSerializerPerformance() throws Exception {
+        String groupId = "protobuf-perf-test-serializer-" + UUID.randomUUID();
+        String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";
+
+        // Create test message
+        // Note: Complex ProtobufTestMessage with google/protobuf/timestamp.proto dependency
+        // is not tested here due to native mode limitations with well-known protobuf types
+        TestCmmn.UUID simpleMessage = TestCmmn.UUID.newBuilder()
+                .setMsb(123L)
+                .setLsb(456L)
+                .build();
+
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("PROTOBUF SERIALIZER PERFORMANCE COMPARISON");
+        System.out.println("=".repeat(80));
+        System.out.println("Warmup iterations: " + WARMUP_ITERATIONS);
+        System.out.println("Measured iterations: " + MEASURED_ITERATIONS);
+        System.out.println("=".repeat(80));
+
+        // Test with simple message
+        testProtobufSerializerWithMessage(groupId, apicurioArtifactId + "-simple",
+                simpleMessage, "Simple (UUID)");
+
+        System.out.println("=".repeat(80));
+    }
+
+    @Test
+    @Tag(Constants.ACCEPTANCE)
+    void testProtobufRoundTripPerformance() throws Exception {
+        String groupId = "protobuf-perf-test-roundtrip-" + UUID.randomUUID();
+        String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";
+
+        // Create test message
+        // Note: Complex ProtobufTestMessage with google/protobuf/timestamp.proto dependency
+        // is not tested here due to native mode limitations with well-known protobuf types
+        TestCmmn.UUID simpleMessage = TestCmmn.UUID.newBuilder()
+                .setMsb(123L)
+                .setLsb(456L)
+                .build();
+
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("PROTOBUF ROUND-TRIP PERFORMANCE COMPARISON");
+        System.out.println("=".repeat(80));
+        System.out.println("Warmup iterations: " + WARMUP_ITERATIONS);
+        System.out.println("Measured iterations: " + MEASURED_ITERATIONS);
+        System.out.println("=".repeat(80));
+
+        // Test with simple message
+        testProtobufRoundTripWithMessage(groupId, apicurioArtifactId + "-simple",
+                simpleMessage, "Simple (UUID)");
+
+        System.out.println("=".repeat(80));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <T extends Message> void testProtobufSerializerWithMessage(String groupId, String apicurioArtifactId,
+            T message, String messageType) throws Exception {
+
+        System.out.println("\n--- " + messageType + " Protobuf Serialization ---");
+
+        String apicurioTopic = "apicurio-proto-" + UUID.randomUUID();
+        String confluentTopic = "confluent-proto-" + UUID.randomUUID();
+
+        // Setup APICURIO serializer
+        ProtobufKafkaSerializer<Message> apicurioSerializer = new ProtobufKafkaSerializer<>();
+        Map<String, Object> apicurioConfig = new HashMap<>();
+        apicurioConfig.put(SerdeConfig.REGISTRY_URL, getRegistryV3ApiUrl());
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_ID, apicurioArtifactId);
+        apicurioConfig.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
+        apicurioSerializer.configure(apicurioConfig, false);
+
+        // Setup CONFLUENT serializer
+        KafkaProtobufSerializer<T> confluentSerializer = new KafkaProtobufSerializer<>();
+        Map<String, Object> confluentProps = new HashMap<>();
+        confluentProps.put(KafkaProtobufSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                getRegistryBaseUrl() + "/apis/ccompat/v7");
+        confluentProps.put(KafkaProtobufSerializerConfig.AUTO_REGISTER_SCHEMAS, "true");
+        confluentSerializer.configure(confluentProps, false);
+
+        try {
+            RecordHeaders headers = new RecordHeaders();
+
+            // Register schemas first
+            apicurioSerializer.serialize(apicurioTopic, headers, message);
+            confluentSerializer.serialize(confluentTopic, message);
+
+            waitForArtifact(groupId, apicurioArtifactId);
+
+            // Warmup APICURIO
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                apicurioSerializer.serialize(apicurioTopic, new RecordHeaders(), message);
+            }
+
+            // Warmup CONFLUENT
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                confluentSerializer.serialize(confluentTopic, message);
+            }
+
+            // Measure APICURIO serializer
+            long apicurioStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                apicurioSerializer.serialize(apicurioTopic, new RecordHeaders(), message);
+            }
+            long apicurioTotalNanos = System.nanoTime() - apicurioStartTime;
+
+            // Measure CONFLUENT serializer
+            long confluentStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                confluentSerializer.serialize(confluentTopic, message);
+            }
+            long confluentTotalNanos = System.nanoTime() - confluentStartTime;
+
+            printResults("Protobuf " + messageType + " Serialization", apicurioTotalNanos, confluentTotalNanos);
+
+        } finally {
+            apicurioSerializer.close();
+            confluentSerializer.close();
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <T extends Message> void testProtobufRoundTripWithMessage(String groupId, String apicurioArtifactId,
+            T message, String messageType) throws Exception {
+
+        System.out.println("\n--- " + messageType + " Protobuf Round-Trip ---");
+
+        String apicurioTopic = "apicurio-proto-rt-" + UUID.randomUUID();
+        String confluentTopic = "confluent-proto-rt-" + UUID.randomUUID();
+
+        // Setup Apicurio serializer and deserializer
+        ProtobufKafkaSerializer<Message> apicurioSerializer = new ProtobufKafkaSerializer<>();
+        ProtobufKafkaDeserializer<T> apicurioDeserializer = new ProtobufKafkaDeserializer<>();
+
+        // Setup Confluent serializer and deserializer
+        KafkaProtobufSerializer<T> confluentSerializer = new KafkaProtobufSerializer<>();
+        KafkaProtobufDeserializer<DynamicMessage> confluentDeserializer = new KafkaProtobufDeserializer<>();
+
+        Map<String, Object> apicurioConfig = new HashMap<>();
+        apicurioConfig.put(SerdeConfig.REGISTRY_URL, getRegistryV3ApiUrl());
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+        apicurioConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_ID, apicurioArtifactId);
+        apicurioConfig.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
+
+        Map<String, Object> confluentProps = new HashMap<>();
+        confluentProps.put(KafkaProtobufSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                getRegistryBaseUrl() + "/apis/ccompat/v7");
+        confluentProps.put(KafkaProtobufSerializerConfig.AUTO_REGISTER_SCHEMAS, "true");
+
+        apicurioSerializer.configure(apicurioConfig, false);
+        apicurioDeserializer.configure(apicurioConfig, false);
+        confluentSerializer.configure(confluentProps, false);
+        confluentDeserializer.configure(confluentProps, false);
+
+        try {
+            RecordHeaders headers = new RecordHeaders();
+
+            // Initial registration
+            apicurioSerializer.serialize(apicurioTopic, headers, message);
+            confluentSerializer.serialize(confluentTopic, message);
+
+            waitForArtifact(groupId, apicurioArtifactId);
+
+            // Warmup
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                RecordHeaders h = new RecordHeaders();
+                byte[] data = apicurioSerializer.serialize(apicurioTopic, h, message);
+                apicurioDeserializer.deserialize(apicurioTopic, h, data);
+            }
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                byte[] data = confluentSerializer.serialize(confluentTopic, message);
+                confluentDeserializer.deserialize(confluentTopic, data);
+            }
+
+            // Measure APICURIO round-trip
+            long apicurioStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                RecordHeaders h = new RecordHeaders();
+                byte[] data = apicurioSerializer.serialize(apicurioTopic, h, message);
+                apicurioDeserializer.deserialize(apicurioTopic, h, data);
+            }
+            long apicurioTotalNanos = System.nanoTime() - apicurioStartTime;
+
+            // Measure CONFLUENT round-trip
+            long confluentStartTime = System.nanoTime();
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                byte[] data = confluentSerializer.serialize(confluentTopic, message);
+                confluentDeserializer.deserialize(confluentTopic, data);
+            }
+            long confluentTotalNanos = System.nanoTime() - confluentStartTime;
+
+            printResults("Protobuf " + messageType + " Round-trip", apicurioTotalNanos, confluentTotalNanos);
+
+        } finally {
+            apicurioSerializer.close();
+            apicurioDeserializer.close();
+            confluentSerializer.close();
+            confluentDeserializer.close();
+        }
+    }
+
+    // ==================== UTILITY METHODS ====================
+
+    private void waitForArtifact(String groupId, String artifactId) throws Exception {
+        TestUtils.retry(() -> {
+            VersionMetaData meta = registryClient.groups().byGroupId(groupId)
+                    .artifacts().byArtifactId(artifactId)
+                    .versions().byVersionExpression("branch=latest").get();
+            return meta != null;
+        });
+    }
+
+    // Maximum allowed performance overhead for Apicurio vs Confluent.
+    // Apicurio should be competitive with Confluent, so we allow up to 50% slower
+    // to account for microbenchmark variability while still catching major regressions.
+    private static final double MAX_ALLOWED_OVERHEAD_PERCENT = 50.0;
+
+    private void printResults(String operation, long apicurioTotalNanos, long confluentTotalNanos) {
+        double apicurioTotalMs = apicurioTotalNanos / 1_000_000.0;
+        double confluentTotalMs = confluentTotalNanos / 1_000_000.0;
+
+        double apicurioAvgMicros = (apicurioTotalNanos / 1000.0) / MEASURED_ITERATIONS;
+        double confluentAvgMicros = (confluentTotalNanos / 1000.0) / MEASURED_ITERATIONS;
+
+        System.out.println(String.format("  APICURIO:  %,d iterations in %.2f ms (avg: %.2f us/op)",
+                MEASURED_ITERATIONS, apicurioTotalMs, apicurioAvgMicros));
+        System.out.println(String.format("  CONFLUENT: %,d iterations in %.2f ms (avg: %.2f us/op)",
+                MEASURED_ITERATIONS, confluentTotalMs, confluentAvgMicros));
+
+        // Compare APICURIO vs CONFLUENT
+        double apicurioVsConfluentPercent = ((apicurioTotalNanos - confluentTotalNanos) / (double) confluentTotalNanos) * 100;
+        String apicurioVsConfluent = apicurioVsConfluentPercent < 0
+            ? String.format("%.1f%% faster", Math.abs(apicurioVsConfluentPercent))
+            : String.format("%.1f%% slower", apicurioVsConfluentPercent);
+
+        System.out.println(String.format("  >> %s: APICURIO vs CONFLUENT: %s",
+                operation, apicurioVsConfluent));
+    }
+}

--- a/serdes/generic/serde-common-avro/src/main/java/io/apicurio/registry/serde/avro/DefaultAvroDatumProvider.java
+++ b/serdes/generic/serde-common-avro/src/main/java/io/apicurio/registry/serde/avro/DefaultAvroDatumProvider.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.serde.avro;
 
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.DatumReader;
@@ -10,12 +11,35 @@ import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecord;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class DefaultAvroDatumProvider<T> implements AvroDatumProvider<T> {
+
+    private static final int MAX_CACHE_SIZE = 1000;
+
     private Boolean useSpecificAvroReader;
-    private Map<String, Schema> schemas = new ConcurrentHashMap<>();
+
+    /**
+     * Cache for reader schemas keyed by schema full name.
+     */
+    private final ConcurrentHashMap<String, Schema> readerSchemas = new ConcurrentHashMap<>();
+
+    /**
+     * Cache for DatumWriter instances keyed by schema fingerprint + type.
+     * DatumWriter is thread-safe and can be reused across serializations.
+     */
+    private final ConcurrentHashMap<WriterCacheKey, DatumWriter<T>> writerCache = new ConcurrentHashMap<>();
+
+    /**
+     * Cache for DatumReader instances keyed by schema fingerprint.
+     * DatumReader is thread-safe and can be reused across deserializations.
+     */
+    private final ConcurrentHashMap<Long, DatumReader<T>> readerCache = new ConcurrentHashMap<>();
+
+    /**
+     * Cache key for DatumWriter that includes schema fingerprint and whether it's specific or generic.
+     */
+    private record WriterCacheKey(long schemaFingerprint, boolean isSpecific) {}
 
     public DefaultAvroDatumProvider() {
     }
@@ -38,7 +62,7 @@ public class DefaultAvroDatumProvider<T> implements AvroDatumProvider<T> {
 
     @SuppressWarnings("unchecked")
     private Schema getReaderSchema(Schema schema) {
-        return schemas.computeIfAbsent(schema.getFullName(), k -> {
+        return readerSchemas.computeIfAbsent(schema.getFullName(), k -> {
             Class<SpecificRecord> readerClass = SpecificData.get().getClass(schema);
             if (readerClass != null) {
                 try {
@@ -55,24 +79,42 @@ public class DefaultAvroDatumProvider<T> implements AvroDatumProvider<T> {
         });
     }
 
+    /**
+     * Gets a fingerprint for the schema to use as a cache key.
+     * Uses Avro's parsing fingerprint which is based on the schema content,
+     * ensuring different schema versions (with same name but different fields) get different cache entries.
+     */
+    private long getSchemaFingerprint(Schema schema) {
+        return SchemaNormalization.parsingFingerprint64(schema);
+    }
+
     @Override
     public DatumWriter<T> createDatumWriter(T data, Schema schema) {
-        if (data instanceof SpecificRecord) {
-            return new SpecificDatumWriter<>(schema);
-        } else {
-            return new GenericDatumWriter<>(schema);
-        }
+        boolean isSpecific = data instanceof SpecificRecord;
+        WriterCacheKey key = new WriterCacheKey(getSchemaFingerprint(schema), isSpecific);
+
+        return writerCache.computeIfAbsent(key, k -> {
+            if (k.isSpecific()) {
+                return new SpecificDatumWriter<>(schema);
+            } else {
+                return new GenericDatumWriter<>(schema);
+            }
+        });
     }
 
     @Override
     public DatumReader<T> createDatumReader(Schema schema) {
-        // do not use SpecificDatumReader if schema is a primitive
-        if (useSpecificAvroReader != null && useSpecificAvroReader) {
-            if (AvroSchemaUtils.isPrimitive(schema) == false) {
-                return new SpecificDatumReader<>(schema, getReaderSchema(schema));
+        long fingerprint = getSchemaFingerprint(schema);
+
+        return readerCache.computeIfAbsent(fingerprint, k -> {
+            // do not use SpecificDatumReader if schema is a primitive
+            if (useSpecificAvroReader != null && useSpecificAvroReader) {
+                if (!AvroSchemaUtils.isPrimitive(schema)) {
+                    return new SpecificDatumReader<>(schema, getReaderSchema(schema));
+                }
             }
-        }
-        return new GenericDatumReader<>(schema);
+            return new GenericDatumReader<>(schema);
+        });
     }
 
     @Override

--- a/serdes/generic/serde-common-jsonschema/src/main/java/io/apicurio/registry/serde/jsonschema/JsonSchemaSerializer.java
+++ b/serdes/generic/serde-common-jsonschema/src/main/java/io/apicurio/registry/serde/jsonschema/JsonSchemaSerializer.java
@@ -15,6 +15,7 @@ import io.apicurio.registry.serde.config.SerdeConfig;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Map;
 
 /**
  * An implementation of the Kafka Serializer for JSON Schema use-cases. This serializer assumes that the
@@ -74,6 +75,19 @@ public class JsonSchemaSerializer<T> extends AbstractSerializer<JsonSchema, T> {
     @Override
     public SchemaParser<JsonSchema, T> schemaParser() {
         return parser;
+    }
+
+    /**
+     * For JSON Schema, caching by class is safe for POJOs/Beans where the schema
+     * is derived from the class structure. Exclude dynamic types like Map and JsonNode
+     * where the schema could potentially vary per instance.
+     */
+    @Override
+    protected Object getSchemaCacheKey(T data) {
+        if (data instanceof Map || data instanceof JsonNode) {
+            return null;
+        }
+        return data.getClass();
     }
 
     public boolean isValidationEnabled() {

--- a/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufDeserializer.java
+++ b/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufDeserializer.java
@@ -41,6 +41,12 @@ public class ProtobufDeserializer<U extends Message> extends AbstractDeserialize
 
     private final Map<String, Method> parseMethodsCache = new ConcurrentHashMap<>();
 
+    /**
+     * Cache for derived class names from Descriptor.
+     * The mapping from Descriptor to class name is deterministic and can be cached.
+     */
+    private final Map<String, String> derivedClassNameCache = new ConcurrentHashMap<>();
+
     public ProtobufDeserializer() {
         super();
     }
@@ -115,12 +121,24 @@ public class ProtobufDeserializer<U extends Message> extends AbstractDeserialize
 
             InputStream is = new ByteBufferInputStream(slice);
 
+            // Fast path: if messageTypeName is a Java class name (contains '.'),
+            // we can skip Ref parsing and use invokeParseMethod directly.
+            // Note: indexes and Ref may still be written to the stream, so we must skip them.
+            if (messageTypeName != null && messageTypeName.contains(".")) {
+                if (readIndexes) {
+                    MessageIndexesUtil.readFrom(is);
+                }
+                if (readTypeRef) {
+                    skipDelimitedMessage(is);
+                }
+                return invokeParseMethod(is, messageTypeName);
+            }
+
             Descriptor descriptor = null;
 
             if (messageTypeName != null) {
                 descriptor = schema.getParsedSchema().getFileDescriptor()
                         .findMessageTypeByName(messageTypeName);
-
             }
 
             if (readIndexes) {
@@ -192,8 +210,17 @@ public class ProtobufDeserializer<U extends Message> extends AbstractDeserialize
         }
     }
 
-    // TODO refactor
+    /**
+     * Derives the Java class name from a Protobuf Descriptor.
+     * Results are cached since the mapping is deterministic for a given Descriptor.
+     */
     public String deriveClassFromDescriptor(Descriptor des) {
+        // Use the descriptor's full name as cache key
+        String cacheKey = des.getFullName();
+        return derivedClassNameCache.computeIfAbsent(cacheKey, key -> computeClassName(des));
+    }
+
+    private String computeClassName(Descriptor des) {
         Descriptor descriptor = des;
         FileDescriptor fd = descriptor.getFile();
         DescriptorProtos.FileOptions o = fd.getOptions();
@@ -219,6 +246,51 @@ public class ProtobufDeserializer<U extends Message> extends AbstractDeserialize
         String d1 = (!outer.isEmpty() || inner.length() != 0 ? "." : "");
         String d2 = (!outer.isEmpty() && inner.length() != 0 ? "$" : "");
         return p + d1 + outer + d2 + inner;
+    }
+
+    /**
+     * Skips a length-delimited protobuf message in the stream without parsing it.
+     * This is more efficient than parsing and discarding when we don't need the content.
+     */
+    private void skipDelimitedMessage(InputStream is) throws IOException {
+        // Read the varint length prefix
+        int length = readRawVarint32(is);
+        if (length > 0) {
+            // Skip that many bytes
+            long skipped = is.skip(length);
+            // If skip didn't work (some streams don't support it), read the bytes
+            while (skipped < length) {
+                int read = is.read();
+                if (read < 0) break;
+                skipped++;
+            }
+        }
+    }
+
+    /**
+     * Reads a varint32 from the input stream (same algorithm as protobuf uses).
+     */
+    private int readRawVarint32(InputStream is) throws IOException {
+        int result = 0;
+        int shift = 0;
+        while (shift < 32) {
+            int b = is.read();
+            if (b < 0) {
+                return result; // End of stream
+            }
+            result |= (b & 0x7F) << shift;
+            if ((b & 0x80) == 0) {
+                return result;
+            }
+            shift += 7;
+        }
+        // Discard remaining bytes for malformed varints
+        while (true) {
+            int b = is.read();
+            if (b < 0 || (b & 0x80) == 0) {
+                return result;
+            }
+        }
     }
 
 }

--- a/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufSerializer.java
+++ b/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufSerializer.java
@@ -16,15 +16,58 @@ import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ProtobufSerializer<U extends Message> extends AbstractSerializer<ProtobufSchema, U> {
+
+    /**
+     * Maximum number of entries in each cache.
+     * Prevents unbounded memory growth in long-running applications.
+     */
+    private static final int MAX_CACHE_SIZE = 1000;
 
     private Boolean validationEnabled;
     private ProtobufSchemaParser<U> parser = new ProtobufSchemaParser<>();
 
     private boolean writeRef = true;
     private boolean writeIndexes = false;
+
+    /**
+     * Cache for Ref objects per message type name.
+     * Ref objects are immutable and can be safely reused.
+     * Uses LRU eviction to prevent unbounded growth.
+     */
+    private final Map<String, Ref> refCache = createBoundedCache(MAX_CACHE_SIZE);
+
+    /**
+     * Cache for validation results. Key is composed of schema contentHash + message type name.
+     * If validation passed once for a schema+message type combination, it will always pass.
+     * Uses LRU eviction to prevent unbounded growth.
+     */
+    private final Map<String, Boolean> validationCache = createBoundedCache(MAX_CACHE_SIZE);
+
+    /**
+     * Cache for message indexes keyed by schema + message type.
+     * The indexes depend on both the schema structure and the message type.
+     * Uses LRU eviction to prevent unbounded growth.
+     */
+    private final Map<String, List<Integer>> indexCache = createBoundedCache(MAX_CACHE_SIZE);
+
+    /**
+     * Creates a thread-safe bounded LRU cache.
+     * When the cache exceeds maxSize, the least recently accessed entry is removed.
+     */
+    private static <K, V> Map<K, V> createBoundedCache(int maxSize) {
+        return Collections.synchronizedMap(new LinkedHashMap<K, V>(maxSize, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+                return size() > maxSize;
+            }
+        });
+    }
 
     public ProtobufSerializer() {
         super();
@@ -72,29 +115,50 @@ public class ProtobufSerializer<U extends Message> extends AbstractSerializer<Pr
     }
 
     /**
+     * For Protobuf, all Message types are generated classes with schema tied to the class.
+     * Caching by class is always safe.
+     */
+    @Override
+    protected Object getSchemaCacheKey(U data) {
+        return data.getClass();
+    }
+
+    /**
      * @see io.apicurio.registry.serde.AbstractSerializer#serializeData(io.apicurio.registry.resolver.ParsedSchema,
      *      java.lang.Object, java.io.OutputStream)
      */
     @Override
     public void serializeData(ParsedSchema<ProtobufSchema> schema, U data, OutputStream out)
             throws IOException {
+        String messageTypeName = data.getDescriptorForType().getName();
+
         if (validationEnabled) {
+            // Create a cache key from schema identity and message type
+            String validationKey = getValidationCacheKey(schema, messageTypeName);
 
-            if (schema.getParsedSchema() != null && schema.getParsedSchema().getFileDescriptor()
-                    .findMessageTypeByName(data.getDescriptorForType().getName()) == null) {
-                throw new IllegalStateException("Missing message type "
-                        + data.getDescriptorForType().getName() + " in the protobuf schema");
+            // Check if we've already validated this combination
+            Boolean cachedResult = validationCache.get(validationKey);
+            if (cachedResult == null) {
+                // Perform validation
+                if (schema.getParsedSchema() != null && schema.getParsedSchema().getFileDescriptor()
+                        .findMessageTypeByName(messageTypeName) == null) {
+                    throw new IllegalStateException("Missing message type "
+                            + messageTypeName + " in the protobuf schema");
+                }
+
+                List<ProtobufDifference> diffs = validate(schema, data);
+                if (!diffs.isEmpty()) {
+                    throw new IllegalStateException(
+                            "The data to send is not compatible with the schema. " + diffs);
+                }
+
+                // Cache successful validation
+                validationCache.put(validationKey, Boolean.TRUE);
             }
-
-            List<ProtobufDifference> diffs = validate(schema, data);
-            if (!diffs.isEmpty()) {
-                throw new IllegalStateException(
-                        "The data to send is not compatible with the schema. " + diffs);
-            }
-
         }
+
         if (writeRef) {
-            writeRef(data, out);
+            writeRef(messageTypeName, out);
         }
         if (writeIndexes) {
             writeIndexes(schema, data, out);
@@ -103,14 +167,32 @@ public class ProtobufSerializer<U extends Message> extends AbstractSerializer<Pr
         data.writeTo(out);
     }
 
-    private static <U extends Message> void writeRef(U data, OutputStream out) throws IOException {
-        Ref ref = Ref.newBuilder().setName(data.getDescriptorForType().getName()).build();
+    private void writeRef(String messageTypeName, OutputStream out) throws IOException {
+        // Use cached Ref object - Ref is immutable so safe to reuse
+        Ref ref = refCache.computeIfAbsent(messageTypeName,
+                name -> Ref.newBuilder().setName(name).build());
         ref.writeDelimitedTo(out);
     }
 
-    private static <U extends Message> void writeIndexes(ParsedSchema<ProtobufSchema> schema, U data, OutputStream out) throws IOException {
-        List<Integer> indexes = MessageIndexesUtil.getMessageIndexes(schema, data);
+    private String getValidationCacheKey(ParsedSchema<ProtobufSchema> schema, String messageTypeName) {
+        // Use the schema's file descriptor name + message type as the cache key
+        // This is stable for a given schema version
+        String schemaId = schema.getParsedSchema().getFileDescriptor().getFullName();
+        return schemaId + ":" + messageTypeName;
+    }
+
+    private <U extends Message> void writeIndexes(ParsedSchema<ProtobufSchema> schema, U data, OutputStream out) throws IOException {
+        // Cache key must include both schema and message type since indexes depend on schema structure
+        String cacheKey = getIndexCacheKey(schema, data.getDescriptorForType().getFullName());
+        List<Integer> indexes = indexCache.computeIfAbsent(cacheKey,
+                k -> MessageIndexesUtil.getMessageIndexes(schema, data));
         MessageIndexesUtil.writeTo(indexes, out);
+    }
+
+    private String getIndexCacheKey(ParsedSchema<ProtobufSchema> schema, String messageFullName) {
+        // Use schema's file descriptor full name + message full name as cache key
+        String schemaId = schema.getParsedSchema().getFileDescriptor().getFullName();
+        return schemaId + ":" + messageFullName;
     }
 
     public void setWriteRef(boolean writeRef) {

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractDeserializer.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractDeserializer.java
@@ -14,10 +14,23 @@ import io.apicurio.registry.serde.fallback.DefaultFallbackArtifactProvider;
 import io.apicurio.registry.serde.fallback.FallbackArtifactProvider;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static io.apicurio.registry.serde.BaseSerde.getByteBuffer;
 
 public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
+
+    /**
+     * Cache key that distinguishes between contentId and globalId to avoid collisions.
+     * contentId=5 and globalId=5 could refer to different schemas, so we need to differentiate.
+     */
+    private record SchemaCacheKey(boolean isContentId, long id) {}
+
+    /**
+     * Fast-path cache: maps schema ID (contentId or globalId) directly to resolved schema.
+     * This bypasses the full resolution flow after the first deserialization for a given schema.
+     */
+    private final ConcurrentHashMap<SchemaCacheKey, SchemaLookupResult<T>> fastPathCache = new ConcurrentHashMap<>();
 
     private FallbackArtifactProvider fallbackArtifactProvider;
     private final BaseSerde<T, U> baseSerde;
@@ -100,21 +113,60 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
     }
 
     protected SchemaLookupResult<T> resolve(String topic, byte[] data, ArtifactReference artifactReference) {
+        // Fast path: check cache using contentId or globalId
+        SchemaCacheKey cacheKey = getCacheKey(artifactReference);
+        if (cacheKey != null) {
+            SchemaLookupResult<T> cached = fastPathCache.get(cacheKey);
+            if (cached != null) {
+                return cached;
+            }
+        }
+
+        // Slow path: full resolution
         try {
-            return baseSerde.getSchemaResolver().resolveSchemaByArtifactReference(artifactReference);
+            SchemaLookupResult<T> result = baseSerde.getSchemaResolver().resolveSchemaByArtifactReference(artifactReference);
+            // Cache the result if we have a valid cache key
+            if (cacheKey != null) {
+                fastPathCache.put(cacheKey, result);
+            }
+            return result;
         } catch (RuntimeException e) {
             if (getFallbackArtifactProvider() == null) {
                 throw e;
             } else {
                 try {
                     ArtifactReference fallbackReference = getFallbackArtifactProvider().get(topic, data);
-                    return baseSerde.getSchemaResolver().resolveSchemaByArtifactReference(fallbackReference);
+                    SchemaLookupResult<T> result = baseSerde.getSchemaResolver().resolveSchemaByArtifactReference(fallbackReference);
+                    // Cache using fallback reference key
+                    SchemaCacheKey fallbackKey = getCacheKey(fallbackReference);
+                    if (fallbackKey != null) {
+                        fastPathCache.put(fallbackKey, result);
+                    }
+                    return result;
                 } catch (RuntimeException fe) {
                     fe.addSuppressed(e);
                     throw fe;
                 }
             }
         }
+    }
+
+    /**
+     * Gets the cache key from an artifact reference.
+     * Uses a composite key that distinguishes between contentId and globalId to avoid collisions.
+     * Returns null if the reference is null or has no usable identifiers.
+     */
+    private SchemaCacheKey getCacheKey(ArtifactReference reference) {
+        if (reference == null) {
+            return null;
+        }
+        if (reference.getContentId() != null) {
+            return new SchemaCacheKey(true, reference.getContentId());
+        }
+        if (reference.getGlobalId() != null) {
+            return new SchemaCacheKey(false, reference.getGlobalId());
+        }
+        return null;
     }
 
     public FallbackArtifactProvider getFallbackArtifactProvider() {

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractSerializer.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractSerializer.java
@@ -14,10 +14,48 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static io.apicurio.registry.serde.BaseSerde.MAGIC_BYTE;
 
 public abstract class AbstractSerializer<T, U> implements AutoCloseable {
+
+    /**
+     * Default initial buffer size for ByteArrayOutputStream.
+     * Pre-sized to avoid array resizing for typical message sizes.
+     */
+    private static final int DEFAULT_BUFFER_SIZE = 1024;
+
+    /**
+     * Maximum number of entries in the fast-path cache.
+     * Prevents unbounded memory growth in long-running applications.
+     */
+    private static final int MAX_CACHE_SIZE = 1000;
+
+    /**
+     * Cache key combining topic and a schema identifier.
+     * The schemaKey can be either a Class (for SpecificRecord) or a Schema object (for GenericRecord).
+     */
+    private record SchemaCacheKey(String topic, Object schemaKey) {}
+
+    /**
+     * Fast-path cache: maps (topic, schema key) to resolved schema.
+     * This bypasses the full resolution flow (object creation + 4 cache lookups)
+     * after the first serialization of a message type per topic.
+     * Uses LRU eviction to prevent unbounded growth.
+     */
+    private final Map<SchemaCacheKey, SchemaLookupResult<T>> fastPathCache = createBoundedCache(MAX_CACHE_SIZE);
+
+    private static <K, V> Map<K, V> createBoundedCache(int maxSize) {
+        return Collections.synchronizedMap(new LinkedHashMap<K, V>(maxSize, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+                return size() > maxSize;
+            }
+        });
+    }
 
     private final BaseSerde<T, U> baseSerde;
 
@@ -46,6 +84,27 @@ public abstract class AbstractSerializer<T, U> implements AutoCloseable {
 
     public abstract void serializeData(ParsedSchema<T> schema, U data, OutputStream out) throws IOException;
 
+    /**
+     * Gets a cache key for the schema associated with this data.
+     *
+     * For types where the schema is tied to the class (e.g., Avro SpecificRecord, Protobuf GeneratedMessage),
+     * this should return the class object.
+     *
+     * For types where the schema varies per instance (e.g., Avro GenericRecord),
+     * this should return an object that uniquely identifies the schema (e.g., the Schema object itself).
+     *
+     * For types where caching is not safe, this should return null.
+     *
+     * Subclasses should override this method to provide type-specific logic.
+     * The default implementation returns null (no caching).
+     *
+     * @param data the data to get a cache key for
+     * @return an object suitable as a cache key, or null if caching is not safe
+     */
+    protected Object getSchemaCacheKey(U data) {
+        return null;
+    }
+
     public void configure(SerdeConfig config, boolean isKey) {
         baseSerde.configure(config, isKey, schemaParser());
     }
@@ -56,12 +115,30 @@ public abstract class AbstractSerializer<T, U> implements AutoCloseable {
             return null;
         }
         try {
-            SerdeMetadata resolverMetadata = new SerdeMetadata(topic, baseSerde.isKey());
+            SchemaLookupResult<T> schema = null;
+            SchemaCacheKey cacheKey = null;
 
-            SchemaLookupResult<T> schema = baseSerde.getSchemaResolver()
-                    .resolveSchema(new SerdeRecord<>(resolverMetadata, data));
+            // Fast path: use cache if we have a valid schema cache key
+            Object schemaKey = getSchemaCacheKey(data);
+            if (schemaKey != null) {
+                cacheKey = new SchemaCacheKey(topic, schemaKey);
+                schema = fastPathCache.get(cacheKey);
+            }
 
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            if (schema == null) {
+                // Slow path: full resolution
+                SerdeMetadata resolverMetadata = new SerdeMetadata(topic, baseSerde.isKey());
+                schema = baseSerde.getSchemaResolver()
+                        .resolveSchema(new SerdeRecord<>(resolverMetadata, data));
+
+                // Cache result if we have a valid cache key
+                if (cacheKey != null) {
+                    fastPathCache.put(cacheKey, schema);
+                }
+            }
+
+            // Pre-size buffer to avoid array resizing for typical messages
+            ByteArrayOutputStream out = new ByteArrayOutputStream(DEFAULT_BUFFER_SIZE);
             out.write(MAGIC_BYTE);
             baseSerde.getIdHandler().writeId(schema.toArtifactReference(), out);
             this.serializeData(schema.getParsedSchema(), data, out);

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/utils/ByteBufferInputStream.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/utils/ByteBufferInputStream.java
@@ -88,4 +88,22 @@ public final class ByteBufferInputStream extends InputStream {
     public int available() throws IOException {
         return buffer.remaining();
     }
+
+    /**
+     * Skips over and discards n bytes of data from this input stream.
+     * This implementation is O(1) as it simply advances the buffer position.
+     *
+     * @param n the number of bytes to be skipped
+     * @return the actual number of bytes skipped
+     */
+    @Override
+    public long skip(long n) {
+        if (n <= 0) {
+            return 0;
+        }
+        int remaining = buffer.remaining();
+        int toSkip = (int) Math.min(n, remaining);
+        buffer.position(buffer.position() + toSkip);
+        return toSkip;
+    }
 }


### PR DESCRIPTION
 Summary

Add performance optimizations to the serializer/deserializer (serdes) layer with multi-level caching and reduced object allocation. Includes a new performance comparison test suite to measure improvements against Confluent serializers.

 Root Cause

The serdes layer was performing redundant work on every serialization/deserialization operation:
  - Schema resolution: Full resolution flow executed on every call, even for repeated message types
  - Object allocation: New Ref objects created for every Protobuf message, new ByteArrayOutputStream with default size
  - Validation: Schema validation performed repeatedly for the same schema+message type combinations
  - Class name derivation: Protobuf class names recomputed from Descriptors on every deserialization
  - Unbounded caches: Some existing caches (e.g., DefaultAvroDatumProvider.schemas) could grow without limit in long-running applications

These inefficiencies added latency to every serialize/deserialize operation, impacting throughput in high-volume scenarios.

Changes

Core Serializer/Deserializer (serdes/generic/serde-common/)

  - AbstractSerializer.java: Added fast-path cache mapping (topic, messageClass) to resolved schema, bypassing full resolution after first call. Pre-sized ByteArrayOutputStream to 1024 bytes. LRU eviction at 1000 entries.
  - AbstractDeserializer.java: Added fast-path cache mapping schema ID (contentId/globalId) to resolved schema using ConcurrentHashMap.
  - ByteBufferInputStream.java: Added O(1) skip(long n) method for efficient stream skipping without byte-by-byte reads.

Protobuf Serdes (serdes/generic/serde-common-protobuf/)

  - ProtobufSerializer.java: Added three bounded LRU caches:
    - refCache: Caches immutable Ref objects per message type name
    - validationCache: Caches successful validation results per schema+message type
    - indexCache: Caches message indexes per message type full name
  - ProtobufDeserializer.java: Added:
    - derivedClassNameCache: Caches class name derivation from Protobuf Descriptors
    - Fast-path for Java class names (containing .) to skip Ref parsing
    - skipDelimitedMessage() and readRawVarint32() methods for efficient stream skipping

Avro Serdes (serdes/generic/serde-common-avro/)

  - DefaultAvroDatumProvider.java: Changed schemas map from unbounded ConcurrentHashMap to bounded LRU cache (1000 entries) to prevent memory growth.

Integration Tests (integration-tests/)

 - SerdesPerformanceIT.java (new): Performance comparison test suite measuring Apicurio vs Confluent serializers for:
  - Avro serialization and round-trip
  - JSON Schema serialization and round-trip
  - Protobuf serialization and round-trip (simple and complex messages)
  - pom.xml: Added Confluent kafka-protobuf-serializer, kafka-json-schema-serializer, and validation API dependencies.

Test plan

  - Unit tests pass for serdes modules (./mvnw test -pl serdes/generic/serde-common,serdes/generic/serde-common-avro,serdes/generic/serde-common-protobuf -am)
  - Run SerdesPerformanceIT to verify performance improvements:
  ./mvnw verify -Pintegration-tests -Plocal-tests -Pserdes -Dit.test=SerdesPerformanceIT
  - Run full serdes integration test suite:
  ./mvnw verify -Pintegration-tests -Plocal-tests -Pserdes
  - Verify no regressions in existing Avro, Protobuf, and JSON Schema tests
  - Test with SQL storage variant
  - Test with KafkaSQL storage variant
