### PR TITLE
Remove registryAvailableSince and studioAvailableSince from @Info

### DIFF
--- a/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
@@ -32,51 +32,51 @@ public class AuthConfig {
     Config config;
 
     @ConfigProperty(name = "quarkus.oidc.tenant-enabled", defaultValue = "false")
-    @Info(category = CATEGORY_AUTH, description = "Enable auth", availableSince = "0.1.18-SNAPSHOT", registryAvailableSince = "2.0.0.Final", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "Enable auth", availableSince = "2.0.0.Final")
     boolean oidcAuthEnabled;
 
     // back to fake auth and use another property
     @Dynamic(label = "HTTP basic authentication", description = "When selected, users are permitted to authenticate using HTTP basic authentication (in addition to OAuth).", requires = "apicurio.authn.enabled=true")
     @ConfigProperty(name = "apicurio.authn.basic-client-credentials.enabled", defaultValue = "false")
-    @Info(category = CATEGORY_AUTH, description = "Enable basic auth client credentials", availableSince = "0.1.18-SNAPSHOT", registryAvailableSince = "2.1.0.Final", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "Enable basic auth client credentials", availableSince = "2.1.0.Final")
     Supplier<Boolean> basicClientCredentialsAuthEnabled;
 
     @ConfigProperty(name = "quarkus.http.auth.basic", defaultValue = "false")
-    @Info(category = CATEGORY_AUTH, description = "Enable basic auth", availableSince = "1.1.X-SNAPSHOT", registryAvailableSince = "3.X.X.Final", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "Enable basic auth", availableSince = "3.X.X.Final")
     boolean basicAuthEnabled;
 
     // TODO: Add suffix?
     @ConfigProperty(name = "apicurio.authn.basic-client-credentials.cache-expiration", defaultValue = "10")
-    @Info(category = CATEGORY_AUTH, description = "Default client credentials token expiration time in minutes.", availableSince = "0.1.18-SNAPSHOT", registryAvailableSince = "2.2.6.Final", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "Default client credentials token expiration time in minutes.", availableSince = "2.2.6.Final")
     Integer accessTokenExpiration;
 
     // TODO: Add suffix?
     @ConfigProperty(name = "apicurio.authn.basic-client-credentials.cache-expiration-offset", defaultValue = "10")
-    @Info(category = CATEGORY_AUTH, description = "Client credentials token expiration offset from JWT expiration, in seconds.", availableSince = "0.2.7", registryAvailableSince = "2.5.9.Final", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "Client credentials token expiration offset from JWT expiration, in seconds.", availableSince = "2.5.9.Final")
     Integer accessTokenExpirationOffset;
 
     @ConfigProperty(name = "apicurio.authn.basic.scope")
-    @Info(category = CATEGORY_AUTH, description = "Client credentials scope.", availableSince = "0.1.21-SNAPSHOT", registryAvailableSince = "2.5.0.Final", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "Client credentials scope.", availableSince = "2.5.0.Final")
     Optional<String> scope;
 
     @ConfigProperty(name = "apicurio.authn.audit.log.prefix", defaultValue = "audit")
-    @Info(category = CATEGORY_AUTH, description = "Prefix used for application audit logging.", availableSince = "0.1.18-SNAPSHOT", registryAvailableSince = "2.2.6", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "Prefix used for application audit logging.", availableSince = "2.2.6")
     String auditLogPrefix;
 
     @ConfigProperty(name = "quarkus.oidc.auth-server-url", defaultValue = "_")
-    @Info(category = CATEGORY_AUTH, description = "Authentication server endpoint.", availableSince = "0.1.18-SNAPSHOT", registryAvailableSince = "2.1.0.Final", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "Authentication server endpoint.", availableSince = "2.1.0.Final")
     String authServerUrl;
 
     @ConfigProperty(name = "quarkus.oidc.token-path", defaultValue = "/protocol/openid-connect/token/")
-    @Info(category = CATEGORY_AUTH, description = "Authentication server token endpoint.", availableSince = "0.1.18-SNAPSHOT", registryAvailableSince = "2.1.0.Final", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "Authentication server token endpoint.", availableSince = "2.1.0.Final")
     String oidcTokenPath;
 
     @ConfigProperty(name = "quarkus.oidc.client-secret")
-    @Info(category = CATEGORY_AUTH, description = "Client secret used by the server for authentication.", availableSince = "0.1.18-SNAPSHOT", registryAvailableSince = "2.1.0.Final", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "Client secret used by the server for authentication.", availableSince = "2.1.0.Final")
     Optional<String> clientSecret;
 
     @ConfigProperty(name = "quarkus.oidc.client-id", defaultValue = "")
-    @Info(category = CATEGORY_AUTH, description = "Client identifier used by the server for authentication.", availableSince = "0.1.18-SNAPSHOT", registryAvailableSince = "2.0.0.Final", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "Client identifier used by the server for authentication.", availableSince = "2.0.0.Final")
     String clientId;
 
     @ConfigProperty(name = "apicurio.auth.role-based-authorization", defaultValue = "false")
@@ -166,7 +166,7 @@ public class AuthConfig {
     String groupsHeader;
 
     @ConfigProperty(name = "apicurio.authn.proxy-header.trust-proxy-authorization", defaultValue = "false")
-    @Info(category = CATEGORY_AUTH, description = "When enabled, authorization checks are skipped and the proxy is trusted to have performed authorization", availableSince = "3.1.0", registryAvailableSince = "3.1.0.Final", studioAvailableSince = "1.0.0")
+    @Info(category = CATEGORY_AUTH, description = "When enabled, authorization checks are skipped and the proxy is trusted to have performed authorization", availableSince = "3.1.0.Final")
     boolean proxyHeaderTrustProxyAuthorization;
 
     @PostConstruct

--- a/app/src/main/java/io/apicurio/registry/contracts/DataContractsConfig.java
+++ b/app/src/main/java/io/apicurio/registry/contracts/DataContractsConfig.java
@@ -15,7 +15,7 @@ import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_CON
 public class DataContractsConfig {
 
     @ConfigProperty(name = "apicurio.contracts.enabled", defaultValue = "false")
-    @Info(category = CATEGORY_CONTRACTS, description = "Enable data contracts support", registryAvailableSince = "3.2.0", experimental = true)
+    @Info(category = CATEGORY_CONTRACTS, description = "Enable data contracts support", availableSince = "3.2.0", experimental = true)
     boolean enabled;
 
     public boolean isEnabled() {

--- a/app/src/main/java/io/apicurio/registry/core/System.java
+++ b/app/src/main/java/io/apicurio/registry/core/System.java
@@ -45,22 +45,22 @@ public class System {
 
     @Inject
     @ConfigProperty(name = "apicurio.app.name")
-    @Info(category = CATEGORY_SYSTEM, registryAvailableSince = "3.0.4")
+    @Info(category = CATEGORY_SYSTEM, availableSince = "3.0.4")
     String name;
 
     @Inject
     @ConfigProperty(name = "apicurio.app.description")
-    @Info(category = CATEGORY_SYSTEM, registryAvailableSince = "3.0.4")
+    @Info(category = CATEGORY_SYSTEM, availableSince = "3.0.4")
     String description;
 
     @Inject
     @ConfigProperty(name = "apicurio.app.version")
-    @Info(category = CATEGORY_SYSTEM, registryAvailableSince = "3.0.4")
+    @Info(category = CATEGORY_SYSTEM, availableSince = "3.0.4")
     String version;
 
     @Inject
     @ConfigProperty(name = "apicurio.app.date")
-    @Info(category = CATEGORY_SYSTEM, registryAvailableSince = "3.0.4")
+    @Info(category = CATEGORY_SYSTEM, availableSince = "3.0.4")
     String date;
 
     @Inject

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
@@ -62,7 +62,7 @@ public class KafkaSqlConfiguration {
             Setting this property to true will partially disable this verification for *all* Apicurio Registry topics. \
             Specifically, 'retention.ms=-1' is not enforced to support automatic cleanup when Apicurio Registry snapshotting feature is used. \
             In this case, snapshots have to be made more frequently than messages are deleted. \
-            IMPORTANT: We might change which topics and which verification checks are affected by this configuration property in the future.""", registryAvailableSince = "3.1.3")
+            IMPORTANT: We might change which topics and which verification checks are affected by this configuration property in the future.""", availableSince = "3.1.3")
     @Getter
     boolean topicConfigurationVerificationOverrideEnabled;
 
@@ -104,7 +104,7 @@ public class KafkaSqlConfiguration {
     // === Snapshots topic and related configurations ===
 
     @ConfigProperty(name = "apicurio.kafkasql.snapshots.topic", defaultValue = "kafkasql-snapshots")
-    @Info(category = CATEGORY_STORAGE, description = "Kafka sql snapshots topic name", registryAvailableSince = "3.0.0")
+    @Info(category = CATEGORY_STORAGE, description = "Kafka sql snapshots topic name", availableSince = "3.0.0")
     @Getter
     String snapshotsTopic;
 
@@ -115,7 +115,7 @@ public class KafkaSqlConfiguration {
             There are two optional Registry-specific configuration properties: 'partitions' and 'replication.factor'. \
             IMPORTANT: As a temporary compatibility measure, configuration properties for this topic are also inherited from 'apicurio.kafkasql.topic' \
             unless explicitly overridden by this property. This will be removed in a next minor version.\
-            """, registryAvailableSince = "3.1.3")
+            """, availableSince = "3.1.3")
     Properties snapshotTopicProperties;
 
     public Map<String, String> getSnapshotTopicProperties() {
@@ -134,19 +134,19 @@ public class KafkaSqlConfiguration {
     }
 
     @ConfigProperty(name = "apicurio.kafkasql.snapshot.every.seconds", defaultValue = "86400s")
-    @Info(category = CATEGORY_STORAGE, description = "Kafka sql journal topic snapshot every", registryAvailableSince = "3.0.0")
+    @Info(category = CATEGORY_STORAGE, description = "Kafka sql journal topic snapshot every", availableSince = "3.0.0")
     @Getter
     String snapshotEvery;
 
     @ConfigProperty(name = "apicurio.storage.snapshot.location", defaultValue = "./")
-    @Info(category = CATEGORY_STORAGE, description = "Kafka sql snapshots store location", registryAvailableSince = "3.0.0")
+    @Info(category = CATEGORY_STORAGE, description = "Kafka sql snapshots store location", availableSince = "3.0.0")
     @Getter
     String snapshotStoreLocation;
 
     // === Events topic and related configurations ===
 
     @ConfigProperty(name = "apicurio.events.kafka.topic", defaultValue = "registry-events")
-    @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage events topic", registryAvailableSince = "3.0.1")
+    @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage events topic", availableSince = "3.0.1")
     @Getter
     String eventsTopic;
 
@@ -157,7 +157,7 @@ public class KafkaSqlConfiguration {
             There is an optional Registry-specific configuration property: 'replication.factor'. \
             IMPORTANT: As a temporary compatibility measure, configuration properties for this topic are also inherited from 'apicurio.kafkasql.topic' \
             unless explicitly overridden by this property. This will be removed in a next minor version.\
-            """, registryAvailableSince = "3.1.3")
+            """, availableSince = "3.1.3")
     Properties eventsTopicProperties;
 
     public Map<String, String> getEventsTopicProperties() {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlEventsProcessor.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlEventsProcessor.java
@@ -23,7 +23,7 @@ import static io.apicurio.registry.utils.ConcurrentUtil.blockOnResult;
 public class KafkaSqlEventsProcessor {
 
     @ConfigProperty(name = "apicurio.storage.kind", defaultValue = "sql")
-    @Info(category = CATEGORY_STORAGE, description = "The type of storage to use for the registry", registryAvailableSince = "3.0.0")
+    @Info(category = CATEGORY_STORAGE, description = "The type of storage to use for the registry", availableSince = "3.0.0")
     String storageType;
 
     @Inject

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
@@ -33,7 +33,7 @@ public class KafkaSqlSubmitter {
     public static final String BOOTSTRAP_MESSAGE_TYPE = "Bootstrap";
 
     @ConfigProperty(name = "apicurio.storage.kind", defaultValue = "sql")
-    @Info(category = CATEGORY_STORAGE, description = "The type of storage to use for the registry", registryAvailableSince = "3.0.0")
+    @Info(category = CATEGORY_STORAGE, description = "The type of storage to use for the registry", availableSince = "3.0.0")
     String storageType;
 
     @Inject

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -117,7 +117,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     RestConfig restConfig;
 
     @ConfigProperty(name = "apicurio.storage.references.max-depth", defaultValue = "100")
-    @Info(category = CATEGORY_STORAGE, description = "Maximum recursion depth for resolving schema references. Prevents stack overflow from deeply nested schemas.", registryAvailableSince = "3.0.6")
+    @Info(category = CATEGORY_STORAGE, description = "Maximum recursion depth for resolving schema references. Prevents stack overflow from deeply nested schemas.", availableSince = "3.0.6")
     int maxReferenceDepth;
 
     protected SqlStatements sqlStatements() {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/ConnectionRetryConfig.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/ConnectionRetryConfig.java
@@ -16,27 +16,27 @@ import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_STO
 public class ConnectionRetryConfig {
 
     @ConfigProperty(name = "apicurio.storage.connection.retry.enabled", defaultValue = "true")
-    @Info(category = CATEGORY_STORAGE, description = "Enable connection retry with exponential backoff for transient database connection failures", registryAvailableSince = "3.1.4")
+    @Info(category = CATEGORY_STORAGE, description = "Enable connection retry with exponential backoff for transient database connection failures", availableSince = "3.1.4")
     @Getter
     boolean enabled;
 
     @ConfigProperty(name = "apicurio.storage.connection.retry.max-attempts", defaultValue = "10")
-    @Info(category = CATEGORY_STORAGE, description = "Maximum number of connection retry attempts", registryAvailableSince = "3.1.4")
+    @Info(category = CATEGORY_STORAGE, description = "Maximum number of connection retry attempts", availableSince = "3.1.4")
     @Getter
     int maxAttempts;
 
     @ConfigProperty(name = "apicurio.storage.connection.retry.initial-delay-ms", defaultValue = "1000")
-    @Info(category = CATEGORY_STORAGE, description = "Initial delay in milliseconds before first retry", registryAvailableSince = "3.1.4")
+    @Info(category = CATEGORY_STORAGE, description = "Initial delay in milliseconds before first retry", availableSince = "3.1.4")
     @Getter
     long initialDelayMs;
 
     @ConfigProperty(name = "apicurio.storage.connection.retry.max-delay-ms", defaultValue = "30000")
-    @Info(category = CATEGORY_STORAGE, description = "Maximum delay in milliseconds between retry attempts", registryAvailableSince = "3.1.4")
+    @Info(category = CATEGORY_STORAGE, description = "Maximum delay in milliseconds between retry attempts", availableSince = "3.1.4")
     @Getter
     long maxDelayMs;
 
     @ConfigProperty(name = "apicurio.storage.connection.retry.backoff-multiplier", defaultValue = "2.0")
-    @Info(category = CATEGORY_STORAGE, description = "Multiplier for exponential backoff between retry attempts", registryAvailableSince = "3.1.4")
+    @Info(category = CATEGORY_STORAGE, description = "Multiplier for exponential backoff between retry attempts", availableSince = "3.1.4")
     @Getter
     double backoffMultiplier;
 }

--- a/config-index/definitions/src/main/java/io/apicurio/common/apps/config/Info.java
+++ b/config-index/definitions/src/main/java/io/apicurio/common/apps/config/Info.java
@@ -39,12 +39,6 @@ public @interface Info {
     @Nonbinding
     String availableSince() default "";
 
-    @Nonbinding
-    String registryAvailableSince() default "";
-
-    @Nonbinding
-    String studioAvailableSince() default "";
-
     /**
      * Lists related configuration properties. TODO: Not used in docs yet
      */

--- a/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
+++ b/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
@@ -228,11 +228,9 @@ public class GenerateAllConfigPartial {
                     var category = ConfigPropertyCategory.valueOf(variant).getRawValue();
                     var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString()).orElse("");
 
-                    var availableSince = Optional.ofNullable(info.get().value("registryAvailableSince"))
+                    var availableSince = Optional.ofNullable(info.get().value("availableSince"))
                             .map(v -> v.value().toString())
-                            .orElse(Optional.ofNullable(info.get().value("availableSince"))
-                                    .map(v -> v.value().toString())
-                                    .orElse(""));
+                            .orElse("");
 
                     var experimental = Optional.ofNullable(info.get().value("experimental"))
                             .map(v -> (boolean) v.value())
@@ -278,11 +276,9 @@ public class GenerateAllConfigPartial {
             var category = ConfigPropertyCategory.valueOf(variant).getRawValue();
             var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString()).orElse("");
 
-            var availableSince = Optional.ofNullable(info.get().value("registryAvailableSince"))
+            var availableSince = Optional.ofNullable(info.get().value("availableSince"))
                     .map(v -> v.value().toString())
-                    .orElse(Optional.ofNullable(info.get().value("availableSince"))
-                            .map(v -> v.value().toString())
-                            .orElse(""));
+                    .orElse("");
 
             var experimental = Optional.ofNullable(info.get().value("experimental"))
                     .map(v -> (boolean) v.value())


### PR DESCRIPTION
## Summary

- Remove `registryAvailableSince` and `studioAvailableSince` from the `@Info` annotation, consolidating to just `availableSince`
- These fields were vestiges of the shared config library era when Registry and Studio both used `apicurio-common-app-components`
- Simplify the config generator to read only `availableSince` instead of the `registryAvailableSince`-with-fallback chain

Closes #7839

## Test plan
- [ ] Build succeeds: `./mvnw clean install -DskipTests`
- [ ] Regenerate config docs: `./mvnw clean install -pl :apicurio-registry-config-generator -am -DskipTests`
- [ ] Verify no remaining references: `grep -rn 'registryAvailableSince\|studioAvailableSince' --include='*.java'`