### PR TITLE
feat(iceberg): implement Iceberg Views support (Phase 3)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/IcebergApiResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/IcebergApiResourceImpl.java
@@ -9,15 +9,18 @@ import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.iceberg.rest.v1.ApisResource;
 import io.apicurio.registry.iceberg.rest.v1.beans.CatalogConfig;
 import io.apicurio.registry.iceberg.rest.v1.beans.CommitTableRequest;
+import io.apicurio.registry.iceberg.rest.v1.beans.CommitViewRequest;
 import io.apicurio.registry.iceberg.rest.v1.beans.Config;
 import io.apicurio.registry.iceberg.rest.v1.beans.CreateNamespaceRequest;
 import io.apicurio.registry.iceberg.rest.v1.beans.CreateNamespaceResponse;
 import io.apicurio.registry.iceberg.rest.v1.beans.CreateTableRequest;
+import io.apicurio.registry.iceberg.rest.v1.beans.CreateViewRequest;
 import io.apicurio.registry.iceberg.rest.v1.beans.Defaults;
 import io.apicurio.registry.iceberg.rest.v1.beans.GetNamespaceResponse;
 import io.apicurio.registry.iceberg.rest.v1.beans.ListNamespacesResponse;
 import io.apicurio.registry.iceberg.rest.v1.beans.ListTablesResponse;
 import io.apicurio.registry.iceberg.rest.v1.beans.LoadTableResponse;
+import io.apicurio.registry.iceberg.rest.v1.beans.LoadViewResponse;
 import io.apicurio.registry.iceberg.rest.v1.beans.Overrides;
 import io.apicurio.registry.iceberg.rest.v1.beans.Properties;
 import io.apicurio.registry.iceberg.rest.v1.beans.Requirement;
@@ -25,10 +28,13 @@ import io.apicurio.registry.iceberg.rest.v1.beans.RenameTableRequest;
 import io.apicurio.registry.iceberg.rest.v1.beans.TableIdentifier;
 import io.apicurio.registry.iceberg.rest.v1.beans.TableMetadata;
 import io.apicurio.registry.iceberg.rest.v1.beans.Update;
+import io.apicurio.registry.iceberg.rest.v1.beans.ViewMetadata;
 import io.apicurio.registry.iceberg.rest.v1.beans.UpdateNamespacePropertiesRequest;
 import io.apicurio.registry.iceberg.rest.v1.beans.UpdateNamespacePropertiesResponse;
 import io.apicurio.registry.iceberg.rest.v1.impl.commit.TableRequirementValidator;
 import io.apicurio.registry.iceberg.rest.v1.impl.commit.TableUpdateApplicator;
+import io.apicurio.registry.iceberg.rest.v1.impl.commit.ViewRequirementValidator;
+import io.apicurio.registry.iceberg.rest.v1.impl.commit.ViewUpdateApplicator;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.logging.audit.Audited;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
@@ -71,12 +77,17 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Implementation of the Iceberg REST Catalog API.
  */
 @Interceptors({ResponseErrorLivenessCheck.class, ResponseTimeoutReadinessCheck.class})
 @Logged
 public class IcebergApiResourceImpl implements ApisResource {
+
+    private static final Logger log = LoggerFactory.getLogger(IcebergApiResourceImpl.class);
 
     private static final String NAMESPACE_SEPARATOR = "\u0000";
 
@@ -112,6 +123,7 @@ public class IcebergApiResourceImpl implements ApisResource {
         defaults.setAdditionalProperty("prefix", icebergConfig.getDefaultPrefix());
 
         Overrides overrides = new Overrides();
+        overrides.setAdditionalProperty("view-endpoints-supported", "true");
 
         config.setDefaults(defaults);
         config.setOverrides(overrides);
@@ -576,15 +588,8 @@ public class IcebergApiResourceImpl implements ApisResource {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
     private LoadTableResponse buildLoadTableResponse(Map<String, Object> metadata) {
-        TableMetadata tableMetadata;
-        try {
-            String json = objectMapper.writeValueAsString(metadata);
-            tableMetadata = objectMapper.readValue(json, TableMetadata.class);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to convert metadata to TableMetadata", e);
-        }
+        TableMetadata tableMetadata = objectMapper.convertValue(metadata, TableMetadata.class);
 
         LoadTableResponse response = new LoadTableResponse();
         response.setMetadata(tableMetadata);
@@ -664,7 +669,7 @@ public class IcebergApiResourceImpl implements ApisResource {
                     metadataJson = objectMapper.writeValueAsString(metadata);
                 }
             } catch (Exception e) {
-                // Keep original metadata if parsing fails
+                log.warn("Failed to update location during rename, keeping original metadata", e);
             }
         }
 
@@ -678,7 +683,363 @@ public class IcebergApiResourceImpl implements ApisResource {
                 EditableArtifactMetaDataDto.builder().build(), null, content,
                 EditableVersionMetaDataDto.builder().build(), null, false, false, getCurrentUser());
 
-        storage.deleteArtifact(sourceGroupId, sourceTable);
+        try {
+            storage.deleteArtifact(sourceGroupId, sourceTable);
+        } catch (Exception e) {
+            log.warn("Rename succeeded but failed to delete source table {}/{}, it may need manual cleanup",
+                    sourceGroupId, sourceTable, e);
+        }
+    }
+
+    // --- Views ---
+
+    @Override
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Read)
+    public ListTablesResponse listViews(String prefix, String namespace, String pageToken,
+            BigInteger pageSize) {
+        requireIcebergEnabled();
+
+        String groupId = namespaceToGroupId(namespace);
+
+        int limit = pageSize != null ? pageSize.intValue() : 100;
+        int offset = 0;
+        if (pageToken != null && !pageToken.isEmpty()) {
+            try {
+                offset = Integer.parseInt(pageToken);
+            } catch (NumberFormatException e) {
+                // Invalid page token, start from beginning
+            }
+        }
+
+        Set<SearchFilter> filters = new HashSet<>();
+        filters.add(SearchFilter.ofGroupId(groupId));
+        filters.add(SearchFilter.ofArtifactType(ArtifactType.ICEBERG_VIEW));
+
+        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, OrderBy.artifactId,
+                OrderDirection.asc, offset, limit);
+
+        List<TableIdentifier> identifiers = results.getArtifacts().stream()
+                .map(a -> {
+                    TableIdentifier id = new TableIdentifier();
+                    id.setNamespace(groupIdToNamespace(a.getGroupId()));
+                    id.setName(a.getArtifactId());
+                    return id;
+                })
+                .collect(Collectors.toList());
+
+        ListTablesResponse response = new ListTablesResponse();
+        response.setIdentifiers(identifiers);
+
+        if (results.getCount() > offset + limit) {
+            response.setNextPageToken(String.valueOf(offset + limit));
+        }
+
+        return response;
+    }
+
+    @Override
+    @Audited
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
+    public LoadViewResponse createView(String prefix, String namespace, CreateViewRequest data) {
+        requireIcebergEnabled();
+
+        String groupId = namespaceToGroupId(namespace);
+        String viewName = data.getName();
+
+        String viewUuid = UUID.randomUUID().toString();
+        String location = data.getLocation();
+        if (location == null || location.isEmpty()) {
+            String warehouse = icebergConfig.getDefaultWarehouse();
+            if (warehouse == null || warehouse.isEmpty()) {
+                warehouse = "/warehouse";
+            }
+            location = warehouse + "/" + groupId.replace(".", "/") + "/" + viewName;
+        }
+
+        long now = System.currentTimeMillis();
+
+        // Build the initial view version from the request
+        Map<String, Object> viewVersion = new HashMap<>();
+        viewVersion.put("version-id", 1);
+        viewVersion.put("schema-id", 0);
+        viewVersion.put("timestamp-ms", now);
+        viewVersion.put("summary", Map.of("operation", "create"));
+        viewVersion.put("default-namespace", groupIdToNamespace(groupId));
+
+        if (data.getViewVersion() != null) {
+            if (data.getViewVersion().getRepresentations() != null) {
+                viewVersion.put("representations", data.getViewVersion().getRepresentations());
+            }
+            if (data.getViewVersion().getDefaultCatalog() != null) {
+                viewVersion.put("default-catalog", data.getViewVersion().getDefaultCatalog());
+            }
+            if (data.getViewVersion().getDefaultNamespace() != null) {
+                viewVersion.put("default-namespace", data.getViewVersion().getDefaultNamespace());
+            }
+            if (data.getViewVersion().getSchemaId() != null) {
+                viewVersion.put("schema-id", data.getViewVersion().getSchemaId());
+            }
+        }
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("format-version", 1);
+        metadata.put("view-uuid", viewUuid);
+        metadata.put("location", location);
+        metadata.put("current-version-id", 1);
+        metadata.put("versions", List.of(viewVersion));
+        metadata.put("version-log", List.of(Map.of("version-id", 1, "timestamp-ms", now)));
+        metadata.put("schemas", List.of(data.getSchema()));
+
+        Map<String, Object> viewProps = new HashMap<>();
+        if (data.getProperties() != null) {
+            viewProps.putAll(data.getProperties().getAdditionalProperties());
+        }
+        metadata.put("properties", viewProps);
+
+        String metadataJson;
+        try {
+            metadataJson = objectMapper.writeValueAsString(metadata);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize view metadata", e);
+        }
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put("view-uuid", viewUuid);
+        labels.put("location", location);
+        if (data.getProperties() != null) {
+            for (Map.Entry<String, Object> entry : data.getProperties().getAdditionalProperties().entrySet()) {
+                labels.put(entry.getKey(), String.valueOf(entry.getValue()));
+            }
+        }
+
+        EditableArtifactMetaDataDto artifactMetaData = EditableArtifactMetaDataDto.builder()
+                .labels(labels)
+                .build();
+        EditableVersionMetaDataDto versionMetaData = EditableVersionMetaDataDto.builder()
+                .build();
+        ContentWrapperDto content = ContentWrapperDto.builder()
+                .content(ContentHandle.create(metadataJson))
+                .contentType(ContentTypes.APPLICATION_JSON)
+                .references(Collections.emptyList())
+                .build();
+
+        storage.createArtifact(groupId, viewName, ArtifactType.ICEBERG_VIEW, artifactMetaData, null,
+                content, versionMetaData, null, false, false, getCurrentUser());
+
+        return buildLoadViewResponse(metadata);
+    }
+
+    @Override
+    @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Read)
+    public LoadViewResponse loadView(String prefix, String namespace, String view) {
+        requireIcebergEnabled();
+
+        String groupId = namespaceToGroupId(namespace);
+
+        StoredArtifactVersionDto artifact = storage.getArtifactVersionContent(groupId, view,
+                storage.getBranchTip(new GA(groupId, view), BranchId.LATEST,
+                        RetrievalBehavior.SKIP_DISABLED_LATEST).getRawVersionId());
+
+        String metadataJson = artifact.getContent().content();
+
+        ViewMetadata metadata;
+        try {
+            metadata = objectMapper.readValue(metadataJson, ViewMetadata.class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse view metadata", e);
+        }
+
+        LoadViewResponse response = new LoadViewResponse();
+        response.setMetadata(metadata);
+        response.setMetadataLocation(metadata.getLocation() + "/metadata/v1.metadata.json");
+        response.setConfig(new Config());
+
+        return response;
+    }
+
+    @Override
+    @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Read)
+    public void viewExists(String prefix, String namespace, String view) {
+        requireIcebergEnabled();
+        String groupId = namespaceToGroupId(namespace);
+        storage.getArtifactMetaData(groupId, view);
+    }
+
+    @Override
+    @Audited
+    @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Admin)
+    public void dropView(String prefix, String namespace, String view) {
+        requireIcebergEnabled();
+        String groupId = namespaceToGroupId(namespace);
+        storage.deleteArtifact(groupId, view);
+    }
+
+    @Override
+    @Audited
+    @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Write)
+    public LoadViewResponse replaceView(String prefix, String namespace, String view,
+            CommitViewRequest data) {
+        requireIcebergEnabled();
+
+        String groupId = namespaceToGroupId(namespace);
+
+        // Load current metadata and record the base version order
+        GAV branchTip = storage.getBranchTip(new GA(groupId, view), BranchId.LATEST,
+                RetrievalBehavior.SKIP_DISABLED_LATEST);
+        ArtifactVersionMetaDataDto currentVersionMeta = storage.getArtifactVersionMetaData(groupId, view,
+                branchTip.getRawVersionId());
+        int baseVersionOrder = currentVersionMeta.getVersionOrder();
+
+        StoredArtifactVersionDto currentArtifact = storage.getArtifactVersionContent(groupId, view,
+                branchTip.getRawVersionId());
+        String currentMetadataJson = currentArtifact.getContent().content();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> currentMetadata;
+        try {
+            currentMetadata = objectMapper.readValue(currentMetadataJson, Map.class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse current view metadata", e);
+        }
+
+        // Validate requirements
+        List<Map<String, Object>> requirements = parseObjectList(data.getRequirements());
+        ViewRequirementValidator.validate(requirements, currentMetadata, groupId, view);
+
+        // Deep-copy metadata and apply updates
+        @SuppressWarnings("unchecked")
+        Map<String, Object> newMetadata;
+        try {
+            String metadataCopy = objectMapper.writeValueAsString(currentMetadata);
+            newMetadata = objectMapper.readValue(metadataCopy, Map.class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to copy view metadata", e);
+        }
+
+        List<Map<String, Object>> updates = parseObjectList(data.getUpdates());
+        ViewUpdateApplicator.apply(updates, newMetadata);
+
+        // Serialize new metadata
+        String newMetadataJson;
+        try {
+            newMetadataJson = objectMapper.writeValueAsString(newMetadata);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize updated view metadata", e);
+        }
+
+        // Create new artifact version
+        ContentWrapperDto content = ContentWrapperDto.builder()
+                .content(ContentHandle.create(newMetadataJson))
+                .contentType(ContentTypes.APPLICATION_JSON)
+                .references(Collections.emptyList())
+                .build();
+
+        // Compute artifact label updates
+        EditableArtifactMetaDataDto artifactMetaData = buildViewArtifactMetaDataIfNeeded(
+                currentMetadata, newMetadata);
+
+        storage.createArtifactVersionIfLatest(groupId, view,
+                null, ArtifactType.ICEBERG_VIEW, content, EditableVersionMetaDataDto.builder().build(),
+                null, false, getCurrentUser(), baseVersionOrder, artifactMetaData);
+
+        return buildLoadViewResponse(newMetadata);
+    }
+
+    @Override
+    @Audited
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Write)
+    public void renameView(String prefix, RenameTableRequest data) {
+        requireIcebergEnabled();
+        TableIdentifier source = data.getSource();
+        TableIdentifier destination = data.getDestination();
+
+        String sourceGroupId = namespaceToGroupId(source.getNamespace());
+        String sourceView = source.getName();
+        String destGroupId = namespaceToGroupId(destination.getNamespace());
+        String destView = destination.getName();
+
+        StoredArtifactVersionDto artifact = storage.getArtifactVersionContent(sourceGroupId, sourceView,
+                storage.getBranchTip(new GA(sourceGroupId, sourceView), BranchId.LATEST,
+                        RetrievalBehavior.SKIP_DISABLED_LATEST).getRawVersionId());
+
+        String metadataJson = artifact.getContent().content();
+
+        if (!sourceGroupId.equals(destGroupId) || !sourceView.equals(destView)) {
+            try {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> metadata = objectMapper.readValue(metadataJson, Map.class);
+                String oldLocation = (String) metadata.get("location");
+                if (oldLocation != null) {
+                    String warehouse = icebergConfig.getDefaultWarehouse();
+                    if (warehouse == null || warehouse.isEmpty()) {
+                        warehouse = "/warehouse";
+                    }
+                    String newLocation = warehouse + "/" + destGroupId.replace(".", "/") + "/" + destView;
+                    metadata.put("location", newLocation);
+                    metadataJson = objectMapper.writeValueAsString(metadata);
+                }
+            } catch (Exception e) {
+                log.warn("Failed to update location during rename, keeping original metadata", e);
+            }
+        }
+
+        ContentWrapperDto content = ContentWrapperDto.builder()
+                .content(ContentHandle.create(metadataJson))
+                .contentType(ContentTypes.APPLICATION_JSON)
+                .references(Collections.emptyList())
+                .build();
+
+        storage.createArtifact(destGroupId, destView, ArtifactType.ICEBERG_VIEW,
+                EditableArtifactMetaDataDto.builder().build(), null, content,
+                EditableVersionMetaDataDto.builder().build(), null, false, false, getCurrentUser());
+
+        try {
+            storage.deleteArtifact(sourceGroupId, sourceView);
+        } catch (Exception e) {
+            log.warn("Rename succeeded but failed to delete source view {}/{}, it may need manual cleanup",
+                    sourceGroupId, sourceView, e);
+        }
+    }
+
+    private LoadViewResponse buildLoadViewResponse(Map<String, Object> metadata) {
+        ViewMetadata viewMetadata = objectMapper.convertValue(metadata, ViewMetadata.class);
+
+        LoadViewResponse response = new LoadViewResponse();
+        response.setMetadata(viewMetadata);
+        String location = (String) metadata.get("location");
+        if (location != null) {
+            response.setMetadataLocation(location + "/metadata/v1.metadata.json");
+        }
+        response.setConfig(new Config());
+        return response;
+    }
+
+    private EditableArtifactMetaDataDto buildViewArtifactMetaDataIfNeeded(
+            Map<String, Object> oldMetadata, Map<String, Object> newMetadata) {
+        String oldUuid = (String) oldMetadata.get("view-uuid");
+        String newUuid = (String) newMetadata.get("view-uuid");
+        String oldLocation = (String) oldMetadata.get("location");
+        String newLocation = (String) newMetadata.get("location");
+
+        boolean needsUpdate = false;
+        if (newUuid != null && !newUuid.equals(oldUuid)) {
+            needsUpdate = true;
+        }
+        if (newLocation != null && !newLocation.equals(oldLocation)) {
+            needsUpdate = true;
+        }
+
+        if (needsUpdate) {
+            Map<String, String> labels = new HashMap<>();
+            if (newUuid != null) {
+                labels.put("view-uuid", newUuid);
+            }
+            if (newLocation != null) {
+                labels.put("location", newLocation);
+            }
+            return EditableArtifactMetaDataDto.builder().labels(labels).build();
+        }
+        return null;
     }
 
     private String namespaceToGroupId(List<String> namespace) {

--- a/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/commit/ViewRequirementValidator.java
+++ b/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/commit/ViewRequirementValidator.java
@@ -1,0 +1,82 @@
+package io.apicurio.registry.iceberg.rest.v1.impl.commit;
+
+import io.apicurio.registry.storage.error.CommitFailedException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Validates Iceberg view requirements against current metadata. Each requirement must be satisfied for a
+ * commit to proceed.
+ */
+public final class ViewRequirementValidator {
+
+    private ViewRequirementValidator() {
+    }
+
+    /**
+     * Validates all requirements against the current view metadata.
+     * @param requirements list of requirement objects, each with a "type" field
+     * @param currentMetadata current view metadata (null if view does not exist)
+     * @param groupId group ID for error messages
+     * @param artifactId artifact ID for error messages
+     * @throws CommitFailedException if any requirement is not met
+     * @throws IllegalArgumentException if a requirement type is unknown
+     */
+    public static void validate(List<Map<String, Object>> requirements,
+            Map<String, Object> currentMetadata, String groupId, String artifactId) {
+        if (requirements == null || requirements.isEmpty()) {
+            return;
+        }
+
+        for (Map<String, Object> req : requirements) {
+            String type = (String) req.get("type");
+            if (type == null) {
+                throw new IllegalArgumentException("Requirement is missing 'type' field");
+            }
+
+            switch (type) {
+                case "assert-create":
+                    assertCreate(currentMetadata, groupId, artifactId);
+                    break;
+                case "assert-view-uuid":
+                    assertViewUuid(req, currentMetadata, groupId, artifactId);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown requirement type: " + type);
+            }
+        }
+    }
+
+    private static void assertCreate(Map<String, Object> currentMetadata, String groupId,
+            String artifactId) {
+        if (currentMetadata != null) {
+            throw new CommitFailedException(groupId, artifactId,
+                    "Requirement failed: assert-create - view already exists");
+        }
+    }
+
+    private static void assertViewUuid(Map<String, Object> req, Map<String, Object> currentMetadata,
+            String groupId, String artifactId) {
+        requireMetadataExists(currentMetadata, groupId, artifactId, "assert-view-uuid");
+        String expectedUuid = (String) req.get("uuid");
+        if (expectedUuid == null) {
+            throw new IllegalArgumentException(
+                    "assert-view-uuid requirement is missing required 'uuid' field");
+        }
+        String actualUuid = (String) currentMetadata.get("view-uuid");
+        if (!expectedUuid.equals(actualUuid)) {
+            throw new CommitFailedException(groupId, artifactId,
+                    "Requirement failed: assert-view-uuid - expected " + expectedUuid + " but was "
+                            + actualUuid);
+        }
+    }
+
+    private static void requireMetadataExists(Map<String, Object> currentMetadata, String groupId,
+            String artifactId, String requirementType) {
+        if (currentMetadata == null) {
+            throw new CommitFailedException(groupId, artifactId,
+                    "Requirement failed: " + requirementType + " - view does not exist");
+        }
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/commit/ViewUpdateApplicator.java
+++ b/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/commit/ViewUpdateApplicator.java
@@ -1,0 +1,206 @@
+package io.apicurio.registry.iceberg.rest.v1.impl.commit;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Applies Iceberg view updates to a mutable metadata map. All updates within a single commit are applied
+ * sequentially to produce one new metadata state.
+ */
+public final class ViewUpdateApplicator {
+
+    private ViewUpdateApplicator() {
+    }
+
+    /**
+     * Applies all updates to the metadata map (mutates it in place).
+     * @param updates list of update objects, each with an "action" field
+     * @param metadata mutable metadata map to apply updates to
+     * @throws IllegalArgumentException if an update action is unknown
+     */
+    @SuppressWarnings("unchecked")
+    public static void apply(List<Map<String, Object>> updates, Map<String, Object> metadata) {
+        if (updates == null || updates.isEmpty()) {
+            return;
+        }
+
+        for (Map<String, Object> update : updates) {
+            String action = (String) update.get("action");
+            if (action == null) {
+                throw new IllegalArgumentException("Update is missing 'action' field");
+            }
+
+            switch (action) {
+                case "assign-uuid":
+                    metadata.put("view-uuid", update.get("uuid"));
+                    break;
+                case "upgrade-format-version":
+                    applyUpgradeFormatVersion(update, metadata);
+                    break;
+                case "add-schema":
+                    applyAddSchema(update, metadata);
+                    break;
+                case "set-location":
+                    metadata.put("location", update.get("location"));
+                    break;
+                case "set-properties":
+                    applySetProperties(update, metadata);
+                    break;
+                case "remove-properties":
+                    applyRemoveProperties(update, metadata);
+                    break;
+                case "add-view-version":
+                    applyAddViewVersion(update, metadata);
+                    break;
+                case "set-current-view-version":
+                    applySetCurrentViewVersion(update, metadata);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown update action: " + action);
+            }
+        }
+    }
+
+    private static void applyUpgradeFormatVersion(Map<String, Object> update,
+            Map<String, Object> metadata) {
+        int newVersion = toInt(update.get("format-version"));
+        int currentVersion = toInt(metadata.getOrDefault("format-version", 1));
+        if (newVersion >= currentVersion) {
+            metadata.put("format-version", newVersion);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void applyAddSchema(Map<String, Object> update, Map<String, Object> metadata) {
+        Map<String, Object> schema = (Map<String, Object>) update.get("schema");
+        if (schema == null) {
+            throw new IllegalArgumentException("add-schema update is missing 'schema' field");
+        }
+
+        List<Object> schemas = getMutableList(metadata, "schemas");
+
+        if (!schema.containsKey("schema-id")) {
+            schema = new HashMap<>(schema);
+            schema.put("schema-id", schemas.size());
+        }
+
+        schemas.add(schema);
+        metadata.put("schemas", schemas);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void applySetProperties(Map<String, Object> update, Map<String, Object> metadata) {
+        Map<String, Object> updates = (Map<String, Object>) update.get("updates");
+        if (updates == null || updates.isEmpty()) {
+            return;
+        }
+
+        Map<String, Object> properties = (Map<String, Object>) metadata.get("properties");
+        if (properties == null) {
+            properties = new HashMap<>();
+        } else {
+            properties = new HashMap<>(properties);
+        }
+        properties.putAll(updates);
+        metadata.put("properties", properties);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void applyRemoveProperties(Map<String, Object> update, Map<String, Object> metadata) {
+        List<String> removals = (List<String>) update.get("removals");
+        if (removals == null || removals.isEmpty()) {
+            return;
+        }
+
+        Map<String, Object> properties = (Map<String, Object>) metadata.get("properties");
+        if (properties != null) {
+            properties = new HashMap<>(properties);
+            for (String key : removals) {
+                properties.remove(key);
+            }
+            metadata.put("properties", properties);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void applyAddViewVersion(Map<String, Object> update, Map<String, Object> metadata) {
+        Map<String, Object> viewVersion = (Map<String, Object>) update.get("view-version");
+        if (viewVersion == null) {
+            throw new IllegalArgumentException("add-view-version update is missing 'view-version' field");
+        }
+
+        List<Object> versions = getMutableList(metadata, "versions");
+
+        // Auto-assign version-id if not present
+        int versionId;
+        if (viewVersion.containsKey("version-id")) {
+            versionId = toInt(viewVersion.get("version-id"));
+        } else {
+            versionId = versions.size() + 1;
+            viewVersion = new HashMap<>(viewVersion);
+            viewVersion.put("version-id", versionId);
+        }
+
+        // Set timestamp if not present
+        if (!viewVersion.containsKey("timestamp-ms")) {
+            viewVersion = viewVersion instanceof HashMap ? viewVersion : new HashMap<>(viewVersion);
+            viewVersion.put("timestamp-ms", System.currentTimeMillis());
+        }
+
+        versions.add(viewVersion);
+        metadata.put("versions", versions);
+        metadata.put("current-version-id", versionId);
+
+        // Update version-log
+        List<Object> versionLog = getMutableList(metadata, "version-log");
+        Map<String, Object> logEntry = new HashMap<>();
+        logEntry.put("version-id", versionId);
+        logEntry.put("timestamp-ms", viewVersion.get("timestamp-ms"));
+        versionLog.add(logEntry);
+        metadata.put("version-log", versionLog);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void applySetCurrentViewVersion(Map<String, Object> update,
+            Map<String, Object> metadata) {
+        int versionId = toInt(update.get("view-version-id"));
+        // The SDK sends -1 as a placeholder for the most recently added version
+        if (versionId == -1) {
+            List<Object> versions = (List<Object>) metadata.get("versions");
+            if (versions != null && !versions.isEmpty()) {
+                Map<String, Object> lastVersion = (Map<String, Object>) versions.get(versions.size() - 1);
+                versionId = toInt(lastVersion.get("version-id"));
+            }
+        }
+        metadata.put("current-version-id", versionId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Object> getMutableList(Map<String, Object> metadata, String key) {
+        Object value = metadata.get(key);
+        if (value == null) {
+            return new ArrayList<>();
+        }
+        if (value instanceof List) {
+            return new ArrayList<>((List<Object>) value);
+        }
+        throw new IllegalArgumentException(
+                "Expected a list for metadata field '" + key + "' but got: " + value.getClass().getName());
+    }
+
+    private static int toInt(Object value) {
+        if (value == null) {
+            return 0;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        try {
+            return Integer.parseInt(value.toString());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Expected a numeric value but got: " + value, e);
+        }
+    }
+}

--- a/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/iceberg/v1/openapi.json
+++ b/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/iceberg/v1/openapi.json
@@ -530,6 +530,259 @@
           }
         }
       }
+    },
+    "/apis/iceberg/v1/{prefix}/namespaces/{namespace}/views": {
+      "get": {
+        "operationId": "listViews",
+        "tags": ["Views"],
+        "summary": "List views in a namespace",
+        "description": "Return all view identifiers under this namespace",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefix"
+          },
+          {
+            "$ref": "#/components/parameters/namespace"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of view identifiers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTablesResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createView",
+        "tags": ["Views"],
+        "summary": "Create a view in a namespace",
+        "description": "Create a view defined by a SQL query",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefix"
+          },
+          {
+            "$ref": "#/components/parameters/namespace"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateViewRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "View created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoadViewResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "$ref": "#/components/responses/ConflictError"
+          }
+        }
+      }
+    },
+    "/apis/iceberg/v1/{prefix}/namespaces/{namespace}/views/{view}": {
+      "get": {
+        "operationId": "loadView",
+        "tags": ["Views"],
+        "summary": "Load a view",
+        "description": "Load a view from the catalog",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefix"
+          },
+          {
+            "$ref": "#/components/parameters/namespace"
+          },
+          {
+            "$ref": "#/components/parameters/view"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "View metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoadViewResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          }
+        }
+      },
+      "head": {
+        "operationId": "viewExists",
+        "tags": ["Views"],
+        "summary": "Check if a view exists",
+        "description": "Check if a view exists. Returns 204 if the view exists, 404 otherwise",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefix"
+          },
+          {
+            "$ref": "#/components/parameters/namespace"
+          },
+          {
+            "$ref": "#/components/parameters/view"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "View exists"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          }
+        }
+      },
+      "post": {
+        "operationId": "replaceView",
+        "tags": ["Views"],
+        "summary": "Replace a view",
+        "description": "Commit updates to a view. Commits can optionally include requirements that must be satisfied for the commit to succeed.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefix"
+          },
+          {
+            "$ref": "#/components/parameters/namespace"
+          },
+          {
+            "$ref": "#/components/parameters/view"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitViewRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "View updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoadViewResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ConflictError"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "dropView",
+        "tags": ["Views"],
+        "summary": "Drop a view",
+        "description": "Drop a view from the catalog",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefix"
+          },
+          {
+            "$ref": "#/components/parameters/namespace"
+          },
+          {
+            "$ref": "#/components/parameters/view"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "View successfully dropped"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          }
+        }
+      }
+    },
+    "/apis/iceberg/v1/{prefix}/views/rename": {
+      "post": {
+        "operationId": "renameView",
+        "tags": ["Views"],
+        "summary": "Rename a view",
+        "description": "Rename a view from its current name to a new name",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefix"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameTableRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "View successfully renamed"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ConflictError"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -557,6 +810,15 @@
         "in": "path",
         "required": true,
         "description": "A table name",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "view": {
+        "name": "view",
+        "in": "path",
+        "required": true,
+        "description": "A view name",
         "schema": {
           "type": "string"
         }
@@ -1081,6 +1343,194 @@
               "additionalProperties": true
             },
             "description": "Updates to apply to the table metadata. Each update has an 'action' field indicating the update type."
+          }
+        }
+      },
+      "CreateViewRequest": {
+        "type": "object",
+        "required": ["name", "schema", "view-version"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "View name"
+          },
+          "location": {
+            "type": "string",
+            "description": "View location. If not specified, the location will be computed by the catalog"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/Schema"
+          },
+          "view-version": {
+            "$ref": "#/components/schemas/ViewVersion"
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ViewVersion": {
+        "type": "object",
+        "required": ["version-id", "schema-id", "timestamp-ms", "representations"],
+        "properties": {
+          "version-id": {
+            "type": "integer",
+            "description": "Version ID"
+          },
+          "schema-id": {
+            "type": "integer",
+            "description": "Schema ID for this version"
+          },
+          "timestamp-ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Timestamp when this version was created"
+          },
+          "summary": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Summary of the version"
+          },
+          "representations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ViewRepresentation"
+            },
+            "description": "SQL representations of the view"
+          },
+          "default-catalog": {
+            "type": "string",
+            "description": "Default catalog for SQL resolution"
+          },
+          "default-namespace": {
+            "$ref": "#/components/schemas/Namespace"
+          }
+        }
+      },
+      "ViewRepresentation": {
+        "type": "object",
+        "required": ["type", "sql", "dialect"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["sql"],
+            "description": "Representation type"
+          },
+          "sql": {
+            "type": "string",
+            "description": "SQL expression"
+          },
+          "dialect": {
+            "type": "string",
+            "description": "SQL dialect"
+          }
+        }
+      },
+      "ViewMetadata": {
+        "type": "object",
+        "required": ["format-version", "view-uuid", "location"],
+        "properties": {
+          "format-version": {
+            "type": "integer",
+            "description": "Iceberg format version"
+          },
+          "view-uuid": {
+            "type": "string",
+            "description": "UUID of the view"
+          },
+          "location": {
+            "type": "string",
+            "description": "View location"
+          },
+          "current-version-id": {
+            "type": "integer",
+            "description": "ID of the current view version"
+          },
+          "versions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ViewVersion"
+            },
+            "description": "List of view versions"
+          },
+          "version-log": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "version-id": {
+                  "type": "integer",
+                  "description": "Version ID"
+                },
+                "timestamp-ms": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "Timestamp in milliseconds"
+                }
+              },
+              "required": ["version-id", "timestamp-ms"]
+            },
+            "description": "Log of version changes"
+          },
+          "schemas": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Schema"
+            },
+            "description": "List of schemas"
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LoadViewResponse": {
+        "type": "object",
+        "required": ["metadata"],
+        "properties": {
+          "metadata-location": {
+            "type": "string",
+            "description": "Location of the metadata file"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/ViewMetadata"
+          },
+          "config": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Configuration for accessing the view"
+          }
+        }
+      },
+      "CommitViewRequest": {
+        "type": "object",
+        "required": ["requirements", "updates"],
+        "properties": {
+          "requirements": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "description": "Requirements that must be met for the commit to succeed. Each requirement has a 'type' field indicating the assertion type."
+          },
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "description": "Updates to apply to the view metadata. Each update has an 'action' field indicating the update type."
           }
         }
       }

--- a/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergApiTest.java
@@ -763,7 +763,312 @@ public class IcebergApiTest extends AbstractResourceTestBase {
         cleanupTable(namespaceName, tableName);
     }
 
+    // --- View Tests ---
+
+    @Test
+    public void testViewLifecycle() {
+        String namespaceName = "test_view_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String viewName = "test_view";
+
+        // Create namespace first
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(Map.of("namespace", List.of(namespaceName), "properties", Map.of()))
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces")
+            .then()
+            .statusCode(200);
+
+        // Create view
+        Map<String, Object> createViewRequest = createViewRequestBody(viewName);
+
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(createViewRequest)
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views")
+            .then()
+            .statusCode(200)
+            .body("metadata.view-uuid", notNullValue())
+            .body("metadata.format-version", equalTo(1));
+
+        // List views
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .get(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views")
+            .then()
+            .statusCode(200)
+            .body("identifiers[0].name", equalTo(viewName));
+
+        // Check view exists
+        given()
+            .when()
+            .head(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + viewName)
+            .then()
+            .statusCode(204);
+
+        // Load view
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .get(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + viewName)
+            .then()
+            .statusCode(200)
+            .body("metadata.view-uuid", notNullValue())
+            .body("metadata.current-version-id", equalTo(1));
+
+        // Drop view
+        given()
+            .when()
+            .delete(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + viewName)
+            .then()
+            .statusCode(204);
+
+        // Drop namespace
+        given()
+            .when()
+            .delete(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName)
+            .then()
+            .statusCode(204);
+    }
+
+    @Test
+    public void testRenameView() {
+        String namespaceName = "test_renameview_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String viewName = "original_view";
+        String newViewName = "renamed_view";
+
+        createNamespaceAndView(namespaceName, viewName);
+
+        // Rename view
+        Map<String, Object> renameRequest = Map.of(
+            "source", Map.of(
+                "namespace", List.of(namespaceName),
+                "name", viewName
+            ),
+            "destination", Map.of(
+                "namespace", List.of(namespaceName),
+                "name", newViewName
+            )
+        );
+
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(renameRequest)
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/views/rename")
+            .then()
+            .statusCode(204);
+
+        // Verify old view is gone
+        given()
+            .when()
+            .head(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + viewName)
+            .then()
+            .statusCode(404);
+
+        // Verify new view exists
+        given()
+            .when()
+            .head(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + newViewName)
+            .then()
+            .statusCode(204);
+
+        cleanupView(namespaceName, newViewName);
+    }
+
+    @Test
+    public void testReplaceViewBasic() {
+        String namespaceName = "test_replaceview_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String viewName = "replace_view";
+
+        createNamespaceAndView(namespaceName, viewName);
+
+        // Replace view: add-view-version
+        Map<String, Object> newVersion = new HashMap<>();
+        newVersion.put("version-id", 2);
+        newVersion.put("schema-id", 0);
+        newVersion.put("timestamp-ms", System.currentTimeMillis());
+        newVersion.put("summary", Map.of("operation", "replace"));
+        newVersion.put("representations", List.of(
+            Map.of("type", "sql", "sql", "SELECT id, data FROM t1 WHERE id > 10", "dialect", "spark")
+        ));
+        newVersion.put("default-namespace", List.of(namespaceName));
+
+        Map<String, Object> commitRequest = Map.of(
+            "requirements", List.of(),
+            "updates", List.of(
+                Map.of("action", "add-view-version", "view-version", newVersion)
+            )
+        );
+
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(commitRequest)
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + viewName)
+            .then()
+            .statusCode(200)
+            .body("metadata.current-version-id", equalTo(2));
+
+        // Verify by loading
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .get(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + viewName)
+            .then()
+            .statusCode(200)
+            .body("metadata.current-version-id", equalTo(2));
+
+        cleanupView(namespaceName, viewName);
+    }
+
+    @Test
+    public void testReplaceViewRequirementSuccess() {
+        String namespaceName = "test_viewreqok_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String viewName = "viewreq_view";
+
+        createNamespaceAndView(namespaceName, viewName);
+
+        // Load the view to get the UUID
+        String viewUuid = given()
+            .when()
+            .contentType(CT_JSON)
+            .get(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + viewName)
+            .then()
+            .statusCode(200)
+            .extract().path("metadata.view-uuid");
+
+        // Commit with assert-view-uuid requirement (should succeed)
+        Map<String, Object> commitRequest = Map.of(
+            "requirements", List.of(Map.of("type", "assert-view-uuid", "uuid", viewUuid)),
+            "updates", List.of(Map.of("action", "set-location", "location", "/new/view/location"))
+        );
+
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(commitRequest)
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + viewName)
+            .then()
+            .statusCode(200)
+            .body("metadata.location", equalTo("/new/view/location"));
+
+        cleanupView(namespaceName, viewName);
+    }
+
+    @Test
+    public void testReplaceViewRequirementFailure() {
+        String namespaceName = "test_viewreqfail_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String viewName = "viewreqfail_view";
+
+        createNamespaceAndView(namespaceName, viewName);
+
+        // Commit with wrong UUID (should fail with 409)
+        Map<String, Object> commitRequest = Map.of(
+            "requirements", List.of(Map.of("type", "assert-view-uuid", "uuid", "wrong-uuid")),
+            "updates", List.of(Map.of("action", "set-location", "location", "/new/location"))
+        );
+
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(commitRequest)
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + viewName)
+            .then()
+            .statusCode(409)
+            .body("error.type", equalTo("CommitFailedException"));
+
+        cleanupView(namespaceName, viewName);
+    }
+
+    @Test
+    public void testNamespaceNotEmptyWithView() {
+        String namespaceName = "test_notemptyview_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String viewName = "test_view";
+
+        createNamespaceAndView(namespaceName, viewName);
+
+        // Try to drop non-empty namespace (should fail)
+        given()
+            .when()
+            .delete(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName)
+            .then()
+            .statusCode(409);
+
+        // Drop view first
+        given()
+            .when()
+            .delete(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + viewName)
+            .then()
+            .statusCode(204);
+
+        // Now drop namespace (should succeed)
+        given()
+            .when()
+            .delete(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName)
+            .then()
+            .statusCode(204);
+    }
+
     // --- Helper Methods ---
+
+    private Map<String, Object> createViewRequestBody(String viewName) {
+        Map<String, Object> viewVersion = new HashMap<>();
+        viewVersion.put("version-id", 1);
+        viewVersion.put("schema-id", 0);
+        viewVersion.put("timestamp-ms", System.currentTimeMillis());
+        viewVersion.put("representations", List.of(
+            Map.of("type", "sql", "sql", "SELECT * FROM t1", "dialect", "spark")
+        ));
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("name", viewName);
+        request.put("schema", Map.of(
+            "type", "struct",
+            "schema-id", 0,
+            "fields", List.of(
+                Map.of("id", 1, "name", "id", "required", true, "type", "long"),
+                Map.of("id", 2, "name", "data", "required", false, "type", "string")
+            )
+        ));
+        request.put("view-version", viewVersion);
+        request.put("properties", Map.of());
+        return request;
+    }
+
+    private void createNamespaceAndView(String namespaceName, String viewName) {
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(Map.of("namespace", List.of(namespaceName), "properties", Map.of()))
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces")
+            .then()
+            .statusCode(200);
+
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(createViewRequestBody(viewName))
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views")
+            .then()
+            .statusCode(200);
+    }
+
+    private void cleanupView(String namespaceName, String viewName) {
+        given()
+            .when()
+            .delete(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/views/" + viewName)
+            .then()
+            .statusCode(204);
+
+        given()
+            .when()
+            .delete(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName)
+            .then()
+            .statusCode(204);
+    }
 
     private void createNamespaceAndTable(String namespaceName, String tableName) {
         given()

--- a/docs/modules/ROOT/pages/getting-started/assembly-using-iceberg-catalog.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-using-iceberg-catalog.adoc
@@ -746,6 +746,27 @@ The following table lists all Iceberg REST Catalog API endpoints supported by {r
 |POST
 |`/apis/iceberg/v1/{prefix}/tables/rename`
 |Rename a table
+|GET
+|`/apis/iceberg/v1/{prefix}/namespaces/{namespace}/views`
+|List views in a namespace
+|POST
+|`/apis/iceberg/v1/{prefix}/namespaces/{namespace}/views`
+|Create a view
+|GET
+|`/apis/iceberg/v1/{prefix}/namespaces/{namespace}/views/{view}`
+|Load a view
+|POST
+|`/apis/iceberg/v1/{prefix}/namespaces/{namespace}/views/{view}`
+|Replace/commit a view
+|HEAD
+|`/apis/iceberg/v1/{prefix}/namespaces/{namespace}/views/{view}`
+|Check if a view exists
+|DELETE
+|`/apis/iceberg/v1/{prefix}/namespaces/{namespace}/views/{view}`
+|Drop a view
+|POST
+|`/apis/iceberg/v1/{prefix}/views/rename`
+|Rename a view
 |===
 
 
@@ -755,10 +776,9 @@ The following table lists all Iceberg REST Catalog API endpoints supported by {r
 [role="_abstract"]
 The {registry} Iceberg REST Catalog implementation has the following limitations:
 
-* *Views are not supported.* Only Iceberg tables are currently supported. The `ICEBERG_VIEW` artifact type is reserved for future use.
 * *Multi-table transactions are not supported.* Each CommitTable operation is scoped to a single table. Cross-table atomic commits are not available.
 * *Server-side content management.* {registry} stores table metadata but does not manage data files. Clients are responsible for writing data files to the configured warehouse location.
-* *Rename is not atomic.* Renaming a table creates the destination and then deletes the source as two separate operations. If the delete fails, both the source and destination may temporarily exist.
+* *Rename is not atomic.* Renaming a table or view creates the destination and then deletes the source as two separate operations. If the delete fails, the source may need manual cleanup.
 * *Experimental feature.* The Iceberg REST Catalog API requires `apicurio.features.experimental.enabled=true` and may change in future releases.
 
 

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/IcebergCatalogIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/IcebergCatalogIT.java
@@ -13,8 +13,10 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.View;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -45,8 +47,9 @@ class IcebergCatalogIT extends ApicurioRegistryBaseIT {
 
     private RESTCatalog catalog;
 
-    // Track namespaces and tables created during tests for cleanup
+    // Track namespaces, tables, and views created during tests for cleanup
     private final java.util.Deque<TableIdentifier> createdTables = new java.util.ArrayDeque<>();
+    private final java.util.Deque<TableIdentifier> createdViews = new java.util.ArrayDeque<>();
     private final java.util.Deque<Namespace> createdNamespaces = new java.util.ArrayDeque<>();
 
     @BeforeAll
@@ -61,7 +64,16 @@ class IcebergCatalogIT extends ApicurioRegistryBaseIT {
 
     @AfterEach
     void cleanupTestData() {
-        // Drop tables first (LIFO order)
+        // Drop views first (LIFO order)
+        while (!createdViews.isEmpty()) {
+            TableIdentifier view = createdViews.pop();
+            try {
+                catalog.dropView(view);
+            } catch (Exception e) {
+                LOGGER.warn("Failed to clean up view {}: {}", view, e.getMessage());
+            }
+        }
+        // Drop tables (LIFO order)
         while (!createdTables.isEmpty()) {
             TableIdentifier table = createdTables.pop();
             try {
@@ -533,5 +545,187 @@ class IcebergCatalogIT extends ApicurioRegistryBaseIT {
     void testLoadNonExistentNamespace() {
         Namespace nonExistent = Namespace.of("ns_does_not_exist_" + UUID.randomUUID());
         assertThrows(NoSuchNamespaceException.class, () -> catalog.loadNamespaceMetadata(nonExistent));
+    }
+
+    // ========== View Lifecycle ==========
+
+    private View createTestView(Namespace ns, String viewName) {
+        TableIdentifier viewId = TableIdentifier.of(ns, viewName);
+        View view = catalog.buildView(viewId)
+                .withSchema(simpleSchema())
+                .withQuery("spark", "SELECT * FROM t1")
+                .withDefaultNamespace(ns)
+                .create();
+        createdViews.push(viewId);
+        return view;
+    }
+
+    @Test
+    void testCreateAndLoadView() {
+        Namespace ns = createTestNamespace("view_create");
+        String viewName = uniqueName("test_view");
+        TableIdentifier viewId = TableIdentifier.of(ns, viewName);
+
+        View created = createTestView(ns, viewName);
+        assertNotNull(created);
+
+        View loaded = catalog.loadView(viewId);
+        assertNotNull(loaded);
+        assertEquals(3, loaded.schema().columns().size());
+        assertNotNull(loaded.currentVersion());
+        assertFalse(loaded.currentVersion().representations().isEmpty(),
+                "View should have at least one representation");
+    }
+
+    @Test
+    void testListViews() {
+        Namespace ns = createTestNamespace("view_list");
+        String view1 = uniqueName("view_a");
+        String view2 = uniqueName("view_b");
+        createTestView(ns, view1);
+        createTestView(ns, view2);
+
+        List<TableIdentifier> views = catalog.listViews(ns);
+        Set<String> viewNames = views.stream()
+                .map(TableIdentifier::name)
+                .collect(Collectors.toSet());
+        assertTrue(viewNames.contains(view1));
+        assertTrue(viewNames.contains(view2));
+    }
+
+    @Test
+    void testViewExists() {
+        Namespace ns = createTestNamespace("view_exists");
+        String viewName = uniqueName("exists_view");
+        TableIdentifier viewId = TableIdentifier.of(ns, viewName);
+
+        assertFalse(catalog.viewExists(viewId));
+        createTestView(ns, viewName);
+        assertTrue(catalog.viewExists(viewId));
+    }
+
+    @Test
+    void testDropView() {
+        Namespace ns = createTestNamespace("view_drop");
+        String viewName = uniqueName("drop_view");
+        TableIdentifier viewId = TableIdentifier.of(ns, viewName);
+        catalog.buildView(viewId)
+                .withSchema(simpleSchema())
+                .withQuery("spark", "SELECT 1")
+                .withDefaultNamespace(ns)
+                .create();
+        // Don't track since we drop manually
+
+        assertTrue(catalog.dropView(viewId));
+        assertFalse(catalog.viewExists(viewId));
+    }
+
+    @Test
+    void testRenameView() {
+        Namespace ns = createTestNamespace("view_rename");
+        String originalName = uniqueName("orig_view");
+        String newName = uniqueName("renamed_view");
+        TableIdentifier originalId = TableIdentifier.of(ns, originalName);
+        TableIdentifier newId = TableIdentifier.of(ns, newName);
+
+        catalog.buildView(originalId)
+                .withSchema(simpleSchema())
+                .withQuery("spark", "SELECT 1")
+                .withDefaultNamespace(ns)
+                .create();
+        // Track the new name for cleanup
+        createdViews.push(newId);
+
+        catalog.renameView(originalId, newId);
+        assertFalse(catalog.viewExists(originalId));
+        assertTrue(catalog.viewExists(newId));
+    }
+
+    @Test
+    void testRenameViewAcrossNamespaces() {
+        Namespace ns1 = createTestNamespace("view_ren_src");
+        Namespace ns2 = createTestNamespace("view_ren_dst");
+        String viewName = uniqueName("cross_view");
+        TableIdentifier srcId = TableIdentifier.of(ns1, viewName);
+        TableIdentifier dstId = TableIdentifier.of(ns2, viewName);
+
+        catalog.buildView(srcId)
+                .withSchema(simpleSchema())
+                .withQuery("spark", "SELECT 1")
+                .withDefaultNamespace(ns1)
+                .create();
+        createdViews.push(dstId);
+
+        catalog.renameView(srcId, dstId);
+        assertFalse(catalog.viewExists(srcId));
+        assertTrue(catalog.viewExists(dstId));
+    }
+
+    @Test
+    void testViewProperties() {
+        Namespace ns = createTestNamespace("view_props");
+        String viewName = uniqueName("props_view");
+        TableIdentifier viewId = TableIdentifier.of(ns, viewName);
+
+        catalog.buildView(viewId)
+                .withSchema(simpleSchema())
+                .withQuery("spark", "SELECT 1")
+                .withDefaultNamespace(ns)
+                .withProperty("custom.key", "custom_value")
+                .create();
+        createdViews.push(viewId);
+
+        View loaded = catalog.loadView(viewId);
+        assertEquals("custom_value", loaded.properties().get("custom.key"));
+
+        loaded.updateProperties()
+                .set("new.key", "new_value")
+                .commit();
+
+        View reloaded = catalog.loadView(viewId);
+        assertEquals("new_value", reloaded.properties().get("new.key"));
+    }
+
+    @Test
+    void testReplaceViewVersion() {
+        Namespace ns = createTestNamespace("view_replace");
+        String viewName = uniqueName("replace_view");
+        TableIdentifier viewId = TableIdentifier.of(ns, viewName);
+
+        View view = catalog.buildView(viewId)
+                .withSchema(simpleSchema())
+                .withQuery("spark", "SELECT * FROM t1")
+                .withDefaultNamespace(ns)
+                .create();
+        createdViews.push(viewId);
+
+        int originalVersionId = view.currentVersion().versionId();
+
+        // Replace the view version with a new SQL query
+        view.replaceVersion()
+                .withSchema(simpleSchema())
+                .withQuery("spark", "SELECT * FROM t2 WHERE id > 0")
+                .withDefaultNamespace(ns)
+                .commit();
+
+        View reloaded = catalog.loadView(viewId);
+        assertTrue(reloaded.currentVersion().versionId() > originalVersionId,
+                "New version should have a higher version ID");
+    }
+
+    @Test
+    void testDropNonEmptyNamespaceWithViewFails() {
+        Namespace ns = createTestNamespace("view_nonempty");
+        createTestView(ns, uniqueName("blocker_view"));
+
+        assertThrows(NamespaceNotEmptyException.class, () -> catalog.dropNamespace(ns));
+    }
+
+    @Test
+    void testLoadNonExistentView() {
+        Namespace ns = createTestNamespace("view_err");
+        TableIdentifier nonExistent = TableIdentifier.of(ns, "does_not_exist");
+
+        assertThrows(NoSuchViewException.class, () -> catalog.loadView(nonExistent));
     }
 }


### PR DESCRIPTION
## Summary
- Implements all 7 Iceberg View REST endpoints: list, create, load, exists, drop, replace (commit), and rename views
- Adds `ViewRequirementValidator` for `assert-create` and `assert-view-uuid` commit requirements
- Adds `ViewUpdateApplicator` for view-specific updates (`add-view-version`, `assign-uuid`, `add-schema`, `set-location`, `set-properties`, `remove-properties`, `upgrade-format-version`)
- Views are stored as `ICEBERG_VIEW` artifacts following the same patterns as existing table implementation
- Updates OpenAPI specification with view endpoints and schemas (`CreateViewRequest`, `ViewMetadata`, `LoadViewResponse`, `CommitViewRequest`, `ViewVersion`, `ViewRepresentation`)
- Removes "Views are not supported" limitation from documentation

Closes #7260

## Test plan
- [x] All 23 Iceberg API tests pass (16 existing table tests + 6 new view tests + 1 config test)
- [x] Verify view lifecycle: create namespace, create view, list views, load view, check exists, drop view
- [x] Verify view rename across namespaces
- [x] Verify replaceView with add-view-version updates current-version-id
- [x] Verify assert-view-uuid requirement succeeds with correct UUID and fails with wrong UUID (409)
- [ ] Verify namespace with views cannot be dropped (409)