### PR TITLE
fix(ui): Add missing readOnly and settings feature guards on Dashboard QuickActions

### DIFF
--- a/ui/ui-app/src/app/pages/dashboard/components/QuickActions.tsx
+++ b/ui/ui-app/src/app/pages/dashboard/components/QuickActions.tsx
@@ -34,17 +34,21 @@ export const QuickActions: FunctionComponent<QuickActionsProps> = ({
             <CardTitle>Quick Actions</CardTitle>
             <CardBody>
                 <Flex direction={{ default: "column" }} spaceItems={{ default: "spaceItemsMd" }}>
-                    <FlexItem>
-                        <Button
-                            variant="primary"
-                            icon={<PlusCircleIcon />}
-                            onClick={onCreateArtifact}
-                            isBlock
-                            data-testid="quick-action-create"
-                        >
-                            Create Artifact
-                        </Button>
-                    </FlexItem>
+                    <IfFeature feature="readOnly" isNot={true}>
+                        <IfAuth isDeveloper={true}>
+                            <FlexItem>
+                                <Button
+                                    variant="primary"
+                                    icon={<PlusCircleIcon />}
+                                    onClick={onCreateArtifact}
+                                    isBlock
+                                    data-testid="quick-action-create"
+                                >
+                                    Create Artifact
+                                </Button>
+                            </FlexItem>
+                        </IfAuth>
+                    </IfFeature>
                     <FlexItem>
                         <Button
                             variant="secondary"
@@ -67,7 +71,7 @@ export const QuickActions: FunctionComponent<QuickActionsProps> = ({
                             Explore Groups
                         </Button>
                     </FlexItem>
-                    <IfFeature feature="settings">
+                    <IfFeature feature="settings" is={true}>
                         <IfAuth isAdmin={true}>
                             <FlexItem>
                                 <Button


### PR DESCRIPTION

### Description

Fixes two missing feature flag guards in the Dashboard `QuickActions` component
(`ui/ui-app/src/app/pages/dashboard/components/QuickActions.tsx`).

### Bug 1: "Create Artifact" button ignores `REGISTRY_FEATURE_READ_ONLY`

The "Create Artifact" button was rendered unconditionally without any `readOnly`
or auth checks. When `REGISTRY_FEATURE_READ_ONLY=true`, all other write/mutate
actions across the UI are properly hidden using:

```tsx
<IfFeature feature="readOnly" isNot={true}>
    <IfAuth isDeveloper={true}>
```

This pattern is consistently applied across 21 other locations (create version,
create branch, edit metadata, delete artifact, etc.) but was missing from the
QuickActions "Create Artifact" button.

**Fix:** Wrapped the button with `<IfFeature feature="readOnly" isNot={true}>`
and `<IfAuth isDeveloper={true}>` to match the rest of the codebase.

### Bug 2: "Settings" button ignores `REGISTRY_FEATURE_SETTINGS=false`

The Settings button used `<IfFeature feature="settings">` without the `is={true}`
prop. The `IfFeature` component's `accept()` logic, when neither `is` nor `isNot`
is provided, only checks `featureValue !== undefined` — it does not evaluate the
actual boolean value. So when `REGISTRY_FEATURE_SETTINGS="false"`, the config
produces `features.settings = false`, which is not `undefined`, causing the button
to still render.

Note: The Settings **tab** in `RootPageHeader.tsx` does not have this bug because
it uses `config.featureSettings()` directly, which properly evaluates the boolean.

**Fix:** Changed `<IfFeature feature="settings">` to
`<IfFeature feature="settings" is={true}>`.

### Steps to reproduce

1. Set `REGISTRY_FEATURE_READ_ONLY=true` and `REGISTRY_FEATURE_SETTINGS=false`
2. Navigate to the Dashboard page
3. Observe the "Create Artifact" button is still visible in Quick Actions
4. Observe the "Settings" button is still visible in Quick Actions

### After fix

- "Create Artifact" is hidden when `readOnly=true` or user is not a developer
- "Settings" is hidden when `REGISTRY_FEATURE_SETTINGS=false`

### Files changed

- `ui/ui-app/src/app/pages/dashboard/components/QuickActions.tsx`

Closes #7592