### PR TITLE
fix(observability): make apicurio.log.level case-insensitive (#7680)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/DynamicLogConfigurationService.java
+++ b/app/src/main/java/io/apicurio/registry/services/DynamicLogConfigurationService.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 
+import java.util.Locale;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
@@ -94,7 +95,7 @@ public class DynamicLogConfigurationService {
      */
     private void applyLogLevel(String logLevel) {
         try {
-            Level level = Level.parse(logLevel);
+            Level level = Level.parse(logLevel.toUpperCase(Locale.ROOT));
             java.util.logging.Logger logger = java.util.logging.Logger.getLogger(APICURIO_LOGGER_NAME);
             logger.setLevel(level);
             log.debug("Set log level for {} to {}", APICURIO_LOGGER_NAME, logLevel);

--- a/app/src/test/java/io/apicurio/registry/services/DynamicLogConfigurationServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/DynamicLogConfigurationServiceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.services;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.logging.Level;
+
+/**
+ * Unit tests for the case-insensitive log level parsing used by
+ * {@link DynamicLogConfigurationService}.
+ */
+public class DynamicLogConfigurationServiceTest {
+
+    /**
+     * Verifies that uppercase log level values are parsed successfully.
+     */
+    @Test
+    public void testUppercaseLogLevels() {
+        String[] levels = {"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF", "ALL",
+                "SEVERE", "WARNING", "CONFIG", "FINE", "FINER", "FINEST"};
+        for (String level : levels) {
+            Assertions.assertDoesNotThrow(
+                    () -> Level.parse(level.toUpperCase(Locale.ROOT)),
+                    "Should parse uppercase level: " + level);
+        }
+    }
+
+    /**
+     * Verifies that lowercase log level values are parsed successfully
+     * after case normalization.
+     */
+    @Test
+    public void testLowercaseLogLevels() {
+        String[] levels = {"trace", "debug", "info", "warn", "error", "off", "all",
+                "severe", "warning", "config", "fine", "finer", "finest"};
+        for (String level : levels) {
+            Assertions.assertDoesNotThrow(
+                    () -> Level.parse(level.toUpperCase(Locale.ROOT)),
+                    "Should parse lowercase level: " + level);
+        }
+    }
+
+    /**
+     * Verifies that mixed-case log level values are parsed successfully
+     * after case normalization.
+     */
+    @Test
+    public void testMixedCaseLogLevels() {
+        String[] levels = {"Debug", "iNfO", "WaRn", "ErRoR", "TrAcE"};
+        for (String level : levels) {
+            Assertions.assertDoesNotThrow(
+                    () -> Level.parse(level.toUpperCase(Locale.ROOT)),
+                    "Should parse mixed-case level: " + level);
+        }
+    }
+
+    /**
+     * Verifies that invalid log level values still throw an exception.
+     */
+    @Test
+    public void testInvalidLogLevels() {
+        String[] levels = {"INVALID", "NOTAREALEVEL", "FOO"};
+        for (String level : levels) {
+            Assertions.assertThrows(
+                    IllegalArgumentException.class,
+                    () -> Level.parse(level.toUpperCase(Locale.ROOT)),
+                    "Should reject invalid level: " + level);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize the `apicurio.log.level` config value to uppercase before passing it to
  `java.util.logging.Level.parse()`, which requires uppercase level names
- Add unit tests verifying that lowercase, mixed-case, and uppercase log levels are all accepted

## Related Issue
Fixes #7680

## Test Plan
- [ ] Set `APICURIO_LOG_LEVEL=debug` (lowercase) and verify the application starts without errors
- [ ] Set `APICURIO_LOG_LEVEL=DeBuG` (mixed case) and verify it works
- [ ] Set `APICURIO_LOG_LEVEL=DEBUG` (uppercase) and verify it still works as before
- [ ] Run unit tests: `./mvnw test -pl app -Dtest=DynamicLogConfigurationServiceTest`