### PR TITLE
fix(system): show actual storage variant in system info API

### DIFF
--- a/app/src/main/java/io/apicurio/registry/core/System.java
+++ b/app/src/main/java/io/apicurio/registry/core/System.java
@@ -25,6 +25,9 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import java.util.Locale;
+import java.util.Map;
+
 import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_SYSTEM;
 
 /**
@@ -32,6 +35,13 @@ import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_SYS
  */
 @ApplicationScoped
 public class System {
+
+    private static final Map<String, String> STORAGE_DISPLAY_NAMES = Map.of(
+            "sql", "SQL",
+            "kafkasql", "KafkaSQL",
+            "gitops", "GitOps",
+            "kubernetesops", "KubernetesOps"
+    );
 
     @Inject
     @ConfigProperty(name = "apicurio.app.name")
@@ -53,8 +63,17 @@ public class System {
     @Info(category = CATEGORY_SYSTEM, registryAvailableSince = "3.0.4")
     String date;
 
+    @Inject
+    @ConfigProperty(name = "apicurio.storage.kind")
+    String storageKind;
+
+    /**
+     * @return the application name, including the storage variant label
+     */
     public String getName() {
-        return name;
+        String displayName = STORAGE_DISPLAY_NAMES.getOrDefault(
+                storageKind.toLowerCase(Locale.ROOT), storageKind);
+        return name + " (" + displayName + ")";
     }
 
     public String getDescription() {

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -89,7 +89,7 @@ quarkus.index-dependency.jaxrs.artifact-id=jakarta.ws.rs-api
 
 # Application
 apicurio.app.id=apicurio-registry
-apicurio.app.name=Apicurio Registry (In Memory)
+apicurio.app.name=Apicurio Registry
 apicurio.app.description=High performance, runtime registry for schemas and API designs.
 apicurio.app.version=${project.version}
 apicurio.app.date=${timestamp}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceTest.java
@@ -14,7 +14,7 @@ public class SystemResourceTest extends AbstractResourceTestBase {
     @Test
     public void testSystemInformation() {
         given().when().contentType(CT_JSON).get("/registry/v3/system/info").then().statusCode(200)
-                .body("name", notNullValue())
+                .body("name", equalTo("Apicurio Registry (SQL)"))
                 .body("description",
                         equalTo("High performance, runtime registry for schemas and API designs."))
                 .body("version", notNullValue()).body("builtOn", notNullValue());

--- a/examples/sdk/go-sdk/README.md
+++ b/examples/sdk/go-sdk/README.md
@@ -21,7 +21,7 @@ bin/example
 Results in:
 
 ```
-Server name: Apicurio Registry (In Memory)
+Server name: Apicurio Registry (SQL)
 Server version: 3.0.6
 Created version 1 of artifact e98c1564-06a9-47fb-b551-ec4ec0cdf235
 ```

--- a/go-sdk/pkg/tests/client_test.go
+++ b/go-sdk/pkg/tests/client_test.go
@@ -90,7 +90,7 @@ func TestAccessSystemInfo(t *testing.T) {
 	info, err := client.System().Info().Get(context.Background(), nil)
 	assert.Nil(t, err)
 
-	assert.Equal(t, "Apicurio Registry (In Memory)", *info.GetName())
+	assert.Equal(t, "Apicurio Registry (SQL)", *info.GetName())
 }
 
 func TestCreateAnArtifact(t *testing.T) {

--- a/typescript-sdk/tests/system-info.test.ts
+++ b/typescript-sdk/tests/system-info.test.ts
@@ -6,5 +6,5 @@ test("System Info", async () => {
     const client = createTestClient();
     const info: SystemInfo | undefined = await client.system.info.get();
     expect(info).toBeDefined();
-    expect(info?.name).toBe("Apicurio Registry (In Memory)");
+    expect(info?.name).toBe("Apicurio Registry (SQL)");
 });


### PR DESCRIPTION
## Summary
- The system info endpoint (`/apis/registry/v2/system/info` and v3 equivalent) was hardcoded to
  return `"Apicurio Registry (In Memory)"` regardless of the configured storage backend
- Changed `System.getName()` to dynamically append the storage variant label (SQL, KafkaSQL,
  GitOps, KubernetesOps) based on the `apicurio.storage.kind` config property
- Updated the default `apicurio.app.name` from `Apicurio Registry (In Memory)` to
  `Apicurio Registry` and updated SDK tests and docs to expect the new format

## Related Issue
Fixes #7791

## Test Plan
- [ ] Run `SystemResourceTest` to verify the v3 system info endpoint returns `"Apicurio Registry (SQL)"`
- [ ] Start with `./mvnw quarkus:dev` and verify `curl http://localhost:8080/apis/registry/v3/system/info`
  returns `"name":"Apicurio Registry (SQL)"`
- [ ] Verify v2 endpoint also returns the correct name
- [ ] Confirm that overriding `apicurio.app.name` still works (e.g. setting it to "My Registry"
  should produce "My Registry (SQL)")