### PR TITLE
POC: per-resource authorization using Kroxylicious Authorizer

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -149,6 +149,30 @@
       <artifactId>quarkus-jdbc-mssql</artifactId>
     </dependency>
 
+    <!-- Kroxylicious Authorizer -->
+    <dependency>
+      <groupId>io.kroxylicious</groupId>
+      <artifactId>kroxylicious-authorizer-api</artifactId>
+      <version>0.20.0-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.kroxylicious</groupId>
+      <artifactId>kroxylicious-authorizer-acl</artifactId>
+      <version>0.20.0-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- Third Party Libraries -->
     <dependency>
       <groupId>io.roastedroot</groupId>

--- a/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
@@ -1,5 +1,7 @@
 package io.apicurio.registry.auth;
 
+import io.apicurio.registry.auth.resourcebased.ResourceBasedAccessController;
+import io.apicurio.registry.auth.resourcebased.ResourceBasedAccessControllerConfig;
 import io.apicurio.registry.util.Priorities;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.UnauthorizedException;
@@ -44,6 +46,12 @@ public class AuthorizedInterceptor {
 
     @Inject
     OwnerBasedAccessController obac;
+
+    @Inject
+    ResourceBasedAccessController resourceAc;
+
+    @Inject
+    ResourceBasedAccessControllerConfig resourceAcConfig;
 
     @AroundInvoke
     public Object authorizeMethod(InvocationContext context) throws Exception {
@@ -148,6 +156,13 @@ public class AuthorizedInterceptor {
                 throw new ForbiddenException("User " + securityIdentity.getPrincipal().getName()
                         + " is not authorized to perform the requested operation.");
             }
+        }
+
+        // If resource-based authorization is enabled, apply per-resource ACL rules
+        if (resourceAcConfig.isEnabled() && !resourceAc.isAuthorized(context)) {
+            log.warn("Resource-based authorization denied access.");
+            throw new ForbiddenException("User " + securityIdentity.getPrincipal().getName()
+                    + " is not authorized to access the requested resource.");
         }
 
         return context.proceed();

--- a/app/src/main/java/io/apicurio/registry/auth/resourcebased/README.md
+++ b/app/src/main/java/io/apicurio/registry/auth/resourcebased/README.md
@@ -1,0 +1,99 @@
+# POC: Per-Resource Authorization with Kroxylicious Authorizer
+
+Proof of concept integrating the [Kroxylicious Authorizer framework](https://github.com/kroxylicious/kroxylicious/tree/main/kroxylicious-authorizer-providers) into Apicurio Registry for fine-grained, per-resource access control.
+
+## What this demonstrates
+
+1. **Kroxylicious Authorizer works with Registry without Kafka on the classpath.** The `kafka-clients` dependency is excluded via Maven `<exclusion>` — the authorizer API (`Subject`, `Principal`, `Authorizer`, `ResourceType`, `Action`) has no runtime dependency on Kafka.
+
+2. **Registry-specific resource types map naturally to the Kroxylicious model.** Two enums — `RegistryArtifact` and `RegistryGroup` — implement `ResourceType` with an `implies()` hierarchy (`Admin` → `Write` → `Read`).
+
+3. **The ACL rules language works with custom resource types.** Admin-friendly rules like:
+   ```
+   allow User with name = "alice" to {Read, Write} RegistryArtifact with name like "team-a/*";
+   ```
+
+4. **Batched authorization enables search result filtering.** The `Authorizer.authorize(subject, List<Action>)` API and `AuthorizeResult.partition()` method are exactly what's needed to filter list/search results per-resource in a single call.
+
+5. **Integration with the existing auth framework is clean.** `ResourceBasedAccessController` implements `IAccessController`, is wired into `AuthorizedInterceptor` after RBAC/OBAC, and is gated by a config flag.
+
+## Architecture
+
+```
+REST request
+  → AuthorizedInterceptor
+    → Admin override check
+    → RBAC check (RoleBasedAccessController)
+    → OBAC check (OwnerBasedAccessController)
+    → Resource-based check (ResourceBasedAccessController)  ← NEW
+      → Builds Kroxylicious Subject from SecurityIdentity
+      → Builds Action from @Authorized annotation (style + level)
+      → Calls Authorizer.authorize(subject, actions)
+      → ALLOW or DENY
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `RegistryArtifact.java` | Resource type enum for artifacts (Read, Write, Admin) |
+| `RegistryGroup.java` | Resource type enum for groups (Read, Write, Admin) |
+| `ResourceBasedAccessController.java` | `IAccessController` implementation bridging to Kroxylicious `Authorizer` |
+| `ResourceBasedAccessControllerConfig.java` | Config properties for enabling and configuring resource-based auth |
+| `ResourceBasedAccessControllerInitializer.java` | Startup bean that loads ACL rules and initializes the authorizer |
+| `AuthorizedInterceptor.java` | Modified to add resource-based check after RBAC/OBAC |
+| `test-acl-rules.acl` | Example ACL rules file used by tests |
+| `ResourceBasedAccessControllerTest.java` | 14 tests covering all scenarios |
+
+## Configuration
+
+```properties
+# Enable resource-based authorization (default: false)
+apicurio.auth.resource-based-authorization.enabled=true
+
+# Path to ACL rules file
+apicurio.auth.resource-based-authorization.acl.file=/path/to/rules.acl
+```
+
+## ACL Rules File Format
+
+Uses the Kroxylicious ACL rules language. Registry resource types must be imported:
+
+```
+from io.apicurio.registry.auth.resourcebased import RegistryArtifact;
+from io.apicurio.registry.auth.resourcebased import RegistryGroup;
+
+// Team-based artifact access
+allow User with name = "alice" to {Read, Write} RegistryArtifact with name like "team-a/*";
+allow User with name = "bob" to Read RegistryArtifact with name like "*";
+
+// Group management
+allow User with name = "alice" to {Read, Write} RegistryGroup with name = "team-a";
+
+// Admin access
+allow User with name = "admin" to {Read, Write, Admin} RegistryArtifact with name like "*";
+
+otherwise deny;
+```
+
+Resource names follow the pattern `{groupId}/{artifactId}` for artifacts and `{groupId}` for groups.
+
+## Running the tests
+
+```bash
+mvn test -pl app -Dtest=ResourceBasedAccessControllerTest -Dcheckstyle.skip=true
+```
+
+## Key findings
+
+- **Kafka exclusion works.** No runtime issues with `kafka-clients` excluded.
+- **`AclAuthorizer.builder()` is package-private.** External consumers must use the file-based `AclAuthorizerService` API. Worth raising with the Kroxylicious team — making the builder public would enable programmatic rule construction.
+- **`AuthorizeResult.partition()` is a perfect fit for search filtering.** Pass a list of search results and get back allowed/denied partitions in one call.
+- **The `implies()` mechanism works.** Granting `Admin` automatically grants `Write` and `Read`.
+
+## What's next
+
+- Validate with a full `@QuarkusTest` using Keycloak for authentication + ACL rules for authorization
+- Discuss with Kroxylicious team about publishing authorizer artifacts independently
+- Add search/list result filtering using batched `authorize()` calls
+- Consider role-based principals (not just `User`) for RBAC+ACL hybrid

--- a/app/src/main/java/io/apicurio/registry/auth/resourcebased/README.md
+++ b/app/src/main/java/io/apicurio/registry/auth/resourcebased/README.md
@@ -148,6 +148,32 @@ There is no runtime API, no UI, and no audit trail of policy changes. For enviro
 - **Management REST API.** Add endpoints for CRUD operations on ACL rules, stored in Registry's own database. Rules loaded from DB at startup and cached in-memory. Provides an audit trail and could be exposed in the UI. This is probably the right middle ground for a production feature.
 - **Registry as policy registry.** Store authorization policies as versioned artifacts in Registry itself (similar to how schemas are managed). Most powerful and most consistent with Registry's identity, but the largest scope — and raises a chicken-and-egg question (the policies that protect Registry are stored in Registry).
 
+## Alternative: OPA policies via WASM (opa-java-wasm)
+
+An alternative to the Kroxylicious Authorizer is evaluating [OPA](https://www.openpolicyagent.org/) policies in-process using [opa-java-wasm](https://github.com/StyraOSS/opa-java-wasm), which compiles Rego policies to WebAssembly and runs them in the JVM via Chicory (a pure-Java WASM runtime). Andrea has already built a prototype of this for Apicurio.
+
+### Why this may be a better fit
+
+- **No dependency concerns.** Dependencies are Chicory + Jackson — no Kafka, no transitive entanglement risk.
+- **Industry standard.** OPA/Rego is widely adopted. Many organizations already run OPA infrastructure, have Rego expertise, and use tooling like Styra DAS, bundle servers, `conftest`, and the Rego playground.
+- **More expressive.** Rego can model RBAC, ABAC, relationship-based, attribute-based, and time-based policies — not just ACL-style name matching.
+- **Better policy management story.** OPA has a mature distribution model with bundle servers and hot-reload built in, partially addressing the static-file limitation above.
+- **Data-driven approach.** Ship a generic Rego policy with Registry; admins only manage a JSON/YAML permissions file (who can access what). No Rego knowledge or WASM compilation needed for day-to-day policy changes.
+- **Internal knowledge.** Andrea has already built the opa-java-wasm integration for Apicurio.
+
+### What you lose vs Kroxylicious
+
+- No built-in `ResourceType` enum model, batched `authorize()`, or `AuthorizeResult.partition()` — you build the integration layer yourself (straightforward, but more custom code).
+- No typed framework — policy input/output is JSON, not a Java type system.
+
+### Long-term: Registry as a policy registry
+
+With the OPA approach, a natural evolution is to store OPA policies as versioned artifacts in Registry itself (a new artifact type for Rego source or compiled WASM bundles). Registry could expose an OPA Bundle API-compatible endpoint, and the in-process evaluator pulls policy updates automatically. Admin UX becomes: upload a new policy version through the Registry API or UI, same workflow as pushing a schema. This is significant scope, but aligns with Registry's identity as a versioned artifact store.
+
+### Conclusion
+
+This POC validated the authorization *model* (resource types, per-resource checks in the interceptor, search result filtering). The *engine* underneath could be Kroxylicious ACL, OPA WASM, or something else — the `ResourceBasedAccessController` integration point is the same regardless of which evaluator sits behind it.
+
 ## What's next
 
 - Validate with a full `@QuarkusTest` using Keycloak for authentication + ACL rules for authorization

--- a/app/src/main/java/io/apicurio/registry/auth/resourcebased/README.md
+++ b/app/src/main/java/io/apicurio/registry/auth/resourcebased/README.md
@@ -132,6 +132,22 @@ mvn test -pl app -Dtest=ResourceBasedAccessControllerTest -Dcheckstyle.skip=true
 - **`AuthorizeResult.partition()` is a perfect fit for search filtering.** Pass a list of search results and get back allowed/denied partitions in one call.
 - **The `implies()` mechanism works.** Granting `Admin` automatically grants `Write` and `Read`.
 
+## Known limitation: policy management
+
+The biggest operational caveat of this POC is policy lifecycle management. ACL rules live in a static file, so any change (adding a user, removing access, onboarding a new team) requires:
+
+1. Editing the rules file
+2. Updating the ConfigMap or volume mount (in Kubernetes)
+3. Restarting the pod — or waiting for mount propagation if hot-reload is implemented
+
+There is no runtime API, no UI, and no audit trail of policy changes. For environments where users and teams change frequently, this is a non-starter.
+
+### Options to address this (roughly ordered by effort)
+
+- **Hot-reload on file change.** Watch the rules file for modifications and re-parse automatically. Avoids pod restarts but still requires ConfigMap updates and provides no management interface.
+- **Management REST API.** Add endpoints for CRUD operations on ACL rules, stored in Registry's own database. Rules loaded from DB at startup and cached in-memory. Provides an audit trail and could be exposed in the UI. This is probably the right middle ground for a production feature.
+- **Registry as policy registry.** Store authorization policies as versioned artifacts in Registry itself (similar to how schemas are managed). Most powerful and most consistent with Registry's identity, but the largest scope — and raises a chicken-and-egg question (the policies that protect Registry are stored in Registry).
+
 ## What's next
 
 - Validate with a full `@QuarkusTest` using Keycloak for authentication + ACL rules for authorization

--- a/app/src/main/java/io/apicurio/registry/auth/resourcebased/README.md
+++ b/app/src/main/java/io/apicurio/registry/auth/resourcebased/README.md
@@ -150,15 +150,17 @@ There is no runtime API, no UI, and no audit trail of policy changes. For enviro
 
 ## Alternative: OPA policies via WASM (opa-java-wasm)
 
-An alternative to the Kroxylicious Authorizer is evaluating [OPA](https://www.openpolicyagent.org/) policies in-process using [opa-java-wasm](https://github.com/StyraOSS/opa-java-wasm), which compiles Rego policies to WebAssembly and runs them in the JVM via Chicory (a pure-Java WASM runtime). Andrea has already built a prototype of this for Apicurio.
+A separate POC branch implements the same authorization model using [opa-java-wasm](https://github.com/StyraOSS/opa-java-wasm) instead of the Kroxylicious Authorizer: **[PR #7829](https://github.com/Apicurio/apicurio-registry/pull/7829)** (`issue-7724-opa-wasm` branch).
+
+This evaluates OPA policies compiled to WebAssembly in-process via Chicory (a pure-Java WASM runtime). Andrea has already built a prototype of this for Apicurio.
 
 ### Why this may be a better fit
 
 - **No dependency concerns.** Dependencies are Chicory + Jackson — no Kafka, no transitive entanglement risk.
 - **Industry standard.** OPA/Rego is widely adopted. Many organizations already run OPA infrastructure, have Rego expertise, and use tooling like Styra DAS, bundle servers, `conftest`, and the Rego playground.
 - **More expressive.** Rego can model RBAC, ABAC, relationship-based, attribute-based, and time-based policies — not just ACL-style name matching.
-- **Better policy management story.** OPA has a mature distribution model with bundle servers and hot-reload built in, partially addressing the static-file limitation above.
 - **Data-driven approach.** Ship a generic Rego policy with Registry; admins only manage a JSON/YAML permissions file (who can access what). No Rego knowledge or WASM compilation needed for day-to-day policy changes.
+- **Better policy management story.** OPA has a mature distribution model with bundle servers and hot-reload built in, partially addressing the static-file limitation above.
 - **Internal knowledge.** Andrea has already built the opa-java-wasm integration for Apicurio.
 
 ### What you lose vs Kroxylicious
@@ -170,9 +172,33 @@ An alternative to the Kroxylicious Authorizer is evaluating [OPA](https://www.op
 
 With the OPA approach, a natural evolution is to store OPA policies as versioned artifacts in Registry itself (a new artifact type for Rego source or compiled WASM bundles). Registry could expose an OPA Bundle API-compatible endpoint, and the in-process evaluator pulls policy updates automatically. Admin UX becomes: upload a new policy version through the Registry API or UI, same workflow as pushing a schema. This is significant scope, but aligns with Registry's identity as a versioned artifact store.
 
-### Conclusion
+## Alternative: Keycloak Authorization Services
 
-This POC validated the authorization *model* (resource types, per-resource checks in the interceptor, search result filtering). The *engine* underneath could be Kroxylicious ACL, OPA WASM, or something else — the `ResourceBasedAccessController` integration point is the same regardless of which evaluator sits behind it.
+Keycloak's built-in Authorization Services (UMA 2.0) is a natural candidate since many Registry deployments already use Keycloak for authentication.
+
+### What it offers
+
+- **Rich permission model.** Resources, scopes, policies (role-based, user-based, time-based, JavaScript-based, aggregated), and permission evaluation — all managed via the Keycloak Admin Console UI.
+- **Good admin UX.** Permissions are managed through Keycloak's UI, not config files. Non-developers can grant and revoke access without touching code or deployment artifacts.
+- **Already in the ecosystem.** Many Registry deployments already use Keycloak. Adding authorization would be a natural extension with no new infrastructure to deploy.
+- **Token-based evaluation.** The RPT (Requesting Party Token) flow lets the client request permissions for specific resources, and Keycloak returns what's allowed in the token itself — reducing per-request authorization calls.
+- **Standard protocol.** UMA 2.0 is an established standard, not a custom framework.
+
+### Why it's problematic for Registry
+
+- **Resource lifecycle synchronization.** Every artifact in Registry needs a corresponding "resource" registered in Keycloak. Create artifact → create Keycloak resource. Delete artifact → delete Keycloak resource. This synchronization is an ongoing operational burden — if it drifts, authorization breaks silently. With thousands of artifacts changing frequently, keeping the two systems in sync is fragile.
+- **Scale concern.** Keycloak's resource server has to manage a resource per artifact. The Protection API isn't designed for bulk "list all resources user X can access" queries, which is what search/list filtering requires. Filtering a search result page would mean querying Keycloak for permissions on every result — the API wasn't designed for this pattern.
+- **Tight coupling to Keycloak.** Locks out teams using other IdPs (Azure AD, Okta, Auth0). The whole point of the authorization design is to be pluggable. Building on Keycloak Authorization Services means users who authenticate with other providers can't use per-resource authorization at all.
+- **Network latency.** Every authorization check requires a call to Keycloak (unless RPTs are cached). For search result filtering, that's N calls per page. Even with caching, the invalidation problem is hard — how does Registry know when a permission changed in Keycloak?
+- **Complexity.** UMA 2.0 is a complex protocol. Debugging permission denials through Keycloak's evaluation chain (policies → permissions → scopes → resources) is non-trivial, especially for administrators unfamiliar with UMA concepts.
+
+### Verdict
+
+Keycloak Authorization Services could work as one **implementation** behind a pluggable authorization SPI — for teams that are already deep in the Keycloak ecosystem and accept the resource synchronization overhead. But it should not be the only option, and the sync problem makes it unsuitable as the default or primary approach.
+
+## Conclusion
+
+This POC validated the authorization *model* (resource types, per-resource checks in the interceptor, search result filtering). The *engine* underneath could be Kroxylicious ACL, OPA WASM, Keycloak, or something else — the `ResourceBasedAccessController` integration point is the same regardless of which evaluator sits behind it.
 
 ## What's next
 

--- a/app/src/main/java/io/apicurio/registry/auth/resourcebased/README.md
+++ b/app/src/main/java/io/apicurio/registry/auth/resourcebased/README.md
@@ -78,6 +78,47 @@ otherwise deny;
 
 Resource names follow the pattern `{groupId}/{artifactId}` for artifacts and `{groupId}` for groups.
 
+## Authentication: where do users come from?
+
+Authentication and authorization are separate concerns in this design. Authentication is handled entirely by Registry's existing mechanisms — the resource-based authorization layer only consumes the authenticated principal name.
+
+### Supported authentication mechanisms
+
+All of Registry's existing authentication options work unchanged:
+
+- **OIDC/OAuth2** (Keycloak, Azure AD, Okta, Auth0, etc.) — `quarkus.oidc.tenant-enabled=true`
+- **HTTP Basic Auth** — `quarkus.http.auth.basic=true` with a properties file or basic-client-credentials exchanged against the OIDC server
+- **Proxy headers** — `apicurio.authn.proxy-header.enabled=true` (e.g., behind Envoy, Nginx, or any auth proxy that sets `X-Forwarded-User`)
+
+### How authentication feeds into authorization
+
+The Quarkus `SecurityIdentity` provides the authenticated principal name. The `ResourceBasedAccessController` uses it to build a Kroxylicious `Subject`:
+
+```java
+Subject subject = new Subject(new User(securityIdentity.getPrincipal().getName()));
+```
+
+The `User` principal in the ACL rules matches against this name. For example, a user authenticates via Keycloak and gets principal `alice`. The rule `allow User with name = "alice" to Read RegistryArtifact with name like "team-a/*"` then grants access. The two layers are fully independent — you can swap authentication providers without changing authorization rules.
+
+### Future: role-based principals
+
+The Kroxylicious `Subject` model supports multiple principals beyond `User`. A future enhancement could populate the `Subject` with additional principals extracted from JWT claims or IdP groups:
+
+```java
+Subject subject = new Subject(Set.of(
+    new User("alice"),
+    new RolePrincipal("team-a-developer")
+));
+```
+
+This would enable rules based on roles or groups rather than individual usernames:
+
+```
+allow RolePrincipal with name = "team-a-developer" to {Read, Write} RegistryArtifact with name like "team-a/*";
+```
+
+This is not implemented in the POC but the framework supports it natively.
+
 ## Running the tests
 
 ```bash

--- a/app/src/main/java/io/apicurio/registry/auth/resourcebased/RegistryArtifact.java
+++ b/app/src/main/java/io/apicurio/registry/auth/resourcebased/RegistryArtifact.java
@@ -1,0 +1,21 @@
+package io.apicurio.registry.auth.resourcebased;
+
+import java.util.Set;
+
+import io.kroxylicious.authorizer.service.ResourceType;
+
+public enum RegistryArtifact implements ResourceType<RegistryArtifact> {
+
+    Read,
+    Write,
+    Admin;
+
+    @Override
+    public Set<RegistryArtifact> implies() {
+        return switch (this) {
+            case Admin -> Set.of(Write, Read);
+            case Write -> Set.of(Read);
+            case Read -> Set.of();
+        };
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/auth/resourcebased/RegistryGroup.java
+++ b/app/src/main/java/io/apicurio/registry/auth/resourcebased/RegistryGroup.java
@@ -1,0 +1,21 @@
+package io.apicurio.registry.auth.resourcebased;
+
+import java.util.Set;
+
+import io.kroxylicious.authorizer.service.ResourceType;
+
+public enum RegistryGroup implements ResourceType<RegistryGroup> {
+
+    Read,
+    Write,
+    Admin;
+
+    @Override
+    public Set<RegistryGroup> implies() {
+        return switch (this) {
+            case Admin -> Set.of(Write, Read);
+            case Write -> Set.of(Read);
+            case Read -> Set.of();
+        };
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/auth/resourcebased/ResourceBasedAccessController.java
+++ b/app/src/main/java/io/apicurio/registry/auth/resourcebased/ResourceBasedAccessController.java
@@ -1,0 +1,129 @@
+package io.apicurio.registry.auth.resourcebased;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import io.apicurio.registry.auth.AbstractAccessController;
+import io.apicurio.registry.auth.Authorized;
+import io.apicurio.registry.auth.AuthorizedLevel;
+import io.apicurio.registry.auth.AuthorizedStyle;
+import io.kroxylicious.authorizer.service.Action;
+import io.kroxylicious.authorizer.service.AuthorizeResult;
+import io.kroxylicious.authorizer.service.Authorizer;
+import io.kroxylicious.authorizer.service.Decision;
+import io.kroxylicious.proxy.authentication.Subject;
+import io.kroxylicious.proxy.authentication.User;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.InvocationContext;
+import org.slf4j.Logger;
+
+@Singleton
+public class ResourceBasedAccessController extends AbstractAccessController {
+
+    @Inject
+    Logger log;
+
+    @Inject
+    SecurityIdentity securityIdentity;
+
+    @Inject
+    ResourceBasedAccessControllerConfig config;
+
+    private Authorizer authorizer;
+
+    void setAuthorizer(Authorizer authorizer) {
+        this.authorizer = authorizer;
+    }
+
+    Authorizer getAuthorizer() {
+        return authorizer;
+    }
+
+    @Override
+    public boolean isAuthorized(InvocationContext context) {
+        if (authorizer == null) {
+            log.warn("Resource-based access controller has no authorizer configured, denying access.");
+            return false;
+        }
+
+        Authorized annotation = context.getMethod().getAnnotation(Authorized.class);
+        if (annotation == null) {
+            return true;
+        }
+
+        AuthorizedStyle style = annotation.style();
+        AuthorizedLevel level = annotation.level();
+
+        if (style == AuthorizedStyle.None || level == AuthorizedLevel.None) {
+            return true;
+        }
+
+        Action action = buildAction(context, style, level);
+        if (action == null) {
+            return true;
+        }
+
+        Subject subject = buildSubject();
+        CompletionStage<AuthorizeResult> resultStage = authorizer.authorize(subject, List.of(action));
+        AuthorizeResult result = resultStage.toCompletableFuture().join();
+
+        Decision decision = result.decision(action.operation(), action.resourceName());
+        log.debug("Resource-based authorization: subject={}, action={}, decision={}",
+                subject, action, decision);
+        return decision == Decision.ALLOW;
+    }
+
+    private Subject buildSubject() {
+        if (securityIdentity == null || securityIdentity.isAnonymous()) {
+            return Subject.anonymous();
+        }
+        return new Subject(new User(securityIdentity.getPrincipal().getName()));
+    }
+
+    private Action buildAction(InvocationContext context, AuthorizedStyle style, AuthorizedLevel level) {
+        String resourceName = extractResourceName(context, style);
+        if (resourceName == null) {
+            return null;
+        }
+
+        return switch (style) {
+            case GroupAndArtifact, ArtifactOnly, GlobalId -> new Action(toArtifactOperation(level), resourceName);
+            case GroupOnly -> new Action(toGroupOperation(level), resourceName);
+            case None -> null;
+        };
+    }
+
+    private String extractResourceName(InvocationContext context, AuthorizedStyle style) {
+        return switch (style) {
+            case GroupAndArtifact -> {
+                String groupId = getStringParam(context, 0);
+                String artifactId = getStringParam(context, 1);
+                yield (groupId != null ? groupId : "default") + "/" + artifactId;
+            }
+            case GroupOnly -> getStringParam(context, 0);
+            case ArtifactOnly -> getStringParam(context, 0);
+            case GlobalId -> String.valueOf(getLongParam(context, 0));
+            case None -> null;
+        };
+    }
+
+    private static RegistryArtifact toArtifactOperation(AuthorizedLevel level) {
+        return switch (level) {
+            case Read -> RegistryArtifact.Read;
+            case Write -> RegistryArtifact.Write;
+            case Admin, AdminOrOwner -> RegistryArtifact.Admin;
+            case None -> RegistryArtifact.Read;
+        };
+    }
+
+    private static RegistryGroup toGroupOperation(AuthorizedLevel level) {
+        return switch (level) {
+            case Read -> RegistryGroup.Read;
+            case Write -> RegistryGroup.Write;
+            case Admin, AdminOrOwner -> RegistryGroup.Admin;
+            case None -> RegistryGroup.Read;
+        };
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/auth/resourcebased/ResourceBasedAccessControllerConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/resourcebased/ResourceBasedAccessControllerConfig.java
@@ -1,0 +1,27 @@
+package io.apicurio.registry.auth.resourcebased;
+
+import io.apicurio.common.apps.config.Info;
+import jakarta.inject.Singleton;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_AUTH;
+
+@Singleton
+public class ResourceBasedAccessControllerConfig {
+
+    @ConfigProperty(name = "apicurio.auth.resource-based-authorization.enabled", defaultValue = "false")
+    @Info(category = CATEGORY_AUTH, description = "Enable resource-based access control using Kroxylicious Authorizer", availableSince = "3.0.0", experimental = true)
+    boolean enabled;
+
+    @ConfigProperty(name = "apicurio.auth.resource-based-authorization.acl.file", defaultValue = "")
+    @Info(category = CATEGORY_AUTH, description = "Path to ACL rules file for resource-based authorization", availableSince = "3.0.0", experimental = true)
+    String aclFilePath;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getAclFilePath() {
+        return aclFilePath;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/auth/resourcebased/ResourceBasedAccessControllerInitializer.java
+++ b/app/src/main/java/io/apicurio/registry/auth/resourcebased/ResourceBasedAccessControllerInitializer.java
@@ -1,0 +1,52 @@
+package io.apicurio.registry.auth.resourcebased;
+
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+
+import io.kroxylicious.authorizer.provider.acl.AclAuthorizerConfig;
+import io.kroxylicious.authorizer.provider.acl.AclAuthorizerService;
+import io.quarkus.runtime.Startup;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+
+@Singleton
+@Startup
+public class ResourceBasedAccessControllerInitializer {
+
+    @Inject
+    Logger log;
+
+    @Inject
+    ResourceBasedAccessControllerConfig config;
+
+    @Inject
+    ResourceBasedAccessController controller;
+
+    @PostConstruct
+    void init() {
+        if (!config.isEnabled()) {
+            log.debug("Resource-based access control is disabled.");
+            return;
+        }
+
+        String aclFile = config.getAclFilePath();
+        if (aclFile == null || aclFile.isBlank()) {
+            log.warn("Resource-based access control is enabled but no ACL file is configured. "
+                    + "Set apicurio.auth.resource-based-authorization.acl.file to a valid path.");
+            return;
+        }
+
+        log.info("Initializing resource-based access control from ACL file: {}", aclFile);
+        try {
+            AclAuthorizerService service = new AclAuthorizerService();
+            service.initialize(new AclAuthorizerConfig(aclFile));
+            controller.setAuthorizer(service.build());
+            log.info("Resource-based access control initialized successfully.");
+        } catch (UncheckedIOException e) {
+            log.error("Failed to load ACL rules file: {}", aclFile, e);
+            throw e;
+        }
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/auth/resourcebased/ResourceBasedAccessControllerTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/resourcebased/ResourceBasedAccessControllerTest.java
@@ -1,0 +1,172 @@
+package io.apicurio.registry.auth.resourcebased;
+
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import io.kroxylicious.authorizer.provider.acl.AclAuthorizerConfig;
+import io.kroxylicious.authorizer.provider.acl.AclAuthorizerService;
+import io.kroxylicious.authorizer.service.Action;
+import io.kroxylicious.authorizer.service.AuthorizeResult;
+import io.kroxylicious.authorizer.service.Authorizer;
+import io.kroxylicious.authorizer.service.Decision;
+import io.kroxylicious.proxy.authentication.Subject;
+import io.kroxylicious.proxy.authentication.User;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ResourceBasedAccessControllerTest {
+
+    private Authorizer authorizer;
+
+    @BeforeEach
+    void setUp() {
+        URL rulesUrl = getClass().getClassLoader().getResource("test-acl-rules.acl");
+        Assertions.assertNotNull(rulesUrl, "test-acl-rules.acl not found on classpath");
+
+        AclAuthorizerService service = new AclAuthorizerService();
+        service.initialize(new AclAuthorizerConfig(rulesUrl.getPath()));
+        authorizer = service.build();
+    }
+
+    @Test
+    void aliceCanReadOwnArtifact() {
+        Assertions.assertEquals(Decision.ALLOW, decide("alice", RegistryArtifact.Read, "team-a/my-schema"));
+    }
+
+    @Test
+    void aliceCanWriteOwnArtifact() {
+        Assertions.assertEquals(Decision.ALLOW, decide("alice", RegistryArtifact.Write, "team-a/my-schema"));
+    }
+
+    @Test
+    void aliceCannotWriteSharedArtifact() {
+        Assertions.assertEquals(Decision.DENY, decide("alice", RegistryArtifact.Write, "shared/common-schema"));
+    }
+
+    @Test
+    void aliceCanReadSharedArtifact() {
+        Assertions.assertEquals(Decision.ALLOW, decide("alice", RegistryArtifact.Read, "shared/common-schema"));
+    }
+
+    @Test
+    void aliceCannotReadTeamBArtifact() {
+        Assertions.assertEquals(Decision.DENY, decide("alice", RegistryArtifact.Read, "team-b/their-schema"));
+    }
+
+    @Test
+    void bobCanReadAnyArtifact() {
+        Assertions.assertEquals(Decision.ALLOW, decide("bob", RegistryArtifact.Read, "team-a/my-schema"));
+        Assertions.assertEquals(Decision.ALLOW, decide("bob", RegistryArtifact.Read, "team-b/their-schema"));
+        Assertions.assertEquals(Decision.ALLOW, decide("bob", RegistryArtifact.Read, "shared/common-schema"));
+    }
+
+    @Test
+    void bobCanWriteOnlyToTeamB() {
+        Assertions.assertEquals(Decision.ALLOW, decide("bob", RegistryArtifact.Write, "team-b/their-schema"));
+        Assertions.assertEquals(Decision.DENY, decide("bob", RegistryArtifact.Write, "team-a/my-schema"));
+    }
+
+    @Test
+    void adminCanDoEverything() {
+        Assertions.assertEquals(Decision.ALLOW, decide("admin", RegistryArtifact.Read, "team-a/x"));
+        Assertions.assertEquals(Decision.ALLOW, decide("admin", RegistryArtifact.Write, "team-b/y"));
+        Assertions.assertEquals(Decision.ALLOW, decide("admin", RegistryArtifact.Admin, "shared/z"));
+    }
+
+    @Test
+    void unknownUserDenied() {
+        Assertions.assertEquals(Decision.DENY, decide("unknown", RegistryArtifact.Read, "team-a/my-schema"));
+    }
+
+    @Test
+    void anonymousUserDenied() {
+        Subject anonymous = Subject.anonymous();
+        AuthorizeResult result = authorizer.authorize(
+                anonymous, List.of(new Action(RegistryArtifact.Read, "team-a/x"))
+        ).toCompletableFuture().join();
+        Assertions.assertEquals(Decision.DENY, result.decision(RegistryArtifact.Read, "team-a/x"));
+    }
+
+    @Test
+    void batchedAuthorizationWorks() {
+        Subject alice = new Subject(new User("alice"));
+        List<Action> actions = List.of(
+                new Action(RegistryArtifact.Read, "team-a/schema-1"),
+                new Action(RegistryArtifact.Read, "team-a/schema-2"),
+                new Action(RegistryArtifact.Read, "team-b/schema-3"),
+                new Action(RegistryArtifact.Read, "shared/schema-4")
+        );
+
+        AuthorizeResult result = authorizer.authorize(alice, actions).toCompletableFuture().join();
+
+        Assertions.assertEquals(3, result.allowed().size());
+        Assertions.assertEquals(1, result.denied().size());
+        Assertions.assertEquals("team-b/schema-3", result.denied().get(0).resourceName());
+    }
+
+    @Test
+    void searchResultFilteringWithPartition() {
+        Subject alice = new Subject(new User("alice"));
+        List<String> searchResults = List.of(
+                "team-a/schema-1", "team-a/schema-2",
+                "team-b/schema-3", "shared/schema-4",
+                "team-b/schema-5", "shared/schema-6"
+        );
+
+        List<Action> actions = searchResults.stream()
+                .map(name -> new Action(RegistryArtifact.Read, name))
+                .toList();
+
+        AuthorizeResult result = authorizer.authorize(alice, actions).toCompletableFuture().join();
+
+        List<String> allowed = result.allowed(RegistryArtifact.Read);
+        List<String> denied = result.denied(RegistryArtifact.Read);
+
+        Assertions.assertEquals(4, allowed.size());
+        Assertions.assertTrue(allowed.contains("team-a/schema-1"));
+        Assertions.assertTrue(allowed.contains("team-a/schema-2"));
+        Assertions.assertTrue(allowed.contains("shared/schema-4"));
+        Assertions.assertTrue(allowed.contains("shared/schema-6"));
+
+        Assertions.assertEquals(2, denied.size());
+        Assertions.assertTrue(denied.contains("team-b/schema-3"));
+        Assertions.assertTrue(denied.contains("team-b/schema-5"));
+    }
+
+    @Test
+    void groupLevelAuthorizationWorks() {
+        Assertions.assertEquals(Decision.ALLOW, decide("alice", RegistryGroup.Read, "team-a"));
+        Assertions.assertEquals(Decision.ALLOW, decide("alice", RegistryGroup.Write, "team-a"));
+        Assertions.assertEquals(Decision.DENY, decide("alice", RegistryGroup.Admin, "team-a"));
+        Assertions.assertEquals(Decision.DENY, decide("alice", RegistryGroup.Read, "team-b"));
+        Assertions.assertEquals(Decision.ALLOW, decide("admin", RegistryGroup.Admin, "team-b"));
+    }
+
+    @Test
+    void impliesWorks() {
+        URL rulesUrl = getClass().getClassLoader().getResource("test-acl-implies.acl");
+        Assertions.assertNotNull(rulesUrl);
+
+        AclAuthorizerService service = new AclAuthorizerService();
+        service.initialize(new AclAuthorizerConfig(rulesUrl.getPath()));
+        Authorizer authz = service.build();
+
+        Assertions.assertEquals(Decision.ALLOW, decideWith(authz, "superuser", RegistryArtifact.Admin, "x"));
+        Assertions.assertEquals(Decision.ALLOW, decideWith(authz, "superuser", RegistryArtifact.Write, "x"));
+        Assertions.assertEquals(Decision.ALLOW, decideWith(authz, "superuser", RegistryArtifact.Read, "x"));
+    }
+
+    private Decision decide(String username, io.kroxylicious.authorizer.service.ResourceType<?> operation, String resourceName) {
+        return decideWith(authorizer, username, operation, resourceName);
+    }
+
+    private Decision decideWith(Authorizer authz, String username, io.kroxylicious.authorizer.service.ResourceType<?> operation, String resourceName) {
+        Subject subject = new Subject(new User(username));
+        CompletionStage<AuthorizeResult> resultStage = authz.authorize(
+                subject, List.of(new Action(operation, resourceName)));
+        AuthorizeResult result = resultStage.toCompletableFuture().join();
+        return result.decision(operation, resourceName);
+    }
+}

--- a/app/src/test/resources/test-acl-implies.acl
+++ b/app/src/test/resources/test-acl-implies.acl
@@ -1,0 +1,6 @@
+from io.apicurio.registry.auth.resourcebased import RegistryArtifact;
+
+// Admin implies Write implies Read
+allow User with name = "superuser" to Admin RegistryArtifact with name like "*";
+
+otherwise deny;

--- a/app/src/test/resources/test-acl-rules.acl
+++ b/app/src/test/resources/test-acl-rules.acl
@@ -1,0 +1,25 @@
+from io.apicurio.registry.auth.resourcebased import RegistryArtifact;
+from io.apicurio.registry.auth.resourcebased import RegistryGroup;
+
+// Alice can read and write artifacts in group "team-a"
+allow User with name = "alice" to {Read, Write} RegistryArtifact with name like "team-a/*";
+
+// Alice can read artifacts in group "shared"
+allow User with name = "alice" to Read RegistryArtifact with name like "shared/*";
+
+// Bob can read all artifacts
+allow User with name = "bob" to Read RegistryArtifact with name like "*";
+
+// Bob can write only to group "team-b"
+allow User with name = "bob" to Write RegistryArtifact with name like "team-b/*";
+
+// Admin can do everything on artifacts
+allow User with name = "admin" to {Read, Write, Admin} RegistryArtifact with name like "*";
+
+// Admin can do everything on groups
+allow User with name = "admin" to {Read, Write, Admin} RegistryGroup with name like "*";
+
+// Alice can read and write group "team-a"
+allow User with name = "alice" to {Read, Write} RegistryGroup with name = "team-a";
+
+otherwise deny;


### PR DESCRIPTION
## Summary

Proof of concept integrating the [Kroxylicious Authorizer framework](https://github.com/kroxylicious/kroxylicious/tree/main/kroxylicious-authorizer-providers) into Apicurio Registry for fine-grained, per-resource access control.

- Adds `kroxylicious-authorizer-api` and `kroxylicious-authorizer-acl` dependencies with `kafka-clients` excluded — compiles and runs without Kafka on the classpath
- Defines Registry-specific resource types (`RegistryArtifact`, `RegistryGroup`) as enums implementing `ResourceType` with an `implies()` hierarchy (Admin → Write → Read)
- Creates `ResourceBasedAccessController` bridging Registry's `IAccessController` with the Kroxylicious `Authorizer` interface
- Wires into `AuthorizedInterceptor` after RBAC/OBAC, gated by `apicurio.auth.resource-based-authorization.enabled`
- ACL rules use the Kroxylicious rules language with Registry resource types imported
- 14 unit tests covering per-user/per-resource allow/deny, batched authorization, search result filtering via `partition()`, group-level auth, `implies()` hierarchy, and anonymous denial

### Key findings

- **Kafka exclusion works** — no runtime dependency on `kafka-clients`
- **`AclAuthorizer.builder()` is package-private** — external consumers must use the file-based `AclAuthorizerService` API (worth raising with Kroxylicious team)
- **`AuthorizeResult.partition()` fits search filtering perfectly** — pass a batch of search results, get back allowed/denied partitions in one call

Relates to #7724

## Test plan

- [x] 14 unit tests pass (`mvn test -pl app -Dtest=ResourceBasedAccessControllerTest`)
- [ ] Full `@QuarkusTest` with Keycloak for authentication + ACL rules for authorization (future)
- [ ] Search/list result filtering integration (future)