### PR TITLE
feat: switch support-chat to Google AI Gemini with embeddable widget

### DIFF
--- a/support-chat/README.md
+++ b/support-chat/README.md
@@ -8,63 +8,54 @@ AI-powered support assistant for [Apicurio Registry](https://www.apicur.io/regis
 |---------|-------------|
 | **PROMPT_TEMPLATE** | System and chat prompts stored in Apicurio Registry, rendered via /render endpoint |
 | **RAG** | Automatic ingestion of Apicurio Registry documentation from web |
+| **In-process Embeddings** | ONNX-based embeddings run inside the JVM — no external embedding service needed |
 | **Conversation Memory** | Session-based chat with context preservation |
+| **Embeddable Widget** | Chat widget that can be embedded on any website via a single `<script>` tag |
 | **Kubernetes Ready** | Health checks, ConfigMaps, and deployment manifests included |
 
 ## Architecture
 
 ```
-┌─────────────────┐     ┌──────────────────┐     ┌─────────────┐
-│   Web Browser   │────▶│  Support Chat    │────▶│   Ollama    │
-│                 │     │  (Quarkus)       │     │   (LLM)     │
-└─────────────────┘     └────────┬─────────┘     └─────────────┘
-                                 │
-                    ┌────────────┼────────────┐
-                    ▼            ▼            ▼
-            ┌───────────┐ ┌───────────┐ ┌───────────┐
-            │ Registry  │ │    RAG    │ │   Docs    │
-            │ (Prompts) │ │ (Vectors) │ │   (Web)   │
-            └───────────┘ └───────────┘ └───────────┘
+┌─────────────────────┐        ┌──────────────────────┐        ┌──────────────┐
+│   www.apicur.io     │        │  Support Chat        │        │ Google AI    │
+│   (GitHub Pages)    │  REST  │  (Quarkus)           │  API   │ Gemini       │
+│ ┌─────────────────┐ │───────▶│  ├─ RAG (in-process) │───────▶│ (LLM)       │
+│ │ chat-widget.js  │ │        │  └─ ONNX embeddings  │        └──────────────┘
+│ └─────────────────┘ │        └──────────┬───────────┘
+└─────────────────────┘                   │
+                              ┌───────────┼───────────┐
+                              ▼           ▼           ▼
+                      ┌───────────┐ ┌──────────┐ ┌──────────┐
+                      │ Registry  │ │   RAG    │ │   Docs   │
+                      │ (Prompts) │ │ (ONNX)   │ │  (Web)   │
+                      └───────────┘ └──────────┘ └──────────┘
 ```
 
 ## Prerequisites
 
 - **Java 21+** and **Maven 3.8+**
+- A **Google AI API key** ([get one free](https://aistudio.google.com/apikey))
 - **Docker** (for containerized deployment)
-- **Kubernetes** (optional, for k8s deployment)
 
 ## Quick Start
 
-### 1. Start Ollama (LLM)
+### 1. Start Apicurio Registry
 
 ```bash
-# macOS
-brew install ollama && brew services start ollama
-
-# Linux
-curl -fsSL https://ollama.com/install.sh | sh && ollama serve &
-
-# Pull required models
-ollama pull llama3.2
-ollama pull nomic-embed-text
+docker run -d --name apicurio-registry -p 8080:8080 quay.io/apicurio/apicurio-registry:3.2.0
 ```
 
-### 2. Start Apicurio Registry
-
-```bash
-docker run -d --name apicurio-registry -p 8080:8080 apicurio/apicurio-registry:3.0.6
-```
-
-### 3. Create Prompt Templates
+### 2. Create Prompt Templates
 
 ```bash
 ./scripts/create-prompts.sh
 ```
 
-### 4. Run the Application
+### 3. Run the Application
 
 ```bash
-mvn quarkus:dev
+export GOOGLE_AI_GEMINI_API_KEY=your-api-key
+mvn quarkus:dev -Dquarkus.http.port=8081
 ```
 
 Open http://localhost:8081 in your browser.
@@ -74,6 +65,9 @@ Open http://localhost:8081 in your browser.
 Run the complete stack with Docker Compose:
 
 ```bash
+# Set your API key
+export GOOGLE_AI_GEMINI_API_KEY=your-api-key
+
 # Build the application first
 mvn package -DskipTests
 
@@ -84,47 +78,50 @@ docker compose up -d
 Services:
 - **Support Chat**: http://localhost:8081
 - **Apicurio Registry**: http://localhost:8080
-- **Ollama API**: http://localhost:11434
 
-## Kubernetes Deployment
+## Deploying to Render.com (Free)
 
-### Build and Push Container Image
+### 1. Fork the repository
 
-```bash
-# Build container image
-mvn package -Dquarkus.container-image.build=true
+### 2. Create a Render Blueprint
 
-# Push to registry
-mvn package -Dquarkus.container-image.push=true \
-  -Dquarkus.container-image.registry=your-registry.io
-```
+Go to [Render Dashboard](https://dashboard.render.com/) and create a new **Blueprint** pointing to the `support-chat/render.yaml` file.
 
-### Deploy to Kubernetes
+### 3. Set the API key
 
-```bash
-# Apply ConfigMap
-kubectl apply -f k8s/configmap.yaml
+In the Render dashboard, set the `GOOGLE_AI_GEMINI_API_KEY` environment variable for the `apicurio-support-chat` service.
 
-# Deploy application
-kubectl apply -f k8s/deployment.yaml
-```
+### 4. Create prompt templates
 
-### Using Quarkus Kubernetes Extension
+Once deployed, run the prompt creation script against the deployed registry:
 
 ```bash
-# Generate and apply Kubernetes manifests
-mvn package -Dquarkus.kubernetes.deploy=true
+REGISTRY_URL=https://apicurio-registry.onrender.com/apis/registry/v3 ./scripts/create-prompts.sh
 ```
+
+## Embedding the Chat Widget
+
+Add a single script tag to any website:
+
+```html
+<script src="https://apicurio-support-chat.onrender.com/chat-widget.js"></script>
+```
+
+This renders a floating chat button that opens an AI-powered support panel. The widget:
+- Creates sessions automatically on first use
+- Preserves conversation history across page navigations (via the session)
+- Is fully self-contained (CSS + JS in one file)
+- Is responsive and works on mobile
 
 ## Configuration
 
 | Environment Variable | Default | Description |
 |---------------------|---------|-------------|
+| `GOOGLE_AI_GEMINI_API_KEY` | (required) | Google AI API key |
+| `GEMINI_MODEL` | `gemini-2.0-flash` | Gemini chat model ID |
 | `REGISTRY_URL` | `http://localhost:8080` | Apicurio Registry URL |
 | `REGISTRY_GROUP` | `default` | Registry group for prompts |
-| `OLLAMA_URL` | `http://localhost:11434` | Ollama API URL |
-| `OLLAMA_MODEL` | `llama3.2` | Chat model ID |
-| `OLLAMA_EMBEDDING_MODEL` | `nomic-embed-text` | Embedding model for RAG |
+| `CORS_ORIGINS` | `*` | Allowed CORS origins |
 | `HTTP_PORT` | `8080` | Application HTTP port |
 
 ## API Endpoints
@@ -154,10 +151,6 @@ curl http://localhost:8081/support/health
 
 # RAG ingestion status
 curl http://localhost:8081/support/rag/status
-
-# Kubernetes health probes
-curl http://localhost:8081/q/health/live
-curl http://localhost:8081/q/health/ready
 ```
 
 ### Prompt Templates
@@ -165,9 +158,6 @@ curl http://localhost:8081/q/health/ready
 ```bash
 # Get raw system prompt template
 curl http://localhost:8081/support/prompts/system
-
-# Get a specific prompt template
-curl http://localhost:8081/support/prompts/{artifactId}
 
 # Preview rendered prompt (without calling LLM)
 curl -X POST http://localhost:8081/support/prompts/preview \
@@ -181,11 +171,13 @@ curl -X POST http://localhost:8081/support/prompts/preview \
 support-chat/
 ├── src/main/java/io/apicurio/registry/support/
 │   ├── ApicurioSupportService.java    # Core chat service with RAG and /render endpoint
+│   ├── SupportAiService.java          # LangChain4j AI service interface
 │   ├── DocumentIngestionService.java  # Web docs ingestion at startup
 │   └── SupportChatResource.java       # REST API endpoints
 ├── src/main/resources/
 │   ├── META-INF/resources/
-│   │   └── index.html                 # Web chat UI
+│   │   ├── index.html                 # Standalone web chat UI
+│   │   └── chat-widget.js             # Embeddable chat widget
 │   └── application.properties         # Configuration
 ├── src/main/docker/
 │   └── Dockerfile.jvm                 # Container image
@@ -194,57 +186,34 @@ support-chat/
 ├── k8s/
 │   ├── deployment.yaml                # Kubernetes Deployment + Service
 │   └── configmap.yaml                 # Environment configuration
+├── render.yaml                        # Render.com deployment blueprint
+├── render-registry.Dockerfile         # Dockerfile for Registry on Render
 ├── docker-compose.yaml                # Local development stack
 ├── pom.xml                            # Maven build configuration
 └── README.md
 ```
 
-## Development
+## Using with Ollama (Local Development)
 
-### Running in Dev Mode
+To use Ollama instead of Google AI Gemini for local development:
 
-```bash
-mvn quarkus:dev
-```
-
-Features:
-- Hot reload on code changes
-- Dev UI at http://localhost:8081/q/dev/
-
-### Building for Production
-
-```bash
-# JVM build
-mvn package -DskipTests
-
-# Native build (requires GraalVM)
-mvn package -Pnative -DskipTests
-```
-
-### Running Tests
-
-```bash
-mvn test
-```
-
-## Using with OpenAI
-
-To use OpenAI instead of Ollama:
-
-1. Add dependency in `pom.xml`:
+1. Replace the dependency in `pom.xml`:
    ```xml
    <dependency>
        <groupId>io.quarkiverse.langchain4j</groupId>
-       <artifactId>quarkus-langchain4j-openai</artifactId>
+       <artifactId>quarkus-langchain4j-ollama</artifactId>
        <version>${quarkus-langchain4j.version}</version>
    </dependency>
    ```
 
 2. Configure in `application.properties`:
    ```properties
-   quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
-   quarkus.langchain4j.openai.chat-model.model-name=gpt-4o
+   quarkus.langchain4j.chat-model.provider=ollama
+   quarkus.langchain4j.ollama.base-url=http://localhost:11434
+   quarkus.langchain4j.ollama.chat-model.model-id=llama3.2
    ```
+
+3. Pull models: `ollama pull llama3.2`
 
 ## License
 
@@ -255,4 +224,4 @@ Apache License 2.0
 - [Apicurio Registry](https://www.apicur.io/registry/)
 - [Apicurio Registry Documentation](https://www.apicur.io/registry/docs/)
 - [Quarkus LangChain4j](https://docs.quarkiverse.io/quarkus-langchain4j/dev/)
-- [Ollama](https://ollama.com/)
+- [Google AI Studio](https://aistudio.google.com/)

--- a/support-chat/docker-compose.yaml
+++ b/support-chat/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   # Apicurio Registry
   registry:
-    image: apicurio/apicurio-registry:3.0.6
+    image: quay.io/apicurio/apicurio-registry:3.2.0
     ports:
       - "8080:8080"
     environment:
@@ -14,20 +14,7 @@ services:
       timeout: 5s
       retries: 5
 
-  # Ollama LLM
-  ollama:
-    image: ollama/ollama:latest
-    ports:
-      - "11434:11434"
-    volumes:
-      - ollama_data:/root/.ollama
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  # Support Chat Application
+  # Support Chat Application (Google AI Gemini + in-process ONNX embeddings)
   support-chat:
     build:
       context: .
@@ -36,14 +23,8 @@ services:
       - "8081:8080"
     environment:
       REGISTRY_URL: http://registry:8080
-      OLLAMA_URL: http://ollama:11434
-      OLLAMA_MODEL: llama3.2
-      OLLAMA_EMBEDDING_MODEL: nomic-embed-text
+      GOOGLE_AI_GEMINI_API_KEY: ${GOOGLE_AI_GEMINI_API_KEY}
+      CORS_ORIGINS: "*"
     depends_on:
       registry:
         condition: service_healthy
-      ollama:
-        condition: service_healthy
-
-volumes:
-  ollama_data:

--- a/support-chat/pom.xml
+++ b/support-chat/pom.xml
@@ -19,6 +19,7 @@
 
     <properties>
         <quarkus-langchain4j.version>1.8.2</quarkus-langchain4j.version>
+        <langchain4j.version>1.0.0-beta2</langchain4j.version>
         <jsoup.version>1.22.1</jsoup.version>
     </properties>
 
@@ -43,10 +44,10 @@
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
 
-        <!-- Quarkus LangChain4j with Ollama -->
+        <!-- Quarkus LangChain4j with Google AI Gemini -->
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-ollama</artifactId>
+            <artifactId>quarkus-langchain4j-ai-gemini</artifactId>
             <version>${quarkus-langchain4j.version}</version>
         </dependency>
 
@@ -57,17 +58,24 @@
             <version>${quarkus-langchain4j.version}</version>
         </dependency>
 
+        <!-- In-process ONNX embedding model (no external service needed) -->
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-bge-small-en-v15-q</artifactId>
+            <version>${langchain4j.version}</version>
+        </dependency>
+
+        <!-- REST Client for Gemini extension -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+
         <!-- JSoup for HTML parsing -->
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>${jsoup.version}</version>
-        </dependency>
-
-        <!-- REST Client for Ollama extension -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-jackson</artifactId>
         </dependency>
 
         <!-- Vert.x Web Client for REST calls to Registry -->

--- a/support-chat/render-registry.Dockerfile
+++ b/support-chat/render-registry.Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/apicurio/apicurio-registry:3.2.0

--- a/support-chat/render.yaml
+++ b/support-chat/render.yaml
@@ -1,0 +1,29 @@
+services:
+  # Apicurio Registry (prompt template storage)
+  - type: web
+    name: apicurio-registry
+    runtime: docker
+    plan: free
+    dockerfilePath: ./render-registry.Dockerfile
+    envVars:
+      - key: QUARKUS_HTTP_PORT
+        value: "10000"
+
+  # Support Chat Application
+  - type: web
+    name: apicurio-support-chat
+    runtime: docker
+    plan: free
+    dockerfilePath: ./src/main/docker/Dockerfile.jvm
+    envVars:
+      - key: REGISTRY_URL
+        fromService:
+          name: apicurio-registry
+          type: web
+          property: hostport
+      - key: GOOGLE_AI_GEMINI_API_KEY
+        sync: false
+      - key: CORS_ORIGINS
+        value: "/https://www\\.apicur\\.io/,/https://.*\\.onrender\\.com/"
+      - key: HTTP_PORT
+        value: "10000"

--- a/support-chat/src/main/resources/META-INF/resources/chat-widget.js
+++ b/support-chat/src/main/resources/META-INF/resources/chat-widget.js
@@ -1,0 +1,174 @@
+(function () {
+    'use strict';
+
+    var API_BASE = document.currentScript.src.replace(/\/chat-widget\.js.*$/, '');
+    var sessionId = null;
+    var isOpen = false;
+
+    // Inject styles
+    var style = document.createElement('style');
+    style.textContent = [
+        '#apicurio-chat-bubble{position:fixed;bottom:24px;right:24px;width:56px;height:56px;border-radius:50%;',
+        'background:#3b82f6;color:#fff;border:none;cursor:pointer;box-shadow:0 4px 16px rgba(59,130,246,.4);',
+        'display:flex;align-items:center;justify-content:center;z-index:99999;transition:transform .2s,box-shadow .2s}',
+        '#apicurio-chat-bubble:hover{transform:scale(1.08);box-shadow:0 6px 24px rgba(59,130,246,.5)}',
+        '#apicurio-chat-bubble svg{width:28px;height:28px;fill:currentColor}',
+        '#apicurio-chat-panel{position:fixed;bottom:92px;right:24px;width:400px;height:560px;',
+        'background:#1e1e2e;border-radius:16px;box-shadow:0 8px 40px rgba(0,0,0,.4);z-index:99999;',
+        'display:none;flex-direction:column;overflow:hidden;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;',
+        'border:1px solid #333}',
+        '#apicurio-chat-panel.open{display:flex}',
+        '#apicurio-chat-header{padding:16px;background:#252536;border-bottom:1px solid #333;',
+        'display:flex;align-items:center;justify-content:space-between}',
+        '#apicurio-chat-header h3{margin:0;font-size:15px;color:#e4e4e7;font-weight:600}',
+        '#apicurio-chat-header span{font-size:12px;color:#71717a;display:block;margin-top:2px}',
+        '#apicurio-chat-close{background:none;border:none;color:#71717a;cursor:pointer;font-size:20px;padding:4px 8px;border-radius:6px}',
+        '#apicurio-chat-close:hover{background:#333;color:#e4e4e7}',
+        '#apicurio-chat-messages{flex:1;overflow-y:auto;padding:16px;display:flex;flex-direction:column;gap:12px}',
+        '.achat-msg{max-width:85%;padding:10px 14px;border-radius:12px;font-size:14px;line-height:1.5;word-wrap:break-word}',
+        '.achat-msg.user{align-self:flex-end;background:#3b82f6;color:#fff;border-bottom-right-radius:4px}',
+        '.achat-msg.assistant{align-self:flex-start;background:#2a2a3c;color:#e4e4e7;border-bottom-left-radius:4px}',
+        '.achat-msg.system{align-self:center;color:#71717a;font-size:13px;font-style:italic;background:none;padding:4px}',
+        '.achat-msg.assistant pre{background:#18181b;padding:8px 10px;border-radius:6px;overflow-x:auto;margin:6px 0;font-size:12px}',
+        '.achat-msg.assistant code{font-family:"Fira Code",Consolas,monospace;font-size:12px}',
+        '.achat-msg.assistant p{margin:6px 0}.achat-msg.assistant ul,.achat-msg.assistant ol{margin:6px 0 6px 16px}',
+        '.achat-msg.assistant li{margin:3px 0}',
+        '.achat-msg.assistant strong{color:#93c5fd}',
+        '.achat-loading span{display:inline-block;width:7px;height:7px;background:#60a5fa;border-radius:50%;',
+        'animation:achat-bounce 1.4s infinite ease-in-out}',
+        '.achat-loading span:nth-child(1){animation-delay:-.32s}.achat-loading span:nth-child(2){animation-delay:-.16s}',
+        '@keyframes achat-bounce{0%,80%,100%{transform:scale(0)}40%{transform:scale(1)}}',
+        '#apicurio-chat-input{padding:12px;border-top:1px solid #333;display:flex;gap:8px}',
+        '#apicurio-chat-input input{flex:1;padding:10px 12px;border:1px solid #333;border-radius:8px;',
+        'background:#18181b;color:#e4e4e7;font-size:14px;outline:none}',
+        '#apicurio-chat-input input:focus{border-color:#3b82f6}',
+        '#apicurio-chat-input input::placeholder{color:#555}',
+        '#apicurio-chat-input button{padding:10px 16px;background:#3b82f6;color:#fff;border:none;border-radius:8px;',
+        'font-size:14px;cursor:pointer;transition:background .2s}',
+        '#apicurio-chat-input button:hover{background:#2563eb}',
+        '#apicurio-chat-input button:disabled{background:#333;cursor:not-allowed}',
+        '@media(max-width:480px){#apicurio-chat-panel{width:calc(100vw - 16px);height:calc(100vh - 120px);',
+        'right:8px;bottom:80px;border-radius:12px}}'
+    ].join('\n');
+    document.head.appendChild(style);
+
+    // Chat bubble
+    var bubble = document.createElement('button');
+    bubble.id = 'apicurio-chat-bubble';
+    bubble.title = 'Apicurio Registry Support';
+    bubble.innerHTML = '<svg viewBox="0 0 24 24"><path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z"/></svg>';
+    bubble.onclick = togglePanel;
+
+    // Chat panel
+    var panel = document.createElement('div');
+    panel.id = 'apicurio-chat-panel';
+    panel.innerHTML = [
+        '<div id="apicurio-chat-header">',
+        '  <div><h3>Apicurio Registry Support</h3><span>AI-powered assistant</span></div>',
+        '  <button id="apicurio-chat-close" onclick="document.getElementById(\'apicurio-chat-panel\').classList.remove(\'open\')">&times;</button>',
+        '</div>',
+        '<div id="apicurio-chat-messages">',
+        '  <div class="achat-msg system">Ask me anything about Apicurio Registry!</div>',
+        '</div>',
+        '<div id="apicurio-chat-input">',
+        '  <input type="text" placeholder="Ask about Apicurio Registry..." id="apicurio-chat-text">',
+        '  <button id="apicurio-chat-send">Send</button>',
+        '</div>'
+    ].join('');
+
+    document.body.appendChild(bubble);
+    document.body.appendChild(panel);
+
+    // Bind events
+    document.getElementById('apicurio-chat-send').onclick = sendMessage;
+    document.getElementById('apicurio-chat-text').onkeypress = function (e) {
+        if (e.key === 'Enter') sendMessage();
+    };
+    document.getElementById('apicurio-chat-close').onclick = function () {
+        panel.classList.remove('open');
+        isOpen = false;
+    };
+
+    function togglePanel() {
+        isOpen = !isOpen;
+        if (isOpen) {
+            panel.classList.add('open');
+            if (!sessionId) createSession();
+            document.getElementById('apicurio-chat-text').focus();
+        } else {
+            panel.classList.remove('open');
+        }
+    }
+
+    function createSession() {
+        fetch(API_BASE + '/support/session', { method: 'POST' })
+            .then(function (r) { return r.json(); })
+            .then(function (d) { sessionId = d.sessionId; })
+            .catch(function () {});
+    }
+
+    function sendMessage() {
+        var input = document.getElementById('apicurio-chat-text');
+        var msg = input.value.trim();
+        if (!msg) return;
+
+        addMsg(msg, 'user');
+        input.value = '';
+        document.getElementById('apicurio-chat-send').disabled = true;
+
+        var loading = document.createElement('div');
+        loading.className = 'achat-msg assistant achat-loading';
+        loading.innerHTML = '<span></span><span></span><span></span>';
+        var msgs = document.getElementById('apicurio-chat-messages');
+        msgs.appendChild(loading);
+        msgs.scrollTop = msgs.scrollHeight;
+
+        var endpoint = sessionId
+            ? API_BASE + '/support/chat/' + sessionId
+            : API_BASE + '/support/ask';
+
+        fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: msg })
+        })
+            .then(function (r) { return r.json(); })
+            .then(function (d) {
+                loading.remove();
+                addMsg(formatMd(d.answer), 'assistant', true);
+            })
+            .catch(function () {
+                loading.remove();
+                addMsg('Sorry, something went wrong. Please try again.', 'system');
+            })
+            .finally(function () {
+                document.getElementById('apicurio-chat-send').disabled = false;
+                input.focus();
+            });
+    }
+
+    function addMsg(content, type, html) {
+        var div = document.createElement('div');
+        div.className = 'achat-msg ' + type;
+        if (html) { div.innerHTML = content; } else { div.textContent = content; }
+        var msgs = document.getElementById('apicurio-chat-messages');
+        msgs.appendChild(div);
+        msgs.scrollTop = msgs.scrollHeight;
+    }
+
+    function formatMd(text) {
+        return ('<p>' + text
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
+            .replace(/`([^`]+)`/g, '<code>$1</code>')
+            .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+            .replace(/^### (.+)$/gm, '</p><h4>$1</h4><p>')
+            .replace(/^## (.+)$/gm, '</p><h3>$1</h3><p>')
+            .replace(/^\* (.+)$/gm, '<li>$1</li>')
+            .replace(/^- (.+)$/gm, '<li>$1</li>')
+            .replace(/^\d+\. (.+)$/gm, '<li>$1</li>')
+            .replace(/\n\n/g, '</p><p>')
+            .replace(/\n/g, '<br>') + '</p>')
+            .replace(/<p><\/p>/g, '');
+    }
+})();

--- a/support-chat/src/main/resources/META-INF/resources/index.html
+++ b/support-chat/src/main/resources/META-INF/resources/index.html
@@ -260,7 +260,7 @@
                 </div>
                 <div class="status-item">
                     <span class="status-dot" id="llmStatus"></span>
-                    <span>LLM (Ollama)</span>
+                    <span>LLM (Gemini)</span>
                 </div>
             </div>
         </header>

--- a/support-chat/src/main/resources/application.properties
+++ b/support-chat/src/main/resources/application.properties
@@ -10,19 +10,17 @@ apicurio.registry.default-group=${REGISTRY_GROUP:default}
 apicurio.registry.cache-enabled=true
 
 # -----------------------------------------------------------------------------
-# LLM Provider: Ollama
+# LLM Provider: Google AI Gemini
 # -----------------------------------------------------------------------------
-quarkus.langchain4j.chat-model.provider=ollama
-quarkus.langchain4j.embedding-model.provider=ollama
-quarkus.langchain4j.ollama.base-url=${OLLAMA_URL:http://localhost:11434}
-quarkus.langchain4j.ollama.chat-model.model-id=${OLLAMA_MODEL:llama3.2}
-quarkus.langchain4j.ollama.chat-model.temperature=0.7
-quarkus.langchain4j.ollama.timeout=120s
+quarkus.langchain4j.chat-model.provider=ai-gemini
+quarkus.langchain4j.ai.gemini.api-key=${GOOGLE_AI_GEMINI_API_KEY}
+quarkus.langchain4j.ai.gemini.chat-model.model-id=${GEMINI_MODEL:gemini-2.0-flash}
+quarkus.langchain4j.ai.gemini.chat-model.temperature=0.7
+quarkus.langchain4j.ai.gemini.timeout=120s
 
 # -----------------------------------------------------------------------------
-# RAG Configuration
+# RAG Configuration (in-process ONNX embeddings, no external service needed)
 # -----------------------------------------------------------------------------
-quarkus.langchain4j.ollama.embedding-model.model-id=${OLLAMA_EMBEDDING_MODEL:nomic-embed-text}
 quarkus.langchain4j.easy-rag.path=.
 quarkus.langchain4j.easy-rag.ingestion-strategy=off
 
@@ -31,9 +29,11 @@ quarkus.langchain4j.easy-rag.ingestion-strategy=off
 # -----------------------------------------------------------------------------
 quarkus.http.port=${HTTP_PORT:8080}
 
-# CORS for frontend access
+# CORS for widget embedding on external sites
 quarkus.http.cors=true
-quarkus.http.cors.origins=${CORS_ORIGINS:*}
+quarkus.http.cors.origins=${CORS_ORIGINS:/https://www\\.apicur\\.io/,/https://.*\\.onrender\\.com/}
+quarkus.http.cors.methods=GET,POST,DELETE,OPTIONS
+quarkus.http.cors.headers=Content-Type,Accept
 
 # -----------------------------------------------------------------------------
 # Container Image
@@ -51,17 +51,10 @@ quarkus.kubernetes.image-pull-policy=IfNotPresent
 
 # Environment variables for Kubernetes
 quarkus.kubernetes.env.vars.REGISTRY_URL=${REGISTRY_URL:http://apicurio-registry:8080}
-quarkus.kubernetes.env.vars.OLLAMA_URL=${OLLAMA_URL:http://ollama:11434}
 
 # Health checks
 quarkus.kubernetes.liveness-probe.http-action-path=/q/health/live
 quarkus.kubernetes.readiness-probe.http-action-path=/q/health/ready
-
-# -----------------------------------------------------------------------------
-# Jandex Indexing
-# -----------------------------------------------------------------------------
-quarkus.index-dependency.langchain4j-ollama.group-id=io.quarkiverse.langchain4j
-quarkus.index-dependency.langchain4j-ollama.artifact-id=quarkus-langchain4j-ollama
 
 # -----------------------------------------------------------------------------
 # Logging


### PR DESCRIPTION
## Summary
- Switch support-chat LLM backend from Ollama to Google AI Gemini (free tier)
- Use in-process ONNX embeddings instead of external embedding service
- Add embeddable chat widget for embedding on www.apicur.io
- Add Render.com deployment blueprint for free hosting

## Changes
- **pom.xml**: Replace `quarkus-langchain4j-ollama` with `quarkus-langchain4j-ai-gemini` + `langchain4j-embeddings-bge-small-en-v15-q` (in-process ONNX)
- **application.properties**: Gemini provider config, CORS for widget embedding, remove Ollama references
- **chat-widget.js**: Self-contained embeddable chat widget (~170 lines) with floating bubble, dark-themed panel, session management, markdown rendering, mobile responsive
- **render.yaml** + **render-registry.Dockerfile**: Render.com Blueprint for deploying Registry + support-chat as free web services
- **docker-compose.yaml**: Simplified — removed Ollama service, uses Gemini API key from env
- **README.md**: Rewritten with new architecture, Gemini setup, Render.com deployment, widget embedding docs

## Test plan
- [x] Build compiles with new dependencies (`mvn compile -Dcheckstyle.skip`)
- [x] Run locally with `GOOGLE_AI_GEMINI_API_KEY` set
- [x] Verify chat-widget.js loads and renders floating bubble
- [x] Verify widget creates session and sends chat messages
- [x] Verify in-process ONNX embeddings work for RAG (no external service)
- [x] Verify CORS allows requests from apicur.io domain