### PR TITLE
Update kotlin-stdlib to 2.3.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <wire-schema.version>5.3.3</wire-schema.version>
     <okhttp.version>4.12.0</okhttp.version>
     <okio.version>3.17.0</okio.version>
-    <kotlin-stdlib.version>2.3.20</kotlin-stdlib.version>
+    <kotlin-stdlib.version>2.3.21</kotlin-stdlib.version>
     <icu4j.version>76.1</icu4j.version>
     <protobuf.version>4.34.1</protobuf.version>
     <xmlsec.version>4.0.4</xmlsec.version>


### PR DESCRIPTION
## Summary
- Update org.jetbrains.kotlin:kotlin-stdlib from 2.3.20 to 2.3.21

## Context
This dependency upgrade was split from Renovate PR #7804 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected