### PR TITLE
ci: add support-chat image build to CI pipeline

### DIFF
--- a/.github/workflows/verify-publish.yaml
+++ b/.github/workflows/verify-publish.yaml
@@ -67,3 +67,19 @@ jobs:
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
+  publish-support-chat-image:
+    name: Publish Support Chat Docker Image
+    uses: ./.github/workflows/reusable-docker-build.yaml
+    with:
+      image-name: 'apicurio/apicurio-registry-support-chat'
+      dockerfile: './support-chat/src/main/docker/Dockerfile.jvm'
+      context: './support-chat'
+      tag: 'latest-snapshot'
+      maven-build: true
+      maven-args: 'package -pl support-chat -am -DskipTests -Dcheckstyle.skip=true --no-transfer-progress'
+      push-to-dockerhub: false
+      platforms: 'linux/amd64,linux/arm64'
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/support-chat/render.yaml
+++ b/support-chat/render.yaml
@@ -2,10 +2,10 @@ services:
   # Apicurio Registry (prompt template storage)
   - type: web
     name: apicurio-registry
-    runtime: docker
+    runtime: image
     plan: free
-    rootDir: support-chat
-    dockerfilePath: ./render-registry.Dockerfile
+    image:
+      url: quay.io/apicurio/apicurio-registry:latest
     envVars:
       - key: QUARKUS_HTTP_PORT
         value: "10000"
@@ -13,9 +13,10 @@ services:
   # Support Chat Application
   - type: web
     name: apicurio-support-chat
-    runtime: docker
+    runtime: image
     plan: free
-    dockerfilePath: ./support-chat/Dockerfile.render
+    image:
+      url: quay.io/apicurio/apicurio-registry-support-chat:latest-snapshot
     envVars:
       - key: REGISTRY_URL
         fromService:


### PR DESCRIPTION
## Summary
- Adds support-chat Docker image to the `verify-publish` workflow, building and pushing to `quay.io/apicurio/apicurio-registry-support-chat:latest-snapshot` on every merge to main
- Updates `render.yaml` to use pre-built images (`runtime: image`) instead of building from source, which fixes Render deployment failures

## Changes
- `.github/workflows/verify-publish.yaml` — new `publish-support-chat-image` job using the existing reusable Docker build workflow
- `support-chat/render.yaml` — switched both services from `runtime: docker` to `runtime: image`, referencing Quay.io images directly

## Test plan
- [ ] Verify CI workflow runs successfully and pushes image to Quay.io
- [ ] Verify Render deployment works with the pre-built images