### PR TITLE
fix(deps): update dependency net.minidev.json-smart [security]

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -230,6 +230,10 @@
       <artifactId>commons-beanutils</artifactId>
       <version>${commons-beanutils.version}</version>
     </dependency>
+    <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+    </dependency>
 
     <!-- Test Only -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,7 @@
     <assertj.core.version>3.27.7</assertj.core.version>
     <semver4j.version>5.8.0</semver4j.version>
     <slf4j.version>2.0.17</slf4j.version>
+    <json-smart.version>2.5.2</json-smart.version>
 
     <!-- Kafka Connect -->
     <connect.version>3.9.2</connect.version>
@@ -716,6 +717,11 @@
             <artifactId>commons-logging</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>${json-smart.version}</version>
       </dependency>
 
       <!-- GraphQL -->


### PR DESCRIPTION
Upgrade from `2.5.0` to `2.5.2` to address CVE-2024-57699:
  Potential DoS via stack exhaustion (incomplete fix for CVE-2023-1370)