### PR TITLE
Fix app JAR locations in prod-verifier (due to Quarkus version change)

### DIFF
--- a/prod-verifier/pom.xml
+++ b/prod-verifier/pom.xml
@@ -49,7 +49,8 @@
             <phase>package</phase>
             <configuration>
               <directories>
-                <param>${projectRoot}/app/target/lib</param>
+                <param>${projectRoot}/app/target/quarkus-app/lib/boot</param>
+                <param>${projectRoot}/app/target/quarkus-app/lib/main</param>
                 <param>${projectRoot}/operator/controller/target/quarkus-app/lib/boot</param>
                 <param>${projectRoot}/operator/controller/target/quarkus-app/lib/main</param>
               </directories>


### PR DESCRIPTION
Updated the "app" directories that the prod verifier checks for .jar files.  The location in "target" where the .jar files live has changed recently with an upgrade to Quarkus.