### PR TITLE
fix(kafkasql): bound journal verification and snapshot consumption loops to prevent startup hang (#7795)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -227,10 +227,20 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         Collection<String> topics = Collections.singleton(configuration.getSnapshotsTopic());
         snapshotsConsumer.subscribe(topics);
 
+        // Wait for partition assignment
+        var assigned = snapshotsConsumer.assignment();
+        while (assigned.isEmpty()) {
+            snapshotsConsumer.poll(configuration.getPollTimeout());
+            assigned = snapshotsConsumer.assignment();
+        }
+
+        // Record the current end offsets so we stop there, even if other pods produce new snapshots
+        var endOffsets = snapshotsConsumer.endOffsets(assigned);
+
         List<ConsumerRecord<String, String>> snapshots = new ArrayList<>();
         String snapshotRecordKey = null;
 
-        // Poll in a loop until we get an empty result, indicating we've reached the end of the topic
+        // Poll until we reach the original end offsets or get an empty result
         ConsumerRecords<String, String> records;
         do {
             records = snapshotsConsumer.poll(configuration.getPollTimeout());
@@ -238,7 +248,9 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
                 records.forEach(snapshots::add);
                 log.debug("Polled {} snapshot records, total collected: {}", records.count(), snapshots.size());
             }
-        } while (records != null && !records.isEmpty());
+        } while (records != null && !records.isEmpty()
+                && endOffsets.entrySet().stream()
+                        .anyMatch(e -> snapshotsConsumer.position(e.getKey()) < e.getValue()));
 
         if (!snapshots.isEmpty()) {
             log.info("Found {} total snapshots in the snapshots topic.", snapshots.size());
@@ -374,7 +386,7 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         // If the key is a Bootstrap key, then we have processed all messages and can set bootstrapped to
         // 'true'
         if (BOOTSTRAP_MESSAGE_TYPE.equals(record.key().getMessageType())) {
-            KafkaSqlMessageKey bkey = (KafkaSqlMessageKey) record.key();
+            KafkaSqlMessageKey bkey = record.key();
             if (bkey.getUuid().equals(bootstrapId)) {
                 this.bootstrapped = true;
                 storageEvent.fireAsync(StorageEvent.builder().type(StorageEventType.READY).build());

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import static io.apicurio.registry.utils.ConcurrentUtil.blockOnResult;
+
 @ApplicationScoped
 @Logged
 @LookupIfProperty(name = "apicurio.storage.kind", stringValue = "kafkasql")
@@ -78,10 +80,15 @@ public class KafkaSqlSubmitter {
         return producer.get().apply(record).thenApply(rm -> requestId);
     }
 
+    /**
+     * Submits a bootstrap marker message and blocks until it is durably written to Kafka.
+     *
+     * @param bootstrapId unique identifier for this bootstrap sequence
+     */
     public void submitBootstrap(String bootstrapId) {
         KafkaSqlMessageKey key = KafkaSqlMessageKey.builder().messageType(BOOTSTRAP_MESSAGE_TYPE).uuid(bootstrapId)
                 .build();
-        send(key, null);
+        blockOnResult(send(key, null));
     }
 
     public CompletableFuture<UUID> submitMessage(KafkaSqlMessage message) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
@@ -181,6 +181,18 @@ public class KafkaAdminUtil {
         }
     }
 
+    /**
+     * Scans recent messages in the KafkaSQL journal topic to detect incompatible content
+     * (e.g. Apicurio Registry v2 records mixed with v3 records). A temporary consumer seeks
+     * to the last {@code MAX_MESSAGE_COUNT} messages, inspects their headers and keys, and
+     * reports or fails fast depending on what it finds.
+     *
+     * <p>The scan is bounded by the end offsets captured before polling begins, so messages
+     * produced by other pods while this method runs are ignored.
+     *
+     * @throws RuntimeAssertionFailedException if the topic contains only v2 records, indicating
+     *         the topic was not properly migrated
+     */
     public void verifyJournalTopicContents() {
 
         var verificationConsumerResource = verificationConsumer.get();
@@ -217,7 +229,7 @@ public class KafkaAdminUtil {
                 boolean foundV3WithHeaders = false;
                 boolean foundUnknownWithHeaders = false;
 
-                while (true) { // We process a limited number of messages, so this will terminate.
+                while (true) {
                     var records = consumer.poll(configuration.get().getPollTimeout());
                     if (records.isEmpty()) {
                         break;
@@ -272,6 +284,18 @@ public class KafkaAdminUtil {
                         } catch (Exception e) {
                             // Ignore
                         }
+                    }
+                    // Stop once we've consumed past the original end offsets — don't chase
+                    // new messages produced by other pods while we're verifying.
+                    boolean allCaughtUp = true;
+                    for (var entry : endOffsets.entrySet()) {
+                        if (consumer.position(entry.getKey()) < entry.getValue()) {
+                            allCaughtUp = false;
+                            break;
+                        }
+                    }
+                    if (allCaughtUp) {
+                        break;
                     }
                 }
 

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
@@ -1,0 +1,172 @@
+package io.apicurio.registry.storage.impl.kafkasql;
+
+import io.apicurio.registry.storage.impl.kafkasql.KafkaSqlFactory.KafkaSqlVerificationJournalConsumer;
+import io.apicurio.registry.storage.impl.util.KafkaAdminUtil;
+import jakarta.enterprise.inject.Instance;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class KafkaAdminUtilTest {
+
+    private static final String TEST_TOPIC = "test-journal-topic";
+    private static final TopicPartition TP0 = new TopicPartition(TEST_TOPIC, 0);
+
+    private KafkaAdminUtil kafkaAdminUtil;
+    private KafkaConsumer<Bytes, Bytes> consumer;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() throws Exception {
+        consumer = mock(KafkaConsumer.class);
+
+        KafkaSqlVerificationJournalConsumer verificationResource =
+                new KafkaSqlVerificationJournalConsumer(() -> consumer);
+
+        Instance<KafkaSqlVerificationJournalConsumer> verificationInstance = mock(Instance.class);
+        when(verificationInstance.get()).thenReturn(verificationResource);
+
+        KafkaSqlConfiguration config = mock(KafkaSqlConfiguration.class);
+        when(config.getPollTimeout()).thenReturn(Duration.ofMillis(100));
+        when(config.getTopic()).thenReturn(TEST_TOPIC);
+
+        Instance<KafkaSqlConfiguration> configInstance = mock(Instance.class);
+        when(configInstance.get()).thenReturn(config);
+
+        kafkaAdminUtil = new KafkaAdminUtil();
+        setField("log", LoggerFactory.getLogger(KafkaAdminUtil.class));
+        setField("verificationConsumer", verificationInstance);
+        setField("configuration", configInstance);
+    }
+
+    /**
+     * Verifies that the verification loop terminates even when the topic keeps receiving new
+     * messages from other pods. Without the end-offset bound, the while(true) loop would poll
+     * indefinitely because records.isEmpty() is never true.
+     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void testVerifyTerminatesWithConcurrentProducers() {
+        long endOffset = 10L;
+
+        // Partition assignment: empty on first call, then assigned
+        when(consumer.assignment())
+                .thenReturn(Collections.emptySet())
+                .thenReturn(Set.of(TP0));
+
+        when(consumer.endOffsets(Set.of(TP0)))
+                .thenReturn(Map.of(TP0, endOffset));
+
+        // Poll sequence:
+        //   1st: empty (triggers partition assignment)
+        //   2nd: 10 records (offsets 0-9, reaches endOffset)
+        //   3rd: would return more records from concurrent producers — should NOT be reached
+        when(consumer.poll(any(Duration.class)))
+                .thenReturn(ConsumerRecords.empty())
+                .thenReturn(createRecords(0, 10))
+                .thenThrow(new AssertionError("Poll called beyond original end offset"));
+
+        // After consuming the first batch, position equals the original end offset
+        when(consumer.position(TP0)).thenReturn(endOffset);
+
+        kafkaAdminUtil.verifyJournalTopicContents();
+
+        // 2 polls: one during assignment wait, one in the verification loop
+        verify(consumer, times(2)).poll(any(Duration.class));
+    }
+
+    /**
+     * Verifies that the loop still terminates via empty poll when there are no concurrent
+     * producers (the original behavior is preserved).
+     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void testVerifyTerminatesOnEmptyPoll() {
+        long endOffset = 5L;
+
+        when(consumer.assignment())
+                .thenReturn(Collections.emptySet())
+                .thenReturn(Set.of(TP0));
+
+        when(consumer.endOffsets(Set.of(TP0)))
+                .thenReturn(Map.of(TP0, endOffset));
+
+        // Poll: assignment poll, then records, then empty (no concurrent producers)
+        when(consumer.poll(any(Duration.class)))
+                .thenReturn(ConsumerRecords.empty())
+                .thenReturn(createRecords(0, 5))
+                .thenReturn(ConsumerRecords.empty());
+
+        // Position hasn't quite reached endOffset, but the next poll is empty so the loop
+        // breaks via the isEmpty() check before reaching the position check.
+        when(consumer.position(TP0)).thenReturn(3L);
+
+        kafkaAdminUtil.verifyJournalTopicContents();
+
+        // 3 polls: assignment, records, empty
+        verify(consumer, times(3)).poll(any(Duration.class));
+    }
+
+    /**
+     * Verifies that on an empty topic (endOffset == 0), the loop terminates immediately.
+     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void testVerifyTerminatesOnEmptyTopic() {
+        when(consumer.assignment())
+                .thenReturn(Collections.emptySet())
+                .thenReturn(Set.of(TP0));
+
+        when(consumer.endOffsets(Set.of(TP0)))
+                .thenReturn(Map.of(TP0, 0L));
+
+        when(consumer.poll(any(Duration.class)))
+                .thenReturn(ConsumerRecords.empty());
+
+        when(consumer.position(TP0)).thenReturn(0L);
+
+        kafkaAdminUtil.verifyJournalTopicContents();
+
+        // 2 polls: assignment + one empty poll in the loop
+        verify(consumer, times(2)).poll(any(Duration.class));
+    }
+
+    private ConsumerRecords<Bytes, Bytes> createRecords(long startOffset, int count) {
+        List<ConsumerRecord<Bytes, Bytes>> records = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            records.add(new ConsumerRecord<>(
+                    TEST_TOPIC, 0, startOffset + i,
+                    new Bytes(new byte[]{1}), new Bytes(new byte[]{2})));
+        }
+        return new ConsumerRecords<>(Map.of(TP0, records));
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        Field field = KafkaAdminUtil.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(kafkaAdminUtil, value);
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
@@ -8,7 +8,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -24,7 +23,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
## Summary

- **Bound the `verifyJournalTopicContents()` loop by end offset**: The `while(true)` loop in
  `KafkaAdminUtil` previously relied solely on an empty poll to terminate. If other pods were
  producing messages to the journal topic, the 5-second poll could continuously return records,
  blocking initialization indefinitely. The loop now records the end offsets before polling and
  breaks once the consumer position reaches them.
- **Make `submitBootstrap()` synchronous**: The bootstrap marker message was sent
  asynchronously (fire-and-forget). If the send failed silently, the consumer would never find
  its bootstrap marker. It now blocks until the message is durably written via `blockOnResult()`.
- **Harden `consumeSnapshotsTopic()` with end-offset bounding**: Applied the same end-offset
  bounding pattern to the snapshots topic consumer loop for robustness.

## Related Issue

Fixes #7795

## Test Plan

- [ ] New unit tests in `KafkaAdminUtilTest` verify the verification loop terminates even when
  the consumer keeps returning records beyond the original end offset
- [ ] Existing KafkaSQL tests (`KafkaSqlRegistryStorageTest`, `KafkaSqlSnapshotTest`) continue
  to pass — bootstrap in isolation is unaffected
- [ ] Manual verification: deploy multi-pod KafkaSQL cluster, scale up while other pods are
  running, confirm the new pod completes bootstrap