### PR TITLE
fix(ui): handle OIDC logout when provider lacks end_session_endpoint (#7650)

### DIFF
--- a/ui/ui-app/package-lock.json
+++ b/ui/ui-app/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "@apicurio/apicurio-registry-sdk": "3.2.2-Dev",
-        "@apicurio/common-ui-components": "4.0.1",
+        "@apicurio/common-ui-components": "4.0.2",
         "@apicurio/data-models": "1.1.33",
         "@microsoft/kiota-abstractions": "1.0.0-preview.99",
         "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.99",
@@ -91,9 +91,9 @@
       "link": true
     },
     "node_modules/@apicurio/common-ui-components": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@apicurio/common-ui-components/-/common-ui-components-4.0.1.tgz",
-      "integrity": "sha512-WhrBmFgcNI23k6Ljff6rNgrGkPUDAof1D5p/WSKqRbCKzJuegza5ysnHZH4noCHfoIaXC+iIlpwOJ82/lqDsrw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@apicurio/common-ui-components/-/common-ui-components-4.0.2.tgz",
+      "integrity": "sha512-CxmawobcuXUa0dWXJ2UYgdpk/T9MKdGbRUXxjY8u4SE5/bb7AN/R9VMw4+SAJQ8khgHq7OzLB5uievvxO1PAhg==",
       "peerDependencies": {
         "@patternfly/patternfly": "~6",
         "@patternfly/react-core": "~6",

--- a/ui/ui-app/package.json
+++ b/ui/ui-app/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@apicurio/apicurio-registry-sdk": "3.2.2-Dev",
-    "@apicurio/common-ui-components": "4.0.1",
+    "@apicurio/common-ui-components": "4.0.2",
     "@apicurio/data-models": "1.1.33",
     "@microsoft/kiota-abstractions": "1.0.0-preview.99",
     "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.99",


### PR DESCRIPTION
## Summary
- Upgrade `@apicurio/common-ui-components` from 4.0.1 to 4.0.2
- The new version adds a `.catch()` fallback in `signoutRedirect()` so that logout works gracefully
  with OIDC providers that don't expose `end_session_endpoint` (e.g. Dex)

## Related Issue
Fixes #7650
Upstream fix: Apicurio/apicurio-common-ui-components#268

## Test Plan
- [ ] Configure Apicurio Registry with an OIDC provider that lacks `end_session_endpoint` (e.g. Dex)
- [ ] Click Logout in the UI and verify the user is redirected (no unhandled error)
- [ ] Verify logout still works normally with providers that do support `end_session_endpoint` (e.g. Keycloak)