### PR TITLE
fix(serdes): prevent NPE in ProtobufSchemaParser when toDescriptor returns null

### DIFF
--- a/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufSchemaParser.java
+++ b/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufSchemaParser.java
@@ -55,9 +55,15 @@ public class ProtobufSchemaParser<U extends Message> implements SchemaParser<Pro
             MessageElement firstMessage = FileDescriptorUtils.firstMessage(fileElem);
             if (firstMessage != null) {
                 try {
-                    final Descriptors.Descriptor fileDescriptor = FileDescriptorUtils
+                    final Descriptors.Descriptor descriptor = FileDescriptorUtils
                             .toDescriptor(firstMessage.getName(), fileElem, dependencies);
-                    return new ProtobufSchema(fileDescriptor.getFile(), fileElem);
+                    if (descriptor == null) {
+                        // toDescriptor returns null when the message can't be resolved, typically due to
+                        // missing imports (e.g. google/protobuf/timestamp.proto). Fall through to the
+                        // alternative parsing method.
+                        return getFileDescriptorFromElement(fileElem);
+                    }
+                    return new ProtobufSchema(descriptor.getFile(), fileElem);
                 } catch (IllegalStateException ise) {
                     // If we fail to init the dynamic schema, try to get the descriptor from the proto element
                     return getFileDescriptorFromElement(fileElem);


### PR DESCRIPTION
## Summary

Fixes #7377

This PR fixes a `NullPointerException` in `ProtobufSchemaParser.parseSchema()` that occurs when deserializing protobuf messages whose schemas have imports (e.g., `google/protobuf/timestamp.proto`) and the `resolvedReferences` map is empty or incomplete.

## Root Cause

When `FileDescriptorUtils.toDescriptor()` is called, it internally calls `toDynamicSchema().getMessageDescriptor(name)`. The `toDynamicSchema()` method silently skips imports that are missing from the `dependencies` map (lines 1539-1545). When required imports like `google/protobuf/timestamp.proto` are not in the dependencies, the message descriptor cannot be resolved and `getMessageDescriptor(name)` returns `null`.

The subsequent call to `.getFile()` on this null descriptor causes the NPE:

```
java.lang.NullPointerException: Cannot invoke "com.google.protobuf.Descriptors$Descriptor.getFile()" 
because "fileDescriptor" is null
    at io.apicurio.registry.serde.protobuf.ProtobufSchemaParser.parseSchema(ProtobufSchemaParser.java:60)
```

The existing catch block only handles `IllegalStateException`, not `NullPointerException`, so the error propagates.

## Changes

- **`ProtobufSchemaParser.java`** (`serdes/generic/serde-common-protobuf`):
  - Added null check for the result of `FileDescriptorUtils.toDescriptor()` in the `parseSchema()` method
  - When `toDescriptor()` returns null, falls through to `getFileDescriptorFromElement()` (the same fallback used for `IllegalStateException`)
  - Renamed variable from `fileDescriptor` to `descriptor` for clarity

- **`FileDescriptorUtils.java`** (`utils/protobuf-schema-utilities`):
  - Added static `WELL_KNOWN_PROTO_ELEMENTS` map that stores `ProtoFileElement` representations of all well-known protobuf types
  - Modified `toDynamicSchema()` to use `WELL_KNOWN_PROTO_ELEMENTS` as a fallback when a dependency is not found in the `dependencies` map
  - Applied the fallback logic to both regular imports and public imports

- **`ProtobufSchemaParserTest.java`** (`serdes/generic/serde-common-protobuf`):
  - Added `testParseSchemaWithWellKnownTypeImportAndEmptyReferences()` - tests parsing schema with `google/protobuf/timestamp.proto` import
  - Added `testParseSchemaWithMultipleWellKnownTypeImports()` - tests parsing schema with multiple well-known type imports (timestamp, duration, any)
  - Added `testParseSchemaWithStructImport()` - tests parsing schema with `google/protobuf/struct.proto` import

## Test plan

- [x] Added unit tests for well-known type imports with empty resolved references
- [x] All 8 tests pass in `ProtobufSchemaParserTest`
- [x] Full build succeeds (`./mvnw clean install -DskipTests`)
- [x] Module tests pass (`./mvnw test -pl serdes/generic/serde-common-protobuf`)
- [ ] Integration tests with protobuf schemas importing well-known types
- [ ] Manual testing with Kafka deserializer using schemas with timestamp/struct imports