### PR TITLE
feat: expose setObjectMapper in JsonSchemaKafka serializers (#7194)

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -244,6 +244,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>kafka-connect-avro-converter</artifactId>
       <scope>test</scope>

--- a/app/src/test/java/io/apicurio/registry/support/Event.java
+++ b/app/src/test/java/io/apicurio/registry/support/Event.java
@@ -1,0 +1,80 @@
+package io.apicurio.registry.support;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+/**
+ * Test class to verify Java 8 Time serialization/deserialization with custom ObjectMapper.
+ * This class is used to test the setObjectMapper() functionality added in issue #7194.
+ */
+public class Event {
+
+    @JsonProperty("eventId")
+    private String eventId;
+
+    @JsonProperty("eventName")
+    private String eventName;
+
+    @JsonProperty("eventDate")
+    private LocalDate eventDate;
+
+    @JsonProperty("eventDateTime")
+    private OffsetDateTime eventDateTime;
+
+    @JsonProperty("eventTimestamp")
+    private Instant eventTimestamp;
+
+    public Event() {
+    }
+
+    public Event(String eventId, String eventName, LocalDate eventDate, OffsetDateTime eventDateTime, Instant eventTimestamp) {
+        this.eventId = eventId;
+        this.eventName = eventName;
+        this.eventDate = eventDate;
+        this.eventDateTime = eventDateTime;
+        this.eventTimestamp = eventTimestamp;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getEventName() {
+        return eventName;
+    }
+
+    public void setEventName(String eventName) {
+        this.eventName = eventName;
+    }
+
+    public LocalDate getEventDate() {
+        return eventDate;
+    }
+
+    public void setEventDate(LocalDate eventDate) {
+        this.eventDate = eventDate;
+    }
+
+    public OffsetDateTime getEventDateTime() {
+        return eventDateTime;
+    }
+
+    public void setEventDateTime(OffsetDateTime eventDateTime) {
+        this.eventDateTime = eventDateTime;
+    }
+
+    public Instant getEventTimestamp() {
+        return eventTimestamp;
+    }
+
+    public void setEventTimestamp(Instant eventTimestamp) {
+        this.eventTimestamp = eventTimestamp;
+    }
+}

--- a/app/src/test/resources/io/apicurio/registry/util/event-schema.json
+++ b/app/src/test/resources/io/apicurio/registry/util/event-schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "eventId": {
+      "type": "string"
+    },
+    "eventName": {
+      "type": "string"
+    },
+    "eventDate": {
+      "type": "string",
+      "format": "date"
+    },
+    "eventDateTime": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "eventTimestamp": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": ["eventId", "eventName", "eventDate", "eventDateTime", "eventTimestamp"]
+}

--- a/serdes/kafka/jsonschema-serde/src/main/java/io/apicurio/registry/serde/jsonschema/JsonSchemaKafkaDeserializer.java
+++ b/serdes/kafka/jsonschema-serde/src/main/java/io/apicurio/registry/serde/jsonschema/JsonSchemaKafkaDeserializer.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.serde.jsonschema;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.JsonSchema;
 import io.apicurio.registry.resolver.SchemaResolver;
 import io.apicurio.registry.resolver.client.RegistryClientFacade;
@@ -43,6 +44,20 @@ public class JsonSchemaKafkaDeserializer<T> extends KafkaDeserializer<JsonSchema
     public void configure(Map<String, ?> configs, boolean isKey) {
         super.configure(configs, isKey);
         this.serdeHeaders = new MessageTypeSerdeHeaders(new HashMap<>(configs), isKey);
+    }
+
+    /**
+     * Sets a custom Jackson ObjectMapper to use for deserialization. This allows users to configure
+     * Jackson features such as custom modules (e.g., JavaTimeModule), serializers, deserializers,
+     * and other ObjectMapper settings.
+     *
+     * <p>This method must be called before the {@link #configure(Map, boolean)} method is invoked,
+     * as the configure method will create a default ObjectMapper if one has not been set.</p>
+     *
+     * @param objectMapper the ObjectMapper to use for deserialization
+     */
+    public void setObjectMapper(ObjectMapper objectMapper) {
+        ((JsonSchemaDeserializer<T>) delegatedDeserializer).setObjectMapper(objectMapper);
     }
 
     @Override

--- a/serdes/kafka/jsonschema-serde/src/main/java/io/apicurio/registry/serde/jsonschema/JsonSchemaKafkaSerializer.java
+++ b/serdes/kafka/jsonschema-serde/src/main/java/io/apicurio/registry/serde/jsonschema/JsonSchemaKafkaSerializer.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.serde.jsonschema;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.JsonSchema;
 import io.apicurio.registry.resolver.ParsedSchema;
 import io.apicurio.registry.resolver.SchemaResolver;
@@ -59,6 +60,20 @@ public class JsonSchemaKafkaSerializer<T> extends KafkaSerializer<JsonSchema, T>
      */
     public void setValidationEnabled(Boolean validationEnabled) {
         ((JsonSchemaSerializer<T>) delegatedSerializer).setValidationEnabled(validationEnabled);
+    }
+
+    /**
+     * Sets a custom Jackson ObjectMapper to use for serialization. This allows users to configure
+     * Jackson features such as custom modules (e.g., JavaTimeModule), serializers, deserializers,
+     * and other ObjectMapper settings.
+     *
+     * <p>This method must be called before the {@link #configure(Map, boolean)} method is invoked,
+     * as the configure method will create a default ObjectMapper if one has not been set.</p>
+     *
+     * @param objectMapper the ObjectMapper to use for serialization
+     */
+    public void setObjectMapper(ObjectMapper objectMapper) {
+        ((JsonSchemaSerializer<T>) delegatedSerializer).setObjectMapper(objectMapper);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Added `setObjectMapper()` method to `JsonSchemaKafkaSerializer` that delegates to underlying `JsonSchemaSerializer`
- Added `setObjectMapper()` method to `JsonSchemaKafkaDeserializer` that delegates to underlying `JsonSchemaDeserializer`
- Added comprehensive tests validating custom ObjectMapper functionality with JavaTimeModule
- Added test support class `Event` and schema demonstrating Java 8 Time type serialization

## Related Issue

Fixes #7194

## Implementation Details

The implementation follows the existing delegation pattern used by `setValidationEnabled()`:
- Both methods include comprehensive Javadoc explaining usage and timing requirements
- Users must call `setObjectMapper()` before `configure()` is invoked
- The underlying generic serializer/deserializer classes already had `setObjectMapper()` support

## Test Plan

- [x] Added `testCustomObjectMapperWithJavaTime()` - validates JavaTimeModule registration works correctly
- [x] Added `testWithoutCustomObjectMapper()` - validates custom ObjectMapper is required for Java 8 Time types
- [x] Tests use parameterized testing with both v2 and v3 Registry clients
- [x] Tests verify ISO-8601/RFC 3339 date format compliance
- [x] All tests passing successfully

## Use Case

This change enables users to register Jackson modules like `JavaTimeModule` to support Java 8 Time classes (LocalDate, OffsetDateTime, Instant) in their serialized data, which was the primary use case reported in the issue.