### PR TITLE
Refactor AbstractSqlRegistryStorage to use repository pattern

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -242,6 +242,10 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     protected void initialize(HandleFactory handleFactory, boolean emitStorageReadyEvent) {
         this.handles = handleFactory;
 
+        // Configure all repositories to use the same HandleFactory
+        // This is essential for GitOps storage which uses a different datasource
+        configureRepositories(handleFactory);
+
         log.info("SqlRegistryStorage constructed successfully.");
 
         handles.withHandleNoException((handle) -> {
@@ -310,6 +314,29 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
              */
             storageEvent.fireAsync(StorageEvent.builder().type(StorageEventType.READY).build());
         }
+    }
+
+    /**
+     * Configure all repositories to use the specified HandleFactory.
+     * This ensures that storage implementations using a different datasource (like GitOps)
+     * can override the default CDI-injected HandleFactory.
+     */
+    protected void configureRepositories(HandleFactory handleFactory) {
+        artifactRepository.setHandleFactory(handleFactory);
+        versionRepository.setHandleFactory(handleFactory);
+        groupRepository.setHandleFactory(handleFactory);
+        branchRepository.setHandleFactory(handleFactory);
+        ruleRepository.setHandleFactory(handleFactory);
+        contentRepository.setHandleFactory(handleFactory);
+        searchRepository.setHandleFactory(handleFactory);
+        commentRepository.setHandleFactory(handleFactory);
+        configRepository.setHandleFactory(handleFactory);
+        roleMappingRepository.setHandleFactory(handleFactory);
+        downloadRepository.setHandleFactory(handleFactory);
+        sequenceRepository.setHandleFactory(handleFactory);
+        exportRepository.setHandleFactory(handleFactory);
+        eventRepository.setHandleFactory(handleFactory);
+        cleanupRepository.setHandleFactory(handleFactory);
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlArtifactRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlArtifactRepository.java
@@ -55,6 +55,14 @@ public class SqlArtifactRepository {
     @Inject
     HandleFactory handles;
 
+    /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
     @Inject
     SecurityIdentity securityIdentity;
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlBranchRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlBranchRepository.java
@@ -63,6 +63,14 @@ public class SqlBranchRepository {
     @Inject
     HandleFactory handles;
 
+    /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
     @Inject
     SecurityIdentity securityIdentity;
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlCleanupRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlCleanupRepository.java
@@ -22,6 +22,14 @@ public class SqlCleanupRepository {
     @Inject
     HandleFactory handles;
 
+    /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
     @Inject
     SqlRuleRepository ruleRepository;
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlCommentRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlCommentRepository.java
@@ -38,6 +38,14 @@ public class SqlCommentRepository {
     @Inject
     HandleFactory handles;
 
+    /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
     @Inject
     SecurityIdentity securityIdentity;
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlConfigRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlConfigRepository.java
@@ -34,6 +34,14 @@ public class SqlConfigRepository {
     HandleFactory handles;
 
     /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
+    /**
      * Get all configuration properties.
      */
     public List<DynamicConfigPropertyDto> getConfigProperties() throws RegistryStorageException {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlContentRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlContentRepository.java
@@ -50,6 +50,14 @@ public class SqlContentRepository {
     @Inject
     HandleFactory handles;
 
+    /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
     @Inject
     SqlSequenceRepository sequenceRepository;
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlDownloadRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlDownloadRepository.java
@@ -38,6 +38,14 @@ public class SqlDownloadRepository {
     HandleFactory handles;
 
     /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
+    /**
      * Create a new download entry.
      */
     public String createDownload(DownloadContextDto context) throws RegistryStorageException {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepository.java
@@ -24,6 +24,14 @@ public class SqlEventRepository {
     @Inject
     HandleFactory handles;
 
+    /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
     @Inject
     @ConfigProperty(name = "apicurio.events.kafka.topic", defaultValue = "registry-events")
     String eventsTopic;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlExportRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlExportRepository.java
@@ -50,6 +50,14 @@ public class SqlExportRepository {
     @Inject
     HandleFactory handles;
 
+    /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
     @Inject
     @ConfigProperty(name = "apicurio.events.kafka.topic", defaultValue = "registry-events")
     String eventsTopic;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlGroupRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlGroupRepository.java
@@ -65,6 +65,14 @@ public class SqlGroupRepository {
     @Inject
     HandleFactory handles;
 
+    /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
     @Inject
     SecurityIdentity securityIdentity;
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlRoleMappingRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlRoleMappingRepository.java
@@ -32,6 +32,14 @@ public class SqlRoleMappingRepository {
     HandleFactory handles;
 
     /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
+    /**
      * Create a new role mapping.
      */
     public void createRoleMapping(String principalId, String role, String principalName)

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlRuleRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlRuleRepository.java
@@ -50,6 +50,14 @@ public class SqlRuleRepository {
     @Inject
     HandleFactory handles;
 
+    /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
     @Inject
     Event<SqlOutboxEvent> outboxEvent;
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
@@ -44,6 +44,14 @@ public class SqlSearchRepository {
     @Inject
     HandleFactory handles;
 
+    /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
     @Inject
     RestConfig restConfig;
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSequenceRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSequenceRepository.java
@@ -44,6 +44,14 @@ public class SqlSequenceRepository {
     HandleFactory handles;
 
     /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
+    /**
      * Get next global ID.
      */
     public long nextGlobalId() {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlVersionRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlVersionRepository.java
@@ -70,6 +70,14 @@ public class SqlVersionRepository {
     @Inject
     HandleFactory handles;
 
+    /**
+     * Set the HandleFactory to use for database operations.
+     * This allows storage implementations to override the default injected HandleFactory.
+     */
+    public void setHandleFactory(HandleFactory handleFactory) {
+        this.handles = handleFactory;
+    }
+
     @Inject
     SecurityIdentity securityIdentity;
 


### PR DESCRIPTION
## Summary

Closes #7187

This PR refactors the `AbstractSqlRegistryStorage` class by extracting domain-specific functionality into dedicated repository classes. This improves code maintainability, testability, and follows the single responsibility principle.

**Key improvements:**
- Reduces `AbstractSqlRegistryStorage` from ~3,962 lines to ~1,317 lines (~67% reduction)
- Separates concerns into domain-specific repository classes
- Maintains the same public API - no breaking changes
- Uses CDI injection for repository dependencies

## Changes

### New Repository Classes

| Repository | Responsibility |
|------------|----------------|
| `SqlArtifactRepository` | Artifact CRUD operations, metadata management |
| `SqlVersionRepository` | Version management, state transitions, version metadata |
| `SqlGroupRepository` | Group CRUD operations, group search and filtering |
| `SqlBranchRepository` | Branch management, version ordering, semver branching |
| `SqlRuleRepository` | Global, group, and artifact rule configuration |
| `SqlContentRepository` | Content storage, references, hash lookups, content creation |
| `SqlSearchRepository` | Artifact and version search operations |
| `SqlCommentRepository` | Version comment CRUD operations |
| `SqlConfigRepository` | Dynamic configuration property management |
| `SqlRoleMappingRepository` | Role mapping CRUD operations |
| `SqlDownloadRepository` | Download context management |
| `SqlSequenceRepository` | ID sequence generation (globalId, contentId, commentId) |
| `SqlExportRepository` | Data export and database snapshot operations |
| `SqlEventRepository` | Outbox event operations |
| `SqlCleanupRepository` | Bulk cleanup and delete operations |

### Architecture

```
AbstractSqlRegistryStorage
    ├── SqlArtifactRepository
    ├── SqlVersionRepository
    ├── SqlGroupRepository
    ├── SqlBranchRepository
    ├── SqlRuleRepository
    ├── SqlContentRepository
    ├── SqlSearchRepository
    ├── SqlCommentRepository
    ├── SqlConfigRepository
    ├── SqlRoleMappingRepository
    ├── SqlDownloadRepository
    ├── SqlSequenceRepository
    ├── SqlExportRepository
    ├── SqlEventRepository
    └── SqlCleanupRepository
```

Each repository is an `@ApplicationScoped` CDI bean that handles a specific domain of operations. The main `AbstractSqlRegistryStorage` class now primarily delegates to these repositories while maintaining the public `RegistryStorage` interface.

## Test Plan

- [x] Verify checkstyle passes (confirmed: `BUILD SUCCESS`)
- [ ] Run unit tests for SQL storage
- [ ] Run integration tests with SQL storage variant
- [ ] Verify no behavioral changes in API responses

## Notes

- All repository classes follow the existing code patterns and use the same `HandleFactory`, `SqlStatements`, and mapper classes
- Cross-repository dependencies are handled via CDI injection (e.g., `SqlBranchRepository` injects `SqlVersionRepository` for state updates)