### PR TITLE
refactor(ci): remove pre-release functionality from release workflows

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -10,7 +10,7 @@ on:
         required: true
         default: 'all'
   release:
-    types: [released, prereleased]
+    types: [released]
 
 permissions:
   id-token: write

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -6,7 +6,7 @@ on:
         description: 'Release tag name'
         required: true
   release:
-    types: [ released, prereleased ]
+    types: [ released ]
 
 
 env:
@@ -21,8 +21,6 @@ jobs:
     if: github.repository_owner == 'Apicurio' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '3.'))
     runs-on: ubuntu-22.04
     timeout-minutes: 120
-    env:
-      RELEASE_TYPE: release
     steps:
       - name: View Disk Usage
         run: df -h
@@ -55,12 +53,6 @@ jobs:
           touch release.json && curl https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${{ github.event.inputs.tag }} > release.json
           echo "RELEASE_VERSION=$(cat release.json | jq -r '.name')" >> $GITHUB_ENV
           echo "BRANCH=$(cat release.json | jq -r '.target_commitish')" >> $GITHUB_ENV
-
-      - name: Determine Release Type
-        if: "contains(env.RELEASE_VERSION, 'RC')"
-        run: |
-          echo "This is a pre-release. Setting 'RELEASE_TYPE' to 'pre-release'"
-          echo "RELEASE_TYPE=pre-release" >> $GITHUB_ENV
 
       - name: Download Source Code
         run: git clone --branch $RELEASE_VERSION --single-branch ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git registry

--- a/.github/workflows/release-milestones.yaml
+++ b/.github/workflows/release-milestones.yaml
@@ -6,7 +6,7 @@ on:
         description: 'Release tag name'
         required: true
   release:
-    types: [released, prereleased]
+    types: [released]
 
 
 env:

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -11,7 +11,7 @@ on:
         default: true
 
   release:
-    types: [ released, prereleased ] # TODO: What to do with pre-release?
+    types: [ released ]
 
 env:
   RELEASE_VERSION: ${{ github.event.release.name }}
@@ -32,14 +32,6 @@ jobs:
           echo "RELEASE_VERSION=$(cat release.json | jq -r '.name')" >> $GITHUB_ENV
           echo "BRANCH=$(cat release.json | jq -r '.target_commitish')" >> $GITHUB_ENV
           echo "RUN_TESTS=${{ github.event.inputs.run_tests }}" >> $GITHUB_ENV
-
-      - name: Check release type
-        if: contains(env.RELEASE_VERSION, 'RC')
-        run: |
-          # TODO: Figure out what pre-release operator looks like. Maybe just skip OperatorHub?
-          # We we would have to remove the pre-release version from standard-release catalog.
-          echo "Operator cannot be released as part of a pre-release version yet."
-          exit 1
 
       - name: Download Source Code
         run: |

--- a/.github/workflows/release-release-notes.yaml
+++ b/.github/workflows/release-release-notes.yaml
@@ -6,7 +6,7 @@ on:
         description: 'Release tag name'
         required: true
   release:
-    types: [ released, prereleased ]
+    types: [ released ]
 
 
 env:

--- a/.github/workflows/release-sdks.yaml
+++ b/.github/workflows/release-sdks.yaml
@@ -10,7 +10,7 @@ on:
         required: true
         default: 'all'
   release:
-    types: [released, prereleased]
+    types: [released]
 
 permissions:
   id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -270,8 +270,6 @@ jobs:
     needs: [release-build-app, release-build-ui, release-build-cli]
     if: github.repository_owner == 'Apicurio'
     runs-on: ubuntu-22.04
-    env:
-      IS_PRE_RELEASE: false
     steps:
       - name: Download Release Artifacts
         uses: actions/download-artifact@v4
@@ -299,20 +297,13 @@ jobs:
             fi
           done
 
-      - name: Determine Release Type
-        if: "contains(github.event.inputs.release-version, 'RC')"
-        run: |
-          echo "This is a pre-release. Setting environment variable 'IS_PRE_RELEASE' to true"
-          echo "IS_PRE_RELEASE=true" >> $GITHUB_ENV
-
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ github.event.inputs.release-version }}
           tag_name: ${{ github.event.inputs.release-version }}
           token: ${{ secrets.ACCESS_TOKEN }}
           target_commitish: ${{ needs.release-prepare.outputs.release-sha }}
-          prerelease: ${{ env.IS_PRE_RELEASE }}
           files: |
             artifacts/*
             cli-zips/*


### PR DESCRIPTION
## Summary
- Remove `prereleased` trigger type from all release workflows (artifacts, images, milestones, operator, release-notes, SDKs)
- Remove pre-release detection logic (`IS_PRE_RELEASE`, `RELEASE_TYPE`, RC version checks) from `release.yaml`, `release-images.yaml`, and `release-operator.yaml`
- Update `softprops/action-gh-release` from pinned hash to `@v2`

## Test plan
- [ ] Verify release workflows pass YAML validation
- [ ] Confirm next release triggers all downstream workflows correctly via `released` event