### PR TITLE
fix: support-chat dev mode fixes for Quarkus 3.27 compatibility

### DIFF
--- a/support-chat/pom.xml
+++ b/support-chat/pom.xml
@@ -18,7 +18,7 @@
     <description>AI-powered support assistant for Apicurio Registry with RAG and LLM integration</description>
 
     <properties>
-        <quarkus-langchain4j.version>0.26.2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.8.2</quarkus-langchain4j.version>
         <jsoup.version>1.22.1</jsoup.version>
     </properties>
 
@@ -62,6 +62,12 @@
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>${jsoup.version}</version>
+        </dependency>
+
+        <!-- REST Client for Ollama extension -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
         </dependency>
 
         <!-- Vert.x Web Client for REST calls to Registry -->

--- a/support-chat/src/main/java/io/apicurio/registry/support/ApicurioSupportService.java
+++ b/support-chat/src/main/java/io/apicurio/registry/support/ApicurioSupportService.java
@@ -3,7 +3,6 @@ package io.apicurio.registry.support;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
@@ -58,7 +57,7 @@ public class ApicurioSupportService {
     String registryGroup;
 
     @Inject
-    ChatLanguageModel chatModel;
+    SupportAiService aiService;
 
     @Inject
     EmbeddingStore<TextSegment> embeddingStore;
@@ -161,7 +160,7 @@ public class ApicurioSupportService {
         String prompt = renderPrompt(CHAT_PROMPT_ARTIFACT, chatPromptVersion, variables);
 
         // Send to LLM
-        String response = chatModel.generate(prompt);
+        String response = aiService.chat(prompt);
 
         // Store in conversation memory
         addToConversationMemory(sessionId, question, response);

--- a/support-chat/src/main/java/io/apicurio/registry/support/DocumentIngestionService.java
+++ b/support-chat/src/main/java/io/apicurio/registry/support/DocumentIngestionService.java
@@ -13,6 +13,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -20,7 +21,6 @@ import org.jsoup.select.Elements;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Service that fetches Apicurio Registry documentation from the web at startup
@@ -52,6 +52,9 @@ public class DocumentIngestionService {
     @Inject
     EmbeddingModel embeddingModel;
 
+    @Inject
+    ManagedExecutor managedExecutor;
+
     private EmbeddingStoreIngestor ingestor;
 
     @PostConstruct
@@ -70,8 +73,8 @@ public class DocumentIngestionService {
     void onStartup(@Observes StartupEvent event) {
         Log.info("Starting Apicurio Registry documentation ingestion from web...");
 
-        // Run ingestion asynchronously to not block startup
-        CompletableFuture.runAsync(this::ingestDocumentation)
+        // Run ingestion asynchronously using Quarkus-managed executor to preserve classloader context
+        managedExecutor.runAsync(this::ingestDocumentation)
             .exceptionally(e -> {
                 Log.error("Failed to ingest documentation", e);
                 return null;

--- a/support-chat/src/main/java/io/apicurio/registry/support/SupportAiService.java
+++ b/support-chat/src/main/java/io/apicurio/registry/support/SupportAiService.java
@@ -1,0 +1,10 @@
+package io.apicurio.registry.support;
+
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+
+@RegisterAiService
+public interface SupportAiService {
+
+    String chat(@UserMessage String message);
+}

--- a/support-chat/src/main/resources/application.properties
+++ b/support-chat/src/main/resources/application.properties
@@ -12,6 +12,8 @@ apicurio.registry.cache-enabled=true
 # -----------------------------------------------------------------------------
 # LLM Provider: Ollama
 # -----------------------------------------------------------------------------
+quarkus.langchain4j.chat-model.provider=ollama
+quarkus.langchain4j.embedding-model.provider=ollama
 quarkus.langchain4j.ollama.base-url=${OLLAMA_URL:http://localhost:11434}
 quarkus.langchain4j.ollama.chat-model.model-id=${OLLAMA_MODEL:llama3.2}
 quarkus.langchain4j.ollama.chat-model.temperature=0.7
@@ -38,7 +40,7 @@ quarkus.http.cors.origins=${CORS_ORIGINS:*}
 # -----------------------------------------------------------------------------
 quarkus.container-image.group=apicurio
 quarkus.container-image.name=registry-support-chat
-quarkus.container-image.tag=${project.version}
+quarkus.container-image.tag=${project.version:latest}
 
 # -----------------------------------------------------------------------------
 # Kubernetes Configuration
@@ -54,6 +56,12 @@ quarkus.kubernetes.env.vars.OLLAMA_URL=${OLLAMA_URL:http://ollama:11434}
 # Health checks
 quarkus.kubernetes.liveness-probe.http-action-path=/q/health/live
 quarkus.kubernetes.readiness-probe.http-action-path=/q/health/ready
+
+# -----------------------------------------------------------------------------
+# Jandex Indexing
+# -----------------------------------------------------------------------------
+quarkus.index-dependency.langchain4j-ollama.group-id=io.quarkiverse.langchain4j
+quarkus.index-dependency.langchain4j-ollama.artifact-id=quarkus-langchain4j-ollama
 
 # -----------------------------------------------------------------------------
 # Logging


### PR DESCRIPTION
## Summary
- Fixes support-chat module to run correctly in Quarkus dev mode with Quarkus 3.27
- Upgrades quarkus-langchain4j from 0.26.2 to 1.8.2 for compatibility
- Fixes classloader issue causing `OllamaRestApi not indexed at build time` error

## Root Cause
- The `quarkus-langchain4j` version 0.26.2 was incompatible with Quarkus 3.27.2
- `DocumentIngestionService` used `CompletableFuture.runAsync()` which runs on `ForkJoinPool.commonPool`, losing the Quarkus classloader context in dev mode
- Missing `quarkus-rest-client-jackson` dependency required by the Ollama extension
- Missing explicit provider and Jandex index configuration
- `${project.version}` in `quarkus.container-image.tag` fails to resolve in dev mode

## Changes
- Upgrade `quarkus-langchain4j` to 1.8.2
- Add `quarkus-rest-client-jackson` dependency
- Replace `CompletableFuture.runAsync()` with `ManagedExecutor.runAsync()` to preserve classloader context
- Add explicit Ollama provider config and Jandex indexing
- Add default value for `quarkus.container-image.tag`
- Use `@RegisterAiService` (`SupportAiService`) instead of direct `ChatLanguageModel` injection

## Test plan
- [x] Start Apicurio Registry 3.2.0 on port 8080
- [x] Start Ollama with llama3.2 and nomic-embed-text models
- [x] Create prompt templates via `scripts/create-prompts.sh`
- [x] Run `mvn quarkus:dev` on port 8081
- [x] Verify health endpoint returns UP
- [x] Verify RAG ingests all 12 documentation pages
- [x] Verify session creation works
- [x] Verify chat with LLM responds correctly
- [x] Verify conversation memory preserves multi-turn context
- [x] Verify prompt template retrieval from registry works