### PR TITLE
Fix environment variable naming inconsistencies in documentation (#5983)

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-configuring-registry-security.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-configuring-registry-security.adoc
@@ -99,7 +99,7 @@ You can use the defaults for the other client settings.
 |The client ID for the {registry} REST API.
 |String
 |`registry-api`
-|`APICURIO_UI_AUTH_OIDC_CLIENT-ID`
+|`APICURIO_UI_AUTH_OIDC_CLIENT_ID`
 |The client ID for the {registry} web console.
 |String
 |`apicurio-registry`
@@ -116,7 +116,7 @@ TIP: For an example of setting environment variables on OpenShift, see xref:conf
 |Java system property
 |Type
 |Default value
-|`APICURIO_AUTH_ROLE-BASED-AUTHORIZATION`
+|`APICURIO_AUTH_ROLE_BASED_AUTHORIZATION`
 |`apicurio.auth.role-based-authorization`
 |Boolean
 |`false`
@@ -158,7 +158,7 @@ TIP: For an example of setting environment variables on OpenShift, see xref:conf
 |Java system property
 |Type
 |Default value
-|`APICURIO_AUTH_OWNER-ONLY-AUTHORIZATION_LIMIT-GROUP-ACCESS`
+|`APICURIO_AUTH_OWNER_ONLY_AUTHORIZATION_LIMIT_GROUP_ACCESS`
 |`apicurio.auth.owner-only-authorization.limit-group-access`
 |Boolean
 |`false`
@@ -226,13 +226,13 @@ IMPORTANT: You must register your {registry} application host as a *Redirect URI
 |Environment variable
 |Description
 |Setting
-|`QUARKUS_OIDC_CLIENT-ID`
+|`QUARKUS_OIDC_CLIENT_ID`
 |The client application ID for the {registry} REST API
 |Your Azure AD Application (client) ID obtained in step 5. For example: `123456a7-b8c9-012d-e3f4-5fg67h8i901`
-|`APICURIO_UI_AUTH_OIDC_CLIENT-ID`
+|`APICURIO_UI_AUTH_OIDC_CLIENT_ID`
 |The client application ID for the {registry} web console.
 |Your Azure AD Application (client) ID obtained in step 5. For example: `123456a7-b8c9-012d-e3f4-5fg67h8i901`
-|`QUARKUS_OIDC_AUTH-SERVER-URL`
+|`QUARKUS_OIDC_AUTH_SERVER_URL`
 |The URL for authentication in Azure AD.
 |Your Azure AD Application (tenant) ID obtained in step 6. For example: `\https://login.microsoftonline.com/1a2bc34d-567e-89f1-g0hi-1j2kl3m4no56/v2.0`.
 |===
@@ -245,19 +245,19 @@ IMPORTANT: You must register your {registry} application host as a *Redirect URI
 |Environment variable
 |Description
 |Setting
-|`QUARKUS_OIDC_TENANT-ENABLED`
+|`QUARKUS_OIDC_TENANT_ENABLED`
 |Enables authentication for {registry}.
 |`true`
 |`QUARKUS_HTTP_CORS_ORIGINS`
 |The host for your {registry} deployment for cross-origin resource sharing (CORS).
 |For example: `\https://test-registry.com`
-|`APICURIO_UI_AUTH_OIDC_REDIRECT-URI`
+|`APICURIO_UI_AUTH_OIDC_REDIRECT_URI`
 |The host for your {registry} web console.
 |For example: `\https://test-registry.com/ui`
-|`APICURIO_AUTH_ROLE-BASED-AUTHORIZATION`
+|`APICURIO_AUTH_ROLE_BASED_AUTHORIZATION`
 |Enables role-based authorization in {registry}.
 |`true`
-|`QUARKUS_OIDC_ROLES_ROLE-CLAIM-PATH`
+|`QUARKUS_OIDC_ROLES_ROLE_CLAIM_PATH`
 |The name of the claim in which Azure AD stores roles.
 |`roles`
 |===
@@ -329,19 +329,19 @@ You can set the following environment variables to configure authentication for 
 |Description
 |Type
 |Default
-|`QUARKUS_OIDC_TENANT-ENABLED`
+|`QUARKUS_OIDC_TENANT_ENABLED`
 |Enables authentication for {registry}. When set to `true`, the environment variables that follow are required for authentication using {keycloak}.
 |String
 |`false`
-|`QUARKUS_OIDC_AUTH-SERVER-URL`
+|`QUARKUS_OIDC_AUTH_SERVER_URL`
 |The URL of the {keycloak} authentication server. For example, `\http://localhost:8080`.
 |String
 |-
-|`QUARKUS_OIDC_CLIENT-ID`
+|`QUARKUS_OIDC_CLIENT_ID`
 |The client ID for the {registry} REST API.
 |String
 |`registry-api`
-|`APICURIO_UI_AUTH_OIDC_CLIENT-ID`
+|`APICURIO_UI_AUTH_OIDC_CLIENT_ID`
 |The client ID for the {registry} web console.
 |String
 |`apicurio-registry`
@@ -356,7 +356,7 @@ You can set the following environment variables to configure authentication for 
 |String
 |-
 
-|`APICURIO_AUTH_ROLE-BASED-AUTHORIZATION`
+|`APICURIO_AUTH_ROLE_BASED_AUTHORIZATION`
 |Enables or disables role-based authorization.
 |Boolean
 |False
@@ -376,11 +376,11 @@ By default, {registry} supports authentication by using OpenID Connect. Users or
 |Java system property
 |Type
 |Default value
-|`QUARKUS_OIDC_TENANT-ENABLED`
+|`QUARKUS_OIDC_TENANT_ENABLED`
 |`quarkus.oidc.tenant-enabled`
 |Boolean
 |`false`
-|`APICURIO_AUTHN_BASIC-CLIENT-CREDENTIALS.ENABLED`
+|`APICURIO_AUTHN_BASIC_CLIENT_CREDENTIALS_ENABLED`
 |`apicurio.authn.basic-client-credentials.enabled`
 |Boolean
 |`false`
@@ -400,7 +400,7 @@ When using {keycloak}, it is best to set this configuration to your {keycloak} J
 |Java system property
 |Type
 |Default value
-|`APICURIO_AUTHN_BASIC-CLIENT-CREDENTIALS_CACHE-EXPIRATION`
+|`APICURIO_AUTHN_BASIC_CLIENT_CREDENTIALS_CACHE_EXPIRATION`
 |`apicurio.authn.basic-client-credentials.cache-expiration`
 |Integer
 |`10`
@@ -420,11 +420,11 @@ You can set the following options to `true` to enable role-based authorization i
 |Java system property
 |Type
 |Default value
-|`QUARKUS_OIDC_TENANT-ENABLED`
+|`QUARKUS_OIDC_TENANT_ENABLED`
 |`quarkus.oidc.tenant-enabled`
 |Boolean
 |`false`
-|`APICURIO_AUTH_ROLE-BASED-AUTHORIZATION`
+|`APICURIO_AUTH_ROLE_BASED_AUTHORIZATION`
 |`apicurio.auth.role-based-authorization`
 |Boolean
 |`false`
@@ -445,7 +445,7 @@ To enable using roles assigned by {keycloak}, set the following environment vari
 |Description
 |Type
 |Default
-|`APICURIO_AUTH_ROLE-SOURCE`
+|`APICURIO_AUTH_ROLE_SOURCE`
 | When set to `token`, user roles are taken from the authentication token.
 |String
 |`token`
@@ -503,7 +503,7 @@ To enable using roles managed internally by {registry}, set the following enviro
 |Description
 |Type
 |Default
-|`APICURIO_AUTH_ROLE-SOURCE`
+|`APICURIO_AUTH_ROLE_SOURCE`
 | When set to `application`, user roles are managed internally by {registry}.
 |String
 |`token`
@@ -528,27 +528,27 @@ Because there are no default admin users in {registry}, it is usually helpful to
 |Description
 |Type
 |Default
-|`APICURIO_AUTH_ADMIN-OVERRIDE_ENABLED`
+|`APICURIO_AUTH_ADMIN_OVERRIDE_ENABLED`
 | Enables the admin-override feature.
 |String
 |`false`
-|`APICURIO_AUTH_ADMIN-OVERRIDE_FROM`
+|`APICURIO_AUTH_ADMIN_OVERRIDE_FROM`
 |Where to look for admin-override information.  Only `token` is currently supported.
 |String
 |`token`
-|`APICURIO_AUTH_ADMIN-OVERRIDE_TYPE`
+|`APICURIO_AUTH_ADMIN_OVERRIDE_TYPE`
 |The type of information used to determine if a user is an admin.  Values depend on the value of the FROM variable, for example, `role` or `claim` when FROM is `token`.
 |String
 |`role`
-|`APICURIO_AUTH_ADMIN-OVERRIDE_ROLE`
+|`APICURIO_AUTH_ADMIN_OVERRIDE_ROLE`
 |The name of the role that indicates a user is an admin.
 |String
 |`sr-admin`
-|`APICURIO_AUTH_ADMIN-OVERRIDE_CLAIM`
+|`APICURIO_AUTH_ADMIN_OVERRIDE_CLAIM`
 |The name of a JWT token claim to use for determining admin-override.
 |String
 |`org-admin`
-|`APICURIO_AUTH_ADMIN-OVERRIDE_CLAIM-VALUE`
+|`APICURIO_AUTH_ADMIN_OVERRIDE_CLAIM_VALUE`
 |The value that the JWT token claim indicated by the CLAIM variable must be for the user to be granted admin-override.
 |String
 |`true`
@@ -577,12 +577,12 @@ You can set the following options to `true` to enable owner-only authorization f
 |Boolean
 |`false`
 
-|`APICURIO_AUTH_OWNER-ONLY-AUTHORIZATION`
+|`APICURIO_AUTH_OWNER_ONLY_AUTHORIZATION`
 |`apicurio.auth.owner-only-authorization`
 |Boolean
 |`false`
 
-|`APICURIO_AUTH_OWNER-ONLY-AUTHORIZATION_LIMIT-GROUP-ACCESS`
+|`APICURIO_AUTH_OWNER_ONLY_AUTHORIZATION_LIMIT_GROUP_ACCESS`
 |`apicurio.auth.owner-only-authorization.limit-group-access`
 |Boolean
 |`false`
@@ -607,11 +607,11 @@ To enable authenticated read access, you must first enable role-based authorizat
 |Java system property
 |Type
 |Default value
-|`QUARKUS_OIDC_TENANT-ENABLED`
+|`QUARKUS_OIDC_TENANT_ENABLED`
 |`quarkus.oidc.tenant-enabled`
 |Boolean
 |`false`
-|`APICURIO_AUTH_AUTHENTICATED-READ-ACCESS_ENABLED`
+|`APICURIO_AUTH_AUTHENTICATED_READ_ACCESS_ENABLED`
 |`apicurio.auth.authenticated-read-access.enabled`
 |Boolean
 |`false`
@@ -636,11 +636,11 @@ calls to the REST API, set the following options to `true`:
 |Java system property
 |Type
 |Default value
-|`QUARKUS_OIDC_TENANT-ENABLED`
+|`QUARKUS_OIDC_TENANT_ENABLED`
 |`quarkus.oidc.tenant-enabled`
 |Boolean
 |`false`
-|`APICURIO_AUTH_ANONYMOUS-READ-ACCESS_ENABLED`
+|`APICURIO_AUTH_ANONYMOUS_READ_ACCESS_ENABLED`
 |`apicurio.auth.anonymous-read-access.enabled`
 |Boolean
 |`false`


### PR DESCRIPTION
## Summary

- Fixed environment variable naming to use underscores instead of hyphens throughout the security configuration documentation
- Corrected 21 environment variables across ~35 occurrences in `assembly-configuring-registry-security.adoc`
- Validated all corrections against source code (ConfigProperty annotations) and working examples (docker-compose files, integration tests)

## Related Issue

Fixes #5983

## Key Changes

The documentation incorrectly used hyphens in environment variable names. According to Quarkus/MicroProfile Config conventions, all hyphens and dots in property names must be converted to underscores when used as environment variables.

**Examples of corrections:**
- `APICURIO_UI_AUTH_OIDC_CLIENT-ID` → `APICURIO_UI_AUTH_OIDC_CLIENT_ID`
- `QUARKUS_OIDC_TENANT-ENABLED` → `QUARKUS_OIDC_TENANT_ENABLED`
- `APICURIO_AUTH_ROLE-BASED-AUTHORIZATION` → `APICURIO_AUTH_ROLE_BASED_AUTHORIZATION`
- `APICURIO_AUTHN_BASIC-CLIENT-CREDENTIALS.ENABLED` → `APICURIO_AUTHN_BASIC_CLIENT_CREDENTIALS_ENABLED`
- And 17 additional environment variables

## Validation Performed

- ✅ Verified against source code configuration properties in `UserInterfaceConfigProperties.java` and other config classes
- ✅ Cross-referenced with all docker-compose examples in `distro/docker-compose/`
- ✅ Validated against integration test YAML files
- ✅ Confirmed no other documentation files contain these issues

## Test Plan

- [ ] Review the diff to verify all environment variable names now use underscores consistently
- [ ] Spot-check a few corrected variables against the source code and examples to confirm correctness
- [ ] Verify the documentation renders correctly in AsciiDoc format