### PR TITLE
Add macOS GitHub Actions workflow for CLI tests. Fixes #7390

### DIFF
--- a/.github/workflows/verify-cli-macos.yaml
+++ b/.github/workflows/verify-cli-macos.yaml
@@ -1,0 +1,41 @@
+name: CLI Tests (macOS)
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        type: string
+        default: '17'
+      image-tag:
+        type: string
+        required: true
+        description: 'Build artifact identifier (commit SHA)'
+
+jobs:
+  cli-tests-macos:
+    name: CLI Unit Tests (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ inputs.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.java-version }}
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ inputs.image-tag }}
+          path: .
+
+      - name: Run CLI Tests
+        run: |
+          ./mvnw test -pl cli -Dtest=InstallCommandTest \
+            --no-transfer-progress \
+            -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
+            -Dmaven.wagon.http.retryHandler.count=5

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -60,6 +60,34 @@ jobs:
     with:
       image-tag: ${{ github.sha }}
 
+  # Path filter for conditional macOS CLI test execution
+  detect-cli-changes:
+    name: Detect CLI Changes
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      cli: ${{ steps.filter.outputs.cli }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Check for CLI changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            cli:
+              - 'cli/**'
+              - '.github/workflows/verify-cli-macos.yaml'
+
+  cli-tests-macos:
+    name: CLI Tests (macOS)
+    needs: detect-cli-changes
+    if: needs.detect-cli-changes.outputs.cli == 'true'
+    uses: ./.github/workflows/verify-cli-macos.yaml
+    with:
+      image-tag: ${{ github.sha }}
+
   # ============================================================================
   # PHASE 4: Integration Tests (matrix-based parallel execution)
   # ============================================================================


### PR DESCRIPTION
## Summary                                                                                                                                                                                           
 
Adds a macOS GitHub Actions workflow to test CLI installation functionality that currently gets skipped in Linux-only CI.                                                                                
                
## Changes

- Created `.github/workflows/verify-cli-macos.yaml`
- Runs on `macos-latest` runner
- Tests `InstallCommandTest` only (macOS-specific installation tests)
- Triggers on changes to:
  - `cli/**` (CLI code changes)
  - `.github/workflows/verify-cli-macos.yaml` (workflow file itself - allows testing workflow updates)

## Testing

- [x] InstallCommandTest: 6 macOS tests pass, 3 Linux tests skipped (expected)
- [x] Workflow triggers on CLI changes and workflow modifications