### PR TITLE
[3.2.x] fix: GAV cache content cross-check (#7788) and cycleReferences keyed by Schema identity (#3606)

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatConnectParametersTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatConnectParametersTest.java
@@ -144,8 +144,7 @@ public class CCompatConnectParametersTest extends AbstractResourceTestBase {
         assertNotEquals(id1.getId(), id2.getId(),
                 "Schemas with different connect.parameters 'allowed' values must get different IDs");
 
-        ConfluentTestUtils.checkNumberOfVersions(
-                new io.confluent.kafka.schemaregistry.client.rest.RestService(getRegistryV3ApiUrl() + "/../ccompat/v7"),
+        ConfluentTestUtils.checkNumberOfVersions(buildConfluentClient(),
                 2, subject);
     }
 
@@ -176,8 +175,7 @@ public class CCompatConnectParametersTest extends AbstractResourceTestBase {
         assertNotEquals(id1.getId(), id2.getId(),
                 "Schemas with different default values must get different IDs");
 
-        ConfluentTestUtils.checkNumberOfVersions(
-                new io.confluent.kafka.schemaregistry.client.rest.RestService(getRegistryV3ApiUrl() + "/../ccompat/v7"),
+        ConfluentTestUtils.checkNumberOfVersions(buildConfluentClient(),
                 2, subject);
     }
 

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatConnectParametersTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatConnectParametersTest.java
@@ -1,0 +1,239 @@
+package io.apicurio.registry.noprofile.ccompat.rest.v7;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ccompat.rest.ContentTypes;
+import io.apicurio.registry.ccompat.rest.v7.beans.RegisterSchemaRequest;
+import io.apicurio.registry.ccompat.rest.v7.beans.SchemaId;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Reproducer tests for Debezium regression: schemas that differ only in
+ * connect.parameters values or field default values must be registered as
+ * separate versions via the Confluent-compatible API.
+ */
+@QuarkusTest
+public class CCompatConnectParametersTest extends AbstractResourceTestBase {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final String SCHEMA_DEBEZIUM_ENUM_V1 = """
+            {
+                "type": "record",
+                "name": "Value",
+                "namespace": "com.example.dbserver1.public.shipments",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "int"
+                    },
+                    {
+                        "name": "status",
+                        "type": [
+                            "null",
+                            {
+                                "type": "string",
+                                "connect.parameters": {
+                                    "allowed": "station,post_office"
+                                },
+                                "connect.name": "io.debezium.data.Enum",
+                                "connect.version": 1
+                            }
+                        ],
+                        "default": null
+                    }
+                ]
+            }
+            """;
+
+    private static final String SCHEMA_DEBEZIUM_ENUM_V2 = """
+            {
+                "type": "record",
+                "name": "Value",
+                "namespace": "com.example.dbserver1.public.shipments",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "int"
+                    },
+                    {
+                        "name": "status",
+                        "type": [
+                            "null",
+                            {
+                                "type": "string",
+                                "connect.parameters": {
+                                    "allowed": "station,post_office,plane"
+                                },
+                                "connect.name": "io.debezium.data.Enum",
+                                "connect.version": 1
+                            }
+                        ],
+                        "default": null
+                    }
+                ]
+            }
+            """;
+
+    private static final String SCHEMA_DEFAULT_VALUE_V1 = """
+            {
+                "type": "record",
+                "name": "Value",
+                "namespace": "com.example.dbserver1.public.config",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "int"
+                    },
+                    {
+                        "name": "shard",
+                        "type": "int",
+                        "default": 0
+                    }
+                ]
+            }
+            """;
+
+    private static final String SCHEMA_DEFAULT_VALUE_V2 = """
+            {
+                "type": "record",
+                "name": "Value",
+                "namespace": "com.example.dbserver1.public.config",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "int"
+                    },
+                    {
+                        "name": "shard",
+                        "type": "int",
+                        "default": 1
+                    }
+                ]
+            }
+            """;
+
+    @Test
+    public void testRegisterSchemaWithDifferentConnectParameters() throws Exception {
+        String subject = "ccompat-connect-params-test-value";
+
+        // Register v1
+        var request1 = new RegisterSchemaRequest();
+        request1.setSchema(SCHEMA_DEBEZIUM_ENUM_V1);
+        SchemaId id1 = given().when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(objectMapper.writeValueAsString(request1))
+                .post("/ccompat/v7/subjects/{subject}/versions", subject)
+                .then().statusCode(200)
+                .extract().as(SchemaId.class);
+
+        // Register v2 with different connect.parameters
+        var request2 = new RegisterSchemaRequest();
+        request2.setSchema(SCHEMA_DEBEZIUM_ENUM_V2);
+        SchemaId id2 = given().when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(objectMapper.writeValueAsString(request2))
+                .post("/ccompat/v7/subjects/{subject}/versions", subject)
+                .then().statusCode(200)
+                .extract().as(SchemaId.class);
+
+        assertNotEquals(id1.getId(), id2.getId(),
+                "Schemas with different connect.parameters 'allowed' values must get different IDs");
+
+        ConfluentTestUtils.checkNumberOfVersions(
+                new io.confluent.kafka.schemaregistry.client.rest.RestService(getRegistryV3ApiUrl() + "/../ccompat/v7"),
+                2, subject);
+    }
+
+    @Test
+    public void testRegisterSchemaWithDifferentDefaultValues() throws Exception {
+        String subject = "ccompat-default-values-test-value";
+
+        // Register v1
+        var request1 = new RegisterSchemaRequest();
+        request1.setSchema(SCHEMA_DEFAULT_VALUE_V1);
+        SchemaId id1 = given().when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(objectMapper.writeValueAsString(request1))
+                .post("/ccompat/v7/subjects/{subject}/versions", subject)
+                .then().statusCode(200)
+                .extract().as(SchemaId.class);
+
+        // Register v2 with different default value
+        var request2 = new RegisterSchemaRequest();
+        request2.setSchema(SCHEMA_DEFAULT_VALUE_V2);
+        SchemaId id2 = given().when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(objectMapper.writeValueAsString(request2))
+                .post("/ccompat/v7/subjects/{subject}/versions", subject)
+                .then().statusCode(200)
+                .extract().as(SchemaId.class);
+
+        assertNotEquals(id1.getId(), id2.getId(),
+                "Schemas with different default values must get different IDs");
+
+        ConfluentTestUtils.checkNumberOfVersions(
+                new io.confluent.kafka.schemaregistry.client.rest.RestService(getRegistryV3ApiUrl() + "/../ccompat/v7"),
+                2, subject);
+    }
+
+    @Test
+    public void testRegisterSchemaWithDifferentConnectParameters_Normalize() throws Exception {
+        String subject = "ccompat-connect-params-normalize-test-value";
+
+        // Register v1
+        var request1 = new RegisterSchemaRequest();
+        request1.setSchema(SCHEMA_DEBEZIUM_ENUM_V1);
+        SchemaId id1 = given().when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(objectMapper.writeValueAsString(request1))
+                .post("/ccompat/v7/subjects/{subject}/versions?normalize=true", subject)
+                .then().statusCode(200)
+                .extract().as(SchemaId.class);
+
+        // Register v2 with different connect.parameters and normalize=true
+        var request2 = new RegisterSchemaRequest();
+        request2.setSchema(SCHEMA_DEBEZIUM_ENUM_V2);
+        SchemaId id2 = given().when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(objectMapper.writeValueAsString(request2))
+                .post("/ccompat/v7/subjects/{subject}/versions?normalize=true", subject)
+                .then().statusCode(200)
+                .extract().as(SchemaId.class);
+
+        assertNotEquals(id1.getId(), id2.getId(),
+                "Schemas with different connect.parameters must get different IDs even with normalize=true");
+    }
+
+    @Test
+    public void testRegisterSchemaWithDifferentDefaultValues_Normalize() throws Exception {
+        String subject = "ccompat-default-values-normalize-test-value";
+
+        // Register v1
+        var request1 = new RegisterSchemaRequest();
+        request1.setSchema(SCHEMA_DEFAULT_VALUE_V1);
+        SchemaId id1 = given().when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(objectMapper.writeValueAsString(request1))
+                .post("/ccompat/v7/subjects/{subject}/versions?normalize=true", subject)
+                .then().statusCode(200)
+                .extract().as(SchemaId.class);
+
+        // Register v2 with different default value and normalize=true
+        var request2 = new RegisterSchemaRequest();
+        request2.setSchema(SCHEMA_DEFAULT_VALUE_V2);
+        SchemaId id2 = given().when()
+                .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(objectMapper.writeValueAsString(request2))
+                .post("/ccompat/v7/subjects/{subject}/versions?normalize=true", subject)
+                .then().statusCode(200)
+                .extract().as(SchemaId.class);
+
+        assertNotEquals(id1.getId(), id2.getId(),
+                "Schemas with different default values must get different IDs even with normalize=true");
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/IfExistsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/IfExistsTest.java
@@ -46,6 +46,100 @@ public class IfExistsTest extends AbstractResourceTestBase {
             }
             """;
 
+    private static final String SCHEMA_DEBEZIUM_ENUM_V1 = """
+            {
+                "type": "record",
+                "name": "Value",
+                "namespace": "com.example.dbserver1.public.shipments",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "int"
+                    },
+                    {
+                        "name": "status",
+                        "type": [
+                            "null",
+                            {
+                                "type": "string",
+                                "connect.parameters": {
+                                    "allowed": "station,post_office"
+                                },
+                                "connect.name": "io.debezium.data.Enum",
+                                "connect.version": 1
+                            }
+                        ],
+                        "default": null
+                    }
+                ]
+            }
+            """;
+    private static final String SCHEMA_DEBEZIUM_ENUM_V2 = """
+            {
+                "type": "record",
+                "name": "Value",
+                "namespace": "com.example.dbserver1.public.shipments",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "int"
+                    },
+                    {
+                        "name": "status",
+                        "type": [
+                            "null",
+                            {
+                                "type": "string",
+                                "connect.parameters": {
+                                    "allowed": "station,post_office,plane"
+                                },
+                                "connect.name": "io.debezium.data.Enum",
+                                "connect.version": 1
+                            }
+                        ],
+                        "default": null
+                    }
+                ]
+            }
+            """;
+
+    private static final String SCHEMA_DEFAULT_VALUE_V1 = """
+            {
+                "type": "record",
+                "name": "Value",
+                "namespace": "com.example.dbserver1.public.config",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "int"
+                    },
+                    {
+                        "name": "shard",
+                        "type": "int",
+                        "default": 0
+                    }
+                ]
+            }
+            """;
+    private static final String SCHEMA_DEFAULT_VALUE_V2 = """
+            {
+                "type": "record",
+                "name": "Value",
+                "namespace": "com.example.dbserver1.public.config",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "int"
+                    },
+                    {
+                        "name": "shard",
+                        "type": "int",
+                        "default": 1
+                    }
+                ]
+            }
+            """;
+
     @Test
     public void testIfExistsFail() throws Exception {
         String groupId = "testIfExistsFail";
@@ -343,6 +437,149 @@ public class IfExistsTest extends AbstractResourceTestBase {
         Assertions.assertNotNull(vsr);
         Assertions.assertEquals(1, vsr.getVersions().size());
         Assertions.assertEquals(1, vsr.getCount().intValue());
+    }
+
+    /**
+     * Reproducer for Debezium regression: when only connect.parameters values change
+     * (e.g. io.debezium.data.Enum "allowed" values), FIND_OR_CREATE_VERSION must create
+     * a new version, not return the existing one.
+     */
+    @Test
+    public void testIfExistsFindOrCreateVersion_DifferentConnectParameters() throws Exception {
+        String groupId = "testIfExistsFindOrCreateVersion_DifferentConnectParameters";
+        String artifactId = "shipments-value";
+
+        CreateGroup createGroup = new CreateGroup();
+        createGroup.setGroupId(groupId);
+        clientV3.groups().post(createGroup);
+
+        // Register v1 with allowed=station,post_office
+        CreateArtifact createArtifact = TestUtils.clientCreateArtifact(artifactId, ArtifactType.AVRO,
+                SCHEMA_DEBEZIUM_ENUM_V1, ContentTypes.APPLICATION_JSON);
+        CreateArtifactResponse car = clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+        Assertions.assertNotNull(car);
+        Assertions.assertEquals("1", car.getVersion().getVersion());
+
+        // Register v2 with allowed=station,post_office,plane using FIND_OR_CREATE_VERSION
+        CreateArtifact ca = TestUtils.clientCreateArtifact(artifactId, ArtifactType.AVRO,
+                SCHEMA_DEBEZIUM_ENUM_V2, ContentTypes.APPLICATION_JSON);
+        car = clientV3.groups().byGroupId(groupId).artifacts().post(ca,
+                config -> config.queryParameters.ifExists = IfArtifactExists.FIND_OR_CREATE_VERSION);
+        Assertions.assertNotNull(car);
+        Assertions.assertEquals("2", car.getVersion().getVersion(),
+                "A new version should be created when connect.parameters values change");
+
+        // Should have two versions
+        VersionSearchResults vsr = clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions().get();
+        Assertions.assertEquals(2, vsr.getCount().intValue());
+    }
+
+    /**
+     * Reproducer for Debezium regression: same as above but with canonical=true.
+     * Even with canonical hashing, different connect.parameters must produce different versions.
+     */
+    @Test
+    public void testIfExistsFindOrCreateVersion_DifferentConnectParameters_Canonical() throws Exception {
+        String groupId = "testIfExistsFindOrCreateVersion_DifferentConnectParameters_Canonical";
+        String artifactId = "shipments-value";
+
+        CreateGroup createGroup = new CreateGroup();
+        createGroup.setGroupId(groupId);
+        clientV3.groups().post(createGroup);
+
+        // Register v1 with allowed=station,post_office
+        CreateArtifact createArtifact = TestUtils.clientCreateArtifact(artifactId, ArtifactType.AVRO,
+                SCHEMA_DEBEZIUM_ENUM_V1, ContentTypes.APPLICATION_JSON);
+        CreateArtifactResponse car = clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+        Assertions.assertNotNull(car);
+        Assertions.assertEquals("1", car.getVersion().getVersion());
+
+        // Register v2 with allowed=station,post_office,plane using FIND_OR_CREATE_VERSION + canonical
+        CreateArtifact ca = TestUtils.clientCreateArtifact(artifactId, ArtifactType.AVRO,
+                SCHEMA_DEBEZIUM_ENUM_V2, ContentTypes.APPLICATION_JSON);
+        car = clientV3.groups().byGroupId(groupId).artifacts().post(ca,
+                config -> {
+                    config.queryParameters.ifExists = IfArtifactExists.FIND_OR_CREATE_VERSION;
+                    config.queryParameters.canonical = true;
+                });
+        Assertions.assertNotNull(car);
+        Assertions.assertEquals("2", car.getVersion().getVersion(),
+                "A new version should be created when connect.parameters values change (canonical mode)");
+
+        // Should have two versions
+        VersionSearchResults vsr = clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions().get();
+        Assertions.assertEquals(2, vsr.getCount().intValue());
+    }
+
+    /**
+     * Reproducer for Debezium regression: when only a field's default value changes,
+     * FIND_OR_CREATE_VERSION must create a new version.
+     */
+    @Test
+    public void testIfExistsFindOrCreateVersion_DifferentDefaultValues() throws Exception {
+        String groupId = "testIfExistsFindOrCreateVersion_DifferentDefaultValues";
+        String artifactId = "config-value";
+
+        CreateGroup createGroup = new CreateGroup();
+        createGroup.setGroupId(groupId);
+        clientV3.groups().post(createGroup);
+
+        // Register v1 with default=0
+        CreateArtifact createArtifact = TestUtils.clientCreateArtifact(artifactId, ArtifactType.AVRO,
+                SCHEMA_DEFAULT_VALUE_V1, ContentTypes.APPLICATION_JSON);
+        CreateArtifactResponse car = clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+        Assertions.assertNotNull(car);
+        Assertions.assertEquals("1", car.getVersion().getVersion());
+
+        // Register v2 with default=1 using FIND_OR_CREATE_VERSION
+        CreateArtifact ca = TestUtils.clientCreateArtifact(artifactId, ArtifactType.AVRO,
+                SCHEMA_DEFAULT_VALUE_V2, ContentTypes.APPLICATION_JSON);
+        car = clientV3.groups().byGroupId(groupId).artifacts().post(ca,
+                config -> config.queryParameters.ifExists = IfArtifactExists.FIND_OR_CREATE_VERSION);
+        Assertions.assertNotNull(car);
+        Assertions.assertEquals("2", car.getVersion().getVersion(),
+                "A new version should be created when field default values change");
+
+        // Should have two versions
+        VersionSearchResults vsr = clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions().get();
+        Assertions.assertEquals(2, vsr.getCount().intValue());
+    }
+
+    /**
+     * Reproducer for Debezium regression: same as above but with canonical=true.
+     * Even with canonical hashing, different default values must produce different versions.
+     */
+    @Test
+    public void testIfExistsFindOrCreateVersion_DifferentDefaultValues_Canonical() throws Exception {
+        String groupId = "testIfExistsFindOrCreateVersion_DifferentDefaultValues_Canonical";
+        String artifactId = "config-value";
+
+        CreateGroup createGroup = new CreateGroup();
+        createGroup.setGroupId(groupId);
+        clientV3.groups().post(createGroup);
+
+        // Register v1 with default=0
+        CreateArtifact createArtifact = TestUtils.clientCreateArtifact(artifactId, ArtifactType.AVRO,
+                SCHEMA_DEFAULT_VALUE_V1, ContentTypes.APPLICATION_JSON);
+        CreateArtifactResponse car = clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+        Assertions.assertNotNull(car);
+        Assertions.assertEquals("1", car.getVersion().getVersion());
+
+        // Register v2 with default=1 using FIND_OR_CREATE_VERSION + canonical
+        CreateArtifact ca = TestUtils.clientCreateArtifact(artifactId, ArtifactType.AVRO,
+                SCHEMA_DEFAULT_VALUE_V2, ContentTypes.APPLICATION_JSON);
+        car = clientV3.groups().byGroupId(groupId).artifacts().post(ca,
+                config -> {
+                    config.queryParameters.ifExists = IfArtifactExists.FIND_OR_CREATE_VERSION;
+                    config.queryParameters.canonical = true;
+                });
+        Assertions.assertNotNull(car);
+        Assertions.assertEquals("2", car.getVersion().getVersion(),
+                "A new version should be created when field default values change (canonical mode)");
+
+        // Should have two versions
+        VersionSearchResults vsr = clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions().get();
+        Assertions.assertEquals(2, vsr.getCount().intValue());
     }
 
 }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
@@ -91,7 +91,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
         }
 
         final ArtifactReference artifactReference = resolveArtifactReference(data, parsedSchema, false, null);
-        return getSchemaFromCache(artifactReference)
+        return getSchemaFromCache(artifactReference, parsedSchema)
                 .orElseGet(() -> getSchemaFromRegistry(parsedSchema, data, artifactReference));
     }
 
@@ -109,7 +109,8 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
                 .setRawSchema(schemaBytes);
     }
 
-    private Optional<SchemaLookupResult<S>> getSchemaFromCache(ArtifactReference artifactReference) {
+    private Optional<SchemaLookupResult<S>> getSchemaFromCache(ArtifactReference artifactReference,
+                                                               ParsedSchema<S> parsedSchema) {
         if (artifactReference.getGlobalId() != null
                 && schemaCache.containsByGlobalId(artifactReference.getGlobalId())) {
             return Optional.of(resolveSchemaByGlobalId(artifactReference.getGlobalId()));
@@ -119,10 +120,17 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
         } else if (artifactReference.getContentHash() != null
                 && schemaCache.containsByContentHash(artifactReference.getContentHash())) {
             return Optional.of(resolveSchemaByContentHash(artifactReference.getContentHash()));
-        } else if (schemaCache.containsByArtifactCoordinates(
-                ArtifactCoordinates.fromArtifactReference(artifactReference))) {
-            return Optional.of(resolveSchemaByArtifactCoordinatesCached(
-                    ArtifactCoordinates.fromArtifactReference(artifactReference)));
+        } else {
+            ArtifactCoordinates coords = ArtifactCoordinates.fromArtifactReference(artifactReference);
+            ContentWithReferences incomingContent = null;
+            if (parsedSchema != null && parsedSchema.getRawSchema() != null) {
+                incomingContent = ContentWithReferences.builder()
+                        .content(IoUtil.toString(parsedSchema.getRawSchema()))
+                        .build();
+            }
+            if (schemaCache.containsByArtifactCoordinatesMatchingContent(coords, incomingContent)) {
+                return Optional.of(resolveSchemaByArtifactCoordinatesCached(coords));
+            }
         }
         return Optional.empty();
     }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -199,6 +199,19 @@ public class ERCache<V> {
         return value != null && !value.isExpired();
     }
 
+    public boolean containsByArtifactCoordinatesMatchingContent(ArtifactCoordinates key,
+                                                                ContentWithReferences expectedContent) {
+        WrappedValue<V> value = this.gavIndex.get(key);
+        if (value == null || value.isExpired()) {
+            return false;
+        }
+        if (expectedContent == null) {
+            return true;
+        }
+        ContentWithReferences cachedContent = contentExtractor.apply(value.value);
+        return expectedContent.equals(cachedContent);
+    }
+
     public boolean containsByContentHash(String key) {
         WrappedValue<V> value = this.contentHashIndex.get(key);
         return value != null && !value.isExpired();

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/ERCacheTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/ERCacheTest.java
@@ -449,6 +449,92 @@ public class ERCacheTest {
         assertDoesNotThrow(() -> cache.shutdown());
     }
 
+    /**
+     * Reproducer for Debezium regression (GH-7788): when two schemas share the same artifact
+     * coordinates (groupId + artifactId) but have different content (e.g. different
+     * connect.parameters), the GAV-index cache hit from the first schema prevents the second
+     * schema from ever being registered, because DefaultSchemaResolver.getSchemaFromCache()
+     * short-circuits before handleAutoCreateArtifact() is reached.
+     *
+     * This test simulates the DefaultSchemaResolver flow:
+     * 1. Schema V1 is registered via content lookup → reindex() populates the GAV index
+     * 2. Schema V2 arrives with same coordinates but different content
+     * 3. The resolver checks containsByArtifactCoordinates() → should NOT match since content changed
+     *
+     * The test asserts the CORRECT behavior: the GAV cache must not shadow different content.
+     * It will FAIL until the caching bug is fixed.
+     */
+    @Test
+    void testGavCacheDoesNotShadowDifferentContent() {
+        ERCache<TestSchemaResult> cache = new ERCache<>();
+        cache.configureLifetime(Duration.ofMinutes(10));
+        cache.configureRetryBackoff(Duration.ofMillis(100));
+        cache.configureRetryCount(0);
+        cache.configureCacheLatest(true);
+
+        cache.configureGlobalIdKeyExtractor(r -> r.globalId);
+        cache.configureContentIdKeyExtractor(r -> r.contentId);
+        cache.configureContentHashKeyExtractor(r -> r.contentHash);
+        cache.configureArtifactCoordinatesKeyExtractor(r -> r.coordinates);
+        cache.configureContentKeyExtractor(r -> ContentWithReferences.builder()
+                .content(r.schemaContent).build());
+
+        // Step 1: Register schema V1 via content lookup (handleAutoCreateArtifact path).
+        // reindex() will populate the GAV index under (default, my-topic-value, null).
+        ContentWithReferences v1ContentKey = ContentWithReferences.builder()
+                .content("{\"type\":\"string\",\"connect.parameters\":{\"allowed\":\"station,post_office\"}}")
+                .build();
+
+        TestSchemaResult v1Result = new TestSchemaResult(
+                1L, 100L, "hash-v1",
+                ArtifactCoordinates.builder().groupId("default").artifactId("my-topic-value").build(),
+                v1ContentKey.getContent());
+
+        cache.getByContent(v1ContentKey, key -> v1Result);
+
+        // Step 2: Schema V2 arrives — same artifact coordinates, different content.
+        // The resolver builds a lookup key with null version (no version specified).
+        ArtifactCoordinates lookupCoords = ArtifactCoordinates.builder()
+                .groupId("default").artifactId("my-topic-value").build();
+
+        ContentWithReferences v2ContentKey = ContentWithReferences.builder()
+                .content("{\"type\":\"string\",\"connect.parameters\":{\"allowed\":\"station,post_office,plane\"}}")
+                .build();
+        assertFalse(cache.containsByContentHash("hash-v2"),
+                "V2 content hash should not be in cache yet");
+
+        // Step 3: The content-aware GAV check must detect the mismatch.
+        // containsByArtifactCoordinatesMatchingContent returns false when content differs,
+        // so the resolver falls through to handleAutoCreateArtifact() which registers V2.
+        assertFalse(cache.containsByArtifactCoordinatesMatchingContent(lookupCoords, v2ContentKey),
+                "GAV cache must not match when the incoming schema content differs from the cached entry");
+
+        // The same check with V1 content should still return true (cache hit for same content).
+        assertTrue(cache.containsByArtifactCoordinatesMatchingContent(lookupCoords, v1ContentKey),
+                "GAV cache should match when the incoming schema content equals the cached entry");
+
+        // When no incoming content is available (parsedSchema is null), fall back to GAV-only check.
+        assertTrue(cache.containsByArtifactCoordinatesMatchingContent(lookupCoords, null),
+                "GAV cache should match when no incoming content is provided (findLatest path)");
+    }
+
+    private static class TestSchemaResult {
+        final long globalId;
+        final long contentId;
+        final String contentHash;
+        final ArtifactCoordinates coordinates;
+        final String schemaContent;
+
+        TestSchemaResult(long globalId, long contentId, String contentHash,
+                         ArtifactCoordinates coordinates, String schemaContent) {
+            this.globalId = globalId;
+            this.contentId = contentId;
+            this.contentHash = contentHash;
+            this.coordinates = coordinates;
+            this.schemaContent = schemaContent;
+        }
+    }
+
     private ERCache<String> newCache(String contentHashKey) {
         ERCache<String> cache = new ERCache<>();
         cache.configureLifetime(Duration.ofDays(30));

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/ERCacheTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/ERCacheTest.java
@@ -518,6 +518,118 @@ public class ERCacheTest {
                 "GAV cache should match when no incoming content is provided (findLatest path)");
     }
 
+    @Test
+    void testDebeziumEnumSchemaEvolutionNotShadowedByGavCache() {
+        ERCache<TestSchemaResult> cache = new ERCache<>();
+        cache.configureLifetime(Duration.ofMinutes(10));
+        cache.configureRetryBackoff(Duration.ofMillis(100));
+        cache.configureRetryCount(0);
+        cache.configureCacheLatest(true);
+
+        cache.configureGlobalIdKeyExtractor(r -> r.globalId);
+        cache.configureContentIdKeyExtractor(r -> r.contentId);
+        cache.configureContentHashKeyExtractor(r -> r.contentHash);
+        cache.configureArtifactCoordinatesKeyExtractor(r -> r.coordinates);
+        cache.configureContentKeyExtractor(r -> ContentWithReferences.builder()
+                .content(r.schemaContent).build());
+
+        ArtifactCoordinates topicCoords = ArtifactCoordinates.builder()
+                .groupId("default").artifactId("dbserver1.inventory.orders-value").build();
+
+        String enumSchemaV1 = "{\"type\":\"record\",\"name\":\"Value\","
+                + "\"namespace\":\"dbserver1.inventory.orders\","
+                + "\"fields\":["
+                + "{\"name\":\"id\",\"type\":\"int\"},"
+                + "{\"name\":\"status\",\"type\":{\"type\":\"string\","
+                + "\"connect.parameters\":{\"allowed\":\"pending,shipped\"},"
+                + "\"connect.name\":\"io.debezium.data.Enum\"}}"
+                + "]}";
+
+        String enumSchemaV2 = "{\"type\":\"record\",\"name\":\"Value\","
+                + "\"namespace\":\"dbserver1.inventory.orders\","
+                + "\"fields\":["
+                + "{\"name\":\"id\",\"type\":\"int\"},"
+                + "{\"name\":\"status\",\"type\":{\"type\":\"string\","
+                + "\"connect.parameters\":{\"allowed\":\"pending,shipped,cancelled\"},"
+                + "\"connect.name\":\"io.debezium.data.Enum\"}}"
+                + "]}";
+
+        TestSchemaResult v1Result = new TestSchemaResult(
+                1L, 100L, "hash-enum-v1", topicCoords, enumSchemaV1);
+        cache.getByContent(
+                ContentWithReferences.builder().content(enumSchemaV1).build(),
+                key -> v1Result);
+
+        ContentWithReferences v2Content = ContentWithReferences.builder()
+                .content(enumSchemaV2).build();
+        assertFalse(cache.containsByArtifactCoordinatesMatchingContent(topicCoords, v2Content),
+                "Adding 'cancelled' to the enum must not be shadowed by the GAV cache");
+
+        ContentWithReferences v1Content = ContentWithReferences.builder()
+                .content(enumSchemaV1).build();
+        assertTrue(cache.containsByArtifactCoordinatesMatchingContent(topicCoords, v1Content),
+                "Original enum schema should still hit the GAV cache");
+    }
+
+    @Test
+    void testDebeziumMultipleDecimalColumnsDifferentPrecisionNotShadowed() {
+        ERCache<TestSchemaResult> cache = new ERCache<>();
+        cache.configureLifetime(Duration.ofMinutes(10));
+        cache.configureRetryBackoff(Duration.ofMillis(100));
+        cache.configureRetryCount(0);
+        cache.configureCacheLatest(true);
+
+        cache.configureGlobalIdKeyExtractor(r -> r.globalId);
+        cache.configureContentIdKeyExtractor(r -> r.contentId);
+        cache.configureContentHashKeyExtractor(r -> r.contentHash);
+        cache.configureArtifactCoordinatesKeyExtractor(r -> r.coordinates);
+        cache.configureContentKeyExtractor(r -> ContentWithReferences.builder()
+                .content(r.schemaContent).build());
+
+        ArtifactCoordinates topicCoords = ArtifactCoordinates.builder()
+                .groupId("default").artifactId("dbserver1.inventory.measurements-value").build();
+
+        String schemaWithPrecision10 = "{\"type\":\"record\",\"name\":\"Value\","
+                + "\"namespace\":\"dbserver1.inventory.measurements\","
+                + "\"fields\":["
+                + "{\"name\":\"id\",\"type\":\"int\"},"
+                + "{\"name\":\"amount\",\"type\":{\"type\":\"record\","
+                + "\"name\":\"VariableScaleDecimal\","
+                + "\"namespace\":\"io.debezium.data\","
+                + "\"connect.parameters\":{\"precision\":\"10\"}}}"
+                + "]}";
+
+        String schemaWithPrecision15 = "{\"type\":\"record\",\"name\":\"Value\","
+                + "\"namespace\":\"dbserver1.inventory.measurements\","
+                + "\"fields\":["
+                + "{\"name\":\"id\",\"type\":\"int\"},"
+                + "{\"name\":\"amount\",\"type\":{\"type\":\"record\","
+                + "\"name\":\"VariableScaleDecimal\","
+                + "\"namespace\":\"io.debezium.data\","
+                + "\"connect.parameters\":{\"precision\":\"15\"}}}"
+                + "]}";
+
+        TestSchemaResult result1 = new TestSchemaResult(
+                1L, 100L, "hash-p10", topicCoords, schemaWithPrecision10);
+        cache.getByContent(
+                ContentWithReferences.builder().content(schemaWithPrecision10).build(),
+                key -> result1);
+
+        ContentWithReferences p15Content = ContentWithReferences.builder()
+                .content(schemaWithPrecision15).build();
+        assertFalse(cache.containsByArtifactCoordinatesMatchingContent(topicCoords, p15Content),
+                "Schema with precision=15 must not be shadowed by cached precision=10 schema");
+
+        TestSchemaResult result2 = new TestSchemaResult(
+                2L, 101L, "hash-p15", topicCoords, schemaWithPrecision15);
+        cache.getByContent(
+                ContentWithReferences.builder().content(schemaWithPrecision15).build(),
+                key -> result2);
+
+        assertTrue(cache.containsByArtifactCoordinatesMatchingContent(topicCoords, p15Content),
+                "After registering precision=15, GAV cache should return it");
+    }
+
     private static class TestSchemaResult {
         final long globalId;
         final long contentId;

--- a/schema-util/avro/src/test/java/io/apicurio/registry/content/canon/SchemaNormalizerTest.java
+++ b/schema-util/avro/src/test/java/io/apicurio/registry/content/canon/SchemaNormalizerTest.java
@@ -349,6 +349,302 @@ class SchemaNormalizerTest {
         assertNotNull(parsed);
     }
 
+    /**
+     * Reproducer: schemas differing only in connect.parameters values must produce different
+     * canonical forms. Debezium uses connect.parameters to track allowed enum values
+     * (e.g. io.debezium.data.Enum with "allowed" parameter).
+     */
+    @Test
+    void parseSchema_SchemasWithDifferentConnectParameters_NotEqual() {
+        String schemaV1 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example.dbserver1.public.shipments\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"status\",\n"
+                + "      \"type\": {\n"
+                + "        \"type\": \"string\",\n"
+                + "        \"connect.parameters\": {\n"
+                + "          \"allowed\": \"station,post_office\"\n"
+                + "        },\n"
+                + "        \"connect.name\": \"io.debezium.data.Enum\"\n"
+                + "      }\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        String schemaV2 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example.dbserver1.public.shipments\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"status\",\n"
+                + "      \"type\": {\n"
+                + "        \"type\": \"string\",\n"
+                + "        \"connect.parameters\": {\n"
+                + "          \"allowed\": \"station,post_office,plane\"\n"
+                + "        },\n"
+                + "        \"connect.name\": \"io.debezium.data.Enum\"\n"
+                + "      }\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        EnhancedAvroContentCanonicalizer canonicalizer = new EnhancedAvroContentCanonicalizer();
+        TypedContent canonicalV1 = canonicalizer.canonicalize(toTypedContent(schemaV1), new HashMap<>());
+        TypedContent canonicalV2 = canonicalizer.canonicalize(toTypedContent(schemaV2), new HashMap<>());
+
+        assertNotEquals(canonicalV1.getContent().content(), canonicalV2.getContent().content(),
+                "Schemas with different connect.parameters values must have different canonical forms");
+    }
+
+    /**
+     * Reproducer: schemas differing only in field-level custom properties must produce
+     * different canonical forms.
+     */
+    @Test
+    void parseSchema_SchemasWithDifferentFieldLevelCustomProperties_NotEqual() {
+        String schemaV1 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"status\",\n"
+                + "      \"type\": \"string\",\n"
+                + "      \"custom.property\": \"value1\"\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        String schemaV2 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"status\",\n"
+                + "      \"type\": \"string\",\n"
+                + "      \"custom.property\": \"value2\"\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        EnhancedAvroContentCanonicalizer canonicalizer = new EnhancedAvroContentCanonicalizer();
+        TypedContent canonicalV1 = canonicalizer.canonicalize(toTypedContent(schemaV1), new HashMap<>());
+        TypedContent canonicalV2 = canonicalizer.canonicalize(toTypedContent(schemaV2), new HashMap<>());
+
+        assertNotEquals(canonicalV1.getContent().content(), canonicalV2.getContent().content(),
+                "Schemas with different field-level custom properties must have different canonical forms");
+    }
+
+    /**
+     * Reproducer: schemas differing only in a field's default value must produce different
+     * canonical forms.
+     */
+    @Test
+    void parseSchema_SchemasWithDifferentDefaultValues_NotEqual() {
+        String schemaV1 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"shard\",\n"
+                + "      \"type\": \"int\",\n"
+                + "      \"default\": 0\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        String schemaV2 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"shard\",\n"
+                + "      \"type\": \"int\",\n"
+                + "      \"default\": 1\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        EnhancedAvroContentCanonicalizer canonicalizer = new EnhancedAvroContentCanonicalizer();
+        TypedContent canonicalV1 = canonicalizer.canonicalize(toTypedContent(schemaV1), new HashMap<>());
+        TypedContent canonicalV2 = canonicalizer.canonicalize(toTypedContent(schemaV2), new HashMap<>());
+
+        assertNotEquals(canonicalV1.getContent().content(), canonicalV2.getContent().content(),
+                "Schemas with different default values must have different canonical forms");
+    }
+
+    /**
+     * Reproducer: schemas differing only in a string field's default value must produce
+     * different canonical forms.
+     */
+    @Test
+    void parseSchema_SchemasWithDifferentStringDefaultValues_NotEqual() {
+        String schemaV1 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"region\",\n"
+                + "      \"type\": \"string\",\n"
+                + "      \"default\": \"us-east-1\"\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        String schemaV2 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"region\",\n"
+                + "      \"type\": \"string\",\n"
+                + "      \"default\": \"eu-west-1\"\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        EnhancedAvroContentCanonicalizer canonicalizer = new EnhancedAvroContentCanonicalizer();
+        TypedContent canonicalV1 = canonicalizer.canonicalize(toTypedContent(schemaV1), new HashMap<>());
+        TypedContent canonicalV2 = canonicalizer.canonicalize(toTypedContent(schemaV2), new HashMap<>());
+
+        assertNotEquals(canonicalV1.getContent().content(), canonicalV2.getContent().content(),
+                "Schemas with different string default values must have different canonical forms");
+    }
+
+    /**
+     * Reproducer: Debezium-style nullable field with connect.parameters in a union.
+     * This is the exact pattern Debezium uses for nullable enum columns.
+     */
+    @Test
+    void parseSchema_DebeziumNullableEnumWithDifferentAllowedValues_NotEqual() {
+        String schemaV1 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example.dbserver1.public.shipments\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"id\",\n"
+                + "      \"type\": \"int\"\n"
+                + "    },\n"
+                + "    {\n"
+                + "      \"name\": \"status\",\n"
+                + "      \"type\": [\n"
+                + "        \"null\",\n"
+                + "        {\n"
+                + "          \"type\": \"string\",\n"
+                + "          \"connect.parameters\": {\n"
+                + "            \"allowed\": \"station,post_office\"\n"
+                + "          },\n"
+                + "          \"connect.name\": \"io.debezium.data.Enum\",\n"
+                + "          \"connect.version\": 1\n"
+                + "        }\n"
+                + "      ],\n"
+                + "      \"default\": null\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        String schemaV2 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example.dbserver1.public.shipments\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"id\",\n"
+                + "      \"type\": \"int\"\n"
+                + "    },\n"
+                + "    {\n"
+                + "      \"name\": \"status\",\n"
+                + "      \"type\": [\n"
+                + "        \"null\",\n"
+                + "        {\n"
+                + "          \"type\": \"string\",\n"
+                + "          \"connect.parameters\": {\n"
+                + "            \"allowed\": \"station,post_office,plane\"\n"
+                + "          },\n"
+                + "          \"connect.name\": \"io.debezium.data.Enum\",\n"
+                + "          \"connect.version\": 1\n"
+                + "        }\n"
+                + "      ],\n"
+                + "      \"default\": null\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        EnhancedAvroContentCanonicalizer canonicalizer = new EnhancedAvroContentCanonicalizer();
+        TypedContent canonicalV1 = canonicalizer.canonicalize(toTypedContent(schemaV1), new HashMap<>());
+        TypedContent canonicalV2 = canonicalizer.canonicalize(toTypedContent(schemaV2), new HashMap<>());
+
+        assertNotEquals(canonicalV1.getContent().content(), canonicalV2.getContent().content(),
+                "Debezium nullable enum schemas with different 'allowed' values must have different canonical forms");
+    }
+
+    /**
+     * Reproducer: connect.parameters with multiple keys where only one value changes.
+     */
+    @Test
+    void parseSchema_SchemasWithDifferentConnectParameterSubset_NotEqual() {
+        String schemaV1 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"amount\",\n"
+                + "      \"type\": {\n"
+                + "        \"type\": \"bytes\",\n"
+                + "        \"connect.parameters\": {\n"
+                + "          \"scale\": \"2\",\n"
+                + "          \"connect.decimal.precision\": \"10\"\n"
+                + "        },\n"
+                + "        \"connect.name\": \"org.apache.kafka.connect.data.Decimal\",\n"
+                + "        \"logicalType\": \"decimal\",\n"
+                + "        \"precision\": 10,\n"
+                + "        \"scale\": 2\n"
+                + "      }\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        String schemaV2 = "{\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"name\": \"Value\",\n"
+                + "  \"namespace\": \"com.example\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"amount\",\n"
+                + "      \"type\": {\n"
+                + "        \"type\": \"bytes\",\n"
+                + "        \"connect.parameters\": {\n"
+                + "          \"scale\": \"4\",\n"
+                + "          \"connect.decimal.precision\": \"10\"\n"
+                + "        },\n"
+                + "        \"connect.name\": \"org.apache.kafka.connect.data.Decimal\",\n"
+                + "        \"logicalType\": \"decimal\",\n"
+                + "        \"precision\": 10,\n"
+                + "        \"scale\": 4\n"
+                + "      }\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        EnhancedAvroContentCanonicalizer canonicalizer = new EnhancedAvroContentCanonicalizer();
+        TypedContent canonicalV1 = canonicalizer.canonicalize(toTypedContent(schemaV1), new HashMap<>());
+        TypedContent canonicalV2 = canonicalizer.canonicalize(toTypedContent(schemaV2), new HashMap<>());
+
+        assertNotEquals(canonicalV1.getContent().content(), canonicalV2.getContent().content(),
+                "Schemas with different connect.parameters scale values must have different canonical forms");
+    }
+
     private String getSchemaFromResource(String resourcePath) throws IOException {
         ClassLoader classLoader = getClass().getClassLoader();
         URL resourceURL = classLoader.getResource(resourcePath);

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
@@ -944,7 +944,7 @@ public class AvroData {
                         : null;
                     baseSchema = org.apache.avro.Schema.createRecord(name, doc, namespace, false);
                     if (schema.name() != null) {
-                        fromConnectContext.cycleReferences.put(schema.name(), baseSchema);
+                        fromConnectContext.cycleReferences.put(schema, baseSchema);
                     }
                     List<org.apache.avro.Schema.Field> fields = new ArrayList<>();
                     for (Field field : schema.fields()) {
@@ -1096,8 +1096,8 @@ public class AvroData {
     public org.apache.avro.Schema fromConnectSchemaWithCycle(Schema schema,
             FromConnectContext fromConnectContext, boolean ignoreOptional) {
         org.apache.avro.Schema resolvedSchema;
-        if (fromConnectContext.cycleReferences.containsKey(schema.name())) {
-            resolvedSchema = fromConnectContext.cycleReferences.get(schema.name());
+        if (fromConnectContext.cycleReferences.containsKey(schema)) {
+            resolvedSchema = fromConnectContext.cycleReferences.get(schema);
             if (!ignoreOptional) {
                 resolvedSchema = maybeMakeOptional(schema, resolvedSchema);
             }
@@ -2467,7 +2467,7 @@ public class AvroData {
         // SchemaMap is used to resolve references that need to mapped as types
         private final Map<Schema, org.apache.avro.Schema> schemaMap;
         // schema name to Schema reference to resolve cycles
-        private final Map<String, org.apache.avro.Schema> cycleReferences;
+        private final Map<Schema, org.apache.avro.Schema> cycleReferences;
         private int defaultSchemaNameIndex = 0;
 
         private FromConnectContext(Map<Schema, org.apache.avro.Schema> schemaMap) {

--- a/utils/converter/src/test/java/io/apicurio/registry/utils/converter/avro/AvroDataTest.java
+++ b/utils/converter/src/test/java/io/apicurio/registry/utils/converter/avro/AvroDataTest.java
@@ -7,12 +7,16 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class AvroDataTest {
 
@@ -100,6 +104,69 @@ public class AvroDataTest {
         // no logical type should be set because this decimal is according to avro specification not allowed
         // "Scale must be zero or a positive integer less than or equal to the precision."
         Assertions.assertNull(result.getSchema().getLogicalType());
+    }
+
+    @Test
+    void testConnectSchemaEqualsConsidersParameters() {
+        Schema schema1 = SchemaBuilder.string()
+                .name("io.debezium.data.Enum")
+                .version(1)
+                .parameter("allowed", "station,post_office")
+                .build();
+
+        Schema schema2 = SchemaBuilder.string()
+                .name("io.debezium.data.Enum")
+                .version(1)
+                .parameter("allowed", "station,post_office,plane")
+                .build();
+
+        assertNotEquals(schema1, schema2,
+                "ConnectSchema.equals() must distinguish schemas with different parameters");
+        assertNotEquals(schema1.hashCode(), schema2.hashCode(),
+                "ConnectSchema.hashCode() must differ for schemas with different parameters");
+    }
+
+    @Test
+    void testConnectSchemaEqualsConsidersDefaultValue() {
+        Schema schema1 = SchemaBuilder.int32().defaultValue(0).build();
+        Schema schema2 = SchemaBuilder.int32().defaultValue(1).build();
+
+        assertNotEquals(schema1, schema2,
+                "ConnectSchema.equals() must distinguish schemas with different default values");
+    }
+
+    @Test
+    void testCacheDistinguishesByParameters() {
+        AvroData avroData = new AvroData(5);
+
+        Schema schemaWithParam1 = SchemaBuilder.struct()
+                .name("io.debezium.data.VariableScaleDecimal")
+                .version(1)
+                .field("scale", Schema.INT32_SCHEMA)
+                .field("value", Schema.BYTES_SCHEMA)
+                .parameter("precision", "10")
+                .optional()
+                .build();
+
+        Schema schemaWithParam2 = SchemaBuilder.struct()
+                .name("io.debezium.data.VariableScaleDecimal")
+                .version(1)
+                .field("scale", Schema.INT32_SCHEMA)
+                .field("value", Schema.BYTES_SCHEMA)
+                .parameter("precision", "15")
+                .optional()
+                .build();
+
+        org.apache.avro.Schema avro1 = avroData.fromConnectSchema(schemaWithParam1);
+        org.apache.avro.Schema avro2 = avroData.fromConnectSchema(schemaWithParam2);
+
+        assertNotEquals(avro1, avro2,
+                "Avro schemas from Connect schemas with different parameters must differ");
+
+        assertSame(avro1, avroData.fromConnectSchema(schemaWithParam1),
+                "Cache must return same instance for identical Connect schema");
+        assertSame(avro2, avroData.fromConnectSchema(schemaWithParam2),
+                "Cache must return same instance for identical Connect schema");
     }
 
     @Test

--- a/utils/converter/src/test/java/io/apicurio/registry/utils/converter/avro/AvroDataTest.java
+++ b/utils/converter/src/test/java/io/apicurio/registry/utils/converter/avro/AvroDataTest.java
@@ -16,7 +16,9 @@ import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AvroDataTest {
 
@@ -167,6 +169,124 @@ public class AvroDataTest {
                 "Cache must return same instance for identical Connect schema");
         assertSame(avro2, avroData.fromConnectSchema(schemaWithParam2),
                 "Cache must return same instance for identical Connect schema");
+    }
+
+    @Test
+    void testDebeziumEnvelopeWithSameNamedFieldsDifferentParameters() {
+        AvroData avroData = new AvroData(5);
+
+        Schema enumField1 = SchemaBuilder.string()
+                .name("io.debezium.data.Enum")
+                .version(1)
+                .parameter("allowed", "station,post_office")
+                .optional()
+                .build();
+
+        Schema enumField2 = SchemaBuilder.string()
+                .name("io.debezium.data.Enum")
+                .version(1)
+                .parameter("allowed", "station,post_office,plane")
+                .optional()
+                .build();
+
+        Schema envelope = SchemaBuilder.struct()
+                .name("test_server.public.shipments.Envelope")
+                .field("before", SchemaBuilder.struct()
+                        .name("test_server.public.shipments.Value")
+                        .field("id", Schema.INT32_SCHEMA)
+                        .field("status", enumField1)
+                        .optional()
+                        .build())
+                .field("after", SchemaBuilder.struct()
+                        .name("test_server.public.shipments.Value")
+                        .field("id", Schema.INT32_SCHEMA)
+                        .field("status", enumField2)
+                        .optional()
+                        .build())
+                .field("op", Schema.STRING_SCHEMA)
+                .build();
+
+        org.apache.avro.Schema avroEnvelope = avroData.fromConnectSchema(envelope);
+
+        assertNotNull(avroEnvelope);
+        org.apache.avro.Schema beforeAvro = avroEnvelope.getField("before").schema();
+        org.apache.avro.Schema afterAvro = avroEnvelope.getField("after").schema();
+
+        org.apache.avro.Schema beforeStatus = unwrapUnion(beforeAvro).getField("status").schema();
+        org.apache.avro.Schema afterStatus = unwrapUnion(afterAvro).getField("status").schema();
+
+        Object beforeParams = unwrapUnion(beforeStatus).getObjectProp("connect.parameters");
+        Object afterParams = unwrapUnion(afterStatus).getObjectProp("connect.parameters");
+
+        assertNotNull(beforeParams, "before.status must have connect.parameters");
+        assertNotNull(afterParams, "after.status must have connect.parameters");
+        String beforeStr = beforeParams.toString();
+        String afterStr = afterParams.toString();
+        assertTrue(beforeStr.contains("station,post_office"),
+                "before.status must have original allowed values, got: " + beforeStr);
+        assertTrue(afterStr.contains("plane"),
+                "after.status must have its own allowed values including 'plane', got: " + afterStr);
+        assertNotEquals(beforeStr, afterStr,
+                "before and after status fields must have different connect.parameters");
+    }
+
+    @Test
+    void testDebeziumVariableScaleDecimalFieldsDifferentPrecision() {
+        AvroData avroData = new AvroData(5);
+
+        Schema decField1 = SchemaBuilder.struct()
+                .name("io.debezium.data.VariableScaleDecimal")
+                .version(1)
+                .field("scale", Schema.INT32_SCHEMA)
+                .field("value", Schema.BYTES_SCHEMA)
+                .parameter("precision", "10")
+                .optional()
+                .build();
+
+        Schema decField2 = SchemaBuilder.struct()
+                .name("io.debezium.data.VariableScaleDecimal")
+                .version(1)
+                .field("scale", Schema.INT32_SCHEMA)
+                .field("value", Schema.BYTES_SCHEMA)
+                .parameter("precision", "15")
+                .optional()
+                .build();
+
+        Schema tableSchema = SchemaBuilder.struct()
+                .name("test_server.public.measurements.Value")
+                .field("id", Schema.INT32_SCHEMA)
+                .field("val_f_10", decField1)
+                .field("val_f_15", decField2)
+                .build();
+
+        org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(tableSchema);
+
+        assertNotNull(avroSchema);
+        org.apache.avro.Schema avroF10 = unwrapUnion(avroSchema.getField("val_f_10").schema());
+        org.apache.avro.Schema avroF15 = unwrapUnion(avroSchema.getField("val_f_15").schema());
+
+        Object paramsF10 = avroF10.getObjectProp("connect.parameters");
+        Object paramsF15 = avroF15.getObjectProp("connect.parameters");
+
+        assertNotNull(paramsF10, "val_f_10 must have connect.parameters");
+        assertNotNull(paramsF15, "val_f_15 must have connect.parameters");
+        String paramsF10Str = paramsF10.toString();
+        String paramsF15Str = paramsF15.toString();
+        assertTrue(paramsF10Str.contains("precision") && paramsF10Str.contains("10"),
+                "val_f_10 must have precision=10, got: " + paramsF10Str);
+        assertTrue(paramsF15Str.contains("precision") && paramsF15Str.contains("15"),
+                "val_f_15 must have precision=15, got: " + paramsF15Str);
+    }
+
+    private static org.apache.avro.Schema unwrapUnion(org.apache.avro.Schema schema) {
+        if (schema.getType() == org.apache.avro.Schema.Type.UNION) {
+            for (org.apache.avro.Schema branch : schema.getTypes()) {
+                if (branch.getType() != org.apache.avro.Schema.Type.NULL) {
+                    return branch;
+                }
+            }
+        }
+        return schema;
     }
 
     @Test


### PR DESCRIPTION
## Summary

Backport of #7789 to `3.2.x`.

Fixes #7788 — Schema resolver GAV cache prevents registration of schemas with different content for the same artifact coordinates.
Fixes #3606 — `cycleReferences` keyed by schema name instead of schema identity causes schemas with different `connect.parameters` or `defaultValue` to be collapsed.

Both bugs together cause the Debezium regression reported in [debezium/debezium#6753](https://github.com/debezium/debezium/pull/6753) where schemas differing only in `connect.parameters` or field default values are not registered as new versions.

### Fix 1: GAV cache content cross-check (#7788)

- **`ERCache`**: Added `containsByArtifactCoordinatesMatchingContent()` that verifies the cached entry's content matches the incoming schema before returning a GAV cache hit
- **`DefaultSchemaResolver`**: Modified `getSchemaFromCache()` to pass the incoming `parsedSchema` and use the content-aware GAV check. When no parsed schema is available (e.g. `findLatest` path), falls back to the original GAV-only check

### Fix 2: cycleReferences keyed by Schema identity (#3606)

- **`AvroData`**: Changed `FromConnectContext.cycleReferences` map key from `String` (schema name) to `Schema` (full Connect schema identity including parameters and defaults)

## Test plan

- [x] `ERCacheTest.testGavCacheDoesNotShadowDifferentContent()` — GAV cache reproducer passes
- [x] `AvroDataTest.testCacheDistinguishesByParameters()` — AvroData cache reproducer passes
- [x] All 52 schema-resolver tests pass
- [x] Cherry-picks applied cleanly from main