### PR TITLE
fix: bulk import fails with MySQL/MSSQL - missing parameter binding

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSequenceRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSequenceRepository.java
@@ -142,9 +142,6 @@ public class SqlSequenceRepository {
         });
     }
 
-    /**
-     * Reset a sequence using an existing handle.
-     */
     private void resetSequenceRaw(Handle handle, String sequenceName, String sqlMaxIdFromTable) {
         Optional<Long> maxIdTable = handle.createQuery(sqlMaxIdFromTable)
                 .mapTo(Long.class)
@@ -174,18 +171,13 @@ public class SqlSequenceRepository {
             log.info("Resetting {} sequence", sequenceName);
             long id = maxId.get();
 
-            if (isPostgresql()) {
-                handle.createUpdate(sqlStatements.resetSequenceValue())
-                        .bind(0, sequenceName)
-                        .bind(1, id)
-                        .bind(2, id)
-                        .execute();
-            } else if (isH2()) {
+            if (isH2()) {
                 sequenceCounters.get(sequenceName).set(id);
             } else {
                 handle.createUpdate(sqlStatements.resetSequenceValue())
                         .bind(0, sequenceName)
                         .bind(1, id)
+                        .bind(2, id)
                         .execute();
             }
 


### PR DESCRIPTION
## Summary
- Fixed `resetSequenceRaw()` in `SqlSequenceRepository` to bind all 3 SQL parameters for MySQL and MSSQL
- The PostgreSQL-specific branch was unnecessarily separated — all non-H2 databases need 3 bind parameters
- Simplified the conditional to just H2 (in-memory counter) vs. all SQL databases (3-parameter bind)

## Related Issue
Related Jira Issue: [APICURIO-20](https://redhat.atlassian.net/browse/APICURIO-20)

## Test Plan
- [ ] Run existing `ImportExportTest` tests to verify no regression
- [ ] Test bulk import via `/apis/registry/v3/admin/import` against MySQL storage
- [ ] Test bulk import via `/apis/registry/v3/admin/import` against MSSQL storage
- [ ] Verify PostgreSQL import still works correctly