### PR TITLE
Refactor VersionsTable to merge checkbox into version column

### DIFF
--- a/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTable.css
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTable.css
@@ -1,0 +1,4 @@
+.versions-table > table > tbody > tr > td {
+    padding-top: 5px;
+    padding-bottom: 15px;
+}

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTable.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTable.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
+import "./VersionsTable.css";
 import { Link } from "react-router-dom";
 import { SortByDirection, ThProps } from "@patternfly/react-table";
 import { FromNow, If, ObjectDropdown, ResponsiveTable } from "@apicurio/common-ui-components";
@@ -48,11 +49,10 @@ export const VersionsTable: FunctionComponent<VersionsTableProps> = (props: Vers
     const user: UserService = useUserService();
 
     const columns: any[] = [
-        { index: 0, id: "select", label: "", width: 5, sortable: false },
-        { index: 1, id: "version", label: "Version", width: 50, sortable: true, sortBy: VersionSortByObject.Version },
-        { index: 2, id: "globalId", label: "Global Id", width: 15, sortable: true, sortBy: VersionSortByObject.GlobalId },
-        { index: 3, id: "contentId", label: "Content Id", width: 15, sortable: true },
-        { index: 4, id: "createdOn", label: "Created on", width: 15, sortable: true, sortBy: VersionSortByObject.CreatedOn },
+        { index: 0, id: "version", label: "Version", width: 55, sortable: true, sortBy: VersionSortByObject.Version },
+        { index: 1, id: "globalId", label: "Global Id", width: 15, sortable: true, sortBy: VersionSortByObject.GlobalId },
+        { index: 2, id: "contentId", label: "Content Id", width: 15, sortable: true },
+        { index: 3, id: "createdOn", label: "Created on", width: 15, sortable: true, sortBy: VersionSortByObject.CreatedOn },
     ];
 
     const isVersionSelected = (version: SearchedVersion): boolean => {
@@ -64,62 +64,61 @@ export const VersionsTable: FunctionComponent<VersionsTableProps> = (props: Vers
     };
 
     const renderColumnData = (column: SearchedVersion, colIndex: number): React.ReactNode => {
-        // Checkbox for selection.
+        // Version name with checkbox.
         if (colIndex === 0) {
-            const isDisabled = props.selectedVersions.length >= 2 && !isVersionSelected(column);
-            return (
-                <Checkbox
-                    id={`select-version-${shash(column.version!)}`}
-                    isChecked={isVersionSelected(column)}
-                    isDisabled={isDisabled}
-                    onChange={(_event, checked) => handleCheckboxChange(column, checked)}
-                    aria-label={`Select version ${column.version}`}
-                />
-            );
-        }
-        // Version name.
-        if (colIndex === 1) {
             const groupId: string = encodeURIComponent(props.artifact.groupId || "default");
             const artifactId: string = encodeURIComponent(props.artifact.artifactId!);
             const version: string = encodeURIComponent(column.version!);
+            const isDisabled = props.selectedVersions.length >= 2 && !isVersionSelected(column);
             return (
-                <div>
-                    <Flex>
-                        <FlexItem>
-                            <Link className="version-title"
-                                style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", textDecoration: "none" }}
-                                to={appNavigation.createLink(`/explore/${groupId}/${artifactId}/versions/${version}`)}
-                            >
-                                <span>{ column.version }</span>
-                                <If condition={column.name != "" && column.name !== undefined && column.name !== null}>
-                                    <span style={{ marginLeft: "10px" }}>({column.name})</span>
-                                </If>
-                            </Link>
-                        </FlexItem>
-                        <FlexItem>
-                            <VersionStateBadge version={column} />
-                        </FlexItem>
-                    </Flex>
-                    <ArtifactDescription className="version-description" style={{ overflow: "hidden", textOverflow: "hidden", whiteSpace: "nowrap", fontSize: "14px" }}
-                        description={column.description}
-                        truncate={true} />
-                </div>
+                <Flex>
+                    <FlexItem>
+                        <Flex>
+                            <FlexItem>
+                                <Checkbox
+                                    id={`select-version-${shash(column.version!)}`}
+                                    isChecked={isVersionSelected(column)}
+                                    isDisabled={isDisabled}
+                                    onChange={(_event, checked) => handleCheckboxChange(column, checked)}
+                                    aria-label={`Select version ${column.version}`}
+                                />
+                            </FlexItem>
+                            <FlexItem>
+                                <Link className="version-title"
+                                    style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", textDecoration: "none" }}
+                                    to={appNavigation.createLink(`/explore/${groupId}/${artifactId}/versions/${version}`)}
+                                >
+                                    <span>{ column.version }</span>
+                                    <If condition={column.name != "" && column.name !== undefined && column.name !== null}>
+                                        <span style={{ marginLeft: "10px" }}>({column.name})</span>
+                                    </If>
+                                </Link>
+                            </FlexItem>
+                            <FlexItem>
+                                <VersionStateBadge version={column} />
+                            </FlexItem>
+                        </Flex>
+                        <ArtifactDescription className="version-description" style={{ overflow: "hidden", textOverflow: "hidden", whiteSpace: "nowrap", fontSize: "14px" }}
+                            description={column.description}
+                            truncate={true} />
+                    </FlexItem>
+                </Flex>
             );
         }
         // Global id.
-        if (colIndex === 2) {
+        if (colIndex === 1) {
             return (
                 <span>{ column.globalId }</span>
             );
         }
         // Content id.
-        if (colIndex === 3) {
+        if (colIndex === 2) {
             return (
                 <span>{ column.contentId }</span>
             );
         }
         // Created on.
-        if (colIndex === 4) {
+        if (colIndex === 3) {
             return (
                 <FromNow date={column.createdOn} />
             );
@@ -170,13 +169,13 @@ export const VersionsTable: FunctionComponent<VersionsTableProps> = (props: Vers
 
     useEffect(() => {
         if (props.sortBy === VersionSortByObject.Version) {
-            setSortByIndex(1);
+            setSortByIndex(0);
         }
         if (props.sortBy === VersionSortByObject.GlobalId) {
-            setSortByIndex(2);
+            setSortByIndex(1);
         }
         if (props.sortBy === VersionSortByObject.CreatedOn) {
-            setSortByIndex(4);
+            setSortByIndex(3);
         }
     }, [props.sortBy]);
 


### PR DESCRIPTION
## Summary
- Improved the layout of the VersionsTable by combining the checkbox selection control with the version name column
- This change makes better use of horizontal space and provides a more compact table layout
- The checkbox is now positioned inline with the version name, description, and state badge

## Changes
- Merged the standalone checkbox column into the version column using nested Flex components
- Removed the separate "select" column from the columns array (reduced from 5 columns to 4)
- Updated all column indexes throughout the component to reflect the new structure
- Adjusted column widths: version column increased from 50% to 55%
- Added `VersionsTable.css` to customize table cell padding for better visual spacing

## Test plan
- [ ] Verify the versions table renders correctly with checkboxes inline with version names
- [ ] Test checkbox selection functionality (single and multiple selections)
- [ ] Verify the "up to 2 selections" limit still works correctly
- [ ] Test that disabled checkboxes appear correctly when limit is reached
- [ ] Verify table layout is responsive and columns align properly
- [ ] Test sorting functionality on version, global ID, and created on columns