### PR TITLE
fix(ci): update deprecated actions in Trivy image scan workflow

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -6,7 +6,24 @@ on:
     - cron: "0 6 * * *"
 
 jobs:
-  call-image-scan-registry:
-    uses: Apicurio/apicurio-gh-workflows/.github/workflows/image-scan.yaml@main
-    with:
-      image: quay.io/apicurio/apicurio-registry:latest-snapshot
+  vulnerability-scan:
+    name: Container vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout "${{ github.ref }}"
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          image-ref: quay.io/apicurio/apicurio-registry:latest-snapshot
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          vuln-type: 'os,library'
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary

- Inline the Trivy image scan workflow (previously called a reusable workflow from `apicurio-gh-workflows`)
- Update deprecated action versions:
  - `actions/checkout` v3 → v4
  - `aquasecurity/trivy-action` 0.6.2 → 0.29.0
  - `github/codeql-action/upload-sarif` v2 → v3

## Root Cause

The reusable workflow in `apicurio-gh-workflows` uses deprecated action versions, causing the CodeQL v2 deprecation error:
```
CodeQL Action major versions v1 and v2 have been deprecated.
```

See failed run: https://github.com/Apicurio/apicurio-registry/actions/runs/22940414589

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and verify it completes without deprecation errors
- [ ] Verify SARIF results are uploaded to the GitHub Security tab

Closes #7526