### PR TITLE
fix(deps): update icu4j to 78.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
     <okhttp.version>4.12.0</okhttp.version>
     <okio.version>3.17.0</okio.version>
     <kotlin-stdlib.version>2.3.21</kotlin-stdlib.version>
-    <icu4j.version>76.1</icu4j.version>
+    <icu4j.version>78.3</icu4j.version>
     <protobuf.version>4.34.1</protobuf.version>
     <xmlsec.version>4.0.4</xmlsec.version>
     <protobuf.googleapi.types.version>2.70.0</protobuf.googleapi.types.version>


### PR DESCRIPTION
## Summary
- Update com.ibm.icu:icu4j from 76.1 to 78.3

## Context
This dependency upgrade was split from Renovate PR #7898 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected