### PR TITLE
fix: remove hardcoded opentelemetry-api version from java-sdk-common

### DIFF
--- a/java-sdk-common/pom.xml
+++ b/java-sdk-common/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
-      <version>1.44.1</version>
       <optional>true</optional>
     </dependency>
     <!-- Test only -->


### PR DESCRIPTION
## Summary
- Removes the hardcoded `opentelemetry-api` version (`1.44.1`) from `java-sdk-common/pom.xml`
- The version is already managed by the `quarkus-bom` imported in the root POM, so the explicit version was an unnecessary override
- This also eliminates spurious Renovate PRs (e.g. #7591) for this dependency

## Test plan
- [ ] Verify the project builds successfully with the BOM-managed version
- [ ] Confirm no version conflicts in the dependency tree