### PR TITLE
docs: add concepts glossary and javadoc to model classes and enums

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rules/RuleApplicationType.java
+++ b/app/src/main/java/io/apicurio/registry/rules/RuleApplicationType.java
@@ -1,7 +1,19 @@
 package io.apicurio.registry.rules;
 
+/**
+ * Indicates the context in which a rule is being applied, so that rule implementations can adjust their
+ * behavior accordingly.
+ */
 public enum RuleApplicationType {
 
-    CREATE, UPDATE;
+    /**
+     * The rule is being applied during creation of a new artifact version (first version of a new artifact).
+     */
+    CREATE,
+
+    /**
+     * The rule is being applied during an update to an existing artifact (adding a new version).
+     */
+    UPDATE;
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/StorageEventType.java
+++ b/app/src/main/java/io/apicurio/registry/storage/StorageEventType.java
@@ -1,9 +1,50 @@
 package io.apicurio.registry.storage;
 
+/**
+ * Enumerates the types of events emitted by the storage layer when registry data changes. These events are
+ * used to notify other components (e.g. caches, Kafka topics) about state changes.
+ */
 public enum StorageEventType {
 
-    /**
-     * The READY event type MUST be fired only once.
-     */
-    READY, ARTIFACT_CREATED, ARTIFACT_DELETED, ARTIFACT_METADATA_UPDATED, GROUP_CREATED, GROUP_DELETED, GROUP_METADATA_UPDATED, ARTIFACT_VERSION_CREATED, ARTIFACT_VERSION_METADATA_UPDATED, ARTIFACT_VERSION_DELETED, GLOBAL_RULE_CONFIGURED, GROUP_RULE_CONFIGURED, ARTIFACT_RULE_CONFIGURED, ARTIFACT_VERSION_STATE_CHANGED
+    /** Fired once when the storage layer has completed initialization and is ready to accept requests. */
+    READY,
+
+    /** An artifact was created. */
+    ARTIFACT_CREATED,
+
+    /** An artifact was deleted. */
+    ARTIFACT_DELETED,
+
+    /** An artifact's metadata was updated. */
+    ARTIFACT_METADATA_UPDATED,
+
+    /** A group was created. */
+    GROUP_CREATED,
+
+    /** A group was deleted. */
+    GROUP_DELETED,
+
+    /** A group's metadata was updated. */
+    GROUP_METADATA_UPDATED,
+
+    /** A new artifact version was created. */
+    ARTIFACT_VERSION_CREATED,
+
+    /** An artifact version's metadata was updated. */
+    ARTIFACT_VERSION_METADATA_UPDATED,
+
+    /** An artifact version was deleted. */
+    ARTIFACT_VERSION_DELETED,
+
+    /** A global rule was created, updated, or deleted. */
+    GLOBAL_RULE_CONFIGURED,
+
+    /** A group-level rule was created, updated, or deleted. */
+    GROUP_RULE_CONFIGURED,
+
+    /** An artifact-level rule was created, updated, or deleted. */
+    ARTIFACT_RULE_CONFIGURED,
+
+    /** An artifact version's lifecycle state was changed (e.g. ENABLED to DEPRECATED). */
+    ARTIFACT_VERSION_STATE_CHANGED
 }

--- a/app/src/main/java/io/apicurio/registry/storage/VersionStateExt.java
+++ b/app/src/main/java/io/apicurio/registry/storage/VersionStateExt.java
@@ -11,6 +11,18 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
+/**
+ * Utility class for managing {@link VersionState} transitions. Defines the valid state transitions between
+ * version states and provides methods for validating and applying state changes.
+ *
+ * <p>
+ * Valid transitions:
+ * <ul>
+ * <li>ENABLED -> DISABLED, DEPRECATED</li>
+ * <li>DISABLED -> ENABLED, DEPRECATED</li>
+ * <li>DEPRECATED -> ENABLED, DISABLED</li>
+ * </ul>
+ */
 @ApplicationScoped
 public class VersionStateExt {
 

--- a/app/src/main/java/io/apicurio/registry/storage/dto/AggregateType.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/AggregateType.java
@@ -1,5 +1,8 @@
 package io.apicurio.registry.storage.dto;
 
+/**
+ * Defines the types of registry entities that can be aggregated in storage operations.
+ */
 public enum AggregateType {
 
     GROUP, ARTIFACT, VERSION, GROUP_RULE, ARTIFACT_RULE, GLOBAL_RULE

--- a/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactMetaDataDto.java
@@ -10,6 +10,11 @@ import lombok.ToString;
 
 import java.util.Map;
 
+/**
+ * Data transfer object representing the metadata of an artifact. This includes identifying information
+ * (groupId, artifactId), descriptive metadata (name, description), the artifact type, labels, and
+ * timestamps. This is the non-version-specific metadata for the artifact as a whole.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactReferenceDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactReferenceDto.java
@@ -3,6 +3,10 @@ package io.apicurio.registry.storage.dto;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.*;
 
+/**
+ * Data transfer object representing a reference from one artifact to another. Artifact references model
+ * relationships such as {@code $ref} in JSON Schema, {@code import} in Protobuf, or type references in Avro.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactVersionMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactVersionMetaDataDto.java
@@ -11,6 +11,11 @@ import lombok.ToString;
 
 import java.util.Map;
 
+/**
+ * Data transfer object representing the metadata of a specific artifact version. This includes the version
+ * identifier, globalId, contentId, version state, artifact type, labels, and timestamps. Each artifact
+ * version is an immutable snapshot of an artifact's content.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/BranchMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/BranchMetaDataDto.java
@@ -8,6 +8,11 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * Data transfer object representing the metadata of an artifact branch. A branch is a named, ordered sequence
+ * of artifact versions within an artifact, used to track parallel evolution paths (e.g. {@code latest},
+ * {@code 1.x}).
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/CommentDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/CommentDto.java
@@ -2,6 +2,10 @@ package io.apicurio.registry.storage.dto;
 
 import lombok.*;
 
+/**
+ * Data transfer object representing a comment attached to an artifact version. Comments allow users to
+ * annotate specific versions with free-text notes.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/ContentWrapperDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/ContentWrapperDto.java
@@ -12,6 +12,10 @@ import lombok.ToString;
 
 import java.util.List;
 
+/**
+ * Data transfer object that wraps artifact content together with its associated metadata, including the
+ * content ID, content hash, and any artifact references contained within the content.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/DownloadContextType.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/DownloadContextType.java
@@ -1,7 +1,23 @@
 package io.apicurio.registry.storage.dto;
 
+/**
+ * Defines the types of download contexts available for retrieving content or data exports from the registry.
+ */
 public enum DownloadContextType {
 
-    EXPORT, CONTENT_BY_GLOBAL_ID, CONTENT_BY_CONTENT_ID, CONTENT_BY_CONTENT_HASH, VERSION_EXPORT
+    /** A full registry data export. */
+    EXPORT,
+
+    /** Download content by the version's global ID. */
+    CONTENT_BY_GLOBAL_ID,
+
+    /** Download content by content ID. */
+    CONTENT_BY_CONTENT_ID,
+
+    /** Download content by content hash. */
+    CONTENT_BY_CONTENT_HASH,
+
+    /** Export a specific artifact version. */
+    VERSION_EXPORT
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/dto/EditableArtifactMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/EditableArtifactMetaDataDto.java
@@ -11,6 +11,10 @@ import lombok.ToString;
 
 import java.util.Map;
 
+/**
+ * Data transfer object representing the user-editable subset of artifact metadata. This includes fields that
+ * can be modified after artifact creation, such as name, description, labels, and owner.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/EditableBranchMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/EditableBranchMetaDataDto.java
@@ -9,6 +9,10 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * Data transfer object representing the user-editable subset of branch metadata. This includes fields that
+ * can be modified after branch creation, such as description.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/EditableGroupMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/EditableGroupMetaDataDto.java
@@ -11,6 +11,10 @@ import lombok.ToString;
 
 import java.util.Map;
 
+/**
+ * Data transfer object representing the user-editable subset of group metadata. This includes fields that can
+ * be modified after group creation, such as description, labels, and owner.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/EditableVersionMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/EditableVersionMetaDataDto.java
@@ -11,6 +11,10 @@ import lombok.ToString;
 
 import java.util.Map;
 
+/**
+ * Data transfer object representing the user-editable subset of artifact version metadata. This includes
+ * fields that can be modified after version creation, such as name, description, labels, and state.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/GroupMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/GroupMetaDataDto.java
@@ -4,6 +4,10 @@ import lombok.*;
 
 import java.util.Map;
 
+/**
+ * Data transfer object representing the metadata of a group. A group is a named namespace for organizing
+ * related artifacts. This DTO includes the group's identifier, description, labels, and timestamps.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/OrderBy.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/OrderBy.java
@@ -1,5 +1,8 @@
 package io.apicurio.registry.storage.dto;
 
+/**
+ * Defines the fields by which search results can be sorted.
+ */
 public enum OrderBy {
     name, createdOn, modifiedOn, // Shared
     groupId, // Group specific

--- a/app/src/main/java/io/apicurio/registry/storage/dto/OrderDirection.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/OrderDirection.java
@@ -1,5 +1,8 @@
 package io.apicurio.registry.storage.dto;
 
+/**
+ * Defines the direction in which search results are sorted: ascending or descending.
+ */
 public enum OrderDirection {
 
     asc, desc

--- a/app/src/main/java/io/apicurio/registry/storage/dto/RoleMappingDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/RoleMappingDto.java
@@ -3,6 +3,10 @@ package io.apicurio.registry.storage.dto;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.*;
 
+/**
+ * Data transfer object representing a mapping from a principal (user identity) to a role within the registry.
+ * Role mappings are used for access control when role-based authorization is enabled.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/RuleConfigurationDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/RuleConfigurationDto.java
@@ -3,6 +3,11 @@ package io.apicurio.registry.storage.dto;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import lombok.*;
 
+/**
+ * Data transfer object representing the configuration of a content rule. A rule defines a validation
+ * constraint (validity, compatibility, or integrity) that is applied when content is added to the registry.
+ * The configuration specifies the level or mode of the rule.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/app/src/main/java/io/apicurio/registry/storage/dto/SearchFilter.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/SearchFilter.java
@@ -3,6 +3,10 @@ package io.apicurio.registry.storage.dto;
 import io.apicurio.registry.types.VersionState;
 import org.apache.commons.lang3.tuple.Pair;
 
+/**
+ * Represents a single filter criterion used in search operations for artifacts and versions. Each filter has
+ * a type (the field to match against), a value, and an optional negation flag.
+ */
 public class SearchFilter {
 
     private SearchFilterType type;

--- a/app/src/main/java/io/apicurio/registry/storage/dto/SearchFilterType.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/SearchFilterType.java
@@ -1,5 +1,9 @@
 package io.apicurio.registry.storage.dto;
 
+/**
+ * Defines the types of filter criteria that can be used when searching for artifacts or versions in the
+ * registry. Each value corresponds to a field or property that can be matched against.
+ */
 public enum SearchFilterType {
 
     groupId, artifactId, version, name, description, labels, contentHash, canonicalHash, globalId, contentId, state, artifactType

--- a/app/src/main/java/io/apicurio/registry/storage/dto/StoredArtifactVersionDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/StoredArtifactVersionDto.java
@@ -12,6 +12,11 @@ import lombok.ToString;
 
 import java.util.List;
 
+/**
+ * Data transfer object representing a stored artifact version together with its content. This combines
+ * version metadata (globalId, version, content ID) with the actual content payload and any artifact
+ * references.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/common/src/main/java/io/apicurio/registry/types/ArtifactType.java
+++ b/common/src/main/java/io/apicurio/registry/types/ArtifactType.java
@@ -1,6 +1,11 @@
 
 package io.apicurio.registry.types;
 
+/**
+ * Defines the supported artifact types in the registry. The artifact type identifies the format or schema
+ * language of an artifact's content and determines how the registry parses, validates, and checks
+ * compatibility of that content.
+ */
 public class ArtifactType {
 
     private ArtifactType() {
@@ -8,18 +13,44 @@ public class ArtifactType {
 
     // TODO: Turn into enum, which can contain both a string value and a numeric identifier.
     // See io.apicurio.registry.storage.impl.kafkasql.serde.ArtifactTypeOrdUtil
+
+    /** Apache Avro schema. */
     public static final String AVRO = "AVRO";
+
+    /** Google Protocol Buffers definition. */
     public static final String PROTOBUF = "PROTOBUF";
+
+    /** JSON Schema. */
     public static final String JSON = "JSON";
+
+    /** OpenAPI specification. */
     public static final String OPENAPI = "OPENAPI";
+
+    /** AsyncAPI specification. */
     public static final String ASYNCAPI = "ASYNCAPI";
+
+    /** GraphQL schema definition language (SDL). */
     public static final String GRAPHQL = "GRAPHQL";
+
+    /** Apache Kafka Connect schema. */
     public static final String KCONNECT = "KCONNECT";
+
+    /** Web Services Description Language (WSDL) definition. */
     public static final String WSDL = "WSDL";
+
+    /** XML Schema Definition (XSD). */
     public static final String XSD = "XSD";
+
+    /** XML document. */
     public static final String XML = "XML";
+
+    /** AI Agent Card for the A2A (Agent-to-Agent) protocol. */
     public static final String AGENT_CARD = "AGENT_CARD";
+
+    /** Apache Iceberg table metadata. */
     public static final String ICEBERG_TABLE = "ICEBERG_TABLE";
+
+    /** Apache Iceberg view metadata. */
     public static final String ICEBERG_VIEW = "ICEBERG_VIEW";
 
 }

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,5 +1,6 @@
 * Introduction
 ** xref:getting-started/assembly-intro-to-the-registry.adoc[]
+** xref:getting-started/assembly-registry-concepts-glossary.adoc[]
 ** xref:getting-started/assembly-intro-to-registry-rules.adoc[]
 * Installation
 ** xref:getting-started/assembly-installing-registry-docker.adoc[]

--- a/docs/modules/ROOT/pages/getting-started/assembly-registry-concepts-glossary.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-registry-concepts-glossary.adoc
@@ -1,0 +1,112 @@
+// Metadata created by nebel
+include::./attributes.adoc[]
+
+[id="registry-concepts-glossary"]
+= Registry Concepts and Glossary
+
+This section provides definitions for the core concepts used throughout {registry}.
+
+[id="concept-group"]
+== Group
+A *group* is a named namespace for organizing related artifacts.
+Every artifact belongs to a group.
+If no group is specified when creating an artifact, it is placed in the `default` group.
+Groups can carry their own metadata (description, labels) and can have group-level rules that apply to all artifacts within the group.
+
+[id="concept-artifact"]
+== Artifact
+An *artifact* is a named schema or API definition within a group, uniquely identified by the combination of `groupId` and `artifactId`.
+An artifact acts as a container for zero or more artifact versions.
+Examples of artifacts include an Avro schema, a Protobuf definition, an OpenAPI specification, or an AsyncAPI definition.
+
+[id="concept-artifact-version"]
+== Artifact Version
+An *artifact version* is an immutable snapshot of an artifact's content.
+Each version is identified within its artifact by a `version` string and is also assigned a globally unique numeric `globalId`.
+Once created, the content of a version cannot be changed.
+Versions have a lifecycle state (see <<concept-version-state>>) and can carry user-defined metadata and labels.
+
+[id="concept-content"]
+== Content
+*Content* is the actual schema or API payload stored in the registry (for example, an Avro JSON schema, a Protobuf `.proto` definition, or an OpenAPI YAML specification).
+Content is deduplicated: if two artifact versions have identical content, they share the same `contentId`.
+
+[id="concept-global-id"]
+== GlobalId
+A *globalId* is a globally unique numeric identifier assigned to each artifact version in the registry.
+It is auto-generated when a version is created and can be used to retrieve a specific version directly, regardless of group or artifact.
+
+[id="concept-content-id"]
+== ContentId
+A *contentId* is a unique numeric identifier for a piece of content.
+Because content is deduplicated, multiple artifact versions with identical content share the same `contentId`.
+This is useful when different artifacts or versions reference the same schema payload.
+
+[id="concept-branch"]
+== Branch
+A *branch* is a named, ordered sequence of artifact versions within an artifact.
+Branches are used to track parallel evolution paths for an artifact.
+For example, an artifact might have a `latest` branch (the default) and a `1.x` branch for maintenance releases.
+
+[id="concept-artifact-reference"]
+== Artifact Reference
+An *artifact reference* is a reference from one artifact to another.
+References model relationships such as `$ref` in JSON Schema, `import` in Protobuf, or type references in Avro.
+When an artifact version contains references, the registry tracks them to support referential integrity validation.
+
+[id="concept-labels"]
+== Labels
+*Labels* are user-defined key-value string pairs that can be attached to groups, artifacts, or artifact versions.
+Labels are used for organization, categorization, and filtering when searching.
+
+[id="concept-rule"]
+== Rule
+A *rule* is a validation constraint that is applied when new content is added to the registry.
+Rules operate at three levels:
+
+* *Global rules* apply to all artifacts in the registry.
+* *Group rules* apply to all artifacts within a specific group.
+* *Artifact rules* apply to a specific artifact.
+
+When a rule is configured at multiple levels, the most specific level takes precedence (artifact > group > global).
+
+The available rule types are:
+
+* *Validity rule* -- validates that the content is syntactically and/or semantically correct for its artifact type.
+* *Compatibility rule* -- validates that new content is compatible with previous versions according to a specified compatibility level.
+* *Integrity rule* -- validates referential integrity of artifact references.
+
+For more information, see xref:getting-started/assembly-rule-reference.adoc[].
+
+[id="concept-version-state"]
+== Version State
+The *version state* represents the lifecycle state of an artifact version.
+The possible states are:
+
+* `ENABLED` -- the version is fully available. Content and metadata can be retrieved normally.
+* `DEPRECATED` -- the version is still available, but the registry returns a warning header to signal that consumers should migrate to a newer version.
+* `DISABLED` -- the version metadata is visible, but the version content cannot be fetched.
+
+State transitions are allowed between any of these three states.
+
+[id="concept-artifact-type"]
+== Artifact Type
+The *artifact type* identifies the format or schema language of an artifact's content.
+The registry uses the artifact type to determine how to parse, validate, and check compatibility of the content.
+Supported artifact types include:
+
+* `AVRO` -- Apache Avro schema
+* `PROTOBUF` -- Google Protocol Buffers definition
+* `JSON` -- JSON Schema
+* `OPENAPI` -- OpenAPI specification
+* `ASYNCAPI` -- AsyncAPI specification
+* `GRAPHQL` -- GraphQL schema definition
+* `KCONNECT` -- Apache Kafka Connect schema
+* `WSDL` -- Web Services Description Language definition
+* `XSD` -- XML Schema Definition
+* `XML` -- XML document
+* `AGENT_CARD` -- AI Agent Card (A2A protocol)
+* `ICEBERG_TABLE` -- Apache Iceberg table metadata
+* `ICEBERG_VIEW` -- Apache Iceberg view metadata
+
+For more information, see xref:getting-started/assembly-artifact-reference.adoc[].

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityLevel.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityLevel.java
@@ -1,5 +1,46 @@
 package io.apicurio.registry.rules.compatibility;
 
+/**
+ * Defines the level of compatibility enforced by the compatibility rule when new content is added to an
+ * artifact. Compatibility checking ensures that new versions of an artifact do not break consumers of previous
+ * versions.
+ */
 public enum CompatibilityLevel {
-    BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE, FULL, FULL_TRANSITIVE, NONE
+
+    /**
+     * New content must be backward compatible with the latest version. Consumers using the new schema can read
+     * data produced with the previous version.
+     */
+    BACKWARD,
+
+    /**
+     * New content must be backward compatible with all previous versions, not just the latest.
+     */
+    BACKWARD_TRANSITIVE,
+
+    /**
+     * New content must be forward compatible with the latest version. Consumers using the previous schema can
+     * read data produced with the new version.
+     */
+    FORWARD,
+
+    /**
+     * New content must be forward compatible with all previous versions, not just the latest.
+     */
+    FORWARD_TRANSITIVE,
+
+    /**
+     * New content must be both backward and forward compatible with the latest version.
+     */
+    FULL,
+
+    /**
+     * New content must be both backward and forward compatible with all previous versions.
+     */
+    FULL_TRANSITIVE,
+
+    /**
+     * No compatibility checking is performed.
+     */
+    NONE
 }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/integrity/IntegrityLevel.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/integrity/IntegrityLevel.java
@@ -1,10 +1,40 @@
 package io.apicurio.registry.rules.integrity;
 
 /**
- * Indicates what level of integrity should be performed by the referential integrity rule.
+ * Defines the level of referential integrity checking performed by the integrity rule when new content is
+ * added to an artifact. Integrity checking validates that artifact references are consistent and correct.
  */
 public enum IntegrityLevel {
 
-    NONE, REFS_EXIST, ALL_REFS_MAPPED, NO_DUPLICATES, NO_CIRCULAR_REFERENCES, FULL;
+    /**
+     * No integrity checking is performed.
+     */
+    NONE,
+
+    /**
+     * Validates that all referenced artifacts exist in the registry.
+     */
+    REFS_EXIST,
+
+    /**
+     * Validates that all references found in the content are mapped to artifact references in the registry.
+     */
+    ALL_REFS_MAPPED,
+
+    /**
+     * Validates that no duplicate artifact references are present.
+     */
+    NO_DUPLICATES,
+
+    /**
+     * Validates that no circular reference chains exist among artifacts.
+     */
+    NO_CIRCULAR_REFERENCES,
+
+    /**
+     * Performs all integrity checks: references exist, all references are mapped, no duplicates, and no
+     * circular references.
+     */
+    FULL;
 
 }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/ValidityLevel.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/ValidityLevel.java
@@ -1,11 +1,26 @@
 package io.apicurio.registry.rules.validity;
 
 /**
- * Indicates what level of validation should be performed by the content validity rule.
+ * Defines the level of validation performed by the content validity rule when new content is added to an
+ * artifact. Validity checking ensures that content is well-formed and correct for its artifact type.
  */
 public enum ValidityLevel {
 
-    // TODO definitions
-    NONE, SYNTAX_ONLY, FULL;
+    /**
+     * No validity checking is performed.
+     */
+    NONE,
+
+    /**
+     * Only syntactic validity is checked (e.g. the content is valid JSON, valid XML, parseable Protobuf).
+     */
+    SYNTAX_ONLY,
+
+    /**
+     * Full validation is performed, including both syntactic and semantic checks (e.g. verifying that a JSON
+     * Schema document conforms to the JSON Schema specification, or that an Avro schema is semantically
+     * valid).
+     */
+    FULL;
 
 }


### PR DESCRIPTION
## Summary
- Add a new AsciiDoc glossary page (`assembly-registry-concepts-glossary.adoc`) defining core registry concepts: Group, Artifact, Artifact Version, Content, GlobalId, ContentId, Branch, Artifact Reference, Labels, Rule, Version State, and Artifact Type
- Add javadoc to all conceptual model enums (`CompatibilityLevel`, `ValidityLevel`, `IntegrityLevel`, `RuleApplicationType`, `StorageEventType`, `DownloadContextType`, `OrderBy`, `OrderDirection`, `SearchFilterType`, `AggregateType`) with class-level and per-value documentation
- Add javadoc to `ArtifactType` class with per-constant documentation for all 13 artifact types
- Add class-level javadoc to 15 DTO classes (`ArtifactMetaDataDto`, `ArtifactVersionMetaDataDto`, `GroupMetaDataDto`, `BranchMetaDataDto`, `CommentDto`, `RuleConfigurationDto`, `StoredArtifactVersionDto`, `ArtifactReferenceDto`, `ContentWrapperDto`, `EditableArtifactMetaDataDto`, `EditableVersionMetaDataDto`, `EditableGroupMetaDataDto`, `EditableBranchMetaDataDto`, `SearchFilter`, `RoleMappingDto`)
- Add javadoc to `VersionStateExt` documenting valid state transitions

Closes #367

## Test plan
- [x] Verify `common` and `schema-util/common` modules compile cleanly
- [ ] Review glossary page for accuracy and completeness
- [ ] Review javadoc for consistency with glossary definitions