### PR TITLE
fix(deps): update groovy to 5.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
     <kiota.base.url>https://github.com/microsoft/kiota/releases/download</kiota.base.url>
 
     <!-- Groovy scripting -->
-    <groovy.version>4.0.31</groovy.version>
+    <groovy.version>5.0.5</groovy.version>
 
     <!-- Test containers version, should be aligned with version used in Quarkus -->
     <pulsar.testcontainers.version>2.0.5</pulsar.testcontainers.version>


### PR DESCRIPTION
## Summary
- Update org.apache.groovy:groovy from 4.0.31 to 5.0.5

## Context
This dependency upgrade was split from Renovate PR #7898 for easier review and testing.

Note: This is a major version bump (4.x → 5.x). Groovy 5.x is a significant update — review
for API compatibility in any Groovy-based scripts or tests.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected