### PR TITLE
fix(ui): implement state-based deep linking for OIDC authentication

### DIFF
--- a/typescript-sdk/package-lock.json
+++ b/typescript-sdk/package-lock.json
@@ -199,7 +199,6 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1387,6 +1386,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1743,7 +1743,6 @@
       "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -1885,7 +1884,8 @@
     "node_modules/@std-uritemplate/std-uritemplate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-2.0.1.tgz",
-      "integrity": "sha512-HC5kiXCa7Mxrv7SI7qH4ECfC1H+vFG15COBtX8aUur8EGEWK17RH3QVyBxtyjUXE448O4fGhQHh3kirEvPGWjw=="
+      "integrity": "sha512-HC5kiXCa7Mxrv7SI7qH4ECfC1H+vFG15COBtX8aUur8EGEWK17RH3QVyBxtyjUXE448O4fGhQHh3kirEvPGWjw==",
+      "peer": true
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
@@ -1965,7 +1965,6 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1982,7 +1981,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2004,7 +2002,6 @@
       "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.52.0",
@@ -2057,7 +2054,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2533,7 +2529,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2741,7 +2736,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -3262,7 +3256,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4708,7 +4701,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4721,7 +4713,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4885,7 +4876,6 @@
       "integrity": "sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -5280,7 +5270,8 @@
     "node_modules/tinyduration": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.3.1.tgz",
-      "integrity": "sha512-39iO6CyHMFTPv9PKFxXPXa1DDc2JHog4oGK6x3fG75T+chRO+SKmuEPT00myYs3aGFIq3nQ6U5J5c5hR0PMKjw=="
+      "integrity": "sha512-39iO6CyHMFTPv9PKFxXPXa1DDc2JHog4oGK6x3fG75T+chRO+SKmuEPT00myYs3aGFIq3nQ6U5J5c5hR0PMKjw==",
+      "peer": true
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
@@ -5330,7 +5321,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5401,7 +5391,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5433,7 +5424,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5542,7 +5532,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5686,7 +5675,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/ui/build-docker.sh
+++ b/ui/build-docker.sh
@@ -5,11 +5,10 @@ then
   DOCKER_CMD="docker"
 fi
 
-if [ ! -d "dist" ]
-then
-  echo "Missing 'dist' directory.  Build first!"
-  exit 1
-fi
+npm install
+npm run clean
+npm run build
+npm run package
 
 $DOCKER_CMD build -t="apicurio/apicurio-registry-ui:latest-snapshot" --rm .
 

--- a/ui/ui-app/package-lock.json
+++ b/ui/ui-app/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "@apicurio/apicurio-registry-sdk": "3.1.7-Dev",
-        "@apicurio/common-ui-components": "2.1.0",
+        "@apicurio/common-ui-components": "2.1.1",
         "@apicurio/data-models": "1.1.33",
         "@microsoft/kiota-abstractions": "1.0.0-preview.99",
         "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.99",
@@ -102,9 +102,9 @@
       "link": true
     },
     "node_modules/@apicurio/common-ui-components": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apicurio/common-ui-components/-/common-ui-components-2.1.0.tgz",
-      "integrity": "sha512-LNbkjuc8AHBzSk6REZgoKxSsxb4qgn3i9IO/52wKodYcuKIdjD0MaUdHMy567BBNhUbMyI9rC4yyIdn4JcELiA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@apicurio/common-ui-components/-/common-ui-components-2.1.1.tgz",
+      "integrity": "sha512-V+uiYqilhpYNeFBDtx1oVHhV2c84zqlRUsTatH9aBBue0ukX5CvcrqvW0gRsAAQDoKxOXBJ6f6UDTtPtChT5Ug==",
       "peerDependencies": {
         "@patternfly/patternfly": "~5",
         "@patternfly/react-core": "~5",
@@ -974,8 +974,7 @@
     "node_modules/@patternfly/patternfly": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.4.2.tgz",
-      "integrity": "sha512-+BaokNR8/AmTYMESxby9UtQXPGACg449BXQd0KejAvW/uGxlgO6mY1X1205DeBEHoK3e/vXkYXjvZPpv/tcxSA==",
-      "peer": true
+      "integrity": "sha512-+BaokNR8/AmTYMESxby9UtQXPGACg449BXQd0KejAvW/uGxlgO6mY1X1205DeBEHoK3e/vXkYXjvZPpv/tcxSA=="
     },
     "node_modules/@patternfly/react-code-editor": {
       "version": "5.4.18",
@@ -1000,7 +999,6 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.4.14.tgz",
       "integrity": "sha512-oXVMzLs9Pa+xmdc39L2u05zbXfY3mWuOFi4GDv44GPdDexZUFy5W69+Nv5P8cwfMim55Nf5kKYpcqmatD2bBXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@patternfly/react-icons": "^5.4.2",
         "@patternfly/react-styles": "^5.4.1",
@@ -1018,7 +1016,6 @@
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.4.2.tgz",
       "integrity": "sha512-CMQ5oHYzW6TPVTs2jpNJmP2vGCAKR/YeTPwHGO9dLkAUej1IcIxtCCWK2Fdo2UJsnBjuZihasyw2b6ehvbUm9Q==",
-      "peer": true,
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
@@ -1034,7 +1031,6 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.4.16.tgz",
       "integrity": "sha512-K/xNdTvFKFyD6WhuBU/GCq/3LTrSaObdXSTmzefWWcPcN0gcf/J3ouiuapj951JIsP13CMmwJBNtEa3aHR8igg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@patternfly/react-core": "^5.4.14",
         "@patternfly/react-icons": "^5.4.2",
@@ -1649,7 +1645,6 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1672,7 +1667,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1694,7 +1688,6 @@
       "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.52.0",
@@ -1747,7 +1740,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2029,7 +2021,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2420,7 +2411,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2658,7 +2648,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3516,7 +3505,6 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
       "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3666,7 +3654,6 @@
       "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.4.1.tgz",
       "integrity": "sha512-jNdst/U28Iasukx/L5MP6b274Vr7ftQs6qAhPBCvz6Wt5rPCA+Q/tUmCzfCHHWweWw5szeMy2Gfrm1rITwUKrw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "jwt-decode": "^4.0.0"
       },
@@ -3918,7 +3905,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3930,7 +3916,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3980,7 +3965,6 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
       "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.23.2",
         "react-router": "6.30.3"
@@ -4374,7 +4358,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4461,7 +4444,6 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4499,7 +4481,6 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
       "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
-      "peer": true,
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1"
       },
@@ -4529,7 +4510,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4642,7 +4622,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4720,7 +4699,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/ui/ui-app/package.json
+++ b/ui/ui-app/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@apicurio/apicurio-registry-sdk": "3.1.7-Dev",
-    "@apicurio/common-ui-components": "2.1.0",
+    "@apicurio/common-ui-components": "2.1.1",
     "@apicurio/data-models": "1.1.33",
     "@microsoft/kiota-abstractions": "1.0.0-preview.99",
     "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.99",

--- a/ui/ui-app/src/app/App.css
+++ b/ui/ui-app/src/app/App.css
@@ -2,17 +2,6 @@
   --myApp-global--spacer--md: 30px;
 }
 
-.app-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: var(--myApp-global--spacer--md);
-}
-
-.notification-container {
-  flex: 0 1 auto;
-}
-
 .pf-c-page {
   width: 100%;
   height: 100vh;

--- a/ui/ui-app/src/app/App.tsx
+++ b/ui/ui-app/src/app/App.tsx
@@ -3,27 +3,10 @@ import "@patternfly/patternfly/patternfly.css";
 import "@patternfly/patternfly/patternfly-addons.css";
 
 import { FunctionComponent } from "react";
-import { Page } from "@patternfly/react-core";
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
-import { AppHeader } from "@app/components";
-import {
-    ArtifactPage,
-    BranchPage,
-    DashboardPage,
-    DraftsPage,
-    EditorPage,
-    ExplorePage,
-    GroupPage,
-    NotFoundPage,
-    RootRedirectPage,
-    RulesPage,
-    SearchPage,
-    VersionPage
-} from "@app/pages";
-import { RolesPage, SettingsPage } from "./pages";
+import { BrowserRouter as Router } from "react-router-dom";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { LoggerService, useLoggerService } from "@services/useLoggerService.ts";
-import { ApplicationAuth, AuthConfig, AuthConfigContext } from "@apicurio/common-ui-components";
+import { MainPageWithAuth } from "@app/MainPageWithAuth.tsx";
 
 export type AppProps = object;
 
@@ -37,99 +20,9 @@ export const App: FunctionComponent<AppProps> = () => {
     const contextPath: string | undefined = config.uiContextPath();
     logger.info("[App] Using app contextPath: ", contextPath);
 
-    const authConfig: AuthConfig = {
-        type: config.authType() as "none" | "oidc",
-        options: config.authOptions()
-    };
-    if (authConfig.type === "oidc") {
-        // Only set redirectUri as fallback if not already configured
-        if (!authConfig.options.redirectUri && window.location?.href) {
-            authConfig.options.redirectUri = window.location.href;
-        } else if (authConfig.options.redirectUri && authConfig.options.redirectUri.startsWith("/")) {
-            authConfig.options.redirectUri = window.location.origin + authConfig.options.redirectUri;
-        }
-        if (authConfig.options.logoutUrl && authConfig.options.logoutUrl.startsWith("/")) {
-            authConfig.options.logoutUrl = window.location.origin + authConfig.options.logoutUrl;
-        }
-    }
-
     return (
-        <AuthConfigContext.Provider value={authConfig}>
-            <ApplicationAuth>
-                <Router basename={contextPath}>
-                    <Page
-                        className="pf-m-redhat-font"
-                        isManagedSidebar={false}
-                        header={<AppHeader />}
-                    >
-                        <Routes>
-                            <Route path="/" element={ <RootRedirectPage /> } />
-                            <Route path="/dashboard" element={ <DashboardPage /> } />
-                            <Route path="/rules" element={ <RulesPage /> } />
-                            <Route path="/roles" element={ <RolesPage /> } />
-                            <Route path="/settings" element={ <SettingsPage /> } />
-                            <Route path="/search" element={ <SearchPage /> } />
-                            <Route path="/drafts" element={ <DraftsPage /> } />
-                            <Route path="/explore" element={ <ExplorePage /> } />
-
-                            <Route
-                                path="/explore/:groupId"
-                                element={ <GroupPage /> }
-                            />
-                            <Route
-                                path="/explore/:groupId/rules"
-                                element={ <GroupPage /> }
-                            />
-
-                            <Route
-                                path="/explore/:groupId/:artifactId"
-                                element={ <ArtifactPage /> }
-                            />
-                            <Route
-                                path="/explore/:groupId/:artifactId/rules"
-                                element={ <ArtifactPage /> }
-                            />
-                            <Route
-                                path="/explore/:groupId/:artifactId/branches"
-                                element={ <ArtifactPage /> }
-                            />
-
-                            <Route
-                                path="/explore/:groupId/:artifactId/versions/:version"
-                                element={ <VersionPage /> }
-                            />
-                            <Route
-                                path="/explore/:groupId/:artifactId/versions/:version/:editor"
-                                element={ <EditorPage /> }
-                            />
-                            <Route
-                                path="/explore/:groupId/:artifactId/versions/:version/content"
-                                element={ <VersionPage /> }
-                            />
-                            <Route
-                                path="/explore/:groupId/:artifactId/versions/:version/documentation"
-                                element={ <VersionPage /> }
-                            />
-                            <Route
-                                path="/explore/:groupId/:artifactId/versions/:version/references"
-                                element={ <VersionPage /> }
-                            />
-
-                            <Route
-                                path="/explore/:groupId/:artifactId/branches/:branchId"
-                                element={ <BranchPage /> }
-                            />
-                            <Route
-                                path="/explore/:groupId/:artifactId/branches/:branchId/versions"
-                                element={ <BranchPage /> }
-                            />
-
-
-                            <Route element={ <NotFoundPage /> } />
-                        </Routes>
-                    </Page>
-                </Router>
-            </ApplicationAuth>
-        </AuthConfigContext.Provider>
+        <Router basename={contextPath}>
+            <MainPageWithAuth />
+        </Router>
     );
 };

--- a/ui/ui-app/src/app/MainPageWithAuth.tsx
+++ b/ui/ui-app/src/app/MainPageWithAuth.tsx
@@ -1,0 +1,130 @@
+import { FunctionComponent } from "react";
+import { Page } from "@patternfly/react-core";
+import { AppHeader } from "@app/components";
+import { Route, Routes } from "react-router-dom";
+import {
+    ArtifactPage,
+    BranchPage,
+    DashboardPage,
+    DraftsPage,
+    EditorPage,
+    ExplorePage,
+    GroupPage,
+    NotFoundPage,
+    RootRedirectPage,
+    RulesPage,
+    SearchPage,
+    VersionPage
+} from "@app/pages";
+import { RolesPage, SettingsPage } from "./pages";
+import { ConfigService, useConfigService } from "@services/useConfigService.ts";
+import { ApplicationAuth, AuthConfig, AuthConfigContext } from "@apicurio/common-ui-components";
+import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
+
+export type MainPageWithAuthProps = object;
+
+/**
+ * The main application class.
+ */
+export const MainPageWithAuth: FunctionComponent<MainPageWithAuthProps> = () => {
+    const config: ConfigService = useConfigService();
+    const appNav: AppNavigation = useAppNavigation();
+
+    const authConfig: AuthConfig = {
+        type: config.authType() as "none" | "oidc",
+        options: config.authOptions()
+    };
+    if (authConfig.type === "oidc") {
+        // Only set redirectUri as fallback if not already configured
+        if (!authConfig.options.redirectUri && window.location?.href) {
+            authConfig.options.redirectUri = window.location.href;
+        } else if (authConfig.options.redirectUri && authConfig.options.redirectUri.startsWith("/")) {
+            authConfig.options.redirectUri = window.location.origin + authConfig.options.redirectUri;
+        }
+        if (authConfig.options.logoutUrl && authConfig.options.logoutUrl.startsWith("/")) {
+            authConfig.options.logoutUrl = window.location.origin + authConfig.options.logoutUrl;
+        }
+    }
+    authConfig.options.onRedirect = (location: string) => {
+        console.info("[MainPageWithAuth] Login success, routing to: ", location);
+        appNav.navigateTo(location);
+    };
+
+    return (
+        <AuthConfigContext.Provider value={authConfig}>
+            <ApplicationAuth>
+                <Page
+                    className="pf-m-redhat-font"
+                    isManagedSidebar={false}
+                    header={<AppHeader />}
+                >
+                    <Routes>
+                        <Route path="/" element={ <RootRedirectPage /> } />
+                        <Route path="/dashboard" element={ <DashboardPage /> } />
+                        <Route path="/rules" element={ <RulesPage /> } />
+                        <Route path="/roles" element={ <RolesPage /> } />
+                        <Route path="/settings" element={ <SettingsPage /> } />
+                        <Route path="/search" element={ <SearchPage /> } />
+                        <Route path="/drafts" element={ <DraftsPage /> } />
+                        <Route path="/explore" element={ <ExplorePage /> } />
+
+                        <Route
+                            path="/explore/:groupId"
+                            element={ <GroupPage /> }
+                        />
+                        <Route
+                            path="/explore/:groupId/rules"
+                            element={ <GroupPage /> }
+                        />
+
+                        <Route
+                            path="/explore/:groupId/:artifactId"
+                            element={ <ArtifactPage /> }
+                        />
+                        <Route
+                            path="/explore/:groupId/:artifactId/rules"
+                            element={ <ArtifactPage /> }
+                        />
+                        <Route
+                            path="/explore/:groupId/:artifactId/branches"
+                            element={ <ArtifactPage /> }
+                        />
+
+                        <Route
+                            path="/explore/:groupId/:artifactId/versions/:version"
+                            element={ <VersionPage /> }
+                        />
+                        <Route
+                            path="/explore/:groupId/:artifactId/versions/:version/:editor"
+                            element={ <EditorPage /> }
+                        />
+                        <Route
+                            path="/explore/:groupId/:artifactId/versions/:version/content"
+                            element={ <VersionPage /> }
+                        />
+                        <Route
+                            path="/explore/:groupId/:artifactId/versions/:version/documentation"
+                            element={ <VersionPage /> }
+                        />
+                        <Route
+                            path="/explore/:groupId/:artifactId/versions/:version/references"
+                            element={ <VersionPage /> }
+                        />
+
+                        <Route
+                            path="/explore/:groupId/:artifactId/branches/:branchId"
+                            element={ <BranchPage /> }
+                        />
+                        <Route
+                            path="/explore/:groupId/:artifactId/branches/:branchId/versions"
+                            element={ <BranchPage /> }
+                        />
+
+
+                        <Route element={ <NotFoundPage /> } />
+                    </Routes>
+                </Page>
+            </ApplicationAuth>
+        </AuthConfigContext.Provider>
+    );
+};

--- a/ui/ui-docs/package-lock.json
+++ b/ui/ui-docs/package-lock.json
@@ -1401,7 +1401,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1436,7 +1435,6 @@
       "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.52.0",
@@ -1489,7 +1487,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -1739,7 +1736,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1975,7 +1971,6 @@
       "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -2153,7 +2148,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2984,7 +2978,6 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -3487,7 +3480,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3499,7 +3491,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3856,7 +3847,6 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.2.0.tgz",
       "integrity": "sha512-ryFCkETE++8jlrBmC+BoGPUN96ld1/Yp0s7t5bcXDobrs4XoXroY1tN+JbFi09hV6a5h3MzbcVi8/BGDP0eCgQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",
@@ -4007,7 +3997,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4099,7 +4088,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4142,7 +4130,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4255,7 +4242,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4320,7 +4306,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/ui/ui-editors/package-lock.json
+++ b/ui/ui-editors/package-lock.json
@@ -311,6 +311,24 @@
                 }
             }
         },
+        "node_modules/@angular-devkit/architect/node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@angular-devkit/architect/node_modules/picomatch": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -331,6 +349,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 14.18.0"
             },
@@ -837,6 +856,24 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/@angular-devkit/schematics/node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@angular-devkit/schematics/node_modules/is-interactive": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -947,6 +984,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 14.18.0"
             },
@@ -986,7 +1024,6 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-18.2.14.tgz",
             "integrity": "sha512-Kp/MWShoYYO+R3lrrZbZgszbbLGVXHB+39mdJZwnIuZMDkeL3JsIBlSOzyJRTnpS1vITc+9jgHvP/6uKbMrW1Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1121,6 +1158,24 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/@angular/cli/node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@angular/cli/node_modules/cliui": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -1162,7 +1217,6 @@
             "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cli-truncate": "^4.0.0",
                 "colorette": "^2.0.20",
@@ -1221,6 +1275,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 14.18.0"
             },
@@ -1319,7 +1374,6 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.14.tgz",
             "integrity": "sha512-ZPRswzaVRiqcfZoowuAM22Hr2/z10ajWOUoFDoQ9tWqz/fH/773kJv2F9VvePIekgNPCzaizqv9gF6tGNqaAwg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1336,7 +1390,6 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.14.tgz",
             "integrity": "sha512-Mpq3v/mztQzGAQAAFV+wAI1hlXxZ0m8eDBgaN2kD3Ue+r4S6bLm1Vlryw0iyUnt05PcFIdxPT6xkcphq5pl6lw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1358,7 +1411,6 @@
             "integrity": "sha512-BmmjyrFSBSYkm0tBSqpu4cwnJX/b/XvhM36mj2k8jah3tNS5zLDDx5w6tyHmaPJa/1D95MlXx2h6u7K9D+Mhew==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "7.25.2",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -1417,7 +1469,6 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.14.tgz",
             "integrity": "sha512-BIPrCs93ZZTY9ym7yfoTgAQ5rs706yoYeAdrgc8kh/bDbM9DawxKlgeKBx2FLt09Y0YQ1bFhKVp0cV4gDEaMxQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1434,7 +1485,6 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-18.2.14.tgz",
             "integrity": "sha512-fZVwXctmBJa5VdopJae/T9MYKPXNd04+6j4k/6X819y+9fiyWLJt2QicSc5Rc+YD9mmhXag3xaljlrnotf9VGA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1453,7 +1503,6 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.14.tgz",
             "integrity": "sha512-W+JTxI25su3RiZVZT3Yrw6KNUCmOIy7OZIZ+612skPgYK2f2qil7VclnW1oCwG896h50cMJU/lnAfxZxefQgyQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1557,7 +1606,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
             "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.24.7",
@@ -5401,7 +5449,6 @@
             "version": "6.3.12",
             "resolved": "https://registry.npmjs.org/@ngx-formly/core/-/core-6.3.12.tgz",
             "integrity": "sha512-88MOfn9dM1B33t04jl8x0Glh0Ed0lUKMkhYajicRH7ZHTmwIdla1SQjiblp2C+EcCFvsY7XAU2/JUZQdl56aUw==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.0.0"
             },
@@ -5894,6 +5941,24 @@
                 }
             }
         },
+        "node_modules/@schematics/angular/node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@schematics/angular/node_modules/picomatch": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -5914,6 +5979,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 14.18.0"
             },
@@ -6467,7 +6533,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
             "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
@@ -6778,7 +6843,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
             "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -6848,7 +6912,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -7313,7 +7376,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@popperjs/core": "^2.11.8"
             }
@@ -7399,7 +7461,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001688",
                 "electron-to-chromium": "^1.5.73",
@@ -7661,7 +7722,6 @@
             "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -7912,7 +7972,6 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
             "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^1.9.0"
             },
@@ -7933,15 +7992,13 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/codelyzer/node_modules/zone.js": {
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.10.3.tgz",
             "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -10342,8 +10399,7 @@
         "node_modules/jquery": {
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-            "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
-            "peer": true
+            "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
         },
         "node_modules/jquery-match-height": {
             "version": "0.7.2",
@@ -10467,7 +10523,6 @@
             "resolved": "https://registry.npmjs.org/less/-/less-4.2.0.tgz",
             "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "copy-anything": "^2.0.1",
                 "parse-node-version": "^1.0.1",
@@ -12295,7 +12350,6 @@
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
             "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -12400,7 +12454,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.1",
@@ -13135,7 +13188,6 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
             "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -13171,7 +13223,6 @@
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
             "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -14146,7 +14197,6 @@
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.6.tgz",
             "integrity": "sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.8.2",
@@ -14331,8 +14381,7 @@
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "peer": true
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/tslint": {
             "version": "6.1.3",
@@ -14340,7 +14389,6 @@
             "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
             "deprecated": "TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "builtin-modules": "^1.1.1",
@@ -14597,7 +14645,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
             "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -14812,7 +14859,6 @@
             "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -15370,7 +15416,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
             "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.5",
                 "@webassemblyjs/ast": "^1.12.1",
@@ -15448,7 +15493,6 @@
             "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.13",
                 "@types/connect-history-api-fallback": "^1.5.4",
@@ -15588,7 +15632,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -15914,7 +15957,6 @@
             "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -15932,8 +15974,7 @@
         "node_modules/zone.js": {
             "version": "0.14.10",
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.10.tgz",
-            "integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==",
-            "peer": true
+            "integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ=="
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes deep linking issues with OIDC authentication, particularly for Microsoft Entra ID, by implementing state-based navigation instead of relying on IDP redirect URIs.

## Changes

- Updated `@apicurio/common-ui-components` from 2.1.0 to 2.1.1
- Refactored `App.tsx` to separate authentication and routing concerns
- Created new `MainPageWithAuth` component that uses the `onRedirect` callback from the common-ui-components library
- Removed unused CSS styles from `App.css`
- Updated `build-docker.sh` to include npm build steps

## Background

Microsoft Entra ID does not allow wildcard redirect URIs, which prevents deep linking to pages within the Apicurio UI. The solution leverages work done in [apicurio-common-ui-components#228](https://github.com/Apicurio/apicurio-common-ui-components/issues/228), which adds support for state-based deep linking by:

1. Storing the user's current location before authentication
2. Using a custom state parameter in the OIDC authentication request
3. Implementing a custom redirect handler that navigates to the original location after successful login

This allows the application to use a single, fixed redirect URI while still supporting deep linking to any page in the application.

## Test Plan

- [x] Verify authentication works with OIDC providers
- [ ] Verify deep linking to various pages works after authentication with Entra ID
- [x] Verify existing authentication flows remain functional

Fixes #6364