### PR TITLE
Show configured API URL on Connection Failed error page (Fixes #5388)

### DIFF
--- a/ui/ui-app/src/app/components/errorPage/ConnectionFailedErrorPage.tsx
+++ b/ui/ui-app/src/app/components/errorPage/ConnectionFailedErrorPage.tsx
@@ -2,18 +2,23 @@ import React, { FunctionComponent } from "react";
 import "./ConnectionFailedErrorPage.css";
 import {
     Button,
+    ClipboardCopy,
     EmptyState,
     EmptyStateActions,
     EmptyStateBody,
     EmptyStateFooter,
     PageSection,
-    
+
 } from "@patternfly/react-core";
 import { NetworkIcon } from "@patternfly/react-icons";
 import { ErrorPageProps } from "./ErrorPage.tsx";
+import { useConfigService } from "@services/useConfigService.ts";
 
 
 export const ConnectionFailedErrorPage: FunctionComponent<ErrorPageProps> = () => {
+
+    const config = useConfigService();
+    const apiUrl: string = config.artifactsUrl();
 
     const reload = (): void => {
         window.location.reload();
@@ -25,8 +30,18 @@ export const ConnectionFailedErrorPage: FunctionComponent<ErrorPageProps> = () =
                 <div className="centerizer">
                     <EmptyState  headingLevel="h4" icon={NetworkIcon}  titleText="Connection failed">
                         <EmptyStateBody>
-                            Connection to the Registry server failed (could not reach the server).  Please
-                            check your connection and try again, or report this error to an admin.
+                            <p>
+                                Connection to the Registry server failed (could not reach the server).  Please
+                                check your connection and try again, or report this error to an admin.
+                            </p>
+                            <p style={{ marginTop: "15px" }}>
+                                The UI is configured to connect to:
+                                &nbsp;
+                                <ClipboardCopy
+                                    isReadOnly
+                                    style={{ border: "1px solid #ccc", padding: "3px" }}
+                                    variant="inline-compact">{ apiUrl }</ClipboardCopy>
+                            </p>
                         </EmptyStateBody>
                         <EmptyStateFooter>
                             <EmptyStateActions>


### PR DESCRIPTION
## Summary

- Display the configured registry backend API URL on the Connection Failed error page so users can
  diagnose misconfiguration issues (e.g. internal Kubernetes service URLs not accessible from the browser)
- Uses PatternFly's `ClipboardCopy` component in read-only inline-compact mode for easy copy/paste of the URL
- Imports `useConfigService` to retrieve the configured `artifactsUrl()`

## Related Issue

Fixes #5388

## Test Plan

- [ ] Run the UI with an unreachable backend URL (e.g. set `REGISTRY_API_URL` to an invalid address)
- [ ] Confirm the Connection Failed error page displays the configured API URL
- [ ] Confirm the URL can be copied to clipboard via the ClipboardCopy button
- [ ] Verify existing UI functionality is unaffected