### PR TITLE
fix: add configurable loadUserInfo for OIDC to support Azure Entra ID

Fixes #7051

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ __pycache__
 
 # Docker/Testcontainers workarounds
 **/docker-java.properties
+
+# Generated Repository Index
+PROJECT_INDEX.md
+PROJECT_INDEX.json

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/SystemResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/SystemResourceImpl.java
@@ -101,6 +101,8 @@ public class SystemResourceImpl implements SystemResource {
             if (!"f5".equals(uiConfig.authOidcLogoutUrl)) {
                 options.put("logoutUrl", uiConfig.authOidcLogoutUrl);
             }
+            // Only include loadUserInfo if explicitly configured
+            uiConfig.loadUserInfo.ifPresent(loadUserInfo -> options.put("loadUserInfo", String.valueOf(loadUserInfo)));
             rval.setOptions(options);
         }
         return rval;

--- a/app/src/main/java/io/apicurio/registry/ui/UserInterfaceConfigProperties.java
+++ b/app/src/main/java/io/apicurio/registry/ui/UserInterfaceConfigProperties.java
@@ -50,4 +50,8 @@ public class UserInterfaceConfigProperties {
     @Info(category = CATEGORY_UI, description = "UI auth OIDC scope value", availableSince = "3.0.8")
     public String scope;
 
+    @ConfigProperty(name = "apicurio.ui.auth.oidc.load-user-info")
+    @Info(category = CATEGORY_UI, description = "Whether to load user info from the OIDC userinfo endpoint. Defaults to true if not specified. Set to false for OIDC providers like Azure Entra ID where the userinfo endpoint has incompatible audience requirements.", availableSince = "3.1.6")
+    public Optional<Boolean> loadUserInfo;
+
 }

--- a/ui/.docker-scripts/create-config.cjs
+++ b/ui/.docker-scripts/create-config.cjs
@@ -21,6 +21,7 @@ const AUTH_CLIENT_ID=process.env["REGISTRY_AUTH_CLIENT_ID"];
 const AUTH_CLIENT_SCOPES=process.env["REGISTRY_AUTH_CLIENT_SCOPES"];
 const AUTH_REDIRECT_URL=process.env["REGISTRY_AUTH_REDIRECT_URL"];
 const AUTH_LOGOUT_URL=process.env["REGISTRY_AUTH_LOGOUT_URL"];
+const AUTH_LOAD_USER_INFO=process.env["REGISTRY_AUTH_LOAD_USER_INFO"];
 const AUTH_TOKEN_TYPE=process.env["REGISTRY_AUTH_TOKEN_TYPE"];
 const AUTH_LOG_TOKENS=process.env["REGISTRY_AUTH_LOG_TOKENS"];
 
@@ -86,6 +87,9 @@ if (AUTH_TYPE === "oidc") {
     }
     if (AUTH_LOGOUT_URL) {
         CONFIG.auth.options.logoutUrl = AUTH_LOGOUT_URL;
+    }
+    if (AUTH_LOAD_USER_INFO) {
+        CONFIG.auth.options.loadUserInfo = AUTH_LOAD_USER_INFO === "true";
     }
     if (AUTH_TOKEN_TYPE) {
         CONFIG.auth.options.tokenType = AUTH_TOKEN_TYPE;

--- a/ui/ui-app/package-lock.json
+++ b/ui/ui-app/package-lock.json
@@ -13,8 +13,8 @@
         "../../typescript-sdk"
       ],
       "dependencies": {
-        "@apicurio/apicurio-registry-sdk": "3.1.5",
-        "@apicurio/common-ui-components": "2.0.15",
+        "@apicurio/apicurio-registry-sdk": "3.1.6-Dev",
+        "@apicurio/common-ui-components": "2.0.16",
         "@apicurio/data-models": "1.1.33",
         "@microsoft/kiota-abstractions": "1.0.0-preview.99",
         "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.99",
@@ -64,7 +64,7 @@
     },
     "../../typescript-sdk": {
       "name": "@apicurio/apicurio-registry-sdk",
-      "version": "3.1.5",
+      "version": "3.1.6-Dev",
       "devDependencies": {
         "@apicurio/eslint-config": "0.3.0",
         "@kiota-community/kiota-gen": "1.0.2",
@@ -102,9 +102,9 @@
       "link": true
     },
     "node_modules/@apicurio/common-ui-components": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@apicurio/common-ui-components/-/common-ui-components-2.0.15.tgz",
-      "integrity": "sha512-YhEIdv6OdWADbqjRsgSwyvCNeHtVGZY1oFlk6WD9cj5LUxjotZgiGHYDSeXmHBDeIIcolRq2kXYlik23LIStNg==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@apicurio/common-ui-components/-/common-ui-components-2.0.16.tgz",
+      "integrity": "sha512-91uZ7xdKUWHMD+vydD16738EONw8NoiU+d9WDt3D2D6VtKoHuQDQ8i5o6IyMnKyTDBVz9NxYo/ZmM9Px4px/eA==",
       "peerDependencies": {
         "@patternfly/patternfly": "~5",
         "@patternfly/react-core": "~5",

--- a/ui/ui-app/package.json
+++ b/ui/ui-app/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@apicurio/apicurio-registry-sdk": "3.1.6-Dev",
-    "@apicurio/common-ui-components": "2.0.15",
+    "@apicurio/common-ui-components": "2.0.16",
     "@apicurio/data-models": "1.1.33",
     "@microsoft/kiota-abstractions": "1.0.0-preview.99",
     "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.99",

--- a/ui/ui-app/src/services/useConfigService.ts
+++ b/ui/ui-app/src/services/useConfigService.ts
@@ -89,6 +89,7 @@ export interface OidcJsAuthOptions {
     clientId: string;
     scope: string;
     logoutUrl?: string;
+    loadUserInfo?: boolean;
 }
 
 // Used when `type=oidc`


### PR DESCRIPTION
## Summary

- Upgraded `@apicurio/common-ui-components` dependency to v2.0.16 which adds support for configurable `loadUserInfo` option
- Added new backend configuration property `apicurio.ui.auth.oidc.load-user-info` (defaults to `true` for backward compatibility)
- Updated backend REST endpoint to include `loadUserInfo` in UI configuration options
- Added Docker environment variable support: `REGISTRY_AUTH_LOAD_USER_INFO`
- Updated TypeScript interfaces to include the new `loadUserInfo` option

## Related Issue

Fixes #7051

## Changes

### Backend (Java)
- **UserInterfaceConfigProperties.java**: Added optional `loadUserInfo` configuration property with detailed documentation
- **SystemResourceImpl.java**: Modified `uiAuthConfig()` to include `loadUserInfo` in options map when explicitly configured

### Frontend (TypeScript)
- **package.json**: Upgraded `@apicurio/common-ui-components` from 2.0.15 to 2.0.16
- **useConfigService.ts**: Added optional `loadUserInfo` property to `OidcJsAuthOptions` interface

### Docker
- **create-config.cjs**: Added support for `REGISTRY_AUTH_LOAD_USER_INFO` environment variable

## Configuration

Users experiencing Azure Entra ID authentication issues can now configure:

**Using Quarkus properties:**
```properties
apicurio.ui.auth.oidc.load-user-info=false
```

**Using Docker environment variables:**
```bash
REGISTRY_AUTH_LOAD_USER_INFO=false
```

## Test Plan

- [ ] Verify backward compatibility: Without configuration, authentication should work as before (loadUserInfo defaults to true)
- [ ] Test with Azure Entra ID: Set `loadUserInfo=false` and verify authentication succeeds with app-scoped tokens
- [ ] Test with other OIDC providers: Verify Keycloak, Auth0, etc. still work correctly
- [ ] Verify Docker deployment: Test that `REGISTRY_AUTH_LOAD_USER_INFO` environment variable is properly processed
- [ ] Verify Quarkus deployment: Test that `apicurio.ui.auth.oidc.load-user-info` property is properly processed