### PR TITLE
Fix owner-based authorization bypass in ccompat API (#7267)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -214,7 +214,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
     @Override
     @MethodMetadata(extractParameters = { "0", MPK_ARTIFACT_ID })
     @Audited
-    @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Write)
     public SchemaId registerSchemaUnderSubject(String subject, Boolean normalize, String format, String groupId, RegisterSchemaRequest request) {
         final boolean fnormalize = normalize == null ? Boolean.FALSE : normalize;
         final GA ga = getGA(groupId, subject);


### PR DESCRIPTION
## Summary

- Fixed authorization bypass vulnerability in ccompat API where non-owners could update artifacts
- Changed `registerSchemaUnderSubject` authorization level from `Read` to `Write`
- Updated existing tests to reflect correct security behavior
- Added comprehensive test coverage for the ownership enforcement fix

## Related Issue

Fixes #7267

## Details

The `registerSchemaUnderSubject` method in the ccompat API had an incorrect authorization annotation 
using `AuthorizedLevel.Read` instead of `AuthorizedLevel.Write`. This allowed non-owner users to 
bypass owner-based authorization controls (OBAC) and update artifacts they don't own.

With `AuthorizedLevel.Read`, the authorization interceptor did not trigger ownership verification, 
allowing write operations to proceed without proper authorization checks. This behavior was 
inconsistent with the V2 and V3 APIs which correctly enforce ownership restrictions.

### Changes Made

1. **SubjectsResourceImpl.java**: Changed authorization annotation to use `AuthorizedLevel.Write`
2. **CCompatAuthTest.java**: Updated `testRegisterWithReadPermission()` to use `getId()` for lookups
3. **CCompatAuthTest.java**: Updated `testAutoRegisterWithReadOnlyUser()` to remove incorrect assertion
4. **CCompatAuthTest.java**: Added `testNonOwnerCannotCreateArtifactsInOwnersGroup()` test

### Security Impact

- Prevents unauthorized artifact updates via the ccompat API
- Enforces owner-based authorization consistently across all APIs (V2, V3, and ccompat)
- Read-only users must now use `getId()` for schema lookups instead of `register()`

## Test Plan

- [x] Run existing ccompat authorization tests
- [x] Verify `testOwnerOnlyAuthorization()` passes
- [x] Verify `testRegisterWithReadPermission()` correctly rejects unauthorized register calls
- [x] Verify new `testNonOwnerCannotCreateArtifactsInOwnersGroup()` test passes
- [x] Verify non-owner users cannot update artifacts they don't own
- [x] Verify owners can still update their own artifacts
- [x] Verify admin role override still works (admins can update any artifact)