### PR TITLE
Fix OTEL build-time vs runtime configuration

### DIFF
--- a/app/src/main/java/io/apicurio/registry/observability/OpenTelemetryConfig.java
+++ b/app/src/main/java/io/apicurio/registry/observability/OpenTelemetryConfig.java
@@ -17,9 +17,13 @@ import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_OBS
 @Singleton
 public class OpenTelemetryConfig {
 
-    @ConfigProperty(name = "quarkus.otel.enabled", defaultValue = "false")
+    @ConfigProperty(name = "quarkus.otel.enabled", defaultValue = "true")
     @Info(category = CATEGORY_OBSERVABILITY, description = "Enable or disable OpenTelemetry for distributed tracing, metrics export via OTLP, and log correlation. When enabled, {registry} exports telemetry data to an OpenTelemetry collector.", availableSince = "3.1.7")
     boolean otelEnabled;
+
+    @ConfigProperty(name = "quarkus.otel.sdk.disabled", defaultValue = "true")
+    @Info(category = CATEGORY_OBSERVABILITY, description = "Disable the OpenTelemetry SDK at runtime. Set to `false` to enable OpenTelemetry. This is the primary runtime control for enabling/disabling all telemetry signals.", availableSince = "3.1.7")
+    boolean otelSdkDisabled;
 
     @ConfigProperty(name = "quarkus.otel.service.name", defaultValue = "apicurio-registry")
     @Info(category = CATEGORY_OBSERVABILITY, description = "The logical service name for this {registry} instance. This name appears in traces and metrics exported to the OpenTelemetry collector.", availableSince = "3.1.7")
@@ -34,7 +38,7 @@ public class OpenTelemetryConfig {
     String otelExporterProtocol;
 
     @ConfigProperty(name = "quarkus.otel.traces.enabled", defaultValue = "true")
-    @Info(category = CATEGORY_OBSERVABILITY, description = "Enable or disable distributed tracing. When enabled, {registry} creates spans for REST API requests and storage operations.", availableSince = "3.1.7")
+    @Info(category = CATEGORY_OBSERVABILITY, description = "BUILD-TIME property to enable distributed tracing instrumentation. When enabled, {registry} creates spans for REST API requests and storage operations. Use `quarkus.otel.sdk.disabled` to control tracing at runtime.", availableSince = "3.1.7")
     boolean otelTracesEnabled;
 
     @ConfigProperty(name = "quarkus.otel.traces.sampler", defaultValue = "parentbased_always_on")
@@ -46,11 +50,11 @@ public class OpenTelemetryConfig {
     String otelTracesSamplerArg;
 
     @ConfigProperty(name = "quarkus.otel.metrics.enabled", defaultValue = "true")
-    @Info(category = CATEGORY_OBSERVABILITY, description = "Enable or disable exporting metrics via OpenTelemetry. This works alongside existing Prometheus metrics export.", availableSince = "3.1.7")
+    @Info(category = CATEGORY_OBSERVABILITY, description = "BUILD-TIME property to enable metrics export via OpenTelemetry. This works alongside existing Prometheus metrics export. Use `quarkus.otel.sdk.disabled` to control metrics at runtime.", availableSince = "3.1.7")
     boolean otelMetricsEnabled;
 
-    @ConfigProperty(name = "quarkus.otel.logs.enabled", defaultValue = "false")
-    @Info(category = CATEGORY_OBSERVABILITY, description = "Enable or disable exporting logs via OpenTelemetry. When enabled along with JSON logging, trace context is automatically included in log entries.", availableSince = "3.1.7")
+    @ConfigProperty(name = "quarkus.otel.logs.enabled", defaultValue = "true")
+    @Info(category = CATEGORY_OBSERVABILITY, description = "BUILD-TIME property to enable log export via OpenTelemetry. When enabled along with JSON logging, trace context is automatically included in log entries. Use `quarkus.otel.sdk.disabled` to control log export at runtime.", availableSince = "3.1.7")
     boolean otelLogsEnabled;
 
     @ConfigProperty(name = "quarkus.otel.resource.attributes", defaultValue = "")

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -49,6 +49,8 @@ quarkus.datasource.metrics.enabled=true
 quarkus.datasource.jdbc.enable-metrics=true
 
 # OpenTelemetry Configuration
+# NOTE: Signal properties (traces/metrics/logs) are BUILD-TIME properties.
+# Use quarkus.otel.sdk.disabled to control OTEL at runtime.
 quarkus.otel.enabled=true
 quarkus.otel.service.name=${apicurio.app.id:apicurio-registry}
 
@@ -56,16 +58,18 @@ quarkus.otel.service.name=${apicurio.app.id:apicurio-registry}
 quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
 quarkus.otel.exporter.otlp.protocol=grpc
 
+# Signal Configuration (BUILD-TIME - enabled to be available at runtime)
+quarkus.otel.traces.enabled=true
+quarkus.otel.metrics.enabled=true
+quarkus.otel.logs.enabled=true
+
 # Tracing Configuration
-quarkus.otel.traces.enabled=false
 quarkus.otel.traces.sampler=parentbased_traceidratio
 quarkus.otel.traces.sampler.arg=0.1
 
-# Metrics Configuration (via OpenTelemetry)
-quarkus.otel.metrics.enabled=false
-
-# Logging Configuration
-quarkus.otel.logs.enabled=false
+# Runtime Control - SDK disabled by default
+# Set QUARKUS_OTEL_SDK_DISABLED=false to enable OpenTelemetry
+quarkus.otel.sdk.disabled=true
 
 # Resource Attributes
 quarkus.otel.resource.attributes=service.version=${apicurio.app.version:unknown},deployment.environment=${quarkus.profile:dev}

--- a/app/src/test/java/io/apicurio/registry/noprofile/otel/OpenTelemetryTracingTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/otel/OpenTelemetryTracingTest.java
@@ -49,9 +49,8 @@ class OpenTelemetryTracingTest extends AbstractResourceTestBase {
         public Map<String, String> getConfigOverrides() {
             return Map.of(
                     "quarkus.otel.enabled", "true",
-                    "quarkus.otel.traces.enabled", "true",
-                    "quarkus.otel.metrics.enabled", "false",
-                    "quarkus.otel.logs.enabled", "false",
+                    // Enable OTEL SDK at runtime (signals are already enabled at build-time)
+                    "quarkus.otel.sdk.disabled", "false",
                     "quarkus.otel.traces.sampler", "always_on",
                     // Use NONE exporter for tests - spans are still created but not exported
                     "quarkus.otel.traces.exporter", "none"

--- a/distro/docker-compose/in-memory-with-observability/docker-compose.yml
+++ b/distro/docker-compose/in-memory-with-observability/docker-compose.yml
@@ -15,9 +15,7 @@ services:
       apicurio.rest.deletion.artifact-version.enabled: "true"
       QUARKUS_HTTP_CORS_ORIGINS: "*"
       # OpenTelemetry Configuration
-      QUARKUS_OTEL_TRACES_ENABLED: "true"
-      QUARKUS_OTEL_METRICS_ENABLED: "true"
-      QUARKUS_OTEL_LOGS_ENABLED: "false"
+      QUARKUS_OTEL_SDK_DISABLED: "false"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger:4317"
       QUARKUS_OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
       QUARKUS_OTEL_TRACES_SAMPLER: "parentbased_always_on"

--- a/docs/modules/ROOT/pages/getting-started/assembly-configuring-the-registry.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-configuring-the-registry.adoc
@@ -67,7 +67,9 @@ Configure the following environment variable:
 [role="_abstract"]
 You can configure {registry} to export telemetry data using OpenTelemetry (OTel) for comprehensive observability. This includes distributed tracing, metrics export via OTLP protocol, and log correlation with trace context.
 
-{registry} is built with OpenTelemetry support, but individual telemetry signals (traces, metrics, logs) are disabled by default. When enabled, {registry} exports telemetry data to an OpenTelemetry-compatible collector such as Jaeger, Grafana Tempo, or the OpenTelemetry Collector.
+{registry} is built with OpenTelemetry support and all telemetry signals (traces, metrics, logs) are enabled at build time. However, the OpenTelemetry SDK is disabled by default at runtime. When enabled, {registry} exports telemetry data to an OpenTelemetry-compatible collector such as Jaeger, Grafana Tempo, or the OpenTelemetry Collector.
+
+IMPORTANT: The individual signal properties (`QUARKUS_OTEL_TRACES_ENABLED`, `QUARKUS_OTEL_METRICS_ENABLED`, `QUARKUS_OTEL_LOGS_ENABLED`) are build-time properties and cannot be changed at runtime. All signals are already enabled in the {registry} build. Use `QUARKUS_OTEL_SDK_DISABLED=false` to enable telemetry at runtime.
 
 .Prerequisites
 * You have already installed {registry}.
@@ -78,37 +80,23 @@ You can configure {registry} to export telemetry data using OpenTelemetry (OTel)
 
 To enable OpenTelemetry observability, configure the following environment variables:
 
-.Environment variables for enabling OpenTelemetry signals
+.Environment variables for enabling OpenTelemetry
 [.table-expandable,width="100%",cols="4,6",options="header"]
 |===
 |Environment Variable
 |Description
-|`QUARKUS_OTEL_TRACES_ENABLED`
-|Set to `true` to enable distributed tracing. Default is `false`.
-|`QUARKUS_OTEL_METRICS_ENABLED`
-|Set to `true` to enable metrics export via OTLP. Default is `false`.
-|`QUARKUS_OTEL_LOGS_ENABLED`
-|Set to `true` to enable log export via OTLP. Default is `false`.
+|`QUARKUS_OTEL_SDK_DISABLED`
+|Set to `false` to enable the OpenTelemetry SDK and all telemetry signals. Default is `true` (disabled).
 |`QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT`
 |The endpoint URL of your OpenTelemetry collector. For example, `http://jaeger:4317` for gRPC or `http://jaeger:4318` for HTTP.
 |===
 
-.Example: Enabling tracing with Jaeger
+.Example: Enabling OpenTelemetry with Jaeger
 [source,yaml]
 ----
 environment:
-  QUARKUS_OTEL_TRACES_ENABLED: "true"
+  QUARKUS_OTEL_SDK_DISABLED: "false"
   QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger:4317"
-----
-
-.Example: Enabling all telemetry signals
-[source,yaml]
-----
-environment:
-  QUARKUS_OTEL_TRACES_ENABLED: "true"
-  QUARKUS_OTEL_METRICS_ENABLED: "true"
-  QUARKUS_OTEL_LOGS_ENABLED: "true"
-  QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
 ----
 
 [discrete]
@@ -131,7 +119,7 @@ In production environments, you should configure trace sampling to reduce overhe
 [source,yaml]
 ----
 environment:
-  QUARKUS_OTEL_TRACES_ENABLED: "true"
+  QUARKUS_OTEL_SDK_DISABLED: "false"
   QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
   QUARKUS_OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
   QUARKUS_OTEL_TRACES_SAMPLER_ARG: "0.1"

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -549,7 +549,7 @@ The following {registry} configuration options are available for each component 
 
 |`quarkus.otel.enabled`
 |`boolean`
-|`false`
+|`true`
 |`3.1.7`
 |Enable or disable OpenTelemetry for distributed tracing, metrics export via OTLP, and log correlation. When enabled, {registry} exports telemetry data to an OpenTelemetry collector.
 |`quarkus.otel.exporter.otlp.endpoint`
@@ -569,19 +569,24 @@ The following {registry} configuration options are available for each component 
 |Enable or disable automatic tracing instrumentation for Kafka operations. Useful for tracing in KafkaSQL storage deployments.
 |`quarkus.otel.logs.enabled`
 |`boolean`
-|`false`
+|`true`
 |`3.1.7`
-|Enable or disable exporting logs via OpenTelemetry. When enabled along with JSON logging, trace context is automatically included in log entries.
+|BUILD-TIME property to enable log export via OpenTelemetry. When enabled along with JSON logging, trace context is automatically included in log entries. Use `quarkus.otel.sdk.disabled` to control log export at runtime.
 |`quarkus.otel.metrics.enabled`
 |`boolean`
 |`true`
 |`3.1.7`
-|Enable or disable exporting metrics via OpenTelemetry. This works alongside existing Prometheus metrics export.
+|BUILD-TIME property to enable metrics export via OpenTelemetry. This works alongside existing Prometheus metrics export. Use `quarkus.otel.sdk.disabled` to control metrics at runtime.
 |`quarkus.otel.resource.attributes`
 |`string`
 |
 |`3.1.7`
 |Additional resource attributes to include in telemetry data, specified as comma-separated key=value pairs. Example: `service.version=3.0.0,deployment.environment=production`
+|`quarkus.otel.sdk.disabled`
+|`boolean`
+|`true`
+|`3.1.7`
+|Disable the OpenTelemetry SDK at runtime. Set to `false` to enable OpenTelemetry. This is the primary runtime control for enabling/disabling all telemetry signals.
 |`quarkus.otel.service.name`
 |`string`
 |`apicurio-registry`
@@ -591,7 +596,7 @@ The following {registry} configuration options are available for each component 
 |`boolean`
 |`true`
 |`3.1.7`
-|Enable or disable distributed tracing. When enabled, {registry} creates spans for REST API requests and storage operations.
+|BUILD-TIME property to enable distributed tracing instrumentation. When enabled, {registry} creates spans for REST API requests and storage operations. Use `quarkus.otel.sdk.disabled` to control tracing at runtime.
 |`quarkus.otel.traces.sampler`
 |`string`
 |`parentbased_always_on`

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/EnvironmentVariables.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/EnvironmentVariables.java
@@ -66,9 +66,7 @@ public class EnvironmentVariables {
     public static final String APICURIO_AUTH_ADMIN_OVERRIDE_CLAIM_VALUE = "APICURIO_AUTH_ADMIN_OVERRIDE_CLAIM_VALUE";
 
     // OpenTelemetry related environment variables
-    public static final String QUARKUS_OTEL_METRICS_ENABLED = "QUARKUS_OTEL_METRICS_ENABLED";
-    public static final String QUARKUS_OTEL_LOGS_ENABLED = "QUARKUS_OTEL_LOGS_ENABLED";
-    public static final String QUARKUS_OTEL_TRACES_ENABLED = "QUARKUS_OTEL_TRACES_ENABLED";
+    public static final String QUARKUS_OTEL_SDK_DISABLED = "QUARKUS_OTEL_SDK_DISABLED";
 
     public static final String QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT = "QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT";
     public static final String QUARKUS_OTEL_EXPORTER_OTLP_PROTOCOL = "QUARKUS_OTEL_EXPORTER_OTLP_PROTOCOL";

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/feat/OTel.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/feat/OTel.java
@@ -43,20 +43,11 @@ public class OTel {
 
         log.info("Configuring OpenTelemetry observability");
 
-        // Enable OpenTelemetry Metrics, Logs, and Traces
+        // Enable OpenTelemetry by setting SDK disabled to false
+        // NOTE: Individual signal properties are build-time only and already enabled
         addEnvVar(envVars, new EnvVarBuilder()
-                .withName(QUARKUS_OTEL_METRICS_ENABLED)
-                .withValue("true")
-                .build());
-
-        addEnvVar(envVars, new EnvVarBuilder()
-                .withName(QUARKUS_OTEL_LOGS_ENABLED)
-                .withValue("true")
-                .build());
-
-        addEnvVar(envVars, new EnvVarBuilder()
-                .withName(QUARKUS_OTEL_TRACES_ENABLED)
-                .withValue("true")
+                .withName(QUARKUS_OTEL_SDK_DISABLED)
+                .withValue("false")
                 .build());
 
         // Configure OTLP endpoint


### PR DESCRIPTION
The OTEL signal properties (traces/metrics/logs enabled) are build-time properties in Quarkus that cannot be changed at runtime. This fix:

- Enables all OTEL signals at build-time (available for use)
- Adds quarkus.otel.sdk.disabled=true as runtime default (OTEL off)
- Users enable OTEL by setting QUARKUS_OTEL_SDK_DISABLED=false

This ensures OTEL can be properly controlled at deployment time.

Fixes #7147