### PR TITLE
fix: inline PRIMARY KEY in MySQL DDL to avoid Error 3750

### DIFF
--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/mysql.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/mysql.ddl
@@ -4,45 +4,45 @@
 
 CREATE TABLE apicurio (
     propName  VARCHAR(255) NOT NULL,
-    propValue VARCHAR(255)
+    propValue VARCHAR(255),
+    PRIMARY KEY (propName)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE apicurio ADD PRIMARY KEY (propName);
 INSERT INTO apicurio (propName, propValue) VALUES ('db_version', 102);
 
 CREATE TABLE sequences (
     seqName  VARCHAR(32) NOT NULL,
-    seqValue BIGINT      NOT NULL
+    seqValue BIGINT      NOT NULL,
+    PRIMARY KEY (seqName)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE sequences ADD PRIMARY KEY (seqName);
 
 CREATE TABLE config (
     propName   VARCHAR(255)  NOT NULL,
     propValue  VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-    modifiedOn BIGINT        NOT NULL
+    modifiedOn BIGINT        NOT NULL,
+    PRIMARY KEY (propName)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE config ADD PRIMARY KEY (propName);
 CREATE INDEX IDX_config_1 ON config (modifiedOn);
 
 CREATE TABLE acls (
     principalId   VARCHAR(256) NOT NULL,
     role          VARCHAR(32)  NOT NULL,
-    principalName VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+    principalName VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    PRIMARY KEY (principalId)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE acls ADD PRIMARY KEY (principalId);
 
 CREATE TABLE downloads (
     downloadId VARCHAR(128) NOT NULL,
     expires    BIGINT       NOT NULL,
-    context    VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+    context    VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    PRIMARY KEY (downloadId)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE downloads ADD PRIMARY KEY (downloadId);
 CREATE INDEX IDX_down_1 ON downloads (expires);
 
 CREATE TABLE global_rules (
     type          VARCHAR(32) NOT NULL,
-    configuration TEXT        CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL
+    configuration TEXT        CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    PRIMARY KEY (type)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE global_rules ADD PRIMARY KEY (type);
 
 CREATE TABLE content (
     contentId     BIGINT      NOT NULL,
@@ -50,9 +50,9 @@ CREATE TABLE content (
     contentHash   VARCHAR(64) NOT NULL,
     contentType   VARCHAR(64) NOT NULL,
     content       BLOB        NOT NULL,
-    refs          TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+    refs          TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    PRIMARY KEY (contentId)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE content ADD PRIMARY KEY (contentId);
 ALTER TABLE content ADD CONSTRAINT UQ_content_1 UNIQUE (contentHash);
 CREATE INDEX IDX_content_1 ON content (canonicalHash);
 CREATE INDEX IDX_content_2 ON content (contentHash);
@@ -62,9 +62,9 @@ CREATE TABLE content_references (
     groupId    VARCHAR(512),
     artifactId VARCHAR(512) NOT NULL,
     version    VARCHAR(256),
-    name       VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL
+    name       VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    PRIMARY KEY (contentId, name)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE content_references ADD PRIMARY KEY (contentId, name);
 ALTER TABLE content_references  ADD CONSTRAINT FK_content_references_1 FOREIGN KEY (contentId) REFERENCES content (contentId) ON DELETE CASCADE;
 
 CREATE TABLE `groups` (
@@ -75,16 +75,16 @@ CREATE TABLE `groups` (
     createdOn     TIMESTAMP    NOT NULL,
     modifiedBy    VARCHAR(256),
     modifiedOn    TIMESTAMP,
-    labels        TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+    labels        TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    PRIMARY KEY (groupId)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE `groups` ADD PRIMARY KEY (groupId);
 
 CREATE TABLE group_labels (
     groupId    VARCHAR(512) NOT NULL,
     labelKey   VARCHAR(256) NOT NULL,
-    labelValue VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+    labelValue VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    PRIMARY KEY (groupId, labelKey)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE group_labels ADD PRIMARY KEY (groupId, labelKey);
 ALTER TABLE group_labels ADD CONSTRAINT FK_glabels_1 FOREIGN KEY (groupId) REFERENCES `groups` (groupId) ON DELETE CASCADE;
 CREATE INDEX IDX_glabels_1 ON group_labels (labelKey);
 CREATE INDEX IDX_glabels_2 ON group_labels (labelValue);
@@ -92,9 +92,9 @@ CREATE INDEX IDX_glabels_2 ON group_labels (labelValue);
 CREATE TABLE group_rules (
     groupId       VARCHAR(512)  NOT NULL,
     type          VARCHAR(32)   NOT NULL,
-    configuration VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL
+    configuration VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    PRIMARY KEY (groupId, type)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE group_rules ADD PRIMARY KEY (groupId, type);
 ALTER TABLE group_rules ADD CONSTRAINT FK_grules_1 FOREIGN KEY (groupId) REFERENCES `groups` (groupId) ON DELETE CASCADE;
 
 CREATE TABLE artifacts (
@@ -107,9 +107,9 @@ CREATE TABLE artifacts (
     modifiedOn  TIMESTAMP,
     name        VARCHAR(512),
     description VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-    labels      TEXT
+    labels      TEXT,
+    PRIMARY KEY (groupId, artifactId)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE artifacts ADD PRIMARY KEY (groupId, artifactId);
 CREATE INDEX IDX_artifacts_0 ON artifacts (type);
 CREATE INDEX IDX_artifacts_1 ON artifacts (owner);
 CREATE INDEX IDX_artifacts_2 ON artifacts (createdOn);
@@ -120,9 +120,9 @@ CREATE TABLE artifact_labels (
     groupId    VARCHAR(512) NOT NULL,
     artifactId VARCHAR(512) NOT NULL,
     labelKey   VARCHAR(256) NOT NULL,
-    labelValue VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+    labelValue VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    PRIMARY KEY (groupId, artifactId, labelKey)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE artifact_labels ADD PRIMARY KEY (groupId, artifactId, labelKey);
 ALTER TABLE artifact_labels ADD CONSTRAINT FK_alabels_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts (groupId, artifactId) ON DELETE CASCADE;
 CREATE INDEX IDX_alabels_1 ON artifact_labels (labelKey);
 CREATE INDEX IDX_alabels_2 ON artifact_labels (labelValue);
@@ -131,9 +131,9 @@ CREATE TABLE artifact_rules (
     groupId       VARCHAR(512)  NOT NULL,
     artifactId    VARCHAR(512)  NOT NULL,
     type          VARCHAR(32)   NOT NULL,
-    configuration VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL
+    configuration VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    PRIMARY KEY (groupId, artifactId, type)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE artifact_rules ADD PRIMARY KEY (groupId, artifactId, type);
 
 CREATE TABLE versions (
     globalId     BIGINT       NOT NULL,
@@ -149,9 +149,9 @@ CREATE TABLE versions (
     modifiedBy   VARCHAR(256),
     modifiedOn   TIMESTAMP    NOT NULL,
     labels       TEXT,
-    contentId    BIGINT       NOT NULL
+    contentId    BIGINT       NOT NULL,
+    PRIMARY KEY (globalId)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE versions ADD PRIMARY KEY (globalId);
 ALTER TABLE versions ADD CONSTRAINT UQ_versions_1 UNIQUE (groupId, artifactId, version);
 ALTER TABLE versions ADD CONSTRAINT UQ_versions_2 UNIQUE (globalId, versionOrder);
 ALTER TABLE versions ADD CONSTRAINT FK_versions_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts (groupId, artifactId) ON DELETE CASCADE;
@@ -168,9 +168,9 @@ CREATE INDEX IDX_versions_8 ON versions (modifiedOn);
 CREATE TABLE version_labels (
     globalId   BIGINT       NOT NULL,
     labelKey   VARCHAR(256) NOT NULL,
-    labelValue VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+    labelValue VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    PRIMARY KEY (globalId, labelKey)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE version_labels ADD PRIMARY KEY (globalId, labelKey);
 ALTER TABLE version_labels ADD CONSTRAINT FK_vlabels_1 FOREIGN KEY (globalId) REFERENCES versions (globalId) ON DELETE CASCADE;
 CREATE INDEX IDX_vlabels_1 ON version_labels (labelKey);
 CREATE INDEX IDX_vlabels_2 ON version_labels (labelValue);
@@ -180,9 +180,9 @@ CREATE TABLE version_comments (
     globalId  BIGINT        NOT NULL,
     owner     VARCHAR(256),
     createdOn TIMESTAMP     NOT NULL,
-    cvalue    VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL
+    cvalue    VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    PRIMARY KEY (commentId)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE version_comments ADD PRIMARY KEY (commentId);
 ALTER TABLE version_comments ADD CONSTRAINT FK_version_comments_1 FOREIGN KEY (globalId) REFERENCES versions (globalId) ON DELETE CASCADE;
 CREATE INDEX IDX_version_comments_1 ON version_comments (owner);
 
@@ -195,9 +195,9 @@ CREATE TABLE branches (
     owner         VARCHAR(256),
     createdOn     TIMESTAMP    NOT NULL,
     modifiedBy    VARCHAR(256),
-    modifiedOn    TIMESTAMP    NOT NULL
+    modifiedOn    TIMESTAMP    NOT NULL,
+    PRIMARY KEY (groupId, artifactId, branchId)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE branches ADD PRIMARY KEY (groupId, artifactId, branchId);
 ALTER TABLE branches ADD CONSTRAINT FK_branches_1 FOREIGN KEY (groupId, artifactId) REFERENCES artifacts (groupId, artifactId) ON DELETE CASCADE;
 
 CREATE TABLE branch_versions (
@@ -205,9 +205,9 @@ CREATE TABLE branch_versions (
     artifactId  VARCHAR(512) NOT NULL,
     branchId    VARCHAR(256) NOT NULL,
     branchOrder INT          NOT NULL,
-    version     VARCHAR(256) NOT NULL
+    version     VARCHAR(256) NOT NULL,
+    PRIMARY KEY (groupId, artifactId, branchId, version)
 ) DEFAULT CHARACTER SET ascii COLLATE ascii_general_ci;
-ALTER TABLE branch_versions ADD PRIMARY KEY (groupId, artifactId, branchId, version);
 ALTER TABLE branch_versions ADD CONSTRAINT FK_branch_versions_1 FOREIGN KEY (groupId, artifactId, branchId) REFERENCES branches (groupId, artifactId, branchId) ON DELETE CASCADE;
 ALTER TABLE branch_versions ADD CONSTRAINT FK_branch_versions_2 FOREIGN KEY (groupId, artifactId, version) REFERENCES versions (groupId, artifactId, version) ON DELETE CASCADE;
 CREATE INDEX IDX_branch_versions_1 ON branch_versions (groupId, artifactId, branchId, branchOrder);

--- a/app/src/main/resources/io/apicurio/registry/storage/impl/sql/upgrades/101/mysql.upgrade.ddl
+++ b/app/src/main/resources/io/apicurio/registry/storage/impl/sql/upgrades/101/mysql.upgrade.ddl
@@ -5,5 +5,4 @@
 
 UPDATE apicurio SET propValue = 101 WHERE propName = 'db_version';
 
-CREATE TABLE outbox (id VARCHAR(128) NOT NULL, aggregatetype VARCHAR(255) NOT NULL, aggregateid VARCHAR(255) NOT NULL, type VARCHAR(255) NOT NULL, payload JSON NOT NULL);
-ALTER TABLE outbox ADD PRIMARY KEY (id);
+CREATE TABLE outbox (id VARCHAR(128) NOT NULL, aggregatetype VARCHAR(255) NOT NULL, aggregateid VARCHAR(255) NOT NULL, type VARCHAR(255) NOT NULL, payload JSON NOT NULL, PRIMARY KEY (id));


### PR DESCRIPTION
## Summary

- Moved all `PRIMARY KEY` definitions from `ALTER TABLE` statements into inline `CREATE TABLE` blocks
  across all 19 tables in `mysql.ddl` and the `outbox` table in the upgrade DDL.
- This prevents MySQL Error 3750 when `sql_require_primary_key = ON`, since tables are never created
  without a primary key.

## Related Issue

Related Jira Issue: [APICURIO-14](https://redhat.atlassian.net/browse/APICURIO-14)
Related GitHub Issue: #7589

## Test Plan

- [ ] Existing SQL storage integration tests pass unchanged
- [ ] Deploy against MySQL with `SET GLOBAL sql_require_primary_key = ON` and verify schema
  initialization succeeds without Error 3750