### PR TITLE
fix: remove apicurio-common-rest-client dependency

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -53,17 +53,6 @@
 
     <dependency>
       <groupId>io.apicurio</groupId>
-      <artifactId>apicurio-common-rest-client-jdk</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.apicurio</groupId>
-      <artifactId>apicurio-common-rest-client-vertx</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-utils-import-export</artifactId>
     </dependency>
 

--- a/app/src/main/java/io/apicurio/registry/auth/AppAuthenticationMechanism.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AppAuthenticationMechanism.java
@@ -19,14 +19,9 @@ package io.apicurio.registry.auth;
 import io.apicurio.registry.logging.audit.AuditHttpRequestContext;
 import io.apicurio.registry.logging.audit.AuditHttpRequestInfo;
 import io.apicurio.registry.logging.audit.AuditLogService;
-import io.apicurio.rest.client.VertxHttpClientProvider;
-import io.apicurio.rest.client.auth.OidcAuth;
-import io.apicurio.rest.client.auth.exception.AuthErrorHandler;
-import io.apicurio.rest.client.auth.exception.AuthException;
-import io.apicurio.rest.client.auth.exception.ForbiddenException;
-import io.apicurio.rest.client.auth.exception.NotAuthorizedException;
-import io.apicurio.rest.client.error.ApicurioRestClientException;
-import io.apicurio.rest.client.spi.ApicurioHttpClient;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.oidc.runtime.OidcAuthenticationMechanism;
 import io.quarkus.security.identity.IdentityProviderManager;
@@ -36,7 +31,7 @@ import io.quarkus.vertx.http.runtime.security.*;
 import io.smallrye.jwt.auth.principal.DefaultJWTParser;
 import io.smallrye.jwt.auth.principal.ParseException;
 import io.smallrye.mutiny.Uni;
-import io.vertx.core.Vertx;
+import io.vertx.core.MultiMap;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Priority;
@@ -81,30 +76,26 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
     Logger log;
 
     @Inject
-    Vertx vertx;
+    WebClient webClient;
 
     @Inject
     DefaultJWTParser jwtParser;
 
-    private ApicurioHttpClient httpClient;
+    private String oidcTokenUrl;
 
     private ConcurrentHashMap<String, WrappedValue<String>> cachedAccessTokens;
-    private ConcurrentHashMap<String, WrappedValue<ApicurioRestClientException>> cachedAuthFailures;
+    private ConcurrentHashMap<String, WrappedValue<RuntimeException>> cachedAuthFailures;
 
     @PostConstruct
     public void init() {
         if (authConfig.oidcAuthEnabled) {
             cachedAccessTokens = new ConcurrentHashMap<>();
             cachedAuthFailures = new ConcurrentHashMap<>();
-            String oidcTokenUrl;
             if (authConfig.oidcTokenPath.startsWith("http")) {
                 oidcTokenUrl = authConfig.oidcTokenPath;
             } else {
                 oidcTokenUrl = authConfig.authServerUrl + authConfig.oidcTokenPath;
             }
-
-            httpClient = new VertxHttpClientProvider(vertx).create(oidcTokenUrl, Collections.emptyMap(),
-                    null, new AuthErrorHandler());
         }
     }
 
@@ -136,7 +127,7 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
                     try {
                         return authenticateWithClientCredentials(clientCredentials, context,
                                 identityProviderManager);
-                    } catch (AuthException | NotAuthorizedException ex) {
+                    } catch (OidcAuthException | io.quarkus.security.UnauthorizedException ex) {
                         log.warn(String.format(
                                 "Exception trying to get an access token with client credentials with client id: %s",
                                 clientCredentials.getLeft()), ex);
@@ -163,8 +154,7 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
             final Pair<String, String> credentialsFromContext = CredentialsHelper
                     .extractCredentialsFromContext(context);
             if (credentialsFromContext != null) {
-                OidcAuth oidcAuth = new OidcAuth(httpClient, authConfig.clientId, authConfig.clientSecret.get());
-                String jwtToken = oidcAuth.obtainAccessTokenPasswordGrant(credentialsFromContext.getLeft(),
+                String jwtToken = obtainAccessTokenPasswordGrant(credentialsFromContext.getLeft(),
                         credentialsFromContext.getRight());
                 if (jwtToken != null) {
                     // If we manage to get a token from basic credentials, try to authenticate it using the
@@ -178,6 +168,28 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
             }
         }
         return Uni.createFrom().nullItem();
+    }
+
+    private String obtainAccessTokenPasswordGrant(String username, String password) {
+        MultiMap form = MultiMap.caseInsensitiveMultiMap()
+                .add("grant_type", "password")
+                .add("client_id", authConfig.clientId)
+                .add("client_secret", authConfig.clientSecret.get())
+                .add("username", username)
+                .add("password", password);
+
+        Buffer responseBody = webClient.postAbs(oidcTokenUrl)
+                .sendForm(form)
+                .toCompletionStage()
+                .toCompletableFuture()
+                .join()
+                .bodyAsBuffer();
+
+        if (responseBody == null) {
+            return null;
+        }
+        JsonObject json = responseBody.toJsonObject();
+        return json.getString("access_token");
     }
 
     private void setAuditLogger(RoutingContext context) {
@@ -273,7 +285,7 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
                 && !cachedAccessTokens.get(credentialsHash).isExpired();
     }
 
-    @Retry(retryOn = AuthException.class, maxRetries = 4, delay = 1, delayUnit = ChronoUnit.SECONDS)
+    @Retry(retryOn = OidcAuthException.class, maxRetries = 4, delay = 1, delayUnit = ChronoUnit.SECONDS)
     public String getAccessToken(Pair<String, String> clientCredentials, String credentialsHash) {
         String clientId = clientCredentials.getLeft();
         String clientSecret = clientCredentials.getRight();
@@ -281,22 +293,45 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
         // Use client-specific scope resolution for Azure Entra ID multi-scope support
         String scopeForClient = authConfig.getScopeForClient(clientId);
 
-        OidcAuth oidcAuth = new OidcAuth(httpClient, clientId, clientSecret,
-                Duration.ofSeconds(1), scopeForClient);
+        MultiMap form = MultiMap.caseInsensitiveMultiMap()
+                .add("grant_type", "client_credentials")
+                .add("client_id", clientId)
+                .add("client_secret", clientSecret);
+        if (scopeForClient != null) {
+            form.add("scope", scopeForClient);
+        }
+
         try {
-            String jwtToken = oidcAuth.authenticate();
-            // If we manage to get a token from basic credentials,
-            // try to authenticate it using the fetched token using
-            // the identity provider manager
+            var response = webClient.postAbs(oidcTokenUrl)
+                    .sendForm(form)
+                    .toCompletionStage()
+                    .toCompletableFuture()
+                    .join();
+
+            int statusCode = response.statusCode();
+            if (statusCode == 401) {
+                var ex = new io.quarkus.security.UnauthorizedException("OIDC token request returned 401");
+                cachedAuthFailures.put(credentialsHash,
+                        new WrappedValue<>(getAccessTokenExpiration(null), Instant.now(), ex));
+                throw ex;
+            } else if (statusCode == 403) {
+                var ex = new io.quarkus.security.ForbiddenException("OIDC token request returned 403");
+                cachedAuthFailures.put(credentialsHash,
+                        new WrappedValue<>(getAccessTokenExpiration(null), Instant.now(), ex));
+                throw ex;
+            } else if (statusCode < 200 || statusCode >= 300) {
+                throw new OidcAuthException("OIDC token request failed with status " + statusCode);
+            }
+
+            JsonObject json = response.bodyAsJsonObject();
+            String jwtToken = json.getString("access_token");
             cachedAccessTokens.put(credentialsHash,
                     new WrappedValue<>(getAccessTokenExpiration(jwtToken), Instant.now(), jwtToken));
             return jwtToken;
-        } catch (NotAuthorizedException | ForbiddenException ex) {
-            cachedAuthFailures.put(credentialsHash,
-                    new WrappedValue<>(getAccessTokenExpiration(null), Instant.now(), ex));
+        } catch (io.quarkus.security.UnauthorizedException | io.quarkus.security.ForbiddenException ex) {
             throw ex;
         } catch (RuntimeException e) {
-            throw e;
+            throw new OidcAuthException("Failed to obtain access token", e);
         }
     }
 

--- a/app/src/main/java/io/apicurio/registry/auth/OidcAuthException.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OidcAuthException.java
@@ -1,0 +1,16 @@
+package io.apicurio.registry.auth;
+
+/**
+ * Exception thrown when OIDC authentication fails (e.g., token endpoint errors).
+ * Used as the retry target for {@link org.eclipse.microprofile.faulttolerance.Retry}.
+ */
+public class OidcAuthException extends RuntimeException {
+
+    public OidcAuthException(String message) {
+        super(message);
+    }
+
+    public OidcAuthException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
@@ -42,8 +42,6 @@ import io.apicurio.registry.storage.error.RuleNotFoundException;
 import io.apicurio.registry.storage.error.VersionAlreadyExistsException;
 import io.apicurio.registry.storage.error.VersionAlreadyExistsOnBranchException;
 import io.apicurio.registry.storage.error.VersionNotFoundException;
-import io.apicurio.rest.client.auth.exception.ForbiddenException;
-import io.apicurio.rest.client.auth.exception.NotAuthorizedException;
 import io.smallrye.mutiny.TimeoutException;
 import jakarta.inject.Singleton;
 import jakarta.validation.ValidationException;
@@ -89,7 +87,6 @@ public class HttpStatusCodeMap {
         map.put(ContentNotFoundException.class, HTTP_NOT_FOUND);
         map.put(DefaultRuleDeletionException.class, HTTP_CONFLICT);
         map.put(DownloadNotFoundException.class, HTTP_NOT_FOUND);
-        map.put(ForbiddenException.class, HTTP_FORBIDDEN);
         map.put(GroupNotFoundException.class, HTTP_NOT_FOUND);
         map.put(GroupAlreadyExistsException.class, HTTP_CONFLICT);
         map.put(InvalidArtifactIdException.class, HTTP_BAD_REQUEST);
@@ -104,7 +101,6 @@ public class HttpStatusCodeMap {
         map.put(InvalidParameterValueException.class, HTTP_BAD_REQUEST);
         map.put(NotAllowedException.class, HTTP_CONFLICT); // We're using 409 instead of 403 to reserve the
         // latter for authx only.
-        map.put(NotAuthorizedException.class, HTTP_FORBIDDEN);
         map.put(NotFoundException.class, HTTP_NOT_FOUND);
         map.put(io.quarkus.security.UnauthorizedException.class, HTTP_UNAUTHORIZED);
         map.put(io.quarkus.security.ForbiddenException.class, HTTP_FORBIDDEN);

--- a/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
+++ b/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
@@ -23,7 +23,6 @@ import io.apicurio.registry.types.ArtifactState;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.utils.tests.ProblemDetailsWatcher;
 import io.apicurio.registry.utils.tests.TestUtils;
-import io.apicurio.rest.client.auth.exception.NotAuthorizedException;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.kiota.http.vertx.VertXRequestAdapter;
@@ -406,7 +405,7 @@ public abstract class AbstractResourceTestBase extends AbstractRegistryTestBase 
     }
 
     protected void assertNotAuthorized(Exception exception) {
-        if (exception instanceof NotAuthorizedException) {
+        if (exception instanceof io.quarkus.security.UnauthorizedException) {
             // thrown by the token provider adapter
         } else if (exception.getClass().equals(io.apicurio.registry.rest.client.models.ProblemDetails.class)) {
             // Kiota maps 401 errors to ProblemDetails

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -92,9 +92,6 @@
     <!-- Vert.x version -->
     <vertx.version>3.9.5</vertx.version>
 
-    <!-- Apicurio REST client-->
-    <apicurio-common-rest-client.version>0.1.18.Final</apicurio-common-rest-client.version>
-
     <!-- Apicurio schema validation library -->
     <apicurio-registry-schema-validation.version>0.0.7</apicurio-registry-schema-validation.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,6 @@
     <!-- Dependency versions -->
     <lombok.version>1.18.44</lombok.version>
     <commons-codec.version>1.21.0</commons-codec.version>
-    <apicurio-common-rest-client.version>0.1.18.Final</apicurio-common-rest-client.version>
     <kafka-clients.version>3.9.2</kafka-clients.version>
     <kafka-oauth-client.version>0.17.1</kafka-oauth-client.version>
     <debezium.version>2.7.4.Final</debezium.version>
@@ -447,22 +446,6 @@
         <artifactId>apicurio-registry-protobuf-schema-utilities</artifactId>
         <version>${project.version}</version>
       </dependency>
-      <dependency>
-        <groupId>io.apicurio</groupId>
-        <artifactId>apicurio-common-rest-client-vertx</artifactId>
-        <version>${apicurio-common-rest-client.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.apicurio</groupId>
-        <artifactId>apicurio-common-rest-client-jdk</artifactId>
-        <version>${apicurio-common-rest-client.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.apicurio</groupId>
-        <artifactId>apicurio-common-rest-client-common</artifactId>
-        <version>${apicurio-common-rest-client.version}</version>
-      </dependency>
-
       <dependency>
         <groupId>io.apicurio</groupId>
         <artifactId>apicurio-registry-config-definitions</artifactId>

--- a/utils/tests/pom.xml
+++ b/utils/tests/pom.xml
@@ -129,10 +129,5 @@
       <artifactId>apicurio-registry-v2-java-sdk</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>io.apicurio</groupId>
-      <artifactId>apicurio-common-rest-client-common</artifactId>
-    </dependency>
-
   </dependencies>
 </project>


### PR DESCRIPTION
## Summary
Remove the `apicurio-common-rest-client-*` dependency (v0.1.18.Final) from the project and replace its usage with direct Vert.x WebClient calls and Quarkus security exceptions. Fixes #7567

## Root Cause
The `apicurio-common-rest-client` library was used in only 3 Java files, solely for OIDC token acquisition (`OidcAuth`, `ApicurioHttpClient`) and a few exception classes (`NotAuthorizedException`, `ForbiddenException`, `AuthException`). The project already has Vert.x WebClient (via `WebClientProducer`) and Quarkus security exceptions (`io.quarkus.security.UnauthorizedException`, `io.quarkus.security.ForbiddenException`) available, making this external dependency unnecessary. Removing it reduces the dependency footprint and eliminates a maintenance burden.

## Changes
- **`app/src/main/java/io/apicurio/registry/auth/AppAuthenticationMechanism.java`**:
  - Replaced `ApicurioHttpClient` field with injected `WebClient` (from existing `WebClientProducer`) and a `String oidcTokenUrl` field
  - Simplified `init()` method — removed `VertxHttpClientProvider`/`AuthErrorHandler` instantiation, now just computes the token URL
  - Replaced `OidcAuth.obtainAccessTokenPasswordGrant()` call with a new private `obtainAccessTokenPasswordGrant()` method using `WebClient.sendForm()` (application/x-www-form-urlencoded)
  - Rewrote `getAccessToken()` method — replaced `OidcAuth.authenticate()` (client_credentials flow) with direct `WebClient.sendForm()` call, with explicit HTTP status code checking (401 → `UnauthorizedException`, 403 → `ForbiddenException`, other errors → `OidcAuthException`)
  - Changed `@Retry(retryOn = ...)` from `AuthException.class` to `OidcAuthException.class`
  - Changed `cachedAuthFailures` map value type from `WrappedValue<ApicurioRestClientException>` to `WrappedValue<RuntimeException>`
  - Updated catch block in `authenticate()` from `AuthException | NotAuthorizedException` to `OidcAuthException | UnauthorizedException`

- **`app/src/main/java/io/apicurio/registry/auth/OidcAuthException.java`** (new):
  - Project-local `RuntimeException` subclass used as the `@Retry` target for transient OIDC failures (replacing the library's `AuthException`)

- **`app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java`**:
  - Removed `ForbiddenException.class → 403` mapping (duplicate of existing `io.quarkus.security.ForbiddenException → 403`)
  - Removed `NotAuthorizedException.class → 403` mapping (the Quarkus `UnauthorizedException → 401` is already present and is the correct HTTP semantics)
  - Removed the two `io.apicurio.rest.client` imports

- **`app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java`**:
  - Replaced `NotAuthorizedException` instanceof check in `assertNotAuthorized()` with `io.quarkus.security.UnauthorizedException`

- **`pom.xml` (root)**: Removed `apicurio-common-rest-client.version` property and all 3 `dependencyManagement` entries (`-vertx`, `-jdk`, `-common`)
- **`app/pom.xml`**: Removed `apicurio-common-rest-client-jdk` (test scope) and `apicurio-common-rest-client-vertx` dependencies
- **`utils/tests/pom.xml`**: Removed `apicurio-common-rest-client-common` dependency
- **`examples/pom.xml`**: Removed `apicurio-common-rest-client.version` property and comment

## Test plan
- [x] Full build passes: `mvn clean install -DskipTests -pl app -am`
- [x] Zero remaining references to `apicurio-common-rest-client` or `io.apicurio.rest.client` in Java source
- [x] Run app unit tests: `mvn test -pl app`
- [x] Verify OIDC password grant flow works in an auth-enabled test environment (Basic auth → OIDC token exchange)
- [x] Verify OIDC client_credentials grant flow works (client ID/secret → access token)
- [x] Verify 401/403 error responses are correctly returned for invalid credentials
- [x] Test with SQL storage variant
- [x] Test with KafkaSQL storage variant