### PR TITLE
feat(ci): improve PR lifecycle with skip-review, status labels, and color updates

### DIFF
--- a/.github/PR_LIFECYCLE.md
+++ b/.github/PR_LIFECYCLE.md
@@ -24,7 +24,9 @@ Opened --> new --> wip --> ready-for-review --> ready-to-merge --> merged
 
 | Label | Meaning |
 |-------|---------|
+| `lifecycle/smoke-tested` | Smoke tests passed for the current HEAD commit. Removed on new pushes or when superseded by `lifecycle/tested`. |
 | `lifecycle/tested` | Full test suite passed for the current HEAD commit. Removed on new pushes. |
+| `lifecycle/review-approved` | PR has an approved review. Removed on new pushes or when changes are requested. |
 | `lifecycle/waiting-on-author` | PR needs action from the author (failed tests or changes requested). |
 | `lifecycle/waiting-on-maintainer` | PR needs maintainer attention (ready to review or merge). |
 | `lifecycle/stale` | No activity for 7 days. PR will be closed after 7 more days of inactivity. |
@@ -87,6 +89,7 @@ When a new PR arrives (`lifecycle/new`):
 | `/accept` | Accept a new PR, transition to WIP |
 | `/reject [reason]` | Reject and close a new PR |
 | `/ready` | Mark a WIP PR as ready for review (can also be done by the author) |
+| `/skip-review` | Skip the review requirement for small changes (tests still required) |
 | `/merge` | Merge a PR that is in `ready-to-merge` state |
 | `/auto-merge` | Toggle auto-merge (PR merges automatically when ready-to-merge is reached) |
 | `/disable-tests` | Disable smoke tests for a WIP PR |

--- a/.github/pr-lifecycle.yml
+++ b/.github/pr-lifecycle.yml
@@ -38,3 +38,12 @@ welcome_message: |
   | `/disable-tests` | Disable smoke tests during development |
   | `/enable-tests` | Re-enable smoke tests |
   | `/unstale` | Remove the stale label |
+
+  **Maintainer commands:**
+  | Command | Description |
+  |---------|-------------|
+  | `/accept` | Accept the PR and transition to WIP |
+  | `/reject [reason]` | Reject and close the PR |
+  | `/skip-review` | Skip review requirement for small changes (tests still required) |
+  | `/auto-merge` | Toggle auto-merge |
+  | `/merge` | Merge the PR |

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -361,18 +361,21 @@ async function handlePrOpened({ github, context, core }) {
   if (isAutoAccepted(config, pr.user.login)) {
     const initialState = pr.draft ? LABELS.WIP : LABELS.READY_FOR_REVIEW;
     await api.addLabel(pr.number, initialState);
+    const maintainerHint = isMaintainer(config, pr.user.login)
+      ? `\n\nA maintainer can use \`/skip-review\` to skip the review requirement for small changes, ` +
+        `or \`/auto-merge\` to merge automatically once approved and tested.`
+      : '';
     if (pr.draft) {
       await api.postComment(pr.number,
         `PR auto-accepted (trusted author). Smoke tests will run on each push.\n\n` +
-        `When ready, use \`/ready\` or mark as non-draft to run the full test suite, ` +
-        `or \`/skip-review\` to skip the review requirement for small changes (tests are still required).`
+        `When ready, use \`/ready\` or mark as non-draft to run the full test suite.` +
+        maintainerHint
       );
     } else {
       await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
       await api.postComment(pr.number,
-        `PR auto-accepted (trusted author). Full test suite will run.\n\n` +
-        `Use \`/skip-review\` to skip the review requirement for small changes, ` +
-        `or \`/auto-merge\` to merge automatically once approved and tested.`
+        `PR auto-accepted (trusted author). Full test suite will run.` +
+        maintainerHint
       );
     }
     core.info(`PR #${pr.number} auto-accepted for ${pr.user.login}, state=${initialState}`);
@@ -682,10 +685,12 @@ async function cmdSkipReview(api, config, core, pr, actor, maintainer, commentId
     const result = await checkAndTransitionToReady(api, freshPr, core);
     if (result === 'auto-merge') {
       await performMerge(api, config, freshPr, core);
+      await api.postComment(pr.number,
+        `Review requirement skipped by @${actor}. PR was tested and has been auto-merged.`
+      );
+    } else if (result === 'ready-to-merge') {
+      // checkAndTransitionToReady already posted its own comment
     }
-    await api.postComment(pr.number,
-      `Review requirement skipped by @${actor}. PR is tested and ready to merge.`
-    );
   } else {
     await api.postComment(pr.number,
       `Review requirement skipped by @${actor}. The PR will move to \`lifecycle/ready-to-merge\` ` +
@@ -855,7 +860,9 @@ async function handleTestResult({ github, context, core }) {
     }
 
     if (state === LABELS.WIP) {
-      if (workflowRun.conclusion === 'success') {
+      if (hasLabel(pr, LABELS.TESTS_DISABLED)) {
+        core.info(`PR #${pr.number} tests disabled, skipping smoke-tested update`);
+      } else if (workflowRun.conclusion === 'success') {
         await api.addLabel(pr.number, LABELS.SMOKE_TESTED);
         core.info(`PR #${pr.number} smoke tests passed, added lifecycle/smoke-tested`);
       } else if (workflowRun.conclusion === 'failure') {

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -266,6 +266,10 @@ async function retriggerVerify(api, pr, core, { waitForRun = false } = {}) {
     await new Promise(r => setTimeout(r, 3000));
   }
 
+  // Allow label changes to propagate through GitHub's eventually-consistent API
+  // before re-triggering, so the scope job sees the current labels.
+  await new Promise(r => setTimeout(r, 5000));
+
   try {
     await api.reRunWorkflow(run.id);
     core.info(`PR #${pr.number} re-triggered Verify run ${run.id}`);

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -19,9 +19,12 @@ const LABELS = {
   WAITING_ON_AUTHOR: 'lifecycle/waiting-on-author',
   WAITING_ON_MAINTAINER: 'lifecycle/waiting-on-maintainer',
   STALE: 'lifecycle/stale',
+  SMOKE_TESTED: 'lifecycle/smoke-tested',
+  REVIEW_APPROVED: 'lifecycle/review-approved',
   DISABLED: 'orchestrator/disabled',
   AUTO_MERGE: 'orchestrator/auto-merge',
   TESTS_DISABLED: 'orchestrator/tests-disabled',
+  REVIEW_SKIPPED: 'orchestrator/review-skipped',
 };
 
 const PRIMARY_STATES = [
@@ -36,8 +39,10 @@ const CONTROL_LABELS = Object.values(LABELS).filter(
 );
 
 const COLORS = {
-  INFO: '7BC8F6',
-  ATTENTION: 'EB6420',
+  INFO: 'A8D8F0',
+  SUCCESS_LIGHT: 'B5E8B5',
+  SUCCESS: '5BB85B',
+  ATTENTION: 'F5A623',
   INACTIVE: 'CCCCCC',
 };
 
@@ -45,14 +50,17 @@ const LABEL_DEFS = {
   [LABELS.NEW]:                  { color: COLORS.INFO, description: 'PR awaiting triage' },
   [LABELS.WIP]:                  { color: COLORS.INFO, description: 'Accepted, author working' },
   [LABELS.READY_FOR_REVIEW]:     { color: COLORS.INFO, description: 'Ready for review, full tests running' },
-  [LABELS.TESTED]:               { color: COLORS.INFO, description: 'Full test suite passed for current HEAD' },
+  [LABELS.SMOKE_TESTED]:         { color: COLORS.SUCCESS_LIGHT, description: 'Smoke tests passed for current HEAD' },
+  [LABELS.TESTED]:               { color: COLORS.SUCCESS, description: 'Full test suite passed for current HEAD' },
+  [LABELS.REVIEW_APPROVED]:      { color: COLORS.SUCCESS, description: 'PR has an approved review' },
   [LABELS.READY_TO_MERGE]:       { color: COLORS.INFO, description: 'Approved and tested, ready to merge' },
   [LABELS.WAITING_ON_AUTHOR]:    { color: COLORS.ATTENTION, description: 'Blocked on contributor action' },
   [LABELS.WAITING_ON_MAINTAINER]:{ color: COLORS.ATTENTION, description: 'Blocked on maintainer action' },
   [LABELS.STALE]:                { color: COLORS.INACTIVE, description: 'No activity for 7+ days' },
-  [LABELS.DISABLED]:              { color: COLORS.INACTIVE, description: 'PR excluded from lifecycle orchestrator' },
+  [LABELS.DISABLED]:             { color: COLORS.INACTIVE, description: 'PR excluded from lifecycle orchestrator' },
   [LABELS.AUTO_MERGE]:           { color: COLORS.INFO, description: 'Auto-merge enabled' },
   [LABELS.TESTS_DISABLED]:       { color: COLORS.INFO, description: 'Smoke tests disabled for this PR' },
+  [LABELS.REVIEW_SKIPPED]:       { color: COLORS.INFO, description: 'Review requirement skipped by maintainer' },
 };
 
 const BOT_LOGIN = 'github-actions[bot]';
@@ -299,9 +307,11 @@ async function performMerge(api, config, pr, core) {
   } catch (e) {
     await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
     await api.removeLabel(pr.number, LABELS.TESTED);
+    await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
     await api.postComment(pr.number,
       `Merge failed: ${e.message}\n\n` +
-      `Reverted to \`lifecycle/ready-for-review\`. The branch may need to be rebased.`
+      `Reverted to \`lifecycle/ready-for-review\`. The branch may need to be rebased. ` +
+      `Use \`/auto-merge\` to merge automatically once approved and tested.`
     );
     core.error(`PR #${pr.number} merge failed: ${e.message}`);
     return false;
@@ -310,10 +320,11 @@ async function performMerge(api, config, pr, core) {
 
 async function checkAndTransitionToReady(api, pr, core) {
   const approved = isApproved(await api.getReviews(pr.number));
+  const reviewSkipped = hasLabel(pr, LABELS.REVIEW_SKIPPED);
   const tested = hasLabel(pr, LABELS.TESTED);
   const state = getLifecycleState(pr);
 
-  if (approved && tested && state === LABELS.READY_FOR_REVIEW) {
+  if ((approved || reviewSkipped) && tested && state === LABELS.READY_FOR_REVIEW) {
     await api.setLifecycleState(pr, LABELS.READY_TO_MERGE);
     await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
     await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
@@ -349,11 +360,15 @@ async function handlePrOpened({ github, context, core }) {
     if (pr.draft) {
       await api.postComment(pr.number,
         `PR auto-accepted (trusted author). Smoke tests will run on each push.\n\n` +
-        `When ready, use \`/ready\` or mark as non-draft to run the full test suite.`
+        `When ready, use \`/ready\` or mark as non-draft to run the full test suite, ` +
+        `or \`/skip-review\` to skip the review requirement for small changes (tests are still required).`
       );
     } else {
+      await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
       await api.postComment(pr.number,
-        `PR auto-accepted (trusted author). Full test suite will run.`
+        `PR auto-accepted (trusted author). Full test suite will run.\n\n` +
+        `Use \`/skip-review\` to skip the review requirement for small changes, ` +
+        `or \`/auto-merge\` to merge automatically once approved and tested.`
       );
     }
     core.info(`PR #${pr.number} auto-accepted for ${pr.user.login}, state=${initialState}`);
@@ -376,6 +391,18 @@ async function handlePrSynchronize({ github, context, core }) {
     await api.removeLabel(pr.number, LABELS.TESTED);
     core.info(`PR #${pr.number} new push, removed lifecycle/tested`);
   }
+  if (hasLabel(pr, LABELS.SMOKE_TESTED)) {
+    await api.removeLabel(pr.number, LABELS.SMOKE_TESTED);
+    core.info(`PR #${pr.number} new push, removed lifecycle/smoke-tested`);
+  }
+  if (hasLabel(pr, LABELS.REVIEW_APPROVED)) {
+    await api.removeLabel(pr.number, LABELS.REVIEW_APPROVED);
+    core.info(`PR #${pr.number} new push, removed lifecycle/review-approved`);
+  }
+  if (hasLabel(pr, LABELS.REVIEW_SKIPPED)) {
+    await api.removeLabel(pr.number, LABELS.REVIEW_SKIPPED);
+    core.info(`PR #${pr.number} new push, removed orchestrator/review-skipped`);
+  }
   if (hasLabel(pr, LABELS.STALE)) {
     await api.removeLabel(pr.number, LABELS.STALE);
     core.info(`PR #${pr.number} new push, removed lifecycle/stale`);
@@ -385,9 +412,11 @@ async function handlePrSynchronize({ github, context, core }) {
   if (state === LABELS.READY_TO_MERGE) {
     const freshPr = await api.getPr(pr.number);
     await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
+    await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+    await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
     await api.postComment(pr.number,
       `New commits pushed. Reverting to \`lifecycle/ready-for-review\` — ` +
-      `the full test suite will re-run.`
+      `the full test suite will re-run. Use \`/auto-merge\` to merge automatically once approved and tested.`
     );
     core.info(`PR #${pr.number} reverted from ready-to-merge to ready-for-review`);
   }
@@ -417,7 +446,8 @@ async function handlePrReadyForReview({ github, context, core }) {
   await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
   await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
   await api.postComment(pr.number,
-    `PR is now ready for review. The full test suite will run.`
+    `PR is now ready for review. The full test suite will run.\n\n` +
+    `A maintainer can use \`/auto-merge\` to merge automatically once approved and tested.`
   );
   core.info(`PR #${pr.number} transitioned to ready-for-review (draft->ready)`);
   await retriggerVerify(api, pr, core);
@@ -446,6 +476,7 @@ async function handleComment({ github, context, core }) {
     'ready': () => cmdReady(api, config, core, pr, actor, isAuthor, maintainer, comment.id),
     'merge': () => cmdMerge(api, config, core, pr, actor, maintainer, comment.id),
     'auto-merge': () => cmdAutoMerge(api, config, core, pr, actor, maintainer, comment.id),
+    'skip-review': () => cmdSkipReview(api, config, core, pr, actor, maintainer, comment.id),
     'disable-tests': () => cmdDisableTests(api, core, pr, actor, isAuthor, maintainer, comment.id),
     'enable-tests': () => cmdEnableTests(api, core, pr, actor, isAuthor, maintainer, comment.id),
     'unstale': () => cmdUnstale(api, config, core, pr, actor, isAuthor, maintainer, comment.id),
@@ -548,7 +579,8 @@ async function cmdReady(api, config, core, pr, actor, isAuthor, maintainer, comm
   await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
   await api.addReaction(commentId, '+1');
   await api.postComment(pr.number,
-    `PR marked as ready for review. The full test suite will run.`
+    `PR marked as ready for review. The full test suite will run.\n\n` +
+    `A maintainer can use \`/auto-merge\` to merge automatically once approved and tested.`
   );
   core.info(`PR #${pr.number} marked ready by ${actor}`);
   await retriggerVerify(api, pr, core);
@@ -611,6 +643,52 @@ async function cmdAutoMerge(api, config, core, pr, actor, maintainer, commentId)
   }
 
   core.info(`PR #${pr.number} auto-merge enabled by ${actor}`);
+}
+
+async function cmdSkipReview(api, config, core, pr, actor, maintainer, commentId) {
+  if (!maintainer) {
+    await api.addReaction(commentId, '-1');
+    await api.postComment(pr.number, `@${actor} Only maintainers can skip the review requirement.`);
+    return;
+  }
+
+  const state = getLifecycleState(pr);
+  if (state !== LABELS.READY_FOR_REVIEW && state !== LABELS.WIP) {
+    await api.addReaction(commentId, 'confused');
+    await api.postComment(pr.number,
+      `@${actor} Cannot skip review: PR must be in \`lifecycle/wip\` or \`lifecycle/ready-for-review\` state ` +
+      `(current: \`${state || 'none'}\`).`
+    );
+    return;
+  }
+
+  if (state === LABELS.WIP) {
+    const freshPr = await api.getPr(pr.number);
+    await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
+    await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+    await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+    await retriggerVerify(api, freshPr, core);
+  }
+
+  await api.addLabel(pr.number, LABELS.REVIEW_SKIPPED);
+  await api.addReaction(commentId, '+1');
+
+  const freshPr = await api.getPr(pr.number);
+  if (hasLabel(freshPr, LABELS.TESTED)) {
+    const result = await checkAndTransitionToReady(api, freshPr, core);
+    if (result === 'auto-merge') {
+      await performMerge(api, config, freshPr, core);
+    }
+    await api.postComment(pr.number,
+      `Review requirement skipped by @${actor}. PR is tested and ready to merge.`
+    );
+  } else {
+    await api.postComment(pr.number,
+      `Review requirement skipped by @${actor}. The PR will move to \`lifecycle/ready-to-merge\` ` +
+      `once tests pass.`
+    );
+  }
+  core.info(`PR #${pr.number} review skipped by ${actor}`);
 }
 
 async function cmdDisableTests(api, core, pr, actor, isAuthor, maintainer, commentId) {
@@ -683,12 +761,14 @@ async function handleReview({ github, context, core }) {
   if (review.state === 'changes_requested') {
     await api.addLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
     await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+    await api.removeLabel(pr.number, LABELS.REVIEW_APPROVED);
     core.info(`PR #${pr.number} changes requested by ${review.user.login}`);
     return;
   }
 
   if (review.state === 'approved') {
     await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+    await api.addLabel(pr.number, LABELS.REVIEW_APPROVED);
     const freshPr = await api.getPr(pr.number);
     const result = await checkAndTransitionToReady(api, freshPr, core);
     if (result === 'auto-merge') {
@@ -760,8 +840,8 @@ async function handleTestResult({ github, context, core }) {
     if (hasLabel(pr, LABELS.DISABLED)) continue;
 
     const state = getLifecycleState(pr);
-    if (state !== LABELS.READY_FOR_REVIEW) {
-      core.info(`PR #${pr.number} not in ready-for-review state, skipping test result`);
+    if (state !== LABELS.READY_FOR_REVIEW && state !== LABELS.WIP) {
+      core.info(`PR #${pr.number} not in ready-for-review or wip state, skipping test result`);
       continue;
     }
 
@@ -770,8 +850,20 @@ async function handleTestResult({ github, context, core }) {
       continue;
     }
 
+    if (state === LABELS.WIP) {
+      if (workflowRun.conclusion === 'success') {
+        await api.addLabel(pr.number, LABELS.SMOKE_TESTED);
+        core.info(`PR #${pr.number} smoke tests passed, added lifecycle/smoke-tested`);
+      } else if (workflowRun.conclusion === 'failure') {
+        await api.removeLabel(pr.number, LABELS.SMOKE_TESTED);
+        core.info(`PR #${pr.number} smoke tests failed`);
+      }
+      continue;
+    }
+
     if (workflowRun.conclusion === 'success') {
       await api.addLabel(pr.number, LABELS.TESTED);
+      await api.removeLabel(pr.number, LABELS.SMOKE_TESTED);
       await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
       core.info(`PR #${pr.number} tests passed, added lifecycle/tested`);
 


### PR DESCRIPTION
## Summary

- Add `/skip-review` maintainer command to bypass the review requirement for small changes (tests still required)
- Add `lifecycle/smoke-tested` (light green) and `lifecycle/review-approved` (green) status labels for better visual feedback
- Change `lifecycle/tested` color from blue to green for consistency with other pass/fail indicators
- Adjust label colors: lighter blue for lifecycle labels, lighter orange for waiting-on labels
- Ensure `waiting-on-maintainer` is set consistently in all code paths that transition to ready-for-review
- Add `/auto-merge` mention in all ready-for-review bot comments as a reminder
- Update welcome message for maintainer PRs to mention `/skip-review`
- Update `PR_LIFECYCLE.md` and `pr-lifecycle.yml` documentation

## Test plan

- [ ] Open a test PR as a maintainer, verify `/skip-review` from WIP transitions to ready-for-review and sets `orchestrator/review-skipped`
- [ ] Verify `/skip-review` from ready-for-review with `lifecycle/tested` transitions to ready-to-merge
- [ ] Verify `orchestrator/review-skipped` is cleared on new pushes
- [ ] Verify `lifecycle/smoke-tested` is added when smoke tests pass in WIP state
- [ ] Verify `lifecycle/smoke-tested` is removed when `lifecycle/tested` is added
- [ ] Verify `lifecycle/review-approved` is added on approval and removed on new push or changes-requested
- [ ] Verify label colors render correctly on GitHub
- [ ] Verify bot comments mention `/auto-merge` when transitioning to ready-for-review