### PR TITLE
fix(storage): move orphan content cleanup to scheduled background job

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/OrphanedContentReaper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/OrphanedContentReaper.java
@@ -1,0 +1,53 @@
+package io.apicurio.registry.storage;
+
+import io.apicurio.registry.cdi.Current;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.slf4j.Logger;
+
+import java.time.Instant;
+
+import static io.quarkus.scheduler.Scheduled.ConcurrentExecution.SKIP;
+
+/**
+ * Periodically cleanup orphaned content (content rows not referenced by any artifact version).
+ */
+@ApplicationScoped
+public class OrphanedContentReaper {
+
+    @Inject
+    Logger log;
+
+    @Inject
+    @Current
+    RegistryStorage storage;
+
+    /**
+     * Minimal granularity is 1 minute.
+     */
+    @Scheduled(delay = 60, concurrentExecution = SKIP, every = "{apicurio.storage.orphan-cleanup.every}")
+    void run() {
+        try {
+            if (storage.isReady()) {
+                if (!storage.isReadOnly()) {
+                    log.debug("Running orphaned content cleanup job at {}", Instant.now());
+                    reap();
+                } else {
+                    log.debug("Skipping orphaned content cleanup because storage is in read-only mode.");
+                }
+            } else {
+                log.debug("Skipping orphaned content cleanup because storage is not ready.");
+            }
+        } catch (Exception ex) {
+            log.error("Exception thrown when running orphaned content cleanup job", ex);
+        }
+    }
+
+    /**
+     * Delete any rows in the "content" table that are not referenced by any artifact version.
+     */
+    void reap() {
+        storage.deleteAllOrphanedContent();
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
@@ -774,6 +774,14 @@ public interface RegistryStorage extends DynamicConfigStorage {
     void deleteAllExpiredDownloads() throws RegistryStorageException;
 
     /**
+     * Called to delete all orphaned content rows - content that is not referenced by any artifact version.
+     * This is a background cleanup operation typically run by a scheduled job.
+     *
+     * @throws RegistryStorageException
+     */
+    void deleteAllOrphanedContent() throws RegistryStorageException;
+
+    /**
      * Gets the raw value of a property, bypassing any caching that might be enabled.
      *
      * @param propertyName the name of a property

--- a/app/src/main/java/io/apicurio/registry/storage/decorator/ReadOnlyRegistryStorageDecorator.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/ReadOnlyRegistryStorageDecorator.java
@@ -340,6 +340,12 @@ public class ReadOnlyRegistryStorageDecorator extends RegistryStorageDecoratorRe
     }
 
     @Override
+    public void deleteAllOrphanedContent() throws RegistryStorageException {
+        checkReadOnly();
+        delegate.deleteAllOrphanedContent();
+    }
+
+    @Override
     public void resetGlobalId() {
         checkReadOnly();
         delegate.resetGlobalId();

--- a/app/src/main/java/io/apicurio/registry/storage/decorator/RegistryStorageDecoratorBase.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/RegistryStorageDecoratorBase.java
@@ -234,6 +234,11 @@ public class RegistryStorageDecoratorBase extends RegistryStorageDecoratorReadOn
     }
 
     @Override
+    public void deleteAllOrphanedContent() throws RegistryStorageException {
+        delegate.deleteAllOrphanedContent();
+    }
+
+    @Override
     public void setConfigProperty(DynamicConfigPropertyDto property) throws RegistryStorageException {
         delegate.setConfigProperty(property);
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/AbstractReadOnlyRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/AbstractReadOnlyRegistryStorage.java
@@ -239,6 +239,11 @@ public abstract class AbstractReadOnlyRegistryStorage implements RegistryStorage
     }
 
     @Override
+    public void deleteAllOrphanedContent() throws RegistryStorageException {
+        readOnlyViolation();
+    }
+
+    @Override
     public void setConfigProperty(DynamicConfigPropertyDto propertyDto) {
         readOnlyViolation();
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -824,6 +824,16 @@ public class KafkaSqlRegistryStorage extends RegistryStorageDecoratorReadOnlyBas
         coordinator.waitForResponse(uuid);
     }
 
+    /**
+     * @see io.apicurio.registry.storage.RegistryStorage#deleteAllOrphanedContent()
+     */
+    @Override
+    public void deleteAllOrphanedContent() throws RegistryStorageException {
+        var message = new DeleteAllOrphanedContent0Message();
+        var uuid = blockOnResult(submitter.submitMessage(message));
+        coordinator.waitForResponse(uuid);
+    }
+
     @Override
     public ContentWrapperDto getContentByReference(ArtifactReferenceDto reference) {
         return sqlStore.getContentByReference(reference);

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/DeleteAllOrphanedContent0Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/DeleteAllOrphanedContent0Message.java
@@ -1,0 +1,26 @@
+package io.apicurio.registry.storage.impl.kafkasql.messages;
+
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.impl.kafkasql.AbstractMessage;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class DeleteAllOrphanedContent0Message extends AbstractMessage {
+
+    @Override
+    public Object dispatchTo(RegistryStorage storage) {
+        storage.deleteAllOrphanedContent();
+        return null;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -1105,6 +1105,14 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     }
 
     @Override
+    public void deleteAllOrphanedContent() throws RegistryStorageException {
+        handles.withHandleNoException(handle -> {
+            contentRepository.deleteAllOrphanedContentRaw(handle);
+            return null;
+        });
+    }
+
+    @Override
     public void deleteAllUserData() {
         cleanupRepository.deleteAllUserData();
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlArtifactRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlArtifactRepository.java
@@ -118,8 +118,6 @@ public class SqlArtifactRepository {
                 throw new ArtifactNotFoundException(groupId, artifactId);
             }
 
-            contentRepository.deleteAllOrphanedContentRaw(handle);
-
             outboxEvent.fire(SqlOutboxEvent.of(ArtifactDeleted.of(groupId, artifactId)));
 
             return versions;
@@ -143,8 +141,6 @@ public class SqlArtifactRepository {
             if (rowCount == 0) {
                 throw new ArtifactNotFoundException(groupId, null);
             }
-
-            contentRepository.deleteAllOrphanedContentRaw(handle);
 
             return null;
         });

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlVersionRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlVersionRepository.java
@@ -181,8 +181,6 @@ public class SqlVersionRepository {
                 throw new RegistryStorageException("Unexpected: deleted more than one version row");
             }
 
-            contentRepository.deleteAllOrphanedContentRaw(handle);
-
             outboxEvent.fire(SqlOutboxEvent.of(ArtifactVersionDeleted.of(groupId, artifactId, version)));
 
             return null;
@@ -516,9 +514,6 @@ public class SqlVersionRepository {
             if (rowCount == 0) {
                 throw new VersionNotFoundException(groupId, artifactId, version);
             }
-
-            // Updating content will typically leave a row in the content table orphaned.
-            contentRepository.deleteAllOrphanedContentRaw(handle);
 
             return null;
         });

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -151,6 +151,9 @@ apicurio.config.cache.enabled=true
 # Downloads
 apicurio.downloads.reaper.every=60s
 
+# Orphaned content cleanup
+apicurio.storage.orphan-cleanup.every=1h
+
 # Dynamic config properties
 apicurio.config.dynamic.allow-all=true
 apicurio.auth.owner-only-authorization.dynamic.allow=${apicurio.config.dynamic.allow-all}

--- a/app/src/test/java/io/apicurio/registry/storage/impl/readonly/ReadOnlyRegistryStorageTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/readonly/ReadOnlyRegistryStorageTest.java
@@ -64,6 +64,8 @@ public class ReadOnlyRegistryStorageTest {
                 entry("createRoleMapping3", new State(true, s -> s.createRoleMapping(null, null, null))),
                 entry("deleteAllExpiredDownloads0",
                         new State(true, RegistryStorage::deleteAllExpiredDownloads)),
+                entry("deleteAllOrphanedContent0",
+                        new State(true, RegistryStorage::deleteAllOrphanedContent)),
                 entry("deleteAllUserData0", new State(true, RegistryStorage::deleteAllUserData)),
                 entry("deleteArtifact2", new State(true, s -> s.deleteArtifact(null, null))),
                 entry("deleteBranch2", new State(true, s -> s.deleteBranch(null, null))),

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -1057,6 +1057,11 @@ The following {registry} configuration options are available for each component 
 |`sql`
 |`3.0.0`
 |The type of storage to use for the registry
+|`apicurio.storage.orphan-cleanup.every`
+|`duration`
+|`1h`
+|`3.x.x`
+|Interval for orphaned content cleanup job (e.g., 1h, 30m, 86400s). Set to "off" to disable.
 |`apicurio.storage.read-only.enabled`
 |`boolean [dynamic]`
 |`false`


### PR DESCRIPTION
## Summary

- Moves `deleteAllOrphanedContentRaw()` from synchronous per-operation calls to a scheduled background job
- Adds `OrphanedContentReaper` that runs every hour by default (following the existing `DownloadReaper` pattern)
- Removes synchronous cleanup calls from artifact/version deletion operations to reduce per-operation overhead

## Root Cause

`deleteAllOrphanedContentRaw()` was being called after every artifact/version deletion, causing two table scans per mutation operation. This impacts performance significantly for high-volume delete operations.

## Changes

**New files:**
- `OrphanedContentReaper.java` - Scheduled background job for orphan content cleanup
- `DeleteAllOrphanedContent0Message.java` - KafkaSQL message for cluster coordination

**Modified files:**
- Added `deleteAllOrphanedContent()` method to `RegistryStorage` interface and all implementations
- Removed synchronous `deleteAllOrphanedContentRaw()` calls from `SqlArtifactRepository` and `SqlVersionRepository`
- Added configuration properties to `application.properties`
- Updated documentation

**Configuration:**
| Property | Default | Description |
|----------|---------|-------------|
| `apicurio.storage.orphan-cleanup.enabled` | `true` | Enable scheduled cleanup |
| `apicurio.storage.orphan-cleanup.every` | `1h` | Cleanup interval |

## Test plan

- [x] Build passes without tests (`./mvnw clean install -DskipTests`)
- [x] Unit tests pass (infrastructure-dependent tests skipped)
- [ ] Integration tests with SQL storage
- [ ] Integration tests with KafkaSQL storage
- [ ] Manual verification: create artifact, delete artifact, verify orphaned content is cleaned up after scheduled job runs

Closes #7311