### PR TITLE
fix(deps): update protobuf-maven-plugin to 5.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
     <apicurio-maven-plugin.version>0.0.8</apicurio-maven-plugin.version>
 
     <!-- Protocol Buffers -->
-    <proto-plugin.version>5.1.2</proto-plugin.version>
+    <proto-plugin.version>5.1.3</proto-plugin.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
 
     <!-- Flink -->


### PR DESCRIPTION
## Summary
- Update `io.github.ascopes:protobuf-maven-plugin` from 5.1.2 to 5.1.3

## Context
This dependency upgrade was split from Renovate PR #7804 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected