### PR TITLE
feat(cli): Enhance version command to display server info. Fixes #7165

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -106,6 +106,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <version>4.1.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/cli/src/main/java/io/apicurio/registry/cli/VersionCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/VersionCommand.java
@@ -4,13 +4,37 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
-import io.apicurio.registry.cli.utils.Mapper;
+import io.apicurio.registry.cli.services.Client;
 import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.models.ArtifactTypeInfo;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
 import lombok.Builder;
+import lombok.Getter;
 import org.eclipse.microprofile.config.ConfigProvider;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 
+import java.util.Date;
+import java.util.List;
+
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPES;
+import static io.apicurio.registry.cli.utils.Columns.CLI_VERSION;
+import static io.apicurio.registry.cli.utils.Columns.FIELD;
+import static io.apicurio.registry.cli.utils.Columns.SERVER_BUILT_ON;
+import static io.apicurio.registry.cli.utils.Columns.SERVER_NAME;
+import static io.apicurio.registry.cli.utils.Columns.SERVER_VERSION;
+import static io.apicurio.registry.cli.utils.Columns.VALUE;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Conversions.convertToString;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+/**
+ * Displays CLI version and, when a server is reachable, server name, version,
+ * build timestamp, and supported artifact types. Always succeeds — server
+ * failures are reported to stderr while CLI version is still shown.
+ */
 @Command(
         name = "version",
         description = "Prints version information"
@@ -21,29 +45,87 @@ public class VersionCommand extends AbstractCommand {
     private OutputTypeMixin outputType;
 
     @Override
-    public void run(OutputBuffer output) throws JsonProcessingException {
-        var version = Version.builder()
-                .version(ConfigProvider.getConfig().getValue("version", String.class))
-                .build();
+    public void run(final OutputBuffer output) throws JsonProcessingException {
+        final var builder = VersionOutput.builder()
+                .cliVersion(ConfigProvider.getConfig().getValue("version", String.class));
+
+        try {
+            final var client = Client.getInstance().getRegistryClient();
+            fetchSystemInfo(client, builder, output);
+            fetchArtifactTypes(client, builder, output);
+        } catch (Exception ex) {
+            output.writeStdErrChunk(err ->
+                    err.append("Could not connect to server: ").append(ex.getMessage()).append('\n'));
+        }
+
+        printVersion(output, builder.build(), outputType);
+    }
+
+    // Fetches server name, version, and build timestamp from /system/info.
+    private void fetchSystemInfo(final RegistryClient client, final VersionOutput.VersionOutputBuilder builder, final OutputBuffer output) {
+        try {
+            final var systemInfo = client.system().info().get();
+            builder.serverName(systemInfo.getName());
+            builder.serverVersion(systemInfo.getVersion());
+            builder.serverBuiltOn(systemInfo.getBuiltOn() != null ? convert(systemInfo.getBuiltOn()) : null);
+        } catch (ProblemDetails ex) {
+            output.writeStdErrChunk(err ->
+                    err.append("Error retrieving system info: ").append(ex.getDetail()).append('\n'));
+        }
+    }
+
+    // Fetches supported artifact types from /admin/config/artifactTypes.
+    private void fetchArtifactTypes(final RegistryClient client, final VersionOutput.VersionOutputBuilder builder, final OutputBuffer output) {
+        try {
+            final var artifactTypes = client.admin().config().artifactTypes().get();
+            builder.artifactTypes(artifactTypes != null ? artifactTypes.stream()
+                    .map(ArtifactTypeInfo::getName)
+                    .toList() : null);
+        } catch (ProblemDetails ex) {
+            output.writeStdErrChunk(err ->
+                    err.append("Error retrieving artifact types: ").append(ex.getDetail()).append('\n'));
+        }
+    }
+
+    private static void printVersion(final OutputBuffer output, final VersionOutput versionOutput, final OutputTypeMixin outputType) throws JsonProcessingException {
         output.writeStdOutChunkWithException(out -> {
             switch (outputType.getOutputType()) {
                 case json -> {
-                    out.append(Mapper.MAPPER.writeValueAsString(version));
+                    out.append(MAPPER.writeValueAsString(versionOutput));
                     out.append('\n');
                 }
                 case table -> {
-                    out.append("CLI version: ")
-                            .append(version.version)
-                            .append('\n');
+                    final var table = new TableBuilder();
+                    table.addColumns(FIELD, VALUE);
+                    table.addRow(CLI_VERSION, versionOutput.getCliVersion());
+                    table.addRow(SERVER_NAME, versionOutput.getServerName());
+                    table.addRow(SERVER_VERSION, versionOutput.getServerVersion());
+                    table.addRow(SERVER_BUILT_ON, versionOutput.getServerBuiltOn() != null ? convertToString(versionOutput.getServerBuiltOn()) : null);
+                    table.addRow(ARTIFACT_TYPES, versionOutput.getArtifactTypes() != null ? String.join(", ", versionOutput.getArtifactTypes()) : null);
+                    table.print(out);
                 }
             }
         });
     }
 
+    /** Output model for the version command, serialized as JSON or rendered as a table. */
     @Builder
-    public static class Version {
+    @Getter
+    public static class VersionOutput {
 
-        @JsonProperty("CLI version")
-        public String version;
+        @JsonProperty(CLI_VERSION)
+        private String cliVersion;
+
+        @JsonProperty(SERVER_NAME)
+        private String serverName;
+
+        @JsonProperty(SERVER_VERSION)
+        private String serverVersion;
+
+        @JsonProperty(SERVER_BUILT_ON)
+        private Date serverBuiltOn;
+
+        @JsonProperty(ARTIFACT_TYPES)
+        private List<String> artifactTypes;
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
@@ -25,6 +25,11 @@ public final class Client {
         return instance;
     }
 
+    // Resets the cached client so a new connection is established on next use.
+    public static synchronized void reset() {
+        instance = null;
+    }
+
     private final Vertx vertx;
 
     private RegistryClient registryClient;

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
@@ -15,4 +15,10 @@ public final class Columns {
 
     public static final String FIELD = "Field";
     public static final String VALUE = "Value";
+
+    public static final String CLI_VERSION = "CLI version";
+    public static final String SERVER_NAME = "Server name";
+    public static final String SERVER_VERSION = "Server version";
+    public static final String SERVER_BUILT_ON = "Server built on";
+    public static final String ARTIFACT_TYPES = "Artifact types";
 }

--- a/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli;
 
 import io.apicurio.registry.cli.config.Config;
+import io.apicurio.registry.cli.services.Client;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,6 +57,7 @@ public abstract class AbstractCLITest {
                         .forStatusCode(200)
                         .withStartupTimeout(ofSeconds(60)));
 
+        Client.reset();
         registryContainer.start();
 
         // Get the dynamically mapped port and construct the URL
@@ -96,7 +98,7 @@ public abstract class AbstractCLITest {
 
         // Then
         assertThat(exitCode)
-                .as(withCliOutput("Group help command should exit with code 0."))
+                .as(withCliOutput("Help command should exit with code 0."))
                 .isEqualTo(0);
         String output = out.toString();
         var usage = "Usage: acr " + String.join(" ", command);

--- a/cli/src/test/java/io/apicurio/registry/cli/VersionCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/VersionCommandTest.java
@@ -1,0 +1,89 @@
+package io.apicurio.registry.cli;
+
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPES;
+import static io.apicurio.registry.cli.utils.Columns.CLI_VERSION;
+import static io.apicurio.registry.cli.utils.Columns.SERVER_BUILT_ON;
+import static io.apicurio.registry.cli.utils.Columns.SERVER_NAME;
+import static io.apicurio.registry.cli.utils.Columns.SERVER_VERSION;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the version command — verifies CLI version and server info
+ * in both JSON and table output, with and without a server connection.
+ */
+public class VersionCommandTest extends AbstractCLITest {
+
+    @Test
+    public void testVersionHelp() {
+        testHelpCommand("version");
+    }
+
+    @Test
+    public void testVersionJsonOutput() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("version", "--output-type", "json");
+
+        final var json = out.toString();
+        assertThatJson(json).node(CLI_VERSION).isString().isNotEqualTo("");
+        assertThatJson(json).node(SERVER_NAME).isString().isNotEqualTo("");
+        assertThatJson(json).node(SERVER_VERSION).isString().isNotEqualTo("");
+        assertThatJson(json).node(SERVER_BUILT_ON).isNumber();
+        assertThatJson(json).node(ARTIFACT_TYPES).isArray().isNotEmpty();
+    }
+
+    @Test
+    public void testVersionTableOutput() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("version");
+        final var output = out.toString();
+
+        assertThat(output).as(withCliOutput("Table should contain CLI version")).contains(CLI_VERSION);
+        assertThat(output).as(withCliOutput("Table should contain Server name")).contains(SERVER_NAME);
+        assertThat(output).as(withCliOutput("Table should contain Server version")).contains(SERVER_VERSION);
+        assertThat(output).as(withCliOutput("Table should contain Server built on")).contains(SERVER_BUILT_ON);
+        assertThat(output).as(withCliOutput("Table should contain Artifact types")).contains(ARTIFACT_TYPES);
+    }
+
+    @Test
+    public void testVersionTableWithoutContext() {
+        executeAndAssertSuccess("context", "delete", "--all");
+
+        try {
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("version");
+            final var output = out.toString();
+
+            assertThat(output)
+                    .as(withCliOutput("Should still show CLI version when server is unreachable"))
+                    .contains(CLI_VERSION);
+            assertThat(output)
+                    .as(withCliOutput("Should still show server field labels"))
+                    .contains(SERVER_NAME, SERVER_VERSION, SERVER_BUILT_ON, ARTIFACT_TYPES);
+        } finally {
+            executeAndAssertSuccess("context", "create", "test", registryUrl);
+        }
+    }
+
+    @Test
+    public void testVersionJsonWithoutContext() {
+        executeAndAssertSuccess("context", "delete", "--all");
+
+        try {
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("version", "--output-type", "json");
+
+            final var json = out.toString();
+            assertThatJson(json).node(CLI_VERSION).isString().isNotEqualTo("");
+            assertThatJson(json).isObject()
+                    .containsEntry(SERVER_NAME, null)
+                    .containsEntry(SERVER_VERSION, null)
+                    .containsEntry(SERVER_BUILT_ON, null)
+                    .containsEntry(ARTIFACT_TYPES, null);
+        } finally {
+            executeAndAssertSuccess("context", "create", "test", registryUrl);
+        }
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                          
The `version` command previously only displayed the CLI version. This PR enhances it to also display server information when a server context is configured and reachable, including server name, version, build timestamp, and supported artifact types.                                                                                                                                             
                                                                                                                                                                                                    
Server info is fetched independently from `/system/info` and `/admin/config/artifactTypes` endpoints, with graceful degradation — errors are reported to stderr while the CLI version is always shown.                                                                                                                                                                                              
                                                                                                                                                                                                    
## Changes       
- `VersionCommand.java` — Fetch and display server info alongside CLI version with graceful error handling.                                                                                         
- `Columns.java` — Added version command column constants.
- `VersionCommandTest.java` — Integration tests for JSON/table output with and without server connection. Adopted JsonUnit AssertJ for JSON assertions.                                                                                 

## Bug fix                                                                                                                                                                                          
Fixed `GroupCommandTest` failures caused by the `Client` singleton caching a stale `RegistryClient` connection. When multiple test classes share the singleton but use different Testcontainers on different ports, the cached client points to a stopped container. Added `Client.reset()` to clear the cache before each test class starts a new container.

## Test plan
- [x] Build succeeds (`mvnw clean install -pl cli -am -DskipTests`)
- [x] Integration tests pass with Docker (`VersionCommandTest` — 5 tests)
- [x] Manual verification: `acr version` or `acr version -o=table` with server running
```
Field             Value                       
---------------   -------------------------   
CLI version       3.2.0-SNAPSHOT              
Server name       Apicurio Registry (In Mem   
                  ory)                        
Server version    3.2.0-SNAPSHOT              
Server built on   2026-02-23T20:23:29         
Artifact types    PROTOBUF, OPENAPI, ASYNCA   
                  PI, JSON, AVRO, GRAPHQL,    
                  KCONNECT, WSDL, XSD, XML,   
                   AGENT_CARD, MODEL_SCHEMA   
                  , PROMPT_TEMPLATE           
-------------------------------------------
```
- [x] Manual verification: `acr version --output-type json` with server running
```
{
  "CLI version" : "3.2.0-SNAPSHOT",
  "Server name" : "Apicurio Registry (In Memory)",
  "Server version" : "3.2.0-SNAPSHOT",
  "Server built on" : 1771878209000,
  "Artifact types" : [ "PROTOBUF", "OPENAPI", "ASYNCAPI", "JSON", "AVRO", "GRAPHQL", "KCONNECT", "WSDL", "XSD", "XML", "AGENT_CARD", "MODEL_SCHEMA", "PROMPT_TEMPLATE" ]
}
```
- [x] Manual verification: `acr version` or `acr version -o=table` without server context
```
Field             Value                                                                                                                                                                             
---------------   ----------------
CLI version       3.2.0-SNAPSHOT                                                                                                                                                                    
Server name     
Server version
Server built on
Artifact types
----------------------------------
```
- [x] Manual verification: `acr version --output-type json` without server context
```
{                  
  "CLI version" : "3.2.0-SNAPSHOT",
  "Server name" : null,                                                                                                                                                                             
  "Server version" : null,
  "Server built on" : null,                                                                                                                                                                         
  "Artifact types" : null
}
```