### PR TITLE
Fallback Id handler to handle migration from 8-byte ids to 4-byte schema ids

### DIFF
--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractDeserializer.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractDeserializer.java
@@ -94,7 +94,8 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
 
         SchemaLookupResult<T> schema = resolve(topic, data, artifactReference);
 
-        int length = buffer.limit() - 1 - baseSerde.getIdHandler().idSize();
+        // Could this be replaced by buffer.limit() - buffer.position(); ?
+        int length = buffer.limit() - 1 - baseSerde.getIdHandler().idSize(artifactReference, buffer);
         int start = buffer.position() + buffer.arrayOffset();
 
         return readData(schema.getParsedSchema(), buffer, start, length);

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/Default4ByteIdHandler.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/Default4ByteIdHandler.java
@@ -15,7 +15,7 @@ import java.util.Map;
 public class Default4ByteIdHandler implements IdHandler {
     static final int idSize = 4; // e.g. Confluent uses 4 / int
 
-    private IdOption idOption = IdOption.contentId;
+    protected IdOption idOption = IdOption.contentId;
 
     /**
      * @see io.apicurio.registry.serde.IdHandler#configure(java.util.Map, boolean)
@@ -69,7 +69,7 @@ public class Default4ByteIdHandler implements IdHandler {
     }
 
     /**
-     * @see io.apicurio.registry.serde.IdHandler#idSize()
+     * @see io.apicurio.registry.serde.IdHandler#idSize(ArtifactReference, ByteBuffer)
      */
     @Override
     public int idSize() {

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/IdHandler.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/IdHandler.java
@@ -22,4 +22,8 @@ public interface IdHandler {
     ArtifactReference readId(ByteBuffer buffer);
 
     int idSize();
+
+    default int idSize(ArtifactReference reference, ByteBuffer buffer) {
+        return idSize();
+    }
 }

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/OptimisticFallbackIdHandler.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/OptimisticFallbackIdHandler.java
@@ -1,0 +1,50 @@
+package io.apicurio.registry.serde;
+
+import io.apicurio.registry.resolver.strategy.ArtifactReference;
+import io.apicurio.registry.serde.config.IdOption;
+
+import java.nio.ByteBuffer;
+
+/**
+ * IdHandler that tries to read a 4-byte ID, but if it sees all zeros in those 4 bytes,
+ * it assumes it was actually an 8-byte ID and reads the full 8 bytes.
+ * <p>
+ * This handler is optimistic in that it makes the following assumptions on schema IDs (global or content):
+ * <ul>
+ *     <li>Schema IDs are strictly positive (non-zero)</li>
+ *     <li>Schema IDs are less than or equal to the max value of a signed 4-byte integer</li>
+ * </ul>
+ * <p>
+ * This is useful during a migration from Apicurio Registry v2 to v3,
+ * deserializing data that may have been written by either a 4-byte (default) or 8-byte (legacy) ID handler.
+ */
+public class OptimisticFallbackIdHandler extends Default4ByteIdHandler {
+
+    @Override
+    public ArtifactReference readId(ByteBuffer buffer) {
+        // Peek at the first 4 bytes
+        int firstFour = buffer.getInt();
+
+        // If we see 0 and there's enough room, we assume it was an 8-byte write
+        if (firstFour == 0 && buffer.remaining() >= 4) {
+            buffer.position(buffer.position() - 4);
+            if (idOption == IdOption.globalId) {
+                return ArtifactReference.builder().globalId(buffer.getLong()).build();
+            } else {
+                return ArtifactReference.builder().contentId(buffer.getLong()).build();
+            }
+        }
+
+        // Otherwise, the first 4 bytes were the ID
+        if (idOption == IdOption.globalId) {
+            return ArtifactReference.builder().globalId((long) firstFour).build();
+        } else {
+            return ArtifactReference.builder().contentId((long) firstFour).build();
+        }
+    }
+
+    @Override
+    public int idSize(ArtifactReference reference, ByteBuffer buffer) {
+        return buffer.position() - 1;
+    }
+}

--- a/serdes/generic/serde-common/src/test/java/io/apicurio/registry/serde/OptimisticFallbackIdHandlerTest.java
+++ b/serdes/generic/serde-common/src/test/java/io/apicurio/registry/serde/OptimisticFallbackIdHandlerTest.java
@@ -1,0 +1,92 @@
+package io.apicurio.registry.serde;
+
+import io.apicurio.registry.resolver.strategy.ArtifactReference;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OptimisticFallbackIdHandlerTest {
+
+    private OptimisticFallbackIdHandler handler;
+
+    @BeforeEach
+    public void setup() {
+        handler = new OptimisticFallbackIdHandler();
+        Map<String, Object> configs = new HashMap<>();
+        // Configure to use Global ID for these tests
+        configs.put("apicurio.registry.use-id", "globalId");
+        handler.configure(configs, false);
+    }
+
+    @Test
+    public void testReadNew4ByteId() {
+        // GIVEN: A 4-byte ID written (1234)
+        int idValue = 1234;
+        ByteBuffer buffer = ByteBuffer.allocate(4);
+        buffer.putInt(idValue);
+        buffer.flip();
+
+        // WHEN: Reading the ID
+        ArtifactReference ref = handler.readId(buffer);
+
+        // THEN: Position should be at the end, and ID should match
+        Assertions.assertEquals(idValue, ref.getGlobalId());
+        Assertions.assertEquals(4, buffer.position(), "Should have consumed 4 bytes");
+    }
+
+    @Test
+    public void testReadLegacy8ByteSmallId() {
+        // GIVEN: An 8-byte legacy ID (1234) -> [0,0,0,0, 0,0,4,D2]
+        long idValue = 1234L;
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+        buffer.putLong(idValue);
+        buffer.flip();
+
+        // WHEN: Reading the ID
+        ArtifactReference ref = handler.readId(buffer);
+
+        // THEN: Should detect the zeros and consume all 8 bytes
+        Assertions.assertEquals(idValue, ref.getGlobalId());
+        Assertions.assertEquals(8, buffer.position(), "Should have consumed all 8 bytes of legacy format");
+    }
+
+    @Test
+    public void testReadLegacy8ByteLargeId() {
+        // GIVEN: A legacy ID larger than Integer.MAX_VALUE
+        // This tests the branch where firstFour != 0
+        long largeId = Integer.MAX_VALUE + 100L;
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+        buffer.putLong(largeId);
+        buffer.flip();
+
+        // WHEN: Reading the ID
+        ArtifactReference ref = handler.readId(buffer);
+
+        // THEN: It should still read correctly because buffer.getLong(pos-4)
+        // effectively captures the full 8 bytes starting from the beginning.
+        Assertions.assertEquals(largeId, ref.getGlobalId());
+        Assertions.assertEquals(8, buffer.position());
+    }
+
+    @Test
+    public void testDynamicIdSize() {
+        // GIVEN: A small ID
+        ByteBuffer smallId = ByteBuffer.allocate(5).put((byte) 0x00).putInt(500).flip();
+        smallId.get();
+        smallId.getInt();
+        ArtifactReference smallRef = ArtifactReference.builder().globalId(500L).build();
+        // GIVEN: A large ID
+        ByteBuffer largeId = ByteBuffer.allocate(9).put((byte) 0x00).putLong(3000000000L).flip();
+        largeId.get();
+        largeId.getLong();
+        ArtifactReference largeRef = ArtifactReference.builder().globalId(3000000000L).build();
+
+        // THEN: Sizes should vary (Note: This assumes your SPI supports this method)
+        Assertions.assertEquals(4, handler.idSize(smallRef, smallId));
+        Assertions.assertEquals(8, handler.idSize(largeRef, largeId));
+    }
+}

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/json/CompactFormatStrategy.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/json/CompactFormatStrategy.java
@@ -26,7 +26,8 @@ public class CompactFormatStrategy implements FormatStrategy {
 
     @Override
     public byte[] fromConnectData(long contentId, byte[] bytes) {
-        ByteBuffer buffer = ByteBuffer.allocate(1 + idHandler.idSize() + bytes.length);
+        ArtifactReference ref = ArtifactReference.fromContentId(contentId);
+        ByteBuffer buffer = ByteBuffer.allocate(1 + idHandler.idSize(ref, ByteBuffer.wrap(bytes)) + bytes.length);
         buffer.put(BaseSerde.MAGIC_BYTE);
         idHandler.writeId(ArtifactReference.fromContentId(contentId), buffer);
         buffer.put(bytes);
@@ -38,7 +39,7 @@ public class CompactFormatStrategy implements FormatStrategy {
         ByteBuffer buffer = BaseSerde.getByteBuffer(bytes);
         ArtifactReference reference = idHandler.readId(buffer);
         long contentId = reference.getContentId();
-        byte[] payload = new byte[bytes.length - idHandler.idSize() - 1];
+        byte[] payload = new byte[bytes.length - idHandler.idSize(reference, buffer) - 1];
         buffer.get(payload);
         return new IdPayload(contentId, payload);
     }


### PR DESCRIPTION
During the testing of https://github.com/quarkusio/quarkus/pull/51401, we realised that the migration to v3 involves handling the change of schema ids from using 8-bytes to 4-bytes. 

While there are distinct IdHandler implementations available to the client application to use, there isn't any easy migration path to use with message processing applications producing/consuming on topics (eg. Kafka).

The problem of an active topic is explained here : https://github.com/quarkusio/quarkus/pull/51401#issuecomment-3718501645

This change proposes an `OptimisticFallbackIdHandler` to write 4-byte ids and read both 4 and 8 byte ids to be used in a migration scenario. 

Because the payload format doesn't include any format versionning, this IdHandler makes the following assumption to distinguish between 4-bytes 8-bytes ids: The schema ids are greater than 0 and smaller than integer max value.

The change requires some non-breaking modifications to `AbstractDeserializer`, and maybe to the `IdHandler` interface that can be discussed.

Additionally, I couldn't figure out what to do for the Go SDK.