### PR TITLE
fix(deps): update json-sKema to 0.30.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
 
     <!-- JSON Schema Validator -->
     <org.everit.json.schema.version>1.14.6</org.everit.json.schema.version>
-    <json-sKema.version>0.29.0</json-sKema.version>
+    <json-sKema.version>0.30.0</json-sKema.version>
     <!-- TODO unification -->
     <org.json.version>20250107</org.json.version>
     <jackson-datatype-json-org.version>2.18.2</jackson-datatype-json-org.version>


### PR DESCRIPTION
## Summary
- Update `com.github.erosb:json-sKema` from 0.29.0 to 0.30.0

## Context
This dependency upgrade was split from Renovate PR #7804 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected