### PR TITLE
fix(deps): update checkstyle (puppycrawl) to 13.4.2

### DIFF
--- a/examples/rest-client/src/main/java/io/apicurio/registry/examples/SimpleRegistryDemo.java
+++ b/examples/rest-client/src/main/java/io/apicurio/registry/examples/SimpleRegistryDemo.java
@@ -13,7 +13,7 @@ import java.util.UUID;
  * <p>
  * 1) Register a new schema in the Registry. 2) Fetch the newly created schema. 3) Delete the schema.
  *
- * @author Carles Arnal <carnalca@redhat.com>
+ * @author Carles Arnal
  */
 public class SimpleRegistryDemo {
 

--- a/examples/rest-client/src/main/java/io/apicurio/registry/examples/SimpleRegistryDemoBasicAuth.java
+++ b/examples/rest-client/src/main/java/io/apicurio/registry/examples/SimpleRegistryDemoBasicAuth.java
@@ -13,7 +13,7 @@ import java.util.UUID;
  * <p>
  * 1) Register a new schema in the Registry. 2) Fetch the newly created schema. 3) Delete the schema.
  *
- * @author Carles Arnal <carnalca@redhat.com>
+ * @author Carles Arnal
  */
 public class SimpleRegistryDemoBasicAuth {
 

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
     <version.org.sonatype.central-publishing-maven-plugin>0.10.0</version.org.sonatype.central-publishing-maven-plugin>
 
     <!-- Plugin Deps -->
-    <version.puppycrawl>8.45.1</version.puppycrawl>
+    <version.puppycrawl>13.4.2</version.puppycrawl>
     <apicurio-maven-plugin.version>0.0.8</apicurio-maven-plugin.version>
 
     <!-- Protocol Buffers -->

--- a/serdes/generic/serde-common-avro/src/main/java/io/apicurio/registry/serde/avro/AvroSchemaParser.java
+++ b/serdes/generic/serde-common-avro/src/main/java/io/apicurio/registry/serde/avro/AvroSchemaParser.java
@@ -42,7 +42,7 @@ public class AvroSchemaParser<U> implements SchemaParser<Schema, U> {
     }
 
     /**
-     * @see io.apicurio.registry.resolver.SchemaParser#parseSchema(byte[], Map<String, ParsedSchema<Schema>>)
+     * @see io.apicurio.registry.resolver.SchemaParser#parseSchema(byte[], Map)
      */
     @Override
     public Schema parseSchema(byte[] rawSchema, Map<String, ParsedSchema<Schema>> resolvedReferences) {

--- a/serdes/generic/serde-common-avro/src/main/java/io/apicurio/registry/serde/avro/AvroSerdeConfig.java
+++ b/serdes/generic/serde-common-avro/src/main/java/io/apicurio/registry/serde/avro/AvroSerdeConfig.java
@@ -9,7 +9,7 @@ public class AvroSerdeConfig extends SerdeConfig {
 
     /**
      * Used by the Avro serde classes to choose an <code>io.apicurio.registry.serde.avro.AvroEncoding</code>,
-     * for example <code>JSON</code> or </code>BINARY</code>. Serializer and Deserializer configuration must
+     * for example <code>JSON</code> or <code>BINARY</code>. Serializer and Deserializer configuration must
      * match.
      */
     public static final String AVRO_ENCODING = "apicurio.registry.avro.encoding";

--- a/serdes/generic/serde-common-jsonschema/src/main/java/io/apicurio/registry/serde/jsonschema/JsonSchemaParser.java
+++ b/serdes/generic/serde-common-jsonschema/src/main/java/io/apicurio/registry/serde/jsonschema/JsonSchemaParser.java
@@ -24,8 +24,7 @@ public class JsonSchemaParser<T> implements SchemaParser<JsonSchema, T> {
     }
 
     /**
-     * @see io.apicurio.registry.resolver.SchemaParser#parseSchema(byte[], Map<String,
-     *      ParsedSchema<JsonSchema>>)
+     * @see io.apicurio.registry.resolver.SchemaParser#parseSchema(byte[], Map)
      */
     @Override
     public JsonSchema parseSchema(byte[] rawSchema,

--- a/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufSchemaParser.java
+++ b/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/ProtobufSchemaParser.java
@@ -36,8 +36,7 @@ public class ProtobufSchemaParser<U extends Message> implements SchemaParser<Pro
     }
 
     /**
-     * @see io.apicurio.registry.resolver.SchemaParser#parseSchema(byte[], Map<String,
-     *      ParsedSchema<ProtobufSchema>>)
+     * @see io.apicurio.registry.resolver.SchemaParser#parseSchema(byte[], Map)
      */
     @Override
     public ProtobufSchema parseSchema(byte[] rawSchema,

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/ExtJsonConverter.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/ExtJsonConverter.java
@@ -142,8 +142,7 @@ public class ExtJsonConverter extends BaseSerde<JsonNode, Object>
     }
 
     /**
-     * @see io.apicurio.registry.resolver.SchemaParser#parseSchema(byte[], Map<String,
-     *      ParsedSchema<JsonNode>>)
+     * @see io.apicurio.registry.resolver.SchemaParser#parseSchema(byte[], Map)
      */
     @Override
     public JsonNode parseSchema(byte[] rawSchema, Map<String, ParsedSchema<JsonNode>> resolvedReferences) {


### PR DESCRIPTION
## Summary
- Update com.puppycrawl.tools:checkstyle from 8.45.1 to 13.4.2

## Context
This dependency upgrade was split from Renovate PR #7898 for easier review and testing.

Note: This is a major version bump (8.x → 13.x). Checkstyle 13.x requires JDK 21 minimum.
Review checkstyle rule compatibility before merging.

## Test Plan
- [ ] Build passes
- [ ] Checkstyle passes with new version: `./mvnw checkstyle:check`
- [ ] No new checkstyle violations introduced