### PR TITLE
feat(llm): JSON Schema backing and MCP prompt serving for LLM artifacts

### DIFF
--- a/app/llm-artifact-types-src/src/PromptTemplateArtifactType.ts
+++ b/app/llm-artifact-types-src/src/PromptTemplateArtifactType.ts
@@ -32,6 +32,27 @@ interface VariableSchema {
     $ref?: string;
 }
 
+/**
+ * MCP (Model Context Protocol) extension for exposing prompt templates via MCP servers.
+ * When enabled, this prompt template can be served via MCP prompts/list and prompts/get.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-06-18/server/prompts
+ */
+interface MCPExtension {
+    /** Whether to expose this template via MCP prompts/list and prompts/get */
+    enabled: boolean;
+    /** MCP prompt name (lowercase with underscores). Defaults to templateId if not specified. */
+    name?: string;
+    /** Description shown in MCP prompts/list. Defaults to template description if not specified. */
+    description?: string;
+    /** Explicit MCP arguments. If not specified, auto-derived from variables. */
+    arguments?: Array<{
+        name: string;
+        description?: string;
+        required?: boolean;
+    }>;
+}
+
 interface PromptTemplate {
     $schema?: string;
     templateId: string;
@@ -42,6 +63,8 @@ interface PromptTemplate {
     variables?: Record<string, VariableSchema>;
     outputSchema?: Record<string, unknown>;
     metadata?: Record<string, unknown>;
+    /** Optional MCP extension for runtime serving via MCP servers */
+    mcp?: MCPExtension;
 }
 
 /**

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
@@ -14,12 +14,16 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 
 /**
- * JAX-RS resource for A2A protocol well-known endpoints.
+ * JAX-RS resource for well-known endpoints including A2A protocol and JSON Schemas.
  *
  * Per the A2A protocol specification, agents publish their Agent Card at
  * /.well-known/agent.json for discovery purposes.
  *
+ * This resource also serves JSON Schemas for LLM artifact types at
+ * /.well-known/schemas/{type}/{version} for IDE autocompletion and validation.
+ *
  * @see <a href="https://a2a-protocol.org/">A2A Protocol</a>
+ * @see <a href="https://json-schema.org/">JSON Schema</a>
  */
 @Path("/.well-known")
 public interface WellKnownResource {
@@ -76,4 +80,23 @@ public interface WellKnownResource {
             @QueryParam("outputMode") List<String> outputModes,
             @QueryParam("offset") @DefaultValue("0") Integer offset,
             @QueryParam("limit") @DefaultValue("20") Integer limit);
+
+    /**
+     * Returns the JSON Schema for a specific LLM artifact type.
+     * This enables IDE autocompletion and validation for PROMPT_TEMPLATE and MODEL_SCHEMA artifacts.
+     *
+     * Supported types:
+     * - prompt-template (versions: v1)
+     * - model-schema (versions: v1)
+     *
+     * @param type the schema type (e.g., "prompt-template", "model-schema")
+     * @param version the schema version (e.g., "v1")
+     * @return the JSON Schema
+     */
+    @GET
+    @Path("/schemas/{type}/{version}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getSchema(
+            @PathParam("type") String type,
+            @PathParam("version") String version);
 }

--- a/app/src/main/resources/schemas/model-schema-v1.json
+++ b/app/src/main/resources/schemas/model-schema-v1.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://apicur.io/schemas/model-schema/v1",
+  "title": "Apicurio Model Schema",
+  "description": "Schema for MODEL_SCHEMA artifacts in Apicurio Registry. Defines input/output schemas for AI/ML models.",
+  "type": "object",
+  "required": ["modelId"],
+  "anyOf": [
+    { "required": ["input"] },
+    { "required": ["output"] }
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Reference to this JSON Schema for IDE autocompletion",
+      "const": "https://apicur.io/schemas/model-schema/v1"
+    },
+    "modelId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for the model"
+    },
+    "provider": {
+      "type": "string",
+      "description": "The provider or vendor of the model (e.g., 'openai', 'anthropic', 'google')"
+    },
+    "version": {
+      "type": "string",
+      "description": "Version of the model"
+    },
+    "input": {
+      "type": "object",
+      "description": "JSON Schema defining the expected input structure for the model"
+    },
+    "output": {
+      "type": "object",
+      "description": "JSON Schema defining the output structure from the model"
+    },
+    "definitions": {
+      "type": "object",
+      "description": "Reusable schema definitions that can be referenced via $ref",
+      "additionalProperties": {
+        "type": "object"
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Additional metadata about the model",
+      "properties": {
+        "contextWindow": {
+          "type": "integer",
+          "description": "Maximum context window size in tokens"
+        },
+        "maxOutputTokens": {
+          "type": "integer",
+          "description": "Maximum output tokens the model can generate"
+        },
+        "capabilities": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of model capabilities (e.g., 'chat', 'completion', 'embedding', 'vision', 'function-calling')"
+        },
+        "pricing": {
+          "type": "object",
+          "description": "Pricing information for the model",
+          "properties": {
+            "inputTokens": {
+              "type": "number",
+              "description": "Cost per 1M input tokens"
+            },
+            "outputTokens": {
+              "type": "number",
+              "description": "Cost per 1M output tokens"
+            },
+            "currency": {
+              "type": "string",
+              "default": "USD",
+              "description": "Currency for pricing"
+            }
+          },
+          "additionalProperties": true
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this model version is deprecated"
+        },
+        "deprecationDate": {
+          "type": "string",
+          "description": "Date when the model will be deprecated (ISO 8601 format)"
+        },
+        "successorModel": {
+          "type": "string",
+          "description": "Recommended successor model if this one is deprecated"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "examples": [
+    {
+      "$schema": "https://apicur.io/schemas/model-schema/v1",
+      "modelId": "gpt-4-turbo",
+      "provider": "openai",
+      "version": "2024-04",
+      "input": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["role", "content"],
+              "properties": {
+                "role": {
+                  "type": "string",
+                  "enum": ["system", "user", "assistant"]
+                },
+                "content": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2
+          }
+        },
+        "required": ["messages"]
+      },
+      "output": {
+        "type": "object",
+        "properties": {
+          "choices": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "object",
+                  "properties": {
+                    "role": { "type": "string" },
+                    "content": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "metadata": {
+        "contextWindow": 128000,
+        "maxOutputTokens": 4096,
+        "capabilities": ["chat", "vision", "function-calling"]
+      }
+    }
+  ]
+}

--- a/app/src/main/resources/schemas/prompt-template-v1.json
+++ b/app/src/main/resources/schemas/prompt-template-v1.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://apicur.io/schemas/prompt-template/v1",
+  "title": "Apicurio Prompt Template",
+  "description": "Schema for PROMPT_TEMPLATE artifacts in Apicurio Registry. Defines prompt templates with variable substitution for LLM interactions.",
+  "type": "object",
+  "required": ["templateId", "template"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Reference to this JSON Schema for IDE autocompletion",
+      "const": "https://apicur.io/schemas/prompt-template/v1"
+    },
+    "templateId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for the prompt template"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable name for the prompt template"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of what this prompt template does"
+    },
+    "version": {
+      "type": "string",
+      "description": "Version of the prompt template"
+    },
+    "template": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The prompt template text with {{variable}} placeholders for substitution"
+    },
+    "variables": {
+      "type": "object",
+      "description": "Schema definitions for template variables",
+      "additionalProperties": {
+        "$ref": "#/$defs/variableSchema"
+      }
+    },
+    "outputSchema": {
+      "type": "object",
+      "description": "JSON Schema defining the expected output structure from the LLM"
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Additional metadata for the prompt template",
+      "properties": {
+        "author": {
+          "type": "string",
+          "description": "Author or team that created this template"
+        },
+        "createdAt": {
+          "type": "string",
+          "description": "Creation date in ISO 8601 format"
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Tags for categorization and search"
+        },
+        "recommendedModels": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of recommended LLM models for this template"
+        },
+        "useCases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Example use cases for this template"
+        }
+      },
+      "additionalProperties": true
+    },
+    "mcp": {
+      "$ref": "#/$defs/mcpExtension",
+      "description": "Optional MCP (Model Context Protocol) extension for runtime serving via MCP servers"
+    }
+  },
+  "$defs": {
+    "variableSchema": {
+      "type": "object",
+      "description": "Schema definition for a template variable",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["string", "integer", "number", "boolean", "array", "object"],
+          "description": "Data type of the variable"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this variable must be provided when rendering"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the variable"
+        },
+        "default": {
+          "description": "Default value if not provided"
+        },
+        "enum": {
+          "type": "array",
+          "description": "List of allowed values for this variable"
+        },
+        "minimum": {
+          "type": "number",
+          "description": "Minimum value for numeric types"
+        },
+        "maximum": {
+          "type": "number",
+          "description": "Maximum value for numeric types"
+        },
+        "$ref": {
+          "type": "string",
+          "description": "Reference to an external schema definition"
+        }
+      },
+      "additionalProperties": true
+    },
+    "mcpExtension": {
+      "type": "object",
+      "description": "MCP (Model Context Protocol) extension for exposing this template as an MCP prompt",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to expose this template via MCP prompts/list and prompts/get"
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z_][a-z0-9_]*$",
+          "description": "MCP prompt name (lowercase with underscores). Defaults to templateId if not specified."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description shown in MCP prompts/list. Defaults to template description if not specified."
+        },
+        "arguments": {
+          "type": "array",
+          "description": "Explicit MCP arguments. If not specified, auto-derived from variables.",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Argument name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Argument description"
+              },
+              "required": {
+                "type": "boolean",
+                "description": "Whether the argument is required"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "examples": [
+    {
+      "$schema": "https://apicur.io/schemas/prompt-template/v1",
+      "templateId": "sentiment-analysis",
+      "name": "Sentiment Analysis Prompt",
+      "template": "Analyze the sentiment of the following text: {{message}}",
+      "variables": {
+        "message": {
+          "type": "string",
+          "required": true,
+          "description": "The text to analyze"
+        }
+      },
+      "mcp": {
+        "enabled": true,
+        "name": "analyze_sentiment"
+      }
+    }
+  ]
+}

--- a/examples/llm-artifact-types/sample-schemas/mcp-enabled-code-review-prompt.yaml
+++ b/examples/llm-artifact-types/sample-schemas/mcp-enabled-code-review-prompt.yaml
@@ -1,0 +1,110 @@
+$schema: https://apicur.io/schemas/prompt-template/v1
+templateId: code-review-assistant
+name: Code Review Assistant
+description: A prompt template for performing code reviews with customizable focus areas
+version: "1.0"
+
+template: |
+  You are a code review assistant. Review the following code with attention to {{focus_area}}.
+
+  ## Code to Review
+  ```{{language}}
+  {{code}}
+  ```
+
+  {{#if context}}
+  ## Additional Context
+  {{context}}
+  {{/if}}
+
+  ## Review Guidelines
+  - Check for bugs and logic errors
+  - Evaluate code style and readability
+  - Identify security vulnerabilities
+  - Suggest performance improvements
+  - Recommend best practices
+
+  Provide a structured review with:
+  1. Summary of findings
+  2. Specific issues with line references
+  3. Suggested improvements
+  4. Overall assessment (score 1-10)
+
+variables:
+  code:
+    type: string
+    required: true
+    description: The code snippet to review
+  language:
+    type: string
+    required: true
+    description: Programming language of the code
+    enum:
+      - java
+      - python
+      - javascript
+      - typescript
+      - go
+      - rust
+      - kotlin
+      - scala
+  focus_area:
+    type: string
+    required: false
+    default: "code quality, security, and performance"
+    description: Specific areas to focus the review on
+  context:
+    type: string
+    required: false
+    description: Additional context about the code or project
+
+outputSchema:
+  type: object
+  properties:
+    summary:
+      type: string
+      description: Brief summary of the review findings
+    issues:
+      type: array
+      items:
+        type: object
+        properties:
+          severity:
+            type: string
+            enum: [critical, major, minor, suggestion]
+          line:
+            type: integer
+          description:
+            type: string
+          suggestion:
+            type: string
+    score:
+      type: integer
+      minimum: 1
+      maximum: 10
+  required:
+    - summary
+    - issues
+    - score
+
+metadata:
+  author: apicurio-team
+  createdAt: "2025-01-21"
+  tags:
+    - code-review
+    - developer-tools
+    - mcp-enabled
+  recommendedModels:
+    - claude-3-opus
+    - gpt-4-turbo
+    - claude-3-sonnet
+  useCases:
+    - Automated code review
+    - Pull request analysis
+    - Developer assistance
+
+# MCP Extension - enables this prompt to be served via MCP prompts/list and prompts/get
+mcp:
+  enabled: true
+  name: review_code
+  description: Review code for quality, security, and performance issues


### PR DESCRIPTION
## Summary
Implements the remaining phases from issue #7254 (JSON Schema Backing for LLM Artifact Types + MCP Format Alignment):

- **Phase 2**: Add `GET /.well-known/schemas/{type}/{version}` endpoint to serve JSON Schemas for PROMPT_TEMPLATE and MODEL_SCHEMA artifact types, enabling IDE autocompletion and validation
- **Phase 4**: Document the MCP extension in the PROMPT_TEMPLATE schema and add sample MCP-enabled prompt template
- **Phase 5**: Implement dynamic MCP prompt serving via the MCP Server, allowing PROMPT_TEMPLATE artifacts to be exposed as MCP prompts

## Root Cause
Issue #7254 identified that while the validation logic for LLM artifact types was implemented, several features were incomplete:
- No endpoint to serve the JSON schemas at the declared `$schema` URLs
- MCP extension not documented in schema
- No MCP `prompts/list` and `prompts/get` functionality to expose PROMPT_TEMPLATEs as MCP prompts

## Changes
### Phase 2: Schema Publishing
- Add `GET /.well-known/schemas/{type}/{version}` endpoint in `WellKnownResource`
- Create `app/src/main/resources/schemas/prompt-template-v1.json` with full JSON Schema including MCP extension
- Create `app/src/main/resources/schemas/model-schema-v1.json` with full JSON Schema

### Phase 4: MCP Extension
- Add `MCPExtension` interface to `PromptTemplateArtifactType.ts` with documentation
- Include `mcp` property in the prompt-template JSON Schema
- Add sample MCP-enabled prompt: `mcp-enabled-code-review-prompt.yaml`

### Phase 5: MCP Prompt Serving  
- Create `PromptsMCPServer.java` with:
  - `list_mcp_prompts`: List all MCP-enabled PROMPT_TEMPLATE artifacts
  - `get_mcp_prompt`: Get and optionally render an MCP-enabled prompt
  - `render_prompt_template`: Render any PROMPT_TEMPLATE with variable substitution
- Add `jackson-dataformat-yaml` dependency to MCP module for YAML parsing

## Test plan
- [x] Build passes: `./mvnw clean install -DskipTests`
- [x] Test `GET /.well-known/schemas/prompt-template/v1` returns valid JSON Schema
- [x] Test `GET /.well-known/schemas/model-schema/v1` returns valid JSON Schema
- [x] Verify MCP tools work with MCP-enabled PROMPT_TEMPLATE artifacts
- [x] Validate sample prompt passes validation and can be rendered