### PR TITLE
Support draft version content update in CLI. Fixes #7691

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
@@ -1,8 +1,8 @@
 package io.apicurio.registry.cli.artifact;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
-import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateVersion;
@@ -14,15 +14,10 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
 import static io.apicurio.registry.cli.artifact.ArtifactGetCommand.printArtifact;
-import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
 import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Conversions.convert;
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
@@ -120,7 +115,7 @@ public class ArtifactCreateCommand extends AbstractCommand {
         }
 
         if (!isBlank(file)) {
-            final var content = readContent(file);
+            final var content = FileUtils.readContent(file);
             final var firstVersion = new CreateVersion();
             if (!isBlank(version)) {
                 firstVersion.setVersion(version);
@@ -153,19 +148,6 @@ public class ArtifactCreateCommand extends AbstractCommand {
                         .append('\n');
             });
             exitQuietServerError();
-        }
-    }
-
-    // Reads content from a file path or stdin (when path is "-").
-    private static String readContent(final String file) {
-        try {
-            if ("-".equals(file)) {
-                return new String(System.in.readAllBytes(), StandardCharsets.UTF_8);
-            } else {
-                return Files.readString(Path.of(file));
-            }
-        } catch (IOException ex) {
-            throw new CliException("Could not read content from: " + file, ex, APPLICATION_ERROR_RETURN_CODE);
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/FileUtils.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/FileUtils.java
@@ -4,6 +4,7 @@ import io.apicurio.registry.cli.common.CliException;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -86,6 +87,19 @@ public final class FileUtils {
                 }
                 zis.closeEntry();
             }
+        }
+    }
+
+    // Reads content from a file path or stdin (when path is "-").
+    public static String readContent(final String file) {
+        try {
+            if ("-".equals(file)) {
+                return new String(System.in.readAllBytes(), StandardCharsets.UTF_8);
+            } else {
+                return Files.readString(Path.of(file));
+            }
+        } catch (IOException ex) {
+            throw new CliException("Could not read content from: " + file, ex, APPLICATION_ERROR_RETURN_CODE);
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionCreateCommand.java
@@ -2,8 +2,8 @@ package io.apicurio.registry.cli.version;
 
 import io.apicurio.registry.cli.artifact.ArtifactUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
-import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.Labels;
@@ -14,14 +14,9 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
 import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Conversions.convert;
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
@@ -121,7 +116,7 @@ public class VersionCreateCommand extends AbstractCommand {
             newVersion.setIsDraft(true);
         }
 
-        final var content = readContent(file);
+        final var content = FileUtils.readContent(file);
         final var versionContent = new VersionContent();
         versionContent.setContent(content);
         versionContent.setContentType(!isBlank(contentType) ? contentType : "application/json");
@@ -150,18 +145,6 @@ public class VersionCreateCommand extends AbstractCommand {
                         .append('\n');
             });
             exitQuietServerError();
-        }
-    }
-
-    private static String readContent(final String file) {
-        try {
-            if ("-".equals(file)) {
-                return new String(System.in.readAllBytes(), StandardCharsets.UTF_8);
-            } else {
-                return Files.readString(Path.of(file));
-            }
-        } catch (IOException ex) {
-            throw new CliException("Could not read content from: " + file, ex, APPLICATION_ERROR_RETURN_CODE);
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionUpdateCommand.java
@@ -2,10 +2,13 @@ package io.apicurio.registry.cli.version;
 
 import io.apicurio.registry.cli.artifact.ArtifactUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.EditableVersionMetaData;
 import io.apicurio.registry.rest.client.models.Labels;
 import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.rest.client.models.VersionState;
 import io.apicurio.registry.rest.client.models.WrappedVersionState;
 import picocli.CommandLine.Command;
@@ -15,13 +18,12 @@ import picocli.CommandLine.Parameters;
 import java.util.List;
 import java.util.Map;
 
-import io.apicurio.registry.cli.common.CliException;
-
 import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 
 /**
- * Updates a version's metadata (name, description, labels) and state.
+ * Updates a version's metadata (name, description, labels), state, and content.
  * Supports state transitions: ENABLED, DISABLED, DEPRECATED.
+ * Content update is only supported for draft versions.
  */
 @Command(
         name = "update",
@@ -78,10 +80,24 @@ public class VersionUpdateCommand extends AbstractCommand {
     )
     private List<String> deleteLabels;
 
+    @Option(
+            names = {"-f", "--file"},
+            description = "Path to the updated content file. Use '-' to read from stdin. " +
+                    "Only draft versions can have their content updated."
+    )
+    private String file;
+
+    @Option(
+            names = {"--content-type"},
+            description = "Content type of the version (e.g. application/json, application/x-protobuf). " +
+                    "Defaults to 'application/json' if not specified."
+    )
+    private String contentType;
+
     @Override
     public void run(final OutputBuffer output) throws Exception {
-        if (name == null && description == null && state == null && setLabels == null && deleteLabels == null) {
-            throw new CliException("At least one update option is required (--name, --description, --state, --set-label, or --delete-label).",
+        if (name == null && description == null && state == null && setLabels == null && deleteLabels == null && file == null) {
+            throw new CliException("At least one update option is required (--name, --description, --state, --set-label, --delete-label, or --file).",
                     CliException.VALIDATION_ERROR_RETURN_CODE);
         }
         final var resolvedGroupId = ArtifactUtil.resolveGroupId(groupId, config);
@@ -129,6 +145,15 @@ public class VersionUpdateCommand extends AbstractCommand {
                 final var wrappedState = new WrappedVersionState();
                 wrappedState.setState(state);
                 versionPath.state().put(wrappedState);
+            }
+
+            // Update content if provided (only works for draft versions)
+            if (file != null) {
+                final var content = FileUtils.readContent(file);
+                final var versionContent = new VersionContent();
+                versionContent.setContent(content);
+                versionContent.setContentType(contentType != null ? contentType : "application/json");
+                versionPath.content().put(versionContent);
             }
 
             output.writeStdOutChunk(out -> {

--- a/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
@@ -62,6 +62,7 @@ public abstract class AbstractCLITest {
                 .withEnv("APICURIO_REST_DELETION_GROUP_ENABLED", "true")
                 .withEnv("APICURIO_REST_DELETION_ARTIFACT_ENABLED", "true")
                 .withEnv("APICURIO_REST_DELETION_ARTIFACT_VERSION_ENABLED", "true")
+                .withEnv("APICURIO_REST_MUTABILITY_ARTIFACT_VERSION_CONTENT_ENABLED", "true")
                 .withExposedPorts(8080)
                 .waitingFor(Wait.forHttp("/apis/registry/v3/system/info")
                         .forStatusCode(200)

--- a/cli/src/test/java/io/apicurio/registry/cli/ArtifactVersionCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ArtifactVersionCommandTest.java
@@ -311,6 +311,49 @@ public class ArtifactVersionCommandTest extends AbstractCLITest {
 
     @Test
     @Order(12)
+    public void testVersionUpdateDraftContent() throws Exception {
+        // Update the draft version's content
+        Path tempFile = Files.createTempFile("updated-draft-content", ".json");
+        Files.writeString(tempFile, """
+                {"type": "number"}
+                """);
+
+        try {
+            executeAndAssertSuccess("artifact", "version", "update",
+                    "--group", "default", "--artifact", "version-test-artifact",
+                    "--file", tempFile.toString(), "3.0.0-draft");
+
+            // Verify content was updated
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("artifact", "version", "get", "--content",
+                    "--group", "default", "--artifact", "version-test-artifact", "3.0.0-draft");
+            assertThat(out.toString())
+                    .as(withCliOutput("Updated draft content should contain 'number'"))
+                    .contains("number");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    @Order(13)
+    public void testVersionUpdateContentNonDraft() throws Exception {
+        // Updating content on a non-draft version should fail
+        Path tempFile = Files.createTempFile("update-content-non-draft", ".json");
+        Files.writeString(tempFile, """
+                {"type": "string"}
+                """);
+        try {
+            executeAndAssertFailure("artifact", "version", "update",
+                    "--group", "default", "--artifact", "version-test-artifact",
+                    "--file", tempFile.toString(), "2.0.0");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    @Order(14)
     public void testVersionDelete() throws JsonProcessingException {
         executeAndAssertSuccess("artifact", "version", "delete",
                 "--group", "default", "--artifact", "version-test-artifact", "2.0.0");
@@ -325,7 +368,7 @@ public class ArtifactVersionCommandTest extends AbstractCLITest {
     }
 
     @Test
-    @Order(13)
+    @Order(15)
     public void testVersionUsesArtifactIdFromContext() throws Exception {
         // Create context with artifactId
         executeAndAssertSuccess("context", "delete", "--all");


### PR DESCRIPTION
## Summary                                                                                                                                                                                          
 
Add `--file` option to `acr artifact version update` for updating draft version content. Also extract `readContent` to `FileUtils` to eliminate duplication across create and update commands.      
                                                                                                                                                                                                  
## Changes

- Add `--file` and `--content-type` options to `VersionUpdateCommand` for content update
- Extract `readContent` method to `FileUtils` (removes duplication from `ArtifactCreateCommand`, `VersionCreateCommand`, and `VersionUpdateCommand`)
- Enable content mutability in test container
- Add tests for draft content update and non-draft content update rejection

## Usage

```bash
acr artifact version update -g myGroup -a myArtifact --file updated-schema.json 1.0.0-draft
cat updated-schema.json | acr artifact version update -g myGroup -a myArtifact --file - 1.0.0-draft
```

## Testing

- [x] All automated tests pass                                                                                                                                                                   
- [x] Manual verification:                                                                                                                                                                        
  - [x] Update draft content from file
  - [x] Update draft content from stdin
  - [x] Update content with --content-type
  - [x] Update content + metadata together
  - [x] Update content on non-draft version fails (ConflictException)
  - [x] Update with no options fails (validation error)

Closes #7691
