### PR TITLE
fix(ci): fix two bugs in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,6 +116,11 @@ jobs:
         run: |
           echo "OPERAND_IMAGE_TAG=${{ github.event.inputs.release-version }}" >> $GITHUB_ENV
 
+      - name: (Operator) Generate CRD
+        working-directory: registry
+        run: |
+          mvn -pl operator/controller -am -Pfull install -DskipTests --no-transfer-progress
+
       - name: (Operator) Update install file
         working-directory: registry/operator
         run: |
@@ -267,7 +272,7 @@ jobs:
   # Only runs after all builds succeed — if any build fails, no release is created.
   release-publish:
     name: Publish Release
-    needs: [release-build-app, release-build-ui, release-build-cli]
+    needs: [release-prepare, release-build-app, release-build-ui, release-build-cli]
     if: github.repository_owner == 'Apicurio'
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## Summary

Ports two release workflow fixes from the `3.2.x` branch, discovered during the 3.2.2 release:

- **Generate operator CRD before building install file.** The `make dist-install-file` step runs `kubectl kustomize` which references a CRD file that is generated by Maven (Fabric8) and gitignored. Without a build step to produce it first, the release-prepare job always fails.

- **Add `release-prepare` to the publish job's `needs` list.** The `release-publish` job references `needs.release-prepare.outputs.release-sha` for the GitHub Release `target_commitish`, but `release-prepare` was not in its `needs` list. GitHub Actions only exposes outputs from direct dependencies, so the SHA resolved to an empty string and the release tag was created on the default branch instead of the release commit.

## Test plan

- [x] Both fixes verified on the `3.2.x` branch during the successful 3.2.2 release
- [ ] Verify next release from `main` succeeds