### PR TITLE
docs: fix incorrect TLS documentation for management interface

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-registry-high-availability.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-registry-high-availability.adoc
@@ -487,13 +487,20 @@ livenessProbe:
   httpGet:
     path: /health/live
     port: 9000
+
+# After (with TLS enabled)
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: 9000
+    scheme: HTTPS
 ----
 
 * *Prometheus scrape targets* - Update your Prometheus configuration or `ServiceMonitor` resources to scrape metrics from port `9000` at path `/metrics`.
 
 * *Network policies* - If you use Kubernetes `NetworkPolicy` resources, ensure that ingress traffic on port `9000` is allowed from your monitoring infrastructure and the kubelet (for health probes).
 
-* *TLS considerations* - The management interface runs as a separate HTTP server and is *not affected* by TLS configuration on the application port. Health probes should always use `scheme: HTTP` with port `9000`, even if TLS is enabled on the main application port (8443).
+* *TLS considerations* - The management interface inherits the default TLS configuration from the Quarkus TLS registry. When TLS is enabled, the management interface on port `9000` also serves HTTPS, and health probes must use `scheme: HTTPS`. The {operator} handles this automatically.
 
 * *{operator} managed deployments* - If you are using the {operator}, it will automatically configure the correct probe ports. No manual changes are required for operator-managed deployments.
 


### PR DESCRIPTION
## Summary

- Fix incorrect documentation claiming the management interface (port 9000) is "not affected" by TLS configuration
- The Quarkus management interface inherits the default TLS configuration — verified empirically on minikube
- Add TLS-aware probe YAML example for manual deployments

## Verification

Deployed the registry on minikube with TLS enabled (`QUARKUS_TLS_KEY_STORE_P12_PATH`). Results:

| Test | Result |
|------|--------|
| HTTPS on management port 9000 | 200 OK |
| HTTP on management port 9000 | Rejected |
| HTTPS on app port 8443 | 200 OK |
| HTTP on app port 8443 | Rejected |

The operator code in `Constants.java` using `scheme: HTTPS` on port 9000 is correct. Only the documentation was wrong.

Closes #7749

## Test plan

- [x] Verified on minikube that management port 9000 serves HTTPS when default TLS is configured
- [x] No code changes — docs only