### PR TITLE
fix: replace printStackTrace() calls with proper logging

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/AllYamlTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/AllYamlTest.java
@@ -18,11 +18,15 @@ import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 
 @QuarkusTest
 public class AllYamlTest extends AbstractResourceTestBase {
+
+    private static final Logger log = LoggerFactory.getLogger(AllYamlTest.class);
 
     private static String YAML_CONTENT = """
             openapi: 3.0.2
@@ -125,8 +129,7 @@ public class AllYamlTest extends AbstractResourceTestBase {
                     YAML_CONTENT, ContentTypes.APPLICATION_YAML);
             clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
         } catch (ProblemDetails e) {
-            System.out.println("ERROR: " + e.getDetail());
-            e.getCause().printStackTrace();
+            log.error("Failed to create YAML artifact: {}", e.getDetail(), e.getCause());
             throw e;
         }
     }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/ImportExportTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/ImportExportTest.java
@@ -30,6 +30,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -46,6 +48,8 @@ import java.util.zip.ZipFile;
 
 @QuarkusTest
 public class ImportExportTest extends AbstractResourceTestBase {
+
+    private static final Logger log = LoggerFactory.getLogger(ImportExportTest.class);
 
     @Inject
     @Current
@@ -334,17 +338,17 @@ public class ImportExportTest extends AbstractResourceTestBase {
     }
 
     private static void listFiles(File tempFile) {
-        System.out.println("--- Export ZIP File Listing ---");
+        log.debug("--- Export ZIP File Listing ---");
         try (ZipFile zipFile = new ZipFile(tempFile)) {
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
-                System.out.println(entry.getName());
+                log.debug(entry.getName());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            log.warn("Failed to list ZIP file entries", e);
         }
-        System.out.println("--- Export ZIP File Listing ---");
+        log.debug("--- Export ZIP File Listing ---");
     }
 
 }

--- a/examples/mtls-minikube/client/src/main/java/io/apicurio/registry/examples/mtls/MtlsClientDemo.java
+++ b/examples/mtls-minikube/client/src/main/java/io/apicurio/registry/examples/mtls/MtlsClientDemo.java
@@ -161,8 +161,10 @@ public class MtlsClientDemo {
             }
 
             System.err.println();
-            System.err.println("Error details:");
-            e.printStackTrace();
+            System.err.println("Error details: " + e.getMessage());
+            if (e.getCause() != null) {
+                System.err.println("Caused by: " + e.getCause().getMessage());
+            }
             System.exit(1);
         } finally {
             // Clean up Vert.x instance

--- a/examples/simple-validation/src/main/java/io/apicurio/registry/examples/simple/json/MessagePublisher.java
+++ b/examples/simple-validation/src/main/java/io/apicurio/registry/examples/simple/json/MessagePublisher.java
@@ -59,7 +59,6 @@ public class MessagePublisher {
             }
         } catch (Exception e) {
             System.err.println("Error publishing message: " + e.getMessage());
-            e.printStackTrace();
         }
     }
 

--- a/examples/simple-validation/src/main/java/io/apicurio/registry/examples/simple/json/SimpleBroker.java
+++ b/examples/simple-validation/src/main/java/io/apicurio/registry/examples/simple/json/SimpleBroker.java
@@ -57,7 +57,7 @@ public class SimpleBroker {
 
             server.start();
         } catch (Throwable tr) {
-            tr.printStackTrace();
+            System.err.println("Failed to start SimpleBroker: " + tr.getMessage());
         }
     }
 

--- a/integration-tests/src/test/java/io/apicurio/tests/auth/SimpleAuthIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/auth/SimpleAuthIT.java
@@ -157,7 +157,7 @@ public class SimpleAuthIT extends ApicurioRegistryBaseIT {
             try {
                 client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).delete();
             } catch (Exception ex) {
-                ex.printStackTrace();
+                logger.warn("Failed to delete test artifact during cleanup", ex);
             }
         }
     }
@@ -199,7 +199,7 @@ public class SimpleAuthIT extends ApicurioRegistryBaseIT {
             try {
                 client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).delete();
             } catch (Exception ex) {
-                ex.printStackTrace();
+                logger.warn("Failed to delete test artifact during cleanup", ex);
             }
         }
     }

--- a/integration-tests/src/test/java/io/apicurio/tests/migration/GenerateCanonicalHashImportIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/migration/GenerateCanonicalHashImportIT.java
@@ -22,6 +22,8 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -43,6 +45,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @Tag(Constants.MIGRATION)
 @Disabled
 public class GenerateCanonicalHashImportIT extends ApicurioRegistryBaseIT {
+
+    private static final Logger log = LoggerFactory.getLogger(GenerateCanonicalHashImportIT.class);
 
     @Test
     public void testGeneratingCanonicalHashOnImport() throws Exception {
@@ -171,7 +175,7 @@ public class GenerateCanonicalHashImportIT extends ApicurioRegistryBaseIT {
 
             return new ByteArrayInputStream(outputStream.toByteArray());
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("Failed to generate exported ZIP", e);
         }
         return null;
     }

--- a/integration-tests/src/test/java/io/apicurio/tests/migration/MigrationTestsDataInitializer.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/migration/MigrationTestsDataInitializer.java
@@ -33,12 +33,17 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.ZipOutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static io.apicurio.tests.migration.DataMigrationIT.doNotPreserveIdsImportArtifacts;
 import static io.apicurio.tests.migration.DataMigrationIT.migrateGlobalIds;
 import static io.apicurio.tests.migration.DataMigrationIT.migrateReferencesMap;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MigrationTestsDataInitializer {
+
+    private static final Logger log = LoggerFactory.getLogger(MigrationTestsDataInitializer.class);
 
     public static void initializeMigrateTest(io.apicurio.registry.rest.client.v2.RegistryClient source,
             String registryBaseUrl) throws Exception {
@@ -293,7 +298,7 @@ public class MigrationTestsDataInitializer {
 
             return new ByteArrayInputStream(outputStream.toByteArray());
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("Failed to generate exported ZIP", e);
         }
         return null;
     }

--- a/schema-resolver/pom.xml
+++ b/schema-resolver/pom.xml
@@ -32,6 +32,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/schema-util/graphql/src/main/java/io/apicurio/registry/graphql/rules/validity/GraphQLContentValidator.java
+++ b/schema-util/graphql/src/main/java/io/apicurio/registry/graphql/rules/validity/GraphQLContentValidator.java
@@ -7,6 +7,8 @@ import io.apicurio.registry.rules.validity.ContentValidator;
 import io.apicurio.registry.rules.validity.ValidityLevel;
 import io.apicurio.registry.rules.violation.RuleViolationException;
 import io.apicurio.registry.types.RuleType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -15,6 +17,8 @@ import java.util.Map;
  * A content validator implementation for the GraphQL content type.
  */
 public class GraphQLContentValidator implements ContentValidator {
+
+    private static final Logger log = LoggerFactory.getLogger(GraphQLContentValidator.class);
 
     /**
      * Constructor.
@@ -32,7 +36,7 @@ public class GraphQLContentValidator implements ContentValidator {
             try {
                 new SchemaParser().parse(content.getContent().content());
             } catch (Exception e) {
-                e.printStackTrace();
+                log.debug("GraphQL schema validation failed", e);
                 throw new RuleViolationException("Syntax violation for GraphQL artifact.", RuleType.VALIDITY,
                         level.name(), e);
             }

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/TestUtils.java
@@ -212,7 +212,7 @@ public class TestUtils {
                 onTimeout.run();
                 TimeoutException exception = new TimeoutException(
                         "Timeout after " + timeoutMs + " ms waiting for " + description);
-                exception.printStackTrace();
+                log.warn("Timeout waiting for: {}", description, exception);
                 throw exception;
             }
             long sleepTime = Math.min(pollIntervalMs, timeLeft);


### PR DESCRIPTION
## Summary
- Replace all `printStackTrace()` calls with proper SLF4J logging throughout the codebase
- Add `slf4j-api` dependency to schema-resolver module

## Root Cause
The codebase contained 18 `printStackTrace()` calls across 13 files, which is not a best practice as it outputs to stderr without proper log formatting, levels, or integration with the logging infrastructure.

## Changes
**Production code:**
- `ERCache.java`: Added SLF4J logger, replaced with `log.error()` and `log.debug()`
- `GraphQLContentValidator.java`: Added SLF4J logger, replaced with `log.debug()`
- `schema-resolver/pom.xml`: Added `slf4j-api` dependency

**Test code:**
- `SimpleAuthIT.java`: Replaced with `logger.warn()` (using base class logger)
- `MigrationTestsDataInitializer.java`: Added logger, replaced with `log.error()`
- `GenerateCanonicalHashImportIT.java`: Added logger, replaced with `log.error()`
- `ImportExportTest.java`: Added logger, replaced with `log.warn()` and `log.debug()`
- `AllYamlTest.java`: Added logger, replaced with `log.error()`
- `TestUtils.java`: Replaced with `log.warn()`

**Examples:**
- `SimpleBroker.java`: Replaced with `System.err.println()`
- `MessagePublisher.java`: Removed redundant `printStackTrace()` (message already printed)
- `MtlsClientDemo.java`: Replaced with structured error output

**Build tools:**
- `GenerateAllConfigPartial.java`: Added logger, replaced 4 calls with proper logging

## Test plan
- [x] Build compiles successfully
- [x] No remaining `printStackTrace()` calls (except auto-generated MavenWrapperDownloader.java)

Fixes #7070