### PR TITLE
fix(test): use correct delimiter in SearchIT label filter (backport #7850)

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/tests/search/SearchIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/search/SearchIT.java
@@ -166,7 +166,7 @@ public class SearchIT extends ApicurioRegistryBaseIT {
         retry(() -> {
             VersionSearchResults results = registryClient.search().versions().get(config -> {
                 config.queryParameters.groupId = GROUP;
-                config.queryParameters.labels = new String[] { labelKey + "=search-smoke-test" };
+                config.queryParameters.labels = new String[] { labelKey + ":search-smoke-test" };
             });
             Assertions.assertEquals(1, results.getCount(),
                     "Expected 1 result when searching by label key:value");


### PR DESCRIPTION
## Summary
- Backport of #7852 to the 3.2.x branch
- Fixed `SearchIT.testSearchVersionsByLabels` to use `:` instead of `=` as the label key-value
  separator, matching the delimiter expected by `SearchResourceImpl.searchVersions`

## Related Issue
Fixes #7850