### PR TITLE
fix(ui-editors): handle non-string schema examples in UI

### DIFF
--- a/ui/ui-editors/src/app/editor/_components/common/inline-example-editor.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/common/inline-example-editor.component.ts
@@ -81,4 +81,9 @@ export class InlineExampleEditorComponent extends TextAreaEditorComponent implem
         }
     }
 
+    protected getValueForSave(): string {
+        // Preserve the raw editor text so example parsing can decide how to coerce it based on schema type.
+        return this.codeEditor.first.text;
+    }
+
 }

--- a/ui/ui-editors/src/app/editor/_components/common/json-summary.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/common/json-summary.component.ts
@@ -19,12 +19,12 @@ import {Component, Input, OnChanges, SimpleChanges, ViewEncapsulation} from "@an
 
 @Component({
     selector: "json-summary",
-    template: `<span class="json-summary" [innerHTML]="convertedData" [class.empty]="isEmpty()"></span>`,
+    template: `<span class="json-summary" [textContent]="convertedData" [class.empty]="isEmpty()"></span>`,
     encapsulation: ViewEncapsulation.None
 })
 export class JsonSummaryComponent implements OnChanges {
     @Input("data")
-    data: string;
+    data: unknown;
     @Input("emptyText")
     emptyText: string = "No value.";
 
@@ -33,6 +33,9 @@ export class JsonSummaryComponent implements OnChanges {
     ngOnChanges(changes: SimpleChanges): void {
         if (this.isEmpty()) {
             this.convertedData = this.emptyText;
+        } else if (typeof this.data === "string") {
+            // Keep plain strings unquoted so example summaries match what users type in the UI.
+            this.convertedData = this.data;
         } else {
             this.convertedData = JSON.stringify(this.data);
         }

--- a/ui/ui-editors/src/app/editor/_components/forms/definition/example-section.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/forms/definition/example-section.component.ts
@@ -21,8 +21,7 @@ import {CommandService} from "../../../_services/command.service";
 import {AbstractBaseComponent} from "../../common/base-component";
 import {DocumentService} from "../../../_services/document.service";
 import {SelectionService} from "../../../_services/selection.service";
-import {ModelUtils} from "../../../_util/model.util";
-import {StringUtils} from "apicurio-ts-core";
+import {ExampleTextValue, ModelUtils} from "../../../_util/model.util";
 
 
 @Component({
@@ -48,31 +47,20 @@ export class DefinitionExampleSectionComponent extends AbstractBaseComponent {
     }
 
     /**
-     * Returns the example.  Converts to a string if the example is an object.
+     * Returns the example formatted for the UI editor:
+     * plain strings are preserved as-is, while non-string values are JSON-stringified.
      */
-    public example(): string {
-        let value: string = this.definition.example;
-        if (value !== null && (typeof value === "object" || Array.isArray(value))) {
-            value = JSON.stringify(value, null,  4);
-        }
-        return value;
+    public example(): ExampleTextValue {
+        return ModelUtils.stringifyExampleValue(this.definition.example);
     }
 
     /**
      * Called when the user changes the example.
-     * @param newExample
      */
     public onExampleChange(newExample: string): void {
         console.info("[DefinitionExampleSectionComponent] User changed the data type example.");
-        let newValue: any = newExample;
-        if (StringUtils.isJSON(newValue)) {
-            try {
-                newValue = JSON.parse(newValue);
-            } catch (e) {
-                console.info("[DefinitionExampleSectionComponent] Failed to parse example: ", e);
-            }
-        }
-        let command: ICommand = CommandFactory.createChangePropertyCommand(this.definition,"example", newValue);
+        const newValue = ModelUtils.parseExampleValue(this.definition.type, newExample);
+        const command = CommandFactory.createChangePropertyCommand(this.definition, "example", newValue);
         this.commandService.emit(command);
     }
 

--- a/ui/ui-editors/src/app/editor/_components/forms/definition/property-row.component.html
+++ b/ui/ui-editors/src/app/editor/_components/forms/definition/property-row.component.html
@@ -15,7 +15,7 @@
         </div>
         <div class="example" (click)="toggleExample()" [class.selected]="isEditingExample()">
             <span class="fa fa-angle-right" [class.fa-angle-down]="isEditingExample()"></span>
-            <markdown-summary [data]="example()" emptyText="No example."></markdown-summary>
+            <json-summary [data]="item.example" emptyText="No example."></json-summary>
         </div>
         <div class="actions">
             <div class="dropdown dropdown-kebab-pf" dropdown>
@@ -200,9 +200,11 @@
                     </div>
                     <div class="property-example" *ngIf="isEditingExample()">
                         <div class="form-label">Example</div>
-                        <inline-markdown-editor [value]="item.example" [noValueMessage]="'No example.'"
-                                                [baseNode]="item" nodePath="example"
-                                                (onChange)="setExample($event)"></inline-markdown-editor>
+                        <inline-example-editor [value]="example()"
+                                               [schema]="item"
+                                               [baseNode]="item" nodePath="example"
+                                               [noValueMessage]="'No example.'"
+                                               (onChange)="setExample($event)"></inline-example-editor>
                     </div>
                 </div>
             </form>

--- a/ui/ui-editors/src/app/editor/_components/forms/definition/property-row.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/forms/definition/property-row.component.ts
@@ -38,6 +38,7 @@ import {
 import Oas20PropertySchema = Oas20Schema.Oas20PropertySchema;
 import Oas30PropertySchema = Oas30Schema.Oas30PropertySchema;
 import {DropDownOption, DropDownOptionValue} from "../../common/drop-down.component";
+import {ExampleTextValue, ModelUtils} from "../../../_util/model.util";
 
 
 @Component({
@@ -94,8 +95,12 @@ export class PropertyRowComponent extends AbstractRowComponent<Oas20PropertySche
         return this.item.description
     }
 
-    public example(): string {
-        return this.item.example
+    /**
+     * Returns the example formatted for the property editor:
+     * plain strings are preserved as-is, while non-string values are JSON-stringified.
+     */
+    public example(): ExampleTextValue {
+        return ModelUtils.stringifyExampleValue(this.item.example);
     }
 
     public minimum(): number {
@@ -245,8 +250,12 @@ export class PropertyRowComponent extends AbstractRowComponent<Oas20PropertySche
         this.commandService.emit(command);
     }
 
+    /**
+     * Parses the UI text value back into the most appropriate schema-aware example type.
+     */
     public setExample(example: string): void {
-        let command: ICommand = CommandFactory.createChangePropertyCommand<string>(this.item, "example", example);
+        const newValue = ModelUtils.parseExampleValue(this.item.type, example);
+        const command = CommandFactory.createChangePropertyCommand(this.item, "example", newValue);
         this.commandService.emit(command);
     }
 

--- a/ui/ui-editors/src/app/editor/_util/model.util.ts
+++ b/ui/ui-editors/src/app/editor/_util/model.util.ts
@@ -17,6 +17,10 @@
 
 import {AaiSchema, Library, Node, OasSchema, ReferenceUtil} from "@apicurio/data-models";
 import {ApiEditorUser} from "../_models/editor-user.model";
+import {StringUtils} from "apicurio-ts-core";
+
+// UI-facing text representation of an example value before it is parsed back into its schema type.
+export type ExampleTextValue = string | null | undefined;
 
 export class ModelUtils {
 
@@ -117,6 +121,72 @@ export class ModelUtils {
     public static generateExampleFromSchema(schema: OasSchema | AaiSchema): any {
         let generator: ExampleGenerator = new ExampleGenerator();
         return generator.generate(schema);
+    }
+
+    /**
+     * Converts a schema example value to a string suitable for display/editing.
+     * Keeps strings as-is and JSON-stringifies all other non-null values.
+     */
+    public static stringifyExampleValue(value: unknown): ExampleTextValue {
+        if (value === null) {
+            return null;
+        }
+        if (value === undefined) {
+            return undefined;
+        }
+        if (typeof value === "string") {
+            return value;
+        }
+        return JSON.stringify(value, null, 4);
+    }
+
+    /**
+     * Parses a user-provided example string according to the schema type.
+     */
+    public static parseExampleValue(type: string | null | undefined, value: string): unknown {
+        // Preserve nullish values as-is so callers can decide how to handle missing examples.
+        if (value === null || value === undefined) {
+            return value;
+        }
+        // String examples are edited as plain text in the UI, so do not coerce them.
+        if (type === "string") {
+            return value;
+        }
+
+        const trimmed: string = value.trim();
+        // Treat an empty editor value as clearing the example.
+        if (trimmed.length === 0) {
+            return null;
+        }
+
+        // Numeric schema types should round-trip as numbers instead of quoted strings.
+        if (type === "integer" || type === "number" || type === "float") {
+            const parsed = Number(trimmed);
+            return Number.isNaN(parsed) ? value : parsed;
+        }
+
+        // Boolean schema types accept only the JSON literals true/false.
+        if (type === "boolean") {
+            if (trimmed === "true") {
+                return true;
+            }
+            if (trimmed === "false") {
+                return false;
+            }
+            return value;
+        }
+
+        // For object/array/null/quoted JSON string inputs, defer to JSON.parse.
+        if (trimmed === "null" || StringUtils.isJSON(trimmed) || trimmed.startsWith("\"")) {
+            try {
+                return JSON.parse(trimmed);
+            } catch (e) {
+                console.info("[ModelUtils] Failed to parse example: ", e);
+            }
+        }
+
+        // Fall back to the raw text when the input does not match a typed coercion rule.
+        return value;
     }
 
 }


### PR DESCRIPTION
## Fixes incorrect handling of non-string example values in the schema editor.

This PR fixes how `example` values are handled in the schema editor UI (`ui-editors`).

Two issues were observed:

1.  If a property/DataType contains a non-string `example`, for example:

``` yaml
someProperty:
  type: integer
  example: 1
```

the editor could crash with an error such as:

`TypeError: this.data.trim is not a function`

<img width="1460" height="351" alt="image" src="https://github.com/user-attachments/assets/a7d60be0-549b-4462-ab3a-52982c4d5134" />


2.  When editing `example` through the UI (instead of the source editor), non-string values were saved incorrectly.

For example, for `type: integer`, entering `1` in the UI was saved as the string `"1"`.

------------------------------------------------------------------------

## Root cause

In the current implementation, property-level `example` was treated as markdown text:

-   the summary was rendered via `markdown-summary`
-   editing was done via `inline-markdown-editor`

This implicitly assumed that `example` is always a string, which is not correct for OpenAPI schemas.

In OpenAPI, `example` may be a number, boolean, object, array, or string.

Because of this:

-   the summary component attempted to call `.trim()` on non-string values
-   the UI editor could not correctly round-trip typed values
-   string examples were displayed in a confusing way when represented as JSON

------------------------------------------------------------------------

## Changes

### 1. Property-level example switched to example-aware components

For property-level `example`:

-   `markdown-summary` was replaced with `json-summary`
-   `inline-markdown-editor` was replaced with `inline-example-editor`

This aligns property-level `example` handling with the existing behavior used for definition-level examples.

------------------------------------------------------------------------

### 2. Shared example conversion logic

Common helper functions were added to `ModelUtils`:

-   `stringifyExampleValue(...)`
-   `parseExampleValue(...)`

A helper alias was also introduced:

-   `ExampleTextValue`

This removes duplicated logic and provides consistent behavior for:

-   property-level examples
-   definition-level examples

------------------------------------------------------------------------

### 3. Schema-aware parsing when saving values

Values entered in the UI are now converted according to the schema type:

-   `string` → stored as string
-   `integer` / `number` / `float` → stored as numbers
-   `boolean` → stored as `true` / `false`
-   `object` / `array` / `null` / JSON strings → parsed using `JSON.parse`
-   empty value → interpreted as clearing the example

This fixes the issue where `1` was previously stored as `"1"`.

------------------------------------------------------------------------

### 4. Safe rendering in JsonSummaryComponent

`JsonSummaryComponent` was updated to use `textContent` instead of `innerHTML`.

After these changes, raw string values may appear in the component, and rendering them via `textContent` is both safer and more appropriate for a summary component, which should display values as text rather than interpret them as HTML.

------------------------------------------------------------------------

### 5. Preserve raw input in inline-example-editor

`inline-example-editor` now overrides `getValueForSave()` so that the raw editor value is preserved instead of being automatically trimmed by the base class.

This prevents:

-   unintended trimming of string examples
-   premature conversion to `null` before schema-aware parsing is applied

------------------------------------------------------------------------

## Why this approach

These changes align property-level `example` handling with the semantics of the field itself.

`example` is not markdown documentation --- it is a typed value.

As a result:

-   the UI no longer crashes on numeric/boolean/object examples
-   the UI editor and source editor behave consistently
-   string examples are displayed more predictably
-   example parsing logic is centralized and easier to maintain
-   summary rendering is safer

------------------------------------------------------------------------

## Testing

Tested manually in the schema editor UI with the following cases:

-   string example
-   integer example
-   boolean example
-   object example
-   array example

Also verified that:

-   editing examples in the UI preserves correct types
-   switching between source and form editor keeps values consistent

Fixes #7491