### PR TITLE
Fix: Exclude internal metadata documents from search results (#7587)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchIndexManager.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchIndexManager.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -26,7 +27,15 @@ public class ElasticsearchIndexManager {
     private static final Logger log = LoggerFactory.getLogger(ElasticsearchIndexManager.class);
 
     private static final int CURRENT_MAPPING_VERSION = 1;
-    private static final String MAPPING_VERSION_DOC_ID = "_mapping_version";
+    public static final String MAPPING_VERSION_DOC_ID = "_mapping_version";
+    public static final String REINDEX_LOCK_DOC_ID = "_reindex_lock";
+
+    /**
+     * List of all internal metadata document IDs that should be excluded from user-facing
+     * queries and operations.
+     */
+    public static final List<String> INTERNAL_DOC_IDS = List.of(
+            MAPPING_VERSION_DOC_ID, REINDEX_LOCK_DOC_ID);
 
     @Inject
     ElasticsearchClient client;
@@ -99,7 +108,7 @@ public class ElasticsearchIndexManager {
         client.deleteByQuery(d -> d
                 .index(indexName)
                 .query(q -> q.bool(b -> b
-                        .mustNot(mn -> mn.ids(ids -> ids.values(MAPPING_VERSION_DOC_ID)))
+                        .mustNot(mn -> mn.ids(ids -> ids.values(INTERNAL_DOC_IDS)))
                 ))
         );
         log.info("Deleted all content documents from index '{}'.", indexName);
@@ -174,7 +183,7 @@ public class ElasticsearchIndexManager {
         CountResponse response = client.count(c -> c
                 .index(config.getIndexName())
                 .query(q -> q.bool(b -> b
-                        .mustNot(mn -> mn.ids(ids -> ids.values(MAPPING_VERSION_DOC_ID)))
+                        .mustNot(mn -> mn.ids(ids -> ids.values(INTERNAL_DOC_IDS)))
                 ))
         );
         return response.count();

--- a/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
@@ -152,11 +152,17 @@ public class ElasticsearchSearchService {
      * @return an Elasticsearch Query
      */
     Query buildEsQuery(Set<SearchFilter> filters) {
+        BoolQuery.Builder builder = new BoolQuery.Builder();
+
+        // Always exclude internal metadata documents from search results
+        builder.mustNot(Query.of(q -> q.ids(ids -> ids
+                .values(ElasticsearchIndexManager.INTERNAL_DOC_IDS))));
+
         if (filters == null || filters.isEmpty()) {
-            return Query.of(q -> q.matchAll(m -> m));
+            builder.must(Query.of(q -> q.matchAll(m -> m)));
+            return Query.of(q -> q.bool(builder.build()));
         }
 
-        BoolQuery.Builder builder = new BoolQuery.Builder();
         boolean hasPositiveClause = false;
 
         for (SearchFilter filter : filters) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchStartupIndexer.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchStartupIndexer.java
@@ -41,7 +41,7 @@ public class ElasticsearchStartupIndexer {
 
     private static final int PROGRESS_LOG_INTERVAL = 100;
     private static final int BULK_BATCH_SIZE = 500;
-    private static final String REINDEX_LOCK_DOC_ID = "_reindex_lock";
+    private static final String REINDEX_LOCK_DOC_ID = ElasticsearchIndexManager.REINDEX_LOCK_DOC_ID;
 
     @Inject
     ElasticsearchSearchConfig config;

--- a/app/src/test/java/io/apicurio/registry/search/SearchVersionsViaIndexTest.java
+++ b/app/src/test/java/io/apicurio/registry/search/SearchVersionsViaIndexTest.java
@@ -37,6 +37,25 @@ public class SearchVersionsViaIndexTest extends AbstractResourceTestBase {
     ElasticsearchIndexUpdater indexUpdater;
 
     @Test
+    public void testSearchWithNoFiltersExcludesInternalDocs() throws Exception {
+        // When no artifacts exist, a search with no filters should return 0 results.
+        // This verifies that internal metadata documents (e.g. _mapping_version,
+        // _reindex_lock) are excluded from search results.
+        VersionSearchResults results = clientV3.search().versions().get(config -> {
+            config.queryParameters.limit = 100;
+        });
+        // The count should not include internal metadata documents. It may be > 0 if
+        // other tests have already created artifacts (tests share an index), but the
+        // important thing is that internal docs are not returned as search hits.
+        for (SearchedVersion version : results.getVersions()) {
+            Assertions.assertNotNull(version.getGlobalId(),
+                    "Internal metadata documents should not appear in search results");
+            Assertions.assertNotNull(version.getArtifactId(),
+                    "Internal metadata documents should not appear in search results");
+        }
+    }
+
+    @Test
     public void testSearchVersionsByGroupId() throws Exception {
         String group1 = TestUtils.generateGroupId();
         String group2 = TestUtils.generateGroupId();


### PR DESCRIPTION
## Summary

- Centralized internal document IDs (`_mapping_version`, `_reindex_lock`) into a public
  `INTERNAL_DOC_IDS` list in `ElasticsearchIndexManager`, replacing scattered references
- Added a `mustNot` clause to `ElasticsearchSearchService.buildEsQuery()` that excludes
  internal metadata documents from all search queries (both filtered and unfiltered)
- Updated `ElasticsearchStartupIndexer` to reference the shared constant instead of
  duplicating the `_reindex_lock` ID

## Related Issue

Fixes #7587

## Test Plan

- [ ] Run `SearchVersionsViaIndexTest` — new `testSearchWithNoFiltersExcludesInternalDocs()`
  test verifies internal docs don't appear in search results
- [ ] Run full `SearchVersionsViaIndexTest` suite to confirm no regressions
- [ ] Deploy with ES search enabled and in-memory storage; verify "Search Versions" page
  shows zero results when no artifacts exist