### PR TITLE
Fix inconsistent KafkaSQL SSL security property naming

### DIFF
--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -806,6 +806,31 @@ The following {registry} configuration options are available for each component 
 |
 |
 |Kafka sql storage ssl truststore type
+|`apicurio.kafkasql.security.ssl.truststore.password`
+|`optional<string>`
+|
+|`3.1.0`
+|Kafka sql storage ssl truststore password
+|`apicurio.kafkasql.security.ssl.keystore.location`
+|`optional<string>`
+|
+|`3.1.0`
+|Kafka sql storage ssl keystore location
+|`apicurio.kafkasql.security.ssl.keystore.type`
+|`optional<string>`
+|
+|`3.1.0`
+|Kafka sql storage ssl keystore type
+|`apicurio.kafkasql.security.ssl.keystore.password`
+|`optional<string>`
+|
+|`3.1.0`
+|Kafka sql storage ssl keystore password
+|`apicurio.kafkasql.security.ssl.key.password`
+|`optional<string>`
+|
+|`3.1.0`
+|Kafka sql storage ssl key password
 |`apicurio.kafkasql.snapshot.every.seconds`
 |`string`
 |`86400s`
@@ -825,27 +850,27 @@ The following {registry} configuration options are available for each component 
 |`optional<string>`
 |
 |
-|Kafka sql storage ssl key password
+|**DEPRECATED** - Use apicurio.kafkasql.security.ssl.key.password instead. This property will be removed in a future version.
 |`apicurio.kafkasql.ssl.keystore.location`
 |`optional<string>`
 |
 |
-|Kafka sql storage ssl keystore location
+|**DEPRECATED** - Use apicurio.kafkasql.security.ssl.keystore.location instead. This property will be removed in a future version.
 |`apicurio.kafkasql.ssl.keystore.password`
 |`optional<string>`
 |
 |
-|Kafka sql storage ssl keystore password
+|**DEPRECATED** - Use apicurio.kafkasql.security.ssl.keystore.password instead. This property will be removed in a future version.
 |`apicurio.kafkasql.ssl.keystore.type`
 |`optional<string>`
 |
 |
-|Kafka sql storage ssl keystore type
+|**DEPRECATED** - Use apicurio.kafkasql.security.ssl.keystore.type instead. This property will be removed in a future version.
 |`apicurio.kafkasql.ssl.truststore.password`
 |`optional<string>`
 |
 |
-|Kafka sql storage ssl truststore password
+|**DEPRECATED** - Use apicurio.kafkasql.security.ssl.truststore.password instead. This property will be removed in a future version.
 |`apicurio.kafkasql.topic`
 |`string`
 |`kafkasql-journal`


### PR DESCRIPTION
## Summary

This PR addresses the inconsistent naming of KafkaSQL SSL security configuration properties by introducing new properties with the consistent `apicurio.kafkasql.security.ssl.*` prefix while maintaining full backward compatibility.

- Added new properties with consistent `.security` prefix for all SSL configuration
- Deprecated old `apicurio.kafkasql.ssl.*` properties with `@Deprecated` annotations
- Implemented fallback logic to support both old and new property names seamlessly
- Added runtime warnings when deprecated properties are used, directing users to migrate
- Updated documentation to reflect new properties and mark deprecated ones

## Related Issue

Fixes #6398

## Changes Made

### Configuration Properties (`KafkaSqlConfiguration.java`)

**New Properties (consistent naming):**
- `apicurio.kafkasql.security.ssl.truststore.password`
- `apicurio.kafkasql.security.ssl.keystore.location`
- `apicurio.kafkasql.security.ssl.keystore.type`
- `apicurio.kafkasql.security.ssl.keystore.password`
- `apicurio.kafkasql.security.ssl.key.password`

**Deprecated Properties (still functional):**
- `apicurio.kafkasql.ssl.truststore.password` → use `apicurio.kafkasql.security.ssl.truststore.password`
- `apicurio.kafkasql.ssl.keystore.location` → use `apicurio.kafkasql.security.ssl.keystore.location`
- `apicurio.kafkasql.ssl.keystore.type` → use `apicurio.kafkasql.security.ssl.keystore.type`
- `apicurio.kafkasql.ssl.keystore.password` → use `apicurio.kafkasql.security.ssl.keystore.password`
- `apicurio.kafkasql.ssl.key.password` → use `apicurio.kafkasql.security.ssl.key.password`

### Implementation Details

1. **Backward Compatibility**: The `tryToConfigureClientSecurity()` method uses `Optional.or()` to prefer new property names while falling back to deprecated ones if needed
2. **User Warnings**: Added SLF4J logging to warn users when deprecated properties are detected, with clear migration guidance
3. **Documentation**: Updated `ref-registry-all-configs.adoc` to include new properties and mark deprecated ones

## Migration Guide

Users currently using the deprecated properties should update their configurations:

| Old Property (Deprecated) | New Property (Recommended) |
|---------------------------|----------------------------|
| `apicurio.kafkasql.ssl.truststore.password` | `apicurio.kafkasql.security.ssl.truststore.password` |
| `apicurio.kafkasql.ssl.keystore.location` | `apicurio.kafkasql.security.ssl.keystore.location` |
| `apicurio.kafkasql.ssl.keystore.type` | `apicurio.kafkasql.security.ssl.keystore.type` |
| `apicurio.kafkasql.ssl.keystore.password` | `apicurio.kafkasql.security.ssl.keystore.password` |
| `apicurio.kafkasql.ssl.key.password` | `apicurio.kafkasql.security.ssl.key.password` |

**Note:** Old properties continue to work but will be removed in a future major version.

## Test Plan

- [ ] Verify that new properties work correctly with SSL/TLS configuration
- [ ] Verify that deprecated properties still work (backward compatibility)
- [ ] Verify that fallback logic prefers new properties over deprecated ones
- [ ] Verify that deprecation warnings are logged when old properties are used
- [ ] Verify that no warnings are logged when new properties are used
- [ ] Review documentation updates for accuracy