### PR TITLE
Add artifact management commands to the CLI. Fixes #7166

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.cli;
 
+import io.apicurio.registry.cli.artifact.ArtifactCommand;
 import lombok.Getter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -21,6 +22,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
         name = "acr",
         description = "Apicurio Registry CLI",
         subcommands = {
+                ArtifactCommand.class,
                 ContextCommand.class,
                 GroupCommand.class,
                 InstallCommand.class,

--- a/cli/src/main/java/io/apicurio/registry/cli/ContextCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/ContextCommand.java
@@ -8,6 +8,7 @@ import picocli.CommandLine.Command;
 
 import java.util.Objects;
 
+import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
 
 @Command(
@@ -32,9 +33,9 @@ public class ContextCommand extends AbstractCommand {
             }
             out.append('\n');
             var table = new TableBuilder();
-            table.addColumns("ID", "Registry URL");
+            table.addColumns("ID", "Registry URL", GROUP_ID);
             Config.getInstance().read().getContext().forEach((id, context) -> {
-                table.addRow(id + (Objects.equals(id, currentContext) ? "*" : ""), context.getRegistryUrl());
+                table.addRow(id + (Objects.equals(id, currentContext) ? "*" : ""), context.getRegistryUrl(), context.getGroupId());
             });
             table.print(out);
         });

--- a/cli/src/main/java/io/apicurio/registry/cli/ContextCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/ContextCreateCommand.java
@@ -27,6 +27,12 @@ public class ContextCreateCommand extends AbstractCommand {
     String registryUrl;
 
     @Option(
+            names = {"-g", "--group"},
+            description = "Group ID to use when not specified in a command."
+    )
+    String groupId;
+
+    @Option(
             names = {"--no-switch-current"},
             description = "Do not make the newly added context the current context.",
             defaultValue = "false"
@@ -41,6 +47,7 @@ public class ContextCreateCommand extends AbstractCommand {
         } else {
             config.getContext().put(name, ConfigModel.Context.builder()
                     .registryUrl(registryUrl)
+                    .groupId(groupId)
                     .build());
             output.writeStdOutChunk(out -> {
                 if (!noSwitchCurrent) {

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCommand.java
@@ -1,0 +1,133 @@
+package io.apicurio.registry.cli.artifact;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.Acr;
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.common.PaginationMixin;
+import io.apicurio.registry.cli.services.Client;
+import io.apicurio.registry.cli.utils.Mapper;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.ArtifactSortBy;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.client.models.SortOrder;
+import lombok.Getter;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPE;
+import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
+import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
+import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
+import static io.apicurio.registry.cli.utils.Columns.LABELS;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_BY;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_ON;
+import static io.apicurio.registry.cli.utils.Columns.NAME;
+import static io.apicurio.registry.cli.utils.Columns.OWNER;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Conversions.convertToString;
+
+/**
+ * Lists artifacts in a group with pagination support.
+ * When no group is specified, falls back to the context groupId or "default".
+ */
+@Command(
+        name = "artifact",
+        aliases = {"artifacts"},
+        description = "Work with artifacts",
+        subcommands = {
+                ArtifactCreateCommand.class,
+                ArtifactUpdateCommand.class,
+                ArtifactGetCommand.class,
+                ArtifactDeleteCommand.class
+        }
+)
+public class ArtifactCommand extends AbstractCommand {
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Group ID. If not provided, uses the groupId from the current context, or 'default'."
+    )
+    private String groupId;
+
+    @Mixin
+    private PaginationMixin pagination;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @ParentCommand
+    @Getter
+    private Acr parent;
+
+    @Override
+    public void run(final OutputBuffer output) throws JsonProcessingException {
+        final var resolvedGroupId = ArtifactUtil.resolveGroupId(groupId);
+        try {
+            final var client = Client.getInstance().getRegistryClient();
+            ArtifactUtil.validateGroup(client, resolvedGroupId);
+            //noinspection ConstantConditions
+            final var artifacts = convert(client
+                    .groups().byGroupId(resolvedGroupId).artifacts().get(r -> {
+                        //noinspection ConstantConditions
+                        r.queryParameters.offset = (pagination.getPage() - 1) * pagination.getSize();
+                        r.queryParameters.limit = pagination.getSize();
+                        r.queryParameters.orderby = ArtifactSortBy.ArtifactId;
+                        r.queryParameters.order = SortOrder.Asc;
+                    }));
+            output.writeStdOutChunkWithException(out -> {
+                switch (outputType.getOutputType()) {
+                    case json -> {
+                        out.append(Mapper.MAPPER.writeValueAsString(artifacts));
+                        out.append('\n');
+                    }
+                    case table -> {
+                        final var table = new TableBuilder();
+                        table.addColumns(
+                                GROUP_ID,
+                                ARTIFACT_ID,
+                                NAME,
+                                ARTIFACT_TYPE,
+                                DESCRIPTION,
+                                CREATED_ON,
+                                OWNER,
+                                MODIFIED_ON,
+                                MODIFIED_BY,
+                                LABELS
+                        );
+                        artifacts.getArtifacts().forEach(a -> {
+                            table.addRow(
+                                    a.getGroupId(),
+                                    a.getArtifactId(),
+                                    a.getName(),
+                                    a.getArtifactType(),
+                                    a.getDescription(),
+                                    convertToString(a.getCreatedOn()),
+                                    a.getOwner(),
+                                    convertToString(a.getModifiedOn()),
+                                    a.getModifiedBy(),
+                                    convertToString(a.getLabels())
+                            );
+                        });
+                        table.setPagination(pagination.getPage(), pagination.getSize(), artifacts.getCount());
+                        table.print(out);
+                    }
+                }
+            });
+        } catch (ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error listing artifacts in group '")
+                        .append(resolvedGroupId)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
@@ -1,0 +1,177 @@
+package io.apicurio.registry.cli.artifact;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.services.Client;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.Labels;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static io.apicurio.registry.cli.artifact.ArtifactGetCommand.printArtifact;
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Utils.isBlank;
+
+/**
+ * Creates a new artifact with optional content from a file or stdin.
+ * Supports specifying artifact type, name, description, labels, and
+ * an initial version identifier.
+ */
+@Command(
+        name = "create",
+        aliases = {"add"},
+        description = "Create a new artifact"
+)
+public class ArtifactCreateCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The artifact ID."
+    )
+    private String artifactId;
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Group ID. If not provided, uses the groupId from the current context, or 'default'."
+    )
+    private String groupId;
+
+    @Option(
+            names = {"-t", "--type"},
+            description = "Artifact type (e.g. AVRO, PROTOBUF, JSON, OPENAPI, ASYNCAPI, GRAPHQL, KCONNECT, WSDL, XSD, XML)."
+    )
+    private String artifactType;
+
+    @Option(
+            names = {"-f", "--file"},
+            description = "Path to the artifact content file. Use '-' to read from stdin."
+    )
+    private String file;
+
+    @Option(
+            names = {"-n", "--name"},
+            description = "Provide artifact name."
+    )
+    private String name;
+
+    @Option(
+            names = {"-d", "--description"},
+            description = "Provide artifact description."
+    )
+    private String description;
+
+    @Option(
+            names = {"-l", "--label"},
+            description = "Provide a list of artifact labels.",
+            mapFallbackValue = ""
+    )
+    private Map<String, String> labels;
+
+    @Option(
+            names = {"--version"},
+            description = "Version identifier for the first version."
+    )
+    private String version;
+
+    @Option(
+            names = {"--content-type"},
+            description = "Content type of the artifact (e.g. application/json, application/x-protobuf). " +
+                    "Defaults to 'application/json' if not specified."
+    )
+    private String contentType;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = ArtifactUtil.resolveGroupId(groupId);
+
+        final var newArtifact = new CreateArtifact();
+        newArtifact.setArtifactId(artifactId);
+        if (!isBlank(artifactType)) {
+            newArtifact.setArtifactType(artifactType);
+        }
+        if (!isBlank(name)) {
+            newArtifact.setName(name);
+        }
+        if (!isBlank(description)) {
+            newArtifact.setDescription(description);
+        }
+        if (labels != null) {
+            final var newLabels = new Labels();
+            newLabels.setAdditionalData((Map<String, Object>) (Map<String, ?>) labels);
+            newArtifact.setLabels(newLabels);
+        }
+
+        if (!isBlank(file)) {
+            final var content = readContent(file);
+            final var firstVersion = new CreateVersion();
+            if (!isBlank(version)) {
+                firstVersion.setVersion(version);
+            }
+            final var versionContent = new VersionContent();
+            versionContent.setContent(content);
+            versionContent.setContentType(!isBlank(contentType) ? contentType : "application/json");
+            firstVersion.setContent(versionContent);
+            newArtifact.setFirstVersion(firstVersion);
+        }
+
+        try {
+            final var result = Client.getInstance().getRegistryClient()
+                    .groups().byGroupId(resolvedGroupId).artifacts().post(newArtifact);
+            //noinspection ConstantConditions
+            final var artifact = convert(result.getArtifact());
+            switch (outputType.getOutputType()) {
+                case json -> output.writeStdErrChunk(out -> successMessage(out, resolvedGroupId, artifact.getArtifactId()));
+                case table -> output.writeStdOutChunk(out -> successMessage(out, resolvedGroupId, artifact.getArtifactId()));
+            }
+            printArtifact(output, artifact, outputType.getOutputType());
+        } catch (ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error creating artifact '")
+                        .append(artifactId)
+                        .append("' in group '")
+                        .append(resolvedGroupId)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+
+    // Reads content from a file path or stdin (when path is "-").
+    private static String readContent(final String file) {
+        try {
+            if ("-".equals(file)) {
+                return new String(System.in.readAllBytes(), StandardCharsets.UTF_8);
+            } else {
+                return Files.readString(Path.of(file));
+            }
+        } catch (IOException ex) {
+            throw new CliException("Could not read content from: " + file, ex, APPLICATION_ERROR_RETURN_CODE);
+        }
+    }
+
+    private static void successMessage(final StringBuilder out, final String groupId, final String artifactId) {
+        out.append("Artifact '").append(artifactId).append("' created successfully in group '")
+                .append(groupId).append("'.\n");
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactDeleteCommand.java
@@ -1,0 +1,58 @@
+package io.apicurio.registry.cli.artifact;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.services.Client;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+
+/** Deletes an existing artifact from a group. */
+@Command(
+        name = "delete",
+        aliases = {"remove", "rm"},
+        description = "Delete an existing artifact. Apicurio Registry must be configured " +
+                "with `apicurio.rest.deletion.artifact.enabled=true` to allow artifact deletions."
+)
+public class ArtifactDeleteCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The artifact ID."
+    )
+    private String artifactId;
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Group ID. If not provided, uses the groupId from the current context, or 'default'."
+    )
+    private String groupId;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = ArtifactUtil.resolveGroupId(groupId);
+        try {
+            final var client = Client.getInstance().getRegistryClient();
+            ArtifactUtil.validateGroup(client, resolvedGroupId);
+            client.groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId).delete();
+            output.writeStdOutChunk(out -> {
+                out.append("Artifact '").append(artifactId).append("' in group '")
+                        .append(resolvedGroupId).append("' deleted successfully.\n");
+            });
+        } catch (ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error deleting artifact '")
+                        .append(artifactId)
+                        .append("' in group '")
+                        .append(resolvedGroupId)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactGetCommand.java
@@ -1,0 +1,156 @@
+package io.apicurio.registry.cli.artifact;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.OutputType;
+import io.apicurio.registry.cli.services.Client;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.v3.beans.ArtifactMetaData;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPE;
+import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
+import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
+import static io.apicurio.registry.cli.utils.Columns.FIELD;
+import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
+import static io.apicurio.registry.cli.utils.Columns.LABELS;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_BY;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_ON;
+import static io.apicurio.registry.cli.utils.Columns.NAME;
+import static io.apicurio.registry.cli.utils.Columns.OWNER;
+import static io.apicurio.registry.cli.utils.Columns.VALUE;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Conversions.convertToString;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+/** Retrieves an existing artifact's metadata or content (latest version). */
+@Command(
+        name = "get",
+        description = "Get an existing artifact"
+)
+public class ArtifactGetCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The artifact ID."
+    )
+    private String artifactId;
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Group ID. If not provided, uses the groupId from the current context, or 'default'."
+    )
+    private String groupId;
+
+    @ArgGroup(exclusive = true)
+    private OutputOptions outputOptions;
+
+    static class OutputOptions {
+        @Option(
+                names = {"-c", "--content"},
+                description = "Retrieve the artifact content (latest version) instead of metadata."
+        )
+        boolean content;
+
+        @Option(
+                names = {"-o", "--output-type"},
+                description = "Write the output in the given format. Valid values: ${COMPLETION-CANDIDATES}. Default is 'table'."
+        )
+        OutputType outputType;
+    }
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = ArtifactUtil.resolveGroupId(groupId);
+        try {
+            final var client = Client.getInstance().getRegistryClient();
+            ArtifactUtil.validateGroup(client, resolvedGroupId);
+            if (outputOptions != null && outputOptions.content) {
+                fetchContent(client, resolvedGroupId, output);
+            } else {
+                fetchMetadata(client, resolvedGroupId, output);
+            }
+        } catch (ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error retrieving artifact '")
+                        .append(artifactId)
+                        .append("' in group '")
+                        .append(resolvedGroupId)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+
+    // Fetches the raw content of the latest version of the artifact.
+    private void fetchContent(final RegistryClient client, final String resolvedGroupId, final OutputBuffer output) {
+        // Validates the artifact exists to provide accurate error messages.
+        client.groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId).get();
+        final String artifactContent;
+        try (final var inputStream = client
+                .groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId)
+                .versions().byVersionExpression("branch=latest").content().get()) {
+            //noinspection ConstantConditions
+            artifactContent = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            throw new CliException("Could not read artifact content.", ex, APPLICATION_ERROR_RETURN_CODE);
+        }
+        output.writeStdOutChunk(out -> {
+            out.append(artifactContent);
+            if (!artifactContent.endsWith("\n")) {
+                out.append('\n');
+            }
+        });
+    }
+
+    // Fetches and prints the artifact metadata.
+    private void fetchMetadata(final RegistryClient client, final String resolvedGroupId, final OutputBuffer output) throws JsonProcessingException {
+        //noinspection ConstantConditions
+        final var artifact = convert(client
+                .groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId).get());
+        final var type = outputOptions != null && outputOptions.outputType != null
+                ? outputOptions.outputType : OutputType.table;
+        printArtifact(output, artifact, type);
+    }
+
+    static void printArtifact(final OutputBuffer output, final ArtifactMetaData artifact, final OutputType outputType) throws JsonProcessingException {
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(artifact));
+                    out.append('\n');
+                }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(FIELD, VALUE);
+                    table.addRow(GROUP_ID, artifact.getGroupId());
+                    table.addRow(ARTIFACT_ID, artifact.getArtifactId());
+                    table.addRow(NAME, artifact.getName());
+                    table.addRow(ARTIFACT_TYPE, artifact.getArtifactType());
+                    table.addRow(DESCRIPTION, artifact.getDescription());
+                    table.addRow(CREATED_ON, convertToString(artifact.getCreatedOn()));
+                    table.addRow(OWNER, artifact.getOwner());
+                    table.addRow(MODIFIED_ON, convertToString(artifact.getModifiedOn()));
+                    table.addRow(MODIFIED_BY, artifact.getModifiedBy());
+                    table.addRow(LABELS, convertToString(artifact.getLabels()));
+                    table.print(out);
+                }
+            }
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactUpdateCommand.java
@@ -1,0 +1,115 @@
+package io.apicurio.registry.cli.artifact;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.services.Client;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.EditableArtifactMetaData;
+import io.apicurio.registry.rest.client.models.Labels;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+
+/**
+ * Updates an existing artifact's metadata (name, description, labels).
+ * Supports adding/updating and deleting individual labels.
+ */
+@Command(
+        name = "update",
+        description = "Update an existing artifact"
+)
+public class ArtifactUpdateCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The artifact ID."
+    )
+    private String artifactId;
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Group ID. If not provided, uses the groupId from the current context, or 'default'."
+    )
+    private String groupId;
+
+    @Option(
+            names = {"-n", "--name"},
+            description = "Updated artifact name."
+    )
+    private String name;
+
+    @Option(
+            names = {"-d", "--description"},
+            description = "Updated artifact description."
+    )
+    private String description;
+
+    @Option(
+            names = {"-l", "--sl", "--set-label"},
+            description = "Add or update an artifact label.",
+            mapFallbackValue = ""
+    )
+    private Map<String, String> setLabels;
+
+    @Option(
+            names = {"--dl", "--delete-label"},
+            description = "Delete an existing artifact label."
+    )
+    private List<String> deleteLabels;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = ArtifactUtil.resolveGroupId(groupId);
+        try {
+            final var client = Client.getInstance().getRegistryClient();
+            ArtifactUtil.validateGroup(client, resolvedGroupId);
+            final var existing = client
+                    .groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId).get();
+            final var updatedArtifact = new EditableArtifactMetaData();
+            //noinspection ConstantConditions
+            updatedArtifact.setName(existing.getName());
+            updatedArtifact.setDescription(existing.getDescription());
+            updatedArtifact.setLabels(existing.getLabels());
+            if (name != null) {
+                updatedArtifact.setName(name);
+            }
+            if (description != null) {
+                updatedArtifact.setDescription(description);
+            }
+            if (setLabels != null) {
+                if (updatedArtifact.getLabels() == null) {
+                    updatedArtifact.setLabels(new Labels());
+                }
+                updatedArtifact.getLabels().getAdditionalData().putAll(setLabels);
+            }
+            if (deleteLabels != null) {
+                if (updatedArtifact.getLabels() != null) {
+                    deleteLabels.forEach(key -> {
+                        updatedArtifact.getLabels().getAdditionalData().remove(key);
+                    });
+                }
+            }
+            client.groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId).put(updatedArtifact);
+            output.writeStdOutChunk(out -> {
+                out.append("Artifact '").append(artifactId).append("' in group '")
+                        .append(resolvedGroupId).append("' updated successfully.\n");
+            });
+        } catch (ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error updating artifact '")
+                        .append(artifactId)
+                        .append("' in group '")
+                        .append(resolvedGroupId)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactUtil.java
@@ -1,0 +1,40 @@
+package io.apicurio.registry.cli.artifact;
+
+import io.apicurio.registry.cli.config.Config;
+import io.apicurio.registry.rest.client.RegistryClient;
+
+import static io.apicurio.registry.cli.utils.Utils.isBlank;
+
+/**
+ * Shared utility for resolving the group ID across artifact commands.
+ * Priority: CLI flag → context groupId → "default".
+ */
+final class ArtifactUtil {
+
+    private static final String DEFAULT_GROUP = "default";
+
+    private ArtifactUtil() {
+    }
+
+    static String resolveGroupId(final String groupId) {
+        if (!isBlank(groupId)) {
+            return groupId;
+        }
+        final var config = Config.getInstance().read();
+        final var contextName = config.getCurrentContext();
+        if (!isBlank(contextName)) {
+            final var context = config.getContext().get(contextName);
+            if (context != null && !isBlank(context.getGroupId())) {
+                return context.getGroupId();
+            }
+        }
+        return DEFAULT_GROUP;
+    }
+
+    // Validates the group exists. Skips validation for the "default" group as it is implicit.
+    static void validateGroup(final RegistryClient client, final String groupId) {
+        if (!DEFAULT_GROUP.equals(groupId)) {
+            client.groups().byGroupId(groupId).get();
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
@@ -35,5 +35,8 @@ public class ConfigModel {
 
         @JsonProperty("registryUrl")
         private String registryUrl;
+
+        @JsonProperty("groupId")
+        private String groupId;
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
@@ -6,6 +6,7 @@ public final class Columns {
     }
 
     public static final String GROUP_ID = "Group ID";
+    public static final String NAME = "Name";
     public static final String DESCRIPTION = "Description";
     public static final String CREATED_ON = "Created On";
     public static final String OWNER = "Owner";
@@ -15,6 +16,9 @@ public final class Columns {
 
     public static final String FIELD = "Field";
     public static final String VALUE = "Value";
+
+    public static final String ARTIFACT_ID = "Artifact ID";
+    public static final String ARTIFACT_TYPE = "Artifact Type";
 
     public static final String CLI_VERSION = "CLI version";
     public static final String SERVER_NAME = "Server name";

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
@@ -1,8 +1,11 @@
 package io.apicurio.registry.cli.utils;
 
 import io.apicurio.registry.rest.client.models.Labels;
+import io.apicurio.registry.rest.v3.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
 import io.apicurio.registry.rest.v3.beans.GroupMetaData;
 import io.apicurio.registry.rest.v3.beans.GroupSearchResults;
+import io.apicurio.registry.rest.v3.beans.SearchedArtifact;
 import io.apicurio.registry.rest.v3.beans.SearchedGroup;
 
 import java.time.OffsetDateTime;
@@ -54,6 +57,45 @@ public final class Conversions {
     public static GroupSearchResults convert(io.apicurio.registry.rest.client.models.GroupSearchResults searchResults) {
         return GroupSearchResults.builder()
                 .groups(searchResults.getGroups().stream()
+                        .map(Conversions::convert)
+                        .collect(Collectors.toList()))
+                .count(searchResults.getCount())
+                .build();
+    }
+
+    public static ArtifactMetaData convert(io.apicurio.registry.rest.client.models.ArtifactMetaData artifact) {
+        return ArtifactMetaData.builder()
+                .groupId(artifact.getGroupId())
+                .artifactId(artifact.getArtifactId())
+                .artifactType(artifact.getArtifactType())
+                .name(artifact.getName())
+                .description(artifact.getDescription())
+                .createdOn(convert(artifact.getCreatedOn()))
+                .owner(artifact.getOwner())
+                .modifiedOn(convert(artifact.getModifiedOn()))
+                .modifiedBy(artifact.getModifiedBy())
+                .labels(convert(artifact.getLabels()))
+                .build();
+    }
+
+    public static SearchedArtifact convert(io.apicurio.registry.rest.client.models.SearchedArtifact artifact) {
+        return SearchedArtifact.builder()
+                .groupId(artifact.getGroupId())
+                .artifactId(artifact.getArtifactId())
+                .artifactType(artifact.getArtifactType())
+                .name(artifact.getName())
+                .description(artifact.getDescription())
+                .createdOn(convert(artifact.getCreatedOn()))
+                .owner(artifact.getOwner())
+                .modifiedOn(convert(artifact.getModifiedOn()))
+                .modifiedBy(artifact.getModifiedBy())
+                .labels(convert(artifact.getLabels()))
+                .build();
+    }
+
+    public static ArtifactSearchResults convert(io.apicurio.registry.rest.client.models.ArtifactSearchResults searchResults) {
+        return ArtifactSearchResults.builder()
+                .artifacts(searchResults.getArtifacts().stream()
                         .map(Conversions::convert)
                         .collect(Collectors.toList()))
                 .count(searchResults.getCount())

--- a/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
@@ -52,6 +52,7 @@ public abstract class AbstractCLITest {
                 .orElse("quay.io/apicurio/apicurio-registry:latest-release");
         registryContainer = new GenericContainer<>(appImage)
                 .withEnv("APICURIO_REST_DELETION_GROUP_ENABLED", "true")
+                .withEnv("APICURIO_REST_DELETION_ARTIFACT_ENABLED", "true")
                 .withExposedPorts(8080)
                 .waitingFor(Wait.forHttp("/apis/registry/v3/system/info")
                         .forStatusCode(200)

--- a/cli/src/test/java/io/apicurio/registry/cli/ArtifactCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ArtifactCommandTest.java
@@ -1,0 +1,329 @@
+package io.apicurio.registry.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.rest.v3.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(OrderAnnotation.class)
+public class ArtifactCommandTest extends AbstractCLITest {
+
+    // -- Unordered tests (no dependency on state) --
+
+    @Test
+    public void testArtifactHelp() {
+        testHelpCommand("artifact");
+        testHelpCommand("artifact", "create");
+        testHelpCommand("artifact", "get");
+        testHelpCommand("artifact", "update");
+        testHelpCommand("artifact", "delete");
+    }
+
+    @Test
+    public void testArtifactCreateCommandFails() {
+        // Required artifactId parameter is missing
+        executeAndAssertFailure("artifact", "create", "--output-type", "json", "--group", "default");
+    }
+
+    @Test
+    public void testArtifactGetContentAndOutputTypeMutuallyExclusive() {
+        // --content and --output-type should not be allowed together
+        executeAndAssertFailure("artifact", "get", "--content", "--output-type", "json",
+                "--group", "default", "test-artifact");
+    }
+
+    @Test
+    public void testArtifactGetNonExistentArtifact() {
+        executeAndAssertFailure("artifact", "get", "--group", "default", "non-existent-artifact");
+    }
+
+    @Test
+    public void testArtifactDeleteNonExistentArtifact() {
+        executeAndAssertFailure("artifact", "delete", "--group", "default", "non-existent-artifact");
+    }
+
+    @Test
+    public void testArtifactUpdateNonExistentArtifact() {
+        executeAndAssertFailure("artifact", "update", "--group", "default",
+                "--name", "New Name", "non-existent-artifact");
+    }
+
+    @Test
+    public void testArtifactListNonExistentGroup() {
+        executeAndAssertFailure("artifact", "--group", "non-existent-group");
+    }
+
+    // -- Ordered tests (depend on state from previous tests) --
+
+    @Test
+    @Order(0)
+    public void testArtifactCommandEmpty() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "--output-type", "json", "--group", "default");
+        var artifacts = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+        assertThat(artifacts.getArtifacts())
+                .as(withCliOutput("There should not be any artifacts initially."))
+                .isEmpty();
+    }
+
+    @Test
+    @Order(1)
+    public void testArtifactCreateCommand() throws Exception {
+        Path tempFile = Files.createTempFile("test-schema", ".json");
+        Files.writeString(tempFile, """
+                {
+                  "type": "record",
+                  "name": "TestRecord",
+                  "fields": [
+                    {"name": "id", "type": "int"},
+                    {"name": "name", "type": "string"}
+                  ]
+                }
+                """);
+
+        try {
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("artifact", "create", "--output-type", "json",
+                    "--group", "default",
+                    "--type", "AVRO",
+                    "--name", "Test Artifact",
+                    "--description", "A test artifact",
+                    "--label", "env=test",
+                    "--label", "color=blue",
+                    "--file", tempFile.toString(),
+                    "test-artifact");
+            var artifact = MAPPER.readValue(out.toString(), ArtifactMetaData.class);
+
+            assertThat(artifact.getArtifactId())
+                    .as(withCliOutput("Created artifact should have the correct artifactId"))
+                    .isEqualTo("test-artifact");
+            assertThat(artifact.getArtifactType())
+                    .as(withCliOutput("Created artifact should have the correct type"))
+                    .isEqualTo("AVRO");
+            assertThat(artifact.getName())
+                    .as(withCliOutput("Created artifact should have the correct name"))
+                    .isEqualTo("Test Artifact");
+            assertThat(artifact.getDescription())
+                    .as(withCliOutput("Created artifact should have the correct description"))
+                    .isEqualTo("A test artifact");
+            assertThat(artifact.getLabels())
+                    .as(withCliOutput("Created artifact should have the correct labels"))
+                    .containsExactlyInAnyOrderEntriesOf(Map.of("env", "test", "color", "blue"));
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    @Order(2)
+    public void testArtifactCreateWithoutFile() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "create", "--output-type", "json",
+                "--group", "default",
+                "--type", "JSON",
+                "--name", "No Content Artifact",
+                "no-content-artifact");
+        var artifact = MAPPER.readValue(out.toString(), ArtifactMetaData.class);
+
+        assertThat(artifact.getArtifactId())
+                .as(withCliOutput("Created artifact should have the correct artifactId"))
+                .isEqualTo("no-content-artifact");
+        assertThat(artifact.getName())
+                .as(withCliOutput("Created artifact should have the correct name"))
+                .isEqualTo("No Content Artifact");
+    }
+
+    @Test
+    @Order(3)
+    public void testArtifactGetCommand() throws JsonProcessingException {
+        // Get metadata
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "get", "--output-type", "json",
+                "--group", "default", "test-artifact");
+        var artifact = MAPPER.readValue(out.toString(), ArtifactMetaData.class);
+
+        assertThat(artifact.getArtifactId())
+                .as(withCliOutput("Retrieved artifact should have the correct artifactId"))
+                .isEqualTo("test-artifact");
+        assertThat(artifact.getName())
+                .as(withCliOutput("Retrieved artifact should have the correct name"))
+                .isEqualTo("Test Artifact");
+
+        // Get content
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "get", "--content",
+                "--group", "default", "test-artifact");
+        var content = out.toString();
+
+        assertThat(content)
+                .as(withCliOutput("Content should contain the Avro schema"))
+                .contains("TestRecord");
+    }
+
+    @Test
+    @Order(4)
+    public void testArtifactListCommand() throws Exception {
+        Path tempFile = Files.createTempFile("test-schema2", ".json");
+        Files.writeString(tempFile, """
+                {
+                  "type": "record",
+                  "name": "SecondRecord",
+                  "fields": [
+                    {"name": "value", "type": "string"}
+                  ]
+                }
+                """);
+
+        try {
+            executeAndAssertSuccess("artifact", "create",
+                    "--group", "default",
+                    "--type", "AVRO",
+                    "--file", tempFile.toString(),
+                    "second-artifact");
+
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("artifact", "--output-type", "json", "--group", "default");
+            var artifacts = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+            assertThat(artifacts.getArtifacts())
+                    .as(withCliOutput("There should be three artifacts."))
+                    .hasSize(3);
+
+            // Test pagination
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("artifact", "--output-type", "json", "--group", "default",
+                    "-p", "1", "-s", "1");
+            artifacts = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+            assertThat(artifacts.getArtifacts())
+                    .as(withCliOutput("Page 1 with size 1 should return one artifact."))
+                    .hasSize(1);
+            assertThat(artifacts.getCount())
+                    .as(withCliOutput("Total count should be 3."))
+                    .isEqualTo(3);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    @Order(5)
+    public void testArtifactUpdateCommand() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "update",
+                "--group", "default",
+                "--name", "Updated Name",
+                "--description", "Updated description",
+                "--set-label", "newkey=newvalue",
+                "test-artifact");
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "get", "--output-type", "json",
+                "--group", "default", "test-artifact");
+        var artifact = MAPPER.readValue(out.toString(), ArtifactMetaData.class);
+        assertThat(artifact.getName())
+                .as(withCliOutput("Updated artifact should have the new name"))
+                .isEqualTo("Updated Name");
+        assertThat(artifact.getDescription())
+                .as(withCliOutput("Updated artifact should have the new description"))
+                .isEqualTo("Updated description");
+        assertThat(artifact.getLabels())
+                .as(withCliOutput("Updated artifact should have the new label"))
+                .containsEntry("newkey", "newvalue");
+    }
+
+    @Test
+    @Order(6)
+    public void testArtifactDeleteLabel() throws JsonProcessingException {
+        // Add a label
+        executeAndAssertSuccess("artifact", "update", "--group", "default",
+                "--set-label", "toremove=value", "test-artifact");
+
+        // Delete the label
+        executeAndAssertSuccess("artifact", "update", "--group", "default",
+                "--delete-label", "toremove", "test-artifact");
+
+        // Verify label is removed
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "get", "--output-type", "json",
+                "--group", "default", "test-artifact");
+        var artifact = MAPPER.readValue(out.toString(), ArtifactMetaData.class);
+        assertThat(artifact.getLabels())
+                .as(withCliOutput("Deleted label should no longer exist"))
+                .doesNotContainKey("toremove");
+    }
+
+    @Test
+    @Order(7)
+    public void testArtifactDeleteCommand() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "delete", "--group", "default", "second-artifact");
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "--output-type", "json", "--group", "default");
+        var artifacts = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+        assertThat(artifacts.getArtifacts())
+                .as(withCliOutput("There should be two artifacts after deletion."))
+                .hasSize(2);
+        assertThat(artifacts.getArtifacts())
+                .as(withCliOutput("Remaining artifacts should not contain second-artifact"))
+                .noneMatch(a -> "second-artifact".equals(a.getArtifactId()));
+    }
+
+    @Test
+    @Order(8)
+    public void testArtifactWithDefaultGroupId() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "--output-type", "json");
+        var artifacts = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+        assertThat(artifacts.getArtifacts())
+                .as(withCliOutput("Should find artifacts in default group without --group flag"))
+                .isNotEmpty();
+    }
+
+    @Test
+    @Order(9)
+    public void testArtifactUsesGroupIdFromContext() throws Exception {
+        executeAndAssertSuccess("group", "create", "context-group");
+        executeAndAssertSuccess("context", "delete", "--all");
+        executeAndAssertSuccess("context", "create", "test-with-group", registryUrl, "--group", "context-group");
+
+        Path tempFile = Files.createTempFile("test-ctx-schema", ".json");
+        Files.writeString(tempFile, """
+                {"type": "string"}
+                """);
+
+        try {
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("artifact", "create", "--type", "JSON",
+                    "--file", tempFile.toString(), "context-artifact");
+
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("artifact", "--output-type", "json");
+            var artifacts = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+            assertThat(artifacts.getArtifacts())
+                    .as(withCliOutput("Should find artifact in group from context"))
+                    .hasSize(1);
+            assertThat(artifacts.getArtifacts().get(0).getArtifactId())
+                    .as(withCliOutput("Artifact should be the one created via context group"))
+                    .isEqualTo("context-artifact");
+            assertThat(artifacts.getArtifacts().get(0).getGroupId())
+                    .as(withCliOutput("Artifact should be in 'context-group'"))
+                    .isEqualTo("context-group");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                             
Add artifact management commands to the Apicurio Registry CLI. Supports create, list, get, update, and delete operations with file/stdin content, pagination, JSON/table output, and context-based group resolution.                                                                                                                                                                                     
                                                                                                                                                                                                    
## Changes                                                                                                                                                                                            
- Add `artifact` sub-package with create, get, update, delete, and list commands                                                                                                                      
- Add `ArtifactUtil` for group ID resolution (CLI flag → context → "default") and validation                                                                                                          
- Add `--group` option to `context create` and display groupId in context listing                                                                                                                     
- Make `--content` and `--output-type` mutually exclusive in get command                                                                                                                              
- Validate group/artifact existence for accurate error messages                                                                                                                                       
- Enable artifact deletion in test container                                                                                                                                                          
                                                                                                                                                                                                    
## Testing         
- [x] Build succeeds (`mvnw clean install -pl cli -am -DskipTests`)
- [x] Integration tests pass with Docker (`ArtifactCommandTest`)
- [x] Manual verification:                                                                                                                                                                                    
  - [x] Help output for all artifact subcommands                                                                                                                                                        
  - [x] Create artifact with file, type, name, description, labels                                                                                                                                      
  - [x] Create artifact without file (no initial version)                                                                                                                                               
  - [x] Create artifact from stdin (`--file -`)                                                                                                                                                         
  - [x] Get artifact metadata (JSON/table output)                                                                                                                                                       
  - [x] Get artifact content (`--content` flag)                                                                                                                                                         
  - [x] Mutually exclusive `--content` and `--output-type` validation                                                                                                                                   
  - [x] List artifacts with pagination                                                                                                                                                                  
  - [x] Update artifact name, description, and labels                                                                                                                                                   
  - [x] Delete individual labels                                                                                                                                                                        
  - [x] Delete artifact and verify removal                                                                                                                                                              
  - [x] Error handling for non-existent artifact                                                                                                                                                        
  - [x] Error handling for non-existent group                                                                                                                                                           
  - [x] Default group fallback when `--group` is omitted                                                                                                                                                
  - [x] Context-based groupId resolution      