### PR TITLE
fix(deps): update proto-google-common-protos to 2.70.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <icu4j.version>76.1</icu4j.version>
     <protobuf.version>4.34.1</protobuf.version>
     <xmlsec.version>4.0.4</xmlsec.version>
-    <protobuf.googleapi.types.version>2.68.0</protobuf.googleapi.types.version>
+    <protobuf.googleapi.types.version>2.70.0</protobuf.googleapi.types.version>
     <wsdl4j.version>1.6.3</wsdl4j.version>
     <google.truth.extension.version>1.4.5</google.truth.extension.version>
 


### PR DESCRIPTION
## Summary
- Update `com.google.api.grpc:proto-google-common-protos` from 2.68.0 to 2.70.0

## Context
This dependency upgrade was split from Renovate PR #7804 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected