### PR TITLE
fix(build): ensure all modules use the project checkstyle config

### DIFF
--- a/docs/config-generator/pom.xml
+++ b/docs/config-generator/pom.xml
@@ -14,6 +14,10 @@
     <name>apicurio-registry-config-generator</name>
     <description>Configuration documentation generator</description>
 
+    <properties>
+        <projectRoot>${project.basedir}/../..</projectRoot>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.apicurio</groupId>

--- a/examples/debezium-otel-tracing/debezium-converter/pom.xml
+++ b/examples/debezium-otel-tracing/debezium-converter/pom.xml
@@ -14,6 +14,7 @@
   <description>Custom Debezium SMT with OpenTelemetry instrumentation for trace context propagation</description>
 
   <properties>
+    <projectRoot>${project.basedir}/../../..</projectRoot>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/kafka-order-processing/order-consumer/pom.xml
+++ b/examples/kafka-order-processing/order-consumer/pom.xml
@@ -16,6 +16,10 @@
     <name>Order Consumer Application</name>
     <description>Quarkus application that consumes order events from Kafka</description>
 
+    <properties>
+        <projectRoot>${project.basedir}/../../..</projectRoot>
+    </properties>
+
     <dependencies>
         <!-- Quarkus -->
         <dependency>

--- a/examples/kafka-order-processing/order-producer/pom.xml
+++ b/examples/kafka-order-processing/order-producer/pom.xml
@@ -16,6 +16,10 @@
     <name>Order Producer Application</name>
     <description>Quarkus application that produces order events to Kafka</description>
 
+    <properties>
+        <projectRoot>${project.basedir}/../../..</projectRoot>
+    </properties>
+
     <dependencies>
         <!-- Quarkus -->
         <dependency>

--- a/examples/kafka-order-processing/order-schema/pom.xml
+++ b/examples/kafka-order-processing/order-schema/pom.xml
@@ -16,6 +16,10 @@
     <name>Order Schema Module</name>
     <description>Avro schema definitions for order processing</description>
 
+    <properties>
+        <projectRoot>${project.basedir}/../../..</projectRoot>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/examples/kafka-order-processing/pom.xml
+++ b/examples/kafka-order-processing/pom.xml
@@ -23,6 +23,7 @@
     </modules>
 
     <properties>
+        <projectRoot>${project.basedir}/../..</projectRoot>
         <quarkus.version>3.27.0</quarkus.version>
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <maven.compiler.release>17</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -1208,6 +1208,14 @@
             <version>${version.puppycrawl}</version>
           </dependency>
         </dependencies>
+        <configuration>
+          <configLocation>${projectRoot}/.checkstyle/simple.xml</configLocation>
+          <headerLocation>${projectRoot}/.checkstyle/java.header</headerLocation>
+          <suppressionsLocation>${projectRoot}/.checkstyle/suppressions.xml</suppressionsLocation>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+          <consoleOutput>true</consoleOutput>
+          <failsOnError>true</failsOnError>
+        </configuration>
         <executions>
           <execution>
             <id>validate</id>
@@ -1215,14 +1223,6 @@
               <goal>check</goal>
             </goals>
             <phase>validate</phase>
-            <configuration>
-              <configLocation>.checkstyle/simple.xml</configLocation>
-              <headerLocation>.checkstyle/java.header</headerLocation>
-              <suppressionsLocation>.checkstyle/suppressions.xml</suppressionsLocation>
-              <includeTestSourceDirectory>true</includeTestSourceDirectory>
-              <consoleOutput>true</consoleOutput>
-              <failsOnError>true</failsOnError>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Summary

- Move checkstyle `<configuration>` from execution-level to plugin-level in the root pom so it applies to both lifecycle-bound (`./mvnw validate`) and direct CLI invocations (`./mvnw checkstyle:check -pl <module>`)

## Problem

The checkstyle config (`simple.xml`) was nested inside the `<execution>` block, so only the `validate` phase used it. Running `./mvnw checkstyle:check -pl <module>` directly fell back to the plugin's built-in Sun/Oracle defaults (`sun_checks.xml`), which enforce javadoc, 80-char line limits, final parameters, etc. — rules the project doesn't intend to enforce.

This also affected the `.claude/hooks/checkstyle-before-commit.sh` hook, which blocked commits with spurious violations.

## Test plan

- [x] `./mvnw checkstyle:check -pl cli` — passes (was failing before)
- [x] `./mvnw checkstyle:check -pl app` — passes (was failing before)
- [x] `./mvnw validate -pl cli,app,common` — still passes
- [ ] CI checks pass

Closes #7662.