### PR TITLE
docs: clarify that in-memory storage is SQL with embedded H2

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-deploying-registry-operator.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-deploying-registry-operator.adoc
@@ -46,22 +46,19 @@ and pod specifications.
 
 {registry} supports the following storage options:
 
-* *In-memory* (default) - Stores data in memory. Suitable for development and testing only. Data is lost when
-the pod restarts.
+* *Embedded H2 database* (default) - When no storage type is specified, {registry} uses SQL storage with an embedded H2 database. Suitable for development and testing only. All data is stored in memory and lost when the pod restarts.
 * *PostgreSQL* - Stores data in a PostgreSQL database. Suitable for production deployments.
 * *MySQL* - Stores data in a MySQL database. Suitable for production deployments.
-* *KafkaSQL* - Stores data in Apache Kafka topics with an in-memory cache. Suitable for production deployments
-when configured with persistent Kafka storage.
+* *KafkaSQL* - Stores data in Apache Kafka topics, with an embedded H2 database as a local SQL store that is rebuilt from the Kafka journal on each startup. Suitable for production deployments when configured with persistent Kafka storage.
 * *KubernetesOps* - Read-only storage that loads registry data from Kubernetes ConfigMaps. Suitable for
 Kubernetes-native and GitOps workflows. This is an experimental feature.
 
-IMPORTANT: The default in-memory storage is not suitable for production environments.
+IMPORTANT: The default embedded H2 configuration is not suitable for production environments. Configure a storage type (`postgresql`, `mysql`, `kafkasql`, or `kubernetesops`) for production use.
 
 [id="deploying-registry-inmemory_{context}"]
-== Deploying {registry} with in-memory storage
+== Deploying {registry} with default configuration (embedded H2 database)
 
-This section shows how to deploy a basic {registry} instance using in-memory storage. This configuration is
-suitable for development and testing environments only.
+This section shows how to deploy a basic {registry} instance using the default storage configuration (SQL with an embedded H2 database). No storage type needs to be specified in the CR -- when omitted, {registry} defaults to an embedded H2 database. This configuration is suitable for development and testing environments only.
 
 .Prerequisites
 * You must have cluster administrator access to an {kubernetes} cluster.
@@ -247,7 +244,7 @@ the database.
 == Deploying {registry} with KafkaSQL storage
 
 This section explains how to deploy {registry} with KafkaSQL storage. KafkaSQL uses Apache Kafka as the primary
-data store with an in-memory H2 database for caching. This configuration is suitable for production environments
+data store, with an embedded H2 database as a local SQL store that is rebuilt from the Kafka journal on each startup. This configuration is suitable for production environments
 when using persistent Kafka storage.
 
 .Prerequisites

--- a/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-docker.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-docker.adoc
@@ -6,7 +6,7 @@ include::{mod-loc}shared/all-attributes.adoc[]
 [role="_abstract"]
 This chapter explains how to install and run {registry} using Docker with the following storage options:
 
-* xref:installing-registry-in-memory-storage_{context}[]
+* xref:installing-registry-h2-storage_{context}[]
 * xref:installing-registry-sql-storage_{context}[]
 * xref:installing-registry-kafka-storage_{context}[]
 
@@ -25,13 +25,13 @@ NOTE: You can install more than one replica of {registry} depending on your envi
 // Metadata created by nebel
 // ParentAssemblies: assemblies/getting-started/as_installing-the-registry.adoc
 
-[id="installing-registry-in-memory-storage_{context}"]
-== Installing {registry} with in-memory storage
+[id="installing-registry-h2-storage_{context}"]
+== Installing {registry} with default configuration (embedded H2 database)
 
 [role="_abstract"]
-This section explains how to install and run {registry} with simple in-memory storage from a container image.
+This section explains how to install and run {registry} with the default storage configuration from a container image. When no storage is explicitly configured, {registry} uses SQL storage with an embedded H2 database.
 
-NOTE: The in-memory storage option is suitable for development only. All data is lost when the container image is restarted.
+NOTE: The default embedded H2 configuration is suitable for development and testing only. All data is stored in memory and lost when the container is restarted. For production, configure PostgreSQL or Kafka storage.
 
 .Prerequisites
 
@@ -320,7 +320,7 @@ mypassword
 
 
 [role="_abstract"]
-This topic explains how to install and run {registry} with Kafka storage from a container image. The `kafkasql` storage option uses a Kafka topic for storage, along with an in-memory H2 database. This storage option is suitable for production environments.
+This topic explains how to install and run {registry} with Kafka storage from a container image. The `kafkasql` storage option uses Kafka as the primary data store, with an embedded H2 database as a local SQL store that is rebuilt from the Kafka journal on each startup. This storage option is suitable for production environments.
 
 .Prerequisites
 

--- a/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-storage-openshift.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-storage-openshift.adoc
@@ -70,7 +70,7 @@ If you do not already have {kafka-streams} installed, you can install the {kafka
 == Configuring {registry} with Kafka storage on OpenShift
 
 [role="_abstract"]
-This section explains how to configure Kafka-based storage for {registry} using {kafka-streams} on OpenShift. The `kafkasql` storage option uses Kafka storage with an in-memory H2 database for caching. This storage option is suitable for production environments when `persistent` storage is configured for the Kafka cluster on OpenShift.
+This section explains how to configure Kafka-based storage for {registry} using {kafka-streams} on OpenShift. The `kafkasql` storage option uses Kafka as the primary data store, with an embedded H2 database as a local SQL store that is rebuilt from the Kafka journal on each startup. This storage option is suitable for production environments when `persistent` storage is configured for the Kafka cluster on OpenShift.
 
 You can install {registry} in an existing Kafka cluster or create a new Kafka cluster, depending on your environment.
 

--- a/docs/modules/ROOT/pages/getting-started/assembly-intro-to-the-registry.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-intro-to-the-registry.adoc
@@ -336,8 +336,8 @@ endif::[]
 |Description
 
 ifdef::apicurio-registry[]
-|In-memory
-|The in-memory storage option is suitable for a development environment only. All data is lost when restarting {registry} with this storage. The PostgreSQL or Kafka storage option is recommended for a production environment.
+|Embedded H2 database (default)
+|When no storage is explicitly configured, {registry} uses SQL storage with an embedded H2 database. This default configuration is suitable for development and testing only. All data is stored in memory and lost when {registry} is restarted. PostgreSQL or Kafka storage is recommended for production environments.
 endif::[]
 
 |PostgreSQL database

--- a/docs/modules/ROOT/pages/getting-started/assembly-operator-config-reference.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-operator-config-reference.adoc
@@ -240,9 +240,9 @@ The `spec.app.storage` section configures the storage backend for {registry}.
 |Default
 
 |`type`
-|Storage type: `<empty>` (in-memory), `postgresql`, `mysql`, `kafkasql`, or `kubernetesops`
+|Storage type: `<empty>` (embedded H2 database), `postgresql`, `mysql`, `kafkasql`, or `kubernetesops`. When left empty, {registry} uses SQL storage with an embedded H2 database.
 |String
-|`""` (in-memory)
+|`""` (embedded H2, development only)
 
 |`sql`
 |SQL database configuration. Required when `type` is `postgresql` or `mysql`
@@ -260,7 +260,7 @@ The `spec.app.storage` section configures the storage backend for {registry}.
 |None
 |===
 
-IMPORTANT: The default in-memory storage is not suitable for production environments.
+IMPORTANT: The default embedded H2 configuration is not suitable for production environments. Specify a storage type for production use.
 
 === SqlSpec
 

--- a/docs/modules/ROOT/pages/getting-started/assembly-registry-high-availability.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-registry-high-availability.adoc
@@ -74,7 +74,7 @@ spec:
 ----
 
 IMPORTANT: Running multiple replicas requires a production-ready storage backend (PostgreSQL, MySQL, or KafkaSQL
-with persistent Kafka). Do not use in-memory storage with multiple replicas.
+with persistent Kafka). Do not use the default embedded H2 configuration with multiple replicas.
 
 === Distributing pods across nodes
 
@@ -351,7 +351,7 @@ When running multiple {registry} replicas with KafkaSQL storage:
 * Each replica uses a unique consumer group ID (automatically generated using UUID)
 * Each replica independently consumes all messages from the journal topic
 * There is no consumer group rebalancing between replicas
-* All replicas build the same in-memory state from the Kafka topic
+* All replicas build the same local state from the Kafka topic (replayed into an embedded H2 database)
 
 This design ensures that:
 
@@ -360,7 +360,7 @@ This design ensures that:
 * Each replica maintains a consistent view of the data
 
 WARNING: Do not configure a fixed Kafka consumer group ID (for example, by setting
-`APICURIO_KAFKASQL_CONSUMER_GROUP_ID`). KafkaSQL uses an in-memory database that is empty on every
+`APICURIO_KAFKASQL_CONSUMER_GROUP_ID`). KafkaSQL uses an embedded H2 database that is empty on every
 restart, so the full journal topic must be replayed from the beginning each time. A fixed consumer
 group ID causes Kafka to resume from previously committed offsets, skipping the journal replay and
 resulting in the registry appearing empty after a restart. If you need a recognizable consumer group


### PR DESCRIPTION
## Summary

- Replace "in-memory storage" terminology with "embedded H2 database (default)" across 6 documentation
  files. The docs previously described "in-memory" as a distinct storage variant, but it is actually the
  default configuration of SQL storage with an embedded H2 database (`apicurio.storage.kind=sql` +
  `apicurio.storage.sql.kind=h2`).
- Correct the KafkaSQL description from "in-memory H2 database for caching" to "embedded H2 database as
  a local SQL store that is rebuilt from the Kafka journal on each startup."
- Update the operator config reference to show `""` as "(embedded H2, development only)" instead of
  "(in-memory)."

## Files Changed

| File | Changes |
|------|---------|
| `assembly-intro-to-the-registry.adoc` | Renamed storage option in table |
| `assembly-installing-registry-docker.adoc` | Renamed section, updated anchor ID, fixed KafkaSQL description |
| `assembly-deploying-registry-operator.adoc` | Updated storage options list, section title, KafkaSQL description |
| `assembly-operator-config-reference.adoc` | Fixed storage type field and IMPORTANT note |
| `assembly-registry-high-availability.adoc` | Fixed HA warning and KafkaSQL state descriptions |
| `assembly-installing-registry-storage-openshift.adoc` | Fixed KafkaSQL description |

## Test plan

- [ ] Verify all AsciiDoc cross-references (xrefs) resolve correctly — anchor IDs were kept stable
      where external references exist (`deploying-registry-inmemory`)
- [ ] Grep for remaining "in-memory storage" or "in-memory H2" in `docs/` to confirm none were missed
- [ ] Build docs with Antora to verify no rendering issues