### PR TITLE
fix(deps): update lombok to 1.18.46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
     <swagger-parser-v3.version>2.1.39</swagger-parser-v3.version>
 
     <!-- Dependency versions -->
-    <lombok.version>1.18.44</lombok.version>
+    <lombok.version>1.18.46</lombok.version>
     <commons-codec.version>1.21.0</commons-codec.version>
     <netty.version>4.1.132.Final</netty.version>
     <kafka-clients.version>3.9.2</kafka-clients.version>


### PR DESCRIPTION
## Summary
- Update `org.projectlombok:lombok` from 1.18.44 to 1.18.46

## Context
This dependency upgrade was split from Renovate PR #7804 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected