### PR TITLE
fix: POST /search/versions misses versions promoted from DRAFT to ENABLED (#7490)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -873,7 +873,28 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     @Override
     public void updateArtifactVersionState(String groupId, String artifactId, String version,
             VersionState newState, boolean dryRun) {
+        // Get the current state before updating.
+        VersionState currentState = versionRepository.getArtifactVersionState(groupId, artifactId, version);
+
+        // Delegate to the version repository to update the state.
         versionRepository.updateArtifactVersionState(groupId, artifactId, version, newState, dryRun);
+
+        // When transitioning from DRAFT to a non-DRAFT state, recalculate content hashes.
+        // Draft content uses fake hashes ("draft:" + UUID) to prevent content-based search.
+        // Once the version is no longer a draft, we need real hashes so that searches work.
+        if (!dryRun && currentState == VersionState.DRAFT && newState != VersionState.DRAFT) {
+            ArtifactVersionMetaDataDto versionMeta = versionRepository.getArtifactVersionMetaData(groupId,
+                    artifactId, version);
+            ContentWrapperDto contentDto = contentRepository.getContentById(versionMeta.getContentId());
+            if (contentDto.getContentHash() != null && contentDto.getContentHash().startsWith("draft:")) {
+                String artifactType = versionMeta.getArtifactType();
+                long newContentId = ensureContentAndGetId(artifactType, contentDto, false);
+                if (newContentId != versionMeta.getContentId()) {
+                    versionRepository.updateArtifactVersionContent(groupId, artifactId, version,
+                            newContentId);
+                }
+            }
+        }
     }
 
     @Override

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/DraftContentTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/DraftContentTest.java
@@ -644,4 +644,93 @@ public class DraftContentTest extends AbstractResourceTestBase {
         Assertions.assertEquals("1.0.0", refs.get(0).getVersion());
     }
 
+    @Test
+    public void testSearchByContentAfterDraftToEnabled() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+
+        // Create the artifact with a non-draft first version.
+        CreateArtifact createArtifact = TestUtils.clientCreateArtifact(artifactId, ArtifactType.AVRO,
+                AVRO_CONTENT_V1, ContentTypes.APPLICATION_JSON);
+        createArtifact.getFirstVersion().setVersion("1.0");
+        clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+
+        // Create a draft version with V2 content.
+        CreateVersion createVersion = TestUtils.clientCreateVersion(AVRO_CONTENT_V2,
+                ContentTypes.APPLICATION_JSON);
+        createVersion.setVersion("2.0");
+        createVersion.setIsDraft(true);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                .post(createVersion);
+
+        // Verify the draft version is NOT found by content search.
+        VersionSearchResults results = clientV3.search().versions()
+                .post(asInputStream(AVRO_CONTENT_V2), ContentTypes.APPLICATION_JSON);
+        Assertions.assertEquals(0, results.getCount(),
+                "Draft version should not be found by content search");
+
+        // Transition the draft version to ENABLED.
+        WrappedVersionState newState = new WrappedVersionState();
+        newState.setState(io.apicurio.registry.rest.client.models.VersionState.ENABLED);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                .byVersionExpression("2.0").state().put(newState);
+
+        // Search by exact content - should now find the version.
+        results = clientV3.search().versions()
+                .post(asInputStream(AVRO_CONTENT_V2), ContentTypes.APPLICATION_JSON);
+        Assertions.assertEquals(1, results.getCount(),
+                "Enabled version should be found by content search");
+
+        // Search by canonical content - should also find the version.
+        results = clientV3.search().versions()
+                .post(asInputStream(AVRO_CONTENT_V2), ContentTypes.APPLICATION_JSON, config -> {
+                    config.queryParameters.canonical = true;
+                    config.queryParameters.artifactType = ArtifactType.AVRO;
+                });
+        Assertions.assertEquals(1, results.getCount(),
+                "Enabled version should be found by canonical content search");
+    }
+
+    @Test
+    public void testSearchByContentAfterDraftToEnabled_Deduplication() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId1 = TestUtils.generateArtifactId();
+        String artifactId2 = TestUtils.generateArtifactId();
+
+        // Create artifact 1 with a non-draft version containing V1 content.
+        CreateArtifact createArtifact = TestUtils.clientCreateArtifact(artifactId1, ArtifactType.AVRO,
+                AVRO_CONTENT_V1, ContentTypes.APPLICATION_JSON);
+        createArtifact.getFirstVersion().setVersion("1.0");
+        clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+
+        // Create artifact 2 with a draft version containing the same V1 content.
+        createArtifact = TestUtils.clientCreateArtifact(artifactId2, ArtifactType.AVRO, AVRO_CONTENT_V1,
+                ContentTypes.APPLICATION_JSON);
+        createArtifact.getFirstVersion().setVersion("1.0");
+        createArtifact.getFirstVersion().setIsDraft(true);
+        clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+
+        // Verify only 1 version is found by content search (the non-draft one).
+        VersionSearchResults results = clientV3.search().versions()
+                .post(asInputStream(AVRO_CONTENT_V1), ContentTypes.APPLICATION_JSON, config -> {
+                    config.queryParameters.groupId = groupId;
+                });
+        Assertions.assertEquals(1, results.getCount(),
+                "Only the non-draft version should be found by content search");
+
+        // Transition the draft version to ENABLED.
+        WrappedVersionState newState = new WrappedVersionState();
+        newState.setState(io.apicurio.registry.rest.client.models.VersionState.ENABLED);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId2).versions()
+                .byVersionExpression("1.0").state().put(newState);
+
+        // Both versions should now be found (they should share the same content row).
+        results = clientV3.search().versions()
+                .post(asInputStream(AVRO_CONTENT_V1), ContentTypes.APPLICATION_JSON, config -> {
+                    config.queryParameters.groupId = groupId;
+                });
+        Assertions.assertEquals(2, results.getCount(),
+                "Both versions should be found after draft is enabled");
+    }
+
 }


### PR DESCRIPTION
## Summary

- When a version transitions from DRAFT to a non-DRAFT state (e.g. ENABLED), recalculate the content hashes from fake `draft:UUID` hashes to real SHA-256/canonical hashes, so that `POST /search/versions` content-based searches can find the version
- Reuses the existing `ensureContentAndGetId` method for hash computation and content deduplication — if a content row with the same real hash already exists, the version is re-pointed to the existing content row
- The fix is in `AbstractSqlRegistryStorage`, which is the base class for both SQL and KafkaSQL processing, so both storage backends are covered

## Related Issue

Fixes #7490

## Test Plan

- [ ] Run `DraftContentTest.testSearchByContentAfterDraftToEnabled` — verifies that a draft version becomes searchable by content (both exact and canonical) after transitioning to ENABLED
- [ ] Run `DraftContentTest.testSearchByContentAfterDraftToEnabled_Deduplication` — verifies that when a draft version has the same content as an existing non-draft version, transitioning to ENABLED deduplicates the content and both versions are found by content search
- [ ] Run existing `DraftContentTest.testSearchForDraftContent` — verifies that draft content is still NOT searchable (no regression)
- [ ] Run the full `DraftContentTest` suite to ensure no regressions