### PR TITLE
fix: use -f flag for support-chat Maven build in CI

### DIFF
--- a/.github/workflows/verify-publish.yaml
+++ b/.github/workflows/verify-publish.yaml
@@ -1,6 +1,7 @@
 name: Publish Images
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       image-tag:
@@ -77,7 +78,7 @@ jobs:
       context: './support-chat'
       tag: 'latest-snapshot'
       maven-build: true
-      maven-args: 'package -pl support-chat -am -DskipTests -Dcheckstyle.skip=true --no-transfer-progress'
+      maven-args: 'package -f support-chat/pom.xml -DskipTests -Dcheckstyle.skip=true --no-transfer-progress'
       push-to-dockerhub: false
       platforms: 'linux/amd64,linux/arm64'
     secrets:


### PR DESCRIPTION
## Summary
- Fixes support-chat Docker image build failure in CI
- The `support-chat` module is not listed in the parent pom's `<modules>`, so `-pl support-chat` fails with "Could not find the selected project in the reactor"
- Changed to `-f support-chat/pom.xml` to build directly from its own pom

## Test plan
- [ ] Verify CI workflow builds and publishes the support-chat image successfully