### PR TITLE
Upgrade apicurio-codegen-plugin to 1.2.8.Final

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -605,6 +605,7 @@
               <projectSettings>
                 <javaPackage>io.apicurio.registry.ccompat.rest.v7</javaPackage>
                 <generatesOpenApi>false</generatesOpenApi>
+                <capitalizeEnumValues>false</capitalizeEnumValues>
               </projectSettings>
               <inputSpec>${project.basedir}/src/main/resources-unfiltered/META-INF/resources/api-specifications/ccompat/v7/openapi.json</inputSpec>
             </configuration>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -100,6 +100,7 @@
               <projectSettings>
                 <javaPackage>io.apicurio.registry.rest.v3</javaPackage>
                 <generatesOpenApi>false</generatesOpenApi>
+                <capitalizeEnumValues>false</capitalizeEnumValues>
               </projectSettings>
               <inputSpec>${project.basedir}/src/main/resources/META-INF/openapi.json</inputSpec>
             </configuration>
@@ -114,6 +115,7 @@
               <projectSettings>
                 <javaPackage>io.apicurio.registry.rest.v2</javaPackage>
                 <generatesOpenApi>false</generatesOpenApi>
+                <capitalizeEnumValues>false</capitalizeEnumValues>
               </projectSettings>
               <inputSpec>${project.basedir}/src/main/resources/META-INF/openapi-v2.json</inputSpec>
             </configuration>
@@ -128,6 +130,7 @@
               <projectSettings>
                 <javaPackage>io.apicurio.registry.types.webhooks</javaPackage>
                 <generatesOpenApi>false</generatesOpenApi>
+                <capitalizeEnumValues>false</capitalizeEnumValues>
               </projectSettings>
               <inputSpec>${project.basedir}/src/main/resources/META-INF/artifact-type-webhooks.json</inputSpec>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
     <version.maven-antrun.plugin>3.1.0</version.maven-antrun.plugin>
     <version.license-maven-plugin>2.7.0</version.license-maven-plugin>
     <version.exec-maven-plugin>3.6.2</version.exec-maven-plugin>
-    <version.apicurio-codegen-plugin>1.2.6.Final</version.apicurio-codegen-plugin>
+    <version.apicurio-codegen-plugin>1.2.8.Final</version.apicurio-codegen-plugin>
     <version.gmavenplus-plugin>4.2.1</version.gmavenplus-plugin>
 
     <!-- Central-Publishing-Maven-Plugin -->


### PR DESCRIPTION
## Summary
- Upgrade apicurio-codegen-maven-plugin from version 1.2.6.Final to 1.2.8.Final
- Add `capitalizeEnumValues=false` property to all plugin executions to maintain backward compatibility with existing enum value behavior

## Changes
- Updated `version.apicurio-codegen-plugin` property in root pom.xml
- Added `capitalizeEnumValues=false` to the following executions:
  - `common/pom.xml`: generate-api-v3, generate-api-v2, generate-artifact-type-webhooks
  - `app/pom.xml`: generate-api-ccompat-v3

## Test plan
- [ ] Verify project builds successfully with the new plugin version
- [ ] Confirm generated code maintains existing enum value format
- [ ] Run existing tests to ensure no regressions