### PR TITLE
docs: fix incorrect /q/ prefix in health and metrics endpoint paths

### DIFF
--- a/distro/docker-compose/in-memory-with-observability/README.md
+++ b/distro/docker-compose/in-memory-with-observability/README.md
@@ -38,7 +38,7 @@ All REST API requests and storage operations are automatically traced. You can:
 
 ### Metrics (Prometheus)
 
-Metrics are exported via the `/q/metrics` endpoint and scraped by Prometheus:
+Metrics are exported via the `/metrics` endpoint (on management port 9000) and scraped by Prometheus:
 
 1. Open Prometheus at http://localhost:9090
 2. Query metrics like:

--- a/operator/docs/modules/ROOT/partials/proc-registry-observability-otel.adoc
+++ b/operator/docs/modules/ROOT/partials/proc-registry-observability-otel.adoc
@@ -86,8 +86,8 @@ To reproduce these benchmarks, see the `OpenTelemetryPerformanceTest` and `OpenT
 .Backwards compatibility
 OpenTelemetry support is fully backwards compatible:
 
-* The existing Prometheus metrics endpoint (`/q/metrics`) remains available and unchanged.
-* Health check endpoints (`/q/health/*`) continue to work as before.
+* The existing Prometheus metrics endpoint (`/metrics`) remains available and unchanged.
+* Health check endpoints (`/health/*`) continue to work as before.
 * All existing Micrometer-based metrics continue to function.
 
 [role="_additional-resources"]


### PR DESCRIPTION
## Summary
- Removes incorrect `/q/` prefix from health and metrics endpoint paths in documentation
- The registry sets `quarkus.management.root-path=/`, so management endpoints are served at `/health/*` and `/metrics`, not `/q/health/*` and `/q/metrics`

## Changes
- **`operator/docs/modules/ROOT/partials/proc-registry-observability-otel.adoc`**: Fixed `/q/metrics` → `/metrics` and `/q/health/*` → `/health/*`
- **`distro/docker-compose/in-memory-with-observability/README.md`**: Fixed `/q/metrics` → `/metrics` and clarified it's on management port 9000

## References
- https://github.com/Apicurio/apicurio-registry/issues/7483#issuecomment-4076232075