### PR TITLE
fix: add rootDir to render.yaml for correct Dockerfile paths

### DIFF
--- a/support-chat/render.yaml
+++ b/support-chat/render.yaml
@@ -4,6 +4,7 @@ services:
     name: apicurio-registry
     runtime: docker
     plan: free
+    rootDir: support-chat
     dockerfilePath: ./render-registry.Dockerfile
     envVars:
       - key: QUARKUS_HTTP_PORT
@@ -14,6 +15,7 @@ services:
     name: apicurio-support-chat
     runtime: docker
     plan: free
+    rootDir: support-chat
     dockerfilePath: ./src/main/docker/Dockerfile.jvm
     envVars:
       - key: REGISTRY_URL


### PR DESCRIPTION
## Summary
- Adds `rootDir: support-chat` to both services in `render.yaml` so Render uses the correct build context when cloning the full repository.
- Without this, Render looks for `render-registry.Dockerfile` at the repo root and fails.

## Test plan
- [x] Verify Render blueprint deployment succeeds for both `apicurio-registry` and `apicurio-support-chat` services