### PR TITLE
chore(deps): migrate from wiremock-jre8 to wiremock v3.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
     <keycloak.testcontainers.version>3.9.1</keycloak.testcontainers.version>
     <embedded-postgres.version>2.2.0</embedded-postgres.version>
     <strimzi.version>0.105.0</strimzi.version>
-    <wiremock-jre8.version>3.0.1</wiremock-jre8.version>
+    <wiremock.version>3.13.2</wiremock.version>
     <strimzi-test-container.version>0.113.0</strimzi-test-container.version>
   </properties>
 
@@ -932,9 +932,9 @@
         <version>${keycloak.testcontainers.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
-        <version>${wiremock-jre8.version}</version>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock</artifactId>
+        <version>${wiremock.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.truth.extensions</groupId>

--- a/utils/maven-plugin/pom.xml
+++ b/utils/maven-plugin/pom.xml
@@ -100,8 +100,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/utils/tests/pom.xml
+++ b/utils/tests/pom.xml
@@ -104,8 +104,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Summary
- Migrate from deprecated `wiremock-jre8` to the official `wiremock` artifact
- Update WireMock version from 3.0.1 to 3.13.2
- Update groupId from `com.github.tomakehurst` to `org.wiremock`

## Changes
- Updated root pom.xml dependency management
- Updated utils/maven-plugin/pom.xml
- Updated utils/tests/pom.xml

## Test plan
- Build the project to ensure all modules compile correctly
- Run existing tests that use WireMock to verify compatibility
- Verify no API breaking changes between wiremock-jre8 and wiremock

🤖 Generated with [Claude Code](https://claude.com/claude-code)