### PR TITLE
docs: add missing NO_CIRCULAR_REFERENCES integrity level

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-rule-reference.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-rule-reference.adoc
@@ -55,6 +55,7 @@ a| Enforce artifact reference integrity when creating or updating artifacts. Ena
 
 * `FULL`: All artifact reference integrity checks are enabled.
 * `NO_DUPLICATES`: Detect if there are any duplicate artifact references.
+* `NO_CIRCULAR_REFERENCES`: Detect circular reference chains among artifacts.
 * `REFS_EXIST`: Detect if there are any references to non-existent artifacts.
 * `ALL_REFS_MAPPED`: Ensure that all artifact references are mapped.
 * `NONE`: All artifact reference integrity checks are disabled.


### PR DESCRIPTION
## Summary

- Add the missing `NO_CIRCULAR_REFERENCES` level to the integrity rule documentation in `assembly-rule-reference.adoc`
- The `IntegrityLevel` enum defines 6 values but the docs only listed 5 — `NO_CIRCULAR_REFERENCES` was omitted

## Test plan

- [ ] Verify the asciidoc renders correctly with the new bullet point
- [ ] Cross-check all 6 `IntegrityLevel` enum values are now documented: `FULL`, `NO_DUPLICATES`, `NO_CIRCULAR_REFERENCES`, `REFS_EXIST`, `ALL_REFS_MAPPED`, `NONE`