### PR TITLE
docs: fix KafkaSqlAuthSpec documentation to match implementation

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-operator-config-reference.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-operator-config-reference.adoc
@@ -409,7 +409,7 @@ spec:
 
 === KafkaSqlAuthSpec
 
-Configure SASL authentication for KafkaSQL storage:
+Configure SASL OAuth authentication for KafkaSQL storage:
 
 [cols="1,2,1,2",options="header"]
 |===
@@ -418,38 +418,38 @@ Configure SASL authentication for KafkaSQL storage:
 |Type
 |Default
 
+|`enabled`
+|Enables SASL OAuth authentication. Must be set to `true` for other auth fields to have effect.
+|Boolean
+|`false`
+
 |`mechanism`
-|SASL mechanism. Examples: `SCRAM-SHA-512`, `PLAIN`, `OAUTHBEARER`
+|SASL mechanism. Use `OAUTHBEARER` for OAuth authentication.
 |String
 |None
 
-|`usernameSecretRef`
-|Reference to a Secret containing the username. Default key: `username`
+|`clientIdRef`
+|Reference to a Secret containing the OAuth client ID. Default key: `clientId`
 |<<SecretKeyRef>>
 |None
 
-|`passwordSecretRef`
-|Reference to a Secret containing the password. Default key: `password`
+|`clientSecretRef`
+|Reference to a Secret containing the OAuth client secret. Default key: `clientSecret`
 |<<SecretKeyRef>>
 |None
 
-|`clientIdSecretRef`
-|Reference to a Secret containing the OAuth client ID (for OAUTHBEARER). Default key: `clientId`
-|<<SecretKeyRef>>
+|`tokenEndpoint`
+|OAuth token endpoint URI
+|String
 |None
 
-|`clientSecretSecretRef`
-|Reference to a Secret containing the OAuth client secret (for OAUTHBEARER). Default key: `clientSecret`
-|<<SecretKeyRef>>
-|None
-
-|`tokenEndpointUri`
-|OAuth token endpoint URI (for OAUTHBEARER)
+|`loginHandlerClass`
+|The login callback handler class for OAuth authentication
 |String
 |None
 |===
 
-Example with SCRAM-SHA-512:
+Example with OAuth:
 [source,yaml]
 ----
 spec:
@@ -459,14 +459,22 @@ spec:
       kafkasql:
         bootstrapServers: my-cluster-kafka-bootstrap.my-project.svc:9093
         auth:
-          mechanism: SCRAM-SHA-512
-          usernameSecretRef:
-            name: kafka-credentials
-            key: username
-          passwordSecretRef:
-            name: kafka-credentials
-            key: password
+          enabled: true
+          mechanism: OAUTHBEARER
+          clientIdRef:
+            name: kafka-oauth-credentials
+            key: clientId
+          clientSecretRef:
+            name: kafka-oauth-credentials
+            key: clientSecret
+          tokenEndpoint: https://identity-server.example.com/token
+          loginHandlerClass: io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
 ----
+
+NOTE: The operator provides first-class support for OAuth (OAUTHBEARER) authentication. For other SASL mechanisms
+such as SCRAM-SHA-512 or PLAIN, you can use custom environment variables via the `spec.app.env` field to configure
+the Kafka client properties directly. See the xref:getting-started/assembly-config-reference.adoc[] for available
+`apicurio.kafkasql.*` configuration properties.
 
 [id="operator-auth-reference_{context}"]
 == Authentication and authorization configuration reference


### PR DESCRIPTION
## Summary
- Fixes the KafkaSqlAuthSpec documentation to accurately reflect the actual CRD implementation
- The documentation incorrectly listed `usernameSecretRef` and `passwordSecretRef` fields which do not exist in the implementation
- Updates field names to match actual implementation (`clientIdRef`, `clientSecretRef`, `tokenEndpoint`)
- Adds missing fields (`enabled`, `loginHandlerClass`)
- Adds a note explaining that SCRAM/PLAIN authentication can be configured via environment variables

## Root Cause
The documentation was written to describe intended functionality, but the v3 operator CRD only implements OAuth Bearer authentication. SCRAM and PLAIN authentication were never implemented in the new CRD structure, though they can still be configured via custom environment variables.

## Changes
- Updated `KafkaSqlAuthSpec` section in the operator config reference documentation
- Removed non-existent fields: `usernameSecretRef`, `passwordSecretRef`
- Fixed field names: `clientIdSecretRef` → `clientIdRef`, `clientSecretSecretRef` → `clientSecretRef`, `tokenEndpointUri` → `tokenEndpoint`
- Added missing fields: `enabled`, `loginHandlerClass`
- Updated example to use OAuth instead of SCRAM
- Added note about using `spec.app.env` for SCRAM/PLAIN authentication via environment variables

## Test plan
- [x] Documentation renders correctly in generated docs
- [x] Field names match the actual `KafkaSqlAuthSpec.java` implementation
- [x] Links to configuration reference work correctly

Fixes #7137

🤖 Generated with [Claude Code](https://claude.ai/code)