### PR TITLE
Fix OTEL environment variable naming and update documentation

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -61,7 +61,7 @@ quarkus.otel.traces.enabled=false
 quarkus.otel.traces.sampler=parentbased_traceidratio
 quarkus.otel.traces.sampler.arg=0.1
 
-# Metrics Configuratio (via OpenTelemetry)
+# Metrics Configuration (via OpenTelemetry)
 quarkus.otel.metrics.enabled=false
 
 # Logging Configuration

--- a/distro/docker-compose/in-memory-with-observability/README.md
+++ b/distro/docker-compose/in-memory-with-observability/README.md
@@ -58,21 +58,25 @@ Grafana is pre-configured with Prometheus and Jaeger datasources:
 
 ### Environment Variables
 
+Apicurio Registry is built with OpenTelemetry support, but individual telemetry signals are disabled by default. Use these environment variables to enable and configure them:
+
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `QUARKUS_OTEL_ENABLED` | Enable/disable OpenTelemetry | `true` |
-| `QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint | `http://jaeger:4317` |
-| `QUARKUS_OTEL_TRACES_SAMPLER` | Sampling strategy | `parentbased_always_on` |
-| `QUARKUS_OTEL_TRACES_SAMPLER_ARG` | Sampler ratio (for traceidratio) | `1.0` |
-| `QUARKUS_OTEL_METRICS_ENABLED` | Enable metrics via OTel | `true` |
-| `QUARKUS_LOG_CONSOLE_JSON` | Enable JSON logging with trace context | `true` |
+| `QUARKUS_OTEL_TRACES_ENABLED` | Enable distributed tracing | `false` |
+| `QUARKUS_OTEL_METRICS_ENABLED` | Enable metrics export via OTLP | `false` |
+| `QUARKUS_OTEL_LOGS_ENABLED` | Enable log export via OTLP | `false` |
+| `QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint | `http://localhost:4317` |
+| `QUARKUS_OTEL_TRACES_SAMPLER` | Sampling strategy | `parentbased_traceidratio` |
+| `QUARKUS_OTEL_TRACES_SAMPLER_ARG` | Sampler ratio (0.0 to 1.0) | `0.1` |
+| `QUARKUS_LOG_CONSOLE_JSON` | Enable JSON logging with trace context | `false` |
 
 ### Production Recommendations
 
 For production deployments:
 
-1. Use sampling to reduce trace volume:
+1. Enable only the signals you need and use sampling to reduce trace volume:
    ```yaml
+   QUARKUS_OTEL_TRACES_ENABLED: "true"
    QUARKUS_OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
    QUARKUS_OTEL_TRACES_SAMPLER_ARG: "0.1"  # 10% sampling
    ```

--- a/distro/docker-compose/in-memory-with-observability/docker-compose.yml
+++ b/distro/docker-compose/in-memory-with-observability/docker-compose.yml
@@ -15,12 +15,12 @@ services:
       apicurio.rest.deletion.artifact-version.enabled: "true"
       QUARKUS_HTTP_CORS_ORIGINS: "*"
       # OpenTelemetry Configuration
-      QUARKUS_OTEL_ENABLED: "true"
+      QUARKUS_OTEL_TRACES_ENABLED: "true"
+      QUARKUS_OTEL_METRICS_ENABLED: "true"
+      QUARKUS_OTEL_LOGS_ENABLED: "false"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger:4317"
       QUARKUS_OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
       QUARKUS_OTEL_TRACES_SAMPLER: "parentbased_always_on"
-      QUARKUS_OTEL_METRICS_ENABLED: "true"
-      QUARKUS_OTEL_LOGS_ENABLED: "false"
       # Structured JSON logging with trace context
       QUARKUS_LOG_CONSOLE_JSON: "true"
     ports:

--- a/docs/modules/ROOT/pages/getting-started/assembly-configuring-the-registry.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-configuring-the-registry.adoc
@@ -67,7 +67,7 @@ Configure the following environment variable:
 [role="_abstract"]
 You can configure {registry} to export telemetry data using OpenTelemetry (OTel) for comprehensive observability. This includes distributed tracing, metrics export via OTLP protocol, and log correlation with trace context.
 
-OpenTelemetry support is disabled by default. When enabled, {registry} exports telemetry data to an OpenTelemetry-compatible collector such as Jaeger, Grafana Tempo, or the OpenTelemetry Collector.
+{registry} is built with OpenTelemetry support, but individual telemetry signals (traces, metrics, logs) are disabled by default. When enabled, {registry} exports telemetry data to an OpenTelemetry-compatible collector such as Jaeger, Grafana Tempo, or the OpenTelemetry Collector.
 
 .Prerequisites
 * You have already installed {registry}.
@@ -78,23 +78,37 @@ OpenTelemetry support is disabled by default. When enabled, {registry} exports t
 
 To enable OpenTelemetry observability, configure the following environment variables:
 
-.Required environment variables for OpenTelemetry
+.Environment variables for enabling OpenTelemetry signals
 [.table-expandable,width="100%",cols="4,6",options="header"]
 |===
 |Environment Variable
 |Description
-|`QUARKUS_OTEL_ENABLED`
-|Set to `true` to enable OpenTelemetry. Default is `false`.
+|`QUARKUS_OTEL_TRACES_ENABLED`
+|Set to `true` to enable distributed tracing. Default is `false`.
+|`QUARKUS_OTEL_METRICS_ENABLED`
+|Set to `true` to enable metrics export via OTLP. Default is `false`.
+|`QUARKUS_OTEL_LOGS_ENABLED`
+|Set to `true` to enable log export via OTLP. Default is `false`.
 |`QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT`
 |The endpoint URL of your OpenTelemetry collector. For example, `http://jaeger:4317` for gRPC or `http://jaeger:4318` for HTTP.
 |===
 
-.Example: Enabling OpenTelemetry with Jaeger
+.Example: Enabling tracing with Jaeger
 [source,yaml]
 ----
 environment:
-  QUARKUS_OTEL_ENABLED: "true"
+  QUARKUS_OTEL_TRACES_ENABLED: "true"
   QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger:4317"
+----
+
+.Example: Enabling all telemetry signals
+[source,yaml]
+----
+environment:
+  QUARKUS_OTEL_TRACES_ENABLED: "true"
+  QUARKUS_OTEL_METRICS_ENABLED: "true"
+  QUARKUS_OTEL_LOGS_ENABLED: "true"
+  QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
 ----
 
 [discrete]
@@ -117,7 +131,7 @@ In production environments, you should configure trace sampling to reduce overhe
 [source,yaml]
 ----
 environment:
-  QUARKUS_OTEL_ENABLED: "true"
+  QUARKUS_OTEL_TRACES_ENABLED: "true"
   QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
   QUARKUS_OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
   QUARKUS_OTEL_TRACES_SAMPLER_ARG: "0.1"
@@ -132,7 +146,7 @@ When using JSON logging format, {registry} automatically includes trace context 
 [source,yaml]
 ----
 environment:
-  QUARKUS_OTEL_ENABLED: "true"
+  QUARKUS_OTEL_TRACES_ENABLED: "true"
   QUARKUS_LOG_CONSOLE_JSON: "true"
 ----
 

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/EnvironmentVariables.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/EnvironmentVariables.java
@@ -67,8 +67,8 @@ public class EnvironmentVariables {
 
     // OpenTelemetry related environment variables
     public static final String QUARKUS_OTEL_METRICS_ENABLED = "QUARKUS_OTEL_METRICS_ENABLED";
-    public static final String QUARKUS_OTEL_LOGGING_ENABLED = "QUARKUS_OTEL_LOGGING_ENABLED";
-    public static final String QUARKUS_OTEL_TRACING_ENABLED = "QUARKUS_OTEL_TRACING_ENABLED";
+    public static final String QUARKUS_OTEL_LOGS_ENABLED = "QUARKUS_OTEL_LOGS_ENABLED";
+    public static final String QUARKUS_OTEL_TRACES_ENABLED = "QUARKUS_OTEL_TRACES_ENABLED";
 
     public static final String QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT = "QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT";
     public static final String QUARKUS_OTEL_EXPORTER_OTLP_PROTOCOL = "QUARKUS_OTEL_EXPORTER_OTLP_PROTOCOL";

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/feat/OTel.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/feat/OTel.java
@@ -43,19 +43,19 @@ public class OTel {
 
         log.info("Configuring OpenTelemetry observability");
 
-        // Enable OpenTelemetry Metrics, Logging, and Tracing
+        // Enable OpenTelemetry Metrics, Logs, and Traces
         addEnvVar(envVars, new EnvVarBuilder()
                 .withName(QUARKUS_OTEL_METRICS_ENABLED)
                 .withValue("true")
                 .build());
 
         addEnvVar(envVars, new EnvVarBuilder()
-                .withName(QUARKUS_OTEL_LOGGING_ENABLED)
+                .withName(QUARKUS_OTEL_LOGS_ENABLED)
                 .withValue("true")
                 .build());
 
         addEnvVar(envVars, new EnvVarBuilder()
-                .withName(QUARKUS_OTEL_TRACING_ENABLED)
+                .withName(QUARKUS_OTEL_TRACES_ENABLED)
                 .withValue("true")
                 .build());
 


### PR DESCRIPTION
- Fix operator env var names to match Quarkus property conventions: QUARKUS_OTEL_TRACING_ENABLED -> QUARKUS_OTEL_TRACES_ENABLED QUARKUS_OTEL_LOGGING_ENABLED -> QUARKUS_OTEL_LOGS_ENABLED
- Update documentation to reflect that OTEL is built-in but signals (traces, metrics, logs) are disabled by default and controlled at runtime
- Remove references to QUARKUS_OTEL_ENABLED (build-time property) from runtime configuration examples
- Fix typo in application.properties comment