### PR TITLE
Fix two bugs in the reference handling functionality

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/AbstractResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/AbstractResourceImpl.java
@@ -128,7 +128,7 @@ public abstract class AbstractResourceImpl {
             return null;
         }
 
-        String path = String.format("/apis/registry/v3/groups/%s/artifacts/%s/versions/%s?references=REWRITE",
+        String path = String.format("/apis/registry/v3/groups/%s/artifacts/%s/versions/%s/content?references=REWRITE",
                 URLEncoder.encode(reference.getGroupId(), StandardCharsets.UTF_8),
                 URLEncoder.encode(reference.getArtifactId(), StandardCharsets.UTF_8),
                 URLEncoder.encode(reference.getVersion(), StandardCharsets.UTF_8));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryContentUtils.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryContentUtils.java
@@ -92,11 +92,15 @@ public class RegistryContentUtils {
                     throw new IllegalStateException("Invalid reference: " + reference);
                 } else {
                     String refName = reference.getName();
+                    JsonPointerExternalReference refPointer = new JsonPointerExternalReference(refName);
+
+                    // Use only the resource part (without JSON pointer component) when building coordinates,
+                    // then reconstruct the full reference with the component to avoid duplication
+                    String resourceOnly = refPointer.getResource() != null ? refPointer.getResource() : refName;
                     String referenceCoordinates = concatArtifactVersionCoordinatesWithRefName(
                             reference.getGroupId(), reference.getArtifactId(), reference.getVersion(),
-                            refName);
+                            resourceOnly);
 
-                    JsonPointerExternalReference refPointer = new JsonPointerExternalReference(refName);
                     JsonPointerExternalReference coordinatePointer = new JsonPointerExternalReference(
                             referenceCoordinates, refPointer.getComponent());
 
@@ -113,7 +117,7 @@ public class RegistryContentUtils {
                                         TypedContent.create(nested.getContent(), nested.getArtifactType()),
                                         nested.getArtifactType(), partialRecursivelyResolvedReferences,
                                         nested.getReferences(), loader, referencesRewrites);
-                                referencesRewrites.put(refName, referenceCoordinates);
+                                referencesRewrites.put(refName, newRefName);
                                 TypedContent rewrittenContent = typeUtilProvider.getContentDereferencer()
                                         .rewriteReferences(rewrittenContentHolder.getRewrittenContent(),
                                                 referencesRewrites);

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
@@ -1855,16 +1855,19 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/content")
                 .then().statusCode(200).body("openapi", equalTo("3.0.2"))
                 .body("paths.widgets.get.responses.200.content.json.schema.items.$ref", endsWith(
-                        "/apis/registry/v3/groups/GroupsResourceTest/artifacts/testGetArtifactVersionWithReferences%2FReferencedTypes/versions/1?references=REWRITE#/components/schemas/Widget"));
+                        "/apis/registry/v3/groups/GroupsResourceTest/artifacts/testGetArtifactVersionWithReferences%2FReferencedTypes/versions/1/content?references=REWRITE#/components/schemas/Widget"));
 
         // Get the content of the artifact inlining/dereferencing external references
+        // After DEREFERENCE, the $ref should be replaced with the actual inlined content
         given().when().pathParam("groupId", GROUP)
                 .pathParam("artifactId", "testGetArtifactVersionWithReferences/WithExternalRef")
                 .queryParam("references", "DEREFERENCE")
                 .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/content")
                 .then().statusCode(200).body("openapi", equalTo("3.0.2"))
-                .body("paths.widgets.get.responses.200.content.json.schema.items.$ref", equalTo(
-                        "GroupsResourceTest:testGetArtifactVersionWithReferences/ReferencedTypes:1:./referenced-types.json#/components/schemas/Widget"));
+                .body("paths.widgets.get.responses.200.content.json.schema.items.title", equalTo("Root Type for Widget"))
+                .body("paths.widgets.get.responses.200.content.json.schema.items.type", equalTo("object"))
+                .body("paths.widgets.get.responses.200.content.json.schema.items.properties.name.type", equalTo("string"))
+                .body("paths.widgets.get.responses.200.content.json.schema.items.properties.description.type", equalTo("string"));
     }
 
 }


### PR DESCRIPTION
   1. REWRITE URLs missing /content - The generated URLs were missing /content in the path, causing them to return version metadata instead of schema content.

   2. DEREFERENCE not inlining content for JSON pointer references - When dereferencing artifacts with references containing JSON pointers (e.g., file.json#/definitions/Type), the content was not being inlined because the JSON pointer component was being duplicated in the map key, causing lookup failures.