### PR TITLE
feat(auth): backport auth chain strategies to 3.2.x (#7821)

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -16,6 +16,7 @@
     <projectRoot>${project.basedir}/..</projectRoot>
     <maven.compiler.release>21</maven.compiler.release>
     <groups/>
+    <argLine/>
   </properties>
 
   <dependencies>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -498,6 +498,8 @@
         <configuration>
           <groups>${groups}</groups>
           <forkCount>1</forkCount>
+          <argLine>@{argLine} -Xmx4g</argLine>
+          <forkedProcessExitTimeoutInSeconds>1800</forkedProcessExitTimeoutInSeconds>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <org.jboss.logging.provider>jboss</org.jboss.logging.provider>

--- a/app/src/main/java/io/apicurio/registry/auth/AppAuthenticationMechanism.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AppAuthenticationMechanism.java
@@ -16,10 +16,7 @@
 
 package io.apicurio.registry.auth;
 
-import io.apicurio.registry.logging.audit.AuditHttpRequestContext;
-import io.apicurio.registry.logging.audit.AuditHttpRequestInfo;
-import io.apicurio.registry.logging.audit.AuditLogService;
-import io.vertx.core.buffer.Buffer;
+import io.quarkus.vertx.http.runtime.security.BasicAuthenticationMechanism;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 import io.quarkus.arc.Unremovable;
@@ -27,9 +24,10 @@ import io.quarkus.oidc.runtime.OidcAuthenticationMechanism;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AuthenticationRequest;
-import io.quarkus.vertx.http.runtime.security.*;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
 import io.smallrye.jwt.auth.principal.DefaultJWTParser;
-import io.smallrye.jwt.auth.principal.ParseException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.MultiMap;
 import io.vertx.ext.web.RoutingContext;
@@ -38,18 +36,23 @@ import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
-import org.apache.commons.codec.digest.DigestUtils;
+import io.apicurio.registry.logging.audit.AuditLogService;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.slf4j.Logger;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 @Alternative
 @Priority(1)
@@ -81,216 +84,121 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
     @Inject
     DefaultJWTParser jwtParser;
 
-    private String oidcTokenUrl;
-
-    private ConcurrentHashMap<String, WrappedValue<String>> cachedAccessTokens;
-    private ConcurrentHashMap<String, WrappedValue<RuntimeException>> cachedAuthFailures;
+    private List<AuthenticationStrategy> authChain;
 
     @PostConstruct
     public void init() {
-        if (authConfig.oidcAuthEnabled) {
-            cachedAccessTokens = new ConcurrentHashMap<>();
-            cachedAuthFailures = new ConcurrentHashMap<>();
-            if (authConfig.oidcTokenPath.startsWith("http")) {
-                oidcTokenUrl = authConfig.oidcTokenPath;
-            } else {
-                oidcTokenUrl = authConfig.authServerUrl + authConfig.oidcTokenPath;
-            }
+        authChain = buildAuthChain();
+        if (authChain.isEmpty()) {
+            log.info("Authentication chain: [none] (no mechanisms enabled)");
+        } else {
+            log.info("Authentication chain: {}",
+                    authChain.stream().map(AuthenticationStrategy::name)
+                            .collect(Collectors.joining(" -> ")));
         }
     }
 
-    private HttpAuthenticationMechanism selectEnabledAuth() {
-        if (authConfig.basicAuthEnabled) {
-            return basicAuthenticationMechanism;
-        } else if (authConfig.oidcAuthEnabled) {
-            return oidcAuthenticationMechanism;
-        } else if (authConfig.proxyHeaderAuthEnabled) {
-            return proxyHeaderAuthenticationMechanism;
-        } else {
-            return null;
+    /**
+     * Builds the ordered authentication chain from the configured mechanism priority list.
+     * Each mechanism name in {@code apicurio.authn.mechanism.priority} is resolved to a
+     * strategy factory. Only mechanisms that are both listed in the priority and enabled via
+     * their respective config property are included. Unknown names are logged as warnings and
+     * skipped; disabled mechanisms are silently omitted.
+     *
+     * @return an unmodifiable, ordered list of enabled authentication strategies
+     */
+    List<AuthenticationStrategy> buildAuthChain() {
+        Map<String, Supplier<AuthenticationStrategy>> strategyFactories = new LinkedHashMap<>();
+        strategyFactories.put("basic", () -> authConfig.basicAuthEnabled
+                ? new DelegatingAuthenticationStrategy("basic", basicAuthenticationMechanism)
+                : null);
+        strategyFactories.put("proxy-header", () -> authConfig.proxyHeaderAuthEnabled
+                ? new DelegatingAuthenticationStrategy("proxy-header",
+                        proxyHeaderAuthenticationMechanism)
+                : null);
+        strategyFactories.put("oidc", () -> {
+            if (!authConfig.oidcAuthEnabled) {
+                return null;
+            }
+            return new OidcAuthenticationStrategy(oidcAuthenticationMechanism, authConfig,
+                    auditLog, webClient, log, this);
+        });
+
+        List<AuthenticationStrategy> chain = new ArrayList<>();
+        for (String name : authConfig.getMechanismPriorityList()) {
+            Supplier<AuthenticationStrategy> factory = strategyFactories.get(name);
+            if (factory == null) {
+                log.warn("Unknown authentication mechanism name in priority list: '{}'. "
+                        + "Valid values are: basic, proxy-header, oidc", name);
+                continue;
+            }
+            AuthenticationStrategy strategy = factory.get();
+            if (strategy != null) {
+                chain.add(strategy);
+            } else {
+                log.debug("Mechanism '{}' is in priority list but not enabled, skipping.",
+                        name);
+            }
         }
+        return Collections.unmodifiableList(chain);
     }
 
     @Override
     public Uni<SecurityIdentity> authenticate(RoutingContext context,
-                                              IdentityProviderManager identityProviderManager) {
-        if (authConfig.basicAuthEnabled) {
-            return basicAuthenticationMechanism.authenticate(context, identityProviderManager);
-        } else if (authConfig.proxyHeaderAuthEnabled) {
-            return proxyHeaderAuthenticationMechanism.authenticate(context, identityProviderManager);
-        } else if (authConfig.oidcAuthEnabled) {
-            setAuditLogger(context);
-            if (authConfig.basicClientCredentialsAuthEnabled.get()) {
-                final Pair<String, String> clientCredentials = CredentialsHelper
-                        .extractCredentialsFromContext(context);
-                if (null != clientCredentials) {
-                    try {
-                        return authenticateWithClientCredentials(clientCredentials, context,
-                                identityProviderManager);
-                    } catch (OidcAuthException | io.quarkus.security.UnauthorizedException ex) {
-                        log.warn(String.format(
-                                "Exception trying to get an access token with client credentials with client id: %s",
-                                clientCredentials.getLeft()), ex);
-                        return oidcAuthenticationMechanism.authenticate(context, identityProviderManager);
-                    }
-                } else {
-                    return customAuthentication(context, identityProviderManager);
-                }
-            } else {
-                // Once we're done with it in the auth layer, the context must be cleared.
-                return customAuthentication(context, identityProviderManager);
-            }
-        } else {
-            return Uni.createFrom().nullItem();
+            IdentityProviderManager identityProviderManager) {
+        Uni<SecurityIdentity> chain = Uni.createFrom().nullItem();
+        for (AuthenticationStrategy strategy : authChain) {
+            chain = chain.onItem().ifNull()
+                    .switchTo(() -> strategy.authenticate(context, identityProviderManager));
         }
-    }
-
-    public Uni<SecurityIdentity> customAuthentication(RoutingContext context,
-                                                      IdentityProviderManager identityProviderManager) {
-        if (authConfig.clientSecret.isEmpty()) {
-            // if no secret is present, try to authenticate with oidc provider
-            return oidcAuthenticationMechanism.authenticate(context, identityProviderManager);
-        } else {
-            final Pair<String, String> credentialsFromContext = CredentialsHelper
-                    .extractCredentialsFromContext(context);
-            if (credentialsFromContext != null) {
-                String jwtToken = obtainAccessTokenPasswordGrant(credentialsFromContext.getLeft(),
-                        credentialsFromContext.getRight());
-                if (jwtToken != null) {
-                    // If we manage to get a token from basic credentials, try to authenticate it using the
-                    // fetched token using the identity provider manager
-                    context.request().headers().set("Authorization", "Bearer " + jwtToken);
-                    return oidcAuthenticationMechanism.authenticate(context, identityProviderManager);
-                }
-            } else {
-                // If we cannot get a token, then try to authenticate using oidc provider as last resource
-                return oidcAuthenticationMechanism.authenticate(context, identityProviderManager);
-            }
-        }
-        return Uni.createFrom().nullItem();
-    }
-
-    private String obtainAccessTokenPasswordGrant(String username, String password) {
-        MultiMap form = MultiMap.caseInsensitiveMultiMap()
-                .add("grant_type", "password")
-                .add("client_id", authConfig.clientId)
-                .add("client_secret", authConfig.clientSecret.get())
-                .add("username", username)
-                .add("password", password);
-
-        Buffer responseBody = webClient.postAbs(oidcTokenUrl)
-                .sendForm(form)
-                .toCompletionStage()
-                .toCompletableFuture()
-                .join()
-                .bodyAsBuffer();
-
-        if (responseBody == null) {
-            return null;
-        }
-        JsonObject json = responseBody.toJsonObject();
-        return json.getString("access_token");
-    }
-
-    private void setAuditLogger(RoutingContext context) {
-        BiConsumer<RoutingContext, Throwable> failureHandler = context
-                .get(QuarkusHttpUser.AUTH_FAILURE_HANDLER);
-        BiConsumer<RoutingContext, Throwable> auditWrapper = (ctx, ex) -> {
-            // this sends the http response
-            if (failureHandler != null) {
-                failureHandler.accept(ctx, ex);
-            }
-            // if it was an error response log it
-            if (ctx.response().getStatusCode() >= 400) {
-                Map<String, String> metadata = new HashMap<>();
-                metadata.put("method", ctx.request().method().name());
-                metadata.put("path", ctx.request().path());
-                metadata.put("response_code", String.valueOf(ctx.response().getStatusCode()));
-                if (ex != null) {
-                    metadata.put("error_msg", ex.getMessage());
-                }
-
-                // request context for AuditHttpRequestContext does not exist at this point
-                auditLog.log(authConfig.auditLogPrefix, "authenticate", AuditHttpRequestContext.FAILURE, metadata,
-                        new AuditHttpRequestInfo() {
-                            @Override
-                            public String getSourceIp() {
-                                return ctx.request().remoteAddress().toString();
-                            }
-
-                            @Override
-                            public String getForwardedFor() {
-                                return ctx.request()
-                                        .getHeader(AuditHttpRequestContext.X_FORWARDED_FOR_HEADER);
-                            }
-                        });
-            }
-        };
-
-        context.put(QuarkusHttpUser.AUTH_FAILURE_HANDLER, auditWrapper);
+        return chain;
     }
 
     @Override
     public Uni<ChallengeData> getChallenge(RoutingContext context) {
-        var enabledAuth = selectEnabledAuth();
-        if (enabledAuth != null) {
-            return enabledAuth.getChallenge(context);
-        } else {
+        if (authChain.isEmpty()) {
             return Uni.createFrom().nullItem();
         }
+        return authChain.get(authChain.size() - 1).getChallenge(context);
     }
 
     @Override
     public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
         Set<Class<? extends AuthenticationRequest>> credentialTypes = new HashSet<>();
-        credentialTypes.addAll(oidcAuthenticationMechanism.getCredentialTypes());
-        credentialTypes.addAll(basicAuthenticationMechanism.getCredentialTypes());
-        credentialTypes.addAll(proxyHeaderAuthenticationMechanism.getCredentialTypes());
+        for (AuthenticationStrategy strategy : authChain) {
+            credentialTypes.addAll(strategy.getCredentialTypes());
+        }
         return credentialTypes;
     }
 
     @Override
     public Uni<HttpCredentialTransport> getCredentialTransport(RoutingContext context) {
-        var enabledAuth = selectEnabledAuth();
-        if (enabledAuth != null) {
-            return enabledAuth.getCredentialTransport(context);
-        } else {
+        if (authChain.isEmpty()) {
             return Uni.createFrom().nullItem();
         }
+        return authChain.get(authChain.size() - 1).getCredentialTransport(context);
     }
 
-    private Uni<SecurityIdentity> authenticateWithClientCredentials(Pair<String, String> clientCredentials,
-                                                                    RoutingContext context, IdentityProviderManager identityProviderManager) {
-        String jwtToken;
-        String credentialsHash = getCredentialsHash(
-                clientCredentials.getLeft() + clientCredentials.getRight());
-        if (authFailureIsCached(credentialsHash)) {
-            throw cachedAuthFailures.get(credentialsHash).getValue();
-        } else if (accessTokenIsCached(credentialsHash)) {
-            jwtToken = cachedAccessTokens.get(credentialsHash).getValue();
-        } else {
-            jwtToken = getAccessToken(clientCredentials, credentialsHash);
-        }
-        context.request().headers().set("Authorization", "Bearer " + jwtToken);
-        return oidcAuthenticationMechanism.authenticate(context, identityProviderManager);
-    }
-
-    private boolean authFailureIsCached(String credentialsHash) {
-        return cachedAuthFailures.containsKey(credentialsHash)
-                && !cachedAuthFailures.get(credentialsHash).isExpired();
-    }
-
-    private boolean accessTokenIsCached(String credentialsHash) {
-        return cachedAccessTokens.containsKey(credentialsHash)
-                && !cachedAccessTokens.get(credentialsHash).isExpired();
-    }
-
-    @Retry(retryOn = OidcAuthException.class, maxRetries = 4, delay = 1, delayUnit = ChronoUnit.SECONDS)
-    public String getAccessToken(Pair<String, String> clientCredentials, String credentialsHash) {
+    /**
+     * Obtains an access token using client credentials grant. This method is hosted on this CDI
+     * bean (rather than on {@link OidcAuthenticationStrategy}) so that the MicroProfile
+     * {@link Retry} interceptor is applied.
+     *
+     * @param clientCredentials the client ID and secret
+     * @param credentialsHash hash key for the token cache
+     * @param cachedAccessTokens token cache (owned by the OIDC strategy)
+     * @param cachedAuthFailures failure cache (owned by the OIDC strategy)
+     * @param oidcTokenUrl the token endpoint URL (computed by the OIDC strategy at init)
+     */
+    @Retry(retryOn = OidcAuthException.class, maxRetries = 4, delay = 1,
+            delayUnit = ChronoUnit.SECONDS)
+    public String getAccessToken(Pair<String, String> clientCredentials, String credentialsHash,
+            ConcurrentHashMap<String, WrappedValue<String>> cachedAccessTokens,
+            ConcurrentHashMap<String, WrappedValue<RuntimeException>> cachedAuthFailures,
+            String oidcTokenUrl) {
         String clientId = clientCredentials.getLeft();
         String clientSecret = clientCredentials.getRight();
 
-        // Use client-specific scope resolution for Azure Entra ID multi-scope support
         String scopeForClient = authConfig.getScopeForClient(clientId);
 
         MultiMap form = MultiMap.caseInsensitiveMultiMap()
@@ -310,59 +218,41 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
 
             int statusCode = response.statusCode();
             if (statusCode == 401) {
-                var ex = new io.quarkus.security.UnauthorizedException("OIDC token request returned 401");
+                var ex = new io.quarkus.security.UnauthorizedException(
+                        "OIDC token request returned 401");
                 cachedAuthFailures.put(credentialsHash,
-                        new WrappedValue<>(getAccessTokenExpiration(null), Instant.now(), ex));
+                        new WrappedValue<>(
+                                OidcAuthenticationStrategy.getAccessTokenExpiration(null,
+                                        authConfig, jwtParser, log),
+                                Instant.now(), ex));
                 throw ex;
             } else if (statusCode == 403) {
-                var ex = new io.quarkus.security.ForbiddenException("OIDC token request returned 403");
+                var ex = new io.quarkus.security.ForbiddenException(
+                        "OIDC token request returned 403");
                 cachedAuthFailures.put(credentialsHash,
-                        new WrappedValue<>(getAccessTokenExpiration(null), Instant.now(), ex));
+                        new WrappedValue<>(
+                                OidcAuthenticationStrategy.getAccessTokenExpiration(null,
+                                        authConfig, jwtParser, log),
+                                Instant.now(), ex));
                 throw ex;
             } else if (statusCode < 200 || statusCode >= 300) {
-                throw new OidcAuthException("OIDC token request failed with status " + statusCode);
+                throw new OidcAuthException(
+                        "OIDC token request failed with status " + statusCode);
             }
 
             JsonObject json = response.bodyAsJsonObject();
             String jwtToken = json.getString("access_token");
             cachedAccessTokens.put(credentialsHash,
-                    new WrappedValue<>(getAccessTokenExpiration(jwtToken), Instant.now(), jwtToken));
+                    new WrappedValue<>(
+                            OidcAuthenticationStrategy.getAccessTokenExpiration(jwtToken,
+                                    authConfig, jwtParser, log),
+                            Instant.now(), jwtToken));
             return jwtToken;
-        } catch (io.quarkus.security.UnauthorizedException | io.quarkus.security.ForbiddenException ex) {
+        } catch (io.quarkus.security.UnauthorizedException
+                | io.quarkus.security.ForbiddenException ex) {
             throw ex;
         } catch (RuntimeException e) {
             throw new OidcAuthException("Failed to obtain access token", e);
         }
-    }
-
-    /**
-     * Figure out how long to cache a given JWT. The token can be null (if authentication fails), in which
-     * case the configured default expiration time will be used.
-     */
-    protected Duration getAccessTokenExpiration(String jwtToken) {
-        if (jwtToken == null) {
-            return Duration.ofMinutes(authConfig.accessTokenExpiration);
-        }
-        try {
-            JsonWebToken parsedToken = jwtParser.parseOnly(jwtToken);
-
-            // Convert the expiration to an Instant, and subtract the offset (we want to stop using it N
-            // seconds before it expires).
-            Instant expirationInstant = Instant.ofEpochSecond(parsedToken.getExpirationTime())
-                    .minusSeconds(authConfig.accessTokenExpirationOffset);
-            Instant nowInstant = Instant.now();
-
-            // Convert the expiration instant to a duration
-            Duration timeUntilExpiration = Duration.between(nowInstant, expirationInstant);
-            return timeUntilExpiration;
-        } catch (ParseException e) {
-            // Could not parse the JWT, just return the default expiration.
-            log.error("Error parsing JWT from auth server (client credentials grant).", e);
-            return Duration.ofMinutes(authConfig.accessTokenExpiration);
-        }
-    }
-
-    private String getCredentialsHash(String credentials) {
-        return DigestUtils.sha256Hex(credentials);
     }
 }

--- a/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -169,12 +170,17 @@ public class AuthConfig {
     @Info(category = CATEGORY_AUTH, description = "When enabled, authorization checks are skipped and the proxy is trusted to have performed authorization", availableSince = "3.1.0", registryAvailableSince = "3.1.0.Final", studioAvailableSince = "1.0.0")
     boolean proxyHeaderTrustProxyAuthorization;
 
+    @ConfigProperty(name = "apicurio.authn.mechanism.priority", defaultValue = "basic,proxy-header,oidc")
+    @Info(category = CATEGORY_AUTH, description = "Comma-separated ordered list of authentication mechanism names. Only mechanisms that are also enabled will be used. Valid values: basic, proxy-header, oidc.", availableSince = "3.2.3")
+    String mechanismPriority;
+
     @PostConstruct
     void onConstruct() {
         log.debug("===============================");
         log.debug("OIDC Auth Enabled: " + oidcAuthEnabled);
         log.debug("Basic Auth Enabled: " + basicAuthEnabled);
         log.debug("Proxy Auth Enabled: " + proxyHeaderAuthEnabled);
+        log.debug("Mechanism Priority: " + mechanismPriority);
         log.debug("Anonymous Read Access Enabled: " + anonymousReadAccessEnabled);
         log.debug("Authenticated Read Access Enabled: " + authenticatedReadAccessEnabled);
         log.debug("RBAC Enabled: " + roleBasedAuthorizationEnabled);
@@ -228,6 +234,18 @@ public class AuthConfig {
 
     public boolean isAuthenticatedReadsEnabled() {
         return authenticatedReadAccessEnabled.get();
+    }
+
+    /**
+     * Returns the ordered list of authentication mechanism names from the configured priority.
+     *
+     * @return list of mechanism names (e.g. ["basic", "proxy-header", "oidc"])
+     */
+    public List<String> getMechanismPriorityList() {
+        return Arrays.stream(mechanismPriority.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/auth/AuthenticationStrategy.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthenticationStrategy.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.auth;
+
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+import java.util.Set;
+
+/**
+ * Abstraction for an authentication strategy in the authentication chain. Each strategy wraps a
+ * specific authentication mechanism and encapsulates all logic needed to authenticate requests of
+ * that type.
+ *
+ * <p>Strategies are tried in priority order. If a strategy cannot handle a request (e.g. the
+ * expected headers or credentials are not present), it returns a {@code Uni} emitting {@code null}
+ * to signal that the next strategy in the chain should be tried.</p>
+ */
+public interface AuthenticationStrategy {
+
+    /**
+     * Returns a human-readable name for this strategy, used in logging (e.g. "basic",
+     * "proxy-header", "oidc").
+     */
+    String name();
+
+    /**
+     * Attempts to authenticate the request. Returns a {@code Uni} emitting a
+     * {@link SecurityIdentity} if this strategy handles the request, or a {@code Uni} emitting
+     * {@code null} if it cannot handle it (allowing the next strategy in the chain to try).
+     */
+    Uni<SecurityIdentity> authenticate(RoutingContext context,
+            IdentityProviderManager identityProviderManager);
+
+    /**
+     * Returns challenge data for 401 responses.
+     */
+    Uni<ChallengeData> getChallenge(RoutingContext context);
+
+    /**
+     * Returns the set of credential types this strategy supports.
+     */
+    Set<Class<? extends AuthenticationRequest>> getCredentialTypes();
+
+    /**
+     * Returns credential transport information.
+     */
+    Uni<HttpCredentialTransport> getCredentialTransport(RoutingContext context);
+}

--- a/app/src/main/java/io/apicurio/registry/auth/DelegatingAuthenticationStrategy.java
+++ b/app/src/main/java/io/apicurio/registry/auth/DelegatingAuthenticationStrategy.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.auth;
+
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+import java.util.Set;
+
+/**
+ * A simple authentication strategy that delegates directly to an underlying
+ * {@link HttpAuthenticationMechanism}. Used for mechanisms that require no additional wrapper
+ * logic (e.g. basic auth, proxy-header auth).
+ */
+public class DelegatingAuthenticationStrategy implements AuthenticationStrategy {
+
+    private final String strategyName;
+    private final HttpAuthenticationMechanism delegate;
+
+    /**
+     * Creates a new delegating strategy.
+     *
+     * @param strategyName human-readable name for logging
+     * @param delegate the underlying authentication mechanism
+     */
+    public DelegatingAuthenticationStrategy(String strategyName,
+            HttpAuthenticationMechanism delegate) {
+        this.strategyName = strategyName;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String name() {
+        return strategyName;
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(RoutingContext context,
+            IdentityProviderManager identityProviderManager) {
+        return delegate.authenticate(context, identityProviderManager);
+    }
+
+    @Override
+    public Uni<ChallengeData> getChallenge(RoutingContext context) {
+        return delegate.getChallenge(context);
+    }
+
+    @Override
+    public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+        return delegate.getCredentialTypes();
+    }
+
+    @Override
+    public Uni<HttpCredentialTransport> getCredentialTransport(RoutingContext context) {
+        return delegate.getCredentialTransport(context);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2025 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.auth;
+
+import io.apicurio.registry.logging.audit.AuditHttpRequestContext;
+import io.apicurio.registry.logging.audit.AuditHttpRequestInfo;
+import io.apicurio.registry.logging.audit.AuditLogService;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
+import io.quarkus.oidc.runtime.OidcAuthenticationMechanism;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.smallrye.jwt.auth.principal.DefaultJWTParser;
+import io.smallrye.jwt.auth.principal.ParseException;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.MultiMap;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+
+/**
+ * Authentication strategy that encapsulates the full OIDC authentication flow, including audit
+ * logging, client credentials grant, and password grant authentication.
+ */
+public class OidcAuthenticationStrategy implements AuthenticationStrategy {
+
+    private final OidcAuthenticationMechanism oidcAuthenticationMechanism;
+    private final AuthConfig authConfig;
+    private final AuditLogService auditLog;
+    private final WebClient webClient;
+    private final Logger log;
+    private final AppAuthenticationMechanism parent;
+
+    private final ConcurrentHashMap<String, WrappedValue<String>> cachedAccessTokens;
+    private final ConcurrentHashMap<String, WrappedValue<RuntimeException>> cachedAuthFailures;
+    private final String oidcTokenUrl;
+
+    /**
+     * Creates a new OIDC authentication strategy.
+     *
+     * @param oidcAuthenticationMechanism the Quarkus OIDC mechanism to delegate to
+     * @param authConfig authentication configuration
+     * @param auditLog audit logging service
+     * @param webClient HTTP client for token requests
+     * @param log logger
+     * @param parent the parent CDI bean (hosts {@code getAccessToken} for @Retry support)
+     */
+    public OidcAuthenticationStrategy(OidcAuthenticationMechanism oidcAuthenticationMechanism,
+            AuthConfig authConfig, AuditLogService auditLog, WebClient webClient,
+            Logger log, AppAuthenticationMechanism parent) {
+        this.oidcAuthenticationMechanism = oidcAuthenticationMechanism;
+        this.authConfig = authConfig;
+        this.auditLog = auditLog;
+        this.webClient = webClient;
+        this.log = log;
+        this.parent = parent;
+
+        this.cachedAccessTokens = new ConcurrentHashMap<>();
+        this.cachedAuthFailures = new ConcurrentHashMap<>();
+
+        if (authConfig.oidcTokenPath.startsWith("http")) {
+            this.oidcTokenUrl = authConfig.oidcTokenPath;
+        } else {
+            this.oidcTokenUrl = authConfig.authServerUrl + authConfig.oidcTokenPath;
+        }
+    }
+
+    @Override
+    public String name() {
+        return "oidc";
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(RoutingContext context,
+            IdentityProviderManager identityProviderManager) {
+        setAuditLogger(context);
+        if (authConfig.basicClientCredentialsAuthEnabled.get()) {
+            final Pair<String, String> clientCredentials = CredentialsHelper
+                    .extractCredentialsFromContext(context);
+            if (null != clientCredentials) {
+                try {
+                    return authenticateWithClientCredentials(clientCredentials, context,
+                            identityProviderManager);
+                } catch (OidcAuthException | io.quarkus.security.UnauthorizedException ex) {
+                    log.warn(String.format(
+                            "Exception trying to get an access token with client credentials with client id: %s",
+                            clientCredentials.getLeft()), ex);
+                    return oidcAuthenticationMechanism.authenticate(context,
+                            identityProviderManager);
+                }
+            } else {
+                return customAuthentication(context, identityProviderManager);
+            }
+        } else {
+            return customAuthentication(context, identityProviderManager);
+        }
+    }
+
+    @Override
+    public Uni<ChallengeData> getChallenge(RoutingContext context) {
+        return oidcAuthenticationMechanism.getChallenge(context);
+    }
+
+    @Override
+    public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+        return oidcAuthenticationMechanism.getCredentialTypes();
+    }
+
+    @Override
+    public Uni<HttpCredentialTransport> getCredentialTransport(RoutingContext context) {
+        return oidcAuthenticationMechanism.getCredentialTransport(context);
+    }
+
+    private Uni<SecurityIdentity> customAuthentication(RoutingContext context,
+            IdentityProviderManager identityProviderManager) {
+        if (authConfig.clientSecret.isEmpty()) {
+            return oidcAuthenticationMechanism.authenticate(context, identityProviderManager);
+        } else {
+            final Pair<String, String> credentialsFromContext = CredentialsHelper
+                    .extractCredentialsFromContext(context);
+            if (credentialsFromContext != null) {
+                String jwtToken = obtainAccessTokenPasswordGrant(
+                        credentialsFromContext.getLeft(), credentialsFromContext.getRight());
+                if (jwtToken != null) {
+                    context.request().headers().set("Authorization", "Bearer " + jwtToken);
+                    return oidcAuthenticationMechanism.authenticate(context,
+                            identityProviderManager);
+                }
+            } else {
+                return oidcAuthenticationMechanism.authenticate(context,
+                        identityProviderManager);
+            }
+        }
+        return Uni.createFrom().nullItem();
+    }
+
+    private String obtainAccessTokenPasswordGrant(String username, String password) {
+        MultiMap form = MultiMap.caseInsensitiveMultiMap()
+                .add("grant_type", "password")
+                .add("client_id", authConfig.clientId)
+                .add("client_secret", authConfig.clientSecret.get())
+                .add("username", username)
+                .add("password", password);
+
+        Buffer responseBody = webClient.postAbs(oidcTokenUrl)
+                .sendForm(form)
+                .toCompletionStage()
+                .toCompletableFuture()
+                .join()
+                .bodyAsBuffer();
+
+        if (responseBody == null) {
+            return null;
+        }
+        JsonObject json = responseBody.toJsonObject();
+        return json.getString("access_token");
+    }
+
+    private void setAuditLogger(RoutingContext context) {
+        BiConsumer<RoutingContext, Throwable> failureHandler = context
+                .get(QuarkusHttpUser.AUTH_FAILURE_HANDLER);
+        BiConsumer<RoutingContext, Throwable> auditWrapper = (ctx, ex) -> {
+            if (failureHandler != null) {
+                failureHandler.accept(ctx, ex);
+            }
+            if (ctx.response().getStatusCode() >= 400) {
+                Map<String, String> metadata = new HashMap<>();
+                metadata.put("method", ctx.request().method().name());
+                metadata.put("path", ctx.request().path());
+                metadata.put("response_code", String.valueOf(ctx.response().getStatusCode()));
+                if (ex != null) {
+                    metadata.put("error_msg", ex.getMessage());
+                }
+
+                auditLog.log(authConfig.auditLogPrefix, "authenticate",
+                        AuditHttpRequestContext.FAILURE, metadata,
+                        new AuditHttpRequestInfo() {
+                            @Override
+                            public String getSourceIp() {
+                                return ctx.request().remoteAddress().toString();
+                            }
+
+                            @Override
+                            public String getForwardedFor() {
+                                return ctx.request().getHeader(
+                                        AuditHttpRequestContext.X_FORWARDED_FOR_HEADER);
+                            }
+                        });
+            }
+        };
+
+        context.put(QuarkusHttpUser.AUTH_FAILURE_HANDLER, auditWrapper);
+    }
+
+    private Uni<SecurityIdentity> authenticateWithClientCredentials(
+            Pair<String, String> clientCredentials, RoutingContext context,
+            IdentityProviderManager identityProviderManager) {
+        String jwtToken;
+        String credentialsHash = getCredentialsHash(
+                clientCredentials.getLeft() + clientCredentials.getRight());
+        if (authFailureIsCached(credentialsHash)) {
+            throw cachedAuthFailures.get(credentialsHash).getValue();
+        } else if (accessTokenIsCached(credentialsHash)) {
+            jwtToken = cachedAccessTokens.get(credentialsHash).getValue();
+        } else {
+            jwtToken = parent.getAccessToken(clientCredentials, credentialsHash,
+                    cachedAccessTokens, cachedAuthFailures, oidcTokenUrl);
+        }
+        context.request().headers().set("Authorization", "Bearer " + jwtToken);
+        return oidcAuthenticationMechanism.authenticate(context, identityProviderManager);
+    }
+
+    private boolean authFailureIsCached(String credentialsHash) {
+        return cachedAuthFailures.containsKey(credentialsHash)
+                && !cachedAuthFailures.get(credentialsHash).isExpired();
+    }
+
+    private boolean accessTokenIsCached(String credentialsHash) {
+        return cachedAccessTokens.containsKey(credentialsHash)
+                && !cachedAccessTokens.get(credentialsHash).isExpired();
+    }
+
+    private String getCredentialsHash(String credentials) {
+        return DigestUtils.sha256Hex(credentials);
+    }
+
+    /**
+     * Calculates how long to cache a given JWT. The token can be null (if authentication fails),
+     * in which case the configured default expiration time will be used.
+     */
+    static Duration getAccessTokenExpiration(String jwtToken, AuthConfig authConfig,
+            DefaultJWTParser jwtParser, Logger log) {
+        if (jwtToken == null) {
+            return Duration.ofMinutes(authConfig.accessTokenExpiration);
+        }
+        try {
+            JsonWebToken parsedToken = jwtParser.parseOnly(jwtToken);
+
+            Instant expirationInstant = Instant.ofEpochSecond(parsedToken.getExpirationTime())
+                    .minusSeconds(authConfig.accessTokenExpirationOffset);
+            Instant nowInstant = Instant.now();
+
+            Duration timeUntilExpiration = Duration.between(nowInstant, expirationInstant);
+            return timeUntilExpiration;
+        } catch (ParseException e) {
+            log.error("Error parsing JWT from auth server (client credentials grant).", e);
+            return Duration.ofMinutes(authConfig.accessTokenExpiration);
+        }
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/auth/ProxyAndOidcDualAuthTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/ProxyAndOidcDualAuthTest.java
@@ -1,0 +1,198 @@
+package io.apicurio.registry.auth;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.AuthTestProfile;
+import io.apicurio.registry.utils.tests.KeycloakTestContainerManager;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests for dual proxy-header + OIDC authentication mode. When both mechanisms are enabled,
+ * proxy headers are tried first. If absent, the request falls back to OIDC authentication.
+ *
+ * <p>This test shares {@link AuthTestProfile} with other auth tests to avoid an extra Quarkus
+ * augmentation. The profile enables both proxy-header and OIDC; existing OIDC-only tests are
+ * unaffected because the proxy-header mechanism returns null when no proxy headers are present.</p>
+ */
+@QuarkusTest
+@TestProfile(AuthTestProfile.class)
+public class ProxyAndOidcDualAuthTest extends AbstractResourceTestBase {
+
+    private static final String ARTIFACT_CONTENT = "{\"name\":\"redhat\"}";
+    private static final String HEADER_USERNAME = "X-Forwarded-User";
+    private static final String HEADER_EMAIL = "X-Forwarded-Email";
+    private static final String HEADER_GROUPS = "X-Forwarded-Groups";
+
+    private static final String PROXY_USERNAME = "proxy-testuser";
+    private static final String PROXY_EMAIL = "proxy-testuser@example.com";
+    private static final String ROLE_ADMIN = "sr-admin";
+    private static final String ROLE_DEVELOPER = "sr-developer";
+
+    @ConfigProperty(name = "quarkus.oidc.token-path")
+    String tokenEndpoint;
+
+    @Override
+    protected void deleteGlobalRules(int expectedDefaultRulesCount) throws Exception {
+        // Skip — would fail without auth headers
+    }
+
+    /**
+     * Obtains a Bearer token from Keycloak using client credentials grant.
+     */
+    private String obtainOidcToken(String clientId, String clientSecret) {
+        return given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("grant_type", "client_credentials")
+                .formParam("client_id", clientId)
+                .formParam("client_secret", clientSecret)
+                .post(tokenEndpoint)
+                .then()
+                .statusCode(200)
+                .extract().path("access_token");
+    }
+
+    /**
+     * When proxy headers are present, proxy authentication is used regardless of OIDC being
+     * enabled. The artifact owner should match the proxy username.
+     */
+    @Test
+    public void testProxyHeadersPresent_ProxyAuthUsed() {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+
+        given()
+                .header(HEADER_USERNAME, PROXY_USERNAME)
+                .header(HEADER_EMAIL, PROXY_EMAIL)
+                .header(HEADER_GROUPS, ROLE_DEVELOPER)
+                .contentType(ContentType.JSON)
+                .body(TestUtils.clientCreateArtifact(artifactId, ArtifactType.JSON,
+                        ARTIFACT_CONTENT, ContentTypes.APPLICATION_JSON))
+                .when()
+                .pathParam("groupId", groupId)
+                .post("/registry/v3/groups/{groupId}/artifacts")
+                .then()
+                .statusCode(200)
+                .body("version.owner", equalTo(PROXY_USERNAME));
+
+        // Clean up
+        given()
+                .header(HEADER_USERNAME, PROXY_USERNAME)
+                .header(HEADER_EMAIL, PROXY_EMAIL)
+                .header(HEADER_GROUPS, ROLE_DEVELOPER)
+                .when()
+                .pathParam("groupId", groupId)
+                .delete("/registry/v3/groups/{groupId}/artifacts/" + artifactId)
+                .then()
+                .statusCode(204);
+    }
+
+    /**
+     * When proxy headers are absent but a valid OIDC Bearer token is present, the request falls
+     * back to OIDC authentication. The artifact owner should match the OIDC client identity.
+     */
+    @Test
+    public void testNoProxyHeaders_OidcFallback() {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+        String token = obtainOidcToken(KeycloakTestContainerManager.ADMIN_CLIENT_ID, "test1");
+
+        given()
+                .header("Authorization", "Bearer " + token)
+                .contentType(ContentType.JSON)
+                .body(TestUtils.clientCreateArtifact(artifactId, ArtifactType.JSON,
+                        ARTIFACT_CONTENT, ContentTypes.APPLICATION_JSON))
+                .when()
+                .pathParam("groupId", groupId)
+                .post("/registry/v3/groups/{groupId}/artifacts")
+                .then()
+                .statusCode(200)
+                .body("version.owner",
+                        equalTo(KeycloakTestContainerManager.ADMIN_CLIENT_ID));
+
+        // Clean up
+        given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .pathParam("groupId", groupId)
+                .delete("/registry/v3/groups/{groupId}/artifacts/" + artifactId)
+                .then()
+                .statusCode(204);
+    }
+
+    /**
+     * When neither proxy headers nor an OIDC token are present, the request should be rejected
+     * with 401.
+     */
+    @Test
+    public void testNeitherPresent_Rejected() {
+        given()
+                .when()
+                .get("/registry/v3/search/artifacts")
+                .then()
+                .statusCode(401);
+    }
+
+    /**
+     * When both proxy headers and an OIDC Bearer token are present, proxy authentication wins
+     * because it is first in the chain. The identity should come from the proxy headers.
+     */
+    @Test
+    public void testBothPresent_ProxyWins() {
+        String token = obtainOidcToken(KeycloakTestContainerManager.ADMIN_CLIENT_ID, "test1");
+
+        given()
+                .header(HEADER_USERNAME, PROXY_USERNAME)
+                .header(HEADER_EMAIL, PROXY_EMAIL)
+                .header(HEADER_GROUPS, ROLE_ADMIN)
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/registry/v3/users/me")
+                .then()
+                .statusCode(200)
+                .body("username", equalTo(PROXY_USERNAME));
+    }
+
+    /**
+     * Verify that OIDC client credentials authentication still works as a fallback when proxy
+     * headers are absent — confirming that the full OIDC client credentials flow (not just Bearer
+     * token pass-through) functions correctly in dual mode.
+     */
+    @Test
+    public void testOidcClientCredentials_WithBasicAuth() {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+
+        given()
+                .auth().preemptive().basic(
+                        KeycloakTestContainerManager.DEVELOPER_CLIENT_ID, "test1")
+                .contentType(ContentType.JSON)
+                .body(TestUtils.clientCreateArtifact(artifactId, ArtifactType.JSON,
+                        ARTIFACT_CONTENT, ContentTypes.APPLICATION_JSON))
+                .when()
+                .pathParam("groupId", groupId)
+                .post("/registry/v3/groups/{groupId}/artifacts")
+                .then()
+                .statusCode(200)
+                .body("version.owner",
+                        equalTo(KeycloakTestContainerManager.DEVELOPER_CLIENT_ID));
+
+        // Clean up
+        given()
+                .auth().preemptive().basic(
+                        KeycloakTestContainerManager.DEVELOPER_CLIENT_ID, "test1")
+                .when()
+                .pathParam("groupId", groupId)
+                .delete("/registry/v3/groups/{groupId}/artifacts/" + artifactId)
+                .then()
+                .statusCode(204);
+    }
+}

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -214,6 +214,11 @@ The following {registry} configuration options are available for each component 
 |
 |`2.5.0.Final`
 |Client credentials scope.
+|`apicurio.authn.mechanism.priority`
+|`string`
+|`basic,proxy-header,oidc`
+|`3.2.3`
+|Comma-separated ordered list of authentication mechanism names. Only mechanisms that are also enabled will be used. Valid values: basic, proxy-header, oidc.
 |`apicurio.authn.proxy-header.email`
 |`string`
 |`X-Forwarded-Email`

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/AuthTestProfile.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/AuthTestProfile.java
@@ -15,6 +15,11 @@ public class AuthTestProfile implements QuarkusTestProfile {
         props.put("apicurio.rest.deletion.group.enabled", "true");
         props.put("apicurio.rest.deletion.artifact.enabled", "true");
         props.put("apicurio.rest.deletion.artifact-version.enabled", "true");
+        // Enable proxy-header auth alongside OIDC so dual-mode tests can run under this
+        // same profile (avoiding an extra Quarkus augmentation). The proxy-header mechanism
+        // returns null when no proxy headers are present, so OIDC-only tests are unaffected.
+        props.put("apicurio.authn.proxy-header.enabled", "true");
+        props.put("apicurio.authn.mechanism.priority", "proxy-header,oidc");
         return props;
     }
 


### PR DESCRIPTION
## Summary

Backport of #7821 to the `3.2.x` branch.

Replaces the if/else cascade in `AppAuthenticationMechanism` with a chain-of-strategies model that allows
multiple authentication mechanisms to be enabled simultaneously. This is a generalization that allows all
enabled mechanisms to be tried in configurable priority order.

- **New interface** `AuthenticationStrategy` — abstraction for each mechanism in the chain
- **`DelegatingAuthenticationStrategy`** — generic wrapper for mechanisms needing no extra logic (basic,
  proxy-header)
- **`OidcAuthenticationStrategy`** — encapsulates audit logging, client credentials, password grant, and
  token caching (extracted from `AppAuthenticationMechanism`)
- **`AppAuthenticationMechanism`** refactored to build a chain at startup and iterate it on each request
- **New config property** `apicurio.authn.mechanism.priority` (default: `basic,proxy-header,oidc`) —
  controls the order mechanisms are tried
- `availableSince` version updated to `3.2.3` for the backport

Closes #7812

## Test plan

- [ ] New `ProxyAndOidcDualAuthTest` — proxy headers present (proxy wins), absent (OIDC fallback), neither
  (401), both present (proxy wins), client credentials in dual mode
- [ ] Existing `ProxyHeaderAuthTest` passes unchanged (proxy-only regression)
- [ ] Existing `SimpleAuthTest` passes unchanged (OIDC-only regression)
- [ ] Existing `BasicAuthWithPropertiesTest` passes unchanged (basic-only regression)
- [ ] All other auth tests pass unchanged
- [ ] Checkstyle passes