### PR TITLE
Fix Edit draft button visibility in readonly mode

### DIFF
--- a/ui/ui-app/src/app/pages/drafts/components/list/DraftsList.tsx
+++ b/ui/ui-app/src/app/pages/drafts/components/list/DraftsList.tsx
@@ -14,6 +14,7 @@ import { FromNow, If, ObjectDropdown } from "@apicurio/common-ui-components";
 import { DraftId } from "@app/pages/drafts/components/list/DraftId.tsx";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { DraftTypeIcon } from "@app/pages/drafts/components/DraftTypeIcon.tsx";
+import { UserService, useUserService } from "@services/useUserService.ts";
 
 export type DraftsListProps = {
     drafts: Draft[];
@@ -28,9 +29,16 @@ export type DraftsListProps = {
 export const DraftsList: FunctionComponent<DraftsListProps> = (props: DraftsListProps) => {
 
     const config: ConfigService = useConfigService();
+    const user: UserService = useUserService();
 
     const isDeleteEnabled = (): boolean => {
         return config.featureDeleteVersion() || false;
+    };
+
+    const isEditEnabled = (draft: Draft): boolean => {
+        return !config.featureReadOnly() &&
+            config.featureDraftMutability() &&
+            user.isUserDeveloper(draft.createdBy);
     };
 
     return (
@@ -102,15 +110,18 @@ export const DraftsList: FunctionComponent<DraftsListProps> = (props: DraftsList
                                         id: "edit-draft",
                                         label: "Edit draft",
                                         testId: "edit-draft-" + idx,
+                                        isVisible: () => isEditEnabled(draft),
                                         action: () => props.onEdit(draft)
                                     },
                                     {
-                                        divider: true
+                                        divider: true,
+                                        isVisible: () => isEditEnabled(draft)
                                     },
                                     {
                                         id: "finalize-draft",
                                         label: "Finalize draft",
                                         testId: "finalize-draft-" + idx,
+                                        isVisible: () => isEditEnabled(draft),
                                         action: () => props.onFinalize(draft)
                                     },
                                     {
@@ -123,6 +134,7 @@ export const DraftsList: FunctionComponent<DraftsListProps> = (props: DraftsList
                                         id: "create-new-draft",
                                         label: "Create draft from...",
                                         testId: "create-new-draft-" + idx,
+                                        isVisible: () => isEditEnabled(draft),
                                         action: () => props.onCreateDraftFrom(draft)
                                     },
                                     {

--- a/ui/ui-app/src/app/pages/search/components/versionList/SearchVersionList.tsx
+++ b/ui/ui-app/src/app/pages/search/components/versionList/SearchVersionList.tsx
@@ -6,6 +6,8 @@ import { SearchVersionName } from "@app/pages";
 import { SearchedVersion } from "@sdk/lib/generated-client/models";
 import { shash } from "@utils/string.utils.ts";
 import { ObjectDropdown } from "@apicurio/common-ui-components";
+import { ConfigService, useConfigService } from "@services/useConfigService.ts";
+import { UserService, useUserService } from "@services/useUserService.ts";
 
 /**
  * Properties
@@ -22,6 +24,8 @@ export type SearchVersionListProps = {
  * Models the list of versions.
  */
 export const SearchVersionList: FunctionComponent<SearchVersionListProps> = (props: SearchVersionListProps) => {
+    const config: ConfigService = useConfigService();
+    const user: UserService = useUserService();
 
     const description = (version: SearchedVersion): string => {
         if (version.description) {
@@ -81,7 +85,10 @@ export const SearchVersionList: FunctionComponent<SearchVersionListProps> = (pro
                                         id: "edit-version",
                                         label: "Edit draft",
                                         testId: "edit-version-" + idx,
-                                        isVisible: () => version.state === "DRAFT",
+                                        isVisible: () => !config.featureReadOnly() &&
+                                            config.featureDraftMutability() &&
+                                            version.state === "DRAFT" &&
+                                            user.isUserDeveloper(version.owner),
                                         action: () => props.onEdit(version)
                                     },
                                 ]}

--- a/ui/ui-app/src/app/pages/version/components/pageheader/VersionPageHeader.tsx
+++ b/ui/ui-app/src/app/pages/version/components/pageheader/VersionPageHeader.tsx
@@ -111,7 +111,7 @@ export const VersionPageHeader: FunctionComponent<VersionPageHeaderProps> = (pro
                             data-testid="header-btn-download" onClick={props.onDownload}>Download</Button>
                         <IfFeature feature="readOnly" isNot={true}>
                             <IfFeature feature="draftMutability" is={true}>
-                                <If condition={props.version?.state === "DRAFT"}>
+                                <If condition={props.version?.state === "DRAFT" && user.isUserDeveloper(props.artifact?.owner)}>
                                     <Button id="edit-version-button" variant="primary" icon={<PencilAltIcon />}
                                         data-testid="header-btn-edit" onClick={props.onEdit}>Edit draft</Button>
                                 </If>


### PR DESCRIPTION
## Summary

- Fixed the "Edit draft" button appearing when the UI is in readonly mode
- Added proper user permission checks to ensure only developers can see the button
- Ensured the button only appears for actual draft versions across all UI components
- Updated visibility checks in VersionPageHeader, SearchVersionList, and DraftsList components

## Related Issue

Fixes #6957

## Test Plan

- [ ] Verify "Edit draft" button is hidden when `APICURIO_UI_FEATURES_READ-ONLY_ENABLED=true`
- [ ] Verify button is hidden for users with sr-readonly role
- [ ] Verify button only appears for draft versions (not enabled/disabled versions)
- [ ] Verify button appears correctly for developers when readonly mode is disabled
- [ ] Test in version details page (VersionPageHeader)
- [ ] Test in search results (SearchVersionList)
- [ ] Test in drafts list page (DraftsList)