### PR TITLE
feat: versioning strategy with multi-channel OLM and minor-series Docker tags

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -77,11 +77,16 @@ jobs:
             core.info(`IS_LATEST_RELEASE=${isLatest}`);
             core.exportVariable('IS_LATEST_RELEASE', String(isLatest));
 
+      - name: Calculate Minor Series Tag
+        run: |
+          MINOR_TAG=$(echo "$RELEASE_VERSION" | awk -F. '{print $1"."$2}')
+          echo "MINOR_TAG=$MINOR_TAG" >> $GITHUB_ENV
+
       - name: Download Source Code
         run: git clone --branch $RELEASE_VERSION --single-branch ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git registry
 
       # We have faced issues in the past where a github release was created from a wrong commit
-      # This step will ensure that the release was created from the right commit  
+      # This step will ensure that the release was created from the right commit
       - name: Verify Project Version
         run: |
           cd registry
@@ -89,7 +94,7 @@ jobs:
           if [[ $PROJECT_VERSION != $RELEASE_VERSION ]]
           then
               echo "ERROR: Project Version '${PROJECT_VERSION}' does not match with Released Version '${RELEASE_VERSION}'"
-              exit 1	  
+              exit 1
           fi
 
       - name: Set up JDK 21
@@ -149,6 +154,7 @@ jobs:
         working-directory: registry/mcp
         run: |
           TAGS="-t quay.io/apicurio/apicurio-registry-mcp-server:$RELEASE_VERSION"
+          TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-mcp-server:$MINOR_TAG"
           if [ "$IS_LATEST_RELEASE" = "true" ]; then
             TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-mcp-server:latest"
           fi
@@ -160,7 +166,9 @@ jobs:
         run: |
           cd registry
           TAGS="-t docker.io/apicurio/apicurio-registry:$RELEASE_VERSION"
+          TAGS="$TAGS -t docker.io/apicurio/apicurio-registry:$MINOR_TAG"
           TAGS="$TAGS -t quay.io/apicurio/apicurio-registry:$RELEASE_VERSION"
+          TAGS="$TAGS -t quay.io/apicurio/apicurio-registry:$MINOR_TAG"
           if [ "$IS_LATEST_RELEASE" = "true" ]; then
             TAGS="$TAGS -t docker.io/apicurio/apicurio-registry:latest"
             TAGS="$TAGS -t docker.io/apicurio/apicurio-registry:latest-release"
@@ -175,7 +183,9 @@ jobs:
         run: |
           cd registry/ui
           TAGS="-t docker.io/apicurio/apicurio-registry-ui:$RELEASE_VERSION"
+          TAGS="$TAGS -t docker.io/apicurio/apicurio-registry-ui:$MINOR_TAG"
           TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-ui:$RELEASE_VERSION"
+          TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-ui:$MINOR_TAG"
           if [ "$IS_LATEST_RELEASE" = "true" ]; then
             TAGS="$TAGS -t docker.io/apicurio/apicurio-registry-ui:latest"
             TAGS="$TAGS -t docker.io/apicurio/apicurio-registry-ui:latest-release"

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -13,16 +13,18 @@ on:
   release:
     types: [ released ]
 
-env:
-  RELEASE_VERSION: ${{ github.event.release.name }}
-  BRANCH: ${{ github.event.release.target_commitish }}
-  RUN_TESTS: 'true'
-
 jobs:
-  release-operator:
+
+  release-build:
+    name: Build & Publish
     if: github.repository_owner == 'Apicurio' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '3.'))
     runs-on: ubuntu-22.04
-    timeout-minutes: 180
+    timeout-minutes: 60
+    outputs:
+      release-version: ${{ steps.config.outputs.release-version }}
+      branch: ${{ steps.config.outputs.branch }}
+      run-tests: ${{ steps.config.outputs.run-tests }}
+      package-version: ${{ steps.config.outputs.package-version }}
     steps:
 
       - name: Fetch Release Details
@@ -32,6 +34,13 @@ jobs:
           echo "RELEASE_VERSION=$(cat release.json | jq -r '.name')" >> $GITHUB_ENV
           echo "BRANCH=$(cat release.json | jq -r '.target_commitish')" >> $GITHUB_ENV
           echo "RUN_TESTS=${{ github.event.inputs.run_tests }}" >> $GITHUB_ENV
+
+      - name: Configure release event env
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          echo "RELEASE_VERSION=${{ github.event.release.name }}" >> $GITHUB_ENV
+          echo "BRANCH=${{ github.event.release.target_commitish }}" >> $GITHUB_ENV
+          echo "RUN_TESTS=true" >> $GITHUB_ENV
 
       - name: Download Source Code
         run: |
@@ -50,27 +59,19 @@ jobs:
               exit 1
           fi
 
-      - name: Configure env. variables 1
+      - name: Configure outputs
+        id: config
         working-directory: registry/operator
         run: |
-          echo "GH_TOKEN=${{ secrets.ACCESS_TOKEN }}" >> "$GITHUB_ENV"
-          echo "CUSTOM_ENV=$(pwd)/custom_env" >> "$GITHUB_ENV"
-          echo "PACKAGE_VERSION=$(make VAR=LC_VERSION variable-get)" >> "$GITHUB_ENV"
-
-      - name: Configure env. variables 2
-        run: |
-          echo "RELEASE_BRANCH=release-$PACKAGE_VERSION" >> "$GITHUB_ENV"
-
-      - name: Configure custom env. variables 1
-        # See https://github.com/actions/runner/issues/1126
-        run: |
-          echo "export OPERAND_IMAGE_TAG=$RELEASE_VERSION" >> "$CUSTOM_ENV"
+          echo "release-version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "run-tests=$RUN_TESTS" >> $GITHUB_OUTPUT
+          echo "package-version=$(make VAR=LC_VERSION variable-get)" >> $GITHUB_OUTPUT
 
       - name: Show make configuration
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make config-show
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION config-show
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -82,7 +83,6 @@ jobs:
       - name: Build the operator
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
           make BUILD_OPTS=--no-transfer-progress SKIP_TESTS=true build
 
       - name: Login to Quay.io Registry
@@ -91,60 +91,185 @@ jobs:
       - name: Build and push operator image
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make ADDITIONAL_IMAGE_TAG=latest image-build image-push
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_IMAGE_TAG=latest image-build image-push
 
       - name: Wait on operand images
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          export REGISTRY_APP_IMAGE="$(make VAR=REGISTRY_APP_IMAGE variable-get)"
+          export REGISTRY_APP_IMAGE="$(make OPERAND_IMAGE_TAG=$RELEASE_VERSION VAR=REGISTRY_APP_IMAGE variable-get)"
           until docker manifest inspect "$REGISTRY_APP_IMAGE" >& /dev/null; do echo "Waiting on $REGISTRY_APP_IMAGE"; sleep 10; done
-          export REGISTRY_UI_IMAGE="$(make VAR=REGISTRY_UI_IMAGE variable-get)"
+          export REGISTRY_UI_IMAGE="$(make OPERAND_IMAGE_TAG=$RELEASE_VERSION VAR=REGISTRY_UI_IMAGE variable-get)"
           until docker manifest inspect "$REGISTRY_UI_IMAGE" >& /dev/null; do echo "Waiting on $REGISTRY_UI_IMAGE"; sleep 10; done
 
       - name: Build operator bundle
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make bundle
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION bundle
 
       - name: Build operator catalog
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make ADDITIONAL_CATALOG_IMAGE_TAG=latest catalog
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_CATALOG_IMAGE_TAG=latest catalog
+
+      - name: Generate install file for tests
+        working-directory: registry/operator
+        run: |
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION INSTALL_FILE=controller/target/test-install.yaml dist-install-file
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-test-artifacts
+          path: |
+            registry/operator/controller/target/
+            registry/operator/model/target/
+            registry/operator/olm-tests/target/
+          retention-days: 1
+
+      - name: Upload bundle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-bundle-artifacts
+          path: |
+            registry/operator/target/bundle/
+          retention-days: 1
+
+  release-test:
+    name: Test (${{ matrix.name }})
+    needs: release-build
+    if: needs.release-build.outputs.run-tests == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: smoke
+            groups: "smoke"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: kafka
+            groups: "kafka"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: auth
+            groups: "auth"
+            excluded-groups: "kafka"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: database
+            groups: "database"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: feature
+            groups: "feature"
+            excluded-groups: "feature-setup"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: feature-setup
+            groups: "feature-setup"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: olm-v1
+            groups: "OLM"
+            olm-enable: "true"
+            olm-v1-enable: "true"
+            extra-build-opts: "-Dtest.operator.olm-version=1"
+          - name: olm-v0
+            groups: "OLM"
+            olm-enable: "true"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+    steps:
+
+      - name: Download Source Code
+        run: |
+          git clone https://github.com/Apicurio/apicurio-registry.git registry
+          cd registry && git checkout "${{ needs.release-build.outputs.release-version }}"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Download test artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: operator-test-artifacts
+          path: registry/operator/
 
       - uses: apicurio/apicurio-github-actions/setup-minikube@v2
-        if: env.RUN_TESTS == 'true'
         with:
-          # Do not use the "docker" driver, it is causing port-forwarding errors. I have no clue why :(
-          # TODO: I might've been wrong, check this again later.
           driver: 'none'
           ingress-enable: 'true'
-          olm-enable: 'true'
-          olm-v1-enable: 'true'
-          start-args: '--alsologtostderr --v=2' # Debug
+          olm-enable: ${{ matrix.olm-enable }}
+          olm-v1-enable: ${{ matrix.olm-v1-enable }}
+          start-args: '--alsologtostderr --v=2'
 
-      - name: Run remote and OLM v1 tests on Minikube
-        if: env.RUN_TESTS == 'true'
+      - name: Run ${{ matrix.name }} tests on Minikube
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make REMOTE_TESTS_ALL_INSTALL_FILE=install/install.yaml BUILD_OPTS="--no-transfer-progress -Dtest.operator.olm-version=1" test-remote-all
+          make BUILD_OPTS="--no-transfer-progress ${{ matrix.extra-build-opts }}" \
+            OPERAND_IMAGE_TAG="${{ needs.release-build.outputs.release-version }}" \
+            REMOTE_TESTS_ALL_INSTALL_FILE=controller/target/test-install.yaml \
+            GROUPS="${{ matrix.groups }}" \
+            EXCLUDED_GROUPS="${{ matrix.excluded-groups }}" \
+            test-remote-group
 
-      - name: Run OLM v0 smoke tests on Minikube
-        if: env.RUN_TESTS == 'true'
+  release-post:
+    name: Post-Release
+    needs: [release-build, release-test]
+    if: always() && needs.release-build.result == 'success' && (needs.release-test.result == 'success' || needs.release-test.result == 'skipped')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    env:
+      RELEASE_VERSION: ${{ needs.release-build.outputs.release-version }}
+      BRANCH: ${{ needs.release-build.outputs.branch }}
+      PACKAGE_VERSION: ${{ needs.release-build.outputs.package-version }}
+    steps:
+
+      - name: Configure env. variables
+        run: |
+          echo "GH_TOKEN=${{ secrets.ACCESS_TOKEN }}" >> "$GITHUB_ENV"
+          echo "RELEASE_BRANCH=release-$PACKAGE_VERSION" >> "$GITHUB_ENV"
+
+      - name: Download Source Code
+        run: |
+          git config --global user.name apicurio-ci
+          git config --global user.email apicurio.ci@gmail.com
+          git clone "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git" registry
+          cd registry && git checkout "$RELEASE_VERSION"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Build operator
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make REMOTE_TESTS_ALL_INSTALL_FILE=install/install.yaml BUILD_OPTS="--no-transfer-progress -Dgroups=OLM" test-remote-all
+          make BUILD_OPTS=--no-transfer-progress SKIP_TESTS=true OPERAND_IMAGE_TAG=$RELEASE_VERSION build
+
+      - name: Download bundle artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: operator-bundle-artifacts
+          path: registry/operator/target/bundle/
 
       - name: Build dist archive and attach to the release
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make dist
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION dist
           DIST_FILE="target/apicurio-registry-operator-$RELEASE_VERSION.tar.gz"
           gh release upload "$RELEASE_VERSION" "$DIST_FILE"
 
@@ -164,7 +289,7 @@ jobs:
         run: |
           git checkout -b "$RELEASE_BRANCH"
           TITLE="Release Apicurio Registry Operator $PACKAGE_VERSION"
-          BODY="$(curl -s https://raw.githubusercontent.com/k8s-operatorhub/community-operators/main/docs/pull_request_template.md)"          
+          BODY="$(curl -s https://raw.githubusercontent.com/k8s-operatorhub/community-operators/main/docs/pull_request_template.md)"
           cp -r "../registry/operator/target/bundle/apicurio-registry-3/$PACKAGE_VERSION" operators/apicurio-registry-3
           git add .
           git commit -s -m "$TITLE"
@@ -196,12 +321,6 @@ jobs:
           gh repo set-default redhat-openshift-ecosystem/community-operators-prod
           gh pr create --title "$TITLE" --body "$BODY" --base main --head "Apicurio:$RELEASE_BRANCH"
 
-      - name: Configure custom env. variables 2
-        run: |
-          # We want to use latest-snapshot instead of x.y.z-snapshot
-          echo "export IMAGE_TAG=latest-snapshot" >> "$CUSTOM_ENV"
-          echo "export OPERAND_IMAGE_TAG=latest-snapshot" >> "$CUSTOM_ENV"
-
       - name: Prepare post-release changes
         working-directory: registry/operator
         run: |
@@ -226,8 +345,7 @@ jobs:
       - name: Update install file
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make SKIP_TESTS=true build INSTALL_FILE=install/install.yaml dist-install-file
+          make IMAGE_TAG=latest-snapshot OPERAND_IMAGE_TAG=latest-snapshot SKIP_TESTS=true build INSTALL_FILE=install/install.yaml dist-install-file
           git add install/*
 
       - name: Commit & push post-release changes

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -13,16 +13,18 @@ on:
   release:
     types: [ released ]
 
-env:
-  RELEASE_VERSION: ${{ github.event.release.name }}
-  BRANCH: ${{ github.event.release.target_commitish }}
-  RUN_TESTS: 'true'
-
 jobs:
-  release-operator:
+
+  release-build:
+    name: Build & Publish
     if: github.repository_owner == 'Apicurio' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '3.'))
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    outputs:
+      release-version: ${{ steps.config.outputs.release-version }}
+      branch: ${{ steps.config.outputs.branch }}
+      run-tests: ${{ steps.config.outputs.run-tests }}
+      package-version: ${{ steps.config.outputs.package-version }}
     steps:
 
       - name: Fetch Release Details
@@ -32,6 +34,13 @@ jobs:
           echo "RELEASE_VERSION=$(cat release.json | jq -r '.name')" >> $GITHUB_ENV
           echo "BRANCH=$(cat release.json | jq -r '.target_commitish')" >> $GITHUB_ENV
           echo "RUN_TESTS=${{ github.event.inputs.run_tests }}" >> $GITHUB_ENV
+
+      - name: Configure release event env
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          echo "RELEASE_VERSION=${{ github.event.release.name }}" >> $GITHUB_ENV
+          echo "BRANCH=${{ github.event.release.target_commitish }}" >> $GITHUB_ENV
+          echo "RUN_TESTS=true" >> $GITHUB_ENV
 
       - name: Download Source Code
         run: |
@@ -61,27 +70,19 @@ jobs:
               exit 1
           fi
 
-      - name: Configure env. variables 1
+      - name: Configure outputs
+        id: config
         working-directory: registry/operator
         run: |
-          echo "GH_TOKEN=${{ secrets.ACCESS_TOKEN }}" >> "$GITHUB_ENV"
-          echo "CUSTOM_ENV=$(pwd)/custom_env" >> "$GITHUB_ENV"
-          echo "PACKAGE_VERSION=$(make VAR=LC_VERSION variable-get)" >> "$GITHUB_ENV"
-
-      - name: Configure env. variables 2
-        run: |
-          echo "RELEASE_BRANCH=release-$PACKAGE_VERSION" >> "$GITHUB_ENV"
-
-      - name: Configure custom env. variables 1
-        # See https://github.com/actions/runner/issues/1126
-        run: |
-          echo "export OPERAND_IMAGE_TAG=$RELEASE_VERSION" >> "$CUSTOM_ENV"
+          echo "release-version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "run-tests=$RUN_TESTS" >> $GITHUB_OUTPUT
+          echo "package-version=$(make VAR=LC_VERSION variable-get)" >> $GITHUB_OUTPUT
 
       - name: Show make configuration
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make config-show
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION config-show
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -93,7 +94,6 @@ jobs:
       - name: Build the operator
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
           make BUILD_OPTS=--no-transfer-progress SKIP_TESTS=true build
 
       - name: Login to Quay.io Registry
@@ -102,60 +102,185 @@ jobs:
       - name: Build and push operator image
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make ADDITIONAL_IMAGE_TAG=latest image-build image-push
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_IMAGE_TAG=latest image-build image-push
 
       - name: Wait on operand images
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          export REGISTRY_APP_IMAGE="$(make VAR=REGISTRY_APP_IMAGE variable-get)"
+          export REGISTRY_APP_IMAGE="$(make OPERAND_IMAGE_TAG=$RELEASE_VERSION VAR=REGISTRY_APP_IMAGE variable-get)"
           until docker manifest inspect "$REGISTRY_APP_IMAGE" >& /dev/null; do echo "Waiting on $REGISTRY_APP_IMAGE"; sleep 10; done
-          export REGISTRY_UI_IMAGE="$(make VAR=REGISTRY_UI_IMAGE variable-get)"
+          export REGISTRY_UI_IMAGE="$(make OPERAND_IMAGE_TAG=$RELEASE_VERSION VAR=REGISTRY_UI_IMAGE variable-get)"
           until docker manifest inspect "$REGISTRY_UI_IMAGE" >& /dev/null; do echo "Waiting on $REGISTRY_UI_IMAGE"; sleep 10; done
 
       - name: Build operator bundle
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make bundle
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION bundle
 
       - name: Build operator catalog
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make ADDITIONAL_CATALOG_IMAGE_TAG=latest catalog
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_CATALOG_IMAGE_TAG=latest catalog
+
+      - name: Generate install file for tests
+        working-directory: registry/operator
+        run: |
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION INSTALL_FILE=controller/target/test-install.yaml dist-install-file
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-test-artifacts
+          path: |
+            registry/operator/controller/target/
+            registry/operator/model/target/
+            registry/operator/olm-tests/target/
+          retention-days: 1
+
+      - name: Upload bundle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-bundle-artifacts
+          path: |
+            registry/operator/target/bundle/
+          retention-days: 1
+
+  release-test:
+    name: Test (${{ matrix.name }})
+    needs: release-build
+    if: needs.release-build.outputs.run-tests == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: smoke
+            groups: "smoke"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: kafka
+            groups: "kafka"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: auth
+            groups: "auth"
+            excluded-groups: "kafka"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: database
+            groups: "database"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: feature
+            groups: "feature"
+            excluded-groups: "feature-setup"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: feature-setup
+            groups: "feature-setup"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: olm-v1
+            groups: "OLM"
+            olm-enable: "true"
+            olm-v1-enable: "true"
+            extra-build-opts: "-Dtest.operator.olm-version=1"
+          - name: olm-v0
+            groups: "OLM"
+            olm-enable: "true"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+    steps:
+
+      - name: Download Source Code
+        run: |
+          git clone https://github.com/Apicurio/apicurio-registry.git registry
+          cd registry && git checkout "${{ needs.release-build.outputs.release-version }}"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Download test artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: operator-test-artifacts
+          path: registry/operator/
 
       - uses: apicurio/apicurio-github-actions/setup-minikube@v2
-        if: env.RUN_TESTS == 'true'
         with:
-          # Do not use the "docker" driver, it is causing port-forwarding errors. I have no clue why :(
-          # TODO: I might've been wrong, check this again later.
           driver: 'none'
           ingress-enable: 'true'
-          olm-enable: 'true'
-          olm-v1-enable: 'true'
-          start-args: '--alsologtostderr --v=2' # Debug
+          olm-enable: ${{ matrix.olm-enable }}
+          olm-v1-enable: ${{ matrix.olm-v1-enable }}
+          start-args: '--alsologtostderr --v=2'
 
-      - name: Run remote and OLM v1 tests on Minikube
-        if: env.RUN_TESTS == 'true'
+      - name: Run ${{ matrix.name }} tests on Minikube
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make REMOTE_TESTS_ALL_INSTALL_FILE=install/install.yaml BUILD_OPTS="--no-transfer-progress -Dtest.operator.olm-version=1" test-remote-all
+          make BUILD_OPTS="--no-transfer-progress ${{ matrix.extra-build-opts }}" \
+            OPERAND_IMAGE_TAG="${{ needs.release-build.outputs.release-version }}" \
+            REMOTE_TESTS_ALL_INSTALL_FILE=controller/target/test-install.yaml \
+            GROUPS="${{ matrix.groups }}" \
+            EXCLUDED_GROUPS="${{ matrix.excluded-groups }}" \
+            test-remote-group
 
-      - name: Run OLM v0 smoke tests on Minikube
-        if: env.RUN_TESTS == 'true'
+  release-post:
+    name: Post-Release
+    needs: [release-build, release-test]
+    if: always() && needs.release-build.result == 'success' && (needs.release-test.result == 'success' || needs.release-test.result == 'skipped')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    env:
+      RELEASE_VERSION: ${{ needs.release-build.outputs.release-version }}
+      BRANCH: ${{ needs.release-build.outputs.branch }}
+      PACKAGE_VERSION: ${{ needs.release-build.outputs.package-version }}
+    steps:
+
+      - name: Configure env. variables
+        run: |
+          echo "GH_TOKEN=${{ secrets.ACCESS_TOKEN }}" >> "$GITHUB_ENV"
+          echo "RELEASE_BRANCH=release-$PACKAGE_VERSION" >> "$GITHUB_ENV"
+
+      - name: Download Source Code
+        run: |
+          git config --global user.name apicurio-ci
+          git config --global user.email apicurio.ci@gmail.com
+          git clone "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git" registry
+          cd registry && git checkout "$RELEASE_VERSION"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Build operator
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make REMOTE_TESTS_ALL_INSTALL_FILE=install/install.yaml BUILD_OPTS="--no-transfer-progress -Dgroups=OLM" test-remote-all
+          make BUILD_OPTS=--no-transfer-progress SKIP_TESTS=true OPERAND_IMAGE_TAG=$RELEASE_VERSION build
+
+      - name: Download bundle artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: operator-bundle-artifacts
+          path: registry/operator/target/bundle/
 
       - name: Build dist archive and attach to the release
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make dist
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION dist
           DIST_FILE="target/apicurio-registry-operator-$RELEASE_VERSION.tar.gz"
           gh release upload "$RELEASE_VERSION" "$DIST_FILE"
 
@@ -219,12 +344,6 @@ jobs:
         if: steps.openshift-community-operators-pr.outcome == 'failure'
         run: echo "::warning::Failed to create Openshift Community Operators PR. Please create it manually."
 
-      - name: Configure custom env. variables 2
-        run: |
-          # We want to use latest-snapshot instead of x.y.z-snapshot
-          echo "export IMAGE_TAG=latest-snapshot" >> "$CUSTOM_ENV"
-          echo "export OPERAND_IMAGE_TAG=latest-snapshot" >> "$CUSTOM_ENV"
-
       - name: Prepare post-release changes
         working-directory: registry/operator
         run: |
@@ -249,8 +368,7 @@ jobs:
       - name: Update install file
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make SKIP_TESTS=true build INSTALL_FILE=install/install.yaml dist-install-file
+          make IMAGE_TAG=latest-snapshot OPERAND_IMAGE_TAG=latest-snapshot SKIP_TESTS=true build INSTALL_FILE=install/install.yaml dist-install-file
           git add install/*
 
       - name: Commit & push post-release changes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
         description: Version being released
         required: true
       branch:
-        description: Branch to release from
+        description: Branch to release from (main for minor releases, release/X.Y.x for patches)
         required: true
         default: main
       no-more-minor-releases:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -414,6 +414,29 @@ jobs:
           npm version ${{ env.SNAPSHOT_UI_VERSION }} --allow-same-version
           popd
 
+      - name: Create maintenance branch for previous minor
+        if: github.event.inputs.branch == 'main'
+        run: |
+          cd registry
+          RELEASE_VERSION="${{ github.event.inputs.release-version }}"
+          MAJOR=$(echo "$RELEASE_VERSION" | awk -F '[.-]' '{print $1}')
+          MINOR=$(echo "$RELEASE_VERSION" | awk -F '[.-]' '{print $2}')
+          PATCH=$(echo "$RELEASE_VERSION" | awk -F '[.-]' '{print $3}')
+
+          if [ "$PATCH" = "0" ] && [ "$MINOR" -gt "0" ]; then
+            PREV_MINOR=$((MINOR - 1))
+            MAINT_BRANCH="release/${MAJOR}.${PREV_MINOR}.x"
+            # Find the latest tag for the previous minor
+            PREV_TAG=$(git tag -l "${MAJOR}.${PREV_MINOR}.*" --sort=-v:refname | head -1)
+            if [ -n "$PREV_TAG" ] && ! git ls-remote --exit-code origin "refs/heads/$MAINT_BRANCH" > /dev/null 2>&1; then
+              echo "Creating maintenance branch $MAINT_BRANCH from tag $PREV_TAG"
+              git branch "$MAINT_BRANCH" "$PREV_TAG"
+              git push origin "$MAINT_BRANCH"
+            else
+              echo "Maintenance branch $MAINT_BRANCH already exists or no previous tag found, skipping"
+            fi
+          fi
+
       - name: Commit Snapshot Version ${{ env.SNAPSHOT_VERSION }}
         run: |
           cd registry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,32 @@ The important parts are as follows:
 - When creating an artifact of a type that is not included in the default, you must _always_ specify the appropriate artifact type.
 - The registry UI will show the plain name of the additional type and won't have an appropriate icon to identify it.
 
+## Versioning & Release Cycle
+
+Apicurio Registry uses [Semantic Versioning](https://semver.org/) with a clear split between minor and patch releases:
+
+| Release type | Contains | Example |
+|--------------|----------|---------|
+| **Minor** (3.3.0 → 3.4.0) | New features, enhancements, bug fixes | Scheduled development milestones |
+| **Patch** (3.3.0 → 3.3.1) | CVE / security fixes only | Dependency upgrades, security patches |
+
+### Support window
+
+We maintain the **latest two minor versions** with security patches. Once a new minor is released, the oldest supported minor reaches end-of-life.
+
+### Branch strategy
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Active development — next minor release |
+| `release/3.3.x` | Maintenance branch for 3.3 patch releases (created when 3.4.0 development starts) |
+
+### Where to target your PR
+
+- **Features and bug fixes** → target `main`
+- **CVE / security backports for N-1** → target the maintenance branch (e.g., `release/3.3.x`), cherry-picked from the fix on `main`
+- Bug fix backports are **not** accepted on maintenance branches — patches are strictly CVE-only
+
 ## The small print
 
 This project is an open source project. Please act responsibly, be nice, polite and enjoy!

--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@
 
 An API/Schema registry - stores and retrieves APIs and Schemas.
 
+## Versioning & Support Policy
+
+Apicurio Registry follows [Semantic Versioning](https://semver.org/):
+
+- **Minor releases** (3.3.0, 3.4.0, ...): new features, enhancements, and bug fixes.
+- **Patch releases** (3.3.1, 3.3.2, ...): CVE and security fixes only. No new features, no bug fixes.
+
+**Support window:** the two most recent minor versions (latest and latest-1) receive patch releases for security issues. Older minors are end-of-life.
+
+**Docker image tags:**
+
+| Tag | Description |
+|-----|-------------|
+| `3.3.0` | Pinned to an exact release |
+| `3.3` | Floating tag — always points to the latest patch in the 3.3.x series |
+| `latest` / `latest-release` | Always points to the most recent stable release |
+| `latest-snapshot` | Most recent build from the `main` branch (unstable) |
+
+**OLM channels (Kubernetes operator):** each minor version has its own OLM channel (e.g., `3.3.x`). Subscribe to a channel to receive only patch updates within that minor. A rolling `3.x` channel is also available for users who always want the latest minor.
+
 ## Build Configuration
 
 This project supports several build configuration options that affect the produced executables.
@@ -171,13 +191,8 @@ variables (The command line parameters are for the `java` executable and at the 
 pass them into the container).  Each docker image will support the environment variable configuration options
 documented above for their respective storage type.
 
-There are a variety of docker image tags to choose from when running the registry docker images.  Each
-release of the project has a specific tag associated with it.  So release `1.2.0.Final` has an equivalent
-docker tag specific to that release.  We also support the following moving tags:
-
-* `latest-snapshot` : represents the most recent docker image produced whenever the `main` branch is updated
-* `latest` : represents the latest stable (released) build of Apicurio Registry
-* `latest-release` : represents the latest stable (released) build of Apicurio Registry (alias for `latest` with clearer semantics)
+See [Versioning & Support Policy](#versioning--support-policy) above for the full list of available
+Docker image tags, including version-pinned, minor-series floating, and latest tags.
 
 Note that if you want to have access to the UI for Registry, you must **also** run the UI container image:
 

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -13,6 +13,8 @@
 ** xref:getting-started/assembly-deploying-registry-secured-kafka.adoc[]
 ** xref:getting-started/assembly-implementing-multitenancy.adoc[]
 ** xref:getting-started/assembly-registry-high-availability.adoc[]
+* Versioning and support
+** xref:getting-started/assembly-versioning-support-policy.adoc[]
 * Migration
 ** xref:getting-started/assembly-migrating-registry-v2-v3.adoc[]
 * Configuration

--- a/docs/modules/ROOT/pages/getting-started/assembly-migrating-registry-v2-v3.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-migrating-registry-v2-v3.adoc
@@ -8,6 +8,8 @@ This documentation describes how to migrate from {registry} {registry-v2} to {re
 
 {registry} 3.x includes breaking changes that require a new deployment, data migration, and client application updates. There is no in-place upgrade path from v2 to v3.
 
+NOTE: For general versioning policy, upgrade guidance within the 3.x series, and rollback procedures, see xref:versioning-support-policy_{context}[].
+
 
 // con-registry-migration-overview
 [id="registry-migration-overview_{context}"]

--- a/docs/modules/ROOT/pages/getting-started/assembly-versioning-support-policy.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-versioning-support-policy.adoc
@@ -1,0 +1,204 @@
+include::{mod-loc}shared/all-attributes.adoc[]
+
+[id="versioning-support-policy_{context}"]
+= Versioning and support policy
+
+[role="_abstract"]
+This chapter describes the {registry} versioning scheme, support policy, release channels, and guidance for upgrading and handling rollbacks.
+
+* xref:versioning-scheme_{context}[]
+* xref:support-window_{context}[]
+* xref:release-channels_{context}[]
+* xref:upgrading-registry_{context}[]
+* xref:downgrades-and-rollbacks_{context}[]
+
+
+[id="versioning-scheme_{context}"]
+== Versioning scheme
+
+[role="_abstract"]
+{registry} follows https://semver.org/[Semantic Versioning] with a clear distinction between minor and patch releases.
+
+[cols="1,2,2", options="header"]
+|===
+| Release type
+| Contents
+| Example
+
+| *Minor* (e.g., 3.3.0 -> 3.4.0)
+| New features, enhancements, and bug fixes
+| Scheduled development milestones
+
+| *Patch* (e.g., 3.3.0 -> 3.3.1)
+| CVE and security fixes only
+| Dependency upgrades, security patches
+|===
+
+Patch releases do not contain new features or bug fixes.
+They are limited to changes that address known security vulnerabilities.
+
+
+[id="support-window_{context}"]
+== Support window
+
+[role="_abstract"]
+{registry} maintains the *two most recent minor versions* with security patches.
+
+When a new minor version is released, the oldest supported minor version reaches end-of-life and no longer receives updates.
+
+.Example support timeline
+[cols="1,1,1", options="header"]
+|===
+| Event
+| Supported versions
+| End-of-life
+
+| 3.3.0 released
+| 3.3.x, 3.2.x
+| 3.1.x and older
+
+| 3.4.0 released
+| 3.4.x, 3.3.x
+| 3.2.x and older
+|===
+
+
+[id="release-channels_{context}"]
+== Release channels
+
+[role="_abstract"]
+{registry} provides multiple release channels so that you can choose the update cadence that suits your deployment.
+
+
+=== Docker image tags
+
+[cols="1,3", options="header"]
+|===
+| Tag
+| Description
+
+| `3.3.0`
+| Pinned to an exact release. Never changes.
+
+| `3.3`
+| Floating tag that always points to the latest patch in the 3.3.x series (e.g., 3.3.0 -> 3.3.1 -> 3.3.2).
+
+| `latest` / `latest-release`
+| Always points to the most recent stable release across all minor versions.
+
+| `latest-snapshot`
+| Most recent build from the `main` branch. Unstable and not recommended for production.
+|===
+
+Use the minor-series floating tag (e.g., `3.3`) to automatically receive security patches without upgrading to a new minor version.
+
+
+=== OLM channels (Kubernetes operator)
+
+If you deploy {registry} using the {operator}, each minor version has its own OLM channel:
+
+[cols="1,3", options="header"]
+|===
+| Channel
+| Description
+
+| `3.3.x`
+| Receives only patch updates within the 3.3 minor version.
+
+| `3.x`
+| Rolling channel that always tracks the latest minor version.
+|===
+
+Subscribe to a minor-version channel (e.g., `3.3.x`) for stability, or to the `3.x` rolling channel to always receive the latest features.
+
+
+[id="upgrading-registry_{context}"]
+== Upgrading {registry}
+
+[role="_abstract"]
+{registry} supports forward upgrades.
+Database schema migrations run automatically on startup and do not require manual intervention.
+
+[IMPORTANT]
+====
+Always back up your database before upgrading to a new minor version.
+See xref:backup-before-upgrade_{context}[].
+====
+
+
+=== Patch upgrades (within a minor version)
+
+Patch upgrades (e.g., 3.3.0 -> 3.3.1) are safe and always recommended.
+They contain only CVE fixes and do not introduce behavioral changes.
+
+.Procedure
+. Back up your database.
+. Replace the {registry} container image with the new patch version or use the minor-series floating tag.
+. Start {registry}. Any required schema migrations run automatically.
+
+
+=== Minor upgrades
+
+Minor upgrades (e.g., 3.3.x -> 3.4.0) include new features, enhancements, and bug fixes.
+
+.Procedure
+. Review the release notes for the target version to understand new features and any behavioral changes.
+. Back up your database.
+. Replace the {registry} container image with the new minor version.
+. Start {registry}. Database schema migrations run automatically.
+. Verify that your client applications work correctly with the new version.
+
+
+=== Skipping minor versions
+
+Upgrading across multiple minor versions (e.g., 3.2.x -> 3.4.x) is supported.
+Database migrations are cumulative and applied in order on startup.
+
+Review the release notes for all intermediate versions to understand the full set of changes.
+
+
+[id="downgrades-and-rollbacks_{context}"]
+== Downgrades and rollbacks
+
+[role="_abstract"]
+{registry} does *not* support downgrades.
+
+Database schema migrations are forward-only and irreversible.
+Starting an older version of {registry} against a database that has been migrated to a newer schema version will fail.
+
+If you deploy {registry} using the {operator}, switching to an older OLM channel is also not supported.
+
+=== Handling a failed upgrade
+
+If an upgrade introduces issues, restore from the database backup taken before the upgrade:
+
+.Procedure
+. Stop {registry}.
+. Restore the database from the backup taken before the upgrade.
+. Deploy the previous version of {registry}.
+. Investigate the issue before attempting the upgrade again.
+
+Do *not* attempt to manually revert database schema changes.
+
+
+[id="backup-before-upgrade_{context}"]
+== Backing up before an upgrade
+
+[role="_abstract"]
+Before any minor version upgrade, create a backup of your {registry} database.
+
+For PostgreSQL deployments:
+
+[source,bash]
+----
+pg_dump -h <host> -U <username> -d <database> -F c -f registry-backup-$(date +%Y%m%d).dump
+----
+
+For KafkaSQL deployments, back up both the Kafka topic data and the SQL snapshot database.
+
+Store backups in a secure location and verify that they can be restored before proceeding with the upgrade.
+
+
+[role="_additional-resources"]
+.Additional resources
+* xref:registry-migration_{context}[Migrating from {registry} {registry-v2} to {registry} 3.x]

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -40,8 +40,12 @@ PACKAGE ?= $(PACKAGE_NAME).v$(LC_VERSION)
 PREVIOUS_PACKAGE_VERSION ?= 3.2.1
 PREVIOUS_PACKAGE ?= $(PACKAGE_NAME).v$(PREVIOUS_PACKAGE_VERSION)
 
-CHANNELS ?= 3.x
-DEFAULT_CHANNEL ?= $(CHANNELS)
+# Auto-derive channel from version (e.g., 3.2.1 -> 3.2.x, 3.3.0-snapshot -> 3.3.x)
+CHANNEL ?= $(shell echo "$(LC_VERSION)" | sed 's/\([0-9]*\.[0-9]*\)\..*/\1.x/')
+PREVIOUS_CHANNEL ?= $(shell echo "$(PREVIOUS_PACKAGE_VERSION)" | sed 's/\([0-9]*\.[0-9]*\)\..*/\1.x/')
+
+CHANNELS ?= $(CHANNEL)
+DEFAULT_CHANNEL ?= $(CHANNEL)
 
 BUNDLE_OPTS ?= --package $(PACKAGE_NAME) --version $(LC_VERSION) --channels=$(CHANNELS) --default-channel=$(DEFAULT_CHANNEL)
 BUNDLE_DIR ?= target/bundle/$(PACKAGE_NAME)/$(LC_VERSION)
@@ -111,6 +115,8 @@ export PLACEHOLDER_BUNDLE_IMAGE := $(BUNDLE_IMAGE)
 export PLACEHOLDER_CATALOG_NAMESPACE := $(CATALOG_NAMESPACE)
 export PLACEHOLDER_CATALOG_IMAGE := $(CATALOG_IMAGE)
 
+export PLACEHOLDER_CHANNEL := $(CHANNEL)
+
 
 ########## Help
 
@@ -148,6 +154,8 @@ endif
 	@echo ""
 	@echo "$(CC_CYAN)Bundle$(CC_END)"
 	@echo "PACKAGE_NAME=$(PACKAGE_NAME)"
+	@echo "CHANNEL=$(CHANNEL)"
+	@echo "PREVIOUS_CHANNEL=$(PREVIOUS_CHANNEL)"
 	@echo "CHANNELS=$(CHANNELS)"
 	@echo "DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)"
 	@echo "BUNDLE_IMAGE=$(BUNDLE_IMAGE)"
@@ -480,8 +488,30 @@ endif
 
 .PHONY: release-catalog-template-update
 release-catalog-template-update: install-yq
+	# Update 3.x rolling channel: replace placeholder with released version, add new placeholder
 	$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "3.x") | .entries[] | select(.name == "$${PLACEHOLDER_PACKAGE}")).name = "$(PREVIOUS_PACKAGE)"' -i $(CATALOG_DIR)/catalog.template.yaml
 	$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "3.x") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}", "replaces": "$(PREVIOUS_PACKAGE)"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml
+	# Update minor-version channel
+	@if $(YQ) -e '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(PREVIOUS_CHANNEL)"))' $(CATALOG_DIR)/catalog.template.yaml > /dev/null 2>&1; then \
+		echo "Updating existing $(PREVIOUS_CHANNEL) channel"; \
+		$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(PREVIOUS_CHANNEL)") | .entries[] | select(.name == "$${PLACEHOLDER_PACKAGE}")).name = "$(PREVIOUS_PACKAGE)"' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	else \
+		echo "Creating new $(PREVIOUS_CHANNEL) channel with $(PREVIOUS_PACKAGE)"; \
+		$(YQ) '.entries |= . + [{"schema": "olm.channel", "package": "$${PLACEHOLDER_PACKAGE_NAME}", "name": "$(PREVIOUS_CHANNEL)", "entries": [{"name": "$(PREVIOUS_PACKAGE)"}]}]' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	fi
+	@if [ "$(CHANNEL)" = "$(PREVIOUS_CHANNEL)" ]; then \
+		echo "Adding placeholder to $(CHANNEL) channel (same minor)"; \
+		$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}", "replaces": "$(PREVIOUS_PACKAGE)"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	elif $(YQ) -e '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)"))' $(CATALOG_DIR)/catalog.template.yaml > /dev/null 2>&1; then \
+		echo "Adding placeholder to existing $(CHANNEL) channel (new minor)"; \
+		$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	else \
+		echo "Creating new $(CHANNEL) channel with placeholder (new minor)"; \
+		$(YQ) '.entries |= . + [{"schema": "olm.channel", "package": "$${PLACEHOLDER_PACKAGE_NAME}", "name": "$(CHANNEL)", "entries": [{"name": "$${PLACEHOLDER_PACKAGE}"}]}]' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	fi
+	# Update defaultChannel to the current channel
+	$(YQ) '(.entries[] | select(.schema == "olm.package")).defaultChannel = "$${PLACEHOLDER_CHANNEL}"' -i $(CATALOG_DIR)/catalog.template.yaml
+	# Add bundle image for the released version
 	$(YQ) '.entries |= . + [{"schema": "olm.bundle", "image": "$(PREVIOUS_BUNDLE_IMAGE)"}]' -i $(CATALOG_DIR)/catalog.template.yaml
 
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -40,8 +40,12 @@ PACKAGE ?= $(PACKAGE_NAME).v$(LC_VERSION)
 PREVIOUS_PACKAGE_VERSION ?= 3.2.4
 PREVIOUS_PACKAGE ?= $(PACKAGE_NAME).v$(PREVIOUS_PACKAGE_VERSION)
 
-CHANNELS ?= 3.x
-DEFAULT_CHANNEL ?= $(CHANNELS)
+# Auto-derive channel from version (e.g., 3.2.1 -> 3.2.x, 3.3.0-snapshot -> 3.3.x)
+CHANNEL ?= $(shell echo "$(LC_VERSION)" | sed 's/\([0-9]*\.[0-9]*\)\..*/\1.x/')
+PREVIOUS_CHANNEL ?= $(shell echo "$(PREVIOUS_PACKAGE_VERSION)" | sed 's/\([0-9]*\.[0-9]*\)\..*/\1.x/')
+
+CHANNELS ?= $(CHANNEL)
+DEFAULT_CHANNEL ?= $(CHANNEL)
 
 BUNDLE_OPTS ?= --package $(PACKAGE_NAME) --version $(LC_VERSION) --channels=$(CHANNELS) --default-channel=$(DEFAULT_CHANNEL)
 BUNDLE_DIR ?= target/bundle/$(PACKAGE_NAME)/$(LC_VERSION)
@@ -111,6 +115,8 @@ export PLACEHOLDER_BUNDLE_IMAGE := $(BUNDLE_IMAGE)
 export PLACEHOLDER_CATALOG_NAMESPACE := $(CATALOG_NAMESPACE)
 export PLACEHOLDER_CATALOG_IMAGE := $(CATALOG_IMAGE)
 
+export PLACEHOLDER_CHANNEL := $(CHANNEL)
+
 
 ########## Help
 
@@ -148,6 +154,8 @@ endif
 	@echo ""
 	@echo "$(CC_CYAN)Bundle$(CC_END)"
 	@echo "PACKAGE_NAME=$(PACKAGE_NAME)"
+	@echo "CHANNEL=$(CHANNEL)"
+	@echo "PREVIOUS_CHANNEL=$(PREVIOUS_CHANNEL)"
 	@echo "CHANNELS=$(CHANNELS)"
 	@echo "DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)"
 	@echo "BUNDLE_IMAGE=$(BUNDLE_IMAGE)"
@@ -480,8 +488,30 @@ endif
 
 .PHONY: release-catalog-template-update
 release-catalog-template-update: install-yq
+	# Update 3.x rolling channel: replace placeholder with released version, add new placeholder
 	$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "3.x") | .entries[] | select(.name == "$${PLACEHOLDER_PACKAGE}")).name = "$(PREVIOUS_PACKAGE)"' -i $(CATALOG_DIR)/catalog.template.yaml
 	$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "3.x") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}", "replaces": "$(PREVIOUS_PACKAGE)"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml
+	# Update minor-version channel
+	@if $(YQ) -e '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(PREVIOUS_CHANNEL)"))' $(CATALOG_DIR)/catalog.template.yaml > /dev/null 2>&1; then \
+		echo "Updating existing $(PREVIOUS_CHANNEL) channel"; \
+		$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(PREVIOUS_CHANNEL)") | .entries[] | select(.name == "$${PLACEHOLDER_PACKAGE}")).name = "$(PREVIOUS_PACKAGE)"' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	else \
+		echo "Creating new $(PREVIOUS_CHANNEL) channel with $(PREVIOUS_PACKAGE)"; \
+		$(YQ) '.entries |= . + [{"schema": "olm.channel", "package": "$${PLACEHOLDER_PACKAGE_NAME}", "name": "$(PREVIOUS_CHANNEL)", "entries": [{"name": "$(PREVIOUS_PACKAGE)"}]}]' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	fi
+	@if [ "$(CHANNEL)" = "$(PREVIOUS_CHANNEL)" ]; then \
+		echo "Adding placeholder to $(CHANNEL) channel (same minor)"; \
+		$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}", "replaces": "$(PREVIOUS_PACKAGE)"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	elif $(YQ) -e '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)"))' $(CATALOG_DIR)/catalog.template.yaml > /dev/null 2>&1; then \
+		echo "Adding placeholder to existing $(CHANNEL) channel (new minor)"; \
+		$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	else \
+		echo "Creating new $(CHANNEL) channel with placeholder (new minor)"; \
+		$(YQ) '.entries |= . + [{"schema": "olm.channel", "package": "$${PLACEHOLDER_PACKAGE_NAME}", "name": "$(CHANNEL)", "entries": [{"name": "$${PLACEHOLDER_PACKAGE}"}]}]' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	fi
+	# Update defaultChannel to the current channel
+	$(YQ) '(.entries[] | select(.schema == "olm.package")).defaultChannel = "$${PLACEHOLDER_CHANNEL}"' -i $(CATALOG_DIR)/catalog.template.yaml
+	# Add bundle image for the released version
 	$(YQ) '.entries |= . + [{"schema": "olm.bundle", "image": "$(PREVIOUS_BUNDLE_IMAGE)"}]' -i $(CATALOG_DIR)/catalog.template.yaml
 
 

--- a/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
+++ b/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
@@ -2,7 +2,7 @@ schema: olm.template.basic
 entries:
   - schema: olm.package
     name: ${PLACEHOLDER_PACKAGE_NAME}
-    defaultChannel: 3.x
+    defaultChannel: ${PLACEHOLDER_CHANNEL}
   - schema: olm.channel
     package: ${PLACEHOLDER_PACKAGE_NAME}
     name: 3.x
@@ -36,6 +36,15 @@ entries:
       - name: apicurio-registry-3.v3.0.8
         replaces: apicurio-registry-3.v3.0.7
       - name: apicurio-registry-3.v3.0.7
+  - schema: olm.channel
+    package: ${PLACEHOLDER_PACKAGE_NAME}
+    name: 3.2.x
+    entries:
+      - name: ${PLACEHOLDER_PACKAGE}
+        replaces: apicurio-registry-3.v3.2.1
+      - name: apicurio-registry-3.v3.2.1
+        replaces: apicurio-registry-3.v3.2.0
+      - name: apicurio-registry-3.v3.2.0
   - schema: olm.bundle
     image: ${PLACEHOLDER_BUNDLE_IMAGE}
   - schema: olm.bundle

--- a/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
+++ b/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
@@ -51,6 +51,11 @@ entries:
       - name: apicurio-registry-3.v3.2.1
         replaces: apicurio-registry-3.v3.2.0
       - name: apicurio-registry-3.v3.2.0
+  - schema: olm.channel
+    package: ${PLACEHOLDER_PACKAGE_NAME}
+    name: 3.3.x
+    entries:
+      - name: ${PLACEHOLDER_PACKAGE}
   - schema: olm.bundle
     image: ${PLACEHOLDER_BUNDLE_IMAGE}
   - schema: olm.bundle

--- a/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
+++ b/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
@@ -2,7 +2,7 @@ schema: olm.template.basic
 entries:
   - schema: olm.package
     name: ${PLACEHOLDER_PACKAGE_NAME}
-    defaultChannel: 3.x
+    defaultChannel: ${PLACEHOLDER_CHANNEL}
   - schema: olm.channel
     package: ${PLACEHOLDER_PACKAGE_NAME}
     name: 3.x
@@ -42,6 +42,15 @@ entries:
       - name: apicurio-registry-3.v3.0.8
         replaces: apicurio-registry-3.v3.0.7
       - name: apicurio-registry-3.v3.0.7
+  - schema: olm.channel
+    package: ${PLACEHOLDER_PACKAGE_NAME}
+    name: 3.2.x
+    entries:
+      - name: ${PLACEHOLDER_PACKAGE}
+        replaces: apicurio-registry-3.v3.2.1
+      - name: apicurio-registry-3.v3.2.1
+        replaces: apicurio-registry-3.v3.2.0
+      - name: apicurio-registry-3.v3.2.0
   - schema: olm.bundle
     image: ${PLACEHOLDER_BUNDLE_IMAGE}
   - schema: olm.bundle

--- a/operator/olm-tests/src/test/deploy/olmv0/subscription.yaml
+++ b/operator/olm-tests/src/test/deploy/olmv0/subscription.yaml
@@ -7,6 +7,6 @@ spec:
   sourceNamespace: ${PLACEHOLDER_CATALOG_NAMESPACE}
   source: apicurio-registry-operator-catalog
   name: ${PLACEHOLDER_PACKAGE_NAME}
-  channel: 3.x
+  channel: ${PLACEHOLDER_CHANNEL}
   startingCSV: ${PLACEHOLDER_PACKAGE}
   installPlanApproval: Automatic

--- a/operator/olm-tests/src/test/deploy/olmv1/cluster-extension.yaml
+++ b/operator/olm-tests/src/test/deploy/olmv1/cluster-extension.yaml
@@ -24,5 +24,5 @@ spec:
           olm.operatorframework.io/metadata.name: apicurio-registry-operator-catalog # Intentional for development and testing.
       packageName: ${PLACEHOLDER_PACKAGE_NAME}
       channels:
-        - 3.x
+        - ${PLACEHOLDER_CHANNEL}
       version: ${PLACEHOLDER_LC_VERSION}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
@@ -162,7 +162,18 @@ public abstract class OLMITBase {
         rawResource = rawResource.replace("${PLACEHOLDER_PACKAGE}", "apicurio-registry-3.v" + projectVersion.toLowerCase());
         rawResource = rawResource.replace("${PLACEHOLDER_VERSION}", projectVersion);
         rawResource = rawResource.replace("${PLACEHOLDER_LC_VERSION}", projectVersion.toLowerCase());
+        rawResource = rawResource.replace("${PLACEHOLDER_CHANNEL}", deriveChannel(projectVersion));
         return rawResource;
+    }
+
+    private static String deriveChannel(String version) {
+        // Derive minor-version channel from version (e.g., "3.2.1" -> "3.2.x", "3.3.0-SNAPSHOT" -> "3.3.x")
+        var lc = version.toLowerCase();
+        var parts = lc.split("\\.");
+        if (parts.length >= 2) {
+            return parts[0] + "." + parts[1] + ".x";
+        }
+        return lc;
     }
 
     @AfterEach


### PR DESCRIPTION
## Summary

Closes #7742

Implements the new versioning strategy for Apicurio Registry starting with 3.3.0:
- **Minor releases** (3.3, 3.4, ...): features + bugfixes
- **Patch releases** (3.3.1, 3.3.2, ...): CVE/security fixes only
- **Support window**: latest + latest-1 receive patches
- **Downgrades**: not supported — database migrations are forward-only, restore from backup

### Multi-channel OLM support
- Auto-derive minor-version OLM channels from the operator version (e.g., `3.2.1` → `3.2.x`) so users can subscribe to a specific minor stream and only receive patch updates
- Add `3.2.x` minor-version channel to catalog template alongside the `3.x` rolling channel for backward compatibility
- Update `release-catalog-template-update` Makefile target to handle multi-channel updates, including creating new minor channels on first release
- Parameterize channel in OLM v0/v1 test manifests via `${PLACEHOLDER_CHANNEL}`

### Minor-series floating Docker tags
- Add `MINOR_TAG` calculation step (e.g., `3.3.0` → `3.3`)
- Apply minor-series tags to app, UI, MCP server images on both Docker Hub and Quay.io
- Users can pin to `apicurio/apicurio-registry:3.3` and automatically receive patch updates

### Documentation
- **README.md**: Add "Versioning & Support Policy" section with release types, support window, Docker tag reference, and OLM channel info
- **CONTRIBUTING.md**: Add "Versioning & Release Cycle" section with branch strategy, backport policy (CVE-only), and PR targeting guidelines
- **Official Antora docs**: New `assembly-versioning-support-policy.adoc` page covering versioning scheme, support window, release channels, upgrade procedures, downgrade policy, and backup guidance
- Cross-reference from migration guide to new versioning page
- Navigation entry under new "Versioning and support" section

### Release workflow parallelization
- Split the monolithic `release-operator` job into 3 jobs: `release-build`, `release-test` (matrix), `release-post`
- Tests run in 8 parallel groups via matrix strategy (smoke, kafka, auth, database, feature, feature-setup, olm-v1, olm-v0)

## Changes

| File | Change |
|------|--------|
| `README.md` | Add versioning policy section, consolidate Docker tag docs |
| `CONTRIBUTING.md` | Add release cycle, branch strategy, backport policy |
| `.github/workflows/release-images.yaml` | Add `MINOR_TAG` calculation and floating tags |
| `.github/workflows/release.yaml` | Update branch input description |
| `docs/.../assembly-versioning-support-policy.adoc` | **New** — full versioning, upgrade, downgrade, backup docs |
| `docs/.../nav.adoc` | Add "Versioning and support" navigation entry |
| `docs/.../assembly-migrating-registry-v2-v3.adoc` | Add cross-reference to versioning policy |
| `operator/Makefile` | Add `CHANNEL`/`PREVIOUS_CHANNEL` auto-derived from version |
| `catalog.template.yaml` | Add minor-version channel alongside `3.x` rolling channel |
| `subscription.yaml` | Parameterize channel via `${PLACEHOLDER_CHANNEL}` |
| `cluster-extension.yaml` | Parameterize channel via `${PLACEHOLDER_CHANNEL}` |
| `release-operator.yaml` | Split into 3 parallel jobs with matrix test strategy |
| `OLMITBase.java` | Add `PLACEHOLDER_CHANNEL` substitution |

## Release Scenarios

| Scenario | CHANNEL | PREVIOUS_CHANNEL | Behavior |
|----------|---------|-------------------|----------|
| Patch release (e.g., 3.2.2) | `3.2.x` | `3.2.x` | Updates both `3.x` and `3.2.x` channels |
| New minor (e.g., 3.3.0) | `3.3.x` | `3.2.x` | Updates `3.x`, finalizes `3.2.x`, creates `3.3.x` |

## Test plan

- [x] Verify README renders correctly with new versioning section
- [x] Verify CONTRIBUTING renders correctly with new release cycle section
- [x] Verify Antora docs page renders with correct cross-references
- [x] Verify `MINOR_TAG` is correctly derived (e.g., `3.3.0` → `3.3`)
- [x] Verify `make config-show` displays correct `CHANNEL` and `PREVIOUS_CHANNEL` values
- [x] Verify `make bundle` generates bundle with correct channel annotations
- [x] Verify `make catalog` builds catalog with both `3.x` and minor-version channels
- [x] Run OLM v0 and v1 tests to verify parameterized channel works