### PR TITLE
fix(sdk): catch RuntimeException in RetryInvocationHandler (#7865)

### DIFF
--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -180,8 +180,9 @@ public class RegistryClientRequestAdapterFactory {
             while (true) {
                 try {
                     return method.invoke(delegate, args);
-                } catch (InvocationTargetException e) {
-                    Throwable cause = e.getCause();
+                } catch (InvocationTargetException | RuntimeException e) {
+                    Throwable cause = (e instanceof InvocationTargetException && e.getCause() != null)
+                            ? e.getCause() : e;
                     if (originalCause == null) {
                         originalCause = cause;
                     }

--- a/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RetryInvocationHandlerTest.java
+++ b/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RetryInvocationHandlerTest.java
@@ -204,6 +204,85 @@ class RetryInvocationHandlerTest {
                 "Should have retried once after wrapped Connection reset IOException");
     }
 
+    /**
+     * Simulates the production scenario where Method.invoke() does NOT wrap the exception in
+     * InvocationTargetException (observed with JDK 21's DirectMethodHandleAccessor). The
+     * RuntimeException with a retryable cause should still trigger retries.
+     */
+    @Test
+    void testRuntimeExceptionWithRetryableCauseIsRetried() throws Throwable {
+        AtomicInteger callCount = new AtomicInteger(0);
+        RequestAdapter realAdapter = throwingAdapter(() -> {
+            if (callCount.incrementAndGet() <= 1) {
+                throw new RuntimeException(
+                        new ExecutionException(new HttpClosedException("Connection was closed")));
+            }
+            return "success";
+        });
+
+        RequestAdapter proxy = (RequestAdapter) java.lang.reflect.Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{RequestAdapter.class},
+                new RegistryClientRequestAdapterFactory.RetryInvocationHandler(
+                        realAdapter, MAX_RETRIES, NO_DELAY, BACKOFF, NO_MAX_DELAY));
+
+        proxy.getBaseUrl();
+
+        assertEquals(2, callCount.get(),
+                "Should have retried once after RuntimeException with retryable cause");
+    }
+
+    /**
+     * A RuntimeException wrapping a non-retryable cause should propagate immediately.
+     */
+    @Test
+    void testRuntimeExceptionWithNonRetryableCauseIsNotRetried() {
+        AtomicInteger callCount = new AtomicInteger(0);
+        RequestAdapter realAdapter = throwingAdapter(() -> {
+            callCount.incrementAndGet();
+            throw new RuntimeException(new IllegalStateException("not retryable"));
+        });
+
+        RequestAdapter proxy = (RequestAdapter) java.lang.reflect.Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{RequestAdapter.class},
+                new RegistryClientRequestAdapterFactory.RetryInvocationHandler(
+                        realAdapter, MAX_RETRIES, NO_DELAY, BACKOFF, NO_MAX_DELAY));
+
+        assertThrows(RuntimeException.class, proxy::getBaseUrl,
+                "Non-retryable RuntimeException should propagate immediately");
+        assertEquals(1, callCount.get(),
+                "Should have been called exactly once with no retries");
+    }
+
+    /**
+     * End-to-end test through a real JDK Proxy to exercise the actual proxy dispatch path
+     * with HttpClosedException wrapped in RuntimeException → ExecutionException.
+     */
+    @Test
+    void testProxyBasedRetryWithHttpClosedException() throws Throwable {
+        AtomicInteger callCount = new AtomicInteger(0);
+        RequestAdapter realAdapter = throwingAdapter(() -> {
+            if (callCount.incrementAndGet() <= 2) {
+                throw new RuntimeException(
+                        new ExecutionException(new HttpClosedException("Connection was closed")));
+            }
+            return "success";
+        });
+
+        RequestAdapter proxy = (RequestAdapter) java.lang.reflect.Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{RequestAdapter.class},
+                new RegistryClientRequestAdapterFactory.RetryInvocationHandler(
+                        realAdapter, MAX_RETRIES, NO_DELAY, BACKOFF, NO_MAX_DELAY));
+
+        String result = proxy.getBaseUrl();
+
+        assertEquals("success", result, "Should succeed after retries");
+        assertEquals(3, callCount.get(),
+                "Should have been called 3 times (1 initial + 2 retries)");
+    }
+
     // ==================== Test Helpers ====================
 
     @FunctionalInterface


### PR DESCRIPTION
## Summary

- Add `RuntimeException` to the catch clause in `RetryInvocationHandler.invoke()` alongside
  `InvocationTargetException`, so retries fire even when JDK 21's `DirectMethodHandleAccessor`
  does not wrap the delegate's exception
- Add three new proxy-based unit tests: retryable `RuntimeException`, non-retryable
  `RuntimeException`, and multi-retry through a real JDK dynamic proxy

## Related Issue

Fixes #7865

## Test Plan

- [ ] `./mvnw test -pl java-sdk/common` — all existing and new `RetryInvocationHandlerTest`
  tests pass
- [ ] Verify new tests: `testRuntimeExceptionWithRetryableCauseIsRetried`,
  `testRuntimeExceptionWithNonRetryableCauseIsNotRetried`,
  `testProxyBasedRetryWithHttpClosedException`
- [ ] Full SDK build: `./mvnw clean install -pl java-sdk/common -DskipTests=false`