### PR TITLE
fix(deps): update semver4j to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
     <jgit.version>7.6.0.202603022253-r</jgit.version>
     <awaitility.version>4.3.0</awaitility.version>
     <assertj.core.version>3.27.7</assertj.core.version>
-    <semver4j.version>5.8.0</semver4j.version>
+    <semver4j.version>6.0.0</semver4j.version>
     <slf4j.version>2.0.17</slf4j.version>
 
     <!-- Kafka Connect -->


### PR DESCRIPTION
## Summary
- Update org.semver4j:semver4j from 5.8.0 to 6.0.0

## Context
This dependency upgrade was split from Renovate PR #7898 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected