### PR TITLE
Fix StackOverflowError for self-referencing AVRO map schemas

### DIFF
--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/canon/EnhancedAvroContentCanonicalizer.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/canon/EnhancedAvroContentCanonicalizer.java
@@ -72,7 +72,7 @@ public class EnhancedAvroContentCanonicalizer implements ContentCanonicalizer {
                 result = Schema.createUnion(normalizeSchemasList(schema.getTypes(), alreadyNormalized));
                 break;
             case MAP:
-                result = Schema.createMap(normalizeSchema(schema.getValueType()));
+                result = Schema.createMap(normalizeSchema(schema.getValueType(), alreadyNormalized));
                 break;
             default:
                 result = Schema.create(schema.getType());

--- a/schema-util/avro/src/test/java/io/apicurio/registry/content/canon/SchemaNormalizerTest.java
+++ b/schema-util/avro/src/test/java/io/apicurio/registry/content/canon/SchemaNormalizerTest.java
@@ -269,6 +269,28 @@ class SchemaNormalizerTest {
                 Schema.parseJsonToObject(normalizedSchemas.get(1).getContent().content()));
     }
 
+    /**
+     * Test for issue #7023: Stackoverflow error with normalized self referencing AVRO schema.
+     * This test verifies that a self-referencing schema with a map type does not cause
+     * infinite recursion during normalization.
+     */
+    @Test
+    void parseSchema_selfReferencingMapSchema() throws Exception {
+        // given a schema that has a map field whose values reference the same type
+        final String schemaWithSelfRefMap = getSchemaFromResource("avro/simple/schema-self-ref-map.avsc");
+        assertNotNull(schemaWithSelfRefMap);
+
+        // the schema should be parsed without infinite recursion
+        EnhancedAvroContentCanonicalizer canonicalizer = new EnhancedAvroContentCanonicalizer();
+        final TypedContent parsed = canonicalizer.canonicalize(toTypedContent(schemaWithSelfRefMap),
+                new HashMap<>());
+
+        // verify the result is not null and contains the expected structure
+        assertNotNull(parsed);
+        assertNotNull(parsed.getContent());
+        assertNotNull(parsed.getContent().content());
+    }
+
     @Test
     void parseSchema_unionOfNullAndSelf() throws Exception {
         // given a schema containing a union of null and its own type

--- a/schema-util/avro/src/test/resources/avro/simple/schema-self-ref-map.avsc
+++ b/schema-util/avro/src/test/resources/avro/simple/schema-self-ref-map.avsc
@@ -1,0 +1,20 @@
+{
+  "type": "record",
+  "name": "Any",
+  "namespace": "foo.bar",
+  "doc": "Self referencing schema with map",
+  "fields": [
+    {
+      "name": "value",
+      "type": [
+        "null",
+        "string",
+        {
+          "type": "map",
+          "values": "foo.bar.Any"
+        }
+      ],
+      "doc": "Union containing null, string, and map of self-references"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Fixed missing `alreadyNormalized` parameter in MAP case of `EnhancedAvroContentCanonicalizer.normalizeSchema()`
- Added test case `parseSchema_selfReferencingMapSchema()` to verify the fix
- Created test resource `schema-self-ref-map.avsc` with self-referencing map schema example

## Related Issue

Fixes #7023

## Test Plan

- [x] Added unit test that verifies self-referencing map schemas can be normalized without causing StackOverflowError
- [x] Run existing test suite to ensure no regressions: `mvn test -pl schema-util/avro`
- [ ] Verify the fix handles the exact schema from the issue report