### PR TITLE
fix(ci): scope Maven builds in release-artifacts workflow to avoid timeout

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -162,7 +162,7 @@ jobs:
       - name: Maven Install
         run: |
           cd registry
-          mvn install -Pprod -Dfull -DskipTests
+          mvn install -pl app -am -Pprod -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress
 
       - name: Generate Maven SBOMs
         run: |
@@ -219,9 +219,9 @@ jobs:
       - name: Generate Maven Site
         run: |
           cd registry
-          mvn clean install -DskipTests
+          mvn clean install -pl utils/maven-plugin -am -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress
           cd utils/maven-plugin
-          mvn site
+          mvn site --no-transfer-progress
 
       - name: Apicurio Website Checkout
         run: |


### PR DESCRIPTION
## Summary

- **release-site job**: Scoped `mvn clean install` from full project to `-pl utils/maven-plugin -am` since only the maven-plugin module needs to be built for `mvn site`. This job [timed out during the 3.2.3 release](https://github.com/Apicurio/apicurio-registry/actions/runs/25025847938) — it was still downloading dependencies when the 30-minute limit hit.
- **release-sboms job**: Scoped `mvn install` from `-Pprod -Dfull` to `-pl app -am -Pprod` since `dependency:tree` only targets `app/pom.xml`. This job completed in 26m21s (of 30m allowed) and was at risk of the same timeout.
- Added `--no-transfer-progress` and `-Dmaven.javadoc.skip=true` to both jobs to reduce log noise and unnecessary work.

These changes match the pattern already used by the `release-builtins` job, which uses `-pl app -am`.

## Test plan

- [ ] Re-run the release-artifacts workflow via `workflow_dispatch` with `artifacts: site` to verify the site job completes well within the 30-minute timeout
- [ ] Re-run with `artifacts: sboms` to verify SBOM generation still works correctly