### PR TITLE
Fix macOS CLI workflow by installing missing dependencies. Fixes #7415

### DIFF
--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -88,6 +88,9 @@ jobs:
             mcp/target/docker/
             java-sdk/target/
             java-sdk-v2/target/
+            config-index/definitions/target/
+            common/target/
+            java-sdk-common/target/
           retention-days: 1
 
   build-ui:

--- a/.github/workflows/verify-cli-macos.yaml
+++ b/.github/workflows/verify-cli-macos.yaml
@@ -33,6 +33,28 @@ jobs:
           name: build-artifacts-${{ inputs.image-tag }}
           path: .
 
+      - name: Install Pre-built Artifacts to Maven Repository
+        run: |
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+          # Install parent POM
+          ./mvnw install:install-file -B -Dfile=pom.xml -DpomFile=pom.xml
+
+          # Install each dependency module
+          for module_path in \
+            config-index/definitions:apicurio-registry-config-definitions \
+            common:apicurio-registry-common \
+            java-sdk-common:apicurio-registry-java-sdk-common \
+            java-sdk:apicurio-registry-java-sdk; do
+
+            dir="${module_path%%:*}"
+            artifact="${module_path##*:}"
+
+            ./mvnw install:install-file -B \
+              -Dfile="${dir}/target/${artifact}-${VERSION}.jar" \
+              -DpomFile="${dir}/pom.xml"
+          done
+
       - name: Run CLI Tests
         run: |
           ./mvnw test -pl cli -Dtest=InstallCommandTest \


### PR DESCRIPTION
## Summary
The macOS CLI workflow (`verify-cli-macos.yaml`) was failing because the CLI module's transitive dependencies were not available in the local Maven repository on the macOS runner. The Linux build job produces the artifacts, but only a subset was being uploaded and none were being installed into the runner's local Maven repo before running tests.                                                 
                                                                                                                                                                                                         
 This PR fixes the issue by:

 - **Adding missing artifacts to the build upload** (`verify-build.yaml`): `config-index/definitions`, `common`, and `java-sdk-common` target directories are now included alongside the existing uploads.
 - **Installing pre-built artifacts into the local Maven repo** (`verify-cli-macos.yaml`): A new step installs the parent POM and all required dependency JARs before running the CLI tests.

 ## Changes

 - `verify-build.yaml` — Added 3 missing module target directories to the `upload-artifact` step.
 - `verify-cli-macos.yaml` — Added an "Install Pre-built Artifacts to Maven Repository" step that dynamically resolves the project version and installs the parent POM + 4 module JARs via a loop.

 ## Test plan
 - [x] Verified version extraction (`mvnw help:evaluate`) returns correct version locally
 - [x] Verified all JAR and POM paths resolve correctly
 - [x] Cleared local Maven repo artifacts, ran the install script, then ran `InstallCommandTest` — 9 tests passed (0 failures, 3 skipped as expected on macOS)
 - [x] CI workflow passes on GitHub Actions