### PR TITLE
ci(operator): split feature tests into two parallel groups

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -142,6 +142,12 @@ jobs:
             extra-build-opts: ""
           - name: feature
             groups: "feature"
+            excluded-groups: "feature-setup"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: feature-setup
+            groups: "feature-setup"
             olm-enable: "false"
             olm-v1-enable: "false"
             extra-build-opts: ""

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/Tags.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/Tags.java
@@ -25,6 +25,9 @@ public final class Tags {
     /** Feature-specific tests (ingress, TLS, env vars, etc.) */
     public static final String FEATURE = "feature";
 
+    /** Feature tests with heavy infrastructure setup (multi-namespace, TLS, operator restarts) */
+    public static final String FEATURE_SETUP = "feature-setup";
+
     /** Slow tests that take significant time */
     public static final String SLOW = "slow";
 

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorConfigITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorConfigITTest.java
@@ -10,11 +10,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static io.apicurio.registry.operator.Tags.FEATURE;
+import static io.apicurio.registry.operator.Tags.FEATURE_SETUP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @Tag(FEATURE)
+@Tag(FEATURE_SETUP)
 public class OperatorConfigITTest extends ITBase {
 
     private static final Logger log = LoggerFactory.getLogger(OperatorConfigITTest.class);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/PodTemplateSpecITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/PodTemplateSpecITTest.java
@@ -12,12 +12,14 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 
 import static io.apicurio.registry.operator.Tags.FEATURE;
+import static io.apicurio.registry.operator.Tags.FEATURE_SETUP;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @Tag(FEATURE)
+@Tag(FEATURE_SETUP)
 public class PodTemplateSpecITTest extends ITBase {
 
     private static final Logger log = LoggerFactory.getLogger(PodTemplateSpecITTest.class);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/RestrictedNamespaceITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/RestrictedNamespaceITTest.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import static io.apicurio.registry.operator.Tags.FEATURE;
+import static io.apicurio.registry.operator.Tags.FEATURE_SETUP;
 import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
 import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
 import static io.apicurio.registry.operator.utils.K8sCell.k8sCell;
@@ -25,6 +26,7 @@ import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @Tag(FEATURE)
+@Tag(FEATURE_SETUP)
 public class RestrictedNamespaceITTest extends ITBase {
 
     private static final Logger log = LoggerFactory.getLogger(RestrictedNamespaceITTest.class);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/TlsITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/TlsITTest.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import java.util.List;
 
 import static io.apicurio.registry.operator.Tags.FEATURE;
+import static io.apicurio.registry.operator.Tags.FEATURE_SETUP;
 import static io.apicurio.registry.operator.api.v1.ContainerNames.REGISTRY_APP_CONTAINER_NAME;
 import static io.apicurio.registry.operator.resource.app.AppDeploymentResource.getContainerFromDeployment;
 import static io.restassured.RestAssured.given;
@@ -25,6 +26,7 @@ import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @Tag(FEATURE)
+@Tag(FEATURE_SETUP)
 public class TlsITTest extends ITBase {
 
     @BeforeAll


### PR DESCRIPTION
## Summary

- Splits the `feature` test group (critical path at ~33 min) into two parallel matrix jobs: `feature` and `feature-setup`
- The 4 heaviest test classes (`RestrictedNamespaceITTest`, `TlsITTest`, `PodTemplateSpecITTest`, `OperatorConfigITTest`) are tagged with `feature-setup` and run in a separate parallel job
- The remaining 8 lighter feature tests run in the `feature` job with `feature-setup` excluded
- Follows up on #7487 which parallelized operator CI tests

## Root Cause

After #7487, the `feature` group became the critical path at ~33 min with 12 test classes. Splitting it into two balanced groups reduces the critical path further.

## Changes

- Added `FEATURE_SETUP` tag constant to `Tags.java`
- Added `@Tag(FEATURE_SETUP)` to 4 heavy test classes (alongside existing `@Tag(FEATURE)`)
- Split the `feature` matrix entry into `feature` (excluding `feature-setup`) and `feature-setup` in `operator.yaml`

## Test plan

- [x] Verify all feature tests still run (no test is lost between the two groups)
- [x] Verify the `feature` job excludes `feature-setup` tagged tests
- [x] Verify the `feature-setup` job runs only `feature-setup` tagged tests
- [x] Confirm reduced wall-clock time for the operator CI workflow