### PR TITLE
fix(references): eliminate duplicate recursive calls and add GAV deduplication in resolveReferences

### DIFF
--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
@@ -8,6 +8,7 @@ import io.apicurio.registry.resolver.client.RegistryClientFacadeFactory;
 import io.apicurio.registry.resolver.client.RegistryVersionCoordinates;
 import io.apicurio.registry.resolver.config.SchemaResolverConfig;
 import io.apicurio.registry.resolver.data.Record;
+import io.apicurio.registry.resolver.strategy.ArtifactCoordinates;
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
 import io.apicurio.registry.resolver.strategy.ArtifactReferenceResolverStrategy;
 import io.apicurio.registry.resolver.utils.Utils;
@@ -192,6 +193,20 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
     }
 
     protected Map<String, ParsedSchema<S>> resolveReferences(List<RegistryArtifactReference> artifactReferences) {
+        return resolveReferences(artifactReferences, new HashMap<>());
+    }
+
+    /**
+     * Resolves artifact references recursively, using a local deduplication cache to avoid
+     * redundant Registry API calls for the same groupId/artifactId/version across the
+     * resolution tree.
+     *
+     * @param artifactReferences the references to resolve
+     * @param gavCache local cache of already-resolved GAV lookups within this resolution pass
+     * @return map of reference name to parsed schema
+     */
+    private Map<String, ParsedSchema<S>> resolveReferences(List<RegistryArtifactReference> artifactReferences,
+                                                            Map<ArtifactCoordinates, ParsedSchema<S>> gavCache) {
         Map<String, ParsedSchema<S>> resolvedReferences = new HashMap<>();
 
         artifactReferences.forEach(reference -> {
@@ -199,18 +214,33 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
             String artifactId = reference.getArtifactId();
             String version = reference.getVersion();
 
+            ArtifactCoordinates coords = ArtifactCoordinates.builder()
+                    .groupId(groupId).artifactId(artifactId).version(version).build();
+
+            // Check the local deduplication cache first
+            ParsedSchema<S> cached = gavCache.get(coords);
+            if (cached != null) {
+                resolvedReferences.put(reference.getName(), cached);
+                return;
+            }
+
             final String referenceContent = this.clientFacade.getSchemaByGAV(groupId, artifactId, version);
             final List<RegistryArtifactReference> referenceReferences =
                     this.clientFacade.getReferencesByGAV(groupId, artifactId, version);
 
             if (!referenceReferences.isEmpty()) {
-                final Map<String, ParsedSchema<S>> nestedReferences = resolveReferences(referenceReferences);
+                final Map<String, ParsedSchema<S>> nestedReferences =
+                        resolveReferences(referenceReferences, gavCache);
                 resolvedReferences.putAll(nestedReferences);
-                resolvedReferences.put(reference.getName(), parseSchemaFromStream(reference.getName(),
-                        referenceContent, resolveReferences(referenceReferences)));
+                ParsedSchema<S> parsed = parseSchemaFromStream(reference.getName(),
+                        referenceContent, nestedReferences);
+                resolvedReferences.put(reference.getName(), parsed);
+                gavCache.put(coords, parsed);
             } else {
-                resolvedReferences.put(reference.getName(),
-                        parseSchemaFromStream(reference.getName(), referenceContent, Collections.emptyMap()));
+                ParsedSchema<S> parsed = parseSchemaFromStream(reference.getName(),
+                        referenceContent, Collections.emptyMap());
+                resolvedReferences.put(reference.getName(), parsed);
+                gavCache.put(coords, parsed);
             }
         });
         return resolvedReferences;

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/AbstractSchemaResolverTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/AbstractSchemaResolverTest.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.resolver;
 
+import io.apicurio.registry.resolver.client.RegistryArtifactReference;
 import io.apicurio.registry.resolver.config.SchemaResolverConfig;
 import io.apicurio.registry.resolver.data.Record;
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -61,6 +63,106 @@ public class AbstractSchemaResolverTest {
 
             assertTrue(resolver.schemaCache.isCacheLatest());
         }
+    }
+
+    @Test
+    void testResolveReferencesDoesNotDuplicateRecursiveCalls() throws Exception {
+        // Set up a schema with one reference that itself has a nested reference.
+        // Without the fix, the nested reference would be resolved twice per level.
+        MockRegistryClientFacade mockFacade = new MockRegistryClientFacade("{\"type\":\"string\"}");
+
+        // nested-ref has no further references (leaf)
+        // parent-ref -> nested-ref
+        RegistryArtifactReference nestedRef = RegistryArtifactReference.builder()
+                .name("nested-ref").groupId("default").artifactId("nested-artifact").version("1").build();
+        mockFacade.addReferencesByGAV("default", "parent-artifact", "1", List.of(nestedRef));
+
+        RegistryArtifactReference parentRef = RegistryArtifactReference.builder()
+                .name("parent-ref").groupId("default").artifactId("parent-artifact").version("1").build();
+
+        try (TestAbstractSchemaResolver<String, Object> resolver = createResolver(mockFacade)) {
+            Map<String, ParsedSchema<String>> result = resolver.resolveReferences(List.of(parentRef));
+
+            // Should contain both the parent and nested reference
+            assertEquals(2, result.size());
+            assertTrue(result.containsKey("parent-ref"));
+            assertTrue(result.containsKey("nested-ref"));
+
+            // Each GAV should be fetched exactly once:
+            // parent-artifact (1 call) + nested-artifact (1 call) = 2 calls each
+            assertEquals(2, mockFacade.getGetSchemaByGAVCallCount(),
+                    "Each unique GAV should be fetched exactly once");
+            assertEquals(2, mockFacade.getGetReferencesByGAVCallCount(),
+                    "References for each unique GAV should be fetched exactly once");
+        }
+    }
+
+    @Test
+    void testResolveReferencesDeduplicatesSharedReferences() throws Exception {
+        // Two top-level references both point to the same nested reference.
+        // The shared nested reference should only be fetched once.
+        MockRegistryClientFacade mockFacade = new MockRegistryClientFacade("{\"type\":\"string\"}");
+
+        RegistryArtifactReference sharedRef = RegistryArtifactReference.builder()
+                .name("shared-ref").groupId("default").artifactId("shared-artifact").version("1").build();
+
+        // Both parent-a and parent-b reference the same shared-ref
+        mockFacade.addReferencesByGAV("default", "parent-a", "1", List.of(sharedRef));
+        mockFacade.addReferencesByGAV("default", "parent-b", "1", List.of(sharedRef));
+
+        RegistryArtifactReference parentA = RegistryArtifactReference.builder()
+                .name("parent-a-ref").groupId("default").artifactId("parent-a").version("1").build();
+        RegistryArtifactReference parentB = RegistryArtifactReference.builder()
+                .name("parent-b-ref").groupId("default").artifactId("parent-b").version("1").build();
+
+        try (TestAbstractSchemaResolver<String, Object> resolver = createResolver(mockFacade)) {
+            Map<String, ParsedSchema<String>> result = resolver.resolveReferences(
+                    List.of(parentA, parentB));
+
+            // Should contain parent-a-ref, parent-b-ref, and shared-ref
+            assertEquals(3, result.size());
+            assertTrue(result.containsKey("parent-a-ref"));
+            assertTrue(result.containsKey("parent-b-ref"));
+            assertTrue(result.containsKey("shared-ref"));
+
+            // 3 unique GAVs: parent-a, parent-b, shared-artifact
+            // shared-artifact should only be fetched once despite being referenced twice
+            assertEquals(3, mockFacade.getGetSchemaByGAVCallCount(),
+                    "Shared reference should only be fetched once");
+            assertEquals(3, mockFacade.getGetReferencesByGAVCallCount(),
+                    "References for shared GAV should only be fetched once");
+        }
+    }
+
+    private TestAbstractSchemaResolver<String, Object> createResolver(MockRegistryClientFacade mockFacade) {
+        Map<String, String> configs = Collections.singletonMap(SchemaResolverConfig.REGISTRY_URL,
+                "http://localhost");
+        SchemaParser<String, Object> parser = new SchemaParser<>() {
+            @Override
+            public String artifactType() {
+                return "JSON";
+            }
+
+            @Override
+            public String parseSchema(byte[] rawSchema,
+                                       Map<String, ParsedSchema<String>> resolvedReferences) {
+                return new String(rawSchema);
+            }
+
+            @Override
+            public ParsedSchema<String> getSchemaFromData(Record<Object> data) {
+                return null;
+            }
+
+            @Override
+            public ParsedSchema<String> getSchemaFromData(Record<Object> data, boolean dereference) {
+                return null;
+            }
+        };
+        TestAbstractSchemaResolver<String, Object> resolver = new TestAbstractSchemaResolver<>();
+        resolver.setClientFacade(mockFacade);
+        resolver.configure(configs, parser);
+        return resolver;
     }
 
     class TestAbstractSchemaResolver<SCHEMA, DATA> extends AbstractSchemaResolver<SCHEMA, DATA> {

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/MockRegistryClientFacade.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/MockRegistryClientFacade.java
@@ -5,7 +5,9 @@ import io.apicurio.registry.resolver.client.RegistryClientFacade;
 import io.apicurio.registry.resolver.client.RegistryVersionCoordinates;
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -19,9 +21,31 @@ public class MockRegistryClientFacade implements RegistryClientFacade {
     private final AtomicInteger createSchemaCallCount = new AtomicInteger(0);
     private final AtomicInteger searchVersionsCallCount = new AtomicInteger(0);
     private final AtomicInteger getSchemaByGlobalIdCallCount = new AtomicInteger(0);
+    private final AtomicInteger getSchemaByGAVCallCount = new AtomicInteger(0);
+    private final AtomicInteger getReferencesByGAVCallCount = new AtomicInteger(0);
+
+    /** Optional per-GAV reference responses for testing nested references. */
+    private Map<String, List<RegistryArtifactReference>> referencesByGAV = new HashMap<>();
 
     public MockRegistryClientFacade(String schemaContent) {
         this.schemaContent = schemaContent;
+    }
+
+    /**
+     * Configures the mock to return the given references when queried for a specific GAV.
+     *
+     * @param groupId the group ID
+     * @param artifactId the artifact ID
+     * @param version the version
+     * @param references the references to return
+     */
+    public void addReferencesByGAV(String groupId, String artifactId, String version,
+                                    List<RegistryArtifactReference> references) {
+        referencesByGAV.put(gavKey(groupId, artifactId, version), references);
+    }
+
+    private static String gavKey(String groupId, String artifactId, String version) {
+        return groupId + "/" + artifactId + "/" + version;
     }
 
     public int getCreateSchemaCallCount() {
@@ -34,6 +58,14 @@ public class MockRegistryClientFacade implements RegistryClientFacade {
 
     public int getGetSchemaByGlobalIdCallCount() {
         return getSchemaByGlobalIdCallCount.get();
+    }
+
+    public int getGetSchemaByGAVCallCount() {
+        return getSchemaByGAVCallCount.get();
+    }
+
+    public int getGetReferencesByGAVCallCount() {
+        return getReferencesByGAVCallCount.get();
     }
 
     @Override
@@ -49,6 +81,7 @@ public class MockRegistryClientFacade implements RegistryClientFacade {
 
     @Override
     public String getSchemaByGAV(String groupId, String artifactId, String version) {
+        getSchemaByGAVCallCount.incrementAndGet();
         return schemaContent;
     }
 
@@ -69,7 +102,9 @@ public class MockRegistryClientFacade implements RegistryClientFacade {
 
     @Override
     public List<RegistryArtifactReference> getReferencesByGAV(String groupId, String artifactId, String version) {
-        return List.of();
+        getReferencesByGAVCallCount.incrementAndGet();
+        List<RegistryArtifactReference> refs = referencesByGAV.get(gavKey(groupId, artifactId, version));
+        return refs != null ? refs : List.of();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Fixed duplicate recursive call in `AbstractSchemaResolver.resolveReferences()` where
  `resolveReferences(referenceReferences)` was called twice per iteration — the second call now
  reuses the already-computed `nestedReferences` variable, preventing exponential API calls with
  reference depth.
- Added a local GAV deduplication cache (`Map<ArtifactCoordinates, ParsedSchema>`) threaded
  through recursive calls, so that the same groupId/artifactId/version is never fetched more
  than once within a single resolution tree.
- Added unit tests verifying both fixes: no duplicate recursive calls, and shared references
  across multiple parents are fetched exactly once.

## Related Issue
Fixes #7681

## Test Plan
- [ ] Run `./mvnw test -pl schema-resolver` to verify new and existing unit tests pass
- [ ] Run `./mvnw checkstyle:check -pl schema-resolver` to verify code style
- [ ] Run integration tests with schemas that have nested references to verify no regressions