### PR TITLE
chore: standardize Maven module names across all POMs

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-app</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-app</name>
+  <name>Registry :: App</name>
 
   <properties>
     <projectRoot>${project.basedir}/..</projectRoot>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>apicurio-registry-cli</artifactId>
 
-    <name>Apicurio Registry CLI</name>
+    <name>Registry :: CLI</name>
 
     <properties>
         <projectRoot>${project.basedir}/..</projectRoot>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-common</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-common</name>
+  <name>Registry :: Common</name>
 
   <properties>
     <projectRoot>${project.basedir}/..</projectRoot>

--- a/config-index/definitions/pom.xml
+++ b/config-index/definitions/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-config-definitions</artifactId>
 
-  <name>apicurio-registry-config-definitions</name>
+  <name>Registry :: Config Index :: Definitions</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/config-index/deployment/pom.xml
+++ b/config-index/deployment/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-config-index-deployment</artifactId>
 
-  <name>apicurio-registry-config-index-deployment</name>
+  <name>Registry :: Config Index :: Deployment</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/config-index/runtime/pom.xml
+++ b/config-index/runtime/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-config-index</artifactId>
 
-  <name>apicurio-registry-config-index</name>
+  <name>Registry :: Config Index :: Runtime</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/distro/connect-converter/pom.xml
+++ b/distro/connect-converter/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>apicurio-registry-distro-connect-converter</artifactId>
-  <name>apicurio-registry-distro-connect-converter</name>
+  <name>Registry :: Distro :: Connect Converter</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/distro/docker/pom.xml
+++ b/distro/docker/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>apicurio-registry-distro-docker</artifactId>
   <packaging>pom</packaging>
-  <name>apicurio-registry-distro-docker</name>
+  <name>Registry :: Distro :: Docker</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <artifactId>apicurio-registry-distro</artifactId>
   <packaging>pom</packaging>
-  <name>apicurio-registry-distro</name>
+  <name>Registry :: Distro</name>
   <modules>
     <module>connect-converter</module>
     <module>docker</module>

--- a/docs/config-generator/pom.xml
+++ b/docs/config-generator/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>apicurio-registry-config-generator</artifactId>
     <packaging>jar</packaging>
-    <name>apicurio-registry-config-generator</name>
+    <name>Registry :: Docs :: Config Generator</name>
     <description>Configuration documentation generator</description>
 
     <properties>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>apicurio-registry-docs</artifactId>
   <packaging>pom</packaging>
-  <name>apicurio-registry-docs</name>
+  <name>Registry :: Docs</name>
   <description>Open Source API &amp; Schema Registry</description>
 
   <url>https://www.apicur.io/</url>

--- a/docs/rest-api/pom.xml
+++ b/docs/rest-api/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>apicurio-registry-docs-rest-api</artifactId>
   <packaging>pom</packaging>
-  <name>apicurio-registry-docs-rest-api</name>
+  <name>Registry :: Docs :: REST API</name>
   <description>Open Source API &amp; Schema Registry</description>
 
   <url>https://www.apicur.io/</url>

--- a/examples/a2a-real-world-integration/pom.xml
+++ b/examples/a2a-real-world-integration/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-examples-a2a-real-world-integration</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-examples-a2a-real-world-integration</name>
+  <name>Registry :: Examples :: A2A Real World Integration</name>
   <description>Real-world A2A integration example demonstrating actual HTTP communication with working A2A protocol agents, orchestration, and multi-agent workflows</description>
 
   <properties>

--- a/examples/asyncapi-avro-maven-with-references-auto/pom.xml
+++ b/examples/asyncapi-avro-maven-with-references-auto/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>apicurio-registry-examples-asyncapi-avro-maven-with-references-auto</artifactId>
     <packaging>jar</packaging>
+    <name>Registry :: Examples :: AsyncAPI Avro Maven With References Auto</name>
 
     <properties>
         <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/avro-bean/pom.xml
+++ b/examples/avro-bean/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-avro-bean</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Avro Bean</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/avro-maven-with-references-auto/pom.xml
+++ b/examples/avro-maven-with-references-auto/pom.xml
@@ -9,6 +9,7 @@
 
   <artifactId>apicurio-registry-examples-avro-maven-with-references-auto</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Avro Maven With References Auto</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/avro-maven-with-references/pom.xml
+++ b/examples/avro-maven-with-references/pom.xml
@@ -9,6 +9,7 @@
 
   <artifactId>apicurio-registry-examples-avro-maven-with-references</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Avro Maven With References</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/confluent-serdes/pom.xml
+++ b/examples/confluent-serdes/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-confluent-serdes</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Confluent SerDes</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/custom-resolver/pom.xml
+++ b/examples/custom-resolver/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-custom-resolver</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Custom Resolver</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/custom-strategy/pom.xml
+++ b/examples/custom-strategy/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-custom-strategy</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Custom Strategy</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/debezium-otel-tracing/cdc-consumer/pom.xml
+++ b/examples/debezium-otel-tracing/cdc-consumer/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-examples-debezium-otel-cdc-consumer</artifactId>
   <packaging>jar</packaging>
-  <name>Apicurio Registry Examples - Debezium OTel CDC Consumer</name>
+  <name>Registry :: Examples :: Debezium OTel Tracing :: CDC Consumer</name>
   <description>CDC consumer that processes Debezium events with OpenTelemetry tracing</description>
 
   <properties>

--- a/examples/debezium-otel-tracing/debezium-converter/pom.xml
+++ b/examples/debezium-otel-tracing/debezium-converter/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-examples-debezium-otel-converter</artifactId>
   <packaging>jar</packaging>
-  <name>Apicurio Registry Examples - Debezium OTel SMT</name>
+  <name>Registry :: Examples :: Debezium OTel Tracing :: Converter</name>
   <description>Custom Debezium SMT with OpenTelemetry instrumentation for trace context propagation</description>
 
   <properties>

--- a/examples/debezium-otel-tracing/order-service/pom.xml
+++ b/examples/debezium-otel-tracing/order-service/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-examples-debezium-otel-order-service</artifactId>
   <packaging>jar</packaging>
-  <name>Apicurio Registry Examples - Debezium OTel Order Service</name>
+  <name>Registry :: Examples :: Debezium OTel Tracing :: Order Service</name>
   <description>Order service that writes to PostgreSQL with OpenTelemetry tracing</description>
 
   <properties>

--- a/examples/debezium-otel-tracing/pom.xml
+++ b/examples/debezium-otel-tracing/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-examples-debezium-otel-tracing</artifactId>
   <packaging>pom</packaging>
-  <name>Apicurio Registry Examples - Debezium CDC with OpenTelemetry Tracing</name>
+  <name>Registry :: Examples :: Debezium OTel Tracing</name>
   <description>Example demonstrating end-to-end distributed tracing with Debezium CDC, Kafka, and Apicurio Registry</description>
 
   <properties>

--- a/examples/docker-compose/pom.xml
+++ b/examples/docker-compose/pom.xml
@@ -11,6 +11,7 @@
 
   <artifactId>apicurio-registry-examples-docker-compose</artifactId>
   <packaging>pom</packaging>
+  <name>Registry :: Examples :: Docker Compose</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/json-maven-with-references-auto/pom.xml
+++ b/examples/json-maven-with-references-auto/pom.xml
@@ -9,6 +9,7 @@
 
   <artifactId>apicurio-registry-examples-json-maven-with-references-auto</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: JSON Maven With References Auto</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/json-maven-with-references/pom.xml
+++ b/examples/json-maven-with-references/pom.xml
@@ -9,6 +9,7 @@
 
   <artifactId>apicurio-registry-examples-json-maven-with-references</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: JSON Maven With References</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/jsonschema-validation/pom.xml
+++ b/examples/jsonschema-validation/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-jsonschema-validation</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: JSON Schema Validation</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/kafka-order-processing/order-consumer/pom.xml
+++ b/examples/kafka-order-processing/order-consumer/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>apicurio-registry-examples-kafka-order-consumer</artifactId>
     <packaging>jar</packaging>
-    <name>Order Consumer Application</name>
+    <name>Registry :: Examples :: Kafka Order Processing :: Order Consumer</name>
     <description>Quarkus application that consumes order events from Kafka</description>
 
     <properties>

--- a/examples/kafka-order-processing/order-producer/pom.xml
+++ b/examples/kafka-order-processing/order-producer/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>apicurio-registry-examples-kafka-order-producer</artifactId>
     <packaging>jar</packaging>
-    <name>Order Producer Application</name>
+    <name>Registry :: Examples :: Kafka Order Processing :: Order Producer</name>
     <description>Quarkus application that produces order events to Kafka</description>
 
     <properties>

--- a/examples/kafka-order-processing/order-schema/pom.xml
+++ b/examples/kafka-order-processing/order-schema/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>apicurio-registry-examples-kafka-order-schema</artifactId>
     <packaging>jar</packaging>
-    <name>Order Schema Module</name>
+    <name>Registry :: Examples :: Kafka Order Processing :: Order Schema</name>
     <description>Avro schema definitions for order processing</description>
 
     <properties>

--- a/examples/kafka-order-processing/pom.xml
+++ b/examples/kafka-order-processing/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>apicurio-registry-examples-kafka-order-processing</artifactId>
     <packaging>pom</packaging>
-    <name>Kafka Order Processing Example</name>
+    <name>Registry :: Examples :: Kafka Order Processing</name>
     <description>Complete Kafka example with producer and consumer using Apicurio Registry for schema management</description>
 
     <modules>

--- a/examples/maven-plugin-tls-credentials/pom.xml
+++ b/examples/maven-plugin-tls-credentials/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>apicurio-registry-examples-maven-plugin-tls-credentials</artifactId>
   <packaging>jar</packaging>
-  <name>Apicurio Registry :: Examples :: Maven Plugin TLS and Credentials</name>
+  <name>Registry :: Examples :: Maven Plugin TLS Credentials</name>
   <description>Example demonstrating TLS and credential configuration for the Apicurio Registry Maven plugin</description>
 
   <properties>

--- a/examples/mix-avro/pom.xml
+++ b/examples/mix-avro/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-mix-avro</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Mix Avro</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/mtls-minikube/client/pom.xml
+++ b/examples/mtls-minikube/client/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>apicurio-registry-examples-mtls-minikube-client</artifactId>
   <packaging>jar</packaging>
-  <name>Apicurio Registry :: Examples :: mTLS Minikube Client</name>
+  <name>Registry :: Examples :: mTLS Minikube Client</name>
   <description>Example client demonstrating mutual TLS authentication with Apicurio Registry</description>
 
   <properties>

--- a/examples/openshift-template/pom.xml
+++ b/examples/openshift-template/pom.xml
@@ -11,6 +11,7 @@
 
   <artifactId>apicurio-registry-examples-openshift-template</artifactId>
   <packaging>pom</packaging>
+  <name>Registry :: Examples :: OpenShift Template</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/otel-tracing/consumer/pom.xml
+++ b/examples/otel-tracing/consumer/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-examples-otel-tracing-consumer</artifactId>
   <packaging>jar</packaging>
-  <name>Apicurio Registry Examples - OTel Tracing Consumer</name>
+  <name>Registry :: Examples :: OTel Tracing :: Consumer</name>
   <description>Quarkus consumer application with OpenTelemetry distributed tracing</description>
 
   <properties>

--- a/examples/otel-tracing/pom.xml
+++ b/examples/otel-tracing/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-examples-otel-tracing</artifactId>
   <packaging>pom</packaging>
-  <name>Apicurio Registry Examples - OpenTelemetry Distributed Tracing</name>
+  <name>Registry :: Examples :: OTel Tracing</name>
   <description>Example demonstrating end-to-end distributed tracing with Strimzi Kafka and Apicurio Registry</description>
 
   <properties>

--- a/examples/otel-tracing/producer/pom.xml
+++ b/examples/otel-tracing/producer/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-examples-otel-tracing-producer</artifactId>
   <packaging>jar</packaging>
-  <name>Apicurio Registry Examples - OTel Tracing Producer</name>
+  <name>Registry :: Examples :: OTel Tracing :: Producer</name>
   <description>Quarkus producer application with OpenTelemetry distributed tracing</description>
 
   <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <artifactId>apicurio-registry-examples</artifactId>
+  <name>Registry :: Examples</name>
   <version>3.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description>Open Source API &amp; Schema Registry</description>

--- a/examples/protobuf-bean/pom.xml
+++ b/examples/protobuf-bean/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-protobuf-bean</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Protobuf Bean</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/protobuf-find-latest/pom.xml
+++ b/examples/protobuf-find-latest/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-protobuf-find-latest</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Protobuf Find Latest</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/protobuf-validation/pom.xml
+++ b/examples/protobuf-validation/pom.xml
@@ -9,6 +9,7 @@
   </parent>
 
   <artifactId>apicurio-registry-examples-protobuf-validation</artifactId>
+  <name>Registry :: Examples :: Protobuf Validation</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/rest-client/pom.xml
+++ b/examples/rest-client/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-rest-client</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: REST Client</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/serdes-with-references/pom.xml
+++ b/examples/serdes-with-references/pom.xml
@@ -9,6 +9,7 @@
   </parent>
 
   <artifactId>apicurio-registry-examples-references</artifactId>
+  <name>Registry :: Examples :: SerDes With References</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/simple-avro-maven/pom.xml
+++ b/examples/simple-avro-maven/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-simple-avro-maven</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Simple Avro Maven</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/simple-avro/pom.xml
+++ b/examples/simple-avro/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-simple-avro</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Simple Avro</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/simple-json/pom.xml
+++ b/examples/simple-json/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-simple-json</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Simple JSON</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/simple-protobuf/pom.xml
+++ b/examples/simple-protobuf/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-simple-protobuf</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Simple Protobuf</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/simple-validation/pom.xml
+++ b/examples/simple-validation/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-examples-simple-validation</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: Simple Validation</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/examples/tools/kafkasql-topic-import/pom.xml
+++ b/examples/tools/kafkasql-topic-import/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>apicurio-registry-tools-kafkasql-topic-import</artifactId>
   <packaging>jar</packaging>
+  <name>Registry :: Examples :: KafkaSQL Topic Import</name>
 
   <properties>
     <projectRoot>${project.basedir}/../../..</projectRoot>

--- a/go-sdk/pom.xml
+++ b/go-sdk/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-go-sdk</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-go-sdk</name>
+  <name>Registry :: Go SDK</name>
 
   <properties>
     <projectRoot>${project.basedir}/..</projectRoot>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -7,6 +7,7 @@
     <version>3.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>apicurio-registry-integration-tests</artifactId>
+  <name>Registry :: Integration Tests</name>
 
   <properties>
     <projectRoot>${project.basedir}/..</projectRoot>

--- a/java-sdk/adapter-jdk/pom.xml
+++ b/java-sdk/adapter-jdk/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>apicurio-registry-java-sdk-adapter-jdk</artifactId>
 
-  <name>apicurio-registry-java-sdk-adapter-jdk</name>
+  <name>Registry :: Java SDK :: Adapter JDK</name>
   <description>JDK HTTP adapter for the Apicurio Registry Java SDK.
     Provides JdkAdapterFactory using java.net.http.HttpClient.
     This module is isolated so that consumers using only the Vert.x adapter

--- a/java-sdk/adapter-vertx/pom.xml
+++ b/java-sdk/adapter-vertx/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>apicurio-registry-java-sdk-adapter-vertx</artifactId>
 
-  <name>apicurio-registry-java-sdk-adapter-vertx</name>
+  <name>Registry :: Java SDK :: Adapter Vert.x</name>
   <description>Vert.x HTTP adapter for the Apicurio Registry Java SDK.
     Provides VertxAdapterFactory and a shared default Vertx instance.
     This module is isolated so that consumers using only the JDK adapter

--- a/java-sdk/client-v2/pom.xml
+++ b/java-sdk/client-v2/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-v2-java-sdk</artifactId>
 
-  <name>apicurio-registry-v2-java-sdk</name>
+  <name>Registry :: Java SDK :: Client V2</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/java-sdk/client/pom.xml
+++ b/java-sdk/client/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-java-sdk</artifactId>
 
-  <name>apicurio-registry-java-sdk</name>
+  <name>Registry :: Java SDK :: Client</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/java-sdk/common/pom.xml
+++ b/java-sdk/common/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-java-sdk-common</artifactId>
 
-  <name>apicurio-registry-java-sdk-common</name>
+  <name>Registry :: Java SDK :: Common</name>
   <description>Shared code for Apicurio Registry Java SDK v2 and v3.
     Contains adapter detection, client options, retry logic, and OpenTelemetry support.
     HTTP adapter implementations are in separate modules (adapter-vertx, adapter-jdk).</description>

--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>apicurio-registry-java-sdk-parent</artifactId>
   <packaging>pom</packaging>
 
-  <name>Apicurio Registry Java SDK Parent</name>
+  <name>Registry :: Java SDK</name>
 
   <properties>
     <projectRoot>${project.basedir}/..</projectRoot>

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>apicurio-registry-mcp-server</artifactId>
 
-    <name>Apicurio Registry MCP Server</name>
+    <name>Registry :: MCP Server</name>
 
     <properties>
         <projectRoot>${project.basedir}/..</projectRoot>

--- a/operator/controller/pom.xml
+++ b/operator/controller/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>apicurio-registry-operator-controller</artifactId>
-  <name>Apicurio Registry Operator :: Controller</name>
+  <name>Registry :: Operator :: Controller</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/operator/install/install.yaml
+++ b/operator/install/install.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: apicurio-registry-operator
     app.kubernetes.io/name: apicurio-registry-operator
     app.kubernetes.io/part-of: apicurio-registry
-    app.kubernetes.io/version: 3.2.2-SNAPSHOT
+    app.kubernetes.io/version: 3.3.0-SNAPSHOT
   name: apicurioregistries3.registry.apicur.io
 spec:
   group: registry.apicur.io
@@ -7092,7 +7092,7 @@ metadata:
     app.kubernetes.io/instance: apicurio-registry-operator
     app.kubernetes.io/name: apicurio-registry-operator
     app.kubernetes.io/part-of: apicurio-registry
-    app.kubernetes.io/version: 3.2.2-SNAPSHOT
+    app.kubernetes.io/version: 3.3.0-SNAPSHOT
   name: apicurio-registry-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7104,7 +7104,7 @@ metadata:
     app.kubernetes.io/instance: apicurio-registry-operator
     app.kubernetes.io/name: apicurio-registry-operator
     app.kubernetes.io/part-of: apicurio-registry
-    app.kubernetes.io/version: 3.2.2-SNAPSHOT
+    app.kubernetes.io/version: 3.3.0-SNAPSHOT
   name: apicurio-registry-operator-clusterrole
 rules:
 - apiGroups:
@@ -7181,7 +7181,7 @@ metadata:
     app.kubernetes.io/instance: apicurio-registry-operator
     app.kubernetes.io/name: apicurio-registry-operator
     app.kubernetes.io/part-of: apicurio-registry
-    app.kubernetes.io/version: 3.2.2-SNAPSHOT
+    app.kubernetes.io/version: 3.3.0-SNAPSHOT
   name: apicurio-registry-operator-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7201,8 +7201,8 @@ metadata:
     app.kubernetes.io/instance: apicurio-registry-operator
     app.kubernetes.io/name: apicurio-registry-operator
     app.kubernetes.io/part-of: apicurio-registry
-    app.kubernetes.io/version: 3.2.2-SNAPSHOT
-  name: apicurio-registry-operator-v3.2.2-snapshot
+    app.kubernetes.io/version: 3.3.0-SNAPSHOT
+  name: apicurio-registry-operator-v3.3.0-snapshot
   namespace: PLACEHOLDER_NAMESPACE
 spec:
   replicas: 1
@@ -7213,7 +7213,7 @@ spec:
       app.kubernetes.io/instance: apicurio-registry-operator
       app.kubernetes.io/name: apicurio-registry-operator
       app.kubernetes.io/part-of: apicurio-registry
-      app.kubernetes.io/version: 3.2.2-SNAPSHOT
+      app.kubernetes.io/version: 3.3.0-SNAPSHOT
   template:
     metadata:
       labels:
@@ -7222,7 +7222,7 @@ spec:
         app.kubernetes.io/instance: apicurio-registry-operator
         app.kubernetes.io/name: apicurio-registry-operator
         app.kubernetes.io/part-of: apicurio-registry
-        app.kubernetes.io/version: 3.2.2-SNAPSHOT
+        app.kubernetes.io/version: 3.3.0-SNAPSHOT
     spec:
       containers:
       - env:

--- a/operator/model/pom.xml
+++ b/operator/model/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <artifactId>apicurio-registry-operator-model</artifactId>
 
-  <name>Apicurio Registry Operator :: Model</name>
+  <name>Registry :: Operator :: Model</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/operator/olm-tests/pom.xml
+++ b/operator/olm-tests/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <artifactId>apicurio-registry-operator-olm-tests</artifactId>
 
-  <name>Apicurio Registry Operator :: OLM Tests</name>
+  <name>Registry :: Operator :: OLM Tests</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>apicurio-registry-operator</artifactId>
   <packaging>pom</packaging>
 
-  <name>Apicurio Registry Operator</name>
+  <name>Registry :: Operator</name>
 
   <modules>
     <module>model</module>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>apicurio-registry</artifactId>
   <version>3.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>apicurio-registry</name>
+  <name>Registry</name>
   <description>Open Source API &amp; Schema Registry</description>
 
   <url>https://www.apicur.io/</url>

--- a/prod-verifier/pom.xml
+++ b/prod-verifier/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <artifactId>apicurio-registry-prod-verifier</artifactId>
   <packaging>pom</packaging>
-  <name>apicurio-registry-prod-verifier</name>
+  <name>Registry :: Prod Verifier</name>
 
   <properties>
     <projectRoot>${project.basedir}/..</projectRoot>

--- a/schema-resolver/pom.xml
+++ b/schema-resolver/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-resolver</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-resolver</name>
+  <name>Registry :: Schema Resolver</name>
 
   <properties>
     <projectRoot>${project.basedir}/..</projectRoot>

--- a/schema-util/asyncapi/pom.xml
+++ b/schema-util/asyncapi/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-asyncapi</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-asyncapi</name>
+  <name>Registry :: Schema Util :: AsyncAPI</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/avro/pom.xml
+++ b/schema-util/avro/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-avro</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-avro</name>
+  <name>Registry :: Schema Util :: Avro</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/common/pom.xml
+++ b/schema-util/common/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-common</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-common</name>
+  <name>Registry :: Schema Util :: Common</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/graphql/pom.xml
+++ b/schema-util/graphql/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-graphql</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-graphql</name>
+  <name>Registry :: Schema Util :: GraphQL</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/iceberg/pom.xml
+++ b/schema-util/iceberg/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-iceberg</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-iceberg</name>
+  <name>Registry :: Schema Util :: Iceberg</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/json/pom.xml
+++ b/schema-util/json/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-json</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-json</name>
+  <name>Registry :: Schema Util :: JSON</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/kconnect/pom.xml
+++ b/schema-util/kconnect/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-kconnect</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-kconnect</name>
+  <name>Registry :: Schema Util :: Kafka Connect</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/openapi/pom.xml
+++ b/schema-util/openapi/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-openapi</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-openapi</name>
+  <name>Registry :: Schema Util :: OpenAPI</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/openrpc/pom.xml
+++ b/schema-util/openrpc/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-openrpc</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-openrpc</name>
+  <name>Registry :: Schema Util :: OpenRPC</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/protobuf/pom.xml
+++ b/schema-util/protobuf/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-protobuf</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-protobuf</name>
+  <name>Registry :: Schema Util :: Protobuf</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/util-provider/pom.xml
+++ b/schema-util/util-provider/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-provider</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-provider</name>
+  <name>Registry :: Schema Util :: Provider</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/wsdl/pom.xml
+++ b/schema-util/wsdl/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-wsdl</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-wsdl</name>
+  <name>Registry :: Schema Util :: WSDL</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/xml/pom.xml
+++ b/schema-util/xml/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-xml</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-xml</name>
+  <name>Registry :: Schema Util :: XML</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-util/xsd/pom.xml
+++ b/schema-util/xsd/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-util-xsd</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-schema-util-xsd</name>
+  <name>Registry :: Schema Util :: XSD</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-validation/avro/pom.xml
+++ b/schema-validation/avro/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>apicurio-registry-schema-validation-avro</artifactId>
-  <name>apicurio-registry-schema-validation-avro</name>
+  <name>Registry :: Schema Validation :: Avro</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-validation/common/pom.xml
+++ b/schema-validation/common/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>apicurio-registry-schema-validation-common</artifactId>
-  <name>apicurio-registry-schema-validation-common</name>
+  <name>Registry :: Schema Validation :: Common</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-validation/jsonschema/pom.xml
+++ b/schema-validation/jsonschema/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>apicurio-registry-schema-validation-jsonschema</artifactId>
-  <name>apicurio-registry-schema-validation-jsonschema</name>
+  <name>Registry :: Schema Validation :: JSON Schema</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/schema-validation/pom.xml
+++ b/schema-validation/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-schema-validation</artifactId>
   <packaging>pom</packaging>
-  <name>apicurio-registry-schema-validation</name>
+  <name>Registry :: Schema Validation</name>
   <description>Standalone schema validation library with Apicurio Registry integration.</description>
 
   <properties>

--- a/schema-validation/protobuf/pom.xml
+++ b/schema-validation/protobuf/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>apicurio-registry-schema-validation-protobuf</artifactId>
-  <name>apicurio-registry-schema-validation-protobuf</name>
+  <name>Registry :: Schema Validation :: Protobuf</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/serdes/generic/serde-common-avro/pom.xml
+++ b/serdes/generic/serde-common-avro/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-serde-common-avro</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-serde-avro-common</name>
+  <name>Registry :: SerDes :: Common Avro</name>
 
   <properties>
     <projectRoot>${project.basedir}/../../..</projectRoot>

--- a/serdes/generic/serde-common-jsonschema/pom.xml
+++ b/serdes/generic/serde-common-jsonschema/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-serde-common-jsonschema</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-serde-common-jsonschema</name>
+  <name>Registry :: SerDes :: Common JSON Schema</name>
 
   <properties>
     <projectRoot>${project.basedir}/../../..</projectRoot>

--- a/serdes/generic/serde-common-protobuf/pom.xml
+++ b/serdes/generic/serde-common-protobuf/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-serde-common-protobuf</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-serde-common-protobuf</name>
+  <name>Registry :: SerDes :: Common Protobuf</name>
 
   <properties>
     <projectRoot>${project.basedir}/../../..</projectRoot>

--- a/serdes/generic/serde-common/pom.xml
+++ b/serdes/generic/serde-common/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-serde-common</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-serde-common</name>
+  <name>Registry :: SerDes :: Common</name>
 
   <properties>
     <projectRoot>${project.basedir}/../../..</projectRoot>

--- a/serdes/kafka/avro-serde/pom.xml
+++ b/serdes/kafka/avro-serde/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-avro-serde-kafka</name>
+  <name>Registry :: SerDes :: Kafka :: Avro</name>
 
   <properties>
     <projectRoot>${project.basedir}/../../..</projectRoot>

--- a/serdes/kafka/jsonschema-serde/pom.xml
+++ b/serdes/kafka/jsonschema-serde/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-jsonschema-serde-kafka</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-jsonschema-serde-kafka</name>
+  <name>Registry :: SerDes :: Kafka :: JSON Schema</name>
 
   <properties>
     <projectRoot>${project.basedir}/../../..</projectRoot>

--- a/serdes/kafka/protobuf-serde/pom.xml
+++ b/serdes/kafka/protobuf-serde/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-protobuf-serde-kafka</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-protobuf-serde-kafka</name>
+  <name>Registry :: SerDes :: Kafka :: Protobuf</name>
 
   <properties>
     <projectRoot>${project.basedir}/../../..</projectRoot>

--- a/serdes/kafka/serde-kafka-common/pom.xml
+++ b/serdes/kafka/serde-kafka-common/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-serde-kafka-common</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-serde-kafka-common</name>
+  <name>Registry :: SerDes :: Kafka :: Common</name>
 
   <properties>
     <projectRoot>${project.basedir}/../../..</projectRoot>

--- a/serdes/nats/avro-serde/pom.xml
+++ b/serdes/nats/avro-serde/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-avro-serde-nats</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-avro-serde-nats</name>
+  <name>Registry :: SerDes :: NATS :: Avro</name>
 
   <properties>
     <projectRoot>${project.basedir}/../../..</projectRoot>

--- a/serdes/pulsar/avro-serde/pom.xml
+++ b/serdes/pulsar/avro-serde/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-avro-serde-pulsar</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-avro-serde-pulsar</name>
+  <name>Registry :: SerDes :: Pulsar :: Avro</name>
 
   <properties>
     <projectRoot>${project.basedir}/../../..</projectRoot>

--- a/support-chat/pom.xml
+++ b/support-chat/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>apicurio-registry-support-chat</name>
+    <name>Registry :: Support Chat</name>
     <description>AI-powered support assistant for Apicurio Registry with RAG and LLM integration</description>
 
     <properties>

--- a/utils/converter/pom.xml
+++ b/utils/converter/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-utils-converter</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-utils-converter</name>
+  <name>Registry :: Utils :: Converter</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/utils/exportConfluent/pom.xml
+++ b/utils/exportConfluent/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-utils-exportConfluent</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-utils-exportConfluent</name>
+  <name>Registry :: Utils :: Export Confluent</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/utils/extra-tests/pom.xml
+++ b/utils/extra-tests/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>apicurio-registry-utils-extra-tests</artifactId>
     <packaging>jar</packaging>
 
-    <name>Apicurio Registry :: Extra Tests</name>
+    <name>Registry :: Utils :: Extra Tests</name>
 
     <properties>
         <projectRoot>${project.basedir}/../..</projectRoot>

--- a/utils/flink/pom.xml
+++ b/utils/flink/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-utils-flink</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-utils-flink</name>
+  <name>Registry :: Utils :: Flink</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/utils/importexport/pom.xml
+++ b/utils/importexport/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-utils-import-export</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-utils-import-export</name>
+  <name>Registry :: Utils :: Import Export</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/utils/maven-plugin/pom.xml
+++ b/utils/maven-plugin/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>Apicurio Registry Maven Plugin</name>
+  <name>Registry :: Utils :: Maven Plugin</name>
   <description>
     This plugin facilitates fast and easy integration with the Apicurio Registry and a Maven based
     build procedure.  It can be used, for example, to register schemas or API designs at build time.

--- a/utils/protobuf-schema-utilities/pom.xml
+++ b/utils/protobuf-schema-utilities/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-protobuf-schema-utilities</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-protobuf-schema-utilities</name>
+  <name>Registry :: Utils :: Protobuf Schema Utilities</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>

--- a/utils/raml-test-micro-service/pom.xml
+++ b/utils/raml-test-micro-service/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>raml-test-micro-service</artifactId>
     <packaging>jar</packaging>
-    <name>raml-test-micro-service</name>
+    <name>Registry :: Utils :: RAML Test Microservice</name>
 
     <properties>
         <projectRoot>${project.basedir}/../..</projectRoot>

--- a/utils/tests/pom.xml
+++ b/utils/tests/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>apicurio-registry-utils-tests</artifactId>
   <packaging>jar</packaging>
-  <name>apicurio-registry-utils-tests</name>
+  <name>Registry :: Utils :: Tests</name>
 
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>


### PR DESCRIPTION
## Summary

- Standardized all 106 Maven module `<name>` elements to use the hierarchical
  `Registry :: <Hierarchy>` convention (e.g., `Registry :: Schema Util :: Avro`,
  `Registry :: SerDes :: Kafka :: Protobuf`)
- Added missing `<name>` elements to 26 modules that had none (mostly examples
  and integration-tests)
- Replaced 80 existing names that used inconsistent styles (artifact-id-style,
  title-case, or `::` with full `Apicurio Registry` prefix)
- Left 3 test-fixture POMs (`test-builds/`, `.github/test-mvn-deploy/`) unchanged
  as they are not part of the main build

This is a cosmetic-only change with zero functional impact. Build output will
now show clean, scannable module names:

```
[INFO] Registry .......................................... SUCCESS
[INFO] Registry :: Common ................................ SUCCESS
[INFO] Registry :: App ................................... SUCCESS
[INFO] Registry :: Schema Util :: Avro ................... SUCCESS
```

## Test plan

- [x] Verify `./mvnw clean install -DskipTests` completes successfully
- [x] Spot-check build output for clean module name rendering