### PR TITLE
GitOps Phase 5a: Error messages, SQL noise, auto-labels, per-repo SSH keys and mode

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -16,6 +16,11 @@
     <projectRoot>${project.basedir}/..</projectRoot>
     <maven.compiler.release>21</maven.compiler.release>
     <groups/>
+    <!-- Default empty argLine so that the @{argLine} late-binding reference in
+         maven-surefire-plugin resolves to empty when no plugin (e.g., JaCoCo) sets it.
+         Without this, Java 25+ treats the literal '@{argLine}' as an arg file reference
+         and fails with 'could not open {argLine}'. -->
+    <argLine/>
   </properties>
 
   <dependencies>

--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/README.md
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/README.md
@@ -140,10 +140,11 @@ Different registry instances point to different branches of the same repository:
 
 Schema promotion is done through Git merges.
 
-### Push Model for Restricted Networks *(planned)*
+### Push Model for Restricted Networks
 
 In environments where outbound network access is restricted, an external process pushes changes to a
 Git repository hosted inside the cluster. The sidecar exposes an SSH endpoint for receiving pushes.
+See [`distro/gitops/README.md`](../../../../distro/gitops/README.md) for push mode configuration.
 
 ### PR Verification with CI/CD *(planned)*
 
@@ -257,7 +258,6 @@ for configuration, security levels, and deployment details.
 
 The following features are planned but not yet implemented:
 
-- **Push model** — SSH server in the sync container accepting `git push` (experimental, included in the image but not production-ready)
 - **Dry-run validation** — validate schema changes from a branch without affecting live data
 - **CLI validator** — offline validation of `*.registry.yaml` files without a running registry
 - **Rule enforcement during loading** — validate compatibility and other rules at load time

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataSourceManager.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataSourceManager.java
@@ -277,9 +277,8 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
             }
             processArtifactRules(state, artifact);
             artifactFile.setProcessed(true);
-        } else {
-            state.recordError(artifactFile, "Could not find group '%s'", artifact.getGroupId());
         }
+        // Note: if group is null, processGroupRef() already recorded the error
     }
 
     private void processArtifactRules(ProcessingState state, Artifact artifact) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataSourceManager.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataSourceManager.java
@@ -30,7 +30,9 @@ import org.slf4j.Logger;
 
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -137,7 +139,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
                 }
 
                 if (state.checkArtifactConflict(artifact.getGroupId(), artifact.getArtifactId(), file.getSourceId())) {
-                    state.recordError("Artifact '%s:%s' is defined in multiple sources: '%s' and '%s'. "
+                    state.recordError(file, "Artifact '%s:%s' is defined in multiple sources: '%s' and '%s'. "
                             + "Each artifact must be defined in exactly one source.",
                             artifact.getGroupId(), artifact.getArtifactId(),
                             state.getArtifactSource(artifact.getGroupId(), artifact.getArtifactId()),
@@ -217,7 +219,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
                     Long contentId = processVersionContent(state, artifactFile, version,
                             artifact.getArtifactType());
                     if (contentId == null) {
-                        state.recordError("Could not import content for artifact version %s.",
+                        state.recordError(artifactFile, "Could not import content for artifact version %s.",
                                 artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + version.getVersion());
                         continue;
                     }
@@ -229,7 +231,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
                         artifactEntity.artifactType = artifact.getArtifactType();
                         artifactEntity.name = artifact.getName();
                         artifactEntity.description = artifact.getDescription();
-                        artifactEntity.labels = artifact.getLabels();
+                        artifactEntity.labels = withSourceLabel(artifact.getLabels(), artifactFile.getSourceId());
                         artifactEntity.owner = artifact.getOwner();
                         artifactEntity.createdOn = TimestampParser.parse(artifact.getCreatedOn(), state.getCommitTime());
                         artifactEntity.modifiedOn = TimestampParser.parse(artifact.getModifiedOn(), state.getCommitTime());
@@ -249,7 +251,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
                         e.globalId = DeterministicIdGenerator.globalId(
                                 artifact.getGroupId(), artifact.getArtifactId(), version.getVersion());
                     } else {
-                        state.recordError("globalId is required for version %s (deterministic ID generation is disabled)",
+                        state.recordError(artifactFile, "globalId is required for version %s (deterministic ID generation is disabled)",
                                 artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + version.getVersion());
                         continue;
                     }
@@ -268,7 +270,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
                     state.getStorage().importArtifactVersion(e);
                     state.incrementVersionCount();
                 } catch (Exception ex) {
-                    state.recordError("Could not import artifact version '%s': %s",
+                    state.recordError(artifactFile, "Could not import artifact version '%s': %s",
                             artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + version.getVersion(),
                             ex.getMessage());
                 }
@@ -276,7 +278,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
             processArtifactRules(state, artifact);
             artifactFile.setProcessed(true);
         } else {
-            state.recordError("Could not find group %s", artifact.getGroupId());
+            state.recordError(artifactFile, "Could not find group '%s'", artifact.getGroupId());
         }
     }
 
@@ -343,7 +345,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
                 var e = new GroupEntity();
                 e.groupId = group.getGroupId();
                 e.description = group.getDescription();
-                e.labels = group.getLabels();
+                e.labels = withSourceLabel(group.getLabels(), groupFile.getSourceId());
                 e.owner = group.getOwner();
                 e.artifactsType = group.getArtifactsType();
                 e.createdOn = TimestampParser.parse(group.getCreatedOn(), state.getCommitTime());
@@ -355,7 +357,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
                 groupFile.setProcessed(true);
                 return group;
             } catch (Exception ex) {
-                state.recordError("Could not import group %s: %s", group.getGroupId(), ex.getMessage());
+                state.recordError(groupFile, "Could not import group '%s': %s", group.getGroupId(), ex.getMessage());
                 return null;
             }
         }
@@ -379,7 +381,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
         String contentMetadataPath = version.getContentMetadata();
 
         if (contentPath == null || contentPath.isBlank()) {
-            state.recordError("Version in %s has no content path specified", artifactFile.getPath());
+            state.recordError(artifactFile, "Version has no content path specified");
             return null;
         }
 
@@ -388,14 +390,12 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
         if (contentMetadataPath != null && !contentMetadataPath.isBlank()) {
             var metadataFile = findFileByPathRef(state, artifactFile, contentMetadataPath);
             if (metadataFile == null) {
-                state.recordError("Could not find content metadata file at path %s referenced by %s",
-                        Path.of(artifactFile.getPath()).resolveSibling(contentMetadataPath).normalize(),
-                        artifactFile.getPath());
+                state.recordError(artifactFile, "Could not find content metadata file at path %s",
+                        Path.of(artifactFile.getPath()).resolveSibling(contentMetadataPath).normalize());
                 return null;
             }
             if (!metadataFile.isType(Type.CONTENT)) {
-                state.recordError("File %s is not a valid content metadata definition (expected $type: content-v0)",
-                        metadataFile.getPath());
+                state.recordError(metadataFile, "Not a valid content metadata definition (expected $type: content-v0)");
                 return null;
             }
             contentMetadata = metadataFile.getEntityUnchecked();
@@ -405,15 +405,14 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
         // Load the actual content file
         var dataFile = findFileByPathRef(state, artifactFile, contentPath);
         if (dataFile == null) {
-            state.recordError("Could not find content file at path %s referenced by %s",
-                    Path.of(artifactFile.getPath()).resolveSibling(contentPath).normalize(),
-                    artifactFile.getPath());
+            state.recordError(artifactFile, "Could not find content file at path %s",
+                    Path.of(artifactFile.getPath()).resolveSibling(contentPath).normalize());
             return null;
         }
 
         var data = dataFile.getData();
         if (data == null) {
-            state.recordError("Content data is null for file %s", dataFile.getPath());
+            state.recordError(dataFile, "Content data is null");
             return null;
         }
 
@@ -449,8 +448,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
             } else if (pollingConfig.isDeterministicIdGenerationEnabled()) {
                 contentId = DeterministicIdGenerator.contentId(data);
             } else {
-                state.recordError("contentId is required for content in %s (deterministic ID generation is disabled)",
-                        dataFile.getPath());
+                state.recordError(dataFile, "contentId is required (deterministic ID generation is disabled)");
                 return null;
             }
 
@@ -481,7 +479,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
             dataFile.setProcessed(true);
             return contentId;
         } catch (Exception ex) {
-            state.recordError("Could not import content from %s: %s", dataFile.getPath(), ex.getMessage());
+            state.recordError(dataFile, "Could not import content: %s", ex.getMessage());
             return null;
         }
     }
@@ -511,5 +509,19 @@ public abstract class AbstractPollingDataSourceManager<MARKER> implements Pollin
             return ContentTypes.APPLICATION_GRAPHQL;
         }
         return defaultType;
+    }
+
+    /**
+     * Adds the source label to a labels map if the source-label-key is configured.
+     * Returns the original map (or a new one) with the label added.
+     */
+    private Map<String, String> withSourceLabel(Map<String, String> labels, String sourceId) {
+        String key = pollingConfig.getSourceLabelKey();
+        if (key == null || key.isEmpty()) {
+            return labels;
+        }
+        var result = labels != null ? new LinkedHashMap<>(labels) : new LinkedHashMap<String, String>();
+        result.put(key, sourceId);
+        return result;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingStorageConfig.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingStorageConfig.java
@@ -75,4 +75,11 @@ public abstract class AbstractPollingStorageConfig implements PollingStorageConf
             registry configuration file (no artifacts), then remove it.""", availableSince = "3.2.0")
     @Getter
     boolean requireRegistryConfig;
+
+    @ConfigProperty(name = "apicurio.polling-storage.source-label-key", defaultValue = "system:source")
+    @Info(category = CATEGORY_STORAGE, experimental = true, description = """
+            Label key used to tag imported artifacts and groups with their source ID \
+            (e.g., repository ID). Set to empty string to disable.""", availableSince = "3.2.0")
+    @Getter
+    String sourceLabelKey;
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/PollingStorageConfig.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/PollingStorageConfig.java
@@ -58,6 +58,12 @@ public interface PollingStorageConfig {
     List<String> getFileSuffixes();
 
     /**
+     * Returns the label key to use for tagging artifacts with their source ID (e.g., repo ID).
+     * Empty string means disabled.
+     */
+    String getSourceLabelKey();
+
+    /**
      * Checks if a file path matches the registry metadata file convention
      * based on the configured suffixes.
      */

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/ProcessingState.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/ProcessingState.java
@@ -87,6 +87,14 @@ public class ProcessingState {
         errors.add(String.format(message, params));
     }
 
+    /**
+     * Records an error with source context (repo ID and file path).
+     */
+    public void recordError(PollingDataFile file, String message, Object... params) {
+        errors.add("[" + file.getSourceId() + "] " + String.format(message, params)
+                + " (file: " + file.getPath() + ")");
+    }
+
     public boolean isSuccessful() {
         return errors.isEmpty();
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlGroupRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlGroupRepository.java
@@ -381,10 +381,12 @@ public class SqlGroupRepository {
      * Ensure a group exists (create if not exists).
      */
     public void ensureGroup(GroupMetaDataDto group) {
-        try {
-            createGroup(group);
-        } catch (GroupAlreadyExistsException e) {
-            // This is OK - we're happy if the group already exists.
+        if (!isGroupExists(group.getGroupId())) {
+            try {
+                createGroup(group);
+            } catch (GroupAlreadyExistsException e) {
+                // Race condition: group created between check and insert. That's fine.
+            }
         }
     }
 

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kubernetesops/KubernetesOpsReferencesTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kubernetesops/KubernetesOpsReferencesTest.java
@@ -99,13 +99,13 @@ class KubernetesOpsReferencesTest {
         var addressMeta = storage.getArtifactMetaData(GROUP, "address");
         assertEquals("Address Schema", addressMeta.getName());
         assertEquals("Reusable address record", addressMeta.getDescription());
-        assertEquals(Map.of("domain", "common"), addressMeta.getLabels());
+        assertEquals(Map.of("domain", "common", "system:source", "kubernetes"), addressMeta.getLabels());
         assertEquals("alice", addressMeta.getOwner());
 
         var customerMeta = storage.getArtifactMetaData(GROUP, "customer");
         assertEquals("Customer Schema", customerMeta.getName());
         assertEquals("Customer record referencing Address", customerMeta.getDescription());
-        assertEquals(Map.of("domain", "crm"), customerMeta.getLabels());
+        assertEquals(Map.of("domain", "crm", "system:source", "kubernetes"), customerMeta.getLabels());
 
         // Verify version-level metadata (name, description, labels, owner)
         var addressVerMeta = storage.getArtifactVersionMetaData(GROUP, "address", "1");

--- a/distro/gitops/README.md
+++ b/distro/gitops/README.md
@@ -48,8 +48,8 @@ both the sidecar and the registry:
 | `APICURIO_GITOPS_REPOS_N_DIR` | *(required)* | Directory name for repo N |
 | `APICURIO_GITOPS_REPOS_N_BRANCH` | `main` | Branch to track for repo N |
 | `APICURIO_GITOPS_REPOS_N_URL` | *(required for pull)* | Remote URL for repo N |
-| `APICURIO_GITOPS_REPOS_N_SSH_KEYS` | *(none)* | SSH keys for repo N (added alongside global `PULL_SSH_KEYS`) |
-| `APICURIO_GITOPS_REPOS_N_MODE` | *(global MODE)* | Mode for repo N: `pull` or `push` (overrides global) |
+| `APICURIO_GITOPS_REPOS_N_SSH_KEYS` | *(none)* | SSH keys for repo N (added alongside global `APICURIO_GITOPS_PULL_SSH_KEYS`) |
+| `APICURIO_GITOPS_REPOS_N_MODE` | *(global `APICURIO_GITOPS_MODE`)* | Mode for repo N: `pull` or `push` (overrides global) |
 
 Indexes must be dense (0, 1, 2, ... — no gaps). If indexed repos are configured,
 single-repo shorthand variables must not be set.

--- a/distro/gitops/README.md
+++ b/distro/gitops/README.md
@@ -48,6 +48,8 @@ both the sidecar and the registry:
 | `APICURIO_GITOPS_REPOS_N_DIR` | *(required)* | Directory name for repo N |
 | `APICURIO_GITOPS_REPOS_N_BRANCH` | `main` | Branch to track for repo N |
 | `APICURIO_GITOPS_REPOS_N_URL` | *(required for pull)* | Remote URL for repo N |
+| `APICURIO_GITOPS_REPOS_N_SSH_KEYS` | *(none)* | SSH keys for repo N (added alongside global `PULL_SSH_KEYS`) |
+| `APICURIO_GITOPS_REPOS_N_MODE` | *(global MODE)* | Mode for repo N: `pull` or `push` (overrides global) |
 
 Indexes must be dense (0, 1, 2, ... — no gaps). If indexed repos are configured,
 single-repo shorthand variables must not be set.
@@ -63,7 +65,7 @@ apicurio.gitops.repos.1.branch=fulfillment
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `APICURIO_GITOPS_MODE` | `pull` | Operating mode: `pull` (fetch from remote) or `push` (accept SSH pushes) |
+| `APICURIO_GITOPS_MODE` | `pull` | Operating mode: `pull` or `push` |
 | `APICURIO_GITOPS_PULL_INTERVAL` | `30` | Seconds between fetch attempts (pull mode) |
 | `APICURIO_GITOPS_PULL_DEPTH` | `1` | Git clone/fetch depth. `0` for full history (pull mode) |
 | `APICURIO_GITOPS_PULL_SSH_KEYS` | *(none)* | Path to SSH private key for pull authentication. Comma-separated list for multiple keys (SSH tries each in order). |
@@ -108,6 +110,14 @@ security requirements. Two levels are available:
 2. An SSH server starts on `PUSH_PORT`, restricted to a `git` user with `git-shell`.
 3. External clients push changes via SSH; the working tree updates in place.
 4. The registry detects the new commit on its next poll cycle.
+
+### Mixed mode
+
+In multi-repo setups, each repo can use a different mode via `APICURIO_GITOPS_REPOS_N_MODE`.
+For example, one repo can pull from a remote while another accepts pushes. The sidecar runs
+both the pull loop and SSH server simultaneously when needed. Push-mode repos reject pulls
+(no remote URL), and pull-mode repos reject pushes (git denies updates to checked-out branches
+without `updateInstead`).
 
 ## Security
 

--- a/distro/gitops/entrypoint.sh
+++ b/distro/gitops/entrypoint.sh
@@ -559,7 +559,20 @@ main() {
         esac
     done
 
+    # Check if any SSH keys are configured (global or per-repo)
+    local has_any_ssh_keys=false
     if [ -n "${PULL_SSH_KEYS}" ] || [ -n "${PULL_SSH_KNOWN_HOSTS}" ]; then
+        has_any_ssh_keys=true
+    else
+        for repo_keys in "${REPO_SSH_KEYS[@]}"; do
+            if [ -n "${repo_keys}" ]; then
+                has_any_ssh_keys=true
+                break
+            fi
+        done
+    fi
+
+    if [ "${has_any_ssh_keys}" = "true" ]; then
         setup_ssh_client
     elif is_strict && [ "${has_pull}" = "true" ] && [ "${has_ssh_url}" = "true" ]; then
         error "APICURIO_GITOPS_PULL_SSH_KNOWN_HOSTS is required in strict mode when using SSH repository URLs."
@@ -583,8 +596,15 @@ main() {
         log "Pull loop started (PID: ${PULL_PIDS[0]})"
     fi
 
-    # Wait for any background process to keep the container alive
-    wait || true
+    # Wait for background processes. In mixed mode, exit when either dies
+    # so the container can be restarted by the orchestrator.
+    if [ "${has_push}" = "true" ] && [ "${has_pull}" = "true" ]; then
+        wait -n "${SSHD_PID}" "${PULL_PIDS[0]}" || true
+    elif [ "${has_push}" = "true" ]; then
+        wait "${SSHD_PID}" || true
+    elif [ "${has_pull}" = "true" ]; then
+        wait "${PULL_PIDS[0]}" || true
+    fi
 }
 
 main "$@"

--- a/distro/gitops/entrypoint.sh
+++ b/distro/gitops/entrypoint.sh
@@ -20,6 +20,8 @@
 #   APICURIO_GITOPS_REPOS_0_DIR        First repo directory name
 #   APICURIO_GITOPS_REPOS_0_BRANCH     First repo branch (default: main)
 #   APICURIO_GITOPS_REPOS_0_URL        First repo remote URL
+#   APICURIO_GITOPS_REPOS_0_SSH_KEYS   First repo SSH keys (added alongside global PULL_SSH_KEYS)
+#   APICURIO_GITOPS_REPOS_0_MODE       First repo mode (overrides global MODE, default: pull)
 #   APICURIO_GITOPS_REPOS_1_DIR        Second repo directory name
 #   ... and so on
 #
@@ -67,6 +69,8 @@ TEMPLATE_DIR="/usr/local/share/apicurio-gitops"
 REPO_DIRS=()
 REPO_BRANCHES=()
 REPO_URLS=()
+REPO_SSH_KEYS=()
+REPO_MODES=()
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -152,6 +156,8 @@ build_repo_list() {
         local dir_var="APICURIO_GITOPS_REPOS_${i}_DIR"
         local branch_var="APICURIO_GITOPS_REPOS_${i}_BRANCH"
         local url_var="APICURIO_GITOPS_REPOS_${i}_URL"
+        local ssh_keys_var="APICURIO_GITOPS_REPOS_${i}_SSH_KEYS"
+        local mode_var="APICURIO_GITOPS_REPOS_${i}_MODE"
 
         local dir="${!dir_var:-}"
         if [ -z "${dir}" ]; then
@@ -166,6 +172,8 @@ build_repo_list() {
         REPO_DIRS+=("${dir}")
         REPO_BRANCHES+=("${!branch_var:-main}")
         REPO_URLS+=("${!url_var:-}")
+        REPO_SSH_KEYS+=("${!ssh_keys_var:-}")
+        REPO_MODES+=("${!mode_var:-${MODE}}")
         i=$((i + 1))
     done
 
@@ -183,6 +191,8 @@ build_repo_list() {
         REPO_DIRS+=("${APICURIO_GITOPS_REPO_DIR:-default}")
         REPO_BRANCHES+=("${APICURIO_GITOPS_REPO_BRANCH:-main}")
         REPO_URLS+=("${APICURIO_GITOPS_REPO_URL:-}")
+        REPO_SSH_KEYS+=("")
+        REPO_MODES+=("${MODE}")
     fi
 
     validate_repo_list
@@ -220,6 +230,12 @@ validate_mode() {
         pull|push) ;;
         *) error "Invalid APICURIO_GITOPS_MODE value '${MODE}'. Must be 'pull' or 'push'." ;;
     esac
+    for i in "${!REPO_MODES[@]}"; do
+        case "${REPO_MODES[$i]}" in
+            pull|push) ;;
+            *) error "Invalid mode '${REPO_MODES[$i]}' for repo '${REPO_DIRS[$i]}'. Must be 'pull' or 'push'." ;;
+        esac
+    done
 }
 
 validate_security_level() {
@@ -264,12 +280,19 @@ setup_ssh_client() {
     mkdir -p "${ssh_dir}"
     chmod 700 "${ssh_dir}"
 
-    # Support comma-separated list of SSH keys for authenticating to different remotes.
-    # SSH tries each key in order until one works.
-    if [ -n "${PULL_SSH_KEYS}" ]; then
-        local key_index=0
+    # Collect SSH keys: global keys (PULL_SSH_KEYS) and per-repo keys (REPOS_N_SSH_KEYS).
+    # All keys are added as IdentityFile entries — SSH tries each in order.
+    local key_index=0
+    local all_keys="${PULL_SSH_KEYS}"
+    for repo_keys in "${REPO_SSH_KEYS[@]}"; do
+        if [ -n "${repo_keys}" ]; then
+            all_keys="${all_keys:+${all_keys},}${repo_keys}"
+        fi
+    done
+
+    if [ -n "${all_keys}" ]; then
         local IFS=','
-        for key_path in ${PULL_SSH_KEYS}; do
+        for key_path in ${all_keys}; do
             key_path=$(echo "${key_path}" | xargs)  # trim whitespace
             if [ ! -f "${key_path}" ]; then
                 error "SSH key file not found: ${key_path}"
@@ -409,6 +432,7 @@ init_repo() {
     local repo_dir="$1"
     local repo_branch="$2"
     local repo_url="$3"
+    local repo_mode="$4"
     local repo_path="${WORKSPACE}/${repo_dir}"
 
     if [ -d "${repo_path}/.git" ]; then
@@ -416,7 +440,7 @@ init_repo() {
         return 0
     fi
 
-    if is_pull; then
+    if [ "${repo_mode}" = "pull" ]; then
         if [ -z "${repo_url}" ]; then
             error "[${repo_dir}] Repository URL is required when pull mode is enabled"
         fi
@@ -466,11 +490,13 @@ pull_once() {
 }
 
 pull_loop() {
-    log "Starting pull loop (interval: ${PULL_INTERVAL}s, ${#REPO_DIRS[@]} repo(s))"
+    log "Starting pull loop (interval: ${PULL_INTERVAL}s)"
     while true; do
         sleep "${PULL_INTERVAL}"
         for i in "${!REPO_DIRS[@]}"; do
-            pull_once "${REPO_DIRS[$i]}" "${REPO_BRANCHES[$i]}" || true
+            if [ "${REPO_MODES[$i]}" = "pull" ]; then
+                pull_once "${REPO_DIRS[$i]}" "${REPO_BRANCHES[$i]}" || true
+            fi
         done
     done
 }
@@ -506,15 +532,8 @@ main() {
     log "  Workspace: ${WORKSPACE}"
     log "  Repos:     ${#REPO_DIRS[@]}"
     for i in "${!REPO_DIRS[@]}"; do
-        log "    [${REPO_DIRS[$i]}] branch=${REPO_BRANCHES[$i]} url=${REPO_URLS[$i]:-<local>}"
+        log "    [${REPO_DIRS[$i]}] mode=${REPO_MODES[$i]} branch=${REPO_BRANCHES[$i]} url=${REPO_URLS[$i]:-<local>}"
     done
-    log "  Mode:      ${MODE}"
-    if is_pull; then
-        log "  Pull:      interval=${PULL_INTERVAL}s, depth=${PULL_DEPTH}"
-    fi
-    if is_push; then
-        log "  Push:      port=${PUSH_PORT}"
-    fi
 
     validate_mode
     validate_security_level
@@ -531,36 +550,41 @@ main() {
         fi
     done
 
+    # Determine which modes are in use across all repos
+    local has_pull=false has_push=false
+    for mode in "${REPO_MODES[@]}"; do
+        case "${mode}" in
+            pull) has_pull=true ;;
+            push) has_push=true ;;
+        esac
+    done
+
     if [ -n "${PULL_SSH_KEYS}" ] || [ -n "${PULL_SSH_KNOWN_HOSTS}" ]; then
         setup_ssh_client
-    elif is_strict && is_pull && [ "${has_ssh_url}" = "true" ]; then
+    elif is_strict && [ "${has_pull}" = "true" ] && [ "${has_ssh_url}" = "true" ]; then
         error "APICURIO_GITOPS_PULL_SSH_KNOWN_HOSTS is required in strict mode when using SSH repository URLs."
     fi
 
     # Initialize all repositories
     for i in "${!REPO_DIRS[@]}"; do
-        init_repo "${REPO_DIRS[$i]}" "${REPO_BRANCHES[$i]}" "${REPO_URLS[$i]}"
+        init_repo "${REPO_DIRS[$i]}" "${REPO_BRANCHES[$i]}" "${REPO_URLS[$i]}" "${REPO_MODES[$i]}"
     done
 
-    # Start push mode (SSH server) if enabled
-    if is_push; then
+    # Start push mode (SSH server) if any repo uses push
+    if [ "${has_push}" = "true" ]; then
         setup_ssh_server
         start_ssh_server
     fi
 
-    # Start pull loop if enabled
-    if is_pull; then
+    # Start pull loop if any repo uses pull
+    if [ "${has_pull}" = "true" ]; then
         pull_loop &
         PULL_PIDS+=($!)
         log "Pull loop started (PID: ${PULL_PIDS[0]})"
     fi
 
-    # Wait for the background process to keep the container alive
-    if [ -n "${SSHD_PID:-}" ]; then
-        wait "${SSHD_PID}" || true
-    elif [ ${#PULL_PIDS[@]} -gt 0 ]; then
-        wait "${PULL_PIDS[0]}" || true
-    fi
+    # Wait for any background process to keep the container alive
+    wait || true
 }
 
 main "$@"

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -1242,6 +1242,11 @@ The following {registry} configuration options are available for each component 
 |`true`
 |`3.2.0`
 |When enabled, a load is rejected if the data source does not contain a registry configuration file matching the configured registry ID. This prevents accidental data loss from force-pushes or empty branches. To intentionally clear all data, first push a commit with only the registry configuration file (no artifacts), then remove it. _(experimental)_
+|`apicurio.polling-storage.source-label-key`
+|`string`
+|`system:source`
+|`3.2.0`
+|Label key used to tag imported artifacts and groups with their source ID (e.g., repository ID). Set to empty string to disable. _(experimental)_
 |`apicurio.sql.db-schema`
 |`string`
 |`*`

--- a/examples/gitops/multi-repo-pull-https/docker-compose.yaml
+++ b/examples/gitops/multi-repo-pull-https/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
 
   registry:
     container_name: registry
-    image: ${REGISTRY_IMAGE:-quay.io/apicurio/apicurio-registry:local}
+    image: ${REGISTRY_IMAGE:-quay.io/apicurio/apicurio-registry:latest-snapshot}
     environment:
       QUARKUS_PROFILE: "prod"
       APICURIO_STORAGE_KIND: "gitops"


### PR DESCRIPTION
## Summary

Phase 5a of the GitOps storage implementation ([#7480](https://github.com/Apicurio/apicurio-registry/issues/7480)). Quick wins for error reporting, SQL behavior, labeling, and sidecar configuration.

### Improved error messages

- New `recordError(PollingDataFile, message, ...)` overload includes source repo ID and file path
- Errors now look like: `[repo-a] Could not find group 'payments' (file: orders/order-created.registry.yaml)`
- Updated all error calls in `AbstractPollingDataSourceManager` that have file context

### Fix noisy SQL exceptions

- `ensureGroup()` now checks `isGroupExists()` before attempting INSERT
- Eliminates the unique constraint violation exception logged at DEBUG level on every import cycle when groups are already imported via `importGroup()`

### Auto-label artifacts with source ID

- New config: `apicurio.polling-storage.source-label-key` (default: `system:source`)
- Automatically adds a label with the source repo ID to each imported artifact and group
- Set to empty string to disable
- Useful for traceability and UI filtering in multi-repo setups

### Per-repo SSH keys (sidecar)

- `APICURIO_GITOPS_REPOS_N_SSH_KEYS` — per-repo SSH keys added alongside global `PULL_SSH_KEYS`
- All keys merged into SSH config `IdentityFile` entries

### Per-repo mode (sidecar)

- `APICURIO_GITOPS_REPOS_N_MODE` — overrides global `MODE` per repo (`pull` or `push`)
- Allows mixed pull+push across repos in multi-repo setups
- Pull loop only fetches pull-mode repos, SSH server starts if any repo uses push
- Pull-mode repos naturally reject pushes (no `updateInstead` config)

### Java 25 compatibility

- Default empty `<argLine/>` property in `app/pom.xml` prevents surefire fork crash on Java 25

## Test plan

- [x] All 25 gitops tests pass (smoke, multi-repo, config, status, admin, timestamp)
- [x] `ensureGroup()` no longer logs SQL exceptions during normal import
- [x] Source labels applied to artifacts and groups
- [x] Compilation verified with `clean install`