### PR TITLE
[UI] Fix missing groupId filter for default group in versions 

### DIFF
--- a/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactOverviewTabContent.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactOverviewTabContent.tsx
@@ -125,7 +125,7 @@ export const ArtifactOverviewTabContent: FunctionComponent<ArtifactOverviewTabCo
         setLoading(true);
 
         const filters: SearchFilter[] = [
-            { by: FilterBy.groupId, value: props.artifact.groupId! },
+            { by: FilterBy.groupId, value: props.artifact.groupId || "default" },
             { by: FilterBy.artifactId, value: props.artifact.artifactId! }
         ];
 


### PR DESCRIPTION
## Summary

- Fixed a bug where artifact versions from all groups were displayed when viewing an artifact in the "default" group
- The issue occurred because the search versions API request was missing the groupId query parameter when the artifact's groupId was null/undefined
- Applied the same normalization pattern used throughout the codebase: `groupId || "default"`

## Related Issue

Fixes #7069

## Test Plan

- [ ] Create two artifacts with the same artifactId in different groups (e.g., "default" and "test-group")
- [ ] Add multiple versions to both artifacts
- [ ] Navigate to the "default" group artifact's versions tab
- [ ] Verify that only versions from the "default" group are displayed
- [ ] Navigate to the "test-group" artifact's versions tab
- [ ] Verify that only versions from "test-group" are displayed