### PR TITLE
fix(deps): update jsoup to 1.22.2

### DIFF
--- a/support-chat/pom.xml
+++ b/support-chat/pom.xml
@@ -18,7 +18,7 @@
         <quarkus.version>3.27.2</quarkus.version>
         <quarkus-langchain4j.version>1.8.4</quarkus-langchain4j.version>
         <apicurio-registry-sdk.version>3.2.1</apicurio-registry-sdk.version>
-        <jsoup.version>1.22.1</jsoup.version>
+        <jsoup.version>1.22.2</jsoup.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary
- Update `org.jsoup:jsoup` from 1.22.1 to 1.22.2

## Context
This dependency upgrade was split from Renovate PR #7804 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected