### PR TITLE
docs: apply IBM Style Guide fixes to H2 storage terminology

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-deploying-registry-operator.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-deploying-registry-operator.adoc
@@ -46,10 +46,10 @@ and pod specifications.
 
 {registry} supports the following storage options:
 
-* *Embedded H2 database* (default) - When no storage type is specified, {registry} uses SQL storage with an embedded H2 database. Suitable for development and testing only. All data is stored in memory and lost when the pod restarts.
+* *Embedded H2 database* (default) - When you do not specify a storage type, {registry} uses SQL storage with an embedded H2 database. Suitable for development and testing only. {registry} stores all data in memory and loses it when the pod restarts.
 * *PostgreSQL* - Stores data in a PostgreSQL database. Suitable for production deployments.
 * *MySQL* - Stores data in a MySQL database. Suitable for production deployments.
-* *KafkaSQL* - Stores data in Apache Kafka topics, with an embedded H2 database as a local SQL store that is rebuilt from the Kafka journal on each startup. Suitable for production deployments when configured with persistent Kafka storage.
+* *KafkaSQL* - Stores data in Apache Kafka topics, with an embedded H2 database as a local SQL store that {registry} rebuilds from the Kafka journal on each startup. Suitable for production deployments when you configure persistent Kafka storage.
 * *KubernetesOps* - Read-only storage that loads registry data from Kubernetes ConfigMaps. Suitable for
 Kubernetes-native and GitOps workflows. This is an experimental feature.
 
@@ -58,7 +58,7 @@ IMPORTANT: The default embedded H2 configuration is not suitable for production 
 [id="deploying-registry-inmemory_{context}"]
 == Deploying {registry} with default configuration (embedded H2 database)
 
-This section shows how to deploy a basic {registry} instance using the default storage configuration (SQL with an embedded H2 database). No storage type needs to be specified in the CR -- when omitted, {registry} defaults to an embedded H2 database. This configuration is suitable for development and testing environments only.
+You can deploy a basic {registry} instance by using the default storage configuration (SQL with an embedded H2 database). You do not need to specify a storage type in the CR. When omitted, {registry} defaults to an embedded H2 database. This configuration is suitable for development and testing environments only.
 
 .Prerequisites
 * You must have cluster administrator access to an {kubernetes} cluster.
@@ -243,9 +243,9 @@ the database.
 [id="deploying-registry-kafkasql_{context}"]
 == Deploying {registry} with KafkaSQL storage
 
-This section explains how to deploy {registry} with KafkaSQL storage. KafkaSQL uses Apache Kafka as the primary
-data store, with an embedded H2 database as a local SQL store that is rebuilt from the Kafka journal on each startup. This configuration is suitable for production environments
-when using persistent Kafka storage.
+You can deploy {registry} with KafkaSQL storage. KafkaSQL uses Apache Kafka as the primary
+data store, with an embedded H2 database as a local SQL store that {registry} rebuilds from the Kafka journal on each startup. This configuration is suitable for production environments
+when you configure persistent Kafka storage.
 
 .Prerequisites
 * You must have cluster administrator access to an {kubernetes} cluster.

--- a/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-docker.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-docker.adoc
@@ -29,9 +29,9 @@ NOTE: You can install more than one replica of {registry} depending on your envi
 == Installing {registry} with default configuration (embedded H2 database)
 
 [role="_abstract"]
-This section explains how to install and run {registry} with the default storage configuration from a container image. When no storage is explicitly configured, {registry} uses SQL storage with an embedded H2 database.
+You can install and run {registry} with the default storage configuration from a container image. When you do not configure storage explicitly, {registry} uses SQL storage with an embedded H2 database.
 
-NOTE: The default embedded H2 configuration is suitable for development and testing only. All data is stored in memory and lost when the container is restarted. For production, configure PostgreSQL or Kafka storage.
+NOTE: The default embedded H2 configuration is suitable for development and testing only. {registry} stores all data in memory and loses it when you restart the container. For production, configure PostgreSQL or Kafka storage.
 
 .Prerequisites
 
@@ -320,7 +320,7 @@ mypassword
 
 
 [role="_abstract"]
-This topic explains how to install and run {registry} with Kafka storage from a container image. The `kafkasql` storage option uses Kafka as the primary data store, with an embedded H2 database as a local SQL store that is rebuilt from the Kafka journal on each startup. This storage option is suitable for production environments.
+You can install and run {registry} with Kafka storage from a container image. The `kafkasql` storage option uses Kafka as the primary data store, with an embedded H2 database as a local SQL store that {registry} rebuilds from the Kafka journal on each startup. This storage option is suitable for production environments.
 
 .Prerequisites
 

--- a/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-storage-openshift.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-storage-openshift.adoc
@@ -70,7 +70,7 @@ If you do not already have {kafka-streams} installed, you can install the {kafka
 == Configuring {registry} with Kafka storage on OpenShift
 
 [role="_abstract"]
-This section explains how to configure Kafka-based storage for {registry} using {kafka-streams} on OpenShift. The `kafkasql` storage option uses Kafka as the primary data store, with an embedded H2 database as a local SQL store that is rebuilt from the Kafka journal on each startup. This storage option is suitable for production environments when `persistent` storage is configured for the Kafka cluster on OpenShift.
+You can configure Kafka-based storage for {registry} by using {kafka-streams} on OpenShift. The `kafkasql` storage option uses Kafka as the primary data store, with an embedded H2 database as a local SQL store that {registry} rebuilds from the Kafka journal on each startup. This storage option is suitable for production environments when you configure `persistent` storage for the Kafka cluster on OpenShift.
 
 You can install {registry} in an existing Kafka cluster or create a new Kafka cluster, depending on your environment.
 

--- a/docs/modules/ROOT/pages/getting-started/assembly-intro-to-the-registry.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-intro-to-the-registry.adoc
@@ -337,7 +337,7 @@ endif::[]
 
 ifdef::apicurio-registry[]
 |Embedded H2 database (default)
-|When no storage is explicitly configured, {registry} uses SQL storage with an embedded H2 database. This default configuration is suitable for development and testing only. All data is stored in memory and lost when {registry} is restarted. PostgreSQL or Kafka storage is recommended for production environments.
+|When you do not configure storage explicitly, {registry} uses SQL storage with an embedded H2 database. This default configuration is suitable for development and testing only. {registry} stores all data in memory and loses it on restart. For production environments, use PostgreSQL or Kafka storage to ensure data persistence.
 endif::[]
 
 |PostgreSQL database

--- a/docs/modules/ROOT/pages/getting-started/assembly-registry-high-availability.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-registry-high-availability.adoc
@@ -351,7 +351,7 @@ When running multiple {registry} replicas with KafkaSQL storage:
 * Each replica uses a unique consumer group ID (automatically generated using UUID)
 * Each replica independently consumes all messages from the journal topic
 * There is no consumer group rebalancing between replicas
-* All replicas build the same local state from the Kafka topic (replayed into an embedded H2 database)
+* All replicas build the same local state from the Kafka topic ({registry} replays data into an embedded H2 database)
 
 This design ensures that:
 


### PR DESCRIPTION
## Summary
- Follow-up to PR #7851 — applies IBM Style Guide compliance fixes to the lines changed in that PR
- Converts passive voice to active voice across 5 docs files (e.g., "is stored" → "{registry} stores", "is rebuilt" → "{registry} rebuilds")
- Removes self-referential text ("This section explains..." → "You can...")
- Replaces em dash (`--`) with sentence split
- Replaces unqualified recommendation ("is recommended") with actionable guidance ("use PostgreSQL or Kafka storage to ensure data persistence")
