### PR TITLE
Fix Javadoc generation failure caused by Lombok builder class

### DIFF
--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
@@ -234,12 +234,14 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
     public void close() throws IOException {
     }
 
-    protected void loadFromVersionCoordinates(RegistryVersionCoordinates version,
-                                              SchemaLookupResult.SchemaLookupResultBuilder<S> resultBuilder) {
-        resultBuilder.globalId(version.getGlobalId());
-        resultBuilder.contentId(version.getContentId());
-        resultBuilder.groupId(version.getGroupId());
-        resultBuilder.artifactId(version.getArtifactId());
-        resultBuilder.version(String.valueOf(version.getVersion()));
+    protected SchemaLookupResult<S> loadFromVersionCoordinates(RegistryVersionCoordinates version, ParsedSchema<S> parsedSchema) {
+        return SchemaLookupResult.<S>builder()
+                .globalId(version.getGlobalId())
+                .contentId(version.getContentId())
+                .groupId(version.getGroupId())
+                .artifactId(version.getArtifactId())
+                .version(String.valueOf(version.getVersion()))
+                .parsedSchema(parsedSchema)
+                .build();
     }
 }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
@@ -265,13 +265,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
                                 rawSchemaString) + "&" + artifactReference);
             }
 
-            SchemaLookupResult.SchemaLookupResultBuilder<S> result = SchemaLookupResult.builder();
-
-            loadFromVersionCoordinates(versions.get(0), result);
-
-            result.parsedSchema(parsedSchema);
-
-            return result.build();
+            return loadFromVersionCoordinates(versions.get(0), parsedSchema);
         });
     }
 
@@ -304,13 +298,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
             RegistryVersionCoordinates versionCoordinates = this.clientFacade.createSchema(artifactType, groupId, artifactId,
                     version, autoCreate, canonicalize, rawSchemaString, clientReferences);
 
-            SchemaLookupResult.SchemaLookupResultBuilder<S> result = SchemaLookupResult.builder();
-
-            loadFromVersionCoordinates(versionCoordinates, result);
-
-            result.parsedSchema(parsedSchema);
-
-            return result.build();
+            return loadFromVersionCoordinates(versionCoordinates, parsedSchema);
         });
     }
 
@@ -343,12 +331,8 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
         // TODO if getArtifactVersion returns the artifact version and globalid in the headers we can reduce
         // this to only one http call
 
-        SchemaLookupResult.SchemaLookupResultBuilder<S> result = SchemaLookupResult.builder();
-
         // Get the version metadata (globalId, contentId, etc)
         RegistryVersionCoordinates versionCoordinates = this.clientFacade.getVersionCoordinatesByGAV(groupId, artifactId, version);
-
-        loadFromVersionCoordinates(versionCoordinates, result);
 
         // Get the schema string (either dereferenced or not based on config)
         String schemaString = this.clientFacade.getSchemaByGlobalId(versionCoordinates.getGlobalId(), resolveDereferenced);
@@ -363,8 +347,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
         byte[] schema = schemaString.getBytes(StandardCharsets.UTF_8);
         S parsed = schemaParser.parseSchema(schema, resolvedReferences);
 
-        result.parsedSchema(new ParsedSchemaImpl<S>().setParsedSchema(parsed).setRawSchema(schema));
-
-        return result.build();
+        ParsedSchemaImpl<S> parsedSchema = new ParsedSchemaImpl<S>().setParsedSchema(parsed).setRawSchema(schema);
+        return loadFromVersionCoordinates(versionCoordinates, parsedSchema);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the Javadoc generation failure that occurs when the Lombok-generated `SchemaLookupResultBuilder` class is referenced in method signatures. Javadoc cannot resolve Lombok-generated classes during documentation generation, causing the build to fail with:

```
error: cannot find symbol
  symbol:   class SchemaLookupResultBuilder
  location: class SchemaLookupResult
```

## Changes

Refactored `AbstractSchemaResolver.loadFromVersionCoordinates()` to eliminate the Lombok builder from the method signature:

**Before:**
```java
protected void loadFromVersionCoordinates(RegistryVersionCoordinates version,
                                          SchemaLookupResult.SchemaLookupResultBuilder<S> resultBuilder) {
    resultBuilder.globalId(version.getGlobalId());
    // ...
}
```

**After:**
```java
protected SchemaLookupResult<S> loadFromVersionCoordinates(RegistryVersionCoordinates version, 
                                                            ParsedSchema<S> parsedSchema) {
    return SchemaLookupResult.<S>builder()
            .globalId(version.getGlobalId())
            // ...
            .build();
}
```

### Benefits

1. **Fixes Javadoc**: The Lombok builder class is no longer exposed in the method signature
2. **Cleaner code**: Call sites reduced from 7 lines to 1 line
3. **Better encapsulation**: Builder pattern is now an implementation detail
4. **More maintainable**: Single return statement pattern is easier to understand

### Call Site Improvements

All three call sites in `DefaultSchemaResolver` are now simplified:

**Before:**
```java
SchemaLookupResult.SchemaLookupResultBuilder<S> result = SchemaLookupResult.builder();
loadFromVersionCoordinates(versionCoordinates, result);
result.parsedSchema(parsedSchema);
return result.build();
```

**After:**
```java
return loadFromVersionCoordinates(versionCoordinates, parsedSchema);
```

## Test Plan

- [x] Verify code compiles successfully
- [ ] Verify Javadoc generation completes without errors
- [ ] Verify existing schema resolver tests pass
- [ ] Verify no behavioral changes in schema resolution logic