### PR TITLE
Add global rules management commands to the CLI. Fixes #7168

### DIFF
--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -78,6 +78,7 @@ jobs:
             java-sdk/client-v2/target/
             config-index/definitions/target/
             common/target/
+            schema-util/common/target/
           retention-days: 1
 
   build-ui:

--- a/.github/workflows/verify-cli.yaml
+++ b/.github/workflows/verify-cli.yaml
@@ -56,6 +56,7 @@ jobs:
           for module_path in \
             config-index/definitions:apicurio-registry-config-definitions \
             common:apicurio-registry-common \
+            schema-util/common:apicurio-registry-schema-util-common \
             java-sdk/common:apicurio-registry-java-sdk-common \
             java-sdk/adapter-vertx:apicurio-registry-java-sdk-adapter-vertx \
             java-sdk/adapter-jdk:apicurio-registry-java-sdk-adapter-jdk \

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -76,6 +76,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-schema-util-common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.semver4j</groupId>
             <artifactId>semver4j</artifactId>
         </dependency>

--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -3,6 +3,7 @@ package io.apicurio.registry.cli;
 import io.apicurio.registry.cli.artifact.ArtifactCommand;
 import io.apicurio.registry.cli.context.ContextCommand;
 import io.apicurio.registry.cli.group.GroupCommand;
+import io.apicurio.registry.cli.globalrule.GlobalRuleCommand;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import lombok.Getter;
 import picocli.CommandLine.Command;
@@ -24,6 +25,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
         subcommands = {
                 ArtifactCommand.class,
                 ContextCommand.class,
+                GlobalRuleCommand.class,
                 GroupCommand.class,
                 InstallCommand.class,
                 UpdateCommand.class,

--- a/cli/src/main/java/io/apicurio/registry/cli/common/RuleUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/RuleUtil.java
@@ -1,0 +1,51 @@
+package io.apicurio.registry.cli.common;
+
+import io.apicurio.registry.rest.client.models.RuleType;
+import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
+import io.apicurio.registry.rules.integrity.IntegrityLevel;
+import io.apicurio.registry.rules.validity.ValidityLevel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+
+public final class RuleUtil {
+
+    private static final List<String> VALID_RULE_TYPES = Stream.of(RuleType.values())
+            .map(RuleType::getValue)
+            .toList();
+
+    private static final Map<String, List<String>> VALID_CONFIGS = Map.of(
+            RuleType.VALIDITY.getValue(), Stream.of(ValidityLevel.values())
+                    .map(Enum::name).toList(),
+            RuleType.COMPATIBILITY.getValue(), Stream.of(CompatibilityLevel.values())
+                    .map(Enum::name).toList(),
+            RuleType.INTEGRITY.getValue(), Stream.of(IntegrityLevel.values())
+                    .map(Enum::name).toList()
+    );
+
+    private RuleUtil() {
+    }
+
+    public static void validateRuleType(final String ruleType) {
+        if (!VALID_RULE_TYPES.contains(ruleType)) {
+            throw new CliException(
+                    "Invalid rule type '" + ruleType + "'. Valid values are: " + String.join(", ", VALID_RULE_TYPES) + ".",
+                    VALIDATION_ERROR_RETURN_CODE
+            );
+        }
+    }
+
+    public static void validateRuleConfig(final String ruleType, final String config) {
+        final var validConfigs = VALID_CONFIGS.get(ruleType);
+        if (validConfigs != null && !validConfigs.contains(config)) {
+            throw new CliException(
+                    "Invalid config '" + config + "' for rule type '" + ruleType + "'. Valid values are: "
+                            + String.join(", ", validConfigs) + ".",
+                    VALIDATION_ERROR_RETURN_CODE
+            );
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleCommand.java
@@ -1,0 +1,72 @@
+package io.apicurio.registry.cli.globalrule;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.Acr;
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.Mapper;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.client.models.RuleType;
+import lombok.Getter;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.ParentCommand;
+
+import java.util.List;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.utils.Columns.RULE_TYPE;
+
+@Command(
+        name = "rule",
+        aliases = {"rules"},
+        description = "Work with global rules",
+        subcommands = {
+                GlobalRuleCreateCommand.class,
+                GlobalRuleGetCommand.class,
+                GlobalRuleUpdateCommand.class,
+                GlobalRuleDeleteCommand.class
+        }
+)
+public class GlobalRuleCommand extends AbstractCommand {
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @ParentCommand
+    @Getter
+    private Acr parent;
+
+    @Override
+    public void run(final OutputBuffer output) throws JsonProcessingException {
+        try {
+            final var ruleTypes = client.getRegistryClient().admin().rules().get();
+            final List<String> ruleTypeNames = ruleTypes != null
+                    ? ruleTypes.stream().map(RuleType::getValue).toList()
+                    : List.of();
+            output.writeStdOutChunkWithException(out -> {
+                switch (outputType.getOutputType()) {
+                    case json -> {
+                        out.append(Mapper.MAPPER.writeValueAsString(ruleTypeNames));
+                        out.append('\n');
+                    }
+                    case table -> {
+                        final var table = new TableBuilder();
+                        table.addColumns(RULE_TYPE);
+                        ruleTypeNames.forEach(table::addRow);
+                        table.print(out);
+                    }
+                }
+            });
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error listing global rules: ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleCreateCommand.java
@@ -1,0 +1,86 @@
+package io.apicurio.registry.cli.globalrule;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.CreateRule;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.client.models.RuleType;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.common.RuleUtil.validateRuleConfig;
+import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
+import static io.apicurio.registry.cli.globalrule.GlobalRuleGetCommand.printRule;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+
+@Command(
+        name = "create",
+        aliases = {"add"},
+        description = "Create a new global rule"
+)
+public class GlobalRuleCreateCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The rule type (VALIDITY, COMPATIBILITY, or INTEGRITY)"
+    )
+    private String ruleType;
+
+    @Option(
+            names = {"-c", "--config"},
+            // NOTE: Keep in sync with RuleUtil.VALID_CONFIGS
+            description = "The rule configuration value.%n" +
+                    "  VALIDITY: FULL | SYNTAX_ONLY | NONE%n" +
+                    "  COMPATIBILITY: BACKWARD | BACKWARD_TRANSITIVE | FORWARD | FORWARD_TRANSITIVE | FULL | FULL_TRANSITIVE | NONE%n" +
+                    "  INTEGRITY: FULL | NO_DUPLICATES | REFS_EXIST | ALL_REFS_MAPPED | NO_CIRCULAR_REFERENCES | NONE",
+            required = true
+    )
+    private String ruleConfig;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        validateRuleType(ruleType);
+        validateRuleConfig(ruleType, ruleConfig);
+        try {
+            final var newRule = new CreateRule();
+            newRule.setRuleType(RuleType.forValue(ruleType));
+            newRule.setConfig(ruleConfig);
+            client.getRegistryClient().admin().rules().post(newRule);
+            switch (outputType.getOutputType()) {
+                case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType));
+                case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType));
+            }
+            try {
+                //noinspection ConstantConditions
+                final var rule = convert(client.getRegistryClient().admin().rules().byRuleType(ruleType).get());
+                printRule(output, rule, outputType);
+            } catch (final ProblemDetails ex) {
+                output.writeStdErrChunk(err -> {
+                    err.append("Warning: Global rule was created but failed to retrieve details: ")
+                            .append(ex.getDetail())
+                            .append('\n');
+                });
+            }
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error creating global rule '")
+                        .append(ruleType)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+
+    private static void successMessage(final StringBuilder out, final String ruleType) {
+        out.append("Global rule '").append(ruleType).append("' created successfully.\n");
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleDeleteCommand.java
@@ -1,0 +1,91 @@
+package io.apicurio.registry.cli.globalrule;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
+
+@Command(
+        name = "delete",
+        aliases = {"remove", "rm"},
+        description = "Delete a global rule or all global rules"
+)
+public class GlobalRuleDeleteCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            arity = "0..1",
+            description = "The rule type to delete (VALIDITY, COMPATIBILITY, or INTEGRITY)"
+    )
+    private String ruleType;
+
+    @Option(
+            names = {"--all"},
+            description = "Delete all global rules.",
+            defaultValue = "false"
+    )
+    private boolean all;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        if (all && ruleType != null) {
+            throw new CliException(
+                    "Cannot use --all together with a specific rule type. Use either --all or specify a rule type.",
+                    VALIDATION_ERROR_RETURN_CODE
+            );
+        }
+        if (!all && ruleType == null) {
+            throw new CliException(
+                    "Please specify a rule type to delete, or use --all to delete all global rules.",
+                    VALIDATION_ERROR_RETURN_CODE
+            );
+        }
+        if (all) {
+            deleteAllRules(output);
+        } else {
+            validateRuleType(ruleType);
+            deleteSingleRule(output);
+        }
+    }
+
+    private void deleteAllRules(final OutputBuffer output) {
+        try {
+            client.getRegistryClient().admin().rules().delete();
+            output.writeStdOutChunk(out -> {
+                out.append("All global rules deleted successfully.\n");
+            });
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error deleting all global rules: ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+
+    private void deleteSingleRule(final OutputBuffer output) {
+        try {
+            client.getRegistryClient().admin().rules().byRuleType(ruleType).delete();
+            output.writeStdOutChunk(out -> {
+                out.append("Global rule '").append(ruleType).append("' deleted successfully.\n");
+            });
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error deleting global rule '")
+                        .append(ruleType)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleGetCommand.java
@@ -1,0 +1,74 @@
+package io.apicurio.registry.cli.globalrule;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.v3.beans.Rule;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
+import static io.apicurio.registry.cli.utils.Columns.CONFIG;
+import static io.apicurio.registry.cli.utils.Columns.FIELD;
+import static io.apicurio.registry.cli.utils.Columns.RULE_TYPE;
+import static io.apicurio.registry.cli.utils.Columns.VALUE;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+@Command(
+        name = "get",
+        description = "Get the configuration of a global rule"
+)
+public class GlobalRuleGetCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The rule type (VALIDITY, COMPATIBILITY, or INTEGRITY)"
+    )
+    private String ruleType;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws JsonProcessingException {
+        validateRuleType(ruleType);
+        try {
+            //noinspection ConstantConditions
+            final var rule = convert(client.getRegistryClient().admin().rules().byRuleType(ruleType).get());
+            printRule(output, rule, outputType);
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error retrieving global rule '")
+                        .append(ruleType)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+
+    static void printRule(final OutputBuffer output, final Rule rule, final OutputTypeMixin outputType) throws JsonProcessingException {
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(rule));
+                    out.append('\n');
+                }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(FIELD, VALUE);
+                    table.addRow(RULE_TYPE, rule.getRuleType() != null ? rule.getRuleType().value() : "");
+                    table.addRow(CONFIG, rule.getConfig());
+                    table.print(out);
+                }
+            }
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleUpdateCommand.java
@@ -1,0 +1,73 @@
+package io.apicurio.registry.cli.globalrule;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.common.RuleUtil.validateRuleConfig;
+import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
+import static io.apicurio.registry.cli.globalrule.GlobalRuleGetCommand.printRule;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+
+@Command(
+        name = "update",
+        description = "Update the configuration of an existing global rule"
+)
+public class GlobalRuleUpdateCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The rule type (VALIDITY, COMPATIBILITY, or INTEGRITY)"
+    )
+    private String ruleType;
+
+    @Option(
+            names = {"-c", "--config"},
+            // NOTE: Keep in sync with RuleUtil.VALID_CONFIGS
+            description = "The rule configuration value.%n" +
+                    "  VALIDITY: FULL | SYNTAX_ONLY | NONE%n" +
+                    "  COMPATIBILITY: BACKWARD | BACKWARD_TRANSITIVE | FORWARD | FORWARD_TRANSITIVE | FULL | FULL_TRANSITIVE | NONE%n" +
+                    "  INTEGRITY: FULL | NO_DUPLICATES | REFS_EXIST | ALL_REFS_MAPPED | NO_CIRCULAR_REFERENCES | NONE",
+            required = true
+    )
+    private String ruleConfig;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        validateRuleType(ruleType);
+        validateRuleConfig(ruleType, ruleConfig);
+        try {
+            final var rule = new io.apicurio.registry.rest.client.models.Rule();
+            rule.setConfig(ruleConfig);
+            //noinspection ConstantConditions
+            final var updatedRule = convert(client.getRegistryClient().admin().rules().byRuleType(ruleType).put(rule));
+            switch (outputType.getOutputType()) {
+                case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType));
+                case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType));
+            }
+            printRule(output, updatedRule, outputType);
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error updating global rule '")
+                        .append(ruleType)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+
+    private static void successMessage(final StringBuilder out, final String ruleType) {
+        out.append("Global rule '").append(ruleType).append("' updated successfully.\n");
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
@@ -30,4 +30,7 @@ public final class Columns {
     public static final String SERVER_VERSION = "Server version";
     public static final String SERVER_BUILT_ON = "Server built on";
     public static final String ARTIFACT_TYPES = "Artifact types";
+
+    public static final String RULE_TYPE = "Rule Type";
+    public static final String CONFIG = "Config";
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli.utils;
 
 import io.apicurio.registry.rest.client.models.Labels;
+import io.apicurio.registry.rest.v3.beans.Rule;
 import io.apicurio.registry.rest.v3.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
 import io.apicurio.registry.rest.v3.beans.GroupMetaData;
@@ -149,6 +150,15 @@ public final class Conversions {
                         .map(Conversions::convert)
                         .collect(Collectors.toList()))
                 .count(searchResults.getCount())
+                .build();
+    }
+
+    public static Rule convert(io.apicurio.registry.rest.client.models.Rule rule) {
+        return Rule.builder()
+                .ruleType(ofNullable(rule.getRuleType())
+                        .map(rt -> io.apicurio.registry.types.RuleType.fromValue(rt.getValue()))
+                        .orElse(null))
+                .config(rule.getConfig())
                 .build();
     }
 

--- a/cli/src/test/java/io/apicurio/registry/cli/GlobalRuleCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/GlobalRuleCommandTest.java
@@ -1,0 +1,243 @@
+package io.apicurio.registry.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.apicurio.registry.rest.v3.beans.Rule;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.List;
+
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the global rules CLI commands.
+ */
+@QuarkusTest
+@TestMethodOrder(OrderAnnotation.class)
+public class GlobalRuleCommandTest extends AbstractCLITest {
+
+    @Test
+    public void testRuleHelp() {
+        testHelpCommand("rule");
+        testHelpCommand("rule", "create");
+        testHelpCommand("rule", "get");
+        testHelpCommand("rule", "update");
+        testHelpCommand("rule", "delete");
+    }
+
+    @Test
+    @Order(0)
+    public void testRuleCommandEmpty() throws JsonProcessingException {
+        // When
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("rule", "--output-type", "json");
+        var rules = MAPPER.readValue(out.toString(), new TypeReference<List<String>>() {
+        });
+
+        // Then
+        assertThat(rules)
+                .as(withCliOutput("There should not be any global rules initially."))
+                .isEmpty();
+    }
+
+    @Test
+    @Order(1)
+    public void testRuleCreateCommand() throws JsonProcessingException {
+        // When
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("rule", "create", "--output-type", "json",
+                "-c", "FULL",
+                "VALIDITY");
+        var rule = MAPPER.readValue(out.toString(), Rule.class);
+
+        // Then
+        assertThat(rule.getRuleType())
+                .as(withCliOutput("Created rule should have the correct ruleType"))
+                .isNotNull();
+        assertThat(rule.getRuleType().value())
+                .as(withCliOutput("Created rule should have ruleType VALIDITY"))
+                .isEqualTo("VALIDITY");
+        assertThat(rule.getConfig())
+                .as(withCliOutput("Created rule should have the correct config"))
+                .isEqualTo("FULL");
+    }
+
+    @Test
+    public void testRuleCreateCommandFails() {
+        // Missing required --config option
+        executeAndAssertFailure("rule", "create", "VALIDITY");
+        // Missing required ruleType parameter
+        executeAndAssertFailure("rule", "create", "-c", "FULL");
+        // Invalid rule type
+        executeAndAssertFailure("rule", "create", "-c", "FULL", "INVALID_TYPE");
+        // Invalid config for VALIDITY
+        executeAndAssertFailure("rule", "create", "-c", "INVALID_CONFIG", "VALIDITY");
+    }
+
+    @Test
+    @Order(2)
+    public void testRuleGetCommand() throws JsonProcessingException {
+        // When
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("rule", "get", "--output-type", "json", "VALIDITY");
+        var rule = MAPPER.readValue(out.toString(), Rule.class);
+
+        // Then
+        assertThat(rule.getRuleType())
+                .as(withCliOutput("Retrieved rule should have the correct ruleType"))
+                .isNotNull();
+        assertThat(rule.getRuleType().value())
+                .as(withCliOutput("Retrieved rule should have ruleType VALIDITY"))
+                .isEqualTo("VALIDITY");
+        assertThat(rule.getConfig())
+                .as(withCliOutput("Retrieved rule should have the correct config"))
+                .isEqualTo("FULL");
+    }
+
+    @Test
+    public void testRuleGetCommandFails() {
+        // Invalid rule type
+        executeAndAssertFailure("rule", "get", "INVALID_TYPE");
+        // Get a rule that does not exist
+        executeAndAssertSuccess("rule", "delete", "--all");
+        executeAndAssertFailure("rule", "get", "COMPATIBILITY");
+    }
+
+    @Test
+    public void testRuleUpdateCommandFails() {
+        // Invalid rule type
+        executeAndAssertFailure("rule", "update", "-c", "FULL", "INVALID_TYPE");
+        // Invalid config for VALIDITY
+        executeAndAssertFailure("rule", "update", "-c", "INVALID_CONFIG", "VALIDITY");
+        // Update a rule that does not exist
+        executeAndAssertSuccess("rule", "delete", "--all");
+        executeAndAssertFailure("rule", "update", "-c", "FULL", "INTEGRITY");
+    }
+
+    @Test
+    @Order(3)
+    public void testRuleUpdateCommand() throws JsonProcessingException {
+        // When
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("rule", "update", "--output-type", "json",
+                "-c", "SYNTAX_ONLY",
+                "VALIDITY");
+        var rule = MAPPER.readValue(out.toString(), Rule.class);
+
+        // Then
+        assertThat(rule.getRuleType())
+                .as(withCliOutput("Updated rule should have the correct ruleType"))
+                .isNotNull();
+        assertThat(rule.getRuleType().value())
+                .as(withCliOutput("Updated rule should have ruleType VALIDITY"))
+                .isEqualTo("VALIDITY");
+        assertThat(rule.getConfig())
+                .as(withCliOutput("Updated rule should have the updated config"))
+                .isEqualTo("SYNTAX_ONLY");
+    }
+
+    @Test
+    @Order(4)
+    public void testRuleCreateIntegrity() throws JsonProcessingException {
+        // When - create an INTEGRITY rule
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("rule", "create", "--output-type", "json",
+                "-c", "FULL",
+                "INTEGRITY");
+        var rule = MAPPER.readValue(out.toString(), Rule.class);
+
+        // Then
+        assertThat(rule.getRuleType())
+                .as(withCliOutput("Created rule should have the correct ruleType"))
+                .isNotNull();
+        assertThat(rule.getRuleType().value())
+                .as(withCliOutput("Created rule should have ruleType INTEGRITY"))
+                .isEqualTo("INTEGRITY");
+        assertThat(rule.getConfig())
+                .as(withCliOutput("Created rule should have the correct config"))
+                .isEqualTo("FULL");
+    }
+
+    @Test
+    @Order(5)
+    public void testRuleListCommand() throws JsonProcessingException {
+        // Create a third rule
+        executeAndAssertSuccess("rule", "create", "-c", "BACKWARD", "COMPATIBILITY");
+
+        // When
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("rule", "--output-type", "json");
+        var rules = MAPPER.readValue(out.toString(), new TypeReference<List<String>>() {
+        });
+
+        // Then - VALIDITY (Order 1) + INTEGRITY (Order 4) + COMPATIBILITY (just created)
+        assertThat(rules)
+                .as(withCliOutput("There should be three global rules."))
+                .hasSize(3);
+    }
+
+    @Test
+    @Order(6)
+    public void testRuleDeleteCommand() throws JsonProcessingException {
+        // When - delete a single rule
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("rule", "delete", "COMPATIBILITY");
+
+        // Then - verify two rules remain
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("rule", "--output-type", "json");
+        var rules = MAPPER.readValue(out.toString(), new TypeReference<List<String>>() {
+        });
+        assertThat(rules)
+                .as(withCliOutput("There should be two global rules after deleting COMPATIBILITY."))
+                .hasSize(2);
+    }
+
+    @Test
+    @Order(7)
+    public void testRuleDeleteAllCommand() throws JsonProcessingException {
+        // Create another rule so we have two
+        executeAndAssertSuccess("rule", "create", "-c", "BACKWARD", "COMPATIBILITY");
+
+        // When - delete all rules
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("rule", "delete", "--all");
+
+        // Then - verify no rules remain
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("rule", "--output-type", "json");
+        var rules = MAPPER.readValue(out.toString(), new TypeReference<List<String>>() {
+        });
+        assertThat(rules)
+                .as(withCliOutput("There should be no global rules after deleting all."))
+                .isEmpty();
+    }
+
+    @Test
+    public void testRuleDeleteCommandFails() {
+        // Delete without specifying rule type or --all
+        executeAndAssertFailure("rule", "delete");
+        // Invalid rule type
+        executeAndAssertFailure("rule", "delete", "INVALID_TYPE");
+        // Mutually exclusive: --all with specific rule type
+        executeAndAssertFailure("rule", "delete", "--all", "VALIDITY");
+        // Delete a rule that does not exist
+        executeAndAssertSuccess("rule", "delete", "--all");
+        executeAndAssertFailure("rule", "delete", "INTEGRITY");
+    }
+
+    @Test
+    public void testRuleTableOutput() {
+        // Verify table output works for list
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("rule");
+        assertThat(out.toString())
+                .as(withCliOutput("Table output should contain column headers"))
+                .contains("Rule Type");
+    }
+}


### PR DESCRIPTION
## Summary

Add global rules management commands to the Apicurio Registry CLI. Supports create, list, get, update, and delete operations for global rules (VALIDITY, COMPATIBILITY, INTEGRITY) with client-side validation, JSON/table output, and delete-all support.

## Changes

- Add `globalrule` sub-package with create, get, update, delete, and list commands
- Add `RuleUtil` in `common` package for reusable rule type and config validation
- Add `Rule` conversion method to `Conversions.java` (SDK model → beans model)
- Add `RULE_TYPE` and `CONFIG` constants to `Columns.java`
- Add `schema-util-common` dependency for config enum validation
- Register `GlobalRuleCommand` as subcommand in `Acr.java`

## Usage

```bash
acr rule                                        # list all global rules
acr rule -o json                                # list in JSON format
acr rule create VALIDITY -c FULL                # create a rule
acr rule get VALIDITY                           # get rule details
acr rule get VALIDITY -o json                   # get in JSON format
acr rule update VALIDITY -c SYNTAX_ONLY         # update rule config
acr rule delete VALIDITY                        # delete a single rule
acr rule delete --all                           # delete all global rules
```

## Testing

- [x] Build succeeds (`mvnw clean install -pl cli -DskipTests`)
- [x] Checkstyle passes with 0 violations
- [x] Integration tests pass with Podman (`GlobalRuleCommandTest` - 14 tests)
- [x] Native binary build succeeds
- [x] Manual verification (38 test cases):
  - [x] Help output for all subcommands (rule, create, get, update, delete)
  - [x] List rules - empty state (table and JSON)
  - [x] Create rules - all 3 types (VALIDITY, COMPATIBILITY, INTEGRITY)
  - [x] Create rules - JSON output format
  - [x] Get rule details (table and JSON)
  - [x] Update rule config and verify change
  - [x] Delete single rule and verify count
  - [x] Delete all rules and verify empty
  - [x] Error: invalid rule type validation
  - [x] Error: invalid config validation per rule type
  - [x] Error: missing required parameters (--config, ruleType)
  - [x] Error: duplicate rule creation
  - [x] Error: get/update/delete non-existent rule
  - [x] Error: mutually exclusive --all with specific rule type on delete
  - [x] Error: delete without args or --all
  - [x] Aliases work (rules, add, rm, remove)

Closes #7168