### PR TITLE
fix(test): add ES indexing delay to SearchIT.testSearchVersionsByLabels (backport #7845)

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/tests/search/SearchIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/search/SearchIT.java
@@ -147,6 +147,9 @@ public class SearchIT extends ApicurioRegistryBaseIT {
         registryClient.groups().byGroupId(GROUP).artifacts().byArtifactId(artifactId)
                 .versions().byVersionExpression(car.getVersion().getVersion()).put(emd);
 
+        // Allow time for ES indexing
+        Thread.sleep(3000);
+
         // Search by label key
         retry(() -> {
             VersionSearchResults results = registryClient.search().versions().get(config -> {


### PR DESCRIPTION
## Summary
Backport of #7845 to the 3.2.x branch.

- Added `Thread.sleep(3000)` before the retry-based search assertions in
  `SearchIT.testSearchVersionsByLabels` to allow time for Elasticsearch indexing
- This matches the pattern already used by all other data-modifying tests in `SearchIT`
- Fixes an intermittent failure observed in CI with Elasticsearch 9.0 on OpenShift

## Related Issue
Fixes #7843

## Test Plan
- [ ] Verify the test compiles: `./mvnw test-compile -pl integration-tests`
- [ ] Run checkstyle: `./mvnw checkstyle:check -pl integration-tests`
- [ ] Full validation via CI: run `SearchIT` against an Elasticsearch-backed registry instance