### PR TITLE
Fix listArtifactVersions sort order

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -1346,7 +1346,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         storage.getArtifactMetaData(gid.getRawGroupIdWithNull(), artifactId);
 
         final OrderBy oBy = OrderBy.valueOf(orderby.name());
-        final OrderDirection oDir = order == null || order == SortOrder.desc ? OrderDirection.asc
+        final OrderDirection oDir = order == null || order == SortOrder.asc ? OrderDirection.asc
             : OrderDirection.desc;
 
         Set<SearchFilter> filters = Set.of(


### PR DESCRIPTION
one of our users noticed results are backwards just for this call, other calls (searchArtifacts, searchVersions, etc) are correct.