### PR TITLE
Fix Maven plugin autoRefs to support YAML OpenAPI files

### DIFF
--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/openapi-yaml/Owner.yaml
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/openapi-yaml/Owner.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.2
+info:
+  title: Owner Schema
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Owner:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        email:
+          type: string
+          format: email

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/openapi-yaml/Pet.yaml
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/openapi-yaml/Pet.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.2
+info:
+  title: Pet Schema
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        owner:
+          $ref: './Owner.yaml#/components/schemas/Owner'

--- a/app/src/test/resources/io/apicurio/registry/noprofile/maven/openapi-yaml/petstore-api.yaml
+++ b/app/src/test/resources/io/apicurio/registry/noprofile/maven/openapi-yaml/petstore-api.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.2
+info:
+  title: Pet Store API
+  version: 1.0.0
+  description: A simple pet store API to demonstrate YAML OpenAPI with references
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      responses:
+        '200':
+          description: An array of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: './Pet.yaml#/components/schemas/Pet'
+    post:
+      summary: Create a pet
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: './Pet.yaml#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Pet created
+  /pets/{petId}:
+    get:
+      summary: Get a pet by ID
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: './Pet.yaml#/components/schemas/Pet'


### PR DESCRIPTION
## Summary

- Fixed the Maven plugin `autoRefs` feature to support YAML OpenAPI files
- Updated `ReferenceIndex.index()` method to parse both JSON and YAML files using `ContentTypeUtil.parseJsonOrYaml()`
- Updated `ReferenceIndex.indexDataModels()` method to use `Library.readDocument()` instead of JSON-only `readDocumentFromJSONString()`
- Added test case `autoRegisterOpenApiYamlWithReferences()` to verify YAML support
- Created test YAML OpenAPI files with external references for validation

## Related Issue

Fixes #6954

## Test Plan

- [x] Run `RegistryMojoWithAutoReferencesTest.autoRegisterOpenApiYamlWithReferences()` test
- [x] Verify YAML OpenAPI files are properly indexed and registered
- [x] Verify references between YAML files are correctly resolved
- [x] Ensure existing JSON OpenAPI tests still pass
- [x] Confirm no `JsonParseException` is thrown when processing YAML files