### PR TITLE
fix(deps): update swagger-parser-v3 to 2.1.40

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
     <!-- OpenAPI -->
     <openapi-diff.version>2.1.7</openapi-diff.version>
     <!-- We need to manually include the version because of dependency issues with snakeyaml -->
-    <swagger-parser-v3.version>2.1.39</swagger-parser-v3.version>
+    <swagger-parser-v3.version>2.1.40</swagger-parser-v3.version>
 
     <!-- Dependency versions -->
     <lombok.version>1.18.46</lombok.version>


### PR DESCRIPTION
## Summary
- Update `io.swagger.parser.v3:swagger-parser-v3` from 2.1.39 to 2.1.40

## Context
This dependency upgrade was split from Renovate PR #7804 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected