### PR TITLE
refactor: Extract shared utilities to reduce code duplication

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/ApiDtoUtils.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ApiDtoUtils.java
@@ -1,0 +1,60 @@
+package io.apicurio.registry.rest;
+
+import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
+import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
+
+/**
+ * Shared utility methods for working with API DTOs.
+ * This class contains methods that are used by both v2 and v3 API implementations.
+ */
+public final class ApiDtoUtils {
+
+    private ApiDtoUtils() {
+        // Utility class - prevent instantiation
+    }
+
+    /**
+     * Sets values from the EditableArtifactMetaDataDto into the ArtifactMetaDataDto.
+     *
+     * @param dto the target DTO to update
+     * @param editableMetaData the source of editable metadata
+     * @return the updated ArtifactMetaDataDto object
+     */
+    public static ArtifactMetaDataDto setEditableMetaDataInArtifact(ArtifactMetaDataDto dto,
+            EditableArtifactMetaDataDto editableMetaData) {
+        if (editableMetaData.getName() != null) {
+            dto.setName(editableMetaData.getName());
+        }
+        if (editableMetaData.getDescription() != null) {
+            dto.setDescription(editableMetaData.getDescription());
+        }
+        if (editableMetaData.getLabels() != null && !editableMetaData.getLabels().isEmpty()) {
+            dto.setLabels(editableMetaData.getLabels());
+        }
+        return dto;
+    }
+
+    /**
+     * Converts a "default" group ID to null.
+     *
+     * @param groupId the group ID
+     * @return null if the groupId is "default", otherwise the original value
+     */
+    public static String defaultGroupIdToNull(String groupId) {
+        if ("default".equalsIgnoreCase(groupId)) {
+            return null;
+        }
+        return groupId;
+    }
+
+    /**
+     * Converts a null group ID to "default".
+     *
+     * @param groupId the group ID
+     * @return "default" if the groupId is null, otherwise the original value
+     */
+    public static String nullGroupIdToDefault(String groupId) {
+        return groupId != null ? groupId : "default";
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/rest/ParameterValidationUtils.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ParameterValidationUtils.java
@@ -1,0 +1,56 @@
+package io.apicurio.registry.rest;
+
+/**
+ * Utility class providing common parameter validation methods for REST API resources.
+ * Centralizes validation logic that was previously duplicated across multiple resource implementations.
+ */
+public final class ParameterValidationUtils {
+
+    private ParameterValidationUtils() {
+        // Utility class - prevent instantiation
+    }
+
+    /**
+     * Validates that a required parameter is not null.
+     *
+     * @param parameterName the name of the parameter (for error messages)
+     * @param parameterValue the value to validate
+     * @throws MissingRequiredParameterException if the parameter value is null
+     */
+    public static void requireParameter(String parameterName, Object parameterValue) {
+        if (parameterValue == null) {
+            throw new MissingRequiredParameterException(parameterName);
+        }
+    }
+
+    /**
+     * Validates that at most one of two mutually exclusive parameters is provided.
+     *
+     * @param parameterOneName the name of the first parameter
+     * @param parameterOneValue the value of the first parameter
+     * @param parameterTwoName the name of the second parameter
+     * @param parameterTwoValue the value of the second parameter
+     * @throws ParametersConflictException if both parameters are non-null
+     */
+    public static void maxOneOf(String parameterOneName, Object parameterOneValue,
+            String parameterTwoName, Object parameterTwoValue) {
+        if (parameterOneValue != null && parameterTwoValue != null) {
+            throw new ParametersConflictException(parameterOneName, parameterTwoName);
+        }
+    }
+
+    /**
+     * Validates that if a parameter is provided, it matches an expected value.
+     *
+     * @param parameterName the name of the parameter
+     * @param expectedValue the expected value
+     * @param actualValue the actual value provided
+     * @throws InvalidParameterValueException if both values are non-null and don't match
+     */
+    public static void requireParameterValue(String parameterName, String expectedValue, String actualValue) {
+        if (actualValue != null && expectedValue != null && !actualValue.equals(expectedValue)) {
+            throw new InvalidParameterValueException(parameterName, actualValue, expectedValue);
+        }
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/AdminResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/AdminResourceImpl.java
@@ -14,6 +14,7 @@ import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
 import io.apicurio.registry.rest.MethodMetadata;
 import io.apicurio.registry.rest.MissingRequiredParameterException;
+import io.apicurio.registry.rest.ParameterValidationUtils;
 import io.apicurio.registry.rest.v2.AdminResource;
 import io.apicurio.registry.rest.v2.beans.ArtifactTypeInfo;
 import io.apicurio.registry.rest.v2.beans.ConfigurationProperty;
@@ -88,12 +89,6 @@ public class AdminResourceImpl implements AdminResource {
     @Inject
     io.apicurio.registry.rest.v3.impl.AdminResourceImpl v3Admin;
 
-    private static void requireParameter(String parameterName, Object parameterValue) {
-        if (parameterValue == null) {
-            throw new MissingRequiredParameterException(parameterName);
-        }
-    }
-
     /**
      * @see io.apicurio.registry.rest.v2.AdminResource#listArtifactTypes()
      */
@@ -128,7 +123,7 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
     public void createGlobalRule(Rule data) {
         RuleType type = data.getType();
-        requireParameter("type", type);
+        ParameterValidationUtils.requireParameter("type", type);
 
         if (data.getConfig() == null || data.getConfig().isEmpty()) {
             throw new MissingRequiredParameterException("Config");
@@ -290,8 +285,8 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
     @RoleBasedAccessApiOperation
     public void updateRoleMapping(String principalId, UpdateRole data) {
-        requireParameter("principalId", principalId);
-        requireParameter("role", data.getRole());
+        ParameterValidationUtils.requireParameter("principalId", principalId);
+        ParameterValidationUtils.requireParameter("role", data.getRole());
         storage.updateRoleMapping(principalId, data.getRole().name());
     }
 

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
@@ -22,7 +22,7 @@ import io.apicurio.registry.model.VersionExpressionParser;
 import io.apicurio.registry.rest.HeadersHack;
 import io.apicurio.registry.rest.MethodMetadata;
 import io.apicurio.registry.rest.MissingRequiredParameterException;
-import io.apicurio.registry.rest.ParametersConflictException;
+import io.apicurio.registry.rest.ParameterValidationUtils;
 import io.apicurio.registry.rest.RestConfig;
 import io.apicurio.registry.rest.v2.GroupsResource;
 import io.apicurio.registry.rest.v2.beans.*;
@@ -131,8 +131,8 @@ public class GroupsResourceImpl implements GroupsResource {
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public Response getLatestArtifact(String groupId, String artifactId, Boolean dereference) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         if (dereference == null) {
             dereference = Boolean.FALSE;
@@ -208,7 +208,7 @@ public class GroupsResourceImpl implements GroupsResource {
     public ArtifactMetaData updateArtifact(String groupId, String artifactId, String xRegistryVersion,
             String xRegistryName, String xRegistryNameEncoded, String xRegistryDescription,
             String xRegistryDescriptionEncoded, ArtifactContent data) {
-        requireParameter("content", data.getContent());
+        ParameterValidationUtils.requireParameter("content", data.getContent());
         return this.updateArtifactWithRefs(groupId, artifactId, xRegistryVersion, xRegistryName,
                 xRegistryNameEncoded, xRegistryDescription, xRegistryDescriptionEncoded,
                 IoUtil.toStream(data.getContent()), data.getReferences());
@@ -243,11 +243,11 @@ public class GroupsResourceImpl implements GroupsResource {
             String xRegistryDescription, String xRegistryDescriptionEncoded, InputStream data,
             List<ArtifactReference> references) {
 
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
-        maxOneOf("X-Registry-Name", xRegistryName, "X-Registry-Name-Encoded", xRegistryNameEncoded);
-        maxOneOf("X-Registry-Description", xRegistryDescription, "X-Registry-Description-Encoded",
+        ParameterValidationUtils.maxOneOf("X-Registry-Name", xRegistryName, "X-Registry-Name-Encoded", xRegistryNameEncoded);
+        ParameterValidationUtils.maxOneOf("X-Registry-Description", xRegistryDescription, "X-Registry-Description-Encoded",
                 xRegistryDescriptionEncoded);
 
         String artifactName = getOneOf(xRegistryName, decode(xRegistryNameEncoded));
@@ -274,8 +274,8 @@ public class GroupsResourceImpl implements GroupsResource {
                     (String[]) null);
         }
 
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         storage.deleteArtifact(defaultGroupIdToNull(groupId), artifactId);
     }
@@ -287,8 +287,8 @@ public class GroupsResourceImpl implements GroupsResource {
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public ArtifactMetaData getArtifactMetaData(String groupId, String artifactId) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         ArtifactMetaDataDto dto = storage.getArtifactMetaData(defaultGroupIdToNull(groupId), artifactId);
         GAV latestGAV = storage.getBranchTip(new GA(groupId, artifactId), BranchId.LATEST,
@@ -337,8 +337,8 @@ public class GroupsResourceImpl implements GroupsResource {
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public ArtifactOwner getArtifactOwner(String groupId, String artifactId) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         ArtifactMetaDataDto dto = storage.getArtifactMetaData(defaultGroupIdToNull(groupId), artifactId);
         ArtifactOwner owner = new ArtifactOwner();
@@ -351,9 +351,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.AdminOrOwner)
     public void updateArtifactOwner(String groupId, String artifactId, ArtifactOwner data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("data", data);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("data", data);
 
         if (data.getOwner().isEmpty()) {
             throw new MissingRequiredParameterException("Missing required owner");
@@ -449,8 +449,8 @@ public class GroupsResourceImpl implements GroupsResource {
 
     private VersionMetaData getArtifactVersionMetaDataByContent(String groupId, String artifactId,
             Boolean canonical, InputStream data, List<ArtifactReference> artifactReferences) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         if (canonical == null) {
             canonical = Boolean.FALSE;
@@ -481,8 +481,8 @@ public class GroupsResourceImpl implements GroupsResource {
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public List<RuleType> listArtifactRules(String groupId, String artifactId) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         return storage.getArtifactRules(defaultGroupIdToNull(groupId), artifactId);
     }
@@ -496,11 +496,11 @@ public class GroupsResourceImpl implements GroupsResource {
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void createArtifactRule(String groupId, String artifactId, Rule data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         RuleType type = data.getType();
-        requireParameter("type", type);
+        ParameterValidationUtils.requireParameter("type", type);
 
         if (data.getConfig() == null || data.getConfig().isEmpty()) {
             throw new MissingRequiredParameterException("Config");
@@ -525,8 +525,8 @@ public class GroupsResourceImpl implements GroupsResource {
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void deleteArtifactRules(String groupId, String artifactId) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         storage.deleteArtifactRules(defaultGroupIdToNull(groupId), artifactId);
     }
@@ -538,9 +538,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public Rule getArtifactRuleConfig(String groupId, String artifactId, RuleType rule) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("rule", rule);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("rule", rule);
 
         RuleConfigurationDto dto = storage.getArtifactRule(defaultGroupIdToNull(groupId), artifactId, rule);
         Rule rval = new Rule();
@@ -559,9 +559,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public Rule updateArtifactRuleConfig(String groupId, String artifactId, RuleType rule, Rule data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("rule", rule);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("rule", rule);
 
         RuleConfigurationDto dto = new RuleConfigurationDto(data.getConfig());
         storage.updateArtifactRule(defaultGroupIdToNull(groupId), artifactId, rule, dto);
@@ -580,9 +580,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void deleteArtifactRule(String groupId, String artifactId, RuleType rule) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("rule", rule);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("rule", rule);
 
         storage.deleteArtifactRule(defaultGroupIdToNull(groupId), artifactId, rule);
     }
@@ -596,9 +596,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactState(String groupId, String artifactId, UpdateState data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("body.state", data.getState());
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("body.state", data.getState());
 
         // Possible race condition here. Worst case should be that the update fails with a reasonable message.
         GAV latestGAV = storage.getBranchTip(new GA(defaultGroupIdToNull(groupId), artifactId),
@@ -613,8 +613,8 @@ public class GroupsResourceImpl implements GroupsResource {
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void testUpdateArtifact(String groupId, String artifactId, InputStream data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ContentHandle content = ContentHandle.create(data);
         if (content.bytes().length == 0) {
             throw new BadRequestException(EMPTY_CONTENT_ERROR_MESSAGE);
@@ -642,9 +642,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public Response getArtifactVersion(String groupId, String artifactId, String version,
             Boolean dereference) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
 
         if (dereference == null) {
             dereference = Boolean.FALSE;
@@ -702,9 +702,9 @@ public class GroupsResourceImpl implements GroupsResource {
                     HttpMethod.GET, (String[]) null);
         }
 
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
 
         storage.deleteArtifactVersion(defaultGroupIdToNull(groupId), artifactId, version);
     }
@@ -716,9 +716,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public VersionMetaData getArtifactVersionMetaData(String groupId, String artifactId, String version) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
 
         if ("latest".equals(version)) {
             var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), "branch=latest",
@@ -759,9 +759,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void deleteArtifactVersionMetaData(String groupId, String artifactId, String version) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
 
         EditableVersionMetaDataDto vmd = EditableVersionMetaDataDto.builder().name("").description("")
                 .labels(Map.of()).build();
@@ -778,9 +778,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public Comment addArtifactVersionComment(String groupId, String artifactId, String version,
             NewComment data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
 
         CommentDto newComment = storage.createArtifactVersionComment(defaultGroupIdToNull(groupId),
                 artifactId, version, data.getValue());
@@ -798,10 +798,10 @@ public class GroupsResourceImpl implements GroupsResource {
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void deleteArtifactVersionComment(String groupId, String artifactId, String version,
             String commentId) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
-        requireParameter("commentId", commentId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("commentId", commentId);
 
         storage.deleteArtifactVersionComment(defaultGroupIdToNull(groupId), artifactId, version, commentId);
     }
@@ -813,9 +813,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public List<Comment> getArtifactVersionComments(String groupId, String artifactId, String version) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
 
         if ("latest".equals(version)) {
             var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), "branch=latest",
@@ -839,11 +839,11 @@ public class GroupsResourceImpl implements GroupsResource {
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactVersionComment(String groupId, String artifactId, String version,
             String commentId, NewComment data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
-        requireParameter("commentId", commentId);
-        requireParameter("value", data.getValue());
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("commentId", commentId);
+        ParameterValidationUtils.requireParameter("value", data.getValue());
 
         storage.updateArtifactVersionComment(defaultGroupIdToNull(groupId), artifactId, version, commentId,
                 data.getValue());
@@ -860,9 +860,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactVersionState(String groupId, String artifactId, String version,
             UpdateState data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
 
         VersionState newState = VersionState.fromValue(data.getState().name());
         storage.updateArtifactVersionState(groupId, artifactId, version, newState, false);
@@ -876,7 +876,7 @@ public class GroupsResourceImpl implements GroupsResource {
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Read)
     public ArtifactSearchResults listArtifactsInGroup(String groupId, BigInteger limit, BigInteger offset,
             SortOrder order, SortBy orderby) {
-        requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
 
         if (orderby == null) {
             orderby = SortBy.name;
@@ -913,7 +913,7 @@ public class GroupsResourceImpl implements GroupsResource {
                     (String[]) null);
         }
 
-        requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
 
         storage.deleteArtifacts(defaultGroupIdToNull(groupId));
     }
@@ -956,7 +956,7 @@ public class GroupsResourceImpl implements GroupsResource {
             String xRegistryDescription, String xRegistryDescriptionEncoded, String xRegistryName,
             String xRegistryNameEncoded, String xRegistryContentHash, String xRegistryHashAlgorithm,
             ArtifactContent data) {
-        requireParameter("content", data.getContent());
+        ParameterValidationUtils.requireParameter("content", data.getContent());
 
         Client client = null;
         InputStream content;
@@ -1054,10 +1054,10 @@ public class GroupsResourceImpl implements GroupsResource {
             String xRegistryNameEncoded, String xRegistryContentHash, String xRegistryHashAlgorithm,
             InputStream data, List<ArtifactReference> references) {
 
-        requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
 
-        maxOneOf("X-Registry-Name", xRegistryName, "X-Registry-Name-Encoded", xRegistryNameEncoded);
-        maxOneOf("X-Registry-Description", xRegistryDescription, "X-Registry-Description-Encoded",
+        ParameterValidationUtils.maxOneOf("X-Registry-Name", xRegistryName, "X-Registry-Name-Encoded", xRegistryNameEncoded);
+        ParameterValidationUtils.maxOneOf("X-Registry-Description", xRegistryDescription, "X-Registry-Description-Encoded",
                 xRegistryDescriptionEncoded);
 
         String artifactName = getOneOf(xRegistryName, decode(xRegistryNameEncoded));
@@ -1175,8 +1175,8 @@ public class GroupsResourceImpl implements GroupsResource {
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public VersionSearchResults listArtifactVersions(String groupId, String artifactId, BigInteger offset,
             BigInteger limit) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         // This will check if the artifact exists (throws 404 if not).
         storage.getArtifactMetaData(defaultGroupIdToNull(groupId), artifactId);
@@ -1225,7 +1225,7 @@ public class GroupsResourceImpl implements GroupsResource {
     public VersionMetaData createArtifactVersion(String groupId, String artifactId, String xRegistryVersion,
             String xRegistryName, String xRegistryDescription, String xRegistryDescriptionEncoded,
             String xRegistryNameEncoded, ArtifactContent data) {
-        requireParameter("content", data.getContent());
+        ParameterValidationUtils.requireParameter("content", data.getContent());
         return this.createArtifactVersionWithRefs(groupId, artifactId, xRegistryVersion, xRegistryName,
                 xRegistryDescription, xRegistryDescriptionEncoded, xRegistryNameEncoded,
                 IoUtil.toStream(data.getContent()), data.getReferences());
@@ -1250,11 +1250,11 @@ public class GroupsResourceImpl implements GroupsResource {
             String xRegistryDescriptionEncoded, String xRegistryNameEncoded, InputStream data,
             List<ArtifactReference> references) {
         // TODO do something with the user-provided version info
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
-        maxOneOf("X-Registry-Name", xRegistryName, "X-Registry-Name-Encoded", xRegistryNameEncoded);
-        maxOneOf("X-Registry-Description", xRegistryDescription, "X-Registry-Description-Encoded",
+        ParameterValidationUtils.maxOneOf("X-Registry-Name", xRegistryName, "X-Registry-Name-Encoded", xRegistryNameEncoded);
+        ParameterValidationUtils.maxOneOf("X-Registry-Description", xRegistryDescription, "X-Registry-Description-Encoded",
                 xRegistryDescriptionEncoded);
 
         String artifactName = getOneOf(xRegistryName, decode(xRegistryNameEncoded));
@@ -1339,19 +1339,6 @@ public class GroupsResourceImpl implements GroupsResource {
      */
     private String getContentType() {
         return request.getContentType();
-    }
-
-    private static final void requireParameter(String parameterName, Object parameterValue) {
-        if (parameterValue == null) {
-            throw new MissingRequiredParameterException(parameterName);
-        }
-    }
-
-    private static void maxOneOf(String parameterOneName, Object parameterOneValue, String parameterTwoName,
-            Object parameterTwoValue) {
-        if (parameterOneValue != null && parameterTwoValue != null) {
-            throw new ParametersConflictException(parameterOneName, parameterTwoName);
-        }
     }
 
     private static <T> T getOneOf(T parameterOneValue, T parameterTwoValue) {

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/V2ApiUtil.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/V2ApiUtil.java
@@ -223,19 +223,12 @@ public final class V2ApiUtil {
      * @param amdd
      * @param editableArtifactMetaData
      * @return the updated ArtifactMetaDataDto object
+     * @deprecated Use {@link io.apicurio.registry.rest.ApiDtoUtils#setEditableMetaDataInArtifact} instead
      */
+    @Deprecated
     public static ArtifactMetaDataDto setEditableMetaDataInArtifact(ArtifactMetaDataDto amdd,
             EditableArtifactMetaDataDto editableArtifactMetaData) {
-        if (editableArtifactMetaData.getName() != null) {
-            amdd.setName(editableArtifactMetaData.getName());
-        }
-        if (editableArtifactMetaData.getDescription() != null) {
-            amdd.setDescription(editableArtifactMetaData.getDescription());
-        }
-        if (editableArtifactMetaData.getLabels() != null && !editableArtifactMetaData.getLabels().isEmpty()) {
-            amdd.setLabels(editableArtifactMetaData.getLabels());
-        }
-        return amdd;
+        return io.apicurio.registry.rest.ApiDtoUtils.setEditableMetaDataInArtifact(amdd, editableArtifactMetaData);
     }
 
     public static Comparator<ArtifactMetaDataDto> comparator(SortOrder sortOrder) {
@@ -356,14 +349,19 @@ public final class V2ApiUtil {
                 .reduce((left, right) -> left + ", " + right).orElse("");
     }
 
+    /**
+     * @deprecated Use {@link io.apicurio.registry.rest.ApiDtoUtils#defaultGroupIdToNull} instead
+     */
+    @Deprecated
     public static String defaultGroupIdToNull(String groupId) {
-        if ("default".equalsIgnoreCase(groupId)) {
-            return null;
-        }
-        return groupId;
+        return io.apicurio.registry.rest.ApiDtoUtils.defaultGroupIdToNull(groupId);
     }
 
+    /**
+     * @deprecated Use {@link io.apicurio.registry.rest.ApiDtoUtils#nullGroupIdToDefault} instead
+     */
+    @Deprecated
     public static String nullGroupIdToDefault(String groupId) {
-        return groupId != null ? groupId : "default";
+        return io.apicurio.registry.rest.ApiDtoUtils.nullGroupIdToDefault(groupId);
     }
 }

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/AdminResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/AdminResourceImpl.java
@@ -17,6 +17,7 @@ import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessChe
 import io.apicurio.registry.rest.ConflictException;
 import io.apicurio.registry.rest.MethodMetadata;
 import io.apicurio.registry.rest.MissingRequiredParameterException;
+import io.apicurio.registry.rest.ParameterValidationUtils;
 import io.apicurio.registry.rest.v3.AdminResource;
 import io.apicurio.registry.rest.v3.beans.ArtifactTypeInfo;
 import io.apicurio.registry.rest.v3.beans.ConfigurationProperty;
@@ -132,12 +133,6 @@ public class AdminResourceImpl implements AdminResource {
     @Info(category = CATEGORY_DOWNLOAD, description = "Download link expiry", availableSince = "2.1.2.Final")
     Supplier<Long> downloadHrefTtl;
 
-    private static void requireParameter(String parameterName, Object parameterValue) {
-        if (parameterValue == null) {
-            throw new MissingRequiredParameterException(parameterName);
-        }
-    }
-
     /**
      * @see io.apicurio.registry.rest.v3.AdminResource#listArtifactTypes()
      */
@@ -181,7 +176,7 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
     public void createGlobalRule(CreateRule data) {
         RuleType ruleType = data.getRuleType();
-        requireParameter("ruleType", ruleType);
+        ParameterValidationUtils.requireParameter("ruleType", ruleType);
 
         if (data.getConfig() == null || data.getConfig().trim().isEmpty()) {
             throw new MissingRequiredParameterException("config");
@@ -433,8 +428,8 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
     @RoleBasedAccessApiOperation
     public void updateRoleMapping(String principalId, UpdateRole data) {
-        requireParameter("principalId", principalId);
-        requireParameter("role", data.getRole());
+        ParameterValidationUtils.requireParameter("principalId", principalId);
+        ParameterValidationUtils.requireParameter("role", data.getRole());
         storage.updateRoleMapping(principalId, data.getRole().name());
     }
 

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -16,9 +16,9 @@ import io.apicurio.registry.model.VersionExpressionParser;
 import io.apicurio.registry.model.VersionId;
 import io.apicurio.registry.rest.ConflictException;
 import io.apicurio.registry.rest.HeadersHack;
-import io.apicurio.registry.rest.InvalidParameterValueException;
 import io.apicurio.registry.rest.MethodMetadata;
 import io.apicurio.registry.rest.MissingRequiredParameterException;
+import io.apicurio.registry.rest.ParameterValidationUtils;
 import io.apicurio.registry.rest.RestConfig;
 import io.apicurio.registry.rest.v3.GroupsResource;
 import io.apicurio.registry.rest.v3.beans.*;
@@ -150,9 +150,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     public ReferenceGraph getArtifactVersionReferencesGraph(String groupId, String artifactId,
             String versionExpression, ReferenceGraphDirection direction, BigInteger depth) {
 
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("versionExpression", versionExpression);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
 
         // Check if the artifact exists first to provide the correct exception type
         if (!storage.isArtifactExists(new GroupId(groupId).getRawGroupIdWithNull(), artifactId)) {
@@ -469,8 +469,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                     (String[]) null);
         }
 
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         storage.deleteArtifact(new GroupId(groupId).getRawGroupIdWithNull(), artifactId);
     }
@@ -482,8 +482,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public ArtifactMetaData getArtifactMetaData(String groupId, String artifactId) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         ArtifactMetaDataDto dto = storage.getArtifactMetaData(new GroupId(groupId).getRawGroupIdWithNull(),
                 artifactId);
@@ -499,8 +499,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactMetaData(String groupId, String artifactId, EditableArtifactMetaData data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         if (data.getOwner() != null) {
             if (data.getOwner().trim().isEmpty()) {
@@ -548,7 +548,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void updateGroupById(String groupId, EditableGroupMetaData data) {
-        requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
 
         EditableGroupMetaDataDto dto = new EditableGroupMetaDataDto();
         dto.setDescription(data.getDescription());
@@ -605,7 +605,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Override
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Read)
     public List<RuleType> listGroupRules(String groupId) {
-        requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
 
         return storage.getGroupRules(new GroupId(groupId).getRawGroupIdWithNull());
     }
@@ -615,9 +615,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void createGroupRule(String groupId, CreateRule data) {
-        requireParameter("groupId", groupId);
-        requireParameter("ruleType", data.getRuleType());
-        requireParameter("config", data.getConfig());
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("ruleType", data.getRuleType());
+        ParameterValidationUtils.requireParameter("config", data.getConfig());
 
         if (data.getConfig() == null || data.getConfig().trim().isEmpty()) {
             throw new MissingRequiredParameterException("config");
@@ -642,9 +642,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public Rule updateGroupRuleConfig(String groupId, RuleType ruleType, Rule data) {
-        requireParameter("groupId", groupId);
-        requireParameter("ruleType", ruleType);
-        requireParameter("config", data.getConfig());
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("ruleType", ruleType);
+        ParameterValidationUtils.requireParameter("config", data.getConfig());
 
         if (data.getConfig() == null || data.getConfig().trim().isEmpty()) {
             throw new MissingRequiredParameterException("config");
@@ -663,7 +663,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void deleteGroupRules(String groupId) {
-        requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
 
         storage.deleteGroupRules(new GroupId(groupId).getRawGroupIdWithNull());
     }
@@ -671,8 +671,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Override
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Read)
     public Rule getGroupRuleConfig(String groupId, RuleType ruleType) {
-        requireParameter("groupId", groupId);
-        requireParameter("ruleType", ruleType);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("ruleType", ruleType);
 
         RuleConfigurationDto dto = storage.getGroupRule(new GroupId(groupId).getRawGroupIdWithNull(),
                 ruleType);
@@ -687,8 +687,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void deleteGroupRule(String groupId, RuleType rule) {
-        requireParameter("groupId", groupId);
-        requireParameter("rule", rule);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("rule", rule);
 
         storage.deleteGroupRule(new GroupId(groupId).getRawGroupIdWithNull(), rule);
     }
@@ -699,8 +699,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public List<RuleType> listArtifactRules(String groupId, String artifactId) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         return storage.getArtifactRules(new GroupId(groupId).getRawGroupIdWithNull(), artifactId);
     }
@@ -713,10 +713,10 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void createArtifactRule(String groupId, String artifactId, CreateRule data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("ruleType", data.getRuleType());
-        requireParameter("config", data.getConfig());
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("ruleType", data.getRuleType());
+        ParameterValidationUtils.requireParameter("config", data.getConfig());
 
         if (data.getConfig() == null || data.getConfig().trim().isEmpty()) {
             throw new MissingRequiredParameterException("config");
@@ -742,8 +742,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void deleteArtifactRules(String groupId, String artifactId) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         storage.deleteArtifactRules(new GroupId(groupId).getRawGroupIdWithNull(), artifactId);
     }
@@ -755,9 +755,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public Rule getArtifactRuleConfig(String groupId, String artifactId, RuleType ruleType) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("ruleType", ruleType);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("ruleType", ruleType);
 
         RuleConfigurationDto dto = storage.getArtifactRule(new GroupId(groupId).getRawGroupIdWithNull(),
                 artifactId, ruleType);
@@ -777,10 +777,10 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public Rule updateArtifactRuleConfig(String groupId, String artifactId, RuleType ruleType, Rule data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("ruleType", ruleType);
-        requireParameter("config", data.getConfig());
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("ruleType", ruleType);
+        ParameterValidationUtils.requireParameter("config", data.getConfig());
 
         if (data.getConfig() == null || data.getConfig().trim().isEmpty()) {
             throw new MissingRequiredParameterException("config");
@@ -803,9 +803,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void deleteArtifactRule(String groupId, String artifactId, RuleType rule) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("rule", rule);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("rule", rule);
 
         storage.deleteArtifactRule(new GroupId(groupId).getRawGroupIdWithNull(), artifactId, rule);
     }
@@ -818,9 +818,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public Response getArtifactVersionContent(String groupId, String artifactId, String versionExpression,
             HandleReferencesType references) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("versionExpression", versionExpression);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), versionExpression,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.SKIP_DISABLED_LATEST));
@@ -858,9 +858,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactVersionContent(String groupId, String artifactId, String versionExpression,
             VersionContent data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("versionExpression", versionExpression);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
 
         if (!restConfig.isArtifactVersionMutabilityEnabled()) {
             throw new NotAllowedException("Artifact version content update operation is not enabled.",
@@ -921,9 +921,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                     HttpMethod.GET, (String[]) null);
         }
 
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), version,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.ALL_STATES));
@@ -939,9 +939,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public VersionMetaData getArtifactVersionMetaData(String groupId, String artifactId, String version) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), version,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.SKIP_DISABLED_LATEST));
@@ -962,9 +962,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactVersionMetaData(String groupId, String artifactId, String versionExpression,
             EditableVersionMetaData data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("versionExpression", versionExpression);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), versionExpression,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.SKIP_DISABLED_LATEST));
@@ -981,9 +981,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public WrappedVersionState getArtifactVersionState(String groupId, String artifactId,
             String versionExpression) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", versionExpression);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", versionExpression);
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), versionExpression,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.ALL_STATES));
@@ -999,10 +999,10 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write, dryRunParam = 3)
     public void updateArtifactVersionState(String groupId, String artifactId, String versionExpression,
             Boolean dryRun, WrappedVersionState data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("versionExpression", versionExpression);
-        requireParameter("body.state", data.getState());
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
+        ParameterValidationUtils.requireParameter("body.state", data.getState());
 
         if (data.getState() == VersionState.DRAFT) {
             throw new BadRequestException("Illegal state transition: cannot transition to DRAFT state.");
@@ -1052,9 +1052,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public Comment addArtifactVersionComment(String groupId, String artifactId, String versionExpression,
             NewComment data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("versionExpression", versionExpression);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), versionExpression,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.ALL_STATES));
@@ -1075,10 +1075,10 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void deleteArtifactVersionComment(String groupId, String artifactId, String versionExpression,
             String commentId) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("versionExpression", versionExpression);
-        requireParameter("commentId", commentId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
+        ParameterValidationUtils.requireParameter("commentId", commentId);
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), versionExpression,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.ALL_STATES));
@@ -1094,9 +1094,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public List<Comment> getArtifactVersionComments(String groupId, String artifactId, String version) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("version", version);
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), version,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.ALL_STATES));
@@ -1117,11 +1117,11 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void updateArtifactVersionComment(String groupId, String artifactId, String versionExpression,
             String commentId, NewComment data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("versionExpression", versionExpression);
-        requireParameter("commentId", commentId);
-        requireParameter("value", data.getValue());
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
+        ParameterValidationUtils.requireParameter("commentId", commentId);
+        ParameterValidationUtils.requireParameter("value", data.getValue());
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), versionExpression,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.ALL_STATES));
@@ -1134,7 +1134,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Read)
     public ArtifactSearchResults listArtifactsInGroup(String groupId, BigInteger limit, BigInteger offset,
             SortOrder order, ArtifactSortBy orderby) {
-        requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
 
         if (orderby == null) {
             orderby = ArtifactSortBy.name;
@@ -1171,7 +1171,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                     (String[]) null);
         }
 
-        requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
 
         storage.deleteArtifacts(new GroupId(groupId).getRawGroupIdWithNull());
     }
@@ -1182,7 +1182,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write, dryRunParam = 3)
     public CreateArtifactResponse createArtifact(String groupId, IfArtifactExists ifExists, Boolean canonical,
             Boolean dryRun, CreateArtifact data) {
-        requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
         if (data.getFirstVersion() != null) {
             boolean contentRequired = true;
             if (data.getArtifactType() != null) {
@@ -1190,10 +1190,10 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                 contentRequired = !contentTypes.isEmpty();
             }
             if (contentRequired) {
-                requireParameter("body.firstVersion.content", data.getFirstVersion().getContent());
-                requireParameter("body.firstVersion.content.content",
+                ParameterValidationUtils.requireParameter("body.firstVersion.content", data.getFirstVersion().getContent());
+                ParameterValidationUtils.requireParameter("body.firstVersion.content.content",
                         data.getFirstVersion().getContent().getContent());
-                requireParameter("body.firstVersion.content.contentType",
+                ParameterValidationUtils.requireParameter("body.firstVersion.content.contentType",
                         data.getFirstVersion().getContent().getContentType());
             } else {
                 if (data.getFirstVersion().getContent() == null) {
@@ -1205,14 +1205,14 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                 if (data.getFirstVersion().getContent().getContentType() == null) {
                     data.getFirstVersion().getContent().setContentType(ContentTypes.APPLICATION_EMPTY);
                 }
-                requireParameterValue("body.firstVersion.content.contentType", ContentTypes.APPLICATION_EMPTY,
+                ParameterValidationUtils.requireParameterValue("body.firstVersion.content.contentType", ContentTypes.APPLICATION_EMPTY,
                         data.getFirstVersion().getContent().getContentType());
             }
             if (data.getFirstVersion().getBranches() == null) {
                 data.getFirstVersion().setBranches(Collections.emptyList());
             }
         } else {
-            requireParameter("body.artifactType", data.getArtifactType());
+            ParameterValidationUtils.requireParameter("body.artifactType", data.getArtifactType());
         }
 
         if (!ArtifactIdValidator.isGroupIdAllowed(groupId)) {
@@ -1328,8 +1328,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public VersionSearchResults listArtifactVersions(String groupId, String artifactId, BigInteger offset,
             BigInteger limit, SortOrder order, VersionSortBy orderby) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
         if (orderby == null) {
             orderby = VersionSortBy.createdOn;
         }
@@ -1363,16 +1363,16 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write, dryRunParam = 2)
     public VersionMetaData createArtifactVersion(String groupId, String artifactId, Boolean dryRun,
             CreateVersion data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         String artifactType = lookupArtifactType(groupId, artifactId);
         ArtifactTypeUtilProvider artifactTypeProvider = factory.getArtifactTypeProvider(artifactType);
         boolean isEmptyContent = artifactTypeProvider.getContentTypes().isEmpty();
         if (!isEmptyContent) {
-            requireParameter("body.content", data.getContent());
-            requireParameter("body.content.content", data.getContent().getContent());
-            requireParameter("body.content.contentType", data.getContent().getContentType());
+            ParameterValidationUtils.requireParameter("body.content", data.getContent());
+            ParameterValidationUtils.requireParameter("body.content.content", data.getContent().getContent());
+            ParameterValidationUtils.requireParameter("body.content.contentType", data.getContent().getContentType());
         } else {
             if (data.getContent() == null) {
                 data.setContent(new VersionContent());
@@ -1423,9 +1423,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public BranchMetaData createBranch(String groupId, String artifactId, CreateBranch data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("branchId", data.getBranchId());
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("branchId", data.getBranchId());
 
         GA ga = new GA(groupId, artifactId);
         BranchId bid = new BranchId(data.getBranchId());
@@ -1438,8 +1438,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public BranchSearchResults listBranches(String groupId, String artifactId, BigInteger offset,
             BigInteger limit) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         if (offset == null) {
             offset = BigInteger.valueOf(0);
@@ -1456,8 +1456,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public BranchMetaData getBranchMetaData(String groupId, String artifactId, String branchId) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
         BranchMetaDataDto branch = storage.getBranchMetaData(new GA(groupId, artifactId),
                 new BranchId(branchId));
@@ -1470,9 +1470,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateBranchMetaData(String groupId, String artifactId, String branchId,
             EditableBranchMetaData data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("branchId", branchId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("branchId", branchId);
 
         EditableBranchMetaDataDto dto = EditableBranchMetaDataDto.builder().description(data.getDescription())
                 .build();
@@ -1484,9 +1484,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void deleteBranch(String groupId, String artifactId, String branchId) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("branchId", branchId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("branchId", branchId);
 
         storage.deleteBranch(new GA(groupId, artifactId), new BranchId(branchId));
     }
@@ -1495,9 +1495,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public VersionSearchResults listBranchVersions(String groupId, String artifactId, String branchId,
             BigInteger offset, BigInteger limit) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("branchId", branchId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("branchId", branchId);
 
         if (offset == null) {
             offset = BigInteger.valueOf(0);
@@ -1523,10 +1523,10 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void replaceBranchVersions(String groupId, String artifactId, String branchId,
             ReplaceBranchVersions data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("branchId", branchId);
-        requireParameter("versions", data.getVersions());
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("branchId", branchId);
+        ParameterValidationUtils.requireParameter("versions", data.getVersions());
 
         GA ga = new GA(groupId, artifactId);
         BranchId bid = new BranchId(branchId);
@@ -1543,9 +1543,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void addVersionToBranch(String groupId, String artifactId, String branchId,
             AddVersionToBranch data) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("branchId", branchId);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("branchId", branchId);
 
         GA ga = new GA(groupId, artifactId);
         BranchId bid = new BranchId(branchId);
@@ -1602,18 +1602,6 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
             return data.getFirstVersion().getContent().getReferences();
         }
         return null;
-    }
-
-    private static void requireParameter(String parameterName, Object parameterValue) {
-        if (parameterValue == null) {
-            throw new MissingRequiredParameterException(parameterName);
-        }
-    }
-
-    private static void requireParameterValue(String parameterName, String expectedValue, String actualValue) {
-        if (actualValue != null && expectedValue != null && !actualValue.equals(expectedValue)) {
-            throw new InvalidParameterValueException(parameterName, actualValue, expectedValue);
-        }
     }
 
     private CreateArtifactResponse handleIfExists(String groupId, String artifactId,
@@ -1762,11 +1750,11 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
             String groupId, String artifactId, String versionExpression,
             io.apicurio.registry.rest.v3.beans.RenderPromptRequest data) {
 
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("versionExpression", versionExpression);
-        requireParameter("data", data);
-        requireParameter("variables", data.getVariables());
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
+        ParameterValidationUtils.requireParameter("data", data);
+        ParameterValidationUtils.requireParameter("variables", data.getVariables());
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), versionExpression,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.ALL_STATES));
@@ -1804,9 +1792,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Override
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public Response exportArtifactVersion(String groupId, String artifactId, String versionExpression) {
-        requireParameter("groupId", groupId);
-        requireParameter("artifactId", artifactId);
-        requireParameter("versionExpression", versionExpression);
+        ParameterValidationUtils.requireParameter("groupId", groupId);
+        ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), versionExpression,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.SKIP_DISABLED_LATEST));

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/V3ApiUtil.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/V3ApiUtil.java
@@ -96,19 +96,12 @@ public final class V3ApiUtil {
      * @param dto
      * @param editableArtifactMetaData
      * @return the updated ArtifactMetaDataDto object
+     * @deprecated Use {@link io.apicurio.registry.rest.ApiDtoUtils#setEditableMetaDataInArtifact} instead
      */
+    @Deprecated
     public static ArtifactMetaDataDto setEditableMetaDataInArtifact(ArtifactMetaDataDto dto,
             EditableArtifactMetaDataDto editableArtifactMetaData) {
-        if (editableArtifactMetaData.getName() != null) {
-            dto.setName(editableArtifactMetaData.getName());
-        }
-        if (editableArtifactMetaData.getDescription() != null) {
-            dto.setDescription(editableArtifactMetaData.getDescription());
-        }
-        if (editableArtifactMetaData.getLabels() != null && !editableArtifactMetaData.getLabels().isEmpty()) {
-            dto.setLabels(editableArtifactMetaData.getLabels());
-        }
-        return dto;
+        return io.apicurio.registry.rest.ApiDtoUtils.setEditableMetaDataInArtifact(dto, editableArtifactMetaData);
     }
 
     public static Comparator<ArtifactMetaDataDto> comparator(SortOrder sortOrder) {

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractSerializer.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractSerializer.java
@@ -9,13 +9,12 @@ import io.apicurio.registry.resolver.strategy.ArtifactReferenceResolverStrategy;
 import io.apicurio.registry.serde.config.SerdeConfig;
 import io.apicurio.registry.serde.data.SerdeMetadata;
 import io.apicurio.registry.serde.data.SerdeRecord;
+import io.apicurio.registry.serde.utils.BoundedCacheFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static io.apicurio.registry.serde.BaseSerde.MAGIC_BYTE;
@@ -46,16 +45,7 @@ public abstract class AbstractSerializer<T, U> implements AutoCloseable {
      * after the first serialization of a message type per topic.
      * Uses LRU eviction to prevent unbounded growth.
      */
-    private final Map<SchemaCacheKey, SchemaLookupResult<T>> fastPathCache = createBoundedCache(MAX_CACHE_SIZE);
-
-    private static <K, V> Map<K, V> createBoundedCache(int maxSize) {
-        return Collections.synchronizedMap(new LinkedHashMap<K, V>(maxSize, 0.75f, true) {
-            @Override
-            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
-                return size() > maxSize;
-            }
-        });
-    }
+    private final Map<SchemaCacheKey, SchemaLookupResult<T>> fastPathCache = BoundedCacheFactory.createLRU(MAX_CACHE_SIZE);
 
     private final BaseSerde<T, U> baseSerde;
 

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/utils/BoundedCacheFactory.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/utils/BoundedCacheFactory.java
@@ -1,0 +1,36 @@
+package io.apicurio.registry.serde.utils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Factory for creating bounded LRU (Least Recently Used) caches.
+ * These caches are thread-safe and automatically evict the least recently accessed entry
+ * when the cache exceeds the specified maximum size.
+ */
+public final class BoundedCacheFactory {
+
+    private BoundedCacheFactory() {
+        // Utility class - prevent instantiation
+    }
+
+    /**
+     * Creates a thread-safe bounded LRU cache.
+     * When the cache exceeds maxSize, the least recently accessed entry is removed.
+     *
+     * @param <K> the type of keys maintained by this cache
+     * @param <V> the type of mapped values
+     * @param maxSize the maximum number of entries the cache should hold
+     * @return a new thread-safe bounded LRU cache
+     */
+    public static <K, V> Map<K, V> createLRU(int maxSize) {
+        return Collections.synchronizedMap(new LinkedHashMap<K, V>(maxSize, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+                return size() > maxSize;
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
## Summary
Reduce code duplication in REST API layer and serdes modules by extracting shared utilities.

Closes #7306, #7308, #7309
Relates to #7305 (Codebase Refactoring Epic)

## Root Cause
The codebase analysis identified significant code duplication across REST API implementations and serializer classes:

1. **Parameter validation methods** (`requireParameter()`, `maxOneOf()`, `requireParameterValue()`) were duplicated across 4 resource implementation classes (v2/v3 AdminResourceImpl and GroupsResourceImpl).

2. **DTO manipulation methods** (`setEditableMetaDataInArtifact()`, group ID utilities) were duplicated in V2ApiUtil and V3ApiUtil with identical logic.

3. **LRU cache creation code** was copy-pasted between `AbstractSerializer` and `ProtobufSerializer` in the serdes modules.

This duplication increases maintenance burden, risks inconsistent fixes, and bloats the codebase unnecessarily.

## Changes

### New Shared Utility Classes

- **`app/.../rest/ParameterValidationUtils.java`** (new)
  - Extracted `requireParameter(String, Object)` - validates required parameters
  - Extracted `maxOneOf(String, Object, String, Object)` - validates mutually exclusive params
  - Extracted `requireParameterValue(String, String, String)` - validates expected values

- **`app/.../rest/ApiDtoUtils.java`** (new)
  - Extracted `setEditableMetaDataInArtifact(ArtifactMetaDataDto, EditableArtifactMetaDataDto)`
  - Extracted `defaultGroupIdToNull(String)` - converts "default" to null
  - Extracted `nullGroupIdToDefault(String)` - converts null to "default"

- **`serdes/.../serde/utils/BoundedCacheFactory.java`** (new)
  - Extracted `createLRU(int maxSize)` - creates thread-safe bounded LRU cache

### Modified Files

- **`rest/v3/impl/AdminResourceImpl.java`** - Uses ParameterValidationUtils
- **`rest/v3/impl/GroupsResourceImpl.java`** - Uses ParameterValidationUtils (100+ call sites)
- **`rest/v2/impl/AdminResourceImpl.java`** - Uses ParameterValidationUtils
- **`rest/v2/impl/GroupsResourceImpl.java`** - Uses ParameterValidationUtils
- **`rest/v2/impl/V2ApiUtil.java`** - Delegates to ApiDtoUtils (deprecated wrappers)
- **`rest/v3/impl/V3ApiUtil.java`** - Delegates to ApiDtoUtils (deprecated wrappers)
- **`serde/AbstractSerializer.java`** - Uses BoundedCacheFactory
- **`serde/protobuf/ProtobufSerializer.java`** - Uses BoundedCacheFactory

### Code Reduction
- **Net reduction**: 66 lines (303 deletions, 237 additions)
- **Duplicate methods eliminated**: 8 methods across 6 files

## Test plan
- [x] Compile `app` module successfully
- [x] Compile `serdes/generic/serde-common` module successfully
- [x] Compile `serdes/generic/serde-common-protobuf` module successfully
- [x] Run unit tests: `mvn test -pl app`
- [x] Run integration tests with SQL storage
- [x] Verify parameter validation still works (test API endpoints with missing/conflicting parameters)
- [x] Verify serialization still works with bounded caches