### PR TITLE
Add ADOPTERS.md for community adoption tracking

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,32 @@
+# Apicurio Registry Adopters
+
+This file lists organizations and individuals who are using Apicurio Registry in production or development environments. If you are using Apicurio Registry and would like to be listed here, please submit a pull request adding your organization to the table below.
+
+## How to add your organization
+
+1. Fork this repository
+2. Add your organization to the table below (alphabetical order)
+3. Submit a pull request
+
+Please include:
+- **Organization**: Your company or project name
+- **Type**: How you use Apicurio Registry (see types below)
+- **Description**: A brief description of your use case
+- **Since**: The year you started using Apicurio Registry
+- **Website**: A link to your organization's website (optional)
+
+### Adopter types
+
+| Type | Description |
+|------|-------------|
+| **End-user** | Organizations running Apicurio Registry in production environments |
+| **Integration** | Organizations whose products integrate with Apicurio Registry |
+| **Vendor** | Organizations that embed or distribute Apicurio Registry as part of a commercial product |
+
+## Adopters
+
+| Organization | Type | Description | Since | Website |
+|---|---|---|---|---|
+| IBM | Vendor | Apicurio Registry is included as the schema registry component in IBM Event Streams | 2020 | [ibm.com/products/event-automation](https://www.ibm.com/products/event-automation) |
+| Red Hat | Vendor | Red Hat build of Apicurio Registry, part of Red Hat Application Foundations | 2020 | [redhat.com](https://www.redhat.com) |
+<!-- Add your organization here! -->


### PR DESCRIPTION
## Summary

Adds an `ADOPTERS.md` file so organizations using Apicurio Registry can publicly list themselves by submitting a PR.

This supports the [CNCF Sandbox application](https://github.com/cncf/sandbox/issues/461) and helps demonstrate real-world adoption to the CNCF Technical Oversight Committee.

## How it works

Organizations add themselves by submitting a PR with a row in the table containing:
- Organization name
- Adopter type (End-user, Integration, or Vendor)
- Brief use case description
- Year started using Apicurio Registry
- Website (optional)

Seeded with IBM (Event Streams) and Red Hat (Application Foundations) as known vendors.

## Call to action

If your organization uses Apicurio Registry, please add yourself! Just edit `ADOPTERS.md` and submit a PR.

## Test plan

- [x] File renders correctly on GitHub