### PR TITLE
fix(ci): handle no-op in update-openapi workflow

### DIFF
--- a/.github/workflows/update-openapi.yaml
+++ b/.github/workflows/update-openapi.yaml
@@ -46,8 +46,12 @@ jobs:
         run: |
           cd registry
           git add ./app/src/main/resources-unfiltered/META-INF/resources/api-specifications/registry/v2/openapi.json
-          git commit -m "Automatically updated the core v2 API OpenAPI definition."
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "Automatically updated the core v2 API OpenAPI definition."
+            git push
+          fi
 
   validate:
     needs: update-openapi


### PR DESCRIPTION
## Summary
- The "Update OpenAPI" workflow fails on main when `openapi.json` (v3) changes but `openapi-v2.json` does not, because `git commit` exits with code 1 on "nothing to commit"
- Adds a `git diff --cached --quiet` check to skip the commit/push when there are no staged changes
- Fixes https://github.com/Apicurio/apicurio-registry/actions/runs/24502660753/job/71613154330

## Test plan
- [x] Verify the workflow still commits and pushes when `openapi-v2.json` actually changes
- [x] Verify the workflow succeeds (no-op) when only `openapi.json` (v3) or the Java tools change