### PR TITLE
docs: Use 'Apicurio Registry' naming consistently in operator docs

### DIFF
--- a/operator/docs/modules/ROOT/partials/shared/attributes.adoc
+++ b/operator/docs/modules/ROOT/partials/shared/attributes.adoc
@@ -40,9 +40,9 @@ ifdef::apicurio-registry-operator-downstream[]
 :service-registry:
 
 :org-name: Red Hat
-:prodnamefull: {org-name} Integration
-:registry-name-full: {prodnamefull} - Service Registry
-:registry: Service Registry
+:prodnamefull: {org-name} build of Apicurio Registry
+:registry-name-full: {prodnamefull}
+:registry: Apicurio Registry
 :operator: {registry} Operator
 :operator-full: {org-name} Integration - {operator}
 
@@ -53,14 +53,6 @@ ifdef::apicurio-registry-operator-downstream[]
 :cli-client: oc
 :kafka-streams: AMQ Streams
 :keycloak: {org-name} Single Sign-On
-
-
-ifdef::RHAF[]
-:prodnamefull: {org-name} Application Foundations
-:registry-name-full: {org-name} build of Apicurio Registry
-:registry: Apicurio Registry
-:operator: {registry} Operator
-endif::[]
 
 endif::[]
 


### PR DESCRIPTION
This PR updates the downstream attributes to always use "Apicurio Registry" instead of the legacy "Service Registry".
