### PR TITLE
Fix OIDC redirect to preserve deep links after authentication

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/SystemResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/SystemResourceImpl.java
@@ -92,7 +92,8 @@ public class SystemResourceImpl implements SystemResource {
         if (authConfig.isOidcAuthEnabled()) {
             Map<String, String> options = new HashMap<>();
             options.put("url", uiConfig.authOidcUrl);
-            options.put("redirectUri", uiConfig.authOidcRedirectUri);
+            // Only include redirectUri if explicitly configured
+            uiConfig.authOidcRedirectUri.ifPresent(uri -> options.put("redirectUri", uri));
             options.put("clientId", uiConfig.authOidcClientId);
             options.put("scope", uiConfig.scope);
             if (!"f5".equals(uiConfig.authOidcLogoutUrl)) {

--- a/app/src/main/java/io/apicurio/registry/ui/UserInterfaceConfigProperties.java
+++ b/app/src/main/java/io/apicurio/registry/ui/UserInterfaceConfigProperties.java
@@ -4,6 +4,8 @@ import io.apicurio.common.apps.config.Info;
 import jakarta.inject.Singleton;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import java.util.Optional;
+
 import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_UI;
 
 @Singleton
@@ -24,9 +26,9 @@ public class UserInterfaceConfigProperties {
 
     @ConfigProperty(name = "quarkus.oidc.auth-server-url", defaultValue = "_")
     public String authOidcUrl;
-    @ConfigProperty(name = "apicurio.ui.auth.oidc.redirect-uri", defaultValue = "/")
+    @ConfigProperty(name = "apicurio.ui.auth.oidc.redirect-uri")
     @Info(category = CATEGORY_UI, description = "The OIDC redirectUri", availableSince = "3.0.0")
-    public String authOidcRedirectUri;
+    public Optional<String> authOidcRedirectUri;
     @ConfigProperty(name = "apicurio.ui.auth.oidc.client-id", defaultValue = "apicurio-registry-ui")
     @Info(category = CATEGORY_UI, description = "The OIDC clientId", availableSince = "3.0.0")
     public String authOidcClientId;

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -251,7 +251,8 @@ apicurio.datasource.green.jdbc.max-size=100
 
 # UI
 apicurio.ui.auth.oidc.client-id=default_client
-apicurio.ui.auth.oidc.redirect-uri=http://localhost:8080
+# apicurio.ui.auth.oidc.redirect-uri is intentionally not set by default
+# When not configured, the UI will use the current window location for deep link support
 
 # Disable OpenAPI class scanning
 mp.openapi.scan.disable=true


### PR DESCRIPTION
## Summary

- Changed `authOidcRedirectUri` from `String` to `Optional<String>` in `UserInterfaceConfigProperties`
- Modified `SystemResourceImpl` to only include `redirectUri` in UI config when explicitly configured
- Removed default value from `application.properties` to allow UI fallback to `window.location.href`

## Related Issue

Fixes #6929

## Test Plan

- [ ] Deploy registry with OIDC enabled but without `REGISTRY_AUTH_REDIRECT_URL` set
- [ ] Open a deep link (e.g., `/explore/{group}/{artifact}/versions/{version}/documentation`)
- [ ] Authenticate via OIDC
- [ ] Verify redirect returns to the original deep link URL, not the root page
- [ ] Test with `REGISTRY_AUTH_REDIRECT_URL` explicitly set to ensure configured redirects still work