### PR TITLE
feat(types): add MCP_TOOL artifact type for MCP tool definitions

### DIFF
--- a/app/src/main/java/io/apicurio/registry/mcptools/McpToolsConfig.java
+++ b/app/src/main/java/io/apicurio/registry/mcptools/McpToolsConfig.java
@@ -1,0 +1,22 @@
+package io.apicurio.registry.mcptools;
+
+import io.apicurio.common.apps.config.Info;
+import jakarta.inject.Singleton;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_MCP;
+
+/**
+ * Configuration properties for MCP tool definition artifact support.
+ */
+@Singleton
+public class McpToolsConfig {
+
+    @ConfigProperty(name = "apicurio.mcp-tools.enabled", defaultValue = "false")
+    @Info(category = CATEGORY_MCP, description = "Enable MCP tool definition discovery endpoints", availableSince = "3.0.0", experimental = true)
+    boolean enabled;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/mcptools/rest/beans/McpToolSearchResult.java
+++ b/app/src/main/java/io/apicurio/registry/mcptools/rest/beans/McpToolSearchResult.java
@@ -1,0 +1,151 @@
+package io.apicurio.registry.mcptools.rest.beans;
+
+import java.util.List;
+
+/**
+ * A single MCP tool search result with metadata.
+ */
+public class McpToolSearchResult {
+
+    private String groupId;
+    private String artifactId;
+    private String name;
+    private String description;
+    private String owner;
+    private long createdOn;
+    private String category;
+    private String provider;
+    private List<String> parameters;
+
+    public McpToolSearchResult() {
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public long getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(long createdOn) {
+        this.createdOn = createdOn;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public List<String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(List<String> parameters) {
+        this.parameters = parameters;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final McpToolSearchResult result = new McpToolSearchResult();
+
+        public Builder groupId(String groupId) {
+            result.groupId = groupId;
+            return this;
+        }
+
+        public Builder artifactId(String artifactId) {
+            result.artifactId = artifactId;
+            return this;
+        }
+
+        public Builder name(String name) {
+            result.name = name;
+            return this;
+        }
+
+        public Builder description(String description) {
+            result.description = description;
+            return this;
+        }
+
+        public Builder owner(String owner) {
+            result.owner = owner;
+            return this;
+        }
+
+        public Builder createdOn(long createdOn) {
+            result.createdOn = createdOn;
+            return this;
+        }
+
+        public Builder category(String category) {
+            result.category = category;
+            return this;
+        }
+
+        public Builder provider(String provider) {
+            result.provider = provider;
+            return this;
+        }
+
+        public Builder parameters(List<String> parameters) {
+            result.parameters = parameters;
+            return this;
+        }
+
+        public McpToolSearchResult build() {
+            return result;
+        }
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/mcptools/rest/beans/McpToolSearchResult.java
+++ b/app/src/main/java/io/apicurio/registry/mcptools/rest/beans/McpToolSearchResult.java
@@ -10,11 +10,10 @@ public class McpToolSearchResult {
     private String groupId;
     private String artifactId;
     private String name;
+    private String title;
     private String description;
     private String owner;
     private long createdOn;
-    private String category;
-    private String provider;
     private List<String> parameters;
 
     public McpToolSearchResult() {
@@ -44,6 +43,14 @@ public class McpToolSearchResult {
         this.name = name;
     }
 
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
     public String getDescription() {
         return description;
     }
@@ -66,22 +73,6 @@ public class McpToolSearchResult {
 
     public void setCreatedOn(long createdOn) {
         this.createdOn = createdOn;
-    }
-
-    public String getCategory() {
-        return category;
-    }
-
-    public void setCategory(String category) {
-        this.category = category;
-    }
-
-    public String getProvider() {
-        return provider;
-    }
-
-    public void setProvider(String provider) {
-        this.provider = provider;
     }
 
     public List<String> getParameters() {
@@ -114,6 +105,11 @@ public class McpToolSearchResult {
             return this;
         }
 
+        public Builder title(String title) {
+            result.title = title;
+            return this;
+        }
+
         public Builder description(String description) {
             result.description = description;
             return this;
@@ -126,16 +122,6 @@ public class McpToolSearchResult {
 
         public Builder createdOn(long createdOn) {
             result.createdOn = createdOn;
-            return this;
-        }
-
-        public Builder category(String category) {
-            result.category = category;
-            return this;
-        }
-
-        public Builder provider(String provider) {
-            result.provider = provider;
             return this;
         }
 

--- a/app/src/main/java/io/apicurio/registry/mcptools/rest/beans/McpToolSearchResults.java
+++ b/app/src/main/java/io/apicurio/registry/mcptools/rest/beans/McpToolSearchResults.java
@@ -1,0 +1,59 @@
+package io.apicurio.registry.mcptools.rest.beans;
+
+import java.util.List;
+
+/**
+ * Search results for MCP tool definitions.
+ */
+public class McpToolSearchResults {
+
+    private long count;
+    private List<McpToolSearchResult> tools;
+
+    public McpToolSearchResults() {
+    }
+
+    public McpToolSearchResults(long count, List<McpToolSearchResult> tools) {
+        this.count = count;
+        this.tools = tools;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+    public List<McpToolSearchResult> getTools() {
+        return tools;
+    }
+
+    public void setTools(List<McpToolSearchResult> tools) {
+        this.tools = tools;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private long count;
+        private List<McpToolSearchResult> tools;
+
+        public Builder count(long count) {
+            this.count = count;
+            return this;
+        }
+
+        public Builder tools(List<McpToolSearchResult> tools) {
+            this.tools = tools;
+            return this;
+        }
+
+        public McpToolSearchResults build() {
+            return new McpToolSearchResults(count, tools);
+        }
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.rest.wellknown;
 
 import io.apicurio.registry.a2a.rest.beans.AgentCard;
 import io.apicurio.registry.a2a.rest.beans.AgentSearchResults;
+import io.apicurio.registry.mcptools.rest.beans.McpToolSearchResults;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -82,14 +83,54 @@ public interface WellKnownResource {
             @QueryParam("limit") @DefaultValue("20") Integer limit);
 
     /**
+     * Returns a specific registered MCP tool definition by group and artifact ID.
+     *
+     * @param groupId the group ID of the MCP tool artifact
+     * @param artifactId the artifact ID of the MCP tool
+     * @param version optional version (defaults to latest)
+     * @return the MCP tool definition content
+     */
+    @GET
+    @Path("/mcp-tools/{groupId}/{artifactId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getRegisteredMcpTool(
+            @PathParam("groupId") String groupId,
+            @PathParam("artifactId") String artifactId,
+            @QueryParam("version") String version);
+
+    /**
+     * Search for registered MCP tool definitions by various criteria.
+     *
+     * @param name filter by tool name (partial match)
+     * @param category filter by tool category
+     * @param provider filter by tool provider
+     * @param parameter filter by input parameter name
+     * @param offset pagination offset
+     * @param limit pagination limit
+     * @return search results containing matching MCP tools
+     */
+    @GET
+    @Path("/mcp-tools")
+    @Produces(MediaType.APPLICATION_JSON)
+    McpToolSearchResults searchMcpTools(
+            @QueryParam("name") String name,
+            @QueryParam("category") List<String> categories,
+            @QueryParam("provider") List<String> providers,
+            @QueryParam("parameter") List<String> parameters,
+            @QueryParam("offset") @DefaultValue("0") Integer offset,
+            @QueryParam("limit") @DefaultValue("20") Integer limit);
+
+    /**
      * Returns the JSON Schema for a specific LLM artifact type.
-     * This enables IDE autocompletion and validation for PROMPT_TEMPLATE and MODEL_SCHEMA artifacts.
+     * This enables IDE autocompletion and validation for PROMPT_TEMPLATE, MODEL_SCHEMA,
+     * and MCP_TOOL artifacts.
      *
      * Supported types:
      * - prompt-template (versions: v1)
      * - model-schema (versions: v1)
+     * - mcp-tool (versions: v1)
      *
-     * @param type the schema type (e.g., "prompt-template", "model-schema")
+     * @param type the schema type (e.g., "prompt-template", "model-schema", "mcp-tool")
      * @param version the schema version (e.g., "v1")
      * @return the JSON Schema
      */

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
@@ -102,8 +102,6 @@ public interface WellKnownResource {
      * Search for registered MCP tool definitions by various criteria.
      *
      * @param name filter by tool name (partial match)
-     * @param category filter by tool category
-     * @param provider filter by tool provider
      * @param parameter filter by input parameter name
      * @param offset pagination offset
      * @param limit pagination limit
@@ -114,8 +112,6 @@ public interface WellKnownResource {
     @Produces(MediaType.APPLICATION_JSON)
     McpToolSearchResults searchMcpTools(
             @QueryParam("name") String name,
-            @QueryParam("category") List<String> categories,
-            @QueryParam("provider") List<String> providers,
             @QueryParam("parameter") List<String> parameters,
             @QueryParam("offset") @DefaultValue("0") Integer offset,
             @QueryParam("limit") @DefaultValue("20") Integer limit);

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -288,8 +288,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
     @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
-    public McpToolSearchResults searchMcpTools(String name, List<String> categories,
-            List<String> providers, List<String> parameters, Integer offset, Integer limit) {
+    public McpToolSearchResults searchMcpTools(String name, List<String> parameters,
+            Integer offset, Integer limit) {
         if (!mcpToolsConfig.isEnabled()) {
             throw new NotFoundException("MCP tools support is disabled");
         }
@@ -300,18 +300,6 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
         if (!StringUtil.isEmpty(name)) {
             filters.add(SearchFilter.ofName(name));
-        }
-
-        if (categories != null && !categories.isEmpty()) {
-            for (String category : categories) {
-                filters.add(SearchFilter.ofStructure("mcp_tool:category:" + category));
-            }
-        }
-
-        if (providers != null && !providers.isEmpty()) {
-            for (String provider : providers) {
-                filters.add(SearchFilter.ofStructure("mcp_tool:provider:" + provider));
-            }
         }
 
         if (parameters != null && !parameters.isEmpty()) {
@@ -333,11 +321,10 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
     /**
      * Converts a searched artifact DTO into an MCP tool search result by fetching and parsing
-     * the latest version content to extract category, provider, and parameters.
+     * the latest version content to extract title and parameters.
      */
     private McpToolSearchResult convertToMcpToolSearchResult(SearchedArtifactDto artifact) {
-        String category = null;
-        String provider = null;
+        String title = null;
         List<String> parameters = new ArrayList<>();
 
         try {
@@ -351,15 +338,9 @@ public class WellKnownResourceImpl implements WellKnownResource {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode root = mapper.readTree(stored.getContent().content());
 
-            // Extract annotations
-            JsonNode annotations = root.path("annotations");
-            if (annotations.isObject()) {
-                if (annotations.has("category") && annotations.get("category").isTextual()) {
-                    category = annotations.get("category").asText();
-                }
-                if (annotations.has("provider") && annotations.get("provider").isTextual()) {
-                    provider = annotations.get("provider").asText();
-                }
+            // Extract title
+            if (root.has("title") && root.get("title").isTextual()) {
+                title = root.get("title").asText();
             }
 
             // Extract parameter names from inputSchema
@@ -378,11 +359,10 @@ public class WellKnownResourceImpl implements WellKnownResource {
                 .groupId(artifact.getGroupId())
                 .artifactId(artifact.getArtifactId())
                 .name(artifact.getName())
+                .title(title)
                 .description(artifact.getDescription())
                 .owner(artifact.getOwner())
                 .createdOn(artifact.getCreatedOn().getTime())
-                .category(category)
-                .provider(provider)
                 .parameters(parameters)
                 .build();
     }

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -11,6 +11,9 @@ import io.apicurio.registry.a2a.rest.beans.AgentSearchResults;
 import io.apicurio.registry.auth.Authorized;
 import io.apicurio.registry.auth.AuthorizedLevel;
 import io.apicurio.registry.auth.AuthorizedStyle;
+import io.apicurio.registry.mcptools.McpToolsConfig;
+import io.apicurio.registry.mcptools.rest.beans.McpToolSearchResult;
+import io.apicurio.registry.mcptools.rest.beans.McpToolSearchResults;
 import io.apicurio.registry.cdi.Current;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
@@ -49,9 +52,10 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Implementation of the A2A well-known endpoint resource.
+ * Implementation of the well-known endpoint resource for A2A agents and MCP tools.
  *
  * @see <a href="https://a2a-protocol.org/">A2A Protocol</a>
+ * @see <a href="https://spec.modelcontextprotocol.io/specification/server/tools/">MCP Tools</a>
  */
 @ApplicationScoped
 @Interceptors({ResponseErrorLivenessCheck.class, ResponseTimeoutReadinessCheck.class})
@@ -60,6 +64,9 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
     @Inject
     A2AConfig a2aConfig;
+
+    @Inject
+    McpToolsConfig mcpToolsConfig;
 
     @Inject
     RegistryAgentCardBuilder agentCardBuilder;
@@ -245,9 +252,145 @@ public class WellKnownResourceImpl implements WellKnownResource {
     }
 
     @Override
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
+    public Response getRegisteredMcpTool(String groupId, String artifactId, String version) {
+        if (!mcpToolsConfig.isEnabled()) {
+            throw new NotFoundException("MCP tools support is disabled");
+        }
+
+        GroupId gid = new GroupId(groupId);
+        String rawGroupId = gid.getRawGroupIdWithNull();
+        GA ga = new GA(rawGroupId, artifactId);
+
+        try {
+            String versionExpression = StringUtil.isEmpty(version) ? "branch=latest" : version;
+            GAV gav = VersionExpressionParser.parse(ga, versionExpression,
+                    (g, branchId) -> storage.getBranchTip(g, branchId,
+                            RetrievalBehavior.SKIP_DISABLED_LATEST));
+
+            StoredArtifactVersionDto artifact = storage.getArtifactVersionContent(
+                    gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
+
+            ArtifactVersionMetaDataDto metadata = storage.getArtifactVersionMetaData(
+                    gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
+
+            if (!ArtifactType.MCP_TOOL.equals(metadata.getArtifactType())) {
+                throw new NotFoundException("Artifact is not an MCP tool definition");
+            }
+
+            return Response.ok(artifact.getContent().content(), "application/json").build();
+
+        } catch (ArtifactNotFoundException | VersionNotFoundException e) {
+            throw new NotFoundException(
+                    "MCP tool not found: " + groupId + "/" + artifactId);
+        }
+    }
+
+    @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
+    public McpToolSearchResults searchMcpTools(String name, List<String> categories,
+            List<String> providers, List<String> parameters, Integer offset, Integer limit) {
+        if (!mcpToolsConfig.isEnabled()) {
+            throw new NotFoundException("MCP tools support is disabled");
+        }
+
+        Set<SearchFilter> filters = new HashSet<>();
+
+        filters.add(SearchFilter.ofArtifactType(ArtifactType.MCP_TOOL));
+
+        if (!StringUtil.isEmpty(name)) {
+            filters.add(SearchFilter.ofName(name));
+        }
+
+        if (categories != null && !categories.isEmpty()) {
+            for (String category : categories) {
+                filters.add(SearchFilter.ofStructure("mcp_tool:category:" + category));
+            }
+        }
+
+        if (providers != null && !providers.isEmpty()) {
+            for (String provider : providers) {
+                filters.add(SearchFilter.ofStructure("mcp_tool:provider:" + provider));
+            }
+        }
+
+        if (parameters != null && !parameters.isEmpty()) {
+            for (String parameter : parameters) {
+                filters.add(SearchFilter.ofStructure("mcp_tool:parameter:" + parameter));
+            }
+        }
+
+        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, OrderBy.createdOn,
+                OrderDirection.desc, offset, limit);
+
+        List<McpToolSearchResult> tools = new ArrayList<>();
+        for (SearchedArtifactDto artifact : results.getArtifacts()) {
+            tools.add(convertToMcpToolSearchResult(artifact));
+        }
+
+        return McpToolSearchResults.builder().count(results.getCount()).tools(tools).build();
+    }
+
+    /**
+     * Converts a searched artifact DTO into an MCP tool search result by fetching and parsing
+     * the latest version content to extract category, provider, and parameters.
+     */
+    private McpToolSearchResult convertToMcpToolSearchResult(SearchedArtifactDto artifact) {
+        String category = null;
+        String provider = null;
+        List<String> parameters = new ArrayList<>();
+
+        try {
+            GA ga = new GA(artifact.getGroupId(), artifact.getArtifactId());
+            GAV gav = VersionExpressionParser.parse(ga, "branch=latest",
+                    (g, branchId) -> storage.getBranchTip(g, branchId,
+                            RetrievalBehavior.SKIP_DISABLED_LATEST));
+            StoredArtifactVersionDto stored = storage.getArtifactVersionContent(
+                    gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
+
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(stored.getContent().content());
+
+            // Extract annotations
+            JsonNode annotations = root.path("annotations");
+            if (annotations.isObject()) {
+                if (annotations.has("category") && annotations.get("category").isTextual()) {
+                    category = annotations.get("category").asText();
+                }
+                if (annotations.has("provider") && annotations.get("provider").isTextual()) {
+                    provider = annotations.get("provider").asText();
+                }
+            }
+
+            // Extract parameter names from inputSchema
+            JsonNode inputSchema = root.path("inputSchema");
+            if (inputSchema.isObject()) {
+                JsonNode properties = inputSchema.path("properties");
+                if (properties.isObject()) {
+                    properties.fieldNames().forEachRemaining(parameters::add);
+                }
+            }
+        } catch (Exception e) {
+            // If content parsing fails, return result with empty metadata
+        }
+
+        return McpToolSearchResult.builder()
+                .groupId(artifact.getGroupId())
+                .artifactId(artifact.getArtifactId())
+                .name(artifact.getName())
+                .description(artifact.getDescription())
+                .owner(artifact.getOwner())
+                .createdOn(artifact.getCreatedOn().getTime())
+                .category(category)
+                .provider(provider)
+                .parameters(parameters)
+                .build();
+    }
+
+    @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.None)
     public Response getSchema(String type, String version) {
-        if (!a2aConfig.isEnabled()) {
+        if (!a2aConfig.isEnabled() && !mcpToolsConfig.isEnabled()) {
             throw new NotFoundException("Schema not found: " + type + "/" + version);
         }
 
@@ -274,6 +417,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
             return "schemas/prompt-template-v1.json";
         } else if ("model-schema".equals(type) && "v1".equals(version)) {
             return "schemas/model-schema-v1.json";
+        } else if ("mcp-tool".equals(type) && "v1".equals(version)) {
+            return "schemas/mcp-tool-v1.json";
         }
         return null;
     }

--- a/app/src/main/resources/schemas/mcp-tool-v1.json
+++ b/app/src/main/resources/schemas/mcp-tool-v1.json
@@ -62,8 +62,7 @@
           "type": "array",
           "description": "Describes the intended audience, e.g. 'user', 'assistant'.",
           "items": {
-            "type": "string",
-            "enum": ["user", "assistant"]
+            "type": "string"
           }
         },
         "priority": {

--- a/app/src/main/resources/schemas/mcp-tool-v1.json
+++ b/app/src/main/resources/schemas/mcp-tool-v1.json
@@ -1,22 +1,22 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://spec.modelcontextprotocol.io/schemas/mcp-tool.json",
+  "$id": "https://apicurio.io/schemas/mcp-tool.json",
   "title": "MCP Tool Definition",
-  "description": "Schema for MCP (Model Context Protocol) tool definitions stored as registry artifacts.",
+  "description": "Schema for MCP (Model Context Protocol) tool definitions stored as registry artifacts, based on the MCP specification 2025-11-25.",
   "type": "object",
   "required": ["name", "inputSchema"],
   "properties": {
     "name": {
       "type": "string",
-      "description": "The name of the tool. Must be unique within a server."
+      "description": "Unique identifier for the tool. Should be between 1 and 128 characters."
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable name of the tool for display purposes."
     },
     "description": {
       "type": "string",
       "description": "A human-readable description of what the tool does."
-    },
-    "version": {
-      "type": "string",
-      "description": "The version of this tool definition."
     },
     "inputSchema": {
       "type": "object",
@@ -25,7 +25,8 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The JSON Schema type (typically 'object')."
+          "const": "object",
+          "description": "The JSON Schema type. Must be 'object' per the MCP specification."
         },
         "properties": {
           "type": "object",
@@ -44,21 +45,32 @@
       },
       "additionalProperties": true
     },
+    "outputSchema": {
+      "type": "object",
+      "description": "Optional JSON Schema defining expected output structure for structured results.",
+      "additionalProperties": true
+    },
     "annotations": {
       "type": "object",
-      "description": "Optional metadata annotations for the tool.",
+      "description": "Optional ToolAnnotations per the MCP specification (title, audience, priority).",
       "properties": {
-        "provider": {
+        "title": {
           "type": "string",
-          "description": "The provider or source of this tool."
+          "description": "An optional title for the tool annotation. Used as fallback display name if top-level title is absent."
         },
-        "category": {
-          "type": "string",
-          "description": "The category this tool belongs to."
+        "audience": {
+          "type": "array",
+          "description": "Describes the intended audience, e.g. 'user', 'assistant'.",
+          "items": {
+            "type": "string",
+            "enum": ["user", "assistant"]
+          }
         },
-        "requiresAuth": {
-          "type": "boolean",
-          "description": "Whether the tool requires authentication to use."
+        "priority": {
+          "type": "number",
+          "description": "Priority hint (0 to 1). Higher values indicate higher priority.",
+          "minimum": 0,
+          "maximum": 1
         }
       },
       "additionalProperties": true

--- a/app/src/main/resources/schemas/mcp-tool-v1.json
+++ b/app/src/main/resources/schemas/mcp-tool-v1.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://spec.modelcontextprotocol.io/schemas/mcp-tool.json",
+  "title": "MCP Tool Definition",
+  "description": "Schema for MCP (Model Context Protocol) tool definitions stored as registry artifacts.",
+  "type": "object",
+  "required": ["name", "inputSchema"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the tool. Must be unique within a server."
+    },
+    "description": {
+      "type": "string",
+      "description": "A human-readable description of what the tool does."
+    },
+    "version": {
+      "type": "string",
+      "description": "The version of this tool definition."
+    },
+    "inputSchema": {
+      "type": "object",
+      "description": "A JSON Schema object defining the expected parameters for the tool.",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The JSON Schema type (typically 'object')."
+        },
+        "properties": {
+          "type": "object",
+          "description": "The input parameter definitions.",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "required": {
+          "type": "array",
+          "description": "List of required parameter names.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "annotations": {
+      "type": "object",
+      "description": "Optional metadata annotations for the tool.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "The provider or source of this tool."
+        },
+        "category": {
+          "type": "string",
+          "description": "The category this tool belongs to."
+        },
+        "requiresAuth": {
+          "type": "boolean",
+          "description": "Whether the tool requires authentication to use."
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/common/src/main/java/io/apicurio/registry/types/ArtifactType.java
+++ b/common/src/main/java/io/apicurio/registry/types/ArtifactType.java
@@ -47,6 +47,9 @@ public class ArtifactType {
     /** AI Agent Card for the A2A (Agent-to-Agent) protocol. */
     public static final String AGENT_CARD = "AGENT_CARD";
 
+    /** MCP (Model Context Protocol) tool definition. */
+    public static final String MCP_TOOL = "MCP_TOOL";
+
     /** Apache Iceberg table metadata. */
     public static final String ICEBERG_TABLE = "ICEBERG_TABLE";
 

--- a/config-index/definitions/src/main/java/io/apicurio/common/apps/config/ConfigPropertyCategory.java
+++ b/config-index/definitions/src/main/java/io/apicurio/common/apps/config/ConfigPropertyCategory.java
@@ -20,6 +20,7 @@ public enum ConfigPropertyCategory {
     CATEGORY_IMPORT("import"),
     CATEGORY_LIMITS("limits"),
     CATEGORY_LOG("log"),
+    CATEGORY_MCP("mcp"),
     CATEGORY_OBSERVABILITY("observability"),
     CATEGORY_REDIRECTS("redirects"),
     CATEGORY_REST("rest"),

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -35,6 +35,7 @@ ifndef::service-registry-downstream[]
 endif::[]
 * AI Agent Integration
 ** xref:getting-started/assembly-a2a-features.adoc[]
+** xref:getting-started/assembly-mcp-tool-features.adoc[]
 ** xref:getting-started/assembly-llm-artifact-types-implementation.adoc[]
 * Confluent Schema Registry Compatibility
 ** xref:getting-started/assembly-confluent-schema-registry-compatibility.adoc[]

--- a/docs/modules/ROOT/pages/getting-started/assembly-artifact-reference.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-artifact-reference.adoc
@@ -51,6 +51,9 @@ You can store and manage a wide range of schema and API artifact types in {regis
 |`KCONNECT`
 |Apache Kafka Connect schema
 |`2.0.0`
+|`MCP_TOOL`
+|MCP tool definitions (Model Context Protocol)
+|`2025-11-25`
 |`MODEL_SCHEMA`
 |AI/ML model input/output schema definitions
 |`v1`
@@ -78,6 +81,16 @@ You can store and manage a wide range of schema and API artifact types in {regis
 === AI/ML artifact types
 
 {registry} includes built-in support for AI/ML artifact types designed for LLMOps and prompt engineering workflows.
+
+==== MCP_TOOL
+MCP (Model Context Protocol) tool definitions. Use this artifact type to:
+
+* Store MCP tool definitions with input/output schemas
+* Track tool evolution with version history and compatibility checking
+* Enable discovery of tools via well-known endpoints
+* Validate tool definitions against the MCP specification
+
+Content types: `application/json`
 
 ==== MODEL_SCHEMA
 Defines and validates AI/ML model input/output schemas and metadata. Use this artifact type to:

--- a/docs/modules/ROOT/pages/getting-started/assembly-mcp-tool-features.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-mcp-tool-features.adoc
@@ -1,0 +1,361 @@
+// MCP Tool Definition Features Documentation
+[id="assembly-mcp-tool-features"]
+= MCP Tool Definition Features in Apicurio Registry
+
+Apicurio Registry supports storing and managing MCP (Model Context Protocol) tool definitions as first-class artifacts. This enables central governance, version management, and discovery of MCP tools across an organization.
+
+== Overview
+
+The https://modelcontextprotocol.io/[Model Context Protocol (MCP)] allows servers to expose tools that can be invoked by language models. Tools enable models to interact with external systems, such as querying databases, calling APIs, or performing computations.
+
+Apicurio Registry acts as a **Tool Registry**, storing MCP tool definitions with:
+
+* **Version management** — Track tool evolution with full version history
+* **Validation** — Ensure tool definitions conform to the MCP specification
+* **Compatibility checking** — Detect breaking changes in tool input schemas
+* **Discovery** — Search for tools by name or input parameter
+* **Well-known endpoints** — Serve tool definitions at standard URLs
+
+[source,text]
+----
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           Apicurio Registry                                  │
+│                                                                              │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │                    MCP Tool Registry                                   │   │
+│  │                                                                        │   │
+│  │  /.well-known/mcp-tools                (search tools)                  │   │
+│  │  /.well-known/mcp-tools/{group}/{id}   (retrieve tool)                 │   │
+│  │                                                                        │   │
+│  │  - Store tool definitions                                              │   │
+│  │  - Search by name or parameter                                         │   │
+│  │  - Version management                                                  │   │
+│  │  - Validation and compatibility checking                               │   │
+│  └──────────────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────────┘
+----
+
+== Configuration
+
+MCP tool features are controlled via configuration properties:
+
+[cols="2,1,3"]
+|===
+|Property |Default |Description
+
+|`apicurio.mcp-tools.enabled`
+|`false`
+|Enable/disable MCP tool definition support (experimental)
+
+|`apicurio.features.experimental.enabled`
+|`false`
+|Must be enabled to use experimental features like MCP tools
+|===
+
+To enable MCP tool support, set both properties:
+
+[source,properties]
+----
+apicurio.features.experimental.enabled=true
+apicurio.mcp-tools.enabled=true
+----
+
+== MCP Tool Definition Schema
+
+Tool definitions follow the https://modelcontextprotocol.io/specification/2025-11-25/server/tools[MCP specification (2025-11-25)].
+
+NOTE: The MCP specification has two authoritative sources: the formal https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-11-25/schema.json[JSON schema] and the https://modelcontextprotocol.io/specification/2025-11-25/server/tools[specification docs]. In some cases these sources diverge. The table below notes where Apicurio Registry's validation follows the spec docs guidance rather than the formal JSON schema.
+
+=== Tool Fields
+
+[cols="1,1,1,3"]
+|===
+|Field |Type |Required |Description
+
+|`name`
+|string
+|Yes
+|Unique identifier for the tool (1-128 characters, alphanumeric + underscore/hyphen/dot)
+
+|`title`
+|string
+|No
+|Human-readable name for display purposes
+
+|`description`
+|string
+|No
+|Human-readable description of tool functionality
+
+|`inputSchema`
+|object
+|Yes
+|JSON Schema defining expected input parameters
+
+|`outputSchema`
+|object
+|No
+|JSON Schema defining expected output structure. _Described in the spec docs but not yet present in the formal MCP JSON schema._
+
+|`annotations`
+|object
+|No
+|Optional metadata annotations (audience, priority)
+
+|`icons`
+|array
+|No
+|Optional icons for display in user interfaces. _Described in the spec docs but not yet present in the formal MCP Tool JSON schema._ Passed through without validation.
+
+|`execution`
+|object
+|No
+|Optional execution-related properties such as task support. _Described in the spec docs but not yet present in the formal MCP Tool JSON schema._ Passed through without validation.
+|===
+
+=== Input Schema
+
+The `inputSchema` field is a JSON Schema object with these properties:
+
+[cols="1,1,1,3"]
+|===
+|Field |Type |Required |Description
+
+|`type`
+|string
+|Yes
+|Must be `"object"`. The formal MCP JSON schema does not enforce this constraint, but the spec docs and all examples require it. Apicurio Registry enforces `type` = `"object"` during full validation.
+
+|`properties`
+|object
+|No
+|Parameter definitions (each value is a JSON Schema object)
+
+|`required`
+|array
+|No
+|List of required parameter names
+|===
+
+=== Annotations (ToolAnnotations)
+
+Annotations provide metadata about the tool using the MCP `ToolAnnotations` type:
+
+[cols="1,1,3"]
+|===
+|Field |Type |Description
+
+|`title`
+|string
+|Optional fallback display name. Per the spec docs, display precedence is: top-level `title` -> `annotations.title` -> `name`. _Note: this field is referenced in the spec docs as a display name fallback but is not formally defined in the `ToolAnnotations` JSON schema._ Apicurio Registry validates and displays it for interoperability.
+
+|`audience`
+|array of strings
+|Intended audience. The MCP spec defines a `Role` enum with values `"user"` and `"assistant"`. Apicurio Registry accepts any string values for forward compatibility with future spec revisions.
+
+|`priority`
+|number (0-1)
+|Priority hint; higher values indicate higher priority
+|===
+
+=== Example Tool Definition
+
+[source,json]
+----
+{
+  "name": "get_weather",
+  "title": "Weather Information Provider",
+  "description": "Get current weather information for a location",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "location": {
+        "type": "string",
+        "description": "City name or zip code"
+      }
+    },
+    "required": ["location"]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "temperature": {
+        "type": "number",
+        "description": "Temperature in celsius"
+      },
+      "conditions": {
+        "type": "string",
+        "description": "Weather conditions"
+      }
+    },
+    "required": ["temperature", "conditions"]
+  },
+  "annotations": {
+    "title": "Weather Lookup",
+    "audience": ["user", "assistant"],
+    "priority": 0.8
+  }
+}
+----
+
+== Well-Known Endpoints
+
+=== GET /.well-known/mcp-tools
+
+Search for registered MCP tool definitions with filtering support.
+
+**Query Parameters:**
+
+[cols="1,1,3"]
+|===
+|Parameter |Type |Description
+
+|`name`
+|string
+|Filter by tool name (partial match)
+
+|`parameter`
+|string (repeatable)
+|Filter by input parameter name
+
+|`offset`
+|integer
+|Pagination offset (default: 0)
+
+|`limit`
+|integer
+|Pagination limit (default: 20)
+|===
+
+**Example Request:**
+[source,bash]
+----
+curl "http://localhost:8080/.well-known/mcp-tools?parameter=location"
+----
+
+**Response:** `McpToolSearchResults`
+
+[source,json]
+----
+{
+  "count": 1,
+  "tools": [
+    {
+      "groupId": "mcp-tools",
+      "artifactId": "weather-tool",
+      "name": "get_weather",
+      "title": "Weather Information Provider",
+      "description": "Get current weather information",
+      "owner": "admin",
+      "createdOn": 1700000000000,
+      "parameters": ["location"]
+    }
+  ]
+}
+----
+
+=== GET /.well-known/mcp-tools/{groupId}/{artifactId}
+
+Retrieve a specific registered MCP tool definition.
+
+**Path Parameters:**
+
+- `groupId` - The group containing the tool definition
+- `artifactId` - The artifact ID of the tool definition
+
+**Query Parameters:**
+
+- `version` (optional) - Specific version (defaults to latest)
+
+**Response:** MCP tool definition JSON document
+
+=== GET /.well-known/schemas/mcp-tool/v1
+
+Returns the JSON Schema for MCP tool definitions. This enables IDE autocompletion and validation.
+
+**Example:**
+[source,bash]
+----
+curl "http://localhost:8080/.well-known/schemas/mcp-tool/v1"
+----
+
+== Creating an MCP Tool Artifact
+
+[source,bash]
+----
+curl -X POST "http://localhost:8080/apis/registry/v3/groups/mcp-tools/artifacts" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "artifactId": "weather-tool",
+    "artifactType": "MCP_TOOL",
+    "firstVersion": {
+      "version": "1.0.0",
+      "content": {
+        "contentType": "application/json",
+        "content": "{\"name\": \"get_weather\", \"title\": \"Weather Tool\", \"description\": \"Get weather data\", \"inputSchema\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\"}}, \"required\": [\"location\"]}}"
+      }
+    }
+  }'
+----
+
+== Validation Rules
+
+MCP tool definitions support three validation levels:
+
+[cols="1,3"]
+|===
+|Level |Description
+
+|`NONE`
+|No validation performed
+
+|`SYNTAX_ONLY`
+|Validates JSON syntax and that the document is a JSON object
+
+|`FULL`
+|Complete validation including:
+- Required `name` field (non-empty string)
+- Required `inputSchema` field (object with `type` = `"object"` per spec docs guidance)
+- Optional `title` and `description` must be strings if present
+- Optional `outputSchema` must be an object if present
+- Optional `annotations` validated as ToolAnnotations: `title` (string), `audience` (array of strings), `priority` (number 0-1). Note: `annotations.title` validation follows spec docs guidance; `audience` values are not restricted to the `Role` enum for forward compatibility.
+|===
+
+== Compatibility Checking
+
+When versioning MCP tool definitions, compatibility rules detect breaking changes:
+
+**Compatible Changes (allowed):**
+
+- Adding optional input parameters
+- Changing name, title, description
+- Changing annotations
+- Adding or modifying outputSchema
+
+**Incompatible Changes (may break clients):**
+
+- Removing input parameters from inputSchema.properties
+- Adding new required parameters
+- Removing required parameters
+- Changing the inputSchema type
+
+== Automatic Label Extraction
+
+When MCP tool definitions are stored, structured elements are automatically extracted for search:
+
+[cols="2,3"]
+|===
+|Element Pattern |Source
+
+|`mcp_tool:parameter:<name>`
+|Each parameter name from inputSchema.properties
+|===
+
+This enables efficient parameter-based discovery using the Registry's search.
+
+== See Also
+
+* xref:getting-started/assembly-a2a-features.adoc[A2A Protocol Features]
+* xref:getting-started/assembly-llm-artifact-types-implementation.adoc[LLM Artifact Types]
+* link:https://modelcontextprotocol.io/specification/2025-11-25/server/tools[MCP Tools Specification]
+* xref:getting-started/assembly-configuring-the-registry.adoc[Registry Configuration]

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -707,6 +707,22 @@ The following {registry} configuration options are available for each component 
 |Dynamic log level for Apicurio Registry
 |===
 
+== mcp
+.mcp configuration options
+[.table-expandable,width="100%",cols="6,3,2,3,5",options="header"]
+|===
+|Name
+|Type
+|Default
+|Available from
+|Description
+|`apicurio.mcp-tools.enabled`
+|`boolean`
+|`false`
+|`3.0.0`
+|Enable MCP tool definition discovery endpoints _(experimental)_
+|===
+
 == observability
 .observability configuration options
 [.table-expandable,width="100%",cols="6,3,2,3,5",options="header"]

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/McpToolContentAccepter.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/McpToolContentAccepter.java
@@ -11,7 +11,7 @@ import java.util.Map;
  * MCP tools are JSON documents that describe tools available to AI agents following the MCP specification.
  * This accepter validates that the content is valid JSON and contains required MCP tool fields.
  *
- * @see <a href="https://spec.modelcontextprotocol.io/specification/server/tools/">MCP Tools</a>
+ * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/tools">MCP Tools</a>
  */
 public class McpToolContentAccepter implements ContentAccepter {
 

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/McpToolContentAccepter.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/McpToolContentAccepter.java
@@ -1,0 +1,38 @@
+package io.apicurio.registry.content;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apicurio.registry.content.util.ContentTypeUtil;
+
+import java.util.Map;
+
+/**
+ * Content accepter for MCP (Model Context Protocol) tool definition artifacts.
+ *
+ * MCP tools are JSON documents that describe tools available to AI agents following the MCP specification.
+ * This accepter validates that the content is valid JSON and contains required MCP tool fields.
+ *
+ * @see <a href="https://spec.modelcontextprotocol.io/specification/server/tools/">MCP Tools</a>
+ */
+public class McpToolContentAccepter implements ContentAccepter {
+
+    @Override
+    public boolean acceptsContent(TypedContent content, Map<String, TypedContent> resolvedReferences) {
+        try {
+            // Must be parseable JSON
+            if (content.getContentType() != null && content.getContentType().toLowerCase().contains("json")
+                    && !ContentTypeUtil.isParsableJson(content.getContent())) {
+                return false;
+            }
+
+            JsonNode tree = ContentTypeUtil.parseJson(content.getContent());
+
+            // An MCP tool definition must have "name" and "inputSchema" fields
+            if (tree.isObject() && tree.has("name") && tree.has("inputSchema")) {
+                return true;
+            }
+        } catch (Exception e) {
+            // Error - invalid syntax
+        }
+        return false;
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/extract/AgentCardContentExtractor.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/extract/AgentCardContentExtractor.java
@@ -1,51 +1,12 @@
 package io.apicurio.registry.content.extract;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.apicurio.registry.content.ContentHandle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-
 /**
  * Performs metadata extraction for A2A Agent Card content.
  *
  * Extracts the agent name and description from the Agent Card JSON structure.
+ * Delegates to {@link JsonNameDescriptionContentExtractor} for the actual extraction.
  *
  * @see <a href="https://a2a-protocol.org/">A2A Protocol</a>
  */
-public class AgentCardContentExtractor implements ContentExtractor {
-
-    private static final Logger log = LoggerFactory.getLogger(AgentCardContentExtractor.class);
-
-    private static final ObjectMapper mapper = new ObjectMapper();
-
-    @Override
-    public ExtractedMetaData extract(ContentHandle content) {
-        try {
-            JsonNode agentCard = mapper.readTree(content.bytes());
-            JsonNode name = agentCard.get("name");
-            JsonNode description = agentCard.get("description");
-
-            ExtractedMetaData metaData = null;
-
-            if (name != null && !name.isNull() && name.isTextual()) {
-                metaData = new ExtractedMetaData();
-                metaData.setName(name.asText());
-            }
-
-            if (description != null && !description.isNull() && description.isTextual()) {
-                if (metaData == null) {
-                    metaData = new ExtractedMetaData();
-                }
-                metaData.setDescription(description.asText());
-            }
-
-            return metaData;
-        } catch (IOException e) {
-            log.warn("Error extracting metadata from Agent Card: {}", e.getMessage());
-            return null;
-        }
-    }
+public class AgentCardContentExtractor extends JsonNameDescriptionContentExtractor {
 }

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/extract/JsonNameDescriptionContentExtractor.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/extract/JsonNameDescriptionContentExtractor.java
@@ -1,0 +1,48 @@
+package io.apicurio.registry.content.extract;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.content.ContentHandle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Generic content extractor for JSON artifacts that have top-level "name" and "description" fields.
+ * Shared by AGENT_CARD and MCP_TOOL artifact types.
+ */
+public class JsonNameDescriptionContentExtractor implements ContentExtractor {
+
+    private static final Logger log = LoggerFactory.getLogger(JsonNameDescriptionContentExtractor.class);
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public ExtractedMetaData extract(ContentHandle content) {
+        try {
+            JsonNode root = mapper.readTree(content.bytes());
+            JsonNode name = root.get("name");
+            JsonNode description = root.get("description");
+
+            ExtractedMetaData metaData = null;
+
+            if (name != null && !name.isNull() && name.isTextual()) {
+                metaData = new ExtractedMetaData();
+                metaData.setName(name.asText());
+            }
+
+            if (description != null && !description.isNull() && description.isTextual()) {
+                if (metaData == null) {
+                    metaData = new ExtractedMetaData();
+                }
+                metaData.setDescription(description.asText());
+            }
+
+            return metaData;
+        } catch (IOException e) {
+            log.warn("Error extracting metadata from JSON content: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/extract/McpToolContentExtractor.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/extract/McpToolContentExtractor.java
@@ -1,0 +1,12 @@
+package io.apicurio.registry.content.extract;
+
+/**
+ * Performs metadata extraction for MCP tool definition content.
+ *
+ * Extracts the tool name and description from the MCP tool JSON structure.
+ * Delegates to {@link JsonNameDescriptionContentExtractor} for the actual extraction.
+ *
+ * @see <a href="https://spec.modelcontextprotocol.io/specification/server/tools/">MCP Tools</a>
+ */
+public class McpToolContentExtractor extends JsonNameDescriptionContentExtractor {
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/extract/McpToolStructuredContentExtractor.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/extract/McpToolStructuredContentExtractor.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 /**
  * Extracts structured elements from MCP tool definition content for search indexing. Parses the MCP tool JSON
- * and extracts category, provider, and input parameters as structured elements.
+ * and extracts input parameter names as structured elements.
  */
 public class McpToolStructuredContentExtractor implements StructuredContentExtractor {
 
@@ -27,28 +27,12 @@ public class McpToolStructuredContentExtractor implements StructuredContentExtra
             JsonNode root = objectMapper.readTree(content.content());
             List<StructuredElement> elements = new ArrayList<>();
 
-            extractAnnotationField(root, "category", elements);
-            extractAnnotationField(root, "provider", elements);
             extractParameters(root, elements);
 
             return elements;
         } catch (Exception e) {
             log.debug("Failed to extract structured content from MCP tool: {}", e.getMessage());
             return Collections.emptyList();
-        }
-    }
-
-    /**
-     * Extracts a string field from the annotations object.
-     */
-    private void extractAnnotationField(JsonNode root, String fieldName,
-            List<StructuredElement> elements) {
-        JsonNode annotations = root.path("annotations");
-        if (!annotations.isMissingNode() && annotations.isObject()) {
-            JsonNode field = annotations.get(fieldName);
-            if (field != null && field.isTextual()) {
-                elements.add(new StructuredElement(fieldName, field.asText()));
-            }
         }
     }
 

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/extract/McpToolStructuredContentExtractor.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/extract/McpToolStructuredContentExtractor.java
@@ -1,0 +1,70 @@
+package io.apicurio.registry.content.extract;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.content.ContentHandle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Extracts structured elements from MCP tool definition content for search indexing. Parses the MCP tool JSON
+ * and extracts category, provider, and input parameters as structured elements.
+ */
+public class McpToolStructuredContentExtractor implements StructuredContentExtractor {
+
+    private static final Logger log = LoggerFactory.getLogger(McpToolStructuredContentExtractor.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public List<StructuredElement> extract(ContentHandle content) {
+        try {
+            JsonNode root = objectMapper.readTree(content.content());
+            List<StructuredElement> elements = new ArrayList<>();
+
+            extractAnnotationField(root, "category", elements);
+            extractAnnotationField(root, "provider", elements);
+            extractParameters(root, elements);
+
+            return elements;
+        } catch (Exception e) {
+            log.debug("Failed to extract structured content from MCP tool: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Extracts a string field from the annotations object.
+     */
+    private void extractAnnotationField(JsonNode root, String fieldName,
+            List<StructuredElement> elements) {
+        JsonNode annotations = root.path("annotations");
+        if (!annotations.isMissingNode() && annotations.isObject()) {
+            JsonNode field = annotations.get(fieldName);
+            if (field != null && field.isTextual()) {
+                elements.add(new StructuredElement(fieldName, field.asText()));
+            }
+        }
+    }
+
+    /**
+     * Extracts parameter names from the inputSchema.properties object.
+     */
+    private void extractParameters(JsonNode root, List<StructuredElement> elements) {
+        JsonNode inputSchema = root.path("inputSchema");
+        if (!inputSchema.isMissingNode() && inputSchema.isObject()) {
+            JsonNode properties = inputSchema.path("properties");
+            if (!properties.isMissingNode() && properties.isObject()) {
+                Iterator<String> fieldNames = properties.fieldNames();
+                while (fieldNames.hasNext()) {
+                    elements.add(new StructuredElement("parameter", fieldNames.next()));
+                }
+            }
+        }
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -1,0 +1,159 @@
+package io.apicurio.registry.rules.compatibility;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.content.TypedContent;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Compatibility checker for MCP tool definition artifacts.
+ *
+ * Compatibility rules for MCP tools:
+ * - Adding optional input parameters: Always compatible
+ * - Removing input parameters: Backward incompatible
+ * - Adding required parameters: Backward incompatible
+ * - Removing required parameters: Backward incompatible
+ * - Changing inputSchema type: Backward incompatible
+ * - Changing name, description, version, annotations: Always compatible
+ */
+public class McpToolCompatibilityChecker
+        extends AbstractCompatibilityChecker<McpToolCompatibilityDifference> {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    protected Set<McpToolCompatibilityDifference> isBackwardsCompatibleWith(String existing,
+            String proposed, Map<String, TypedContent> resolvedReferences) {
+        Set<McpToolCompatibilityDifference> differences = new HashSet<>();
+
+        try {
+            JsonNode existingNode = mapper.readTree(existing);
+            JsonNode proposedNode = mapper.readTree(proposed);
+
+            // Check inputSchema type changes
+            checkInputSchemaTypeChange(existingNode, proposedNode, differences);
+
+            // Check removed properties
+            checkPropertyRemovals(existingNode, proposedNode, differences);
+
+            // Check added required parameters
+            checkRequiredParamAdditions(existingNode, proposedNode, differences);
+
+            // Check removed required parameters
+            checkRequiredParamRemovals(existingNode, proposedNode, differences);
+
+        } catch (Exception e) {
+            differences.add(new McpToolCompatibilityDifference(
+                    McpToolCompatibilityDifference.Type.PARSE_ERROR,
+                    "Failed to parse MCP tool definition: " + e.getMessage()));
+        }
+
+        return differences;
+    }
+
+    private void checkInputSchemaTypeChange(JsonNode existing, JsonNode proposed,
+            Set<McpToolCompatibilityDifference> differences) {
+        String existingType = getInputSchemaType(existing);
+        String proposedType = getInputSchemaType(proposed);
+
+        if (existingType != null && proposedType != null && !existingType.equals(proposedType)) {
+            differences.add(new McpToolCompatibilityDifference(
+                    McpToolCompatibilityDifference.Type.INPUT_SCHEMA_TYPE_CHANGED,
+                    "inputSchema type changed from '" + existingType + "' to '" + proposedType
+                            + "'"));
+        }
+    }
+
+    private void checkPropertyRemovals(JsonNode existing, JsonNode proposed,
+            Set<McpToolCompatibilityDifference> differences) {
+        Set<String> existingProps = extractPropertyNames(existing);
+        Set<String> proposedProps = extractPropertyNames(proposed);
+
+        for (String prop : existingProps) {
+            if (!proposedProps.contains(prop)) {
+                differences.add(new McpToolCompatibilityDifference(
+                        McpToolCompatibilityDifference.Type.PROPERTY_REMOVED,
+                        "Input property '" + prop + "' was removed"));
+            }
+        }
+    }
+
+    private void checkRequiredParamAdditions(JsonNode existing, JsonNode proposed,
+            Set<McpToolCompatibilityDifference> differences) {
+        Set<String> existingRequired = extractRequiredParams(existing);
+        Set<String> proposedRequired = extractRequiredParams(proposed);
+
+        for (String param : proposedRequired) {
+            if (!existingRequired.contains(param)) {
+                differences.add(new McpToolCompatibilityDifference(
+                        McpToolCompatibilityDifference.Type.REQUIRED_PARAM_ADDED,
+                        "Required parameter '" + param + "' was added"));
+            }
+        }
+    }
+
+    private void checkRequiredParamRemovals(JsonNode existing, JsonNode proposed,
+            Set<McpToolCompatibilityDifference> differences) {
+        Set<String> existingRequired = extractRequiredParams(existing);
+        Set<String> proposedRequired = extractRequiredParams(proposed);
+
+        for (String param : existingRequired) {
+            if (!proposedRequired.contains(param)) {
+                differences.add(new McpToolCompatibilityDifference(
+                        McpToolCompatibilityDifference.Type.REQUIRED_PARAM_REMOVED,
+                        "Required parameter '" + param + "' was removed"));
+            }
+        }
+    }
+
+    private String getInputSchemaType(JsonNode node) {
+        JsonNode inputSchema = node.get("inputSchema");
+        if (inputSchema != null && inputSchema.isObject()) {
+            JsonNode type = inputSchema.get("type");
+            if (type != null && type.isTextual()) {
+                return type.asText();
+            }
+        }
+        return null;
+    }
+
+    private Set<String> extractPropertyNames(JsonNode node) {
+        Set<String> properties = new HashSet<>();
+        JsonNode inputSchema = node.get("inputSchema");
+        if (inputSchema != null && inputSchema.isObject()) {
+            JsonNode props = inputSchema.get("properties");
+            if (props != null && props.isObject()) {
+                Iterator<String> fieldNames = props.fieldNames();
+                while (fieldNames.hasNext()) {
+                    properties.add(fieldNames.next());
+                }
+            }
+        }
+        return properties;
+    }
+
+    private Set<String> extractRequiredParams(JsonNode node) {
+        Set<String> required = new HashSet<>();
+        JsonNode inputSchema = node.get("inputSchema");
+        if (inputSchema != null && inputSchema.isObject()) {
+            JsonNode requiredNode = inputSchema.get("required");
+            if (requiredNode != null && requiredNode.isArray()) {
+                for (JsonNode item : requiredNode) {
+                    if (item.isTextual()) {
+                        required.add(item.asText());
+                    }
+                }
+            }
+        }
+        return required;
+    }
+
+    @Override
+    protected CompatibilityDifference transform(McpToolCompatibilityDifference original) {
+        return original;
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -18,7 +18,7 @@ import java.util.Set;
  * - Adding required parameters: Backward incompatible
  * - Removing required parameters: Backward incompatible
  * - Changing inputSchema type: Backward incompatible
- * - Changing name, description, version, annotations: Always compatible
+ * - Changing name, title, description, annotations: Always compatible
  */
 public class McpToolCompatibilityChecker
         extends AbstractCompatibilityChecker<McpToolCompatibilityDifference> {

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityDifference.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityDifference.java
@@ -1,0 +1,69 @@
+package io.apicurio.registry.rules.compatibility;
+
+import io.apicurio.registry.rules.violation.RuleViolation;
+
+import java.util.Objects;
+
+/**
+ * Represents a compatibility difference for MCP tool definition artifacts.
+ */
+public class McpToolCompatibilityDifference implements CompatibilityDifference {
+
+    public enum Type {
+        REQUIRED_PARAM_ADDED("inputSchema/required"),
+        REQUIRED_PARAM_REMOVED("inputSchema/required"),
+        INPUT_SCHEMA_TYPE_CHANGED("inputSchema/type"),
+        PROPERTY_REMOVED("inputSchema/properties"),
+        PARSE_ERROR("document");
+
+        private final String context;
+
+        Type(String context) {
+            this.context = context;
+        }
+
+        public String getContext() {
+            return "/" + context;
+        }
+    }
+
+    private final Type type;
+    private final String description;
+
+    public McpToolCompatibilityDifference(Type type, String description) {
+        this.type = Objects.requireNonNull(type);
+        this.description = Objects.requireNonNull(description);
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public RuleViolation asRuleViolation() {
+        return new RuleViolation(description, type.getContext());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        McpToolCompatibilityDifference that = (McpToolCompatibilityDifference) o;
+        return type == that.type && Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, description);
+    }
+
+    @Override
+    public String toString() {
+        return "McpToolCompatibilityDifference{" + "type=" + type + ", description='" + description
+                + '\'' + '}';
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AgentCardContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AgentCardContentValidator.java
@@ -87,15 +87,9 @@ public class AgentCardContentValidator implements ContentValidator {
 
     private void validateStringFields(JsonNode tree, Set<RuleViolation> violations) {
         // Validate optional string fields
-        validateOptionalString(tree, "description", violations);
-        validateOptionalString(tree, "version", violations);
-        validateOptionalString(tree, "url", violations);
-    }
-
-    private void validateOptionalString(JsonNode tree, String fieldName, Set<RuleViolation> violations) {
-        if (tree.has(fieldName) && !tree.get(fieldName).isTextual()) {
-            violations.add(new RuleViolation("'" + fieldName + "' field must be a string", "/" + fieldName));
-        }
+        JsonValidationUtils.validateOptionalString(tree, "description", violations);
+        JsonValidationUtils.validateOptionalString(tree, "version", violations);
+        JsonValidationUtils.validateOptionalString(tree, "url", violations);
     }
 
     private void validateProviderField(JsonNode tree, Set<RuleViolation> violations) {
@@ -188,13 +182,15 @@ public class AgentCardContentValidator implements ContentValidator {
             if (skill.has("tags") && !skill.get("tags").isArray()) {
                 violations.add(new RuleViolation("Skill 'tags' must be an array", basePath + "/tags"));
             } else if (skill.has("tags")) {
-                validateStringArray(skill.get("tags"), basePath + "/tags", "tag", violations);
+                JsonValidationUtils.validateStringArray(skill.get("tags"), basePath + "/tags", "tag",
+                        violations);
             }
 
             if (skill.has("examples") && !skill.get("examples").isArray()) {
                 violations.add(new RuleViolation("Skill 'examples' must be an array", basePath + "/examples"));
             } else if (skill.has("examples")) {
-                validateStringArray(skill.get("examples"), basePath + "/examples", "example", violations);
+                JsonValidationUtils.validateStringArray(skill.get("examples"), basePath + "/examples",
+                        "example", violations);
             }
 
             index++;
@@ -202,33 +198,8 @@ public class AgentCardContentValidator implements ContentValidator {
     }
 
     private void validateArrayFields(JsonNode tree, Set<RuleViolation> violations) {
-        validateStringArrayField(tree, "defaultInputModes", violations);
-        validateStringArrayField(tree, "defaultOutputModes", violations);
-    }
-
-    private void validateStringArrayField(JsonNode tree, String fieldName, Set<RuleViolation> violations) {
-        if (!tree.has(fieldName)) {
-            return;
-        }
-
-        JsonNode array = tree.get(fieldName);
-        if (!array.isArray()) {
-            violations.add(new RuleViolation("'" + fieldName + "' field must be an array", "/" + fieldName));
-            return;
-        }
-
-        validateStringArray(array, "/" + fieldName, "item", violations);
-    }
-
-    private void validateStringArray(JsonNode array, String basePath, String itemName, Set<RuleViolation> violations) {
-        int index = 0;
-        for (JsonNode item : array) {
-            if (!item.isTextual()) {
-                violations.add(new RuleViolation("Each " + itemName + " must be a string",
-                        basePath + "/" + index));
-            }
-            index++;
-        }
+        JsonValidationUtils.validateStringArrayField(tree, "defaultInputModes", violations);
+        JsonValidationUtils.validateStringArrayField(tree, "defaultOutputModes", violations);
     }
 
     private void validateAuthenticationField(JsonNode tree, Set<RuleViolation> violations) {
@@ -247,7 +218,8 @@ public class AgentCardContentValidator implements ContentValidator {
                 violations.add(new RuleViolation("'authentication.schemes' must be an array",
                         "/authentication/schemes"));
             } else {
-                validateStringArray(auth.get("schemes"), "/authentication/schemes", "scheme", violations);
+                JsonValidationUtils.validateStringArray(auth.get("schemes"),
+                        "/authentication/schemes", "scheme", violations);
             }
         }
 

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/JsonValidationUtils.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/JsonValidationUtils.java
@@ -1,0 +1,62 @@
+package io.apicurio.registry.rules.validity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apicurio.registry.rules.violation.RuleViolation;
+
+import java.util.Set;
+
+/**
+ * Shared JSON validation utility methods used by content validators for JSON-based artifact types
+ * such as AGENT_CARD and MCP_TOOL.
+ */
+public final class JsonValidationUtils {
+
+    private JsonValidationUtils() {
+        // Utility class
+    }
+
+    /**
+     * Validates that an optional field, if present, is a string.
+     */
+    public static void validateOptionalString(JsonNode tree, String fieldName,
+            Set<RuleViolation> violations) {
+        if (tree.has(fieldName) && !tree.get(fieldName).isTextual()) {
+            violations.add(
+                    new RuleViolation("'" + fieldName + "' field must be a string", "/" + fieldName));
+        }
+    }
+
+    /**
+     * Validates that an optional field, if present, is an array of strings.
+     */
+    public static void validateStringArrayField(JsonNode tree, String fieldName,
+            Set<RuleViolation> violations) {
+        if (!tree.has(fieldName)) {
+            return;
+        }
+
+        JsonNode array = tree.get(fieldName);
+        if (!array.isArray()) {
+            violations.add(
+                    new RuleViolation("'" + fieldName + "' field must be an array", "/" + fieldName));
+            return;
+        }
+
+        validateStringArray(array, "/" + fieldName, "item", violations);
+    }
+
+    /**
+     * Validates that every element in a JSON array is a string.
+     */
+    public static void validateStringArray(JsonNode array, String basePath, String itemName,
+            Set<RuleViolation> violations) {
+        int index = 0;
+        for (JsonNode item : array) {
+            if (!item.isTextual()) {
+                violations.add(new RuleViolation("Each " + itemName + " must be a string",
+                        basePath + "/" + index));
+            }
+            index++;
+        }
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
@@ -1,0 +1,171 @@
+package io.apicurio.registry.rules.validity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.content.util.ContentTypeUtil;
+import io.apicurio.registry.rest.v3.beans.ArtifactReference;
+import io.apicurio.registry.rules.violation.RuleViolation;
+import io.apicurio.registry.rules.violation.RuleViolationException;
+import io.apicurio.registry.types.RuleType;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Content validator for MCP (Model Context Protocol) tool definition artifacts.
+ *
+ * Validates that the content is a valid MCP tool definition JSON document.
+ *
+ * Validation levels:
+ * - NONE: No validation
+ * - SYNTAX_ONLY: Validates that the content is valid JSON and is an object
+ * - FULL: Full schema validation including required fields, type checking, and structure validation
+ *
+ * @see <a href="https://spec.modelcontextprotocol.io/specification/server/tools/">MCP Tools</a>
+ */
+public class McpToolContentValidator implements ContentValidator {
+
+    @Override
+    public void validate(ValidityLevel level, TypedContent content,
+            Map<String, TypedContent> resolvedReferences) throws RuleViolationException {
+
+        if (level == ValidityLevel.NONE) {
+            return;
+        }
+
+        Set<RuleViolation> violations = new HashSet<>();
+
+        try {
+            JsonNode tree = ContentTypeUtil.parseJson(content.getContent());
+
+            if (!tree.isObject()) {
+                throw new RuleViolationException("MCP tool definition must be a JSON object",
+                        RuleType.VALIDITY, level.name(),
+                        Collections.singleton(
+                                new RuleViolation("MCP tool definition must be a JSON object", "")));
+            }
+
+            // SYNTAX_ONLY level: just check it's valid JSON object (already done)
+            if (level == ValidityLevel.SYNTAX_ONLY) {
+                return;
+            }
+
+            // FULL level: comprehensive validation
+            validateNameField(tree, violations);
+            validateStringFields(tree, violations);
+            validateInputSchemaField(tree, violations);
+            validateAnnotationsField(tree, violations);
+
+            if (!violations.isEmpty()) {
+                throw new RuleViolationException("Invalid MCP tool definition", RuleType.VALIDITY,
+                        level.name(), violations);
+            }
+
+        } catch (RuleViolationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuleViolationException(
+                    "Invalid MCP tool definition JSON: " + e.getMessage(), RuleType.VALIDITY,
+                    level.name(), e);
+        }
+    }
+
+    private void validateNameField(JsonNode tree, Set<RuleViolation> violations) {
+        if (!tree.has("name")) {
+            violations.add(
+                    new RuleViolation("MCP tool definition must have a 'name' field", "/name"));
+        } else if (!tree.get("name").isTextual()) {
+            violations.add(new RuleViolation("'name' field must be a string", "/name"));
+        } else if (tree.get("name").asText().trim().isEmpty()) {
+            violations.add(new RuleViolation("'name' field must not be empty", "/name"));
+        }
+    }
+
+    private void validateStringFields(JsonNode tree, Set<RuleViolation> violations) {
+        JsonValidationUtils.validateOptionalString(tree, "description", violations);
+        JsonValidationUtils.validateOptionalString(tree, "version", violations);
+    }
+
+    private void validateInputSchemaField(JsonNode tree, Set<RuleViolation> violations) {
+        if (!tree.has("inputSchema")) {
+            violations.add(new RuleViolation("MCP tool definition must have an 'inputSchema' field",
+                    "/inputSchema"));
+            return;
+        }
+
+        JsonNode inputSchema = tree.get("inputSchema");
+        if (!inputSchema.isObject()) {
+            violations.add(
+                    new RuleViolation("'inputSchema' field must be an object", "/inputSchema"));
+            return;
+        }
+
+        // inputSchema must have a "type" field
+        if (!inputSchema.has("type")) {
+            violations.add(new RuleViolation("'inputSchema' must have a 'type' field",
+                    "/inputSchema/type"));
+        } else if (!inputSchema.get("type").isTextual()) {
+            violations.add(new RuleViolation("'inputSchema.type' must be a string",
+                    "/inputSchema/type"));
+        }
+
+        // If "properties" is present, it must be an object
+        if (inputSchema.has("properties") && !inputSchema.get("properties").isObject()) {
+            violations.add(new RuleViolation("'inputSchema.properties' must be an object",
+                    "/inputSchema/properties"));
+        }
+
+        // If "required" is present, it must be an array of strings
+        if (inputSchema.has("required")) {
+            if (!inputSchema.get("required").isArray()) {
+                violations.add(new RuleViolation("'inputSchema.required' must be an array",
+                        "/inputSchema/required"));
+            } else {
+                JsonValidationUtils.validateStringArray(inputSchema.get("required"),
+                        "/inputSchema/required", "required parameter name", violations);
+            }
+        }
+    }
+
+    private void validateAnnotationsField(JsonNode tree, Set<RuleViolation> violations) {
+        if (!tree.has("annotations")) {
+            return;
+        }
+
+        JsonNode annotations = tree.get("annotations");
+        if (!annotations.isObject()) {
+            violations.add(new RuleViolation("'annotations' field must be an object",
+                    "/annotations"));
+            return;
+        }
+
+        if (annotations.has("category") && !annotations.get("category").isTextual()) {
+            violations.add(new RuleViolation("'annotations.category' must be a string",
+                    "/annotations/category"));
+        }
+
+        if (annotations.has("provider") && !annotations.get("provider").isTextual()) {
+            violations.add(new RuleViolation("'annotations.provider' must be a string",
+                    "/annotations/provider"));
+        }
+
+        if (annotations.has("requiresAuth") && !annotations.get("requiresAuth").isBoolean()) {
+            violations.add(new RuleViolation("'annotations.requiresAuth' must be a boolean",
+                    "/annotations/requiresAuth"));
+        }
+    }
+
+    @Override
+    public void validateReferences(TypedContent content, List<ArtifactReference> references)
+            throws RuleViolationException {
+        // MCP tool definitions don't support references
+        if (references != null && !references.isEmpty()) {
+            throw new RuleViolationException("MCP tool definitions do not support references",
+                    RuleType.INTEGRITY, "NONE", Collections.singleton(new RuleViolation(
+                            "References are not supported for MCP tool definitions", "")));
+        }
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
@@ -17,14 +17,14 @@ import java.util.Set;
 /**
  * Content validator for MCP (Model Context Protocol) tool definition artifacts.
  *
- * Validates that the content is a valid MCP tool definition JSON document.
+ * Validates that the content is a valid MCP tool definition JSON document per the MCP specification 2025-11-25.
  *
  * Validation levels:
  * - NONE: No validation
  * - SYNTAX_ONLY: Validates that the content is valid JSON and is an object
  * - FULL: Full schema validation including required fields, type checking, and structure validation
  *
- * @see <a href="https://spec.modelcontextprotocol.io/specification/server/tools/">MCP Tools</a>
+ * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/tools">MCP Tools</a>
  */
 public class McpToolContentValidator implements ContentValidator {
 
@@ -55,8 +55,9 @@ public class McpToolContentValidator implements ContentValidator {
 
             // FULL level: comprehensive validation
             validateNameField(tree, violations);
-            validateStringFields(tree, violations);
+            validateOptionalStringFields(tree, violations);
             validateInputSchemaField(tree, violations);
+            validateOutputSchemaField(tree, violations);
             validateAnnotationsField(tree, violations);
 
             if (!violations.isEmpty()) {
@@ -84,9 +85,9 @@ public class McpToolContentValidator implements ContentValidator {
         }
     }
 
-    private void validateStringFields(JsonNode tree, Set<RuleViolation> violations) {
+    private void validateOptionalStringFields(JsonNode tree, Set<RuleViolation> violations) {
+        JsonValidationUtils.validateOptionalString(tree, "title", violations);
         JsonValidationUtils.validateOptionalString(tree, "description", violations);
-        JsonValidationUtils.validateOptionalString(tree, "version", violations);
     }
 
     private void validateInputSchemaField(JsonNode tree, Set<RuleViolation> violations) {
@@ -103,12 +104,16 @@ public class McpToolContentValidator implements ContentValidator {
             return;
         }
 
-        // inputSchema must have a "type" field
+        // inputSchema must have a "type" field with value "object"
         if (!inputSchema.has("type")) {
             violations.add(new RuleViolation("'inputSchema' must have a 'type' field",
                     "/inputSchema/type"));
         } else if (!inputSchema.get("type").isTextual()) {
             violations.add(new RuleViolation("'inputSchema.type' must be a string",
+                    "/inputSchema/type"));
+        } else if (!"object".equals(inputSchema.get("type").asText())) {
+            violations.add(new RuleViolation(
+                    "'inputSchema.type' must be 'object' per the MCP specification",
                     "/inputSchema/type"));
         }
 
@@ -130,6 +135,13 @@ public class McpToolContentValidator implements ContentValidator {
         }
     }
 
+    private void validateOutputSchemaField(JsonNode tree, Set<RuleViolation> violations) {
+        if (tree.has("outputSchema") && !tree.get("outputSchema").isObject()) {
+            violations.add(new RuleViolation("'outputSchema' field must be an object",
+                    "/outputSchema"));
+        }
+    }
+
     private void validateAnnotationsField(JsonNode tree, Set<RuleViolation> violations) {
         if (!tree.has("annotations")) {
             return;
@@ -142,19 +154,35 @@ public class McpToolContentValidator implements ContentValidator {
             return;
         }
 
-        if (annotations.has("category") && !annotations.get("category").isTextual()) {
-            violations.add(new RuleViolation("'annotations.category' must be a string",
-                    "/annotations/category"));
+        // title: optional string (fallback display name per MCP spec)
+        JsonValidationUtils.validateOptionalString(annotations, "title", violations);
+
+        // audience: optional array of strings ("user", "assistant")
+        if (annotations.has("audience")) {
+            JsonNode audience = annotations.get("audience");
+            if (!audience.isArray()) {
+                violations.add(new RuleViolation("'annotations.audience' must be an array",
+                        "/annotations/audience"));
+            } else {
+                JsonValidationUtils.validateStringArray(audience,
+                        "/annotations/audience", "audience role", violations);
+            }
         }
 
-        if (annotations.has("provider") && !annotations.get("provider").isTextual()) {
-            violations.add(new RuleViolation("'annotations.provider' must be a string",
-                    "/annotations/provider"));
-        }
-
-        if (annotations.has("requiresAuth") && !annotations.get("requiresAuth").isBoolean()) {
-            violations.add(new RuleViolation("'annotations.requiresAuth' must be a boolean",
-                    "/annotations/requiresAuth"));
+        // priority: optional number between 0 and 1
+        if (annotations.has("priority")) {
+            JsonNode priority = annotations.get("priority");
+            if (!priority.isNumber()) {
+                violations.add(new RuleViolation("'annotations.priority' must be a number",
+                        "/annotations/priority"));
+            } else {
+                double value = priority.asDouble();
+                if (value < 0 || value > 1) {
+                    violations.add(new RuleViolation(
+                            "'annotations.priority' must be between 0 and 1",
+                            "/annotations/priority"));
+                }
+            }
         }
     }
 

--- a/schema-util/common/src/main/resources/io/apicurio/registry/rules/validity/mcp-tool-schema.json
+++ b/schema-util/common/src/main/resources/io/apicurio/registry/rules/validity/mcp-tool-schema.json
@@ -62,8 +62,7 @@
           "type": "array",
           "description": "Describes the intended audience, e.g. 'user', 'assistant'.",
           "items": {
-            "type": "string",
-            "enum": ["user", "assistant"]
+            "type": "string"
           }
         },
         "priority": {

--- a/schema-util/common/src/main/resources/io/apicurio/registry/rules/validity/mcp-tool-schema.json
+++ b/schema-util/common/src/main/resources/io/apicurio/registry/rules/validity/mcp-tool-schema.json
@@ -1,22 +1,22 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://spec.modelcontextprotocol.io/schemas/mcp-tool.json",
+  "$id": "https://apicurio.io/schemas/mcp-tool.json",
   "title": "MCP Tool Definition",
-  "description": "Schema for MCP (Model Context Protocol) tool definitions stored as registry artifacts.",
+  "description": "Schema for MCP (Model Context Protocol) tool definitions stored as registry artifacts, based on the MCP specification 2025-11-25.",
   "type": "object",
   "required": ["name", "inputSchema"],
   "properties": {
     "name": {
       "type": "string",
-      "description": "The name of the tool. Must be unique within a server."
+      "description": "Unique identifier for the tool. Should be between 1 and 128 characters."
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable name of the tool for display purposes."
     },
     "description": {
       "type": "string",
       "description": "A human-readable description of what the tool does."
-    },
-    "version": {
-      "type": "string",
-      "description": "The version of this tool definition."
     },
     "inputSchema": {
       "type": "object",
@@ -25,7 +25,8 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The JSON Schema type (typically 'object')."
+          "const": "object",
+          "description": "The JSON Schema type. Must be 'object' per the MCP specification."
         },
         "properties": {
           "type": "object",
@@ -44,21 +45,32 @@
       },
       "additionalProperties": true
     },
+    "outputSchema": {
+      "type": "object",
+      "description": "Optional JSON Schema defining expected output structure for structured results.",
+      "additionalProperties": true
+    },
     "annotations": {
       "type": "object",
-      "description": "Optional metadata annotations for the tool.",
+      "description": "Optional ToolAnnotations per the MCP specification (title, audience, priority).",
       "properties": {
-        "provider": {
+        "title": {
           "type": "string",
-          "description": "The provider or source of this tool."
+          "description": "An optional title for the tool annotation. Used as fallback display name if top-level title is absent."
         },
-        "category": {
-          "type": "string",
-          "description": "The category this tool belongs to."
+        "audience": {
+          "type": "array",
+          "description": "Describes the intended audience, e.g. 'user', 'assistant'.",
+          "items": {
+            "type": "string",
+            "enum": ["user", "assistant"]
+          }
         },
-        "requiresAuth": {
-          "type": "boolean",
-          "description": "Whether the tool requires authentication to use."
+        "priority": {
+          "type": "number",
+          "description": "Priority hint (0 to 1). Higher values indicate higher priority.",
+          "minimum": 0,
+          "maximum": 1
         }
       },
       "additionalProperties": true

--- a/schema-util/common/src/main/resources/io/apicurio/registry/rules/validity/mcp-tool-schema.json
+++ b/schema-util/common/src/main/resources/io/apicurio/registry/rules/validity/mcp-tool-schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://spec.modelcontextprotocol.io/schemas/mcp-tool.json",
+  "title": "MCP Tool Definition",
+  "description": "Schema for MCP (Model Context Protocol) tool definitions stored as registry artifacts.",
+  "type": "object",
+  "required": ["name", "inputSchema"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the tool. Must be unique within a server."
+    },
+    "description": {
+      "type": "string",
+      "description": "A human-readable description of what the tool does."
+    },
+    "version": {
+      "type": "string",
+      "description": "The version of this tool definition."
+    },
+    "inputSchema": {
+      "type": "object",
+      "description": "A JSON Schema object defining the expected parameters for the tool.",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The JSON Schema type (typically 'object')."
+        },
+        "properties": {
+          "type": "object",
+          "description": "The input parameter definitions.",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "required": {
+          "type": "array",
+          "description": "List of required parameter names.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "annotations": {
+      "type": "object",
+      "description": "Optional metadata annotations for the tool.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "The provider or source of this tool."
+        },
+        "category": {
+          "type": "string",
+          "description": "The category this tool belongs to."
+        },
+        "requiresAuth": {
+          "type": "boolean",
+          "description": "Whether the tool requires authentication to use."
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/DefaultArtifactTypeUtilProviderImpl.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/DefaultArtifactTypeUtilProviderImpl.java
@@ -16,7 +16,8 @@ public class DefaultArtifactTypeUtilProviderImpl implements ArtifactTypeUtilProv
                     new AvroArtifactTypeUtilProvider(), new GraphQLArtifactTypeUtilProvider(),
                     new KConnectArtifactTypeUtilProvider(), new WsdlArtifactTypeUtilProvider(),
                     new XsdArtifactTypeUtilProvider(), new XmlArtifactTypeUtilProvider(),
-                    new AgentCardArtifactTypeUtilProvider(), new IcebergTableArtifactTypeUtilProvider(),
+                    new AgentCardArtifactTypeUtilProvider(), new McpToolArtifactTypeUtilProvider(),
+                    new IcebergTableArtifactTypeUtilProvider(),
                     new IcebergViewArtifactTypeUtilProvider(),
                     new OpenRpcArtifactTypeUtilProvider()));
 

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/McpToolArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/McpToolArtifactTypeUtilProvider.java
@@ -1,0 +1,94 @@
+package io.apicurio.registry.types.provider;
+
+import io.apicurio.registry.content.ContentAccepter;
+import io.apicurio.registry.content.McpToolContentAccepter;
+import io.apicurio.registry.content.canon.ContentCanonicalizer;
+import io.apicurio.registry.content.dereference.ContentDereferencer;
+import io.apicurio.registry.content.dereference.NoopContentDereferencer;
+import io.apicurio.registry.content.extract.ContentExtractor;
+import io.apicurio.registry.content.extract.McpToolContentExtractor;
+import io.apicurio.registry.content.extract.McpToolStructuredContentExtractor;
+import io.apicurio.registry.content.extract.StructuredContentExtractor;
+import io.apicurio.registry.content.refs.DefaultReferenceArtifactIdentifierExtractor;
+import io.apicurio.registry.content.refs.NoOpReferenceFinder;
+import io.apicurio.registry.content.refs.ReferenceArtifactIdentifierExtractor;
+import io.apicurio.registry.content.refs.ReferenceFinder;
+import io.apicurio.registry.json.content.canon.JsonContentCanonicalizer;
+import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
+import io.apicurio.registry.rules.compatibility.McpToolCompatibilityChecker;
+import io.apicurio.registry.rules.validity.ContentValidator;
+import io.apicurio.registry.rules.validity.McpToolContentValidator;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+
+import java.util.Set;
+
+/**
+ * Artifact type utility provider for MCP (Model Context Protocol) tool definition artifacts.
+ *
+ * MCP tools are JSON documents that describe tools available to AI agents following the MCP specification.
+ *
+ * @see <a href="https://spec.modelcontextprotocol.io/specification/server/tools/">MCP Tools</a>
+ */
+public class McpToolArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvider {
+
+    @Override
+    public String getArtifactType() {
+        return ArtifactType.MCP_TOOL;
+    }
+
+    @Override
+    public Set<String> getContentTypes() {
+        return Set.of(ContentTypes.APPLICATION_JSON);
+    }
+
+    @Override
+    protected ContentAccepter createContentAccepter() {
+        return new McpToolContentAccepter();
+    }
+
+    @Override
+    protected CompatibilityChecker createCompatibilityChecker() {
+        return new McpToolCompatibilityChecker();
+    }
+
+    @Override
+    protected ContentCanonicalizer createContentCanonicalizer() {
+        return new JsonContentCanonicalizer();
+    }
+
+    @Override
+    protected ContentValidator createContentValidator() {
+        return new McpToolContentValidator();
+    }
+
+    @Override
+    protected ContentExtractor createContentExtractor() {
+        return new McpToolContentExtractor();
+    }
+
+    @Override
+    protected ContentDereferencer createContentDereferencer() {
+        return NoopContentDereferencer.INSTANCE;
+    }
+
+    @Override
+    protected ReferenceFinder createReferenceFinder() {
+        return NoOpReferenceFinder.INSTANCE;
+    }
+
+    @Override
+    public boolean supportsReferencesWithContext() {
+        return false;
+    }
+
+    @Override
+    protected ReferenceArtifactIdentifierExtractor createReferenceArtifactIdentifierExtractor() {
+        return new DefaultReferenceArtifactIdentifierExtractor();
+    }
+
+    @Override
+    protected StructuredContentExtractor createStructuredContentExtractor() {
+        return new McpToolStructuredContentExtractor();
+    }
+}

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -279,8 +279,8 @@ class McpToolCompatibilityCheckerTest {
                         }
                     },
                     "annotations": {
-                        "category": "database",
-                        "provider": "internal"
+                        "audience": ["user"],
+                        "priority": 0.5
                     }
                 }
                 """;
@@ -295,9 +295,9 @@ class McpToolCompatibilityCheckerTest {
                         }
                     },
                     "annotations": {
-                        "category": "search",
-                        "provider": "external",
-                        "requiresAuth": true
+                        "audience": ["user", "assistant"],
+                        "priority": 0.9,
+                        "lastModified": "2025-11-25T10:30:00Z"
                     }
                 }
                 """;

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -249,7 +249,6 @@ class McpToolCompatibilityCheckerTest {
                 {
                     "name": "renamed_tool",
                     "description": "New description",
-                    "version": "2.0.0",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -264,7 +263,7 @@ class McpToolCompatibilityCheckerTest {
                 createMcpTool(proposed), Map.of());
 
         assertTrue(result.isCompatible(),
-                "Changing name, description, and version should be compatible");
+                "Changing name and description should be compatible");
     }
 
     @Test
@@ -296,8 +295,7 @@ class McpToolCompatibilityCheckerTest {
                     },
                     "annotations": {
                         "audience": ["user", "assistant"],
-                        "priority": 0.9,
-                        "lastModified": "2025-11-25T10:30:00Z"
+                        "priority": 0.9
                     }
                 }
                 """;

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -1,0 +1,349 @@
+package io.apicurio.registry.rules.compatibility;
+
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.types.ContentTypes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for McpToolCompatibilityChecker.
+ */
+class McpToolCompatibilityCheckerTest {
+
+    private McpToolCompatibilityChecker checker;
+
+    @BeforeEach
+    void setUp() {
+        checker = new McpToolCompatibilityChecker();
+    }
+
+    private TypedContent createMcpTool(String json) {
+        return TypedContent.create(ContentHandle.create(json), ContentTypes.APPLICATION_JSON);
+    }
+
+    @Test
+    void testCompatibleWhenNoExistingArtifacts() {
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, Collections.emptyList(), createMcpTool(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(), "Should be compatible when no existing artifacts");
+    }
+
+    @Test
+    void testBackwardCompatibleAddingOptionalProperty() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" },
+                            "limit": { "type": "integer" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Adding an optional property should be backward compatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleRemovingProperty() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" },
+                            "limit": { "type": "integer" }
+                        }
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Removing a property should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleAddingRequiredParam() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" },
+                            "format": { "type": "string" }
+                        },
+                        "required": ["query", "format"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Adding a required parameter should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleRemovingRequiredParam() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" },
+                            "format": { "type": "string" }
+                        },
+                        "required": ["query", "format"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" },
+                            "format": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Removing a required parameter should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleChangingSchemaType() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Changing inputSchema type should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardCompatibleChangingNameAndDescription() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "description": "Old description",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "renamed_tool",
+                    "description": "New description",
+                    "version": "2.0.0",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Changing name, description, and version should be compatible");
+    }
+
+    @Test
+    void testBackwardCompatibleChangingAnnotations() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    },
+                    "annotations": {
+                        "category": "database",
+                        "provider": "internal"
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    },
+                    "annotations": {
+                        "category": "search",
+                        "provider": "external",
+                        "requiresAuth": true
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Changing annotations should be compatible");
+    }
+
+    @Test
+    void testFullCompatibilityBothDirections() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        // Same schema, just description change — should be FULL compatible
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "description": "Updated description",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.FULL, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(), "Identical schema with description change should be fully compatible");
+    }
+}

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
@@ -82,8 +82,8 @@ public class McpToolContentValidatorTest extends ArtifactUtilProviderTestBase {
             validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
         });
         Assertions.assertFalse(error.getCauses().isEmpty());
-        // Should have violations for audience (not array), priority (not number),
-        // lastModified (not string)
+        // Should have violations for title (not string), audience (not array),
+        // and priority (not number)
         Assertions.assertTrue(error.getCauses().size() >= 3);
     }
 

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
@@ -82,8 +82,8 @@ public class McpToolContentValidatorTest extends ArtifactUtilProviderTestBase {
             validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
         });
         Assertions.assertFalse(error.getCauses().isEmpty());
-        // Should have violations for category (not string), provider (not string),
-        // requiresAuth (not boolean)
+        // Should have violations for audience (not array), priority (not number),
+        // lastModified (not string)
         Assertions.assertTrue(error.getCauses().size() >= 3);
     }
 

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
@@ -1,0 +1,135 @@
+package io.apicurio.registry.rules.validity;
+
+import io.apicurio.registry.content.McpToolContentAccepter;
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.content.extract.ExtractedMetaData;
+import io.apicurio.registry.content.extract.McpToolContentExtractor;
+import io.apicurio.registry.rules.violation.RuleViolationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+/**
+ * Tests the MCP tool content validator, accepter, and extractor.
+ */
+public class McpToolContentValidatorTest extends ArtifactUtilProviderTestBase {
+
+    @Test
+    public void testValidMcpTool() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-valid.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+    }
+
+    @Test
+    public void testValidMcpToolSyntaxOnly() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-valid.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        validator.validate(ValidityLevel.SYNTAX_ONLY, content, Collections.emptyMap());
+    }
+
+    @Test
+    public void testMcpToolMissingName() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-missing-name.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertFalse(error.getCauses().isEmpty());
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getDescription().contains("name")));
+    }
+
+    @Test
+    public void testMcpToolMissingInputSchema() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-missing-inputschema.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertFalse(error.getCauses().isEmpty());
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getDescription().contains("inputSchema")));
+    }
+
+    @Test
+    public void testMcpToolInvalidJson() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-invalid-json.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.SYNTAX_ONLY, content, Collections.emptyMap());
+        });
+    }
+
+    @Test
+    public void testMcpToolInvalidInputSchema() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-invalid-inputschema.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertFalse(error.getCauses().isEmpty());
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getDescription().contains("inputSchema")));
+    }
+
+    @Test
+    public void testMcpToolInvalidAnnotations() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-invalid-annotations.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertFalse(error.getCauses().isEmpty());
+        // Should have violations for category (not string), provider (not string),
+        // requiresAuth (not boolean)
+        Assertions.assertTrue(error.getCauses().size() >= 3);
+    }
+
+    @Test
+    public void testMcpToolMinimal() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-minimal.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+    }
+
+    @Test
+    public void testMcpToolAccepterAccepts() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-valid.json");
+        McpToolContentAccepter accepter = new McpToolContentAccepter();
+        Assertions.assertTrue(accepter.acceptsContent(content, Collections.emptyMap()));
+    }
+
+    @Test
+    public void testMcpToolAccepterRejectsAgentCard() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("agentcard-valid.json");
+        McpToolContentAccepter accepter = new McpToolContentAccepter();
+        Assertions.assertFalse(accepter.acceptsContent(content, Collections.emptyMap()));
+    }
+
+    @Test
+    public void testMcpToolAccepterRejectsInvalidJson() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-invalid-json.json");
+        McpToolContentAccepter accepter = new McpToolContentAccepter();
+        Assertions.assertFalse(accepter.acceptsContent(content, Collections.emptyMap()));
+    }
+
+    @Test
+    public void testMcpToolExtractor() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-valid.json");
+        McpToolContentExtractor extractor = new McpToolContentExtractor();
+        ExtractedMetaData metaData = extractor.extract(content.getContent());
+        Assertions.assertNotNull(metaData);
+        Assertions.assertEquals("search_database", metaData.getName());
+        Assertions.assertEquals("Search the product database with filters",
+                metaData.getDescription());
+    }
+
+    @Test
+    public void testMcpToolValidationNoneLevel() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-invalid-json.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        validator.validate(ValidityLevel.NONE, content, Collections.emptyMap());
+    }
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-annotations.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-annotations.json
@@ -4,8 +4,8 @@
     "type": "object"
   },
   "annotations": {
-    "category": 123,
-    "provider": true,
-    "requiresAuth": "yes"
+    "title": 123,
+    "audience": "not-an-array",
+    "priority": "not-a-number"
   }
 }

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-annotations.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-annotations.json
@@ -1,0 +1,11 @@
+{
+  "name": "annotated_tool",
+  "inputSchema": {
+    "type": "object"
+  },
+  "annotations": {
+    "category": 123,
+    "provider": true,
+    "requiresAuth": "yes"
+  }
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-inputschema.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-inputschema.json
@@ -1,0 +1,4 @@
+{
+  "name": "bad_schema_tool",
+  "inputSchema": "not-an-object"
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-json.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-json.json
@@ -1,0 +1,1 @@
+{ this is not valid json !!!

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-minimal.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-minimal.json
@@ -1,0 +1,6 @@
+{
+  "name": "simple_tool",
+  "inputSchema": {
+    "type": "object"
+  }
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-missing-inputschema.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-missing-inputschema.json
@@ -1,0 +1,4 @@
+{
+  "name": "broken_tool",
+  "description": "A tool without inputSchema"
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-missing-name.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-missing-name.json
@@ -1,0 +1,6 @@
+{
+  "description": "A tool without a name",
+  "inputSchema": {
+    "type": "object"
+  }
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-valid.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-valid.json
@@ -1,0 +1,18 @@
+{
+  "name": "search_database",
+  "description": "Search the product database with filters",
+  "version": "1.0.0",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "query": { "type": "string", "description": "Search query" },
+      "limit": { "type": "integer", "default": 10 }
+    },
+    "required": ["query"]
+  },
+  "annotations": {
+    "provider": "internal",
+    "category": "database",
+    "requiresAuth": true
+  }
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-valid.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-valid.json
@@ -1,7 +1,7 @@
 {
   "name": "search_database",
+  "title": "Database Search Tool",
   "description": "Search the product database with filters",
-  "version": "1.0.0",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -10,9 +10,17 @@
     },
     "required": ["query"]
   },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "results": { "type": "array", "description": "Search results" },
+      "total": { "type": "integer", "description": "Total count" }
+    },
+    "required": ["results", "total"]
+  },
   "annotations": {
-    "provider": "internal",
-    "category": "database",
-    "requiresAuth": true
+    "title": "DB Search",
+    "audience": ["user", "assistant"],
+    "priority": 0.8
   }
 }

--- a/ui/ui-app/src/app/components/mcpTool/McpToolViewer.css
+++ b/ui/ui-app/src/app/components/mcpTool/McpToolViewer.css
@@ -1,0 +1,7 @@
+.mcp-tool-viewer {
+    padding: 10px 0;
+}
+
+.mcp-tool-divider {
+    margin: 15px 0;
+}

--- a/ui/ui-app/src/app/components/mcpTool/McpToolViewer.tsx
+++ b/ui/ui-app/src/app/components/mcpTool/McpToolViewer.tsx
@@ -25,35 +25,46 @@ export type McpToolViewerProps = {
 
 /**
  * Component to display an MCP tool definition in a structured, read-only view.
+ * Follows the MCP specification 2025-11-25.
  */
 export const McpToolViewer: FunctionComponent<McpToolViewerProps> = (props: McpToolViewerProps) => {
     const spec = props.spec || {};
     const inputSchema = spec.inputSchema || {};
+    const outputSchema = spec.outputSchema;
     const properties = inputSchema.properties || {};
     const required: string[] = inputSchema.required || [];
     const annotations = spec.annotations || {};
     const paramNames = Object.keys(properties);
+    const hasAnnotations = annotations.title || annotations.audience || annotations.priority !== undefined;
+    // MCP spec display name fallback: title → annotations.title → name
+    const displayTitle = spec.title || annotations.title || spec.name || "Unnamed Tool";
 
     return (
         <div className={`mcp-tool-viewer ${props.className || ""}`}>
             <Card isPlain>
                 <CardHeader>
                     <CardTitle>
-                        <Title headingLevel="h2">{spec.name || "Unnamed Tool"}</Title>
+                        <Title headingLevel="h2">{displayTitle}</Title>
                     </CardTitle>
                 </CardHeader>
                 <CardBody>
                     <DescriptionList isHorizontal>
+                        {spec.name && (
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Name</DescriptionListTerm>
+                                <DescriptionListDescription><code>{spec.name}</code></DescriptionListDescription>
+                            </DescriptionListGroup>
+                        )}
+                        {spec.title && (
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Title</DescriptionListTerm>
+                                <DescriptionListDescription>{spec.title}</DescriptionListDescription>
+                            </DescriptionListGroup>
+                        )}
                         {spec.description && (
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Description</DescriptionListTerm>
                                 <DescriptionListDescription>{spec.description}</DescriptionListDescription>
-                            </DescriptionListGroup>
-                        )}
-                        {spec.version && (
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Version</DescriptionListTerm>
-                                <DescriptionListDescription>{spec.version}</DescriptionListDescription>
                             </DescriptionListGroup>
                         )}
                     </DescriptionList>
@@ -61,7 +72,7 @@ export const McpToolViewer: FunctionComponent<McpToolViewerProps> = (props: McpT
             </Card>
 
             {/* Annotations */}
-            {Object.keys(annotations).length > 0 && (
+            {hasAnnotations && (
                 <>
                     <Divider className="mcp-tool-divider" />
                     <Card isPlain>
@@ -72,16 +83,16 @@ export const McpToolViewer: FunctionComponent<McpToolViewerProps> = (props: McpT
                         </CardHeader>
                         <CardBody>
                             <LabelGroup>
-                                {annotations.category && (
-                                    <Label color="blue">Category: {annotations.category}</Label>
+                                {annotations.title && (
+                                    <Label color="grey">Title: {annotations.title}</Label>
                                 )}
-                                {annotations.provider && (
-                                    <Label color="green">Provider: {annotations.provider}</Label>
+                                {annotations.audience && Array.isArray(annotations.audience) && (
+                                    annotations.audience.map((role: string) => (
+                                        <Label key={role} color="blue">Audience: {role}</Label>
+                                    ))
                                 )}
-                                {annotations.requiresAuth !== undefined && (
-                                    <Label color={annotations.requiresAuth ? "orange" : "grey"}>
-                                        {annotations.requiresAuth ? "Auth Required" : "No Auth"}
-                                    </Label>
+                                {annotations.priority !== undefined && (
+                                    <Label color="green">Priority: {annotations.priority}</Label>
                                 )}
                             </LabelGroup>
                         </CardBody>
@@ -125,6 +136,52 @@ export const McpToolViewer: FunctionComponent<McpToolViewerProps> = (props: McpT
                                                     )}
                                                 </td>
                                                 <td>{param.description || "-"}</td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </CardBody>
+                    </Card>
+                </>
+            )}
+
+            {/* Output Schema */}
+            {outputSchema && outputSchema.properties && (
+                <>
+                    <Divider className="mcp-tool-divider" />
+                    <Card isPlain>
+                        <CardHeader>
+                            <CardTitle>
+                                <Title headingLevel="h3">Output Schema</Title>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardBody>
+                            <table className="pf-v5-c-table pf-m-compact pf-m-grid-md">
+                                <thead>
+                                    <tr>
+                                        <th>Field</th>
+                                        <th>Type</th>
+                                        <th>Required</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {Object.keys(outputSchema.properties).map((fieldName) => {
+                                        const field = outputSchema.properties[fieldName] || {};
+                                        const isRequired = (outputSchema.required || []).includes(fieldName);
+                                        return (
+                                            <tr key={fieldName}>
+                                                <td><strong>{fieldName}</strong></td>
+                                                <td>{field.type || "any"}</td>
+                                                <td>
+                                                    {isRequired ? (
+                                                        <Label color="red" isCompact>required</Label>
+                                                    ) : (
+                                                        <Label color="grey" isCompact>optional</Label>
+                                                    )}
+                                                </td>
+                                                <td>{field.description || "-"}</td>
                                             </tr>
                                         );
                                     })}

--- a/ui/ui-app/src/app/components/mcpTool/McpToolViewer.tsx
+++ b/ui/ui-app/src/app/components/mcpTool/McpToolViewer.tsx
@@ -1,0 +1,139 @@
+import { FunctionComponent } from "react";
+import "./McpToolViewer.css";
+import {
+    Card,
+    CardBody,
+    CardHeader,
+    CardTitle,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Divider,
+    Label,
+    LabelGroup,
+    Title
+} from "@patternfly/react-core";
+
+/**
+ * Properties for the MCP tool viewer.
+ */
+export type McpToolViewerProps = {
+    spec: any;
+    className?: string;
+};
+
+/**
+ * Component to display an MCP tool definition in a structured, read-only view.
+ */
+export const McpToolViewer: FunctionComponent<McpToolViewerProps> = (props: McpToolViewerProps) => {
+    const spec = props.spec || {};
+    const inputSchema = spec.inputSchema || {};
+    const properties = inputSchema.properties || {};
+    const required: string[] = inputSchema.required || [];
+    const annotations = spec.annotations || {};
+    const paramNames = Object.keys(properties);
+
+    return (
+        <div className={`mcp-tool-viewer ${props.className || ""}`}>
+            <Card isPlain>
+                <CardHeader>
+                    <CardTitle>
+                        <Title headingLevel="h2">{spec.name || "Unnamed Tool"}</Title>
+                    </CardTitle>
+                </CardHeader>
+                <CardBody>
+                    <DescriptionList isHorizontal>
+                        {spec.description && (
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Description</DescriptionListTerm>
+                                <DescriptionListDescription>{spec.description}</DescriptionListDescription>
+                            </DescriptionListGroup>
+                        )}
+                        {spec.version && (
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Version</DescriptionListTerm>
+                                <DescriptionListDescription>{spec.version}</DescriptionListDescription>
+                            </DescriptionListGroup>
+                        )}
+                    </DescriptionList>
+                </CardBody>
+            </Card>
+
+            {/* Annotations */}
+            {Object.keys(annotations).length > 0 && (
+                <>
+                    <Divider className="mcp-tool-divider" />
+                    <Card isPlain>
+                        <CardHeader>
+                            <CardTitle>
+                                <Title headingLevel="h3">Annotations</Title>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardBody>
+                            <LabelGroup>
+                                {annotations.category && (
+                                    <Label color="blue">Category: {annotations.category}</Label>
+                                )}
+                                {annotations.provider && (
+                                    <Label color="green">Provider: {annotations.provider}</Label>
+                                )}
+                                {annotations.requiresAuth !== undefined && (
+                                    <Label color={annotations.requiresAuth ? "orange" : "grey"}>
+                                        {annotations.requiresAuth ? "Auth Required" : "No Auth"}
+                                    </Label>
+                                )}
+                            </LabelGroup>
+                        </CardBody>
+                    </Card>
+                </>
+            )}
+
+            {/* Input Schema */}
+            {paramNames.length > 0 && (
+                <>
+                    <Divider className="mcp-tool-divider" />
+                    <Card isPlain>
+                        <CardHeader>
+                            <CardTitle>
+                                <Title headingLevel="h3">Input Parameters</Title>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardBody>
+                            <table className="pf-v5-c-table pf-m-compact pf-m-grid-md">
+                                <thead>
+                                    <tr>
+                                        <th>Parameter</th>
+                                        <th>Type</th>
+                                        <th>Required</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {paramNames.map((paramName) => {
+                                        const param = properties[paramName] || {};
+                                        const isRequired = required.includes(paramName);
+                                        return (
+                                            <tr key={paramName}>
+                                                <td><strong>{paramName}</strong></td>
+                                                <td>{param.type || "any"}</td>
+                                                <td>
+                                                    {isRequired ? (
+                                                        <Label color="red" isCompact>required</Label>
+                                                    ) : (
+                                                        <Label color="grey" isCompact>optional</Label>
+                                                    )}
+                                                </td>
+                                                <td>{param.description || "-"}</td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </CardBody>
+                    </Card>
+                </>
+            )}
+        </div>
+    );
+};

--- a/ui/ui-app/src/app/components/mcpTool/index.ts
+++ b/ui/ui-app/src/app/components/mcpTool/index.ts
@@ -1,0 +1,1 @@
+export * from "./McpToolViewer";

--- a/ui/ui-app/src/app/pages/version/VersionPage.tsx
+++ b/ui/ui-app/src/app/pages/version/VersionPage.tsx
@@ -167,6 +167,7 @@ export const VersionPage: FunctionComponent<PageProperties> = () => {
         return type === ArtifactTypes.OPENAPI
             || type === ArtifactTypes.ASYNCAPI
             || type === ArtifactTypes.AGENT_CARD
+            || type === ArtifactTypes.MCP_TOOL
             || type === ArtifactTypes.JSON
             || type === ArtifactTypes.MODEL_SCHEMA
             || type === ArtifactTypes.PROMPT_TEMPLATE;

--- a/ui/ui-app/src/app/pages/version/components/tabs/DocumentationTabContent.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/DocumentationTabContent.tsx
@@ -6,6 +6,7 @@ import {
     AgentCardVisualizer,
     AsyncApiVisualizer,
     JsonSchemaVisualizer,
+    McpToolVisualizer,
     ModelSchemaVisualizer,
     OpenApiVisualizer,
     PromptTemplateVisualizer
@@ -14,7 +15,7 @@ import { ArtifactTypes } from "@services/useArtifactTypesService.ts";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
 
 enum VisualizerType {
-    OPENAPI, ASYNCAPI, AGENT_CARD, JSON_SCHEMA, MODEL_SCHEMA, PROMPT_TEMPLATE, OTHER
+    OPENAPI, ASYNCAPI, AGENT_CARD, MCP_TOOL, JSON_SCHEMA, MODEL_SCHEMA, PROMPT_TEMPLATE, OTHER
 }
 
 const getVisualizerType = (artifactType: string): VisualizerType => {
@@ -26,6 +27,9 @@ const getVisualizerType = (artifactType: string): VisualizerType => {
     }
     if (artifactType === ArtifactTypes.AGENT_CARD) {
         return VisualizerType.AGENT_CARD;
+    }
+    if (artifactType === ArtifactTypes.MCP_TOOL) {
+        return VisualizerType.MCP_TOOL;
     }
     if (artifactType === ArtifactTypes.JSON) {
         return VisualizerType.JSON_SCHEMA;
@@ -121,6 +125,9 @@ export const DocumentationTabContent: FunctionComponent<DocumentationTabContentP
             </If>
             <If condition={visualizerType === VisualizerType.AGENT_CARD}>
                 <AgentCardVisualizer spec={parsedContent} />
+            </If>
+            <If condition={visualizerType === VisualizerType.MCP_TOOL}>
+                <McpToolVisualizer spec={parsedContent} />
             </If>
             <If condition={visualizerType === VisualizerType.JSON_SCHEMA}>
                 <JsonSchemaVisualizer spec={parsedContent} />

--- a/ui/ui-app/src/app/pages/version/components/tabs/visualizers/McpToolVisualizer.css
+++ b/ui/ui-app/src/app/pages/version/components/tabs/visualizers/McpToolVisualizer.css
@@ -1,0 +1,3 @@
+.mcp-tool-visualizer {
+    padding: 15px;
+}

--- a/ui/ui-app/src/app/pages/version/components/tabs/visualizers/McpToolVisualizer.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/visualizers/McpToolVisualizer.tsx
@@ -1,0 +1,19 @@
+import { FunctionComponent } from "react";
+import "./McpToolVisualizer.css";
+import { McpToolViewer } from "@app/components/mcpTool";
+
+export type McpToolVisualizerProps = {
+    spec: any;
+    className?: string;
+};
+
+/**
+ * Visualizer for MCP tool definition content in the documentation tab.
+ */
+export const McpToolVisualizer: FunctionComponent<McpToolVisualizerProps> = (props: McpToolVisualizerProps) => {
+    return (
+        <div className={`mcp-tool-visualizer ${props.className || ""}`}>
+            <McpToolViewer spec={props.spec} />
+        </div>
+    );
+};

--- a/ui/ui-app/src/app/pages/version/components/tabs/visualizers/index.ts
+++ b/ui/ui-app/src/app/pages/version/components/tabs/visualizers/index.ts
@@ -1,6 +1,7 @@
 export * from "./AsyncApiVisualizer.tsx";
 export * from "./OpenApiVisualizer.tsx";
 export * from "./AgentCardVisualizer.tsx";
+export * from "./McpToolVisualizer.tsx";
 export * from "./JsonSchemaVisualizer.tsx";
 export * from "./ModelSchemaVisualizer.tsx";
 export * from "./PromptTemplateVisualizer.tsx";

--- a/ui/ui-app/src/services/useArtifactTypesService.ts
+++ b/ui/ui-app/src/services/useArtifactTypesService.ts
@@ -12,6 +12,7 @@ export class ArtifactTypes {
     public static XSD = "XSD";
     public static XML = "XML";
     public static AGENT_CARD = "AGENT_CARD";
+    public static MCP_TOOL = "MCP_TOOL";
     public static MODEL_SCHEMA = "MODEL_SCHEMA";
     public static PROMPT_TEMPLATE = "PROMPT_TEMPLATE";
 
@@ -50,6 +51,9 @@ export class ArtifactTypes {
                 break;
             case "AGENT_CARD":
                 title = "A2A Agent Card";
+                break;
+            case "MCP_TOOL":
+                title = "MCP Tool Definition";
                 break;
             case "MODEL_SCHEMA":
                 title = "AI Model Schema";
@@ -97,6 +101,9 @@ export class ArtifactTypes {
             case "AGENT_CARD":
                 title = "Agent Card";
                 break;
+            case "MCP_TOOL":
+                title = "MCP Tool";
+                break;
             case "MODEL_SCHEMA":
                 title = "Model Schema";
                 break;
@@ -142,6 +149,9 @@ export class ArtifactTypes {
                 break;
             case "AGENT_CARD":
                 classes += " agentcard-icon24";
+                break;
+            case "MCP_TOOL":
+                classes += " mcptool-icon24";
                 break;
             case "MODEL_SCHEMA":
                 classes += " modelschema-icon24";


### PR DESCRIPTION
## Summary

Adds a new `MCP_TOOL` artifact type for storing MCP (Model Context Protocol) tool definitions as first-class registry artifacts. This enables central governance, version management, and discovery of MCP tools across an organization.

Fixes #7227

## Changes

- **Shared utilities** — Extracted `JsonNameDescriptionContentExtractor` and `JsonValidationUtils` from the existing AGENT_CARD implementation so both artifact types share common JSON extraction and validation logic.
- **Core artifact type** — `MCP_TOOL` constant, content accepter (discriminates on `name` + `inputSchema`), content validator (SYNTAX_ONLY and FULL levels), compatibility checker (detects backward-incompatible changes to inputSchema), structured content extractor (indexes category, provider, parameter for search).
- **Well-known REST endpoints** — `GET /.well-known/mcp-tools` (search) and `GET /.well-known/mcp-tools/{groupId}/{artifactId}` (retrieve), gated behind `apicurio.mcp-tools.enabled` (experimental, default false).
- **UI support** — MCP_TOOL registered in artifact type service, Documentation tab shows a structured visualizer (name, description, version, annotations, input parameters table).
- **Tests** — 13 validator tests, 9 compatibility checker tests, 7 JSON test fixtures.

## Sharing with AGENT_CARD

| Component | Shared? |
|---|---|
| ContentExtractor | Yes — `JsonNameDescriptionContentExtractor` |
| JSON validation helpers | Yes — `JsonValidationUtils` |
| ContentCanonicalizer | Yes — `JsonContentCanonicalizer` |
| WellKnownResource | Yes — same JAX-RS class |
| AbstractCompatibilityChecker | Yes — existing base class |

## Test plan

- [x] Unit tests pass: `./mvnw test -pl schema-util/util-provider`
- [x] Full build: `./mvnw clean install -DskipTests`
- [x] App tests: `./mvnw test -pl app`
- [x] Integration tests with `apicurio.mcp-tools.enabled=true`
- [x] UI: create an MCP_TOOL artifact and verify Documentation tab renders
- [x] Verify AGENT_CARD still works after refactor (no regression)
- [x] Config doc regeneration: `./mvnw clean install -pl :apicurio-registry-config-generator -am -DskipTests`