### PR TITLE
fix(docs): update stale Kafka topic cleanup policy in documentation

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-storage-openshift.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-storage-openshift.adoc
@@ -156,10 +156,12 @@ spec:
   partitions: 3
   replicas: 3
   config:
-    cleanup.policy: compact
+    cleanup.policy: delete
+    retention.ms: -1
+    retention.bytes: -1
 ----
 +
-WARNING: You must configure the Kafka topic used by {registry} (named `kafkasql-journal` by default) with a compaction cleanup policy, otherwise a data loss might occur.
+WARNING: The journal topic must use `cleanup.policy: delete` with infinite retention (`retention.ms: -1` and `retention.bytes: -1`) to prevent data loss. {registry} will check these settings on startup and refuse to start if they are not configured correctly.
 
 [role="_additional-resources"]
 .Additional resources

--- a/operator/docs/modules/ROOT/partials/proc-persistence-kafkasql-plain.adoc
+++ b/operator/docs/modules/ROOT/partials/proc-persistence-kafkasql-plain.adoc
@@ -91,7 +91,9 @@ spec:
   partitions: 2
   replicas: 1
   config:
-    cleanup.policy: compact
+    cleanup.policy: delete
+    retention.ms: -1
+    retention.bytes: -1
 ----
 
 . Select the *{operator}*, and in the *ApicurioRegistry3* tab, click *Create ApicurioRegistry3*, using the following example, but replace your value in the `bootstrapServers` field.

--- a/operator/docs/modules/ROOT/partials/proc-persistence-kafkasql-scram.adoc
+++ b/operator/docs/modules/ROOT/partials/proc-persistence-kafkasql-scram.adoc
@@ -83,7 +83,9 @@ spec:
   partitions: 2
   replicas: 1
   config:
-    cleanup.policy: compact
+    cleanup.policy: delete
+    retention.ms: -1
+    retention.bytes: -1
 ----
 
 . Create a *Kafka User* resource to configure SCRAM authentication and authorization for the {registry} user. You can specify a user name in the `metadata` section or use the default `my-user`.

--- a/operator/docs/modules/ROOT/partials/proc-persistence-kafkasql-tls.adoc
+++ b/operator/docs/modules/ROOT/partials/proc-persistence-kafkasql-tls.adoc
@@ -78,7 +78,9 @@ spec:
   partitions: 2
   replicas: 1
   config:
-    cleanup.policy: compact
+    cleanup.policy: delete
+    retention.ms: -1
+    retention.bytes: -1
 ----
 
 . Create a *Kafka User* resource to configure authentication and authorization for the {registry} user. You can specify a user name in the `metadata` section or use the default `my-user`.


### PR DESCRIPTION
## Summary
- Updated 4 documentation files that still recommended the v2.x `cleanup.policy: compact` for
  KafkaSQL topics, which is incorrect for v3.x
- Changed all YAML examples to use `cleanup.policy: delete` with `retention.ms: -1` and
  `retention.bytes: -1` (matching the migration guide and HA guide)
- Rewrote the warning text in the OpenShift installation guide to accurately describe the v3.x
  startup validation behavior

## Related Issue
Fixes #7830

## Test Plan
- [ ] Grep for `cleanup.policy.*compact` across `docs/` and `operator/docs/` — should only appear
  in the migration guide (where it warns *against* using compact)
- [ ] Grep for `compaction cleanup` — should return zero results
- [ ] Visually confirm the updated YAML blocks and warning text are consistent with the HA guide
  (`assembly-registry-high-availability.adoc`)