### PR TITLE
Fix KafkaSQL data loss on restart with fixed consumer group ID (#7753)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
@@ -195,7 +195,7 @@ public class KafkaSqlConfiguration {
     String groupPrefix;
 
     @Inject
-    @RegistryProperties(prefixes = {"apicurio.kafka.common", "apicurio.kafkasql.consumer"}, defaults = {"ssl.endpoint.identification.algorithm="})
+    @RegistryProperties(prefixes = {"apicurio.kafka.common", "apicurio.kafkasql.consumer"}, defaults = {"ssl.endpoint.identification.algorithm="}, excluded = {"group.id", "group-id"})
     Properties consumerProperties;
 
     public Map<String, String> getConsumerProperties() {
@@ -205,7 +205,18 @@ public class KafkaSqlConfiguration {
 
         props.putIfAbsent(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
         props.putIfAbsent(ConsumerConfig.CLIENT_ID_CONFIG, "apicurio-consumer-" + UUID.randomUUID());
-        props.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, getGroupPrefix() + UUID.randomUUID());
+
+        // Always generate a random consumer group ID. KafkaSQL uses an in-memory H2 database that
+        // is empty on every restart, so the full journal must be replayed from the beginning. A fixed
+        // consumer group ID would cause Kafka to resume from committed offsets, skipping the replay
+        // and leaving the registry empty.
+        if (props.containsKey(ConsumerConfig.GROUP_ID_CONFIG)) {
+            log.warn("Ignoring user-configured Kafka consumer group.id. "
+                    + "KafkaSQL requires a unique consumer group on each startup to ensure full journal replay. "
+                    + "Use 'apicurio.kafkasql.consumer.group-prefix' to set a recognizable prefix instead.");
+            props.remove(ConsumerConfig.GROUP_ID_CONFIG);
+        }
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, getGroupPrefix() + UUID.randomUUID());
 
         props.putIfAbsent(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
         props.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -289,7 +289,6 @@ apicurio.kafkasql.bootstrap.servers=localhost:9092
 apicurio.kafkasql.topic=kafkasql-journal
 apicurio.kafkasql.producer.client.id=${registry.id}-producer
 apicurio.kafkasql.consumer.poll.timeout=5000
-apicurio.kafkasql.consumer.group.id=${registry.id}-${quarkus.uuid}
 apicurio.kafkasql.snapshot.every.seconds=86400s
 apicurio.kafkasql.snapshots.topic=kafkasql-snapshots
 

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfigurationTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfigurationTest.java
@@ -1,0 +1,72 @@
+package io.apicurio.registry.storage.impl.kafkasql;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Properties;
+
+public class KafkaSqlConfigurationTest {
+
+    private KafkaSqlConfiguration configuration;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        configuration = new KafkaSqlConfiguration();
+        setField("groupPrefix", "apicurio-");
+        setField("bootstrapServers", "localhost:9092");
+        setField("consumerProperties", new Properties());
+    }
+
+    @Test
+    public void testConsumerGroupIdIsAlwaysRandom() throws Exception {
+        Map<String, String> props1 = configuration.getConsumerProperties();
+        Map<String, String> props2 = configuration.getConsumerProperties();
+
+        String groupId1 = props1.get(ConsumerConfig.GROUP_ID_CONFIG);
+        String groupId2 = props2.get(ConsumerConfig.GROUP_ID_CONFIG);
+
+        Assertions.assertNotNull(groupId1);
+        Assertions.assertNotNull(groupId2);
+        Assertions.assertTrue(groupId1.startsWith("apicurio-"));
+        Assertions.assertTrue(groupId2.startsWith("apicurio-"));
+        Assertions.assertNotEquals(groupId1, groupId2,
+                "Each call must generate a unique consumer group ID");
+    }
+
+    @Test
+    public void testUserProvidedGroupIdIsOverridden() throws Exception {
+        Properties propsWithGroupId = new Properties();
+        propsWithGroupId.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "my-fixed-group");
+        setField("consumerProperties", propsWithGroupId);
+
+        Map<String, String> props = configuration.getConsumerProperties();
+        String groupId = props.get(ConsumerConfig.GROUP_ID_CONFIG);
+
+        Assertions.assertNotNull(groupId);
+        Assertions.assertNotEquals("my-fixed-group", groupId,
+                "User-provided group.id must be overridden with a random UUID");
+        Assertions.assertTrue(groupId.startsWith("apicurio-"));
+    }
+
+    @Test
+    public void testGroupPrefixIsUsed() throws Exception {
+        setField("groupPrefix", "custom-prefix-");
+
+        Map<String, String> props = configuration.getConsumerProperties();
+        String groupId = props.get(ConsumerConfig.GROUP_ID_CONFIG);
+
+        Assertions.assertNotNull(groupId);
+        Assertions.assertTrue(groupId.startsWith("custom-prefix-"),
+                "Consumer group ID must use the configured prefix");
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        Field field = KafkaSqlConfiguration.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(configuration, value);
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfigurationTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfigurationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 public class KafkaSqlConfigurationTest {
@@ -19,6 +20,19 @@ public class KafkaSqlConfigurationTest {
         setField("groupPrefix", "apicurio-");
         setField("bootstrapServers", "localhost:9092");
         setField("consumerProperties", new Properties());
+        setField("protocol", Optional.empty());
+        setField("trustStoreLocation", Optional.empty());
+        setField("trustStoreType", Optional.empty());
+        setField("trustStorePassword", Optional.empty());
+        setField("trustStorePasswordDeprecated", Optional.empty());
+        setField("keyStoreLocation", Optional.empty());
+        setField("keyStoreLocationDeprecated", Optional.empty());
+        setField("keyStoreType", Optional.empty());
+        setField("keyStoreTypeDeprecated", Optional.empty());
+        setField("keyStorePassword", Optional.empty());
+        setField("keyStorePasswordDeprecated", Optional.empty());
+        setField("keyPassword", Optional.empty());
+        setField("keyPasswordDeprecated", Optional.empty());
     }
 
     @Test

--- a/docs/modules/ROOT/pages/getting-started/assembly-migrating-registry-v2-v3.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-migrating-registry-v2-v3.adoc
@@ -1024,7 +1024,8 @@ You must use a different Kafka topic for v3 than v2 because the journal formats 
 | `APICURIO_KAFKASQL_TOPIC`
 
 | `REGISTRY_KAFKASQL_CONSUMER_GROUP_ID`
-| `APICURIO_KAFKASQL_CONSUMER_GROUP_ID` (optional)
+| Not applicable — remove this property. In v3, the consumer group ID is always auto-generated. Use
+`APICURIO_KAFKASQL_CONSUMER_GROUP_PREFIX` to set a recognizable prefix if needed.
 
 | Not applicable
 | `APICURIO_STORAGE_KIND=kafkasql` (required)

--- a/docs/modules/ROOT/pages/getting-started/assembly-registry-high-availability.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-registry-high-availability.adoc
@@ -359,6 +359,14 @@ This design ensures that:
 * Pod restarts only affect the restarting pod, not others
 * Each replica maintains a consistent view of the data
 
+WARNING: Do not configure a fixed Kafka consumer group ID (for example, by setting
+`APICURIO_KAFKASQL_CONSUMER_GROUP_ID`). KafkaSQL uses an in-memory database that is empty on every
+restart, so the full journal topic must be replayed from the beginning each time. A fixed consumer
+group ID causes Kafka to resume from previously committed offsets, skipping the journal replay and
+resulting in the registry appearing empty after a restart. If you need a recognizable consumer group
+name for monitoring, use the `APICURIO_KAFKASQL_CONSUMER_GROUP_PREFIX` environment variable instead,
+which sets a prefix while still generating a unique group ID on each startup.
+
 [id="ha-monitoring_{context}"]
 == Monitoring high availability deployments
 

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -1546,11 +1546,6 @@ The following {registry} configuration options are available for each component 
 |`60s`
 |
 |
-|`apicurio.kafkasql.consumer.group.id`
-|`unknown`
-|`${registry.id}-${quarkus.uuid}`
-|
-|
 |`apicurio.kafkasql.producer.client.id`
 |`unknown`
 |`${registry.id}-producer`


### PR DESCRIPTION
## Summary

- Force a random Kafka consumer group ID on every startup, preventing user-configured
  `group.id` from causing stale committed offsets to skip journal replay
- Exclude `group.id` from `@RegistryProperties` injection and log a warning when a
  user-provided value is detected, directing them to use `group-prefix` instead
- Remove the now-redundant `apicurio.kafkasql.consumer.group.id` from `application.properties`
- Update HA and migration documentation to warn against setting a fixed consumer group ID

## Related Issue

Fixes #7753

## Test Plan

- [ ] Run existing KafkaSQL tests (`KafkaSqlRegistryStorageTest`, `KafkaSqlSnapshotTest`)
- [ ] Run new `KafkaSqlConfigurationTest` to verify consumer group ID is always randomized
- [ ] Verify that setting `APICURIO_KAFKASQL_CONSUMER_GROUP_ID` logs a warning and is overridden
- [ ] Deploy with KafkaSQL storage, create schemas, restart pod, verify data is preserved