### PR TITLE
fix(deps): update git-commit-id-maven-plugin to 10.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1263,7 +1263,7 @@
       <plugin>
         <groupId>io.github.git-commit-id</groupId>
         <artifactId>git-commit-id-maven-plugin</artifactId>
-        <version>9.2.0</version>
+        <version>10.0.0</version>
         <configuration>
           <skip>${skipCommitIdPlugin}</skip>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>


### PR DESCRIPTION
## Summary
- Update io.github.git-commit-id:git-commit-id-maven-plugin from 9.2.0 to 10.0.0

## Context
This dependency upgrade was split from Renovate PR #7898 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass