### PR TITLE
fix(ci): update trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: quay.io/apicurio/apicurio-registry:latest-snapshot
           format: 'sarif'


### PR DESCRIPTION
## Summary

- Update `aquasecurity/trivy-action` from `0.29.0` to `0.35.0` (latest release)
- v0.29.0 bundled Trivy binary v0.57.1 which failed to install during CI

## Root Cause

The Trivy image scan workflow updated in #7527 used `trivy-action@0.29.0`, which bundles Trivy v0.57.1. That binary fails to install on the CI runner, causing the workflow to fail: https://github.com/Apicurio/apicurio-registry/actions/runs/22950638293

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and verify it completes successfully

Closes #7526