### PR TITLE
Fix copy pastes bugs in logging and Javadoc

### DIFF
--- a/schema-util/asyncapi/src/main/java/io/apicurio/registry/content/refs/AsyncApiReferenceFinder.java
+++ b/schema-util/asyncapi/src/main/java/io/apicurio/registry/content/refs/AsyncApiReferenceFinder.java
@@ -1,7 +1,7 @@
 package io.apicurio.registry.content.refs;
 
 /**
- * OpenAPI implementation of a reference finder. Parses the OpenAPI document, finds all $refs, converts them
+ * AsyncAPI implementation of a reference finder. Parses the AsyncAPI document, finds all $refs, converts them
  * to external references, and returns them.
  */
 public class AsyncApiReferenceFinder extends AbstractDataModelsReferenceFinder {

--- a/schema-util/json/src/main/java/io/apicurio/registry/content/refs/JsonSchemaReferenceFinder.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/content/refs/JsonSchemaReferenceFinder.java
@@ -34,7 +34,7 @@ public class JsonSchemaReferenceFinder implements ReferenceFinder {
             return externalTypes.stream().map(type -> new JsonPointerExternalReference(type))
                     .filter(ref -> ref.getResource() != null).collect(Collectors.toSet());
         } catch (Exception e) {
-            log.error("Error finding external references in an Avro file.", e);
+            log.error("Error finding external references in a JSON Schema file.", e);
             return Collections.emptySet();
         }
     }


### PR DESCRIPTION
The PR closes the copy-paste bugs in the documentation reported by @carlesarnal in issue #6941. I’ve applied the suggested changes.