### PR TITLE
feat(operator): auto-create RBAC resources for KubernetesOps storage

### DIFF
--- a/operator/controller/src/main/deploy/rbac/cluster/cluster-role.yaml
+++ b/operator/controller/src/main/deploy/rbac/cluster/cluster-role.yaml
@@ -35,6 +35,15 @@ rules:
       - configmaps
       - pods
       - services
+      - serviceaccounts
+    verbs:
+      - '*'
+
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
     verbs:
       - '*'
 

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/ApicurioRegistry3Reconciler.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/ApicurioRegistry3Reconciler.java
@@ -6,6 +6,9 @@ import io.apicurio.registry.operator.resource.app.AppDeploymentResource;
 import io.apicurio.registry.operator.resource.app.AppIngressResource;
 import io.apicurio.registry.operator.resource.app.AppNetworkPolicyResource;
 import io.apicurio.registry.operator.resource.app.AppPodDisruptionBudgetResource;
+import io.apicurio.registry.operator.resource.app.AppRoleBindingResource;
+import io.apicurio.registry.operator.resource.app.AppRoleResource;
+import io.apicurio.registry.operator.resource.app.AppServiceAccountResource;
 import io.apicurio.registry.operator.resource.app.AppServiceResource;
 import io.apicurio.registry.operator.resource.ui.UIDeploymentResource;
 import io.apicurio.registry.operator.resource.ui.UIIngressResource;
@@ -34,6 +37,9 @@ import static io.apicurio.registry.operator.CRContext.deleteCRContext;
 import static io.apicurio.registry.operator.resource.ActivationConditions.AppIngressActivationCondition;
 import static io.apicurio.registry.operator.resource.ActivationConditions.AppNetworkPolicyActivationCondition;
 import static io.apicurio.registry.operator.resource.ActivationConditions.AppPodDisruptionBudgetActivationCondition;
+import static io.apicurio.registry.operator.resource.ActivationConditions.KubernetesOpsRoleActivationCondition;
+import static io.apicurio.registry.operator.resource.ActivationConditions.KubernetesOpsRoleBindingActivationCondition;
+import static io.apicurio.registry.operator.resource.ActivationConditions.KubernetesOpsServiceAccountActivationCondition;
 import static io.apicurio.registry.operator.resource.ActivationConditions.UIIngressActivationCondition;
 import static io.apicurio.registry.operator.resource.ActivationConditions.UINetworkPolicyActivationCondition;
 import static io.apicurio.registry.operator.resource.ActivationConditions.UIPodDisruptionBudgetActivationCondition;
@@ -41,6 +47,9 @@ import static io.apicurio.registry.operator.resource.ResourceKey.APP_DEPLOYMENT_
 import static io.apicurio.registry.operator.resource.ResourceKey.APP_INGRESS_ID;
 import static io.apicurio.registry.operator.resource.ResourceKey.APP_NETWORK_POLICY_ID;
 import static io.apicurio.registry.operator.resource.ResourceKey.APP_POD_DISRUPTION_BUDGET_ID;
+import static io.apicurio.registry.operator.resource.ResourceKey.APP_ROLE_BINDING_ID;
+import static io.apicurio.registry.operator.resource.ResourceKey.APP_ROLE_ID;
+import static io.apicurio.registry.operator.resource.ResourceKey.APP_SERVICE_ACCOUNT_ID;
 import static io.apicurio.registry.operator.resource.ResourceKey.APP_SERVICE_ID;
 import static io.apicurio.registry.operator.resource.ResourceKey.UI_DEPLOYMENT_ID;
 import static io.apicurio.registry.operator.resource.ResourceKey.UI_INGRESS_ID;
@@ -79,6 +88,23 @@ import static io.apicurio.registry.operator.utils.Mapper.copy;
                         name = APP_NETWORK_POLICY_ID,
                         dependsOn = {APP_DEPLOYMENT_ID},
                         activationCondition = AppNetworkPolicyActivationCondition.class
+                ),
+                // ===== KubernetesOps RBAC
+                @Dependent(
+                        type = AppServiceAccountResource.class,
+                        name = APP_SERVICE_ACCOUNT_ID,
+                        activationCondition = KubernetesOpsServiceAccountActivationCondition.class
+                ),
+                @Dependent(
+                        type = AppRoleResource.class,
+                        name = APP_ROLE_ID,
+                        activationCondition = KubernetesOpsRoleActivationCondition.class
+                ),
+                @Dependent(
+                        type = AppRoleBindingResource.class,
+                        name = APP_ROLE_BINDING_ID,
+                        dependsOn = {APP_SERVICE_ACCOUNT_ID, APP_ROLE_ID},
+                        activationCondition = KubernetesOpsRoleBindingActivationCondition.class
                 ),
                 // ===== Registry UI
                 @Dependent(

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/feat/KubernetesOps.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/feat/KubernetesOps.java
@@ -3,7 +3,9 @@ package io.apicurio.registry.operator.feat;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Spec;
 import io.apicurio.registry.operator.api.v1.spec.AppSpec;
+import io.apicurio.registry.operator.api.v1.spec.KubernetesOpsSpec;
 import io.apicurio.registry.operator.api.v1.spec.StorageSpec;
+import io.apicurio.registry.operator.api.v1.spec.StorageType;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,5 +58,51 @@ public class KubernetesOps {
                     log.debug("KubernetesOps storage configured with registry ID: {}",
                             k8sOps.getRegistryId());
                 });
+    }
+
+    /**
+     * Check if KubernetesOps storage is enabled for the given primary resource.
+     */
+    public static boolean isEnabled(ApicurioRegistry3 primary) {
+        return ofNullable(primary.getSpec())
+                .map(ApicurioRegistry3Spec::getApp)
+                .map(AppSpec::getStorage)
+                .map(StorageSpec::getType)
+                .map(type -> type == StorageType.KUBERNETESOPS)
+                .orElse(false);
+    }
+
+    /**
+     * Get the configured namespace, or fall back to the primary resource's namespace.
+     */
+    public static String getNamespace(ApicurioRegistry3 primary) {
+        return ofNullable(primary.getSpec())
+                .map(ApicurioRegistry3Spec::getApp)
+                .map(AppSpec::getStorage)
+                .map(StorageSpec::getKubernetesops)
+                .map(KubernetesOpsSpec::getNamespace)
+                .filter(ns -> !isBlank(ns))
+                .orElse(primary.getMetadata().getNamespace());
+    }
+
+    /**
+     * Get the service account name for the KubernetesOps storage.
+     */
+    public static String getServiceAccountName(ApicurioRegistry3 primary) {
+        return primary.getMetadata().getName() + "-kubeops";
+    }
+
+    /**
+     * Get the role name for the KubernetesOps storage.
+     */
+    public static String getRoleName(ApicurioRegistry3 primary) {
+        return primary.getMetadata().getName() + "-kubeops";
+    }
+
+    /**
+     * Get the role binding name for the KubernetesOps storage.
+     */
+    public static String getRoleBindingName(ApicurioRegistry3 primary) {
+        return primary.getMetadata().getName() + "-kubeops";
     }
 }

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/resource/ActivationConditions.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/resource/ActivationConditions.java
@@ -8,17 +8,24 @@ import io.apicurio.registry.operator.api.v1.spec.IngressSpec;
 import io.apicurio.registry.operator.api.v1.spec.NetworkPolicySpec;
 import io.apicurio.registry.operator.api.v1.spec.PodDisruptionSpec;
 import io.apicurio.registry.operator.api.v1.spec.UiSpec;
+import io.apicurio.registry.operator.feat.KubernetesOps;
 import io.apicurio.registry.operator.resource.app.AppIngressResource;
 import io.apicurio.registry.operator.resource.app.AppNetworkPolicyResource;
 import io.apicurio.registry.operator.resource.app.AppPodDisruptionBudgetResource;
+import io.apicurio.registry.operator.resource.app.AppRoleBindingResource;
+import io.apicurio.registry.operator.resource.app.AppRoleResource;
+import io.apicurio.registry.operator.resource.app.AppServiceAccountResource;
 import io.apicurio.registry.operator.resource.ui.UIDeploymentResource;
 import io.apicurio.registry.operator.resource.ui.UIIngressResource;
 import io.apicurio.registry.operator.resource.ui.UINetworkPolicyResource;
 import io.apicurio.registry.operator.resource.ui.UIPodDisruptionBudgetResource;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
@@ -81,6 +88,47 @@ public class ActivationConditions {
                     .orElse(Boolean.TRUE);
             if (!isManaged) {
                 ((AppNetworkPolicyResource) resource).delete(primary, context);
+            }
+            return isManaged;
+        }
+    }
+
+    // ===== KubernetesOps RBAC
+
+    public static class KubernetesOpsServiceAccountActivationCondition
+            implements Condition<ServiceAccount, ApicurioRegistry3> {
+        @Override
+        public boolean isMet(DependentResource<ServiceAccount, ApicurioRegistry3> resource,
+                             ApicurioRegistry3 primary, Context<ApicurioRegistry3> context) {
+            boolean isManaged = KubernetesOps.isEnabled(primary);
+            if (!isManaged) {
+                ((AppServiceAccountResource) resource).delete(primary, context);
+            }
+            return isManaged;
+        }
+    }
+
+    public static class KubernetesOpsRoleActivationCondition
+            implements Condition<Role, ApicurioRegistry3> {
+        @Override
+        public boolean isMet(DependentResource<Role, ApicurioRegistry3> resource,
+                             ApicurioRegistry3 primary, Context<ApicurioRegistry3> context) {
+            boolean isManaged = KubernetesOps.isEnabled(primary);
+            if (!isManaged) {
+                ((AppRoleResource) resource).delete(primary, context);
+            }
+            return isManaged;
+        }
+    }
+
+    public static class KubernetesOpsRoleBindingActivationCondition
+            implements Condition<RoleBinding, ApicurioRegistry3> {
+        @Override
+        public boolean isMet(DependentResource<RoleBinding, ApicurioRegistry3> resource,
+                             ApicurioRegistry3 primary, Context<ApicurioRegistry3> context) {
+            boolean isManaged = KubernetesOps.isEnabled(primary);
+            if (!isManaged) {
+                ((AppRoleBindingResource) resource).delete(primary, context);
             }
             return isManaged;
         }

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/resource/ResourceKey.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/resource/ResourceKey.java
@@ -2,10 +2,13 @@ package io.apicurio.registry.operator.resource;
 
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -29,6 +32,9 @@ public class ResourceKey<R> {
     public static final String APP_INGRESS_ID = "AppIngressResource";
     public static final String APP_POD_DISRUPTION_BUDGET_ID = "AppPodDisruptionBudgetResource";
     public static final String APP_NETWORK_POLICY_ID = "AppNetworkPolicyResource";
+    public static final String APP_SERVICE_ACCOUNT_ID = "AppServiceAccountResource";
+    public static final String APP_ROLE_ID = "AppRoleResource";
+    public static final String APP_ROLE_BINDING_ID = "AppRoleBindingResource";
 
     public static final String UI_DEPLOYMENT_ID = "UIDeploymentResource";
     public static final String UI_SERVICE_ID = "UIServiceResource";
@@ -49,6 +55,12 @@ public class ResourceKey<R> {
     public static final ResourceKey<NetworkPolicy> APP_NETWORK_POLICY_KEY = new ResourceKey<>(APP_NETWORK_POLICY_ID, NetworkPolicy.class, COMPONENT_APP, ResourceFactory.INSTANCE::getDefaultAppNetworkPolicy);
 
     public static final ResourceKey<PodDisruptionBudget> APP_POD_DISRUPTION_BUDGET_KEY = new ResourceKey<>(APP_POD_DISRUPTION_BUDGET_ID, PodDisruptionBudget.class, COMPONENT_APP, ResourceFactory.INSTANCE::getDefaultAppPodDisruptionBudget);
+
+    public static final ResourceKey<ServiceAccount> APP_SERVICE_ACCOUNT_KEY = new ResourceKey<>(APP_SERVICE_ACCOUNT_ID, ServiceAccount.class, COMPONENT_APP, null);
+
+    public static final ResourceKey<Role> APP_ROLE_KEY = new ResourceKey<>(APP_ROLE_ID, Role.class, COMPONENT_APP, null);
+
+    public static final ResourceKey<RoleBinding> APP_ROLE_BINDING_KEY = new ResourceKey<>(APP_ROLE_BINDING_ID, RoleBinding.class, COMPONENT_APP, null);
 
     // ===== Registry UI
 

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/resource/app/AppDeploymentResource.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/resource/app/AppDeploymentResource.java
@@ -128,7 +128,11 @@ public class AppDeploymentResource extends CRUDKubernetesDependentResource<Deplo
                     switch (storageType) {
                         case POSTGRESQL, MYSQL -> SqlStorage.configureDatasource(primary, envVars);
                         case KAFKASQL -> KafkaSql.configureKafkaSQL(primary, deployment, envVars);
-                        case KUBERNETESOPS -> KubernetesOps.configureKubernetesOps(primary, envVars);
+                        case KUBERNETESOPS -> {
+                            KubernetesOps.configureKubernetesOps(primary, envVars);
+                            deployment.getSpec().getTemplate().getSpec()
+                                    .setServiceAccountName(KubernetesOps.getServiceAccountName(primary));
+                        }
                     }
                 });
 

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/resource/app/AppRoleBindingResource.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/resource/app/AppRoleBindingResource.java
@@ -1,0 +1,53 @@
+package io.apicurio.registry.operator.resource.app;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.feat.KubernetesOps;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
+import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static io.apicurio.registry.operator.utils.Mapper.toYAML;
+
+@KubernetesDependent
+public class AppRoleBindingResource
+        extends CRUDKubernetesDependentResource<RoleBinding, ApicurioRegistry3> {
+
+    private static final Logger log = LoggerFactory.getLogger(AppRoleBindingResource.class);
+
+    public AppRoleBindingResource() {
+        super(RoleBinding.class);
+    }
+
+    @Override
+    protected RoleBinding desired(ApicurioRegistry3 primary, Context<ApicurioRegistry3> context) {
+        var roleBinding = new RoleBindingBuilder()
+                .withMetadata(new ObjectMetaBuilder()
+                        .withName(KubernetesOps.getRoleBindingName(primary))
+                        .withNamespace(KubernetesOps.getNamespace(primary))
+                        .build())
+                .withRoleRef(new RoleRefBuilder()
+                        .withApiGroup("rbac.authorization.k8s.io")
+                        .withKind("Role")
+                        .withName(KubernetesOps.getRoleName(primary))
+                        .build())
+                .withSubjects(List.of(
+                        new SubjectBuilder()
+                                .withKind("ServiceAccount")
+                                .withName(KubernetesOps.getServiceAccountName(primary))
+                                .withNamespace(primary.getMetadata().getNamespace())
+                                .build()))
+                .build();
+
+        log.trace("Desired AppRoleBindingResource is {}", toYAML(roleBinding));
+        return roleBinding;
+    }
+}

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/resource/app/AppRoleResource.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/resource/app/AppRoleResource.java
@@ -1,0 +1,46 @@
+package io.apicurio.registry.operator.resource.app;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.feat.KubernetesOps;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static io.apicurio.registry.operator.utils.Mapper.toYAML;
+
+@KubernetesDependent
+public class AppRoleResource extends CRUDKubernetesDependentResource<Role, ApicurioRegistry3> {
+
+    private static final Logger log = LoggerFactory.getLogger(AppRoleResource.class);
+
+    public AppRoleResource() {
+        super(Role.class);
+    }
+
+    @Override
+    protected Role desired(ApicurioRegistry3 primary, Context<ApicurioRegistry3> context) {
+        var role = new RoleBuilder()
+                .withMetadata(new ObjectMetaBuilder()
+                        .withName(KubernetesOps.getRoleName(primary))
+                        .withNamespace(KubernetesOps.getNamespace(primary))
+                        .build())
+                .withRules(List.of(
+                        new PolicyRuleBuilder()
+                                .withApiGroups("")
+                                .withResources("configmaps")
+                                .withVerbs("get", "list", "watch")
+                                .build()))
+                .build();
+
+        log.trace("Desired AppRoleResource is {}", toYAML(role));
+        return role;
+    }
+}

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/resource/app/AppServiceAccountResource.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/resource/app/AppServiceAccountResource.java
@@ -1,0 +1,38 @@
+package io.apicurio.registry.operator.resource.app;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.feat.KubernetesOps;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.apicurio.registry.operator.utils.Mapper.toYAML;
+
+@KubernetesDependent
+public class AppServiceAccountResource
+        extends CRUDKubernetesDependentResource<ServiceAccount, ApicurioRegistry3> {
+
+    private static final Logger log = LoggerFactory.getLogger(AppServiceAccountResource.class);
+
+    public AppServiceAccountResource() {
+        super(ServiceAccount.class);
+    }
+
+    @Override
+    protected ServiceAccount desired(ApicurioRegistry3 primary, Context<ApicurioRegistry3> context) {
+        var sa = new ServiceAccountBuilder()
+                .withMetadata(new ObjectMetaBuilder()
+                        .withName(KubernetesOps.getServiceAccountName(primary))
+                        .withNamespace(primary.getMetadata().getNamespace())
+                        .build())
+                .build();
+
+        log.trace("Desired AppServiceAccountResource is {}", toYAML(sa));
+        return sa;
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KubernetesOpsRbacITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KubernetesOpsRbacITTest.java
@@ -1,0 +1,160 @@
+package io.apicurio.registry.operator.it;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.KubernetesOpsSpec;
+import io.apicurio.registry.operator.api.v1.spec.StorageType;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.apicurio.registry.operator.Tags.FEATURE;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.utils.K8sCell.k8sCellCreate;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@QuarkusTest
+@Tag(FEATURE)
+public class KubernetesOpsRbacITTest extends ITBase {
+
+    private static final Logger log = LoggerFactory.getLogger(KubernetesOpsRbacITTest.class);
+
+    @Test
+    void testRbacResourcesCreatedForKubernetesOps() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setNamespace(namespace);
+        registry.getSpec().getApp().getIngress().setHost(ingressManager.getIngressHost("app"));
+        registry.getSpec().getUi().getIngress().setHost(ingressManager.getIngressHost("ui"));
+
+        // Configure KubernetesOps storage
+        registry.getSpec().getApp().withStorage().setType(StorageType.KUBERNETESOPS);
+        var k8sOps = new KubernetesOpsSpec();
+        k8sOps.setRegistryId("test-registry");
+        registry.getSpec().getApp().getStorage().setKubernetesops(k8sOps);
+
+        client.resource(registry).create();
+
+        var saName = registry.getMetadata().getName() + "-kubeops";
+
+        // Verify ServiceAccount is created
+        await().ignoreExceptions().untilAsserted(() -> {
+            ServiceAccount sa = client.serviceAccounts().inNamespace(namespace)
+                    .withName(saName).get();
+            assertThat(sa).isNotNull();
+        });
+
+        // Verify Role is created with correct permissions
+        await().ignoreExceptions().untilAsserted(() -> {
+            Role role = client.rbac().roles().inNamespace(namespace)
+                    .withName(saName).get();
+            assertThat(role).isNotNull();
+            assertThat(role.getRules()).hasSize(1);
+            assertThat(role.getRules().get(0).getApiGroups()).containsExactly("");
+            assertThat(role.getRules().get(0).getResources()).containsExactly("configmaps");
+            assertThat(role.getRules().get(0).getVerbs()).containsExactlyInAnyOrder("get", "list", "watch");
+        });
+
+        // Verify RoleBinding is created linking SA to Role
+        await().ignoreExceptions().untilAsserted(() -> {
+            RoleBinding rb = client.rbac().roleBindings().inNamespace(namespace)
+                    .withName(saName).get();
+            assertThat(rb).isNotNull();
+            assertThat(rb.getRoleRef().getKind()).isEqualTo("Role");
+            assertThat(rb.getRoleRef().getName()).isEqualTo(saName);
+            assertThat(rb.getSubjects()).hasSize(1);
+            assertThat(rb.getSubjects().get(0).getKind()).isEqualTo("ServiceAccount");
+            assertThat(rb.getSubjects().get(0).getName()).isEqualTo(saName);
+            assertThat(rb.getSubjects().get(0).getNamespace()).isEqualTo(namespace);
+        });
+
+        // Verify Deployment has serviceAccountName set
+        await().ignoreExceptions().untilAsserted(() -> {
+            var deployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(registry.getMetadata().getName() + "-app-deployment").get();
+            assertThat(deployment).isNotNull();
+            assertThat(deployment.getSpec().getTemplate().getSpec().getServiceAccountName())
+                    .isEqualTo(saName);
+        });
+    }
+
+    @Test
+    void testRbacResourcesNotCreatedWithoutKubernetesOps() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setNamespace(namespace);
+        registry.getSpec().getApp().getIngress().setHost(ingressManager.getIngressHost("app"));
+        registry.getSpec().getUi().getIngress().setHost(ingressManager.getIngressHost("ui"));
+
+        client.resource(registry).create();
+
+        // Wait for deployment to be ready (in-memory storage)
+        checkDeploymentExists(registry, COMPONENT_APP, 1);
+
+        var saName = registry.getMetadata().getName() + "-kubeops";
+
+        // Verify RBAC resources are NOT created
+        assertThat(client.serviceAccounts().inNamespace(namespace).withName(saName).get()).isNull();
+        assertThat(client.rbac().roles().inNamespace(namespace).withName(saName).get()).isNull();
+        assertThat(client.rbac().roleBindings().inNamespace(namespace).withName(saName).get()).isNull();
+
+        // Verify Deployment does NOT have serviceAccountName set to kubeops
+        var deployment = client.apps().deployments().inNamespace(namespace)
+                .withName(registry.getMetadata().getName() + "-app-deployment").get();
+        assertThat(deployment.getSpec().getTemplate().getSpec().getServiceAccountName())
+                .isNotEqualTo(saName);
+    }
+
+    @Test
+    void testRbacResourcesCleanedUpOnStorageTypeChange() {
+        final var registry = k8sCellCreate(client, () -> {
+            var r = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                    ApicurioRegistry3.class);
+            r.getMetadata().setNamespace(namespace);
+            r.getSpec().getApp().getIngress().setHost(ingressManager.getIngressHost("app"));
+            r.getSpec().getUi().getIngress().setHost(ingressManager.getIngressHost("ui"));
+
+            // Start with KubernetesOps storage
+            r.getSpec().getApp().withStorage().setType(StorageType.KUBERNETESOPS);
+            var k8sOps = new KubernetesOpsSpec();
+            k8sOps.setRegistryId("test-registry");
+            r.getSpec().getApp().getStorage().setKubernetesops(k8sOps);
+
+            return r;
+        });
+
+        var saName = registry.getCached().getMetadata().getName() + "-kubeops";
+
+        // Wait for RBAC resources to exist
+        await().ignoreExceptions().untilAsserted(() -> {
+            assertThat(client.serviceAccounts().inNamespace(namespace)
+                    .withName(saName).get()).isNotNull();
+            assertThat(client.rbac().roles().inNamespace(namespace)
+                    .withName(saName).get()).isNotNull();
+            assertThat(client.rbac().roleBindings().inNamespace(namespace)
+                    .withName(saName).get()).isNotNull();
+        });
+
+        // Switch to in-memory storage (no storage type = in-memory)
+        registry.update(r -> {
+            r.getSpec().getApp().getStorage().setType(null);
+            r.getSpec().getApp().getStorage().setKubernetesops(null);
+        });
+
+        // Verify RBAC resources are cleaned up
+        await().untilAsserted(() -> {
+            assertThat(client.serviceAccounts().inNamespace(namespace)
+                    .withName(saName).get()).isNull();
+            assertThat(client.rbac().roles().inNamespace(namespace)
+                    .withName(saName).get()).isNull();
+            assertThat(client.rbac().roleBindings().inNamespace(namespace)
+                    .withName(saName).get()).isNull();
+        });
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/resource/app/KubernetesOpsRbacResourceTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/resource/app/KubernetesOpsRbacResourceTest.java
@@ -1,0 +1,76 @@
+package io.apicurio.registry.operator.resource.app;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KubernetesOpsRbacResourceTest {
+
+    private static final ClassLoader CLASS_LOADER = KubernetesOpsRbacResourceTest.class.getClassLoader();
+
+    @Test
+    void testServiceAccountDesired() {
+        var registry = loadCR("k8s/examples/kubernetesops/example-default.yaml");
+        var resource = new AppServiceAccountResource();
+        var sa = resource.desired(registry, null);
+
+        assertThat(sa.getMetadata().getName()).isEqualTo("my-registry-kubeops");
+        assertThat(sa.getMetadata().getNamespace()).isEqualTo("test-ns");
+    }
+
+    @Test
+    void testRoleDesiredDefaultNamespace() {
+        var registry = loadCR("k8s/examples/kubernetesops/example-default.yaml");
+        var resource = new AppRoleResource();
+        var role = resource.desired(registry, null);
+
+        assertThat(role.getMetadata().getName()).isEqualTo("my-registry-kubeops");
+        assertThat(role.getMetadata().getNamespace()).isEqualTo("test-ns");
+        assertThat(role.getRules()).hasSize(1);
+        assertThat(role.getRules().get(0).getApiGroups()).containsExactly("");
+        assertThat(role.getRules().get(0).getResources()).containsExactly("configmaps");
+        assertThat(role.getRules().get(0).getVerbs()).containsExactlyInAnyOrder("get", "list", "watch");
+    }
+
+    @Test
+    void testRoleDesiredCustomNamespace() {
+        var registry = loadCR("k8s/examples/kubernetesops/example-custom-namespace.yaml");
+        var resource = new AppRoleResource();
+        var role = resource.desired(registry, null);
+
+        assertThat(role.getMetadata().getNamespace()).isEqualTo("configmaps-ns");
+    }
+
+    @Test
+    void testRoleBindingDesiredDefaultNamespace() {
+        var registry = loadCR("k8s/examples/kubernetesops/example-default.yaml");
+        var resource = new AppRoleBindingResource();
+        var roleBinding = resource.desired(registry, null);
+
+        assertThat(roleBinding.getMetadata().getName()).isEqualTo("my-registry-kubeops");
+        assertThat(roleBinding.getMetadata().getNamespace()).isEqualTo("test-ns");
+        assertThat(roleBinding.getRoleRef().getApiGroup()).isEqualTo("rbac.authorization.k8s.io");
+        assertThat(roleBinding.getRoleRef().getKind()).isEqualTo("Role");
+        assertThat(roleBinding.getRoleRef().getName()).isEqualTo("my-registry-kubeops");
+        assertThat(roleBinding.getSubjects()).hasSize(1);
+        assertThat(roleBinding.getSubjects().get(0).getKind()).isEqualTo("ServiceAccount");
+        assertThat(roleBinding.getSubjects().get(0).getName()).isEqualTo("my-registry-kubeops");
+        assertThat(roleBinding.getSubjects().get(0).getNamespace()).isEqualTo("test-ns");
+    }
+
+    @Test
+    void testRoleBindingDesiredCustomNamespace() {
+        var registry = loadCR("k8s/examples/kubernetesops/example-custom-namespace.yaml");
+        var resource = new AppRoleBindingResource();
+        var roleBinding = resource.desired(registry, null);
+
+        assertThat(roleBinding.getMetadata().getNamespace()).isEqualTo("configmaps-ns");
+        assertThat(roleBinding.getSubjects().get(0).getNamespace()).isEqualTo("test-ns");
+    }
+
+    private ApicurioRegistry3 loadCR(String path) {
+        return ResourceFactory.deserialize(path, ApicurioRegistry3.class, CLASS_LOADER);
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/unit/KubernetesOpsTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/unit/KubernetesOpsTest.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/unit/KubernetesOpsTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/unit/KubernetesOpsTest.java
@@ -8,10 +8,13 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class KubernetesOpsTest {
+
+    private static final ClassLoader CLASS_LOADER = KubernetesOpsTest.class.getClassLoader();
 
     @Test
     public void testBasicConfiguration() {
@@ -95,8 +98,49 @@ public class KubernetesOpsTest {
         assertThat(envVars).isEmpty();
     }
 
+    @Test
+    void testIsEnabled() {
+        var registry = deserialize("k8s/examples/kubernetesops/example-default.yaml");
+        assertThat(KubernetesOps.isEnabled(registry)).isTrue();
+    }
+
+    @Test
+    void testIsNotEnabledForSimpleCR() {
+        var registry = deserialize("k8s/examples/simple.apicurioregistry3.yaml");
+        assertThat(KubernetesOps.isEnabled(registry)).isFalse();
+    }
+
+    @Test
+    void testServiceAccountName() {
+        var registry = deserialize("k8s/examples/kubernetesops/example-default.yaml");
+        assertThat(KubernetesOps.getServiceAccountName(registry)).isEqualTo("my-registry-kubeops");
+    }
+
+    @Test
+    void testRoleName() {
+        var registry = deserialize("k8s/examples/kubernetesops/example-default.yaml");
+        assertThat(KubernetesOps.getRoleName(registry)).isEqualTo("my-registry-kubeops");
+    }
+
+    @Test
+    void testRoleBindingName() {
+        var registry = deserialize("k8s/examples/kubernetesops/example-default.yaml");
+        assertThat(KubernetesOps.getRoleBindingName(registry)).isEqualTo("my-registry-kubeops");
+    }
+
+    @Test
+    void testNamespaceDefaultsToPrimaryNamespace() {
+        var registry = deserialize("k8s/examples/kubernetesops/example-default.yaml");
+        assertThat(KubernetesOps.getNamespace(registry)).isEqualTo("test-ns");
+    }
+
+    @Test
+    void testCustomNamespace() {
+        var registry = deserialize("k8s/examples/kubernetesops/example-custom-namespace.yaml");
+        assertThat(KubernetesOps.getNamespace(registry)).isEqualTo("configmaps-ns");
+    }
+
     private ApicurioRegistry3 deserialize(String path) {
-        return ResourceFactory.deserialize(path, ApicurioRegistry3.class,
-                KubernetesOpsTest.class.getClassLoader());
+        return ResourceFactory.deserialize(path, ApicurioRegistry3.class, CLASS_LOADER);
     }
 }

--- a/operator/controller/src/test/resources/k8s/examples/kubernetesops/example-custom-namespace.yaml
+++ b/operator/controller/src/test/resources/k8s/examples/kubernetesops/example-custom-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: registry.apicur.io/v1
+kind: ApicurioRegistry3
+metadata:
+  name: my-registry
+  namespace: test-ns
+spec:
+  app:
+    storage:
+      type: kubernetesops
+      kubernetesops:
+        registryId: my-registry
+        namespace: configmaps-ns

--- a/operator/controller/src/test/resources/k8s/examples/kubernetesops/example-default.yaml
+++ b/operator/controller/src/test/resources/k8s/examples/kubernetesops/example-default.yaml
@@ -1,0 +1,11 @@
+apiVersion: registry.apicur.io/v1
+kind: ApicurioRegistry3
+metadata:
+  name: my-registry
+  namespace: test-ns
+spec:
+  app:
+    storage:
+      type: kubernetesops
+      kubernetesops:
+        registryId: my-registry

--- a/operator/install/install.yaml
+++ b/operator/install/install.yaml
@@ -6914,6 +6914,14 @@ rules:
   - configmaps
   - pods
   - services
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
   verbs:
   - '*'
 - apiGroups:

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/spec/KubernetesOpsSpec.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/spec/KubernetesOpsSpec.java
@@ -32,11 +32,6 @@ import static lombok.AccessLevel.PRIVATE;
 @ToString
 public class KubernetesOpsSpec {
 
-    /**
-     * Unique identifier for this registry instance. Only ConfigMaps with a matching label will be loaded.
-     * <p>
-     * Required if <code>app.storage.type</code> is <code>kubernetesops</code>.
-     */
     @JsonProperty("registryId")
     @JsonPropertyDescription("""
             Unique identifier for this registry instance. Only ConfigMaps with a matching label will be loaded.
@@ -45,37 +40,24 @@ public class KubernetesOpsSpec {
     @JsonSetter(nulls = SKIP)
     private String registryId;
 
-    /**
-     * Kubernetes namespace to watch for ConfigMaps. Defaults to the namespace of the registry deployment.
-     */
     @JsonProperty("namespace")
     @JsonPropertyDescription("""
             Kubernetes namespace to watch for ConfigMaps. Defaults to the namespace of the registry deployment.""")
     @JsonSetter(nulls = SKIP)
     private String namespace;
 
-    /**
-     * How often to poll for ConfigMap changes. Supports duration format (e.g., 10s, 1m). Defaults to 30s.
-     */
     @JsonProperty("refreshEvery")
     @JsonPropertyDescription("""
             How often to poll for ConfigMap changes. Supports duration format (e.g., `10s`, `1m`). Defaults to `30s`.""")
     @JsonSetter(nulls = SKIP)
     private String refreshEvery;
 
-    /**
-     * Label key used to identify ConfigMaps belonging to this registry. Defaults to
-     * <code>apicurio.io/registry-id</code>.
-     */
     @JsonProperty("labelRegistryId")
     @JsonPropertyDescription("""
             Label key used to identify ConfigMaps belonging to this registry. Defaults to `apicurio.io/registry-id`.""")
     @JsonSetter(nulls = SKIP)
     private String labelRegistryId;
 
-    /**
-     * Enable Watch API for real-time ConfigMap change detection. Defaults to true.
-     */
     @JsonProperty("watchEnabled")
     @JsonPropertyDescription("""
             Enable Watch API for real-time ConfigMap change detection. Set to `false` to use polling only. \
@@ -83,10 +65,6 @@ public class KubernetesOpsSpec {
     @JsonSetter(nulls = SKIP)
     private Boolean watchEnabled;
 
-    /**
-     * Base delay before reconnecting after watch failure. Uses exponential backoff up to 5 minutes.
-     * Defaults to 10s.
-     */
     @JsonProperty("watchReconnectDelay")
     @JsonPropertyDescription("""
             Base delay before reconnecting after watch failure. Uses exponential backoff up to 5 minutes. \

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/spec/StorageSpec.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/spec/StorageSpec.java
@@ -71,16 +71,6 @@ public class StorageSpec {
     @JsonSetter(nulls = SKIP)
     private KafkaSqlSpec kafkasql;
 
-    /**
-     * Configure KubernetesOps storage type (read-only, experimental).
-     */
-    @JsonProperty("kubernetesops")
-    @JsonPropertyDescription("""
-            Configure KubernetesOps storage type (read-only, experimental). \
-            Loads registry data from Kubernetes ConfigMaps.""")
-    @JsonSetter(nulls = SKIP)
-    private KubernetesOpsSpec kubernetesops;
-
     public SqlSpec withSql() {
         if (sql == null) {
             sql = new SqlSpec();
@@ -94,6 +84,16 @@ public class StorageSpec {
         }
         return kafkasql;
     }
+
+    /**
+     * Configure KubernetesOps storage type (read-only, experimental).
+     */
+    @JsonProperty("kubernetesops")
+    @JsonPropertyDescription("""
+            Configure KubernetesOps storage type (read-only, experimental). \
+            Loads registry data from Kubernetes ConfigMaps.""")
+    @JsonSetter(nulls = SKIP)
+    private KubernetesOpsSpec kubernetesops;
 
     public KubernetesOpsSpec withKubernetesops() {
         if (kubernetesops == null) {

--- a/operator/olm-tests/src/test/deploy/olmv1/cluster-role.yaml
+++ b/operator/olm-tests/src/test/deploy/olmv1/cluster-role.yaml
@@ -112,6 +112,15 @@ rules:
       - configmaps
       - pods
       - services
+      - serviceaccounts
+    verbs:
+      - '*'
+
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
     verbs:
       - '*'
 


### PR DESCRIPTION
## Summary

Closes #7720

When `spec.app.storage.type: kubernetesops` is configured, the operator now automatically creates the necessary RBAC resources so the registry pod can list/watch ConfigMaps:

- **ServiceAccount** (`<registry-name>-kubeops`) — created in the registry's namespace
- **Role** — grants `get`, `list`, `watch` on `configmaps`, scoped to the configured namespace (falls back to registry namespace)
- **RoleBinding** — links the ServiceAccount to the Role
- **Deployment** — `serviceAccountName` is set on the pod spec

Resources are only created when KubernetesOps storage is selected (activation condition) and are automatically cleaned up when the storage type changes.

### Prerequisites

This PR also includes the prerequisite changes for KubernetesOps operator support:
- `KUBERNETESOPS` added to `StorageType` enum
- `KubernetesOpsSpec` model class
- `KubernetesOps` feature configuration (env vars)
- Environment variable constants

## Test plan

- [x] 15 unit tests covering:
  - KubernetesOps enablement detection
  - Resource naming conventions
  - Namespace resolution (default vs custom)
  - Environment variable configuration (default and full)
  - ServiceAccount, Role, and RoleBinding desired state
  - Cross-namespace Role/RoleBinding scenarios
- [x] Build passes with checkstyle
- [x] Integration test on a Kubernetes cluster with KubernetesOps storage configured