### PR TITLE
refactor(test): auto-configure test infra from groups, remove complex profiles

### DIFF
--- a/.github/workflows/verify-integration-tests.yaml
+++ b/.github/workflows/verify-integration-tests.yaml
@@ -28,8 +28,8 @@ jobs:
           - { storage: h2, name: default, remote-profile: remote-mem }
           - { storage: h2, groups: auth, remote-profile: remote-mem }
           - { storage: h2, groups: migration, remote-profile: remote-mem }
-          - { storage: h2, name: debezium, groups: 'debezium,debezium-snapshot,debezium-mysql,debezium-mysql-snapshot', profile: debezium-all, remote-profile: remote-mem }
-          - { storage: h2, groups: iceberg, profile: iceberg, remote-profile: remote-mem }
+          - { storage: h2, name: debezium, groups: 'debezium,debezium-snapshot,debezium-mysql,debezium-mysql-snapshot', remote-profile: remote-mem }
+          - { storage: h2, groups: iceberg, remote-profile: remote-mem }
           # postgresql storage
           - { storage: postgresql, name: default, remote-profile: remote-sql }
           - { storage: postgresql, groups: auth, remote-profile: remote-sql }
@@ -66,7 +66,6 @@ jobs:
         run: |
           ./mvnw verify -am --no-transfer-progress \
             -Pintegration-tests \
-            ${{ matrix.profile && format('-P{0}', matrix.profile) || '' }} \
             -P${{ matrix.remote-profile }} \
             ${{ matrix.groups && format('-Dgroups={0}', matrix.groups) || '' }} \
             -Dregistry-image=apicurio/apicurio-registry:${{ inputs.image-tag }} \

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -10,11 +10,11 @@ The integration-tests module is not built by default. To include it, activate th
 `-Pintegration-tests` profile. The project must be built first (`mvn clean install -DskipTests`).
 
 ```bash
-# Run default test groups (smoke + serdes + acceptance) with local app
-./mvnw verify -Pintegration-tests -Plocal-tests -pl integration-tests -am
+# Run default test groups (smoke + serdes + acceptance) locally
+./mvnw verify -Pintegration-tests -pl integration-tests -am
 
 # Run a specific test group
-./mvnw verify -Pintegration-tests -Plocal-tests -Dgroups=auth -pl integration-tests -am
+./mvnw verify -Pintegration-tests -Dgroups=auth -pl integration-tests -am
 
 # Run against a remote in-memory deployment (Kubernetes)
 ./mvnw verify -Pintegration-tests -Premote-mem -pl integration-tests -am
@@ -38,7 +38,7 @@ any extra infrastructure.
 | `smoke`                   | Basic functionality tests                        | None                    |
 | `serdes`                  | Serialization/deserialization and converter tests | None                    |
 | `acceptance`              | Acceptance tests                                 | None                    |
-| `iceberg`                 | Iceberg REST Catalog tests                       | None (needs feature flag, see `-Piceberg`) |
+| `iceberg`                 | Iceberg REST Catalog tests                       | None (auto-configured)  |
 | **Docker-based infrastructure** | | |
 | `auth`                    | Authentication tests                             | Docker (Keycloak)       |
 | `migration`               | Data migration between registry versions         | Docker (two registry instances) |
@@ -55,42 +55,55 @@ Multiple groups can be combined using JUnit 5 tag expressions:
 
 ```bash
 # Run smoke and auth tests
-./mvnw verify -Pintegration-tests -Plocal-tests -Dgroups="smoke | auth" -pl integration-tests -am
+./mvnw verify -Pintegration-tests -Dgroups="smoke | auth" -pl integration-tests -am
 ```
 
-## Deployment Profiles
+## Deployment Modes
 
-These profiles configure **how** the registry is deployed for testing:
+The integration tests support four ways to run the registry under test:
 
-| Profile               | Description                                      |
-|-----------------------|--------------------------------------------------|
-| `-Plocal-tests`       | Run the registry embedded in the test JVM via `@QuarkusIntegrationTest` |
-| `-Premote-mem`        | Deploy in-memory registry to a Kubernetes cluster |
-| `-Premote-sql`        | Deploy SQL registry to a Kubernetes cluster      |
-| `-Premote-kafka`      | Deploy KafkaSQL registry to a Kubernetes cluster |
-| `-Premote-kubernetesops` | Deploy via Kubernetes operator                |
+| Mode | How it works | Used by |
+|------|-------------|---------|
+| **Local JAR** (default) | `@QuarkusIntegrationTest` starts the app JAR as a separate process | Developers |
+| **Local Docker** | `@QuarkusIntegrationTest` runs a pre-built Docker image (automatic when container image was built with `-Dquarkus.container-image.build=true`) | Developers |
+| **Kubernetes** | `RegistryDeploymentManager` deploys the registry to a cluster via `-Premote-*` profiles | CI (minikube) |
+| **External** | Tests point at an already-running registry via `-Dquarkus.http.test-host` and `-Dquarkus.http.test-port` | Manual testing, OpenShift |
 
-When no deployment profile is specified, you can point tests at any running registry
-using `-Dquarkus.http.test-host` and `-Dquarkus.http.test-port`.
+The local JAR vs Docker distinction is handled automatically by the Quarkus test
+framework based on whether a container image was produced during the build.
 
-The `remote-*` profiles deploy Docker images to the cluster. The image can be overridden:
+### Kubernetes deployment profiles
+
+For Kubernetes mode, use one of the `remote-*` profiles to select the storage variant:
+
+| Profile                  | Storage variant deployed to the cluster |
+|--------------------------|-----------------------------------------|
+| `-Premote-mem`           | In-memory                               |
+| `-Premote-sql`           | PostgreSQL                              |
+| `-Premote-kafka`         | KafkaSQL                                |
+| `-Premote-kubernetesops` | Kubernetes operator                     |
+
+The registry Docker image is deployed to the cluster. The image can be overridden:
 
 ```bash
 ./mvnw verify -Pintegration-tests -Premote-mem \
-  -Dregistry-in-memory-image=apicurio/apicurio-registry:my-tag \
+  -Dregistry-image=apicurio/apicurio-registry:my-tag \
   -pl integration-tests -am
 ```
 
-## Special Profiles
+## Auto-configured Infrastructure
 
-Some test groups require infrastructure configuration beyond group selection.
-These are activated using Maven profiles:
+Some test groups require additional infrastructure or configuration beyond just
+group selection. `RegistryDeploymentManager` auto-detects the active groups and
+configures the test environment accordingly:
 
-| Profile          | Groups activated                                                          | Extra configuration                     |
-|------------------|---------------------------------------------------------------------------|----------------------------------------|
-| `-Pdebezium-all` | `debezium,debezium-snapshot,debezium-mysql,debezium-mysql-snapshot`        | Deploys all Debezium infrastructure    |
-| `-Piceberg`      | `iceberg`                                                                 | Enables experimental feature flags     |
-| `-Popenshift`    | *(none)*                                                                  | Enables OpenShift-specific resources   |
+| Group pattern | Auto-configuration |
+|---------------|-------------------|
+| `debezium*` | Deploys all Debezium infrastructure (Kafka, PostgreSQL, MySQL, Debezium Connect) |
+| `iceberg` | Enables experimental feature flags (`apicurio.iceberg.enabled`) |
+| `openshift` | Enables OpenShift-specific resources and routing |
+
+No special profiles are needed - just pass `-Dgroups=...` as usual.
 
 ## Helper Script
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -69,6 +69,21 @@
     </dependency>
     <dependency>
       <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-app</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-app</artifactId>
+      <type>test-jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>io.apicurio</groupId>
+          <artifactId>apicurio-registry-schema-util-provider</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-maven-plugin</artifactId>
       <type>maven-plugin</type>
       <scope>test</scope>
@@ -241,109 +256,77 @@
               </artifactItems>
             </configuration>
           </execution>
+          <execution>
+            <id>unpack-static-resources</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>apicurio-registry-app</artifactId>
+                  <version>${project.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>**/web.xml,**/application.properties</includes>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack-test-dependencies</id>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <phase>process-test-classes</phase>
+            <configuration>
+              <includeGroupIds>io.apicurio</includeGroupIds>
+              <includeTypes>test-jar</includeTypes>
+              <includeScope>test</includeScope>
+              <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
+              <includes>**/*IT.class, **/*.properties</includes>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <property>
+                  <name>quarkus.http.test-scheme</name>
+                  <value>${quarkus.http.test-scheme}</value>
+                </property>
+                <property>
+                  <name>quarkus.http.test-host</name>
+                  <value>${quarkus.http.test-host}</value>
+                </property>
+                <property>
+                  <name>quarkus.http.test-port</name>
+                  <value>${quarkus.http.test-port}</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
 
   <profiles>
-    <!-- Deployment profiles: configure how the registry is deployed for testing -->
-    <profile>
-      <id>local-tests</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.apicurio</groupId>
-          <artifactId>apicurio-registry-app</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>io.apicurio</groupId>
-          <artifactId>apicurio-registry-app</artifactId>
-          <type>test-jar</type>
-          <exclusions>
-            <exclusion>
-              <groupId>io.apicurio</groupId>
-              <artifactId>apicurio-registry-schema-util-provider</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>unpack-static-resources</id>
-                <goals>
-                  <goal>unpack</goal>
-                </goals>
-                <phase>generate-resources</phase>
-                <configuration>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>${project.groupId}</groupId>
-                      <artifactId>apicurio-registry-app</artifactId>
-                      <version>${project.version}</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <includes>**/web.xml,**/application.properties</includes>
-                    </artifactItem>
-                  </artifactItems>
-                  <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                  <overWriteReleases>false</overWriteReleases>
-                  <overWriteSnapshots>true</overWriteSnapshots>
-                </configuration>
-              </execution>
-              <execution>
-                <id>unpack-test-dependencies</id>
-                <goals>
-                  <goal>unpack-dependencies</goal>
-                </goals>
-                <phase>process-test-classes</phase>
-                <configuration>
-                  <includeGroupIds>io.apicurio</includeGroupIds>
-                  <includeTypes>test-jar</includeTypes>
-                  <includeScope>test</includeScope>
-                  <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                  <includes>**/*IT.class, **/*.properties</includes>
-                  <overWriteReleases>false</overWriteReleases>
-                  <overWriteSnapshots>true</overWriteSnapshots>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>properties-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>set-system-properties</goal>
-                </goals>
-                <configuration>
-                  <properties>
-                    <property>
-                      <name>quarkus.http.test-scheme</name>
-                      <value>${quarkus.http.test-scheme}</value>
-                    </property>
-                    <property>
-                      <name>quarkus.http.test-host</name>
-                      <value>${quarkus.http.test-host}</value>
-                    </property>
-                    <property>
-                      <name>quarkus.http.test-port</name>
-                      <value>${quarkus.http.test-port}</value>
-                    </property>
-                  </properties>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <!-- Remote deployment profiles -->
     <profile>
       <id>remote-mem</id>
@@ -457,81 +440,9 @@
       </build>
     </profile>
 
-    <!-- Complex test profiles: these configure infrastructure beyond just group selection (QW-5 will refactor these) -->
-    <profile>
-      <id>debezium-all</id>
-      <properties>
-        <groups>debezium,debezium-snapshot,debezium-mysql,debezium-mysql-snapshot</groups>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>integration-test</goal>
-                </goals>
-                <configuration>
-                  <systemPropertyVariables>
-                    <deployAllDebezium>true</deployAllDebezium>
-                  </systemPropertyVariables>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>iceberg</id>
-      <properties>
-        <groups>iceberg</groups>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>integration-test</goal>
-                </goals>
-                <configuration>
-                  <systemPropertyVariables>
-                    <quarkus.args>-Dapicurio.features.experimental.enabled=true -Dapicurio.iceberg.enabled=true</quarkus.args>
-                  </systemPropertyVariables>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>openshift</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>integration-test</goal>
-                </goals>
-                <configuration>
-                  <systemPropertyVariables>
-                    <openshift.resources>true</openshift.resources>
-                  </systemPropertyVariables>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
+    <!-- Infrastructure for debezium, iceberg, and openshift test groups
+         is auto-configured by RegistryDeploymentManager based on the
+         active -Dgroups value. No separate profiles needed. -->
 
   </profiles>
 </project>

--- a/integration-tests/src/main/java/io/apicurio/deployment/Constants.java
+++ b/integration-tests/src/main/java/io/apicurio/deployment/Constants.java
@@ -20,36 +20,21 @@ public final class Constants {
      */
     static final String REGISTRY_IMAGE = "registry-image";
 
-    /**
-     * Tag for auth tests profile.
-     */
-    static final String AUTH = "auth";
+    // ── JUnit 5 test group tag constants ──
 
-    /**
-     * Tag for kafkasql tests profile.
-     */
-    static final String KAFKA_SQL = "kafkasqlit";
-
-    /**
-     * Tag for kafkasql snapshotting tests profile.
-     */
-    static final String KAFKA_SQL_SNAPSHOTTING =
-            "kafkasql-snapshotting";
-
-    /**
-     * Tag for sql tests profile.
-     */
-    static final String SQL = "sqlit";
-
-    /**
-     * Tag for kubernetesops tests profile.
-     */
-    static final String KUBERNETES_OPS = "kubernetesops";
-
-    /**
-     * Tag for iceberg tests profile.
-     */
-    static final String ICEBERG = "iceberg";
+    public static final String SMOKE = "smoke";
+    public static final String SERDES = "serdes";
+    public static final String ACCEPTANCE = "acceptance";
+    public static final String MIGRATION = "migration";
+    public static final String AUTH = "auth";
+    public static final String KAFKA_SQL_SNAPSHOTTING = "kafkasql-snapshotting";
+    public static final String DEBEZIUM = "debezium";
+    public static final String DEBEZIUM_MYSQL = "debezium-mysql";
+    public static final String DEBEZIUM_SNAPSHOT = "debezium-snapshot";
+    public static final String DEBEZIUM_MYSQL_SNAPSHOT = "debezium-mysql-snapshot";
+    public static final String KUBERNETES_OPS = "kubernetesops";
+    public static final String ICEBERG = "iceberg";
+    public static final String SEARCH = "search";
 
     /**
      * Active test groups from the Maven groups property.

--- a/integration-tests/src/main/java/io/apicurio/deployment/package-info.java
+++ b/integration-tests/src/main/java/io/apicurio/deployment/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Deployment infrastructure for integration tests.
- */
-package io.apicurio.deployment;

--- a/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
@@ -56,6 +56,12 @@ public class RegistryDeploymentManager implements TestExecutionListener {
 
     @Override
     public void testPlanExecutionStarted(TestPlan testPlan) {
+        // Set quarkus.args for iceberg before Quarkus starts (must be a system property, read by the framework)
+        if (Constants.isGroupActive(Constants.ICEBERG)) {
+            System.setProperty("quarkus.args",
+                    "-Dapicurio.features.experimental.enabled=true -Dapicurio.iceberg.enabled=true");
+        }
+
         if (Boolean.parseBoolean(System.getProperty("cluster.tests"))) {
 
             kubernetesClient = new KubernetesClientBuilder().build();
@@ -132,27 +138,21 @@ public class RegistryDeploymentManager implements TestExecutionListener {
             testLogsIdentifier = "apicurio-registry-kubernetesops";
         }
 
-        // Deploy ALL Debezium infrastructure if requested (optimized for CI)
-        // This deploys everything once: Kafka + PostgreSQL + MySQL + both Debezium Connect variants
-        if (Boolean.parseBoolean(System.getProperty("deployAllDebezium"))) {
-            LOGGER.info(
-                    "Deploying ALL Debezium infrastructure (PostgreSQL + MySQL + both converter types) ##################################################");
+        // Deploy Debezium infrastructure based on active test groups.
+        // When all debezium groups are active, deploy everything at once (CI optimization).
+        // Otherwise, deploy only the infrastructure needed for the specific group.
+        boolean hasPostgres = Constants.isGroupActive(Constants.DEBEZIUM) || Constants.isGroupActive(Constants.DEBEZIUM_SNAPSHOT);
+        boolean hasMySQL = Constants.isGroupActive(Constants.DEBEZIUM_MYSQL) || Constants.isGroupActive(Constants.DEBEZIUM_MYSQL_SNAPSHOT);
+        boolean useLocalConverters = Constants.isGroupActive(Constants.DEBEZIUM_SNAPSHOT) || Constants.isGroupActive(Constants.DEBEZIUM_MYSQL_SNAPSHOT);
+
+        if (hasPostgres && hasMySQL) {
+            LOGGER.info("Deploying ALL Debezium infrastructure ##################################################");
             DebeziumDeploymentManager.deployAllDebeziumInfra();
-        }
-        // Deploy Debezium infrastructure if requested (for Debezium integration tests)
-        // Note: With idempotent deployment, multiple calls will reuse already-deployed infrastructure
-        else if (Boolean.parseBoolean(System.getProperty("deployDebezium"))) {
-            LOGGER.info(
-                    "Deploying Debezium PostgreSQL infrastructure ##################################################");
-            boolean useLocalConverters = Boolean.parseBoolean(System.getProperty("deployDebeziumLocalConverters"));
+        } else if (hasPostgres) {
+            LOGGER.info("Deploying Debezium PostgreSQL infrastructure ##################################################");
             DebeziumDeploymentManager.deployDebeziumInfra(useLocalConverters);
-        }
-        // Deploy Debezium MySQL infrastructure if requested (for MySQL Debezium integration tests)
-        // Note: With idempotent deployment, multiple calls will reuse already-deployed infrastructure
-        else if (Boolean.parseBoolean(System.getProperty("deployDebeziumMySQL"))) {
-            LOGGER.info(
-                    "Deploying Debezium MySQL infrastructure ##################################################");
-            boolean useLocalConverters = Boolean.parseBoolean(System.getProperty("deployDebeziumLocalConverters"));
+        } else if (hasMySQL) {
+            LOGGER.info("Deploying Debezium MySQL infrastructure ##################################################");
             DebeziumDeploymentManager.deployDebeziumMySQLInfra(useLocalConverters);
         }
     }
@@ -200,8 +200,8 @@ public class RegistryDeploymentManager implements TestExecutionListener {
     }
 
     static void setupTestNetworking() {
-        // For openshift, a route to the application is created we use it to set up the networking needs.
-        if (Boolean.parseBoolean(System.getProperty("openshift.resources"))) {
+        // For openshift, a route to the application is created and used for networking.
+        if (Constants.isGroupActive("openshift")) {
 
             OpenShiftClient openShiftClient = new DefaultOpenShiftClient();
 

--- a/integration-tests/src/test/java/io/apicurio/tests/auth/SimpleAuthIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/auth/SimpleAuthIT.java
@@ -20,7 +20,7 @@ import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.tests.KeycloakTestContainerManager;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Tag(Constants.AUTH)
+@Tag(AUTH)
 @QuarkusIntegrationTest
 public class SimpleAuthIT extends ApicurioRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
@@ -24,7 +24,7 @@ import io.apicurio.registry.utils.converter.json.PrettyFormatStrategy;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.utils.AvroGenericRecordSchemaFactory;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData.Record;
@@ -50,8 +50,8 @@ import static org.apache.kafka.connect.data.SchemaBuilder.int16;
 import static org.apache.kafka.connect.data.SchemaBuilder.string;
 import static org.apache.kafka.connect.data.SchemaBuilder.struct;
 
-@Tag(Constants.SERDES)
-@Tag(Constants.ACCEPTANCE)
+@Tag(SERDES)
+@Tag(ACCEPTANCE)
 @QuarkusIntegrationTest
 public class RegistryConverterIT extends ApicurioRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/kafkasql/KafkaSqlSnapshottingIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/kafkasql/KafkaSqlSnapshottingIT.java
@@ -1,14 +1,14 @@
 package io.apicurio.tests.kafkasql;
 
 import io.apicurio.tests.ApicurioRegistryBaseIT;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-@Tag(Constants.KAFKA_SQL_SNAPSHOTTING)
+@Tag(KAFKA_SQL_SNAPSHOTTING)
 public class KafkaSqlSnapshottingIT extends ApicurioRegistryBaseIT {
 
     private static final String NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID = "SNAPSHOT_TEST_GROUP_ID";

--- a/integration-tests/src/test/java/io/apicurio/tests/kubernetesops/KubernetesOpsIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/kubernetesops/KubernetesOpsIT.java
@@ -11,7 +11,7 @@ import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ReadOnlyRegistryBaseIT;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * The KubernetesOps storage is read-only: all data comes from ConfigMaps, and write
  * operations are not supported. These tests verify read operations only.
  */
-@Tag(Constants.KUBERNETES_OPS)
+@Tag(KUBERNETES_OPS)
 @QuarkusIntegrationTest
 public class KubernetesOpsIT extends ReadOnlyRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/migration/DataMigrationIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/migration/DataMigrationIT.java
@@ -8,7 +8,7 @@ import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.utils.AbstractTestDataInitializer;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.kiota.http.vertx.VertXRequestAdapter;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = DataMigrationIT.MigrateTestInitializer.class, restrictToAnnotatedClass = true)
-@Tag(Constants.MIGRATION)
+@Tag(MIGRATION)
 public class DataMigrationIT extends ApicurioRegistryBaseIT {
 
     private static final Logger log = LoggerFactory.getLogger(DataMigrationIT.class);

--- a/integration-tests/src/test/java/io/apicurio/tests/migration/DoNotPreserveIdsImportIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/migration/DoNotPreserveIdsImportIT.java
@@ -10,7 +10,7 @@ import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.serdes.apicurio.AvroGenericRecordSchemaFactory;
 import io.apicurio.tests.serdes.apicurio.JsonSchemaMsgFactory;
 import io.apicurio.tests.utils.AbstractTestDataInitializer;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.kiota.http.vertx.VertXRequestAdapter;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = DoNotPreserveIdsImportIT.DoNotPreserveIdsInitializer.class, restrictToAnnotatedClass = true)
-@Tag(Constants.MIGRATION)
+@Tag(MIGRATION)
 @Disabled
 public class DoNotPreserveIdsImportIT extends ApicurioRegistryBaseIT {
     private static final Logger log = LoggerFactory.getLogger(DataMigrationIT.class);

--- a/integration-tests/src/test/java/io/apicurio/tests/migration/GenerateCanonicalHashImportIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/migration/GenerateCanonicalHashImportIT.java
@@ -14,7 +14,7 @@ import io.apicurio.registry.utils.impexp.v3.ContentEntity;
 import io.apicurio.registry.utils.impexp.v3.EntityWriter;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.serdes.apicurio.JsonSchemaMsgFactory;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.kiota.http.vertx.VertXRequestAdapter;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.vertx.core.Vertx;
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusIntegrationTest
-@Tag(Constants.MIGRATION)
+@Tag(MIGRATION)
 @Disabled
 public class GenerateCanonicalHashImportIT extends ApicurioRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/search/SearchIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/search/SearchIT.java
@@ -9,7 +9,7 @@ import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
@@ -23,7 +23,7 @@ import java.util.Map;
  * They are excluded from normal test runs and can be executed via the {@code -Psearch} maven
  * profile or by selecting the {@code search} JUnit tag.
  */
-@Tag(Constants.SEARCH)
+@Tag(SEARCH)
 @QuarkusIntegrationTest
 public class SearchIT extends ApicurioRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/AvroSerdeIT.java
@@ -18,7 +18,7 @@ import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.registry.utils.tests.TooManyRequestsMock;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.common.serdes.TestObject;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.apicurio.tests.utils.KafkaFacade;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.avro.Schema;
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Tag(Constants.SERDES)
+@Tag(SERDES)
 @QuarkusIntegrationTest
 public class AvroSerdeIT extends ApicurioRegistryBaseIT {
 
@@ -60,7 +60,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testTopicIdStrategyFindLatest() throws Exception {
         String topicName = TestUtils.generateTopic();
         String artifactId = topicName + "-value";
@@ -83,7 +83,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testSimpleTopicIdStrategyFindLatest() throws Exception {
         String topicName = TestUtils.generateTopic();
         String artifactId = topicName;
@@ -157,7 +157,7 @@ public class AvroSerdeIT extends ApicurioRegistryBaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testTopicIdStrategyAutoRegister() throws Exception {
         String topicName = TestUtils.generateTopic();
         // because of using TopicIdStrategy

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/JsonSchemaSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/JsonSchemaSerdeIT.java
@@ -13,7 +13,7 @@ import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.common.serdes.json.InvalidMessage;
 import io.apicurio.tests.common.serdes.json.ValidMessage;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.apicurio.tests.utils.KafkaFacade;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.kafka.connect.json.JsonSerializer;
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-@Tag(Constants.SERDES)
+@Tag(SERDES)
 @QuarkusIntegrationTest
 public class JsonSchemaSerdeIT extends ApicurioRegistryBaseIT {
 
@@ -43,7 +43,7 @@ public class JsonSchemaSerdeIT extends ApicurioRegistryBaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testTopicIdStrategyFindLatest() throws Exception {
         String topicName = TestUtils.generateTopic();
         String artifactId = topicName + "-value";
@@ -81,7 +81,7 @@ public class JsonSchemaSerdeIT extends ApicurioRegistryBaseIT {
 
     // there is no mechanism for json serdes to auto register a schema, yet
     // @Test
-    // @Tag(Constants.ACCEPTANCE)
+    // @Tag(ACCEPTANCE)
     // void testTopicIdStrategyAutoRegister() throws Exception {
     // String topicName = TestUtils.generateTopic();
     // //because of using TopicIdStrategy

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/ProtobufSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/ProtobufSerdeIT.java
@@ -15,7 +15,7 @@ import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.common.serdes.proto.TestCmmn;
 import io.apicurio.tests.protobuf.ProtobufTestMessage;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.apicurio.tests.utils.KafkaFacade;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.AfterAll;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Tag(Constants.SERDES)
+@Tag(SERDES)
 @QuarkusIntegrationTest
 public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
 
@@ -44,7 +44,7 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testTopicIdStrategyFindLatest() throws Exception {
         String topicName = TestUtils.generateTopic();
         String artifactId = topicName + "-value";
@@ -325,7 +325,7 @@ public class ProtobufSerdeIT extends ApicurioRegistryBaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testTopicIdStrategyAutoRegister() throws Exception {
         String topicName = TestUtils.generateTopic();
         // because of using TopicIdStrategy

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SerdesPerformanceIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SerdesPerformanceIT.java
@@ -18,7 +18,7 @@ import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.common.serdes.json.ValidMessage;
 import io.apicurio.tests.common.serdes.proto.TestCmmn;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
@@ -48,7 +48,7 @@ import java.util.UUID;
  * - JSON Schema
  * - Protobuf
  */
-@Tag(Constants.SERDES)
+@Tag(SERDES)
 @QuarkusIntegrationTest
 public class SerdesPerformanceIT extends ApicurioRegistryBaseIT {
 
@@ -84,7 +84,7 @@ public class SerdesPerformanceIT extends ApicurioRegistryBaseIT {
     // ==================== AVRO TESTS ====================
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testAvroSerializerPerformance() throws Exception {
         String groupId = "avro-perf-test-serializer-" + UUID.randomUUID();
         String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";
@@ -106,7 +106,7 @@ public class SerdesPerformanceIT extends ApicurioRegistryBaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testAvroRoundTripPerformance() throws Exception {
         String groupId = "avro-perf-test-roundtrip-" + UUID.randomUUID();
         String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";
@@ -277,7 +277,7 @@ public class SerdesPerformanceIT extends ApicurioRegistryBaseIT {
     // ==================== JSON SCHEMA TESTS ====================
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testJsonSchemaSerializerPerformance() throws Exception {
         String groupId = "json-perf-test-serializer-" + UUID.randomUUID();
         String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";
@@ -302,7 +302,7 @@ public class SerdesPerformanceIT extends ApicurioRegistryBaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testJsonSchemaRoundTripPerformance() throws Exception {
         String groupId = "json-perf-test-roundtrip-" + UUID.randomUUID();
         String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";
@@ -474,7 +474,7 @@ public class SerdesPerformanceIT extends ApicurioRegistryBaseIT {
     // ==================== PROTOBUF TESTS ====================
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testProtobufSerializerPerformance() throws Exception {
         String groupId = "protobuf-perf-test-serializer-" + UUID.randomUUID();
         String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";
@@ -502,7 +502,7 @@ public class SerdesPerformanceIT extends ApicurioRegistryBaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testProtobufRoundTripPerformance() throws Exception {
         String groupId = "protobuf-perf-test-roundtrip-" + UUID.randomUUID();
         String apicurioArtifactId = TestUtils.generateSubject() + "-apicurio";

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroIntegrationIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroIntegrationIT.java
@@ -1,7 +1,7 @@
 package io.apicurio.tests.serdes.apicurio.debezium.mysql;
 
 import io.apicurio.tests.serdes.apicurio.debezium.DebeziumAvroV2DeserializerMixin;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.debezium.testing.testcontainers.DebeziumContainer;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -15,7 +15,7 @@ import org.testcontainers.containers.MySQLContainer;
  *
  * Tests schema auto-registration, evolution, MySQL data types, and CDC operations.
  */
-@Tag(Constants.DEBEZIUM_MYSQL)
+@Tag(DEBEZIUM_MYSQL)
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = DebeziumMySQLContainerResource.class, restrictToAnnotatedClass = true)
 public class DebeziumMySQLAvroIntegrationIT extends DebeziumMySQLAvroBaseIT

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroLocalConvertersIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroLocalConvertersIT.java
@@ -1,7 +1,7 @@
 package io.apicurio.tests.serdes.apicurio.debezium.mysql;
 
 import io.apicurio.tests.serdes.apicurio.debezium.DebeziumAvroV3DeserializerMixin;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.debezium.testing.testcontainers.DebeziumContainer;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -17,7 +17,7 @@ import org.testcontainers.containers.MySQLContainer;
  *
  * Tests schema auto-registration, evolution, MySQL data types, and CDC operations.
  */
-@Tag(Constants.DEBEZIUM_MYSQL_SNAPSHOT)
+@Tag(DEBEZIUM_MYSQL_SNAPSHOT)
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = DebeziumMySQLLocalConvertersResource.class, restrictToAnnotatedClass = true)
 public class DebeziumMySQLAvroLocalConvertersIT extends DebeziumMySQLAvroBaseIT

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroIntegrationIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroIntegrationIT.java
@@ -1,7 +1,7 @@
 package io.apicurio.tests.serdes.apicurio.debezium.postgresql;
 
 import io.apicurio.tests.serdes.apicurio.debezium.DebeziumAvroV2DeserializerMixin;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.debezium.testing.testcontainers.DebeziumContainer;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -16,7 +16,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
  * Tests schema auto-registration, evolution, PostgreSQL data types, and CDC
  * operations.
  */
-@Tag(Constants.DEBEZIUM)
+@Tag(DEBEZIUM)
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = DebeziumContainerResource.class, restrictToAnnotatedClass = true)
 public class DebeziumPostgreSQLAvroIntegrationIT extends DebeziumPostgreSQLAvroBaseIT

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroLocalConvertersIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroLocalConvertersIT.java
@@ -1,7 +1,7 @@
 package io.apicurio.tests.serdes.apicurio.debezium.postgresql;
 
 import io.apicurio.tests.serdes.apicurio.debezium.DebeziumAvroV3DeserializerMixin;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.debezium.testing.testcontainers.DebeziumContainer;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -22,7 +22,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
  * Tests schema auto-registration, evolution, PostgreSQL data types, and CDC
  * operations.
  */
-@Tag(Constants.DEBEZIUM_SNAPSHOT)
+@Tag(DEBEZIUM_SNAPSHOT)
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = DebeziumLocalConvertersResource.class, restrictToAnnotatedClass = true)
 public class DebeziumPostgreSQLAvroLocalConvertersIT extends DebeziumPostgreSQLAvroBaseIT

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/nats/AvroNatsSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/nats/AvroNatsSerdeIT.java
@@ -8,7 +8,7 @@ import io.apicurio.registry.serde.avro.nats.client.streaming.producers.NatsProdu
 import io.apicurio.registry.serde.avro.strategy.TopicRecordIdStrategy;
 import io.apicurio.registry.serde.config.SerdeConfig;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.nats.client.Connection;
 import io.nats.client.JetStreamApiException;
 import io.nats.client.JetStreamManagement;
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
 
-@Tag(Constants.SERDES)
+@Tag(SERDES)
 @QuarkusIntegrationTest
 public class AvroNatsSerdeIT extends ApicurioRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/pulsar/AvroPulsarSerdeIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/pulsar/AvroPulsarSerdeIT.java
@@ -10,7 +10,7 @@ import io.apicurio.registry.utils.IoUtil;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.serdes.apicurio.AvroGenericRecordSchemaFactory;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.apicurio.tests.utils.PulsarFacade;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.avro.generic.GenericRecord;
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Tag(Constants.SERDES)
+@Tag(SERDES)
 @QuarkusIntegrationTest
 public class AvroPulsarSerdeIT extends ApicurioRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
@@ -12,7 +12,6 @@ import io.apicurio.tests.serdes.apicurio.KafkaSerdesTester;
 import io.apicurio.tests.serdes.apicurio.SimpleSerdesTesterBuilder;
 import io.apicurio.tests.serdes.apicurio.WrongConfiguredSerdesTesterBuilder;
 import io.apicurio.tests.utils.AvroGenericRecordSchemaFactory;
-import io.apicurio.tests.utils.Constants;
 import io.apicurio.tests.utils.KafkaFacade;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
@@ -35,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.apicurio.tests.utils.Constants.SERDES;
+import static io.apicurio.deployment.Constants.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag(SERDES)
@@ -55,7 +54,7 @@ public class BasicConfluentSerDesIT extends ConfluentBaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testAvroConfluentSerDes() throws Exception {
         String topicName = TestUtils.generateTopic();
         String subjectName = topicName + "-value";
@@ -113,7 +112,7 @@ public class BasicConfluentSerDesIT extends ConfluentBaseIT {
     }
 
     @Test
-    @Tag(Constants.ACCEPTANCE)
+    @Tag(ACCEPTANCE)
     void testAvroConfluentSerDesFail() throws Exception {
         String topicName = TestUtils.generateTopic();
         String subjectName = "myrecordconfluent2";

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AgentCardIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AgentCardIT.java
@@ -1,5 +1,7 @@
 package io.apicurio.tests.smokeTests.apicurio;
 
+import static io.apicurio.deployment.Constants.*;
+
 import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateArtifactResponse;
 import io.apicurio.registry.rest.client.models.CreateRule;
@@ -17,8 +19,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static io.apicurio.tests.utils.Constants.ACCEPTANCE;
-import static io.apicurio.tests.utils.Constants.SMOKE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AllArtifactTypesIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AllArtifactTypesIT.java
@@ -1,5 +1,7 @@
 package io.apicurio.tests.smokeTests.apicurio;
 
+import static io.apicurio.deployment.Constants.*;
+
 import io.apicurio.registry.rest.client.models.CreateRule;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.IfArtifactExists;
@@ -22,7 +24,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static io.apicurio.tests.utils.Constants.SMOKE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
@@ -20,7 +20,7 @@ import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.apicurio.tests.utils.AvroGenericRecordSchemaFactory;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@Tag(Constants.SMOKE)
+@Tag(SMOKE)
 @QuarkusIntegrationTest
 class ArtifactsIT extends ApicurioRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/IcebergCatalogIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/IcebergCatalogIT.java
@@ -1,7 +1,7 @@
 package io.apicurio.tests.smokeTests.apicurio;
 
 import io.apicurio.tests.ApicurioRegistryBaseIT;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.PartitionSpec;
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Tag(Constants.ICEBERG)
+@Tag(ICEBERG)
 @QuarkusIntegrationTest
 class IcebergCatalogIT extends ApicurioRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/MetadataIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/MetadataIT.java
@@ -8,7 +8,7 @@ import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.hamcrest.number.OrderingComparison;
 import org.junit.jupiter.api.Tag;
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@Tag(Constants.SMOKE)
+@Tag(SMOKE)
 @QuarkusIntegrationTest
 class MetadataIT extends ApicurioRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ReferenceGraphIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ReferenceGraphIT.java
@@ -14,7 +14,7 @@ import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Integration tests for the Reference Graph API endpoint.
  */
-@Tag(Constants.SMOKE)
+@Tag(SMOKE)
 @QuarkusIntegrationTest
 class ReferenceGraphIT extends ApicurioRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
@@ -10,7 +10,7 @@ import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
-import io.apicurio.tests.utils.Constants;
+import static io.apicurio.deployment.Constants.*;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
@@ -26,7 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@Tag(Constants.SMOKE)
+@Tag(SMOKE)
 @QuarkusIntegrationTest
 class RulesResourceIT extends ApicurioRegistryBaseIT {
 

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/MetadataConfluentIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/MetadataConfluentIT.java
@@ -1,5 +1,7 @@
 package io.apicurio.tests.smokeTests.confluent;
 
+import static io.apicurio.deployment.Constants.*;
+
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ConfluentBaseIT;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
@@ -15,7 +17,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
-import static io.apicurio.tests.utils.Constants.SMOKE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/RulesResourceConfluentIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/RulesResourceConfluentIT.java
@@ -1,5 +1,7 @@
 package io.apicurio.tests.smokeTests.confluent;
 
+import static io.apicurio.deployment.Constants.*;
+
 import io.apicurio.registry.rest.client.models.RuleType;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.tests.ConfluentBaseIT;
@@ -14,7 +16,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-import static io.apicurio.tests.utils.Constants.SMOKE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag(SMOKE)

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
@@ -1,5 +1,7 @@
 package io.apicurio.tests.smokeTests.confluent;
 
+import static io.apicurio.deployment.Constants.*;
+
 import io.apicurio.registry.rest.client.models.CreateRule;
 import io.apicurio.registry.rest.client.models.Rule;
 import io.apicurio.registry.rest.client.models.RuleType;
@@ -29,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static io.apicurio.tests.utils.Constants.SMOKE;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/integration-tests/src/test/java/io/apicurio/tests/utils/Constants.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/utils/Constants.java
@@ -5,7 +5,7 @@ import java.nio.file.Paths;
 import java.time.Duration;
 
 /**
- * Interface for keep global constants used across system tests.
+ * Non-tag constants used across integration tests.
  */
 public interface Constants {
     long POLL_INTERVAL = Duration.ofSeconds(1).toMillis();
@@ -13,83 +13,9 @@ public interface Constants {
     long TIMEOUT_FOR_REGISTRY_READY = Duration.ofSeconds(30).toMillis();
     long TIMEOUT_GLOBAL = Duration.ofSeconds(30).toMillis();
 
-    /**
-     * Tag for tests, which are testing basic functionality
-     */
-    String SMOKE = "smoke";
-    /**
-     * Tag for tests, which are working with the cluster (integration of kafka with registries) such as serdes
-     * and converters
-     */
-    String SERDES = "serdes";
-    /**
-     * Tag for acceptance tests, less tests than smoke testing
-     */
-    String ACCEPTANCE = "acceptance";
-
-    /**
-     * Tag for migration tests, the suite will deploy two registries and perform data migration between the
-     * two
-     */
-    String MIGRATION = "migration";
-
-    /**
-     * Tag for auth tests, the suite will deploy apicurio registry with keycloak and verify the api is secured
-     */
-    String AUTH = "auth";
-
-    /**
-     * Tag for kafkasql snapshotting tests, the test will be executed only when the storage variant is
-     * kafkasql.
-     */
-    String KAFKA_SQL_SNAPSHOTTING = "kafkasql-snapshotting";
-
-    /**
-     * Tag for Debezium integration tests
-     */
-    String DEBEZIUM = "debezium";
-
-    /**
-     * Tag for Debezium integration tests
-     */
-    String DEBEZIUM_MYSQL = "debezium-mysql";
-
-    /**
-     * Tag for Debezium integration tests
-     */
-    String DEBEZIUM_SNAPSHOT = "debezium-snapshot";
-
-    /**
-     * Tag for Debezium mysql integration tests
-     */
-    String DEBEZIUM_MYSQL_SNAPSHOT = "debezium-mysql-snapshot";
-
-    /**
-     * Tag for kubernetesops tests, the test will be executed only when the storage variant is kubernetesops.
-     */
-    String KUBERNETES_OPS = "kubernetesops";
-
-    /**
-     * Tag for Iceberg REST Catalog integration tests
-     */
-    String ICEBERG = "iceberg";
-
-    /**
-     * Tag for search tests, requires Elasticsearch to be available and the search feature enabled
-     */
-    String SEARCH = "search";
-
     Path LOGS_DIR = Paths.get("target/logs/");
 
-    /**
-     * Env var name for mandating the testsuite to avoid using docker for running required infrastructure
-     */
-    public static final String NO_DOCKER_ENV_VAR = "NO_DOCKER";
-
-    /**
-     * Current CI environment running the testsuite
-     */
-    public static final String CURRENT_ENV = "CURRENT_ENV";
-    public static final String CURRENT_ENV_MAS_REGEX = ".*mas.*";
-
+    String NO_DOCKER_ENV_VAR = "NO_DOCKER";
+    String CURRENT_ENV = "CURRENT_ENV";
+    String CURRENT_ENV_MAS_REGEX = ".*mas.*";
 }


### PR DESCRIPTION
## Summary

Implements **QW-5** from #7628: remove complex integration test group profiles and replace them with auto-detection logic.

- Remove `debezium-all`, `iceberg`, `openshift`, and `local-tests` Maven profiles from `integration-tests/pom.xml`
- Refactor `RegistryDeploymentManager` to derive infrastructure needs (Debezium, Iceberg feature flags, OpenShift routing) from the active `-Dgroups=...` value
- Move `local-tests` profile configuration (app dependency, resource unpacking, system properties) into the default build so no extra profile is needed for local runs
- Consolidate all JUnit `@Tag` constants into `io.apicurio.deployment.Constants` (main scope), removing duplicates from `io.apicurio.tests.utils.Constants`
- Update CI workflow to stop passing `-P` profile references for debezium/iceberg
- Update `integration-tests/README.md` to document the new auto-configuration approach

**Before:** `mvn verify -Pintegration-tests -Pdebezium-all -Premote-mem ...`
**After:** `mvn verify -Pintegration-tests -Premote-mem -Dgroups="debezium,debezium-snapshot,debezium-mysql,debezium-mysql-snapshot" ...`

## Test plan

- [ ] CI integration test matrix passes (debezium, iceberg, default groups)
- [ ] Local test run works without `-Plocal-tests`: `./mvnw verify -Pintegration-tests -pl integration-tests -am`
- [ ] Verify `RegistryDeploymentManager` correctly deploys Debezium infra when groups contain debezium variants
- [ ] Verify iceberg tests get `quarkus.args` set for experimental feature flags