### PR TITLE
fix: use multi-stage Dockerfile for Render deployment

### DIFF
--- a/support-chat/Dockerfile.render
+++ b/support-chat/Dockerfile.render
@@ -1,0 +1,38 @@
+# Stage 1: Build the application with Maven
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS build
+
+RUN microdnf install -y java-21-openjdk-devel findutils && microdnf clean all
+
+WORKDIR /build
+
+# Copy Maven wrapper and parent pom
+COPY .mvn ./.mvn
+COPY mvnw ./mvnw
+COPY pom.xml ./pom.xml
+RUN chmod +x ./mvnw
+
+# Copy the support-chat module
+COPY support-chat ./support-chat
+
+# Build the support-chat module
+RUN ./mvnw package -pl support-chat -am -DskipTests -Dcheckstyle.skip=true --no-transfer-progress
+
+# Stage 2: Runtime image
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
+
+RUN microdnf install -y java-21-openjdk-headless && microdnf clean all
+
+ENV LANGUAGE='en_US:en'
+
+COPY --from=build --chown=1001:0 /build/support-chat/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=1001:0 /build/support-chat/target/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=1001:0 /build/support-chat/target/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=1001:0 /build/support-chat/target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER 1001
+
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+WORKDIR /deployments
+CMD java $JAVA_OPTIONS -jar quarkus-run.jar

--- a/support-chat/render.yaml
+++ b/support-chat/render.yaml
@@ -15,8 +15,7 @@ services:
     name: apicurio-support-chat
     runtime: docker
     plan: free
-    rootDir: support-chat
-    dockerfilePath: ./src/main/docker/Dockerfile.jvm
+    dockerfilePath: ./support-chat/Dockerfile.render
     envVars:
       - key: REGISTRY_URL
         fromService:


### PR DESCRIPTION
## Summary
- Adds `Dockerfile.render` with a multi-stage build: Maven builds the app in stage 1, stage 2 copies artifacts into a slim runtime image
- Updates `render.yaml` to use the new Dockerfile with the repo root as build context (so it can access parent `pom.xml` and Maven wrapper)
- Fixes Render deployment failure where `target/quarkus-app/` was missing because the existing `Dockerfile.jvm` assumes a pre-built application

## Test plan
- [ ] Verify Render blueprint deployment succeeds for the `apicurio-support-chat` service