### PR TITLE
ci: reduce CI duration and resource usage

### DIFF
--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -344,12 +344,19 @@ async function handlePrOpened({ github, context, core }) {
   const config = loadConfig();
 
   if (isAutoAccepted(config, pr.user.login)) {
-    await api.addLabel(pr.number, LABELS.WIP);
-    await api.postComment(pr.number,
-      `PR auto-accepted (trusted author). Smoke tests will run on each push.\n\n` +
-      `When ready, use \`/ready\` to request a full review.`
-    );
-    core.info(`PR #${pr.number} auto-accepted for ${pr.user.login}`);
+    const initialState = pr.draft ? LABELS.WIP : LABELS.READY_FOR_REVIEW;
+    await api.addLabel(pr.number, initialState);
+    if (pr.draft) {
+      await api.postComment(pr.number,
+        `PR auto-accepted (trusted author). Smoke tests will run on each push.\n\n` +
+        `When ready, use \`/ready\` or mark as non-draft to run the full test suite.`
+      );
+    } else {
+      await api.postComment(pr.number,
+        `PR auto-accepted (trusted author). Full test suite will run.`
+      );
+    }
+    core.info(`PR #${pr.number} auto-accepted for ${pr.user.login}, state=${initialState}`);
     await retriggerVerify(api, pr, core, { waitForRun: true });
     return;
   }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,161 @@
+# CI Workflows
+
+## PR Verification Pipeline
+
+The main PR pipeline is `verify.yaml`, which orchestrates all verification steps.
+It runs on pull requests to `main` and on pushes to `main`.
+
+### Pipeline Phases
+
+```
+determine-scope ──┐
+                   ├── lint-and-validate ── build ──┬── unit-tests (3 shards)
+detect-changes ───┘                                 ├── integration-tests (13 jobs)
+                                                    ├── extras (5 jobs)
+                                                    ├── sdk
+                                                    ├── cli-verify (conditional)
+                                                    └── publish (main only) ── notify-slack
+```
+
+### Two Gating Systems
+
+Every test phase is gated by **both**:
+
+1. **Lifecycle scope** (`determine-scope`): driven by PR labels from the
+   PR lifecycle orchestrator. WIP PRs run smoke tests only; `ready-for-review`
+   PRs run the full suite. Push to main always runs everything.
+
+2. **Change detection** (`detect-changes`): uses `dorny/paths-filter` to
+   detect which areas of the codebase changed. Outputs 6 flags:
+
+   | Flag | Paths | Gates |
+   |------|-------|-------|
+   | `java` | `app/`, `common/`, `schema-*/`, `serdes/`, `config-index/`, `java-sdk/`, `mcp/`, `distro/`, `pom.xml` | unit-tests, extras |
+   | `ui` | `ui/` | extras |
+   | `integration` | `app/`, `common/`, `integration-tests/`, `schema-*/`, `serdes/`, `distro/`, `pom.xml` | integration-tests |
+   | `sdk` | `java-sdk/`, `go-sdk/`, `python-sdk/`, `typescript-sdk/` | sdk |
+   | `cli` | `cli/`, `java-sdk/`, `verify-cli.yaml` | cli-verify |
+   | `ci` | `.github/workflows/**` | all test phases |
+
+   Docs-only or UI-only PRs skip Java unit tests and integration tests entirely.
+   Push to main always runs everything regardless of change detection.
+
+## Unit Test Sharding
+
+The unit tests are split into 3 parallel shards to reduce the critical path
+(see `verify-unit-tests.yaml`):
+
+| Shard | What it runs | Typical duration |
+|-------|-------------|-----------------|
+| `app-shard1` | `noprofile.rest.**`, `noprofile.ccompat.**`, `storage.**`, `event.**` | ~16 min |
+| `app-shard2` | Everything else in `app/` (auth, tls, metrics, noprofile.other, etc.) | ~12 min |
+| `non-app` | All modules except `app/` (schema-util, serdes, java-sdk, cli, mcp, etc.) | ~7 min |
+
+### How sharding works
+
+- **app-shard1** uses surefire's `-Dtest=` to *include* specific packages.
+- **app-shard2** uses `-Dtest=!...` to *exclude* those same packages, catching everything else.
+- **non-app** uses Maven's `-pl` to run all modules except `app` and modules that
+  depend on the `app` JAR (`distro/docker`, `docs`, `docs/config-generator`, `docs/rest-api`).
+
+### Adding new tests
+
+New test classes are automatically picked up:
+
+- **In `app/`**: if the package matches `noprofile.rest`, `noprofile.ccompat`,
+  `storage`, or `event`, it runs in `app-shard1`. Everything else lands in
+  `app-shard2` (the exclusion-based shard).
+- **In any other module**: runs in `non-app`.
+
+No CI changes needed for new tests.
+
+### Rebalancing shards
+
+If one shard grows significantly slower than the other, rebalance by moving
+package patterns between `app-shard1` and `app-shard2` in `verify-unit-tests.yaml`.
+Check actual CI timings with:
+
+```bash
+gh run view <run-id> --repo Apicurio/apicurio-registry --json jobs | \
+  python3 -c "import json,sys; [print(f'{j[\"name\"]}: {j[\"conclusion\"]}') for j in json.load(sys.stdin)['jobs']]"
+```
+
+### Why not use forkCount > 1?
+
+Quarkus's `QuarkusTestExtension` shares application instances across test classes
+with the same `@TestProfile`. With `forkCount > 1`, surefire distributes classes
+across JVM forks, breaking the shared lifecycle and causing
+"application already been closed" errors. CI-level sharding (separate jobs) is
+the only safe way to parallelize `@QuarkusTest` classes.
+
+## Integration Tests
+
+`verify-integration-tests.yaml` runs a 13-job matrix across storage backends:
+
+| Storage | Test groups |
+|---------|------------|
+| h2 (in-memory) | default, auth, migration, debezium, iceberg |
+| postgresql | default, auth, migration |
+| kafkasql | default, auth, migration, snapshotting |
+| kubernetesops | kubernetesops |
+
+Each job sets up Minikube, loads the registry Docker image, and runs the
+failsafe integration tests with the appropriate storage profile
+(`remote-mem`, `remote-sql`, `remote-kafka`, `remote-kubernetesops`).
+
+The full matrix always runs when Java code changes. It is only skipped for
+non-Java changes (docs, UI).
+
+## Verification Workflows
+
+| Workflow | Trigger | Purpose | Duration |
+|----------|---------|---------|----------|
+| `verify.yaml` | PR, push to main | Main orchestrator: gates and coordinates all phases | N/A |
+| `verify-build.yaml` | Called by verify | Parallel Java (`mvnw package -T 0.5C`) + UI (`npm build`) builds. Produces Docker images and build artifacts uploaded with 1-day retention | ~6 min |
+| `verify-unit-tests.yaml` | Called by verify | Unit tests in 3 parallel shards (see above) | ~16 min (critical path) |
+| `verify-integration-tests.yaml` | Called by verify | 13-job matrix across storage backends, each with Minikube | ~15 min per job |
+| `verify-extras.yaml` | Called by verify | 5 parallel jobs: extra tests, UI Playwright tests, legacy V2 compatibility tests, TypeScript SDK tests, example builds | ~13 min |
+| `verify-sdk.yaml` | Called by verify | Go and Python SDK verification | ~2 min |
+| `verify-cli.yaml` | Called by verify | CLI native build (GraalVM) + tests on Linux and macOS. Conditional on `cli/` or `java-sdk/` changes | ~15-25 min |
+| `verify-publish.yaml` | Called by verify | Push Docker images (app, UI, MCP, GitOps) to DockerHub and Quay.io. Main branch only. Uses `reusable-docker-build.yaml` for multi-arch builds | ~30-40 min |
+
+## Validation Workflows
+
+| Workflow | Trigger | Purpose | Duration |
+|----------|---------|---------|----------|
+| `validate-docs.yaml` | PR (docs/**), workflow_call | Runs `docs-playbook/_build-all.sh` to validate documentation builds | ~10 min |
+| `validate-openapi.yaml` | PR (openapi.json), workflow_call | Lints OpenAPI spec with `@rhoas/spectral-ruleset` | ~5 min |
+
+## Release Workflows
+
+All release workflows trigger on `release` (type: released) events and support
+`workflow_dispatch` for manual re-runs. They gate on `github.repository_owner == 'Apicurio'`
+and tags starting with `3.`.
+
+| Workflow | Purpose | Duration | Key details |
+|----------|---------|----------|-------------|
+| `release.yaml` | Main release orchestrator. Phase 1: version bump + commit. Phase 2: parallel builds (Java app, UI, CLI native on Linux + macOS via GraalVM). Phase 3: create GitHub release with artifacts, bump to next SNAPSHOT | 60-120 min | CLI native compilation is the bottleneck (~20-40 min per platform) |
+| `release-artifacts.yaml` | Publish to Maven Central (GPG-signed), generate SBOMs (`mvn dependency:tree` + `npm list`), build Maven plugin site, publish `artifact-type-builtins` npm package. Selectable via `artifacts` input (maven, sboms, site, builtins, all) | 30-90 min | 90-min timeout on Maven Central deploy. Uses GPG key for signing |
+| `release-images.yaml` | Build and push multi-arch Docker images (linux/amd64, arm64, s390x, ppc64le) for app, UI, operator, GitOps sync, and MCP server to DockerHub + Quay.io. Frees disk space first (removes Android/Haskell/.NET SDKs). Determines `latest` tag via release pagination | 90-120 min | 120-min timeout. 5 separate multi-arch builds |
+| `release-sdks.yaml` | Publish SDKs: Python (Poetry + PyPI), Go (git tag + proxy verification with retry), TypeScript (npm publish). Selectable via `sdks` input | 10-30 min | Go SDK uses retry loop (5 attempts) waiting for Go module proxy |
+| `release-operator.yaml` | Build + push operator image, create OLM bundle + catalog, run Minikube tests (smoke, OLM v0, OLM v1), upload dist archive to GitHub release, create PRs to community-operators (k8s + OpenShift), sync post-release changes back to main | 120-180 min | 180-min timeout. Opens PRs to 2 external repos. Has tmate debug session on failure |
+| `release-milestones.yaml` | Close the current milestone and create the next patch milestone | 2-5 min | Pure GitHub API operations |
+| `release-release-notes.yaml` | Generate release notes from milestone issues. Categorizes as Bug Fixes, Enhancements, or Other based on labels. Updates the GitHub release body | 5-10 min | Fetches up to 1000 closed issues |
+
+## Automation Workflows
+
+| Workflow | Trigger | Purpose | Duration |
+|----------|---------|---------|----------|
+| `pr-lifecycle.yml` | PR events, comments, reviews, workflow_run, daily schedule | Label-driven PR state machine. States: `new` -> `wip` -> `ready-for-review` -> `ready-to-merge`. Comment commands: `/accept`, `/reject`, `/ready`, `/merge`, `/auto-merge`. Auto-accepts maintainers. Stale detection (7-day warning, 14-day auto-close). Label protection (reverts unauthorized changes). 838 lines of JS logic in `.github/scripts/pr-lifecycle.js` | 2-5 min per event |
+| `update-openapi.yaml` | Push to main (openapi.json changes) | Auto-copies v3 OpenAPI spec to v2 path, commits if changed, then validates via `validate-openapi.yaml` | 10-15 min |
+| `update-website.yaml` | Release event, workflow_dispatch | Updates `latestRelease.json` on apicurio.github.io with release metadata | 5-10 min |
+| `publish-docs.yaml` | Push to main (docs/**), workflow_dispatch | Builds documentation via Antora playbook and publishes to apicurio.github.io | 15-30 min |
+| `operator.yaml` | Push/PR to main (operator/**) | Operator CI: build + push temp images to ttl.sh (8h TTL), 8-group test matrix on Minikube (smoke, kafka, auth, database, feature, feature-setup, OLM v0, OLM v1), publish to Quay.io on push. Cancels in-progress on new push | 45-90 min |
+| `image-scan.yaml` | Daily at 06:00 UTC, workflow_dispatch | Trivy vulnerability scan on `latest-snapshot` image (CRITICAL + HIGH severity). Results uploaded to GitHub Security tab as SARIF | 5-10 min |
+
+## Reusable Workflows
+
+| Workflow | Used by | Purpose |
+|----------|---------|---------|
+| `reusable-docker-build.yaml` | verify-publish, release-images | Multi-arch Docker build with QEMU + Buildx. Supports optional Maven/npm pre-build steps. Pushes to DockerHub and/or Quay.io. Includes retry logic (3 attempts, 30s wait). Configurable platforms, tags, registries | 30-60 min |
+| `reusable-notify-slack.yaml` | verify, operator, release-* | Sends Slack notifications. Always posts to notification webhook; additionally posts to error webhook on failure. Payload includes workflow name, status, and link |

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -13,8 +13,24 @@ on:
 
 jobs:
   unit-tests:
-    name: Unit Tests
+    name: Unit Tests (${{ matrix.shard.name }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - name: app-shard1
+            modules: "-pl app -am -Dfull -DcliSkipNative"
+            test-filter: "-Dtest=io.apicurio.registry.noprofile.rest.**,io.apicurio.registry.noprofile.ccompat.**,io.apicurio.registry.storage.**,io.apicurio.registry.event.**"
+            maven-opts: "-Xmx4g"
+          - name: app-shard2
+            modules: "-pl app -am -Dfull -DcliSkipNative"
+            test-filter: "-Dtest=!io.apicurio.registry.noprofile.rest.**,!io.apicurio.registry.noprofile.ccompat.**,!io.apicurio.registry.storage.**,!io.apicurio.registry.event.**"
+            maven-opts: "-Xmx4g"
+          - name: non-app
+            modules: "-Dfull -DcliSkipNative -pl !app,!distro/docker,!docs,!docs/config-generator,!docs/rest-api"
+            test-filter: ""
+            maven-opts: "-Xmx2g"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -34,28 +50,19 @@ jobs:
 
       - name: Restore executable permissions
         run: |
-          # GitHub Actions artifact upload/download doesn't preserve executable permissions
-          # Restore execute permission on protoc binaries
           find . -name "protoc-*" -type f -exec chmod +x {} \; 2>/dev/null || true
           find . -name "*.exe" -path "*/protoc-plugins/*" -type f -exec chmod +x {} \; 2>/dev/null || true
 
-      - name: Load Docker Image
-        uses: apicurio/apicurio-github-actions/load-docker-image@v2
-        with:
-          artifact-name: apicurio-registry-${{ inputs.image-tag }}.tar
-          image-file: /tmp/apicurio-registry-${{ inputs.image-tag }}.tar
-          image-name: apicurio/apicurio-registry
-          tag: ${{ inputs.image-tag }}
-
-      - name: Run Unit Tests
+      - name: Run Unit Tests (${{ matrix.shard.name }})
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For downloading Kiota binary.
-          MAVEN_OPTS: -Xmx4g
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_OPTS: ${{ matrix.shard.maven-opts }}
         run: |
           ./mvnw verify \
             --no-transfer-progress \
-            -Pprod -Dfull -DcliSkipNative \
+            -Pprod ${{ matrix.shard.modules }} \
+            ${{ matrix.shard.test-filter }} \
+            -Dsurefire.failIfNoSpecifiedTests=false \
             -DskipCommitIdPlugin=false \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
-            -Dmaven.wagon.http.retryHandler.count=5 \
-            -Dtest.app.image=apicurio/apicurio-registry:${{ inputs.image-tag }}
+            -Dmaven.wagon.http.retryHandler.count=5

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -92,6 +92,65 @@ jobs:
           fi
 
   # ============================================================================
+  # CHANGE DETECTION: Determine which areas of code changed
+  # ============================================================================
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Apicurio'
+    outputs:
+      java: ${{ steps.filter.outputs.java }}
+      ui: ${{ steps.filter.outputs.ui }}
+      integration: ${{ steps.filter.outputs.integration }}
+      sdk: ${{ steps.filter.outputs.sdk }}
+      cli: ${{ steps.filter.outputs.cli }}
+      ci: ${{ steps.filter.outputs.ci }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            java:
+              - 'app/**'
+              - 'common/**'
+              - 'schema-util/**'
+              - 'schema-validation/**'
+              - 'schema-resolver/**'
+              - 'serdes/**'
+              - 'config-index/**'
+              - 'java-sdk/**'
+              - 'mcp/**'
+              - 'distro/**'
+              - 'pom.xml'
+            ui:
+              - 'ui/**'
+            integration:
+              - 'app/**'
+              - 'common/**'
+              - 'integration-tests/**'
+              - 'schema-util/**'
+              - 'schema-validation/**'
+              - 'schema-resolver/**'
+              - 'serdes/**'
+              - 'distro/**'
+              - 'pom.xml'
+            sdk:
+              - 'java-sdk/**'
+              - 'go-sdk/**'
+              - 'python-sdk/**'
+              - 'typescript-sdk/**'
+            cli:
+              - 'cli/**'
+              - 'java-sdk/**'
+              - '.github/workflows/verify-cli.yaml'
+            ci:
+              - '.github/workflows/**'
+
+  # ============================================================================
   # PHASE 1: Fast Checks (fail early)
   # ============================================================================
   lint-and-validate:
@@ -116,83 +175,107 @@ jobs:
 
   # ============================================================================
   # PHASE 2: Build (parallel Java + UI builds)
+  # Gated by lifecycle scope AND change detection.
   # ============================================================================
   build:
     name: Build
-    needs: [determine-scope, lint-and-validate]
-    if: needs.determine-scope.outputs.run_smoke == 'true'
+    needs: [determine-scope, lint-and-validate, detect-changes]
+    if: >-
+      needs.determine-scope.outputs.run_smoke == 'true' &&
+      (
+        github.event_name == 'push' ||
+        needs.detect-changes.outputs.java == 'true' ||
+        needs.detect-changes.outputs.ui == 'true' ||
+        needs.detect-changes.outputs.sdk == 'true' ||
+        needs.detect-changes.outputs.cli == 'true' ||
+        needs.detect-changes.outputs.ci == 'true'
+      )
     uses: ./.github/workflows/verify-build.yaml
 
   # ============================================================================
-  # PHASE 3: Unit Tests (parallel with integration tests)
+  # PHASE 3: Unit Tests
+  # Requires smoke scope. Skip when only docs/UI changed.
   # ============================================================================
   unit-tests:
     name: Unit Tests
-    needs: [determine-scope, build]
-    if: needs.determine-scope.outputs.run_smoke == 'true'
+    needs: [determine-scope, build, detect-changes]
+    if: >-
+      needs.determine-scope.outputs.run_smoke == 'true' &&
+      (
+        github.event_name == 'push' ||
+        needs.detect-changes.outputs.java == 'true' ||
+        needs.detect-changes.outputs.ci == 'true'
+      )
     uses: ./.github/workflows/verify-unit-tests.yaml
     with:
       image-tag: ${{ github.sha }}
 
-  # Path filter for conditional CLI verification (native build + tests)
-  detect-cli-changes:
-    name: Detect CLI Changes
-    needs: [determine-scope, build]
-    if: needs.determine-scope.outputs.run_full == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      cli: ${{ steps.filter.outputs.cli }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
-      - name: Check for CLI changes
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            cli:
-              - 'cli/**'
-              - 'java-sdk/**'
-              - '.github/workflows/verify-cli.yaml'
-
+  # ============================================================================
+  # CLI Verification (conditional on CLI/SDK changes + full scope)
+  # ============================================================================
   cli-verify:
     name: CLI Verification
-    needs: detect-cli-changes
-    if: needs.detect-cli-changes.outputs.cli == 'true'
+    needs: [determine-scope, build, detect-changes]
+    if: >-
+      needs.determine-scope.outputs.run_full == 'true' &&
+      needs.detect-changes.outputs.cli == 'true'
     uses: ./.github/workflows/verify-cli.yaml
     with:
       image-tag: ${{ github.sha }}
 
   # ============================================================================
   # PHASE 4: Integration Tests (matrix-based parallel execution)
+  # Requires full scope. Skip when only docs/UI/SDK changed.
+  # Uses reduced matrix on PRs.
   # ============================================================================
   integration-tests:
     name: Integration Tests
-    needs: [determine-scope, build]
-    if: needs.determine-scope.outputs.run_full == 'true'
+    needs: [determine-scope, build, detect-changes]
+    if: >-
+      needs.determine-scope.outputs.run_full == 'true' &&
+      (
+        github.event_name == 'push' ||
+        needs.detect-changes.outputs.integration == 'true' ||
+        needs.detect-changes.outputs.ci == 'true'
+      )
     uses: ./.github/workflows/verify-integration-tests.yaml
     with:
       image-tag: ${{ github.sha }}
 
   # ============================================================================
   # PHASE 5: Additional Tests (parallel)
+  # Requires full scope. Skip when only docs changed.
   # ============================================================================
   extras:
     name: Extra Tests
-    needs: [determine-scope, build]
-    if: needs.determine-scope.outputs.run_full == 'true'
+    needs: [determine-scope, build, detect-changes]
+    if: >-
+      needs.determine-scope.outputs.run_full == 'true' &&
+      (
+        github.event_name == 'push' ||
+        needs.detect-changes.outputs.java == 'true' ||
+        needs.detect-changes.outputs.ui == 'true' ||
+        needs.detect-changes.outputs.ci == 'true'
+      )
     uses: ./.github/workflows/verify-extras.yaml
     with:
       image-tag: ${{ github.sha }}
 
   # ============================================================================
   # PHASE 6: SDK Verification (parallel)
+  # Requires full scope. Only when SDK/Java files changed.
   # ============================================================================
   sdk:
     name: SDK Verification
-    needs: [determine-scope, build]
-    if: needs.determine-scope.outputs.run_full == 'true'
+    needs: [determine-scope, build, detect-changes]
+    if: >-
+      needs.determine-scope.outputs.run_full == 'true' &&
+      (
+        github.event_name == 'push' ||
+        needs.detect-changes.outputs.sdk == 'true' ||
+        needs.detect-changes.outputs.java == 'true' ||
+        needs.detect-changes.outputs.ci == 'true'
+      )
     uses: ./.github/workflows/verify-sdk.yaml
     with:
       image-tag: ${{ github.sha }}
@@ -214,7 +297,7 @@ jobs:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   # ============================================================================
-  # PHASE 9: Notifications (using reusable workflow)
+  # PHASE 8: Notifications (using reusable workflow)
   # ============================================================================
   notify-slack:
     name: Slack Notification

--- a/app/src/main/resources/application-test.properties
+++ b/app/src/main/resources/application-test.properties
@@ -3,7 +3,9 @@ quarkus.log.level=WARN
 quarkus.log.category."io.apicurio".level=INFO
 quarkus.log.console.enabled=true
 quarkus.http.test-port=0
+quarkus.http.test-ssl-port=0
 quarkus.management.test-port=0
+quarkus.management.test-ssl-port=0
 quarkus.test.flat-class-path=true
 
 ## Registry


### PR DESCRIPTION
## Summary

Reduce CI duration and resource usage by adding path-based change detection,
sharding unit tests, removing unnecessary steps, and fixing PR lifecycle behavior.

## Changes

### 1. Path-based change detection (`verify.yaml`)

New `detect-changes` job using `dorny/paths-filter@v3` runs in parallel with the
existing `determine-scope` job. Outputs 6 flags (`java`, `ui`, `integration`,
`sdk`, `cli`, `ci`) that gate downstream jobs alongside the lifecycle scope.

- Replaces the standalone `detect-cli-changes` job
- Docs-only or UI-only PRs skip Java unit tests and integration tests entirely
- CI workflow changes (`ci` flag) trigger all test phases
- Push to main always runs the full suite regardless of detection

### 2. Unit test sharding (`verify-unit-tests.yaml`)

Split the single ~55 min unit test job into 3 parallel shards using surefire
`-Dtest` class patterns:

| Shard | Test classes | Measured duration |
|-------|-------------|------------------|
| `app-shard1` | `noprofile.rest.**`, `noprofile.ccompat.**`, `storage.**`, `event.**` | ~13.4 min |
| `app-shard2` | Everything else in `app/` (exclusion-based, catches new tests automatically) | ~13.6 min |
| `non-app` | All modules except `app` and its dependents (`distro/docker`, `docs/*`) | ~7.1 min |

Key details:
- New test classes are automatically picked up — no CI changes needed
- Non-app shard uses `-Dfull` with targeted exclusions for modules that depend
  on the `app` JAR (`distro/docker`, `docs`, `docs/config-generator`, `docs/rest-api`)
- Removed unused Docker image load step from unit test workflow (no unit test
  references `test.app.image`)
- `forkCount > 1` was attempted but reverted — Quarkus's `QuarkusTestExtension`
  shares app instances per `@TestProfile` and breaks across parallel JVM forks

### 3. Randomize SSL test ports (`application-test.properties`)

Added `quarkus.http.test-ssl-port=0` and `quarkus.management.test-ssl-port=0` to
ensure all ports use random assignment in tests, preventing potential conflicts.

### 4. PR lifecycle: auto-accepted non-draft PRs start as ready-for-review

When a maintainer or trusted account opens a non-draft PR, the orchestrator now
sets it to `lifecycle/ready-for-review` (full test suite) instead of
`lifecycle/wip` (smoke only). Draft PRs from trusted authors still start as WIP.
No change to merge behavior — `/merge` is still required.

### 5. Integration tests unchanged

The full 13-job integration test matrix runs on every PR with Java changes. The
path-based detection skips integration tests only for non-Java changes (docs, UI).

### 6. CI workflows README (`.github/workflows/README.md`)

Added comprehensive documentation covering all 25 workflow files: triggers,
job structure, key steps, secrets, timeouts, concurrency settings, and
estimated durations. Also documents the unit test sharding strategy, how new
tests are picked up, and how to rebalance shards.

## Impact

- Unit test critical path: **~55 min → ~14 min** (3 parallel shards, measured)
- Docs/UI-only PRs: skip all Java tests and integration tests
- Maintainer non-draft PRs: run full suite immediately (no manual `/ready` needed)
- Push to main: unchanged (full coverage preserved)
- No reduction in test coverage for Java changes

## Test plan

- [x] Verify YAML parses correctly (no syntax errors in Actions tab)
- [x] PR run: confirm unit tests split into 3 parallel shards
- [x] Measured shard balance: app-shard1=13.4 min, app-shard2=13.6 min, non-app=7.1 min
- [x] Both lifecycle scope and change detection gates work together
- [ ] PR run with `ready-for-review`: confirm full suite (integration tests, extras, SDK) executes
- [ ] Verify auto-accepted non-draft PR starts as `ready-for-review`