### PR TITLE
Add version comments management commands to the CLI. Fixes #7785

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # CLI for Apicurio Registry
 
-> NOTE: The CLI is a dev-preview project, and some features of Apicurio Registry are not supported yet.
+> NOTE: The CLI is a dev-preview project, and some features of Apicurio Registry are not supported yet. Apicurio Registry CLI is currently unstable; its arguments and behavior are subject to backwards-incompatible changes.
 
 ### Supported Platforms
 

--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -14,7 +14,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
 @TopCommand
 @Command(
         name = "acr",
-        description = "Apicurio Registry CLI",
+        description = "Apicurio Registry CLI — manage schemas and APIs from the command line. Currently unstable; its arguments and behavior are subject to backwards-incompatible changes.",
         header = {
                 "   ___        _              _",
                 "  / _ | ___  (_)_____ ______(_)__",
@@ -42,7 +42,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
 public class Acr {
 
     @Option(
-            names = {"-v", "--verbose"},
+            names = {"--verbose"},
             description = "Enable verbose output.",
             scope = INHERIT
     )

--- a/cli/src/main/java/io/apicurio/registry/cli/common/IdUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/IdUtil.java
@@ -7,7 +7,7 @@ import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETU
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
 
 /**
- * Shared utility for resolving and validating group and artifact IDs across CLI commands.
+ * Shared utility for resolving and validating group and artifact IDs, and validating version existence across CLI commands.
  */
 public final class IdUtil {
 
@@ -57,5 +57,12 @@ public final class IdUtil {
     // Validates the artifact exists within the given group.
     public static void validateArtifact(final RegistryClient client, final String groupId, final String artifactId) {
         client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).get();
+    }
+
+    // Validates the version exists for the given artifact.
+    public static void validateVersion(final RegistryClient client, final String groupId,
+                                       final String artifactId, final String versionExpression) {
+        client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId)
+                .versions().byVersionExpression(versionExpression).get();
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
@@ -33,4 +33,7 @@ public final class Columns {
 
     public static final String RULE_TYPE = "Rule Type";
     public static final String CONFIG = "Config";
+
+    public static final String COMMENT_ID = "Comment ID";
+    public static final String COMMENT = "Comment";
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli.utils;
 
 import io.apicurio.registry.rest.client.models.Labels;
+import io.apicurio.registry.rest.v3.beans.Comment;
 import io.apicurio.registry.rest.v3.beans.Rule;
 import io.apicurio.registry.rest.v3.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
@@ -150,6 +151,15 @@ public final class Conversions {
                         .map(Conversions::convert)
                         .collect(Collectors.toList()))
                 .count(searchResults.getCount())
+                .build();
+    }
+
+    public static Comment convert(io.apicurio.registry.rest.client.models.Comment comment) {
+        return Comment.builder()
+                .commentId(comment.getCommentId())
+                .value(comment.getValue())
+                .owner(comment.getOwner())
+                .createdOn(ofNullable(comment.getCreatedOn()).map(Conversions::convert).orElse(null))
                 .build();
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/version/CommentCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/CommentCommand.java
@@ -1,0 +1,27 @@
+package io.apicurio.registry.cli.version;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+@Command(
+        name = "comment",
+        aliases = {"comments"},
+        description = "Work with version comments",
+        subcommands = {
+                CommentCreateCommand.class,
+                CommentDeleteCommand.class,
+                CommentListCommand.class,
+                CommentUpdateCommand.class
+        }
+)
+public class CommentCommand implements Runnable {
+
+    @Spec
+    CommandSpec spec;
+
+    @Override
+    public void run() {
+        spec.commandLine().usage(spec.commandLine().getOut());
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/version/CommentCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/CommentCreateCommand.java
@@ -1,0 +1,122 @@
+package io.apicurio.registry.cli.version;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.NewComment;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.v3.beans.Comment;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.utils.Columns.COMMENT;
+import static io.apicurio.registry.cli.utils.Columns.COMMENT_ID;
+import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
+import static io.apicurio.registry.cli.utils.Columns.FIELD;
+import static io.apicurio.registry.cli.utils.Columns.OWNER;
+import static io.apicurio.registry.cli.utils.Columns.VALUE;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Conversions.convertToString;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+@Command(
+        name = "create",
+        aliases = {"add"},
+        description = "Add a comment to an artifact version"
+)
+public class CommentCreateCommand extends AbstractCommand {
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Group ID. If not provided, uses the groupId from the current context, or 'default'."
+    )
+    private String groupId;
+
+    @Option(
+            names = {"-a", "--artifact"},
+            description = "Artifact ID. If not provided, uses the artifactId from the current context."
+    )
+    private String artifactId;
+
+    @Option(
+            names = {"-v", "--version"},
+            description = "The version expression (e.g. 1.0.0, latest)",
+            required = true
+    )
+    private String versionExpression;
+
+    @Option(
+            names = {"-m", "--message"},
+            description = "The comment text. Use '-' to read from stdin.",
+            required = true
+    )
+    private String commentText;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
+        final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
+        try {
+            final var registryClient = client.getRegistryClient();
+            IdUtil.validateGroup(registryClient, resolvedGroupId);
+            IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+            final var resolvedText = "-".equals(commentText)
+                    ? new String(System.in.readAllBytes()).trim()
+                    : commentText;
+            final var newComment = new NewComment();
+            newComment.setValue(resolvedText);
+            //noinspection ConstantConditions
+            final var created = convert(registryClient.groups().byGroupId(resolvedGroupId)
+                    .artifacts().byArtifactId(resolvedArtifactId)
+                    .versions().byVersionExpression(versionExpression)
+                    .comments().post(newComment));
+            switch (outputType.getOutputType()) {
+                case json -> output.writeStdErrChunk(out -> out.append("Comment added successfully.\n"));
+                case table -> output.writeStdOutChunk(out -> out.append("Comment added successfully.\n"));
+            }
+            printComment(output, created, outputType);
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error adding comment to version '")
+                        .append(versionExpression)
+                        .append("' of artifact '")
+                        .append(resolvedArtifactId)
+                        .append("' in group '")
+                        .append(resolvedGroupId)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+
+    static void printComment(final OutputBuffer output, final Comment comment,
+                             final OutputTypeMixin outputType) throws JsonProcessingException {
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(comment));
+                    out.append('\n');
+                }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(FIELD, VALUE);
+                    table.addRow(COMMENT_ID, comment.getCommentId());
+                    table.addRow(COMMENT, comment.getValue());
+                    table.addRow(OWNER, comment.getOwner());
+                    table.addRow(CREATED_ON, convertToString(comment.getCreatedOn()));
+                    table.print(out);
+                }
+            }
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/version/CommentDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/CommentDeleteCommand.java
@@ -1,0 +1,78 @@
+package io.apicurio.registry.cli.version;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+
+@Command(
+        name = "delete",
+        aliases = {"remove", "rm"},
+        description = "Delete a comment"
+)
+public class CommentDeleteCommand extends AbstractCommand {
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Group ID. If not provided, uses the groupId from the current context, or 'default'."
+    )
+    private String groupId;
+
+    @Option(
+            names = {"-a", "--artifact"},
+            description = "Artifact ID. If not provided, uses the artifactId from the current context."
+    )
+    private String artifactId;
+
+    @Option(
+            names = {"-v", "--version"},
+            description = "The version expression (e.g. 1.0.0, latest)",
+            required = true
+    )
+    private String versionExpression;
+
+    @Parameters(
+            index = "0",
+            description = "The comment ID to delete"
+    )
+    private String commentId;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
+        final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
+        try {
+            final var registryClient = client.getRegistryClient();
+            IdUtil.validateGroup(registryClient, resolvedGroupId);
+            IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+            registryClient.groups().byGroupId(resolvedGroupId)
+                    .artifacts().byArtifactId(resolvedArtifactId)
+                    .versions().byVersionExpression(versionExpression)
+                    .comments().byCommentId(commentId)
+                    .delete();
+            output.writeStdOutChunk(out -> {
+                out.append("Comment '").append(commentId).append("' deleted successfully.\n");
+            });
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error deleting comment '")
+                        .append(commentId)
+                        .append("' on version '")
+                        .append(versionExpression)
+                        .append("' of artifact '")
+                        .append(resolvedArtifactId)
+                        .append("' in group '")
+                        .append(resolvedGroupId)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/version/CommentListCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/CommentListCommand.java
@@ -1,0 +1,107 @@
+package io.apicurio.registry.cli.version;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.Conversions;
+import io.apicurio.registry.rest.v3.beans.Comment;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.utils.Columns.COMMENT;
+import static io.apicurio.registry.cli.utils.Columns.COMMENT_ID;
+import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
+import static io.apicurio.registry.cli.utils.Columns.OWNER;
+import static io.apicurio.registry.cli.utils.Conversions.convertToString;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+@Command(
+        name = "list",
+        aliases = {"ls"},
+        description = "List all comments for an artifact version"
+)
+public class CommentListCommand extends AbstractCommand {
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Group ID. If not provided, uses the groupId from the current context, or 'default'."
+    )
+    private String groupId;
+
+    @Option(
+            names = {"-a", "--artifact"},
+            description = "Artifact ID. If not provided, uses the artifactId from the current context."
+    )
+    private String artifactId;
+
+    @Option(
+            names = {"-v", "--version"},
+            description = "The version expression (e.g. 1.0.0, latest)",
+            required = true
+    )
+    private String versionExpression;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
+        final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
+        try {
+            final var registryClient = client.getRegistryClient();
+            IdUtil.validateGroup(registryClient, resolvedGroupId);
+            IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+            IdUtil.validateVersion(registryClient, resolvedGroupId, resolvedArtifactId, versionExpression);
+            final var comments = registryClient.groups().byGroupId(resolvedGroupId)
+                    .artifacts().byArtifactId(resolvedArtifactId)
+                    .versions().byVersionExpression(versionExpression)
+                    .comments().get();
+            final List<Comment> convertedComments = comments != null
+                    ? comments.stream().map(Conversions::convert).collect(Collectors.toList())
+                    : List.of();
+            output.writeStdOutChunkWithException(out -> {
+                switch (outputType.getOutputType()) {
+                    case json -> {
+                        out.append(MAPPER.writeValueAsString(convertedComments));
+                        out.append('\n');
+                    }
+                    case table -> {
+                        final var table = new TableBuilder();
+                        table.addColumns(COMMENT_ID, COMMENT, OWNER, CREATED_ON);
+                        convertedComments.forEach(c -> {
+                            table.addRow(
+                                    c.getCommentId(),
+                                    c.getValue(),
+                                    c.getOwner(),
+                                    convertToString(c.getCreatedOn())
+                            );
+                        });
+                        table.print(out);
+                    }
+                }
+            });
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error listing comments for version '")
+                        .append(versionExpression)
+                        .append("' of artifact '")
+                        .append(resolvedArtifactId)
+                        .append("' in group '")
+                        .append(resolvedGroupId)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/version/CommentUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/CommentUpdateCommand.java
@@ -1,0 +1,90 @@
+package io.apicurio.registry.cli.version;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.NewComment;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+
+@Command(
+        name = "update",
+        description = "Update an existing comment"
+)
+public class CommentUpdateCommand extends AbstractCommand {
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Group ID. If not provided, uses the groupId from the current context, or 'default'."
+    )
+    private String groupId;
+
+    @Option(
+            names = {"-a", "--artifact"},
+            description = "Artifact ID. If not provided, uses the artifactId from the current context."
+    )
+    private String artifactId;
+
+    @Option(
+            names = {"-v", "--version"},
+            description = "The version expression (e.g. 1.0.0, latest)",
+            required = true
+    )
+    private String versionExpression;
+
+    @Parameters(
+            index = "0",
+            description = "The comment ID to update"
+    )
+    private String commentId;
+
+    @Option(
+            names = {"-m", "--message"},
+            description = "The new comment text. Use '-' to read from stdin.",
+            required = true
+    )
+    private String commentText;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
+        final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
+        try {
+            final var registryClient = client.getRegistryClient();
+            IdUtil.validateGroup(registryClient, resolvedGroupId);
+            IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+            final var resolvedText = "-".equals(commentText)
+                    ? new String(System.in.readAllBytes()).trim()
+                    : commentText;
+            final var updatedComment = new NewComment();
+            updatedComment.setValue(resolvedText);
+            registryClient.groups().byGroupId(resolvedGroupId)
+                    .artifacts().byArtifactId(resolvedArtifactId)
+                    .versions().byVersionExpression(versionExpression)
+                    .comments().byCommentId(commentId)
+                    .put(updatedComment);
+            output.writeStdOutChunk(out -> {
+                out.append("Comment '").append(commentId).append("' updated successfully.\n");
+            });
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error updating comment '")
+                        .append(commentId)
+                        .append("' on version '")
+                        .append(versionExpression)
+                        .append("' of artifact '")
+                        .append(resolvedArtifactId)
+                        .append("' in group '")
+                        .append(resolvedGroupId)
+                        .append("': ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionCommand.java
@@ -35,10 +35,11 @@ import static io.apicurio.registry.cli.utils.Conversions.convertToString;
         aliases = {"versions"},
         description = "Work with artifact versions",
         subcommands = {
+                CommentCommand.class,
                 VersionCreateCommand.class,
+                VersionDeleteCommand.class,
                 VersionGetCommand.class,
-                VersionUpdateCommand.class,
-                VersionDeleteCommand.class
+                VersionUpdateCommand.class
         }
 )
 public class VersionCommand extends AbstractCommand {

--- a/cli/src/test/java/io/apicurio/registry/cli/CommentCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/CommentCommandTest.java
@@ -1,0 +1,230 @@
+package io.apicurio.registry.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.apicurio.registry.rest.v3.beans.Comment;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the version comments CLI commands.
+ */
+@QuarkusTest
+@TestMethodOrder(OrderAnnotation.class)
+public class CommentCommandTest extends AbstractCLITest {
+
+    private static final String TEST_GROUP = "comment-test-group-" + System.currentTimeMillis();
+    private static final String TEST_ARTIFACT = "comment-test-artifact-" + System.currentTimeMillis();
+    private static String createdCommentId;
+
+    @Test
+    @Order(0)
+    public void testSetup() throws Exception {
+        executeAndAssertSuccess("group", "create", TEST_GROUP);
+        final Path tempFile = Files.createTempFile("comment-test", ".json");
+        Files.writeString(tempFile, "{\"type\": \"string\"}");
+        try {
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("artifact", "create", "-g", TEST_GROUP,
+                    "--type", "JSON", "--file", tempFile.toString(), TEST_ARTIFACT);
+            // Verify artifact was created with a version
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("artifact", "version", "-g", TEST_GROUP,
+                    "-a", TEST_ARTIFACT, "--output-type", "json");
+            assertThat(out.toString())
+                    .as(withCliOutput("Artifact should have at least one version"))
+                    .contains("versions");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    public void testCommentHelp() {
+        testHelpCommand("artifact", "version", "comment");
+        testHelpCommand("artifact", "version", "comment", "list");
+        testHelpCommand("artifact", "version", "comment", "create");
+        testHelpCommand("artifact", "version", "comment", "update");
+        testHelpCommand("artifact", "version", "comment", "delete");
+    }
+
+    @Test
+    @Order(1)
+    public void testCommentListEmpty() throws JsonProcessingException {
+        // When
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "version", "comment", "list",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1",
+                "--output-type", "json");
+        var comments = MAPPER.readValue(out.toString(), new TypeReference<List<Comment>>() {
+        });
+
+        // Then
+        assertThat(comments)
+                .as(withCliOutput("There should not be any comments initially."))
+                .isEmpty();
+    }
+
+    @Test
+    @Order(2)
+    public void testCommentCreateCommand() throws JsonProcessingException {
+        // When
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "version", "comment", "create",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1",
+                "--output-type", "json",
+                "-m", "This is a test comment");
+        var comment = MAPPER.readValue(out.toString(), Comment.class);
+
+        // Then
+        assertThat(comment.getCommentId())
+                .as(withCliOutput("Created comment should have a commentId"))
+                .isNotNull()
+                .isNotEmpty();
+        assertThat(comment.getValue())
+                .as(withCliOutput("Created comment should have the correct value"))
+                .isEqualTo("This is a test comment");
+        createdCommentId = comment.getCommentId();
+    }
+
+    @Test
+    @Order(3)
+    public void testCommentListWithComments() throws JsonProcessingException {
+        // Add a second comment
+        executeAndAssertSuccess("artifact", "version", "comment", "create",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1",
+                "-m", "Second comment");
+
+        // When
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "version", "comment", "list",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1",
+                "--output-type", "json");
+        var comments = MAPPER.readValue(out.toString(), new TypeReference<List<Comment>>() {
+        });
+
+        // Then
+        assertThat(comments)
+                .as(withCliOutput("There should be two comments."))
+                .hasSize(2);
+    }
+
+    @Test
+    @Order(4)
+    public void testCommentUpdateCommand() {
+        // When
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "version", "comment", "update",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1",
+                createdCommentId, "-m", "Updated comment text");
+
+        // Then
+        assertThat(out.toString())
+                .as(withCliOutput("Update should show success message"))
+                .contains("updated successfully");
+    }
+
+    @Test
+    @Order(5)
+    public void testCommentDeleteCommand() throws JsonProcessingException {
+        // When
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "version", "comment", "delete",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1",
+                createdCommentId);
+
+        // Then
+        assertThat(out.toString())
+                .as(withCliOutput("Delete should show success message"))
+                .contains("deleted successfully");
+
+        // Verify one comment remains
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "version", "comment", "list",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1",
+                "--output-type", "json");
+        var comments = MAPPER.readValue(out.toString(), new TypeReference<List<Comment>>() {
+        });
+        assertThat(comments)
+                .as(withCliOutput("There should be one comment after deletion."))
+                .hasSize(1);
+    }
+
+    @Test
+    public void testCommentCreateCommandFails() {
+        // Missing message
+        executeAndAssertFailure("artifact", "version", "comment", "create",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1");
+        // Missing version
+        executeAndAssertFailure("artifact", "version", "comment", "create",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-m", "text");
+    }
+
+    @Test
+    public void testCommentUpdateCommandFails() {
+        // Missing message (-m)
+        executeAndAssertFailure("artifact", "version", "comment", "update",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1", "some-id");
+        // Missing comment ID (positional)
+        executeAndAssertFailure("artifact", "version", "comment", "update",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1", "-m", "text");
+    }
+
+    @Test
+    public void testCommentDeleteCommandFails() {
+        // Missing comment ID
+        executeAndAssertFailure("artifact", "version", "comment", "delete",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1");
+        // Non-existent comment
+        executeAndAssertFailure("artifact", "version", "comment", "delete",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1", "non-existent-id");
+    }
+
+    @Test
+    public void testMissingArtifactId() {
+        executeAndAssertFailure("artifact", "version", "comment", "list",
+                "-g", TEST_GROUP, "-v", "1");
+        executeAndAssertFailure("artifact", "version", "comment", "create",
+                "-g", TEST_GROUP, "-v", "1", "-m", "text");
+    }
+
+    @Test
+    public void testNonExistentGroupOrArtifact() {
+        // Non-existent group
+        executeAndAssertFailure("artifact", "version", "comment", "list",
+                "-g", "non-existent-group", "-a", TEST_ARTIFACT, "-v", "1");
+        executeAndAssertFailure("artifact", "version", "comment", "create",
+                "-g", "non-existent-group", "-a", TEST_ARTIFACT, "-v", "1", "-m", "text");
+        // Non-existent artifact
+        executeAndAssertFailure("artifact", "version", "comment", "list",
+                "-g", TEST_GROUP, "-a", "non-existent-artifact", "-v", "1");
+        executeAndAssertFailure("artifact", "version", "comment", "create",
+                "-g", TEST_GROUP, "-a", "non-existent-artifact", "-v", "1", "-m", "text");
+        // Non-existent version
+        executeAndAssertFailure("artifact", "version", "comment", "list",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "999");
+    }
+
+    @Test
+    @Order(6)
+    public void testCommentTableOutput() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "version", "comment", "list",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-v", "1");
+        assertThat(out.toString())
+                .as(withCliOutput("Table output should contain column headers"))
+                .contains("Comment ID")
+                .contains("Comment")
+                .contains("Owner");
+    }
+}


### PR DESCRIPTION
## Summary

Add version comments management commands to the Apicurio Registry CLI. Supports list, create, update, and delete operations for comments on artifact versions with JSON/table output, context-based group/artifact ID resolution, stdin support, and proper validation for group, artifact, and version existence.

## Changes

- Add `CommentCommand` (parent, shows help), `CommentListCommand`, `CommentCreateCommand`, `CommentUpdateCommand`, `CommentDeleteCommand` in the `version` package
- Add `IdUtil.validateVersion()` for version existence validation
- Add `Comment` conversion method in `Conversions.java` (SDK → beans)
- Add `COMMENT_ID` and `COMMENT` column constants in `Columns.java`
- Register `CommentCommand` as subcommand of `VersionCommand`
- Update `IdUtil` Javadoc to reflect version validation
- Remove `-v` short option from `--verbose` globally to free it for `--version`
- Add `-v` as short option for `--version` in all comment commands
- Add CLI unstable disclaimer in `Acr.java` description and `README.md`
- Add stdin support — pass `-m -` to read comment text from stdin
- Changed `throws JsonProcessingException` to `throws Exception` on list/create commands

## Usage

```bash
acr artifact version comment                                                          # show help
acr artifact version comment list -g myGroup -a myArtifact -v 1.0.0                   # list comments
acr artifact version comment list -g myGroup -a myArtifact -v 1.0.0 -o json           # list in JSON
acr artifact version comment create -g myGroup -a myArtifact -v 1.0.0 -m "my comment" # add
echo "my comment" | acr artifact version comment create -g myGroup -a myArtifact -v 1.0.0 -m -  # add from stdin
acr artifact version comment update -g myGroup -a myArtifact -v 1.0.0 commentId -m "new text"   # update
acr artifact version comment delete -g myGroup -a myArtifact -v 1.0.0 commentId       # delete
```

## Design Decisions

- `CommentCommand` is a pure parent (shows help only) — avoids PicoCLI required-option conflict with subcommands when `--version` is required
- `list` is an explicit subcommand (not the parent's default action)
- `-v`/`--version` as option (not positional) — avoids conflict with subcommand names. `-v` freed by removing it from `--verbose`
- `-m`/`--message` for comment text on both create and update — keeps the two commands consistent since update needs a positional `commentId`, using positional for text too would be confusing
- Stdin support with `-m -` — reads comment text from stdin
- Comment ID as positional parameter for update/delete
- `validateGroup` + `validateArtifact` on all 4 commands — backend returns misleading errors for non-existent groups/artifacts
- `validateVersion` only on list — backend returns silent `[]` for non-existent versions; create/update/delete correctly throw `VersionNotFoundException`

## Testing

- [x] Build succeeds
- [x] Checkstyle passes with 0 violations
- [x] All CLI tests pass (129 tests, 0 failures)
- [x] Manual verification (30 test cases):
  - [x] Help output for parent and all subcommands
  - [x] List comments - empty state (table and JSON)
  - [x] Create comments - single and multi-word text
  - [x] Create comments - JSON output format
  - [x] List comments - with multiple comments
  - [x] Update comment text and verify
  - [x] Delete comment and verify count decreases
  - [x] Error: non-existent group (GroupNotFoundException)
  - [x] Error: non-existent artifact (ArtifactNotFoundException)
  - [x] Error: non-existent version (VersionNotFoundException)
  - [x] Error: non-existent comment (CommentNotFoundException)
  - [x] Error: missing required parameters (-v, -m, commentId, -a)
  - [x] Aliases work (comments, add, ls, rm)

Closes #7785