### PR TITLE
feat(ci): add PR lifecycle orchestrator

### DIFF
--- a/.github/PR_LIFECYCLE.md
+++ b/.github/PR_LIFECYCLE.md
@@ -120,7 +120,6 @@ The orchestrator is configured in `.github/pr-lifecycle.yml`:
 - **stale.days_until_stale** — days of inactivity before marking as stale (default: 7)
 - **stale.days_until_close** — total days of inactivity before closing (default: 14)
 - **welcome_message** — message posted when a PR is opened
-- **smoke_tests.enabled_by_default** — whether smoke tests run by default in WIP state
 
 ## Test Gating
 

--- a/.github/PR_LIFECYCLE.md
+++ b/.github/PR_LIFECYCLE.md
@@ -1,0 +1,139 @@
+# PR Lifecycle
+
+Apicurio Registry uses an automated PR lifecycle orchestrator to manage pull requests.
+The orchestrator controls test execution, tracks PR state via labels, and provides
+comment commands for contributors and maintainers.
+
+## Lifecycle Overview
+
+Every PR moves through these states:
+
+```
+Opened --> new --> wip --> ready-for-review --> ready-to-merge --> merged
+```
+
+| State | Label | What happens |
+|-------|-------|--------------|
+| **New** | `lifecycle/new` | PR just opened. A welcome message is posted. No tests run. A maintainer must triage. PRs from maintainers and trusted accounts (e.g., Renovate) skip this state. |
+| **WIP** | `lifecycle/wip` | Maintainer accepted the PR (or auto-accepted for trusted authors). Smoke tests (lint, build, unit tests) run on each push. |
+| **Ready for review** | `lifecycle/ready-for-review` | Author marked the PR as ready. Full test suite runs. Reviewers can review. |
+| **Ready to merge** | `lifecycle/ready-to-merge` | PR is approved and all tests pass. A maintainer can merge. |
+| **Merged** | — | PR is merged. Branch may be deleted automatically. |
+
+### Additional labels
+
+| Label | Meaning |
+|-------|---------|
+| `lifecycle/tested` | Full test suite passed for the current HEAD commit. Removed on new pushes. |
+| `lifecycle/waiting-on-author` | PR needs action from the author (failed tests or changes requested). |
+| `lifecycle/waiting-on-maintainer` | PR needs maintainer attention (ready to review or merge). |
+| `lifecycle/stale` | No activity for 7 days. PR will be closed after 7 more days of inactivity. |
+
+## For Contributors
+
+### Opening a PR
+
+1. Open a PR against `main` (draft or regular — both work the same way)
+2. The orchestrator posts a welcome message and adds `lifecycle/new`
+3. A maintainer will review and accept your PR with `/accept`
+
+### During development (WIP)
+
+- Push commits as normal. Smoke tests run automatically (lint, build, unit tests)
+- If you want to disable smoke tests (e.g., documentation PR), comment `/disable-tests`
+- To re-enable, comment `/enable-tests`
+
+### When ready for review
+
+1. Make sure a maintainer has assigned at least one reviewer
+2. Comment `/ready` on the PR (or convert from draft to ready if using draft PRs)
+3. The full test suite runs automatically
+4. Wait for review and test results
+
+### After review
+
+- If changes are requested, push fixes. Tests re-run automatically.
+- Once approved and tests pass, the PR moves to `ready-to-merge`
+- A maintainer will merge it, or it merges automatically if auto-merge is enabled
+
+### Stale PRs
+
+If your PR has no activity for 7 days, it will be marked as stale. You will be
+pinged. Comment or push to remove the stale label, or use `/unstale`. After 14
+total days of inactivity, the PR will be closed automatically.
+
+### Available commands
+
+| Command | Description |
+|---------|-------------|
+| `/ready` | Mark your PR as ready for review |
+| `/disable-tests` | Disable smoke tests during WIP |
+| `/enable-tests` | Re-enable smoke tests |
+| `/unstale` | Remove the stale label |
+
+## For Maintainers
+
+### Triaging new PRs
+
+When a new PR arrives (`lifecycle/new`):
+1. Review the PR description and scope
+2. Assign a reviewer
+3. Accept with `/accept` or reject with `/reject [reason]`
+
+### Managing the lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `/accept` | Accept a new PR, transition to WIP |
+| `/reject [reason]` | Reject and close a new PR |
+| `/ready` | Mark a WIP PR as ready for review (can also be done by the author) |
+| `/merge` | Merge a PR that is in `ready-to-merge` state |
+| `/auto-merge` | Toggle auto-merge (PR merges automatically when ready-to-merge is reached) |
+| `/disable-tests` | Disable smoke tests for a WIP PR |
+| `/enable-tests` | Re-enable smoke tests |
+| `/unstale` | Remove the stale label |
+
+### Merge strategy
+
+PRs are merged using **rebase** by default (linear history). This can be changed to
+**squash** in `.github/pr-lifecycle.yml`. Branches are automatically deleted after merge.
+
+### Label protection
+
+All `lifecycle/*` and `orchestrator/*` labels are managed exclusively by the orchestrator.
+Manual label changes will be reverted automatically. Use the appropriate slash command
+instead of adding or removing labels directly.
+
+### Auto-merge
+
+Use `/auto-merge` to enable automatic merging. When the PR reaches `ready-to-merge`
+(approved + tested), it will be merged automatically. Use `/auto-merge` again to disable.
+
+## Configuration
+
+The orchestrator is configured in `.github/pr-lifecycle.yml`:
+
+- **maintainers** — GitHub usernames of maintainers (controls who can use maintainer commands)
+- **auto_accept** — GitHub usernames of accounts that skip triage (auto-accepted to WIP). Maintainers are always auto-accepted.
+- **merge.strategy** — `rebase` (default) or `squash`
+- **merge.delete_branch** — whether to delete the branch after merge
+- **stale.days_until_stale** — days of inactivity before marking as stale (default: 7)
+- **stale.days_until_close** — total days of inactivity before closing (default: 14)
+- **welcome_message** — message posted when a PR is opened
+- **smoke_tests.enabled_by_default** — whether smoke tests run by default in WIP state
+
+## Test Gating
+
+The orchestrator controls which tests run at each lifecycle stage:
+
+| State | Tests |
+|-------|-------|
+| `lifecycle/new` | None |
+| `lifecycle/wip` | Smoke: lint, build, unit tests |
+| `lifecycle/ready-for-review` | Full suite: lint, build, unit tests, integration tests, SDK tests, extras |
+| No orchestrator label | Full suite (backward compatible with non-orchestrated PRs) |
+
+## Opt-in Mode
+
+During rollout, the orchestrator only manages PRs with the `orchestrator/enabled` label.
+PRs without this label use the existing workflow (full test suite on every push).

--- a/.github/pr-lifecycle.yml
+++ b/.github/pr-lifecycle.yml
@@ -1,0 +1,43 @@
+maintainers:
+  - EricWittmann
+  - NikishaPatil
+  - andreaTP
+  - carlesarnal
+  - jsenko
+  - paoloantinori
+  - vandanayadav7
+
+auto_accept:
+  - renovate[bot]
+
+merge:
+  strategy: rebase
+  delete_branch: true
+
+stale:
+  days_until_stale: 7
+  days_until_close: 14
+  stale_message: |
+    This PR has been inactive for 7 days. @{author}, please update or comment
+    to keep it open. It will be closed in 7 days if no activity occurs.
+    Use `/unstale` to remove this label.
+  close_message: |
+    Closing this PR due to inactivity. Feel free to reopen if you
+    want to continue working on it.
+
+welcome_message: |
+  Thanks for opening this PR!
+
+  A maintainer will review and accept it shortly. In the meantime, you can
+  continue pushing changes.
+
+  **Available commands:**
+  | Command | Description |
+  |---------|-------------|
+  | `/ready` | Mark as ready for review (after a maintainer accepts the PR) |
+  | `/disable-tests` | Disable smoke tests during development |
+  | `/enable-tests` | Re-enable smoke tests |
+  | `/unstale` | Remove the stale label |
+
+smoke_tests:
+  enabled_by_default: true

--- a/.github/pr-lifecycle.yml
+++ b/.github/pr-lifecycle.yml
@@ -38,6 +38,3 @@ welcome_message: |
   | `/disable-tests` | Disable smoke tests during development |
   | `/enable-tests` | Re-enable smoke tests |
   | `/unstale` | Remove the stale label |
-
-smoke_tests:
-  enabled_by_default: true

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -1,0 +1,838 @@
+// PR Lifecycle Orchestrator
+//
+// State machine for PR lifecycle management. Labels drive state,
+// comment commands drive transitions. See .github/pr-lifecycle.yml for config.
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LABELS = {
+  NEW: 'lifecycle/new',
+  WIP: 'lifecycle/wip',
+  READY_FOR_REVIEW: 'lifecycle/ready-for-review',
+  TESTED: 'lifecycle/tested',
+  READY_TO_MERGE: 'lifecycle/ready-to-merge',
+  WAITING_ON_AUTHOR: 'lifecycle/waiting-on-author',
+  WAITING_ON_MAINTAINER: 'lifecycle/waiting-on-maintainer',
+  STALE: 'lifecycle/stale',
+  OPT_IN: 'orchestrator/enabled',
+  AUTO_MERGE: 'orchestrator/auto-merge',
+  TESTS_DISABLED: 'orchestrator/tests-disabled',
+};
+
+const PRIMARY_STATES = [
+  LABELS.NEW,
+  LABELS.WIP,
+  LABELS.READY_FOR_REVIEW,
+  LABELS.READY_TO_MERGE,
+];
+
+const CONTROL_LABELS = Object.values(LABELS).filter(
+  l => l.startsWith('lifecycle/') || l.startsWith('orchestrator/')
+);
+
+const COLORS = {
+  INFO: '7BC8F6',
+  ATTENTION: 'EB6420',
+  INACTIVE: 'CCCCCC',
+};
+
+const LABEL_DEFS = {
+  [LABELS.NEW]:                  { color: COLORS.INFO, description: 'PR awaiting triage' },
+  [LABELS.WIP]:                  { color: COLORS.INFO, description: 'Accepted, author working' },
+  [LABELS.READY_FOR_REVIEW]:     { color: COLORS.INFO, description: 'Ready for review, full tests running' },
+  [LABELS.TESTED]:               { color: COLORS.INFO, description: 'Full test suite passed for current HEAD' },
+  [LABELS.READY_TO_MERGE]:       { color: COLORS.INFO, description: 'Approved and tested, ready to merge' },
+  [LABELS.WAITING_ON_AUTHOR]:    { color: COLORS.ATTENTION, description: 'Blocked on contributor action' },
+  [LABELS.WAITING_ON_MAINTAINER]:{ color: COLORS.ATTENTION, description: 'Blocked on maintainer action' },
+  [LABELS.STALE]:                { color: COLORS.INACTIVE, description: 'No activity for 7+ days' },
+  [LABELS.OPT_IN]:               { color: COLORS.INFO, description: 'PR managed by lifecycle orchestrator' },
+  [LABELS.AUTO_MERGE]:           { color: COLORS.INFO, description: 'Auto-merge enabled' },
+  [LABELS.TESTS_DISABLED]:       { color: COLORS.INFO, description: 'Smoke tests disabled for this PR' },
+};
+
+const BOT_LOGIN = 'github-actions[bot]';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function loadConfig() {
+  const configPath = path.join(process.cwd(), '.github', 'pr-lifecycle.json');
+  return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+}
+
+function isMaintainer(config, username) {
+  return config.maintainers.includes(username);
+}
+
+function isAutoAccepted(config, username) {
+  return config.maintainers.includes(username) ||
+    (config.auto_accept || []).includes(username);
+}
+
+function parseCommand(body) {
+  for (const line of body.split('\n')) {
+    const trimmed = line.trim();
+    const match = trimmed.match(/^\/(\S+)(?:\s+(.*))?$/);
+    if (match) {
+      return { command: match[1], args: match[2] ? match[2].trim() : '' };
+    }
+  }
+  return null;
+}
+
+function getLabelNames(pr) {
+  return (pr.labels || []).map(l => l.name);
+}
+
+function hasLabel(pr, label) {
+  return getLabelNames(pr).includes(label);
+}
+
+function getLifecycleState(pr) {
+  const labels = getLabelNames(pr);
+  for (const state of PRIMARY_STATES) {
+    if (labels.includes(state)) return state;
+  }
+  return null;
+}
+
+function createApi(github, owner, repo) {
+  const ensuredLabels = new Set();
+
+  async function ensureLabel(name) {
+    if (ensuredLabels.has(name)) return;
+    const def = LABEL_DEFS[name];
+    if (!def) return;
+    try {
+      const { data: existing } = await github.rest.issues.getLabel({ owner, repo, name });
+      if (existing.color !== def.color) {
+        await github.rest.issues.updateLabel({ owner, repo, name, color: def.color, description: def.description });
+      }
+    } catch (e) {
+      if (e.status === 404) {
+        await github.rest.issues.createLabel({ owner, repo, name, color: def.color, description: def.description });
+      } else {
+        throw e;
+      }
+    }
+    ensuredLabels.add(name);
+  }
+
+  return {
+    addLabel: async (prNumber, label) => {
+      await ensureLabel(label);
+      await github.rest.issues.addLabels({
+        owner, repo, issue_number: prNumber, labels: [label],
+      });
+    },
+
+    removeLabel: async (prNumber, label) => {
+      try {
+        await github.rest.issues.removeLabel({
+          owner, repo, issue_number: prNumber, name: label,
+        });
+      } catch (e) {
+        if (e.status !== 404) throw e;
+      }
+    },
+
+    setLifecycleState: async (pr, newState) => {
+      const labels = getLabelNames(pr);
+      for (const state of PRIMARY_STATES) {
+        if (labels.includes(state)) {
+          await github.rest.issues.removeLabel({
+            owner, repo, issue_number: pr.number, name: state,
+          }).catch(e => { if (e.status !== 404) throw e; });
+        }
+      }
+      if (newState) {
+        await ensureLabel(newState);
+        await github.rest.issues.addLabels({
+          owner, repo, issue_number: pr.number, labels: [newState],
+        });
+      }
+    },
+
+    postComment: async (prNumber, body) => {
+      await github.rest.issues.createComment({
+        owner, repo, issue_number: prNumber, body,
+      });
+    },
+
+    addReaction: async (commentId, reaction) => {
+      await github.rest.reactions.createForIssueComment({
+        owner, repo, comment_id: commentId, content: reaction,
+      });
+    },
+
+    getPr: async (prNumber) => {
+      const { data } = await github.rest.pulls.get({
+        owner, repo, pull_number: prNumber,
+      });
+      return data;
+    },
+
+    getReviews: async (prNumber) => {
+      const { data } = await github.rest.pulls.listReviews({
+        owner, repo, pull_number: prNumber,
+      });
+      return data;
+    },
+
+    closePr: async (prNumber) => {
+      await github.rest.pulls.update({
+        owner, repo, pull_number: prNumber, state: 'closed',
+      });
+    },
+
+    mergePr: async (prNumber, method, commitTitle) => {
+      await github.rest.pulls.merge({
+        owner, repo, pull_number: prNumber,
+        merge_method: method,
+        commit_title: commitTitle,
+      });
+    },
+
+    deleteBranch: async (branch) => {
+      try {
+        await github.rest.git.deleteRef({
+          owner, repo, ref: `heads/${branch}`,
+        });
+      } catch (e) {
+        if (e.status !== 422) throw e;
+      }
+    },
+  };
+}
+
+function isApproved(reviews) {
+  const latestByReviewer = new Map();
+  for (const review of reviews) {
+    if (review.state === 'APPROVED' || review.state === 'CHANGES_REQUESTED') {
+      const existing = latestByReviewer.get(review.user.login);
+      if (!existing || new Date(review.submitted_at) > new Date(existing.submitted_at)) {
+        latestByReviewer.set(review.user.login, review);
+      }
+    }
+  }
+  const latest = Array.from(latestByReviewer.values());
+  const hasApproval = latest.some(r => r.state === 'APPROVED');
+  const hasChangesRequested = latest.some(r => r.state === 'CHANGES_REQUESTED');
+  return hasApproval && !hasChangesRequested;
+}
+
+async function checkAndTransitionToReady(api, pr, core) {
+  const approved = isApproved(await api.getReviews(pr.number));
+  const tested = hasLabel(pr, LABELS.TESTED);
+  const state = getLifecycleState(pr);
+
+  if (approved && tested && state === LABELS.READY_FOR_REVIEW) {
+    await api.setLifecycleState(pr, LABELS.READY_TO_MERGE);
+    await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+    await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+    await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+
+    if (hasLabel(pr, LABELS.AUTO_MERGE)) {
+      core.info(`PR #${pr.number} auto-merge enabled, will merge`);
+      return 'auto-merge';
+    }
+    await api.postComment(pr.number,
+      `This PR is approved and tested. A maintainer can merge it with \`/merge\`, ` +
+      `or enable auto-merge with \`/auto-merge\`.`
+    );
+    core.info(`PR #${pr.number} is ready to merge`);
+    return 'ready-to-merge';
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Event Handlers
+// ---------------------------------------------------------------------------
+
+async function handlePrOpened({ github, context, core }) {
+  const pr = context.payload.pull_request;
+  const { owner, repo } = context.repo;
+  const api = createApi(github, owner, repo);
+  const config = loadConfig();
+
+  if (isAutoAccepted(config, pr.user.login)) {
+    await api.addLabel(pr.number, LABELS.WIP);
+    await api.postComment(pr.number,
+      `PR auto-accepted (trusted author). Smoke tests will run on each push.\n\n` +
+      `When ready, use \`/ready\` to request a full review.`
+    );
+    core.info(`PR #${pr.number} auto-accepted for ${pr.user.login}`);
+    return;
+  }
+
+  await api.addLabel(pr.number, LABELS.NEW);
+  const message = config.welcome_message.replace(/\{author\}/g, pr.user.login);
+  await api.postComment(pr.number, message);
+  core.info(`PR #${pr.number} opened, set to lifecycle/new`);
+}
+
+async function handlePrSynchronize({ github, context, core }) {
+  const pr = context.payload.pull_request;
+  const { owner, repo } = context.repo;
+  const api = createApi(github, owner, repo);
+
+  if (hasLabel(pr, LABELS.TESTED)) {
+    await api.removeLabel(pr.number, LABELS.TESTED);
+    core.info(`PR #${pr.number} new push, removed lifecycle/tested`);
+  }
+  if (hasLabel(pr, LABELS.STALE)) {
+    await api.removeLabel(pr.number, LABELS.STALE);
+    core.info(`PR #${pr.number} new push, removed lifecycle/stale`);
+  }
+
+  const state = getLifecycleState(pr);
+  if (state === LABELS.READY_TO_MERGE) {
+    const freshPr = await api.getPr(pr.number);
+    await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
+    await api.postComment(pr.number,
+      `New commits pushed. Reverting to \`lifecycle/ready-for-review\` — ` +
+      `the full test suite will re-run.`
+    );
+    core.info(`PR #${pr.number} reverted from ready-to-merge to ready-for-review`);
+  }
+}
+
+async function handlePrReadyForReview({ github, context, core }) {
+  const pr = context.payload.pull_request;
+  const { owner, repo } = context.repo;
+  const api = createApi(github, owner, repo);
+  const state = getLifecycleState(pr);
+
+  if (state !== LABELS.WIP) {
+    core.info(`PR #${pr.number} draft->ready but not in WIP state (${state}), skipping`);
+    return;
+  }
+
+  const freshPr = await api.getPr(pr.number);
+  if (!freshPr.requested_reviewers?.length && !freshPr.requested_teams?.length) {
+    await api.postComment(pr.number,
+      `Cannot transition to ready-for-review: no reviewer is assigned. ` +
+      `Please ask a maintainer to assign a reviewer first, then use \`/ready\`.`
+    );
+    return;
+  }
+
+  await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
+  await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+  await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+  await api.postComment(pr.number,
+    `PR is now ready for review. The full test suite will run on the next push ` +
+    `or label update.`
+  );
+  core.info(`PR #${pr.number} transitioned to ready-for-review (draft->ready)`);
+}
+
+async function handleComment({ github, context, core }) {
+  const comment = context.payload.comment;
+  const issue = context.payload.issue;
+
+  if (!issue.pull_request) return;
+
+  const parsed = parseCommand(comment.body);
+  if (!parsed) return;
+
+  const { owner, repo } = context.repo;
+  const api = createApi(github, owner, repo);
+  const config = loadConfig();
+  const pr = await api.getPr(issue.number);
+  const actor = comment.user.login;
+  const maintainer = isMaintainer(config, actor);
+  const isAuthor = actor === pr.user.login;
+
+  const handlers = {
+    'accept': () => cmdAccept(api, config, core, pr, actor, maintainer, comment.id),
+    'reject': () => cmdReject(api, config, core, pr, actor, maintainer, parsed.args, comment.id),
+    'ready': () => cmdReady(api, config, core, pr, actor, isAuthor, maintainer, comment.id),
+    'merge': () => cmdMerge(api, config, core, pr, actor, maintainer, comment.id),
+    'auto-merge': () => cmdAutoMerge(api, config, core, pr, actor, maintainer, comment.id),
+    'disable-tests': () => cmdDisableTests(api, core, pr, actor, isAuthor, maintainer, comment.id),
+    'enable-tests': () => cmdEnableTests(api, core, pr, actor, isAuthor, maintainer, comment.id),
+    'unstale': () => cmdUnstale(api, core, pr, actor, comment.id),
+  };
+
+  const handler = handlers[parsed.command];
+  if (handler) {
+    await handler();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command Handlers
+// ---------------------------------------------------------------------------
+
+async function cmdAccept(api, config, core, pr, actor, maintainer, commentId) {
+  if (!maintainer) {
+    await api.addReaction(commentId, '-1');
+    await api.postComment(pr.number, `@${actor} Only maintainers can accept PRs.`);
+    return;
+  }
+
+  const state = getLifecycleState(pr);
+  if (state !== LABELS.NEW) {
+    await api.addReaction(commentId, 'confused');
+    await api.postComment(pr.number,
+      `@${actor} Cannot accept: PR is not in \`lifecycle/new\` state (current: \`${state || 'none'}\`).`
+    );
+    return;
+  }
+
+  await api.setLifecycleState(pr, LABELS.WIP);
+  await api.addReaction(commentId, '+1');
+  await api.postComment(pr.number,
+    `PR accepted by @${actor}. @${pr.user.login}, you can now work on your changes.\n\n` +
+    `Smoke tests will run on each push. When ready, use \`/ready\` to request a full review.`
+  );
+  core.info(`PR #${pr.number} accepted by ${actor}`);
+}
+
+async function cmdReject(api, config, core, pr, actor, maintainer, reason, commentId) {
+  if (!maintainer) {
+    await api.addReaction(commentId, '-1');
+    await api.postComment(pr.number, `@${actor} Only maintainers can reject PRs.`);
+    return;
+  }
+
+  const state = getLifecycleState(pr);
+  if (state !== LABELS.NEW) {
+    await api.addReaction(commentId, 'confused');
+    await api.postComment(pr.number,
+      `@${actor} Cannot reject: PR is not in \`lifecycle/new\` state (current: \`${state || 'none'}\`).`
+    );
+    return;
+  }
+
+  const reasonText = reason ? `\n\nReason: ${reason}` : '';
+  await api.postComment(pr.number,
+    `PR rejected by @${actor}.${reasonText}\n\n` +
+    `@${pr.user.login}, please address the feedback and reopen if appropriate.`
+  );
+  await api.setLifecycleState(pr, null);
+  await api.closePr(pr.number);
+  await api.addReaction(commentId, '+1');
+  core.info(`PR #${pr.number} rejected by ${actor}`);
+}
+
+async function cmdReady(api, config, core, pr, actor, isAuthor, maintainer, commentId) {
+  if (!isAuthor && !maintainer) {
+    await api.addReaction(commentId, '-1');
+    await api.postComment(pr.number,
+      `@${actor} Only the PR author or a maintainer can mark a PR as ready.`
+    );
+    return;
+  }
+
+  const state = getLifecycleState(pr);
+  if (state !== LABELS.WIP) {
+    await api.addReaction(commentId, 'confused');
+    await api.postComment(pr.number,
+      `@${actor} Cannot mark as ready: PR is not in \`lifecycle/wip\` state (current: \`${state || 'none'}\`).`
+    );
+    return;
+  }
+
+  const freshPr = await api.getPr(pr.number);
+  if (!freshPr.requested_reviewers?.length && !freshPr.requested_teams?.length) {
+    await api.addReaction(commentId, '-1');
+    await api.postComment(pr.number,
+      `@${actor} Cannot mark as ready: no reviewer is assigned. ` +
+      `Please ask a maintainer to assign a reviewer first.`
+    );
+    return;
+  }
+
+  await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
+  await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+  await api.removeLabel(pr.number, LABELS.TESTS_DISABLED);
+  await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+  await api.addReaction(commentId, '+1');
+  await api.postComment(pr.number,
+    `PR marked as ready for review. The full test suite will run on the next label-triggered ` +
+    `build cycle.`
+  );
+  core.info(`PR #${pr.number} marked ready by ${actor}`);
+}
+
+async function cmdMerge(api, config, core, pr, actor, maintainer, commentId) {
+  if (!maintainer) {
+    await api.addReaction(commentId, '-1');
+    await api.postComment(pr.number, `@${actor} Only maintainers can merge PRs.`);
+    return;
+  }
+
+  const state = getLifecycleState(pr);
+  if (state !== LABELS.READY_TO_MERGE) {
+    await api.addReaction(commentId, 'confused');
+    await api.postComment(pr.number,
+      `@${actor} Cannot merge: PR is not in \`lifecycle/ready-to-merge\` state ` +
+      `(current: \`${state || 'none'}\`). The PR must be both approved and tested.`
+    );
+    return;
+  }
+
+  const strategy = config.merge?.strategy || 'rebase';
+  try {
+    await api.mergePr(pr.number, strategy, pr.title);
+    await api.addReaction(commentId, '+1');
+    if (config.merge?.delete_branch) {
+      await api.deleteBranch(pr.head.ref);
+    }
+    core.info(`PR #${pr.number} merged by ${actor} using ${strategy}`);
+  } catch (e) {
+    await api.addReaction(commentId, '-1');
+    await api.postComment(pr.number,
+      `@${actor} Merge failed: ${e.message}\n\n` +
+      `The branch may need to be rebased. Try rebasing locally and force-pushing.`
+    );
+    core.error(`PR #${pr.number} merge failed: ${e.message}`);
+  }
+}
+
+async function cmdAutoMerge(api, config, core, pr, actor, maintainer, commentId) {
+  if (!maintainer) {
+    await api.addReaction(commentId, '-1');
+    await api.postComment(pr.number, `@${actor} Only maintainers can enable auto-merge.`);
+    return;
+  }
+
+  const state = getLifecycleState(pr);
+  if (!state || state === LABELS.NEW) {
+    await api.addReaction(commentId, 'confused');
+    await api.postComment(pr.number,
+      `@${actor} Cannot enable auto-merge: PR must be accepted first.`
+    );
+    return;
+  }
+
+  if (hasLabel(pr, LABELS.AUTO_MERGE)) {
+    await api.removeLabel(pr.number, LABELS.AUTO_MERGE);
+    await api.addReaction(commentId, '+1');
+    await api.postComment(pr.number, `Auto-merge disabled by @${actor}.`);
+    core.info(`PR #${pr.number} auto-merge disabled by ${actor}`);
+    return;
+  }
+
+  await api.addLabel(pr.number, LABELS.AUTO_MERGE);
+  await api.addReaction(commentId, '+1');
+  await api.postComment(pr.number,
+    `Auto-merge enabled by @${actor}. This PR will be merged automatically ` +
+    `when it reaches \`lifecycle/ready-to-merge\` state. Use \`/auto-merge\` again to disable.`
+  );
+
+  if (state === LABELS.READY_TO_MERGE) {
+    const strategy = config.merge?.strategy || 'rebase';
+    try {
+      await api.mergePr(pr.number, strategy, pr.title);
+      if (config.merge?.delete_branch) {
+        await api.deleteBranch(pr.head.ref);
+      }
+      core.info(`PR #${pr.number} auto-merged by ${actor} using ${strategy}`);
+    } catch (e) {
+      await api.postComment(pr.number,
+        `Auto-merge failed: ${e.message}\n\nThe branch may need to be rebased.`
+      );
+      core.error(`PR #${pr.number} auto-merge failed: ${e.message}`);
+    }
+  }
+
+  core.info(`PR #${pr.number} auto-merge enabled by ${actor}`);
+}
+
+async function cmdDisableTests(api, core, pr, actor, isAuthor, maintainer, commentId) {
+  if (!isAuthor && !maintainer) {
+    await api.addReaction(commentId, '-1');
+    return;
+  }
+  const state = getLifecycleState(pr);
+  if (state !== LABELS.WIP) {
+    await api.addReaction(commentId, 'confused');
+    await api.postComment(pr.number,
+      `@${actor} Tests can only be disabled in \`lifecycle/wip\` state.`
+    );
+    return;
+  }
+  await api.addLabel(pr.number, LABELS.TESTS_DISABLED);
+  await api.addReaction(commentId, '+1');
+  core.info(`PR #${pr.number} smoke tests disabled by ${actor}`);
+}
+
+async function cmdEnableTests(api, core, pr, actor, isAuthor, maintainer, commentId) {
+  if (!isAuthor && !maintainer) {
+    await api.addReaction(commentId, '-1');
+    return;
+  }
+  const state = getLifecycleState(pr);
+  if (state !== LABELS.WIP) {
+    await api.addReaction(commentId, 'confused');
+    return;
+  }
+  await api.removeLabel(pr.number, LABELS.TESTS_DISABLED);
+  await api.addReaction(commentId, '+1');
+  core.info(`PR #${pr.number} smoke tests re-enabled by ${actor}`);
+}
+
+async function cmdUnstale(api, core, pr, actor, commentId) {
+  if (!hasLabel(pr, LABELS.STALE)) {
+    await api.addReaction(commentId, 'confused');
+    return;
+  }
+  await api.removeLabel(pr.number, LABELS.STALE);
+  await api.addReaction(commentId, '+1');
+  core.info(`PR #${pr.number} unstaled by ${actor}`);
+}
+
+// ---------------------------------------------------------------------------
+// Review Handler
+// ---------------------------------------------------------------------------
+
+async function handleReview({ github, context, core }) {
+  const review = context.payload.review;
+  const pr = context.payload.pull_request;
+  const { owner, repo } = context.repo;
+  const api = createApi(github, owner, repo);
+
+  const state = getLifecycleState(pr);
+  if (state !== LABELS.READY_FOR_REVIEW && state !== LABELS.READY_TO_MERGE) {
+    core.info(`PR #${pr.number} review submitted but not in reviewable state (${state}), skipping`);
+    return;
+  }
+
+  if (review.state === 'changes_requested') {
+    await api.addLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+    await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+    core.info(`PR #${pr.number} changes requested by ${review.user.login}`);
+    return;
+  }
+
+  if (review.state === 'approved') {
+    await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+    const freshPr = await api.getPr(pr.number);
+    const result = await checkAndTransitionToReady(api, freshPr, core);
+    if (result === 'auto-merge') {
+      const config = loadConfig();
+      const strategy = config.merge?.strategy || 'rebase';
+      try {
+        await api.mergePr(pr.number, strategy, pr.title);
+        if (config.merge?.delete_branch) {
+          await api.deleteBranch(pr.head.ref);
+        }
+        core.info(`PR #${pr.number} auto-merged after approval`);
+      } catch (e) {
+        await api.postComment(pr.number,
+          `Auto-merge failed: ${e.message}\n\nThe branch may need to be rebased.`
+        );
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Label Protection
+// ---------------------------------------------------------------------------
+
+async function handleLabelChange({ github, context, core }) {
+  const pr = context.payload.pull_request;
+  const label = context.payload.label;
+  const action = context.payload.action;
+  const actor = context.payload.sender.login;
+  const { owner, repo } = context.repo;
+  const api = createApi(github, owner, repo);
+
+  if (actor === BOT_LOGIN) return;
+
+  if (label.name === LABELS.OPT_IN && action === 'labeled') {
+    const state = getLifecycleState(pr);
+    if (!state) {
+      core.info(`PR #${pr.number} opted in, initializing lifecycle`);
+      const config = loadConfig();
+      if (isAutoAccepted(config, pr.user.login)) {
+        await api.addLabel(pr.number, LABELS.WIP);
+        await api.postComment(pr.number,
+          `PR auto-accepted (trusted author). Smoke tests will run on each push.\n\n` +
+          `When ready, use \`/ready\` to request a full review.`
+        );
+      } else {
+        await api.addLabel(pr.number, LABELS.NEW);
+        const message = config.welcome_message.replace(/\{author\}/g, pr.user.login);
+        await api.postComment(pr.number, message);
+      }
+    }
+    return;
+  }
+
+  if (!CONTROL_LABELS.includes(label.name)) return;
+
+  if (action === 'labeled') {
+    await api.removeLabel(pr.number, label.name);
+    await api.postComment(pr.number,
+      `@${actor} The label \`${label.name}\` is managed by the PR lifecycle orchestrator ` +
+      `and cannot be added manually. Use the appropriate slash command instead.`
+    );
+    core.info(`PR #${pr.number} reverted unauthorized label add: ${label.name} by ${actor}`);
+  } else if (action === 'unlabeled') {
+    await api.addLabel(pr.number, label.name);
+    await api.postComment(pr.number,
+      `@${actor} The label \`${label.name}\` is managed by the PR lifecycle orchestrator ` +
+      `and cannot be removed manually. Use the appropriate slash command instead.`
+    );
+    core.info(`PR #${pr.number} reverted unauthorized label remove: ${label.name} by ${actor}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test Result Handler
+// ---------------------------------------------------------------------------
+
+async function handleTestResult({ github, context, core }) {
+  const workflowRun = context.payload.workflow_run;
+  if (workflowRun.event !== 'pull_request' || !workflowRun.pull_requests?.length) {
+    core.info('Workflow run is not from a PR, skipping');
+    return;
+  }
+
+  const { owner, repo } = context.repo;
+  const api = createApi(github, owner, repo);
+
+  for (const prRef of workflowRun.pull_requests) {
+    const pr = await api.getPr(prRef.number);
+
+    if (!hasLabel(pr, LABELS.OPT_IN)) continue;
+
+    const state = getLifecycleState(pr);
+    if (state !== LABELS.READY_FOR_REVIEW) {
+      core.info(`PR #${pr.number} not in ready-for-review state, skipping test result`);
+      continue;
+    }
+
+    if (pr.head.sha !== workflowRun.head_sha) {
+      core.info(`PR #${pr.number} head SHA mismatch (PR: ${pr.head.sha}, run: ${workflowRun.head_sha}), skipping`);
+      continue;
+    }
+
+    if (workflowRun.conclusion === 'success') {
+      await api.addLabel(pr.number, LABELS.TESTED);
+      await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+      core.info(`PR #${pr.number} tests passed, added lifecycle/tested`);
+
+      const result = await checkAndTransitionToReady(api, pr, core);
+      if (result === 'auto-merge') {
+        const config = loadConfig();
+        const strategy = config.merge?.strategy || 'rebase';
+        try {
+          await api.mergePr(pr.number, strategy, pr.title);
+          if (config.merge?.delete_branch) {
+            await api.deleteBranch(pr.head.ref);
+          }
+          core.info(`PR #${pr.number} auto-merged after tests passed`);
+        } catch (e) {
+          await api.postComment(pr.number,
+            `Auto-merge failed: ${e.message}\n\nThe branch may need to be rebased.`
+          );
+        }
+      }
+    } else if (workflowRun.conclusion === 'failure') {
+      await api.addLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+      await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+      await api.postComment(pr.number,
+        `The test suite failed for commit ${workflowRun.head_sha.substring(0, 7)}. ` +
+        `@${pr.user.login}, please check the ` +
+        `[workflow run](${workflowRun.html_url}) and push a fix.`
+      );
+      core.info(`PR #${pr.number} tests failed`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stale Detection
+// ---------------------------------------------------------------------------
+
+async function handleStale({ github, context, core }) {
+  const { owner, repo } = context.repo;
+  const api = createApi(github, owner, repo);
+  const config = loadConfig();
+  const daysUntilStale = config.stale?.days_until_stale || 7;
+  const daysUntilClose = config.stale?.days_until_close || 14;
+  const now = new Date();
+
+  const { data: prs } = await github.rest.pulls.list({
+    owner, repo, state: 'open', per_page: 100,
+  });
+
+  for (const pr of prs) {
+    if (!hasLabel(pr, LABELS.OPT_IN)) continue;
+
+    const state = getLifecycleState(pr);
+    if (!state) continue;
+    if (state === LABELS.READY_TO_MERGE) continue;
+
+    const updatedAt = new Date(pr.updated_at);
+    const daysSinceUpdate = (now - updatedAt) / (1000 * 60 * 60 * 24);
+
+    if (hasLabel(pr, LABELS.STALE)) {
+      const { data: events } = await github.rest.issues.listEventsForTimeline({
+        owner, repo, issue_number: pr.number, per_page: 100,
+      });
+
+      const staleEvent = events
+        .filter(e => e.event === 'labeled' && e.label?.name === LABELS.STALE)
+        .pop();
+
+      if (!staleEvent) continue;
+
+      const staleSince = new Date(staleEvent.created_at);
+      const daysSinceStale = (now - staleSince) / (1000 * 60 * 60 * 24);
+
+      const hasActivity = events.some(e => {
+        if (new Date(e.created_at) <= staleSince) return false;
+        if (e.actor?.login === BOT_LOGIN || e.user?.login === BOT_LOGIN) return false;
+        return e.event === 'commented' || e.event === 'committed' ||
+               e.event === 'head_ref_force_pushed';
+      });
+
+      if (hasActivity) {
+        await api.removeLabel(pr.number, LABELS.STALE);
+        core.info(`PR #${pr.number} stale removed (activity detected)`);
+      } else if (daysSinceStale >= (daysUntilClose - daysUntilStale)) {
+        const closeMessage = (config.stale?.close_message || 'Closing due to inactivity.')
+          .replace(/\{author\}/g, pr.user.login);
+        await api.postComment(pr.number, closeMessage);
+        await api.closePr(pr.number);
+        core.info(`PR #${pr.number} closed due to extended inactivity`);
+      }
+    } else if (daysSinceUpdate >= daysUntilStale) {
+      await api.addLabel(pr.number, LABELS.STALE);
+      const staleMessage = (config.stale?.stale_message || 'This PR is stale.')
+        .replace(/\{author\}/g, pr.user.login);
+      await api.postComment(pr.number, staleMessage);
+      core.info(`PR #${pr.number} marked as stale`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+module.exports = {
+  handlePrOpened,
+  handlePrSynchronize,
+  handlePrReadyForReview,
+  handleComment,
+  handleReview,
+  handleLabelChange,
+  handleTestResult,
+  handleStale,
+  LABELS,
+};

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -111,7 +111,7 @@ function createApi(github, owner, repo) {
     if (!def) return;
     try {
       const { data: existing } = await github.rest.issues.getLabel({ owner, repo, name });
-      if (existing.color !== def.color) {
+      if (existing.color !== def.color || existing.description !== def.description) {
         await github.rest.issues.updateLabel({ owner, repo, name, color: def.color, description: def.description });
       }
     } catch (e) {
@@ -144,18 +144,18 @@ function createApi(github, owner, repo) {
 
     setLifecycleState: async (pr, newState) => {
       const labels = getLabelNames(pr);
-      for (const state of PRIMARY_STATES) {
-        if (labels.includes(state)) {
-          await github.rest.issues.removeLabel({
-            owner, repo, issue_number: pr.number, name: state,
-          }).catch(e => { if (e.status !== 404) throw e; });
-        }
-      }
       if (newState) {
         await ensureLabel(newState);
         await github.rest.issues.addLabels({
           owner, repo, issue_number: pr.number, labels: [newState],
         });
+      }
+      for (const state of PRIMARY_STATES) {
+        if (state !== newState && labels.includes(state)) {
+          await github.rest.issues.removeLabel({
+            owner, repo, issue_number: pr.number, name: state,
+          }).catch(e => { if (e.status !== 404) throw e; });
+        }
       }
     },
 
@@ -179,10 +179,9 @@ function createApi(github, owner, repo) {
     },
 
     getReviews: async (prNumber) => {
-      const { data } = await github.rest.pulls.listReviews({
-        owner, repo, pull_number: prNumber,
+      return github.paginate(github.rest.pulls.listReviews, {
+        owner, repo, pull_number: prNumber, per_page: 100,
       });
-      return data;
     },
 
     closePr: async (prNumber) => {
@@ -225,6 +224,32 @@ function isApproved(reviews) {
   const hasApproval = latest.some(r => r.state === 'APPROVED');
   const hasChangesRequested = latest.some(r => r.state === 'CHANGES_REQUESTED');
   return hasApproval && !hasChangesRequested;
+}
+
+async function performMerge(api, config, pr, core) {
+  const freshPr = await api.getPr(pr.number);
+  if (!hasLabel(freshPr, LABELS.TESTED) || !hasLabel(freshPr, LABELS.READY_TO_MERGE)) {
+    core.warning(`PR #${pr.number} merge aborted: state changed since merge was initiated`);
+    return false;
+  }
+  const strategy = config.merge?.strategy || 'rebase';
+  try {
+    await api.mergePr(pr.number, strategy, freshPr.title);
+    if (config.merge?.delete_branch) {
+      await api.deleteBranch(freshPr.head.ref);
+    }
+    core.info(`PR #${pr.number} merged using ${strategy}`);
+    return true;
+  } catch (e) {
+    await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
+    await api.removeLabel(pr.number, LABELS.TESTED);
+    await api.postComment(pr.number,
+      `Merge failed: ${e.message}\n\n` +
+      `Reverted to \`lifecycle/ready-for-review\`. The branch may need to be rebased.`
+    );
+    core.error(`PR #${pr.number} merge failed: ${e.message}`);
+    return false;
+  }
 }
 
 async function checkAndTransitionToReady(api, pr, core) {
@@ -359,7 +384,7 @@ async function handleComment({ github, context, core }) {
     'auto-merge': () => cmdAutoMerge(api, config, core, pr, actor, maintainer, comment.id),
     'disable-tests': () => cmdDisableTests(api, core, pr, actor, isAuthor, maintainer, comment.id),
     'enable-tests': () => cmdEnableTests(api, core, pr, actor, isAuthor, maintainer, comment.id),
-    'unstale': () => cmdUnstale(api, core, pr, actor, comment.id),
+    'unstale': () => cmdUnstale(api, config, core, pr, actor, isAuthor, maintainer, comment.id),
   };
 
   const handler = handlers[parsed.command];
@@ -481,22 +506,8 @@ async function cmdMerge(api, config, core, pr, actor, maintainer, commentId) {
     return;
   }
 
-  const strategy = config.merge?.strategy || 'rebase';
-  try {
-    await api.mergePr(pr.number, strategy, pr.title);
-    await api.addReaction(commentId, '+1');
-    if (config.merge?.delete_branch) {
-      await api.deleteBranch(pr.head.ref);
-    }
-    core.info(`PR #${pr.number} merged by ${actor} using ${strategy}`);
-  } catch (e) {
-    await api.addReaction(commentId, '-1');
-    await api.postComment(pr.number,
-      `@${actor} Merge failed: ${e.message}\n\n` +
-      `The branch may need to be rebased. Try rebasing locally and force-pushing.`
-    );
-    core.error(`PR #${pr.number} merge failed: ${e.message}`);
-  }
+  const merged = await performMerge(api, config, pr, core);
+  await api.addReaction(commentId, merged ? '+1' : '-1');
 }
 
 async function cmdAutoMerge(api, config, core, pr, actor, maintainer, commentId) {
@@ -531,19 +542,7 @@ async function cmdAutoMerge(api, config, core, pr, actor, maintainer, commentId)
   );
 
   if (state === LABELS.READY_TO_MERGE) {
-    const strategy = config.merge?.strategy || 'rebase';
-    try {
-      await api.mergePr(pr.number, strategy, pr.title);
-      if (config.merge?.delete_branch) {
-        await api.deleteBranch(pr.head.ref);
-      }
-      core.info(`PR #${pr.number} auto-merged by ${actor} using ${strategy}`);
-    } catch (e) {
-      await api.postComment(pr.number,
-        `Auto-merge failed: ${e.message}\n\nThe branch may need to be rebased.`
-      );
-      core.error(`PR #${pr.number} auto-merge failed: ${e.message}`);
-    }
+    await performMerge(api, config, pr, core);
   }
 
   core.info(`PR #${pr.number} auto-merge enabled by ${actor}`);
@@ -582,7 +581,14 @@ async function cmdEnableTests(api, core, pr, actor, isAuthor, maintainer, commen
   core.info(`PR #${pr.number} smoke tests re-enabled by ${actor}`);
 }
 
-async function cmdUnstale(api, core, pr, actor, commentId) {
+async function cmdUnstale(api, config, core, pr, actor, isAuthor, maintainer, commentId) {
+  if (!isAuthor && !maintainer) {
+    await api.addReaction(commentId, '-1');
+    await api.postComment(pr.number,
+      `@${actor} Only the PR author or a maintainer can remove the stale label.`
+    );
+    return;
+  }
   if (!hasLabel(pr, LABELS.STALE)) {
     await api.addReaction(commentId, 'confused');
     return;
@@ -621,18 +627,7 @@ async function handleReview({ github, context, core }) {
     const result = await checkAndTransitionToReady(api, freshPr, core);
     if (result === 'auto-merge') {
       const config = loadConfig();
-      const strategy = config.merge?.strategy || 'rebase';
-      try {
-        await api.mergePr(pr.number, strategy, pr.title);
-        if (config.merge?.delete_branch) {
-          await api.deleteBranch(pr.head.ref);
-        }
-        core.info(`PR #${pr.number} auto-merged after approval`);
-      } catch (e) {
-        await api.postComment(pr.number,
-          `Auto-merge failed: ${e.message}\n\nThe branch may need to be rebased.`
-        );
-      }
+      await performMerge(api, config, freshPr, core);
     }
   }
 }
@@ -651,24 +646,33 @@ async function handleLabelChange({ github, context, core }) {
 
   if (actor === BOT_LOGIN) return;
 
-  if (label.name === LABELS.OPT_IN && action === 'labeled') {
-    const state = getLifecycleState(pr);
-    if (!state) {
-      core.info(`PR #${pr.number} opted in, initializing lifecycle`);
+  if (label.name === LABELS.OPT_IN) {
+    if (action === 'unlabeled') {
       const config = loadConfig();
-      if (isAutoAccepted(config, pr.user.login)) {
-        await api.addLabel(pr.number, LABELS.WIP);
-        await api.postComment(pr.number,
-          `PR auto-accepted (trusted author). Smoke tests will run on each push.\n\n` +
-          `When ready, use \`/ready\` to request a full review.`
-        );
-      } else {
-        await api.addLabel(pr.number, LABELS.NEW);
-        const message = config.welcome_message.replace(/\{author\}/g, pr.user.login);
-        await api.postComment(pr.number, message);
+      if (isMaintainer(config, actor)) {
+        core.info(`PR #${pr.number} opted out by maintainer ${actor}`);
+        return;
       }
+      // Non-maintainer removal: fall through to label protection below
+    } else if (action === 'labeled') {
+      const state = getLifecycleState(pr);
+      if (!state) {
+        core.info(`PR #${pr.number} opted in, initializing lifecycle`);
+        const config = loadConfig();
+        if (isAutoAccepted(config, pr.user.login)) {
+          await api.addLabel(pr.number, LABELS.WIP);
+          await api.postComment(pr.number,
+            `PR auto-accepted (trusted author). Smoke tests will run on each push.\n\n` +
+            `When ready, use \`/ready\` to request a full review.`
+          );
+        } else {
+          await api.addLabel(pr.number, LABELS.NEW);
+          const message = config.welcome_message.replace(/\{author\}/g, pr.user.login);
+          await api.postComment(pr.number, message);
+        }
+      }
+      return;
     }
-    return;
   }
 
   if (!CONTROL_LABELS.includes(label.name)) return;
@@ -725,21 +729,11 @@ async function handleTestResult({ github, context, core }) {
       await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
       core.info(`PR #${pr.number} tests passed, added lifecycle/tested`);
 
-      const result = await checkAndTransitionToReady(api, pr, core);
+      const freshPr = await api.getPr(pr.number);
+      const result = await checkAndTransitionToReady(api, freshPr, core);
       if (result === 'auto-merge') {
         const config = loadConfig();
-        const strategy = config.merge?.strategy || 'rebase';
-        try {
-          await api.mergePr(pr.number, strategy, pr.title);
-          if (config.merge?.delete_branch) {
-            await api.deleteBranch(pr.head.ref);
-          }
-          core.info(`PR #${pr.number} auto-merged after tests passed`);
-        } catch (e) {
-          await api.postComment(pr.number,
-            `Auto-merge failed: ${e.message}\n\nThe branch may need to be rebased.`
-          );
-        }
+        await performMerge(api, config, freshPr, core);
       }
     } else if (workflowRun.conclusion === 'failure') {
       await api.addLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
@@ -766,7 +760,7 @@ async function handleStale({ github, context, core }) {
   const daysUntilClose = config.stale?.days_until_close || 14;
   const now = new Date();
 
-  const { data: prs } = await github.rest.pulls.list({
+  const prs = await github.paginate(github.rest.pulls.list, {
     owner, repo, state: 'open', per_page: 100,
   });
 

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -1,0 +1,216 @@
+name: PR Lifecycle
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+    branches: [main]
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  workflow_run:
+    workflows: ["Verify"]
+    types: [completed]
+  schedule:
+    - cron: '17 8 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-lifecycle-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  # ==========================================================================
+  # PR Opened / Reopened
+  # ==========================================================================
+  pr-opened:
+    name: PR Opened
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request_target' &&
+      (github.event.action == 'opened' || github.event.action == 'reopened') &&
+      contains(github.event.pull_request.labels.*.name, 'orchestrator/enabled')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Convert config to JSON
+        run: yq -o json .github/pr-lifecycle.yml > .github/pr-lifecycle.json
+
+      - name: Handle PR opened
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const handler = require('./.github/scripts/pr-lifecycle.js');
+            await handler.handlePrOpened({ github, context, core });
+
+  # ==========================================================================
+  # PR Synchronize (new push)
+  # ==========================================================================
+  pr-synchronize:
+    name: PR Push
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'synchronize' &&
+      contains(github.event.pull_request.labels.*.name, 'orchestrator/enabled')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Convert config to JSON
+        run: yq -o json .github/pr-lifecycle.yml > .github/pr-lifecycle.json
+
+      - name: Handle push
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const handler = require('./.github/scripts/pr-lifecycle.js');
+            await handler.handlePrSynchronize({ github, context, core });
+
+  # ==========================================================================
+  # Draft -> Ready
+  # ==========================================================================
+  pr-ready-for-review:
+    name: Draft to Ready
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'ready_for_review' &&
+      contains(github.event.pull_request.labels.*.name, 'orchestrator/enabled')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Convert config to JSON
+        run: yq -o json .github/pr-lifecycle.yml > .github/pr-lifecycle.json
+
+      - name: Handle ready for review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const handler = require('./.github/scripts/pr-lifecycle.js');
+            await handler.handlePrReadyForReview({ github, context, core });
+
+  # ==========================================================================
+  # Comment Commands
+  # ==========================================================================
+  command:
+    name: Command
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/') &&
+      contains(github.event.issue.labels.*.name, 'orchestrator/enabled')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Convert config to JSON
+        run: yq -o json .github/pr-lifecycle.yml > .github/pr-lifecycle.json
+
+      - name: Handle command
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const handler = require('./.github/scripts/pr-lifecycle.js');
+            await handler.handleComment({ github, context, core });
+
+  # ==========================================================================
+  # Review Submitted
+  # ==========================================================================
+  review:
+    name: Review
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request_review' &&
+      github.event.action == 'submitted' &&
+      contains(github.event.pull_request.labels.*.name, 'orchestrator/enabled')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Convert config to JSON
+        run: yq -o json .github/pr-lifecycle.yml > .github/pr-lifecycle.json
+
+      - name: Handle review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const handler = require('./.github/scripts/pr-lifecycle.js');
+            await handler.handleReview({ github, context, core });
+
+  # ==========================================================================
+  # Label Protection
+  # ==========================================================================
+  label-guard:
+    name: Label Guard
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request_target' &&
+      (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+      github.event.sender.login != 'github-actions[bot]' &&
+      (startsWith(github.event.label.name, 'lifecycle/') || startsWith(github.event.label.name, 'orchestrator/'))
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Convert config to JSON
+        run: yq -o json .github/pr-lifecycle.yml > .github/pr-lifecycle.json
+
+      - name: Handle label change
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const handler = require('./.github/scripts/pr-lifecycle.js');
+            await handler.handleLabelChange({ github, context, core });
+
+  # ==========================================================================
+  # Test Results (Verify workflow completed)
+  # ==========================================================================
+  test-result:
+    name: Test Result
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Convert config to JSON
+        run: yq -o json .github/pr-lifecycle.yml > .github/pr-lifecycle.json
+
+      - name: Handle test result
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const handler = require('./.github/scripts/pr-lifecycle.js');
+            await handler.handleTestResult({ github, context, core });
+
+  # ==========================================================================
+  # Stale Detection (daily cron)
+  # ==========================================================================
+  stale:
+    name: Stale Detection
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Convert config to JSON
+        run: yq -o json .github/pr-lifecycle.yml > .github/pr-lifecycle.json
+
+      - name: Check for stale PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const handler = require('./.github/scripts/pr-lifecycle.js');
+            await handler.handleStale({ github, context, core });

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -7,6 +7,7 @@ on:
       - 'README*'
     branches: [main]
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
     paths-ignore:
       - '.gitignore'
       - 'LICENSE'
@@ -19,12 +20,78 @@ concurrency:
 
 jobs:
   # ============================================================================
+  # SCOPE: Determine which test phases to run based on lifecycle labels
+  # ============================================================================
+  determine-scope:
+    name: Determine Test Scope
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Apicurio'
+    outputs:
+      run_smoke: ${{ steps.scope.outputs.run_smoke }}
+      run_full: ${{ steps.scope.outputs.run_full }}
+    steps:
+      - name: Evaluate scope
+        id: scope
+        run: |
+          EVENT="${{ github.event_name }}"
+          ACTION="${{ github.event.action }}"
+
+          # Push events: always run full
+          if [ "$EVENT" = "push" ]; then
+            echo "run_smoke=true" >> $GITHUB_OUTPUT
+            echo "run_full=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Labeled events: only react to lifecycle label changes
+          if [ "$ACTION" = "labeled" ]; then
+            LABEL='${{ github.event.label.name }}'
+            if [[ "$LABEL" != lifecycle/* ]]; then
+              echo "run_smoke=false" >> $GITHUB_OUTPUT
+              echo "run_full=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+
+          if echo "$LABELS" | grep -q '"orchestrator/enabled"'; then
+            # Orchestrated PR: scope based on lifecycle state
+            if echo "$LABELS" | grep -q '"lifecycle/ready-for-review"' || echo "$LABELS" | grep -q '"lifecycle/ready-to-merge"'; then
+              echo "run_smoke=true" >> $GITHUB_OUTPUT
+              echo "run_full=true" >> $GITHUB_OUTPUT
+            elif echo "$LABELS" | grep -q '"lifecycle/wip"'; then
+              if echo "$LABELS" | grep -q '"orchestrator/tests-disabled"'; then
+                echo "run_smoke=false" >> $GITHUB_OUTPUT
+                echo "run_full=false" >> $GITHUB_OUTPUT
+              else
+                echo "run_smoke=true" >> $GITHUB_OUTPUT
+                echo "run_full=false" >> $GITHUB_OUTPUT
+              fi
+            else
+              # lifecycle/new or no lifecycle label: skip tests
+              echo "run_smoke=false" >> $GITHUB_OUTPUT
+              echo "run_full=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            # Non-orchestrated PR: existing behavior (DO NOT MERGE backward compat)
+            if echo "$LABELS" | grep -q '"DO NOT MERGE"'; then
+              echo "run_smoke=false" >> $GITHUB_OUTPUT
+              echo "run_full=false" >> $GITHUB_OUTPUT
+            else
+              echo "run_smoke=true" >> $GITHUB_OUTPUT
+              echo "run_full=true" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+  # ============================================================================
   # PHASE 1: Fast Checks (fail early)
   # ============================================================================
   lint-and-validate:
     name: Lint and Validate
     runs-on: ubuntu-22.04
-    if: github.repository_owner == 'Apicurio' && !contains(github.event.*.labels.*.name, 'DO NOT MERGE')
+    needs: determine-scope
+    if: needs.determine-scope.outputs.run_smoke == 'true'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -45,8 +112,8 @@ jobs:
   # ============================================================================
   build:
     name: Build
-    needs: lint-and-validate
-    if: github.repository_owner == 'Apicurio' && !contains(github.event.*.labels.*.name, 'DO NOT MERGE')
+    needs: [determine-scope, lint-and-validate]
+    if: needs.determine-scope.outputs.run_smoke == 'true'
     uses: ./.github/workflows/verify-build.yaml
 
   # ============================================================================
@@ -54,8 +121,8 @@ jobs:
   # ============================================================================
   unit-tests:
     name: Unit Tests
-    needs: build
-    if: github.repository_owner == 'Apicurio' && !contains(github.event.*.labels.*.name, 'DO NOT MERGE')
+    needs: [determine-scope, build]
+    if: needs.determine-scope.outputs.run_smoke == 'true'
     uses: ./.github/workflows/verify-unit-tests.yaml
     with:
       image-tag: ${{ github.sha }}
@@ -63,7 +130,8 @@ jobs:
   # Path filter for conditional CLI verification (native build + tests)
   detect-cli-changes:
     name: Detect CLI Changes
-    needs: build
+    needs: [determine-scope, build]
+    if: needs.determine-scope.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     outputs:
       cli: ${{ steps.filter.outputs.cli }}
@@ -94,8 +162,8 @@ jobs:
   # ============================================================================
   integration-tests:
     name: Integration Tests
-    needs: build
-    if: github.repository_owner == 'Apicurio' && !contains(github.event.*.labels.*.name, 'DO NOT MERGE')
+    needs: [determine-scope, build]
+    if: needs.determine-scope.outputs.run_full == 'true'
     uses: ./.github/workflows/verify-integration-tests.yaml
     with:
       image-tag: ${{ github.sha }}
@@ -105,8 +173,8 @@ jobs:
   # ============================================================================
   extras:
     name: Extra Tests
-    needs: build
-    if: github.repository_owner == 'Apicurio' && !contains(github.event.*.labels.*.name, 'DO NOT MERGE')
+    needs: [determine-scope, build]
+    if: needs.determine-scope.outputs.run_full == 'true'
     uses: ./.github/workflows/verify-extras.yaml
     with:
       image-tag: ${{ github.sha }}
@@ -116,8 +184,8 @@ jobs:
   # ============================================================================
   sdk:
     name: SDK Verification
-    needs: build
-    if: github.repository_owner == 'Apicurio' && !contains(github.event.*.labels.*.name, 'DO NOT MERGE')
+    needs: [determine-scope, build]
+    if: needs.determine-scope.outputs.run_full == 'true'
     uses: ./.github/workflows/verify-sdk.yaml
     with:
       image-tag: ${{ github.sha }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -54,14 +54,15 @@ jobs:
           fi
 
           LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          has_label() { echo "$LABELS" | jq -e "index(\"$1\")" > /dev/null 2>&1; }
 
-          if echo "$LABELS" | grep -q '"orchestrator/enabled"'; then
+          if has_label "orchestrator/enabled"; then
             # Orchestrated PR: scope based on lifecycle state
-            if echo "$LABELS" | grep -q '"lifecycle/ready-for-review"' || echo "$LABELS" | grep -q '"lifecycle/ready-to-merge"'; then
+            if has_label "lifecycle/ready-for-review" || has_label "lifecycle/ready-to-merge"; then
               echo "run_smoke=true" >> $GITHUB_OUTPUT
               echo "run_full=true" >> $GITHUB_OUTPUT
-            elif echo "$LABELS" | grep -q '"lifecycle/wip"'; then
-              if echo "$LABELS" | grep -q '"orchestrator/tests-disabled"'; then
+            elif has_label "lifecycle/wip"; then
+              if has_label "orchestrator/tests-disabled"; then
                 echo "run_smoke=false" >> $GITHUB_OUTPUT
                 echo "run_full=false" >> $GITHUB_OUTPUT
               else
@@ -75,7 +76,7 @@ jobs:
             fi
           else
             # Non-orchestrated PR: existing behavior (DO NOT MERGE backward compat)
-            if echo "$LABELS" | grep -q '"DO NOT MERGE"'; then
+            if has_label "DO NOT MERGE"; then
               echo "run_smoke=false" >> $GITHUB_OUTPUT
               echo "run_full=false" >> $GITHUB_OUTPUT
             else


### PR DESCRIPTION
## Summary

- Introduce a label-driven PR lifecycle orchestrator that manages PR state transitions, gates test execution based on readiness, and provides comment commands for contributors and maintainers
- PRs move through `lifecycle/new` → `lifecycle/wip` → `lifecycle/ready-for-review` → `lifecycle/ready-to-merge` states, with test scope controlled by labels (smoke tests for WIP, full suite for ready-for-review)
- Gated behind `orchestrator/enabled` label for gradual rollout; non-orchestrated PRs and `DO NOT MERGE` continue to work as before

### Key features

- **Comment commands**: `/accept`, `/reject`, `/ready`, `/merge`, `/auto-merge`, `/disable-tests`, `/enable-tests`, `/unstale`
- **Auto-accept**: Maintainers and configured accounts (e.g., Renovate bot) skip triage and go directly to WIP
- **Test gating**: `determine-scope` job in `verify.yaml` controls which test phases run based on lifecycle labels
- **Label protection**: Unauthorized manual changes to `lifecycle/*` and `orchestrator/*` labels are reverted
- **Stale detection**: Daily cron marks inactive PRs as stale after 7 days, closes after 14
- **Auto-merge**: `/auto-merge` command enables automatic merge when PR reaches ready-to-merge state
- **Label auto-creation**: All lifecycle labels are created on first use with correct colors

### Files

| File | Purpose |
|------|---------|
| `.github/pr-lifecycle.yml` | Config: maintainers, auto-accept list, merge strategy, stale settings, welcome message |
| `.github/scripts/pr-lifecycle.js` | Core orchestrator logic (~550 lines) |
| `.github/workflows/pr-lifecycle.yml` | GitHub Actions workflow with 8 jobs routing events to handlers |
| `.github/workflows/verify.yaml` | Modified: added `determine-scope` job for lifecycle-based test gating |
| `.github/PR_LIFECYCLE.md` | Documentation for contributors and maintainers |

### Rollout plan

1. Merge this PR
2. Add `orchestrator/enabled` label to a few test PRs to validate all handlers
3. Remove the opt-in gate once stable and make it default for all PRs

## Test plan

- [ ] Open a test PR with `orchestrator/enabled` label, verify welcome message and `lifecycle/new` label
- [ ] Test `/accept` command transitions to `lifecycle/wip` and smoke tests run
- [ ] Test `/ready` command transitions to `lifecycle/ready-for-review` and full tests run
- [ ] Verify `lifecycle/tested` is added on test success, removed on new push
- [ ] Test `/merge` command with rebase strategy
- [ ] Verify label protection reverts unauthorized label changes
- [ ] Test auto-accept for maintainer-authored PRs
- [ ] Verify non-orchestrated PRs continue running full test suite
- [ ] Verify `DO NOT MERGE` still works on non-orchestrated PRs