### PR TITLE
fix(deps): update quarkus-langchain4j to 1.9.1

### DIFF
--- a/support-chat/pom.xml
+++ b/support-chat/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <quarkus.version>3.27.2</quarkus.version>
-        <quarkus-langchain4j.version>1.8.4</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.9.1</quarkus-langchain4j.version>
         <apicurio-registry-sdk.version>3.2.1</apicurio-registry-sdk.version>
         <jsoup.version>1.22.2</jsoup.version>
     </properties>


### PR DESCRIPTION
## Summary
- Update `io.quarkiverse.langchain4j:quarkus-langchain4j-easy-rag` and `quarkus-langchain4j-ai-gemini` from 1.8.4 to 1.9.1

## Context
This dependency upgrade was split from Renovate PR #7804 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected