### PR TITLE
fix: implement apicurio.storage.orphan-cleanup.enabled property

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/OrphanedContentReaper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/OrphanedContentReaper.java
@@ -4,6 +4,8 @@ import io.apicurio.registry.cdi.Current;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 
 import java.time.Instant;
@@ -23,12 +25,20 @@ public class OrphanedContentReaper {
     @Current
     RegistryStorage storage;
 
+    @ConfigProperty(name = "apicurio.storage.orphan-cleanup.enabled", defaultValue = "true")
+    boolean enabled;
+
     /**
      * Minimal granularity is 1 minute.
      */
     @Scheduled(delay = 60, concurrentExecution = SKIP, every = "{apicurio.storage.orphan-cleanup.every}")
     void run() {
         try {
+            if (!enabled) {
+                log.debug("Skipping orphaned content cleanup because it is disabled.");
+                return;
+            }
+
             if (storage.isReady()) {
                 if (!storage.isReadOnly()) {
                     log.debug("Running orphaned content cleanup job at {}", Instant.now());

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -157,6 +157,7 @@ apicurio.config.cache.enabled=true
 apicurio.downloads.reaper.every=60s
 
 # Orphaned content cleanup
+apicurio.storage.orphan-cleanup.enabled=true
 apicurio.storage.orphan-cleanup.every=1h
 
 # Elasticsearch search index

--- a/app/src/test/java/io/apicurio/registry/storage/OrphanedContentReaperTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/OrphanedContentReaperTest.java
@@ -1,0 +1,45 @@
+package io.apicurio.registry.storage;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+@TestProfile(OrphanedContentReaperTest.DisabledProfile.class)
+public class OrphanedContentReaperTest {
+
+    @Inject
+    OrphanedContentReaper reaper;
+
+    @Inject
+    Logger log;
+
+    @Test
+    public void testOrphanCleanupDisabled() {
+        OrphanedContentReaper spyReaper = spy(reaper);
+
+        RegistryStorage mockStorage = mock(RegistryStorage.class);
+        when(mockStorage.isReady()).thenReturn(true);
+        when(mockStorage.isReadOnly()).thenReturn(false);
+
+        spyReaper.storage = mockStorage;
+        assertDoesNotThrow(() -> spyReaper.run());
+
+        verify(mockStorage, never()).deleteAllOrphanedContent();
+        verify(mockStorage, never()).isReady();
+    }
+
+    public static class DisabledProfile implements io.quarkus.test.junit.QuarkusTestProfile {
+        @Override
+        public java.util.Map<String, String> getConfigOverrides() {
+            return java.util.Map.of(
+                "apicurio.storage.orphan-cleanup.enabled", "false"
+            );
+        }
+    }
+}

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -1626,6 +1626,10 @@ The following {registry} configuration options are available for each component 
 |`${apicurio.config.dynamic.allow-all}`
 |
 |
+|`apicurio.storage.orphan-cleanup.enabled`
+|`unknown`
+|`true`
+|
 |`apicurio.storage.orphan-cleanup.every`
 |`unknown`
 |`1h`


### PR DESCRIPTION
- Add `apicurio.storage.orphan-cleanup.enabled=true` to application.properties
- Add early return check when cleanup is disabled with appropriate debug logging
- Update configuration documentation in ref-registry-all-configs.adoc
- Add unit test (OrphanedContentReaperTest) to verify the enabled flag works correctly