### PR TITLE
feat(a2a): agent discovery endpoints and visibility model

### DIFF
--- a/app/src/main/java/io/apicurio/registry/a2a/A2AConfig.java
+++ b/app/src/main/java/io/apicurio/registry/a2a/A2AConfig.java
@@ -50,6 +50,18 @@ public class A2AConfig {
     @Info(category = CATEGORY_A2A, description = "Whether the agent supports push notifications", availableSince = "3.0.0")
     boolean capabilitiesPushNotifications;
 
+    @ConfigProperty(name = "apicurio.a2a.public-discovery.enabled", defaultValue = "true")
+    @Info(category = CATEGORY_A2A, description = "Enable public (unauthenticated) agent discovery endpoint", availableSince = "3.0.0")
+    boolean publicDiscoveryEnabled;
+
+    @ConfigProperty(name = "apicurio.a2a.entitlements.enabled", defaultValue = "true")
+    @Info(category = CATEGORY_A2A, description = "Enable entitlement-based agent filtering", availableSince = "3.0.0")
+    boolean entitlementsEnabled;
+
+    @ConfigProperty(name = "apicurio.a2a.default-visibility", defaultValue = "entitled")
+    @Info(category = CATEGORY_A2A, description = "Default visibility for new Agent Card artifacts (public, entitled, private)", availableSince = "3.0.0")
+    String defaultVisibility;
+
     @ConfigProperty(name = "apicurio.a2a.agent.protocol-version", defaultValue = "1.0")
     @Info(category = CATEGORY_A2A, description = "A2A protocol version supported by the registry agent", availableSince = "3.0.0")
     String protocolVersion;
@@ -108,5 +120,17 @@ public class A2AConfig {
 
     public Optional<String> getIconUrl() {
         return iconUrl;
+    }
+
+    public boolean isPublicDiscoveryEnabled() {
+        return publicDiscoveryEnabled;
+    }
+
+    public boolean isEntitlementsEnabled() {
+        return entitlementsEnabled;
+    }
+
+    public String getDefaultVisibility() {
+        return defaultVisibility;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/a2a/A2AConfig.java
+++ b/app/src/main/java/io/apicurio/registry/a2a/A2AConfig.java
@@ -1,10 +1,13 @@
 package io.apicurio.registry.a2a;
 
 import io.apicurio.common.apps.config.Info;
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Singleton;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_A2A;
 
@@ -13,6 +16,17 @@ import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_A2A
  */
 @Singleton
 public class A2AConfig {
+
+    private static final Set<String> VALID_VISIBILITIES = Set.of("public", "entitled", "private");
+
+    @PostConstruct
+    void validate() {
+        if (!VALID_VISIBILITIES.contains(defaultVisibility.toLowerCase(Locale.ROOT))) {
+            throw new IllegalArgumentException(
+                    "Invalid value for apicurio.a2a.default-visibility: '" + defaultVisibility
+                            + "'. Must be one of: " + VALID_VISIBILITIES);
+        }
+    }
 
     @ConfigProperty(name = "apicurio.a2a.enabled", defaultValue = "false")
     @Info(category = CATEGORY_A2A, description = "Enable A2A protocol support", availableSince = "3.0.0", experimental = true)

--- a/app/src/main/java/io/apicurio/registry/a2a/rest/beans/AgentSearchFilters.java
+++ b/app/src/main/java/io/apicurio/registry/a2a/rest/beans/AgentSearchFilters.java
@@ -1,0 +1,83 @@
+package io.apicurio.registry.a2a.rest.beans;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Structured filters for agent search requests.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AgentSearchFilters {
+
+    @JsonProperty("capabilities")
+    private Map<String, Boolean> capabilities;
+
+    @JsonProperty("skills")
+    private List<String> skills;
+
+    @JsonProperty("labels")
+    private Map<String, String> labels;
+
+    @JsonProperty("inputModes")
+    private List<String> inputModes;
+
+    @JsonProperty("outputModes")
+    private List<String> outputModes;
+
+    @JsonProperty("protocolBindings")
+    private List<String> protocolBindings;
+
+    public AgentSearchFilters() {
+    }
+
+    public Map<String, Boolean> getCapabilities() {
+        return capabilities;
+    }
+
+    public void setCapabilities(Map<String, Boolean> capabilities) {
+        this.capabilities = capabilities;
+    }
+
+    public List<String> getSkills() {
+        return skills;
+    }
+
+    public void setSkills(List<String> skills) {
+        this.skills = skills;
+    }
+
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
+    }
+
+    public List<String> getInputModes() {
+        return inputModes;
+    }
+
+    public void setInputModes(List<String> inputModes) {
+        this.inputModes = inputModes;
+    }
+
+    public List<String> getOutputModes() {
+        return outputModes;
+    }
+
+    public void setOutputModes(List<String> outputModes) {
+        this.outputModes = outputModes;
+    }
+
+    public List<String> getProtocolBindings() {
+        return protocolBindings;
+    }
+
+    public void setProtocolBindings(List<String> protocolBindings) {
+        this.protocolBindings = protocolBindings;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/a2a/rest/beans/AgentSearchRequest.java
+++ b/app/src/main/java/io/apicurio/registry/a2a/rest/beans/AgentSearchRequest.java
@@ -1,0 +1,58 @@
+package io.apicurio.registry.a2a.rest.beans;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Request body for the advanced agent search endpoint (POST /.well-known/agents/search).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AgentSearchRequest {
+
+    @JsonProperty("query")
+    private String query;
+
+    @JsonProperty("filters")
+    private AgentSearchFilters filters;
+
+    @JsonProperty("limit")
+    private int limit = 20;
+
+    @JsonProperty("offset")
+    private int offset = 0;
+
+    public AgentSearchRequest() {
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public AgentSearchFilters getFilters() {
+        return filters;
+    }
+
+    public void setFilters(AgentSearchFilters filters) {
+        this.filters = filters;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/a2a/rest/beans/AgentSearchRequest.java
+++ b/app/src/main/java/io/apicurio/registry/a2a/rest/beans/AgentSearchRequest.java
@@ -15,6 +15,8 @@ public class AgentSearchRequest {
     @JsonProperty("filters")
     private AgentSearchFilters filters;
 
+    private static final int MAX_LIMIT = 500;
+
     @JsonProperty("limit")
     private int limit = 20;
 
@@ -45,7 +47,7 @@ public class AgentSearchRequest {
     }
 
     public void setLimit(int limit) {
-        this.limit = limit;
+        this.limit = Math.max(1, Math.min(limit, MAX_LIMIT));
     }
 
     public int getOffset() {
@@ -53,6 +55,6 @@ public class AgentSearchRequest {
     }
 
     public void setOffset(int offset) {
-        this.offset = offset;
+        this.offset = Math.max(0, offset);
     }
 }

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
@@ -1,10 +1,13 @@
 package io.apicurio.registry.rest.wellknown;
 
 import io.apicurio.registry.a2a.rest.beans.AgentCard;
+import io.apicurio.registry.a2a.rest.beans.AgentSearchRequest;
 import io.apicurio.registry.a2a.rest.beans.AgentSearchResults;
 import io.apicurio.registry.mcptools.rest.beans.McpToolSearchResults;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -65,6 +68,37 @@ public interface WellKnownResource {
             @PathParam("groupId") String groupId,
             @PathParam("artifactId") String artifactId,
             @QueryParam("version") String version);
+
+    /**
+     * Returns agents marked as public. No authentication required.
+     */
+    @GET
+    @Path("/agents/public")
+    @Produces(MediaType.APPLICATION_JSON)
+    AgentSearchResults getPublicAgents(
+            @QueryParam("offset") @DefaultValue("0") Integer offset,
+            @QueryParam("limit") @DefaultValue("20") Integer limit);
+
+    /**
+     * Returns agents the authenticated caller is entitled to access.
+     * Includes public agents plus agents in groups the caller can read.
+     */
+    @GET
+    @Path("/agents/entitled")
+    @Produces(MediaType.APPLICATION_JSON)
+    AgentSearchResults getEntitledAgents(
+            @QueryParam("offset") @DefaultValue("0") Integer offset,
+            @QueryParam("limit") @DefaultValue("20") Integer limit);
+
+    /**
+     * Advanced agent search with combined text query and structured filters.
+     * Respects the caller's entitlements.
+     */
+    @POST
+    @Path("/agents/search")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    AgentSearchResults searchAgentsAdvanced(AgentSearchRequest request);
 
     /**
      * Search for registered Agent Cards by various criteria.

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -149,16 +149,23 @@ public class WellKnownResourceImpl implements WellKnownResource {
         ArtifactSearchResultsDto results = storage.searchArtifacts(
                 filters, OrderBy.createdOn, OrderDirection.desc, 0, Integer.MAX_VALUE);
 
-        List<AgentSearchResult> agents = filterByVisibility(results.getArtifacts());
+        // Filter by visibility on DTOs first (cheap), then paginate, then convert (expensive)
+        List<SearchedArtifactDto> visible = filterDtosByVisibility(results.getArtifacts());
 
-        int total = agents.size();
-        int fromIndex = Math.min(offset, total);
-        int toIndex = Math.min(fromIndex + limit, total);
-        List<AgentSearchResult> page = agents.subList(fromIndex, toIndex);
+        int total = visible.size();
+        int safeOffset = Math.max(0, Math.min(offset, total));
+        int safeLimit = Math.max(0, limit);
+        int toIndex = Math.min(safeOffset + safeLimit, total);
+        List<SearchedArtifactDto> page = visible.subList(safeOffset, toIndex);
+
+        List<AgentSearchResult> agents = new ArrayList<>();
+        for (SearchedArtifactDto artifact : page) {
+            agents.add(convertToAgentSearchResult(artifact));
+        }
 
         return AgentSearchResults.builder()
                 .count((long) total)
-                .agents(page)
+                .agents(agents)
                 .build();
     }
 
@@ -215,26 +222,34 @@ public class WellKnownResourceImpl implements WellKnownResource {
             }
         }
 
+        int safeOffset = Math.max(0, request.getOffset());
+        int safeLimit = Math.max(1, Math.min(request.getLimit(), 500));
+
         if (a2aConfig.isEntitlementsEnabled()) {
             ArtifactSearchResultsDto results = storage.searchArtifacts(
                     filters, OrderBy.createdOn, OrderDirection.desc, 0, Integer.MAX_VALUE);
 
-            List<AgentSearchResult> agents = filterByVisibility(results.getArtifacts());
+            // Filter by visibility on DTOs first (cheap), then paginate, then convert (expensive)
+            List<SearchedArtifactDto> visible = filterDtosByVisibility(results.getArtifacts());
 
-            int total = agents.size();
-            int fromIndex = Math.min(request.getOffset(), total);
-            int toIndex = Math.min(fromIndex + request.getLimit(), total);
-            List<AgentSearchResult> page = agents.subList(fromIndex, toIndex);
+            int total = visible.size();
+            int fromIndex = Math.min(safeOffset, total);
+            int toIndex = Math.min(fromIndex + safeLimit, total);
+            List<SearchedArtifactDto> page = visible.subList(fromIndex, toIndex);
+
+            List<AgentSearchResult> agents = new ArrayList<>();
+            for (SearchedArtifactDto artifact : page) {
+                agents.add(convertToAgentSearchResult(artifact));
+            }
 
             return AgentSearchResults.builder()
                     .count((long) total)
-                    .agents(page)
+                    .agents(agents)
                     .build();
         }
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(
-                filters, OrderBy.createdOn, OrderDirection.desc,
-                request.getOffset(), request.getLimit());
+                filters, OrderBy.createdOn, OrderDirection.desc, safeOffset, safeLimit);
 
         List<AgentSearchResult> agents = new ArrayList<>();
         for (SearchedArtifactDto artifact : results.getArtifacts()) {
@@ -585,16 +600,17 @@ public class WellKnownResourceImpl implements WellKnownResource {
         }
     }
 
-    private List<AgentSearchResult> filterByVisibility(List<SearchedArtifactDto> artifacts) {
+    /**
+     * Filters artifact DTOs by visibility rules without performing expensive content conversion.
+     * When no auth is enabled, all artifacts are returned. Otherwise, visibility is determined
+     * by the {@code apicurio.agent.visibility} label (falling back to the configured default).
+     */
+    private List<SearchedArtifactDto> filterDtosByVisibility(List<SearchedArtifactDto> artifacts) {
         boolean authEnabled = authConfig.isOidcAuthEnabled()
                 || authConfig.isBasicAuthEnabled();
 
         if (!authEnabled) {
-            List<AgentSearchResult> result = new ArrayList<>();
-            for (SearchedArtifactDto artifact : artifacts) {
-                result.add(convertToAgentSearchResult(artifact));
-            }
-            return result;
+            return new ArrayList<>(artifacts);
         }
 
         boolean isAuthenticated = securityIdentity != null && !securityIdentity.isAnonymous();
@@ -602,29 +618,37 @@ public class WellKnownResourceImpl implements WellKnownResource {
         String currentUser = isAuthenticated
                 ? securityIdentity.getPrincipal().getName() : null;
 
-        List<AgentSearchResult> result = new ArrayList<>();
+        List<SearchedArtifactDto> result = new ArrayList<>();
         for (SearchedArtifactDto artifact : artifacts) {
-            String visibility = getVisibilityLabel(artifact.getLabels());
+            String visibility = resolveVisibility(artifact.getLabels());
             if ("public".equals(visibility)) {
-                result.add(convertToAgentSearchResult(artifact));
+                result.add(artifact);
             } else if (!isAuthenticated) {
                 continue;
             } else if ("private".equals(visibility)) {
                 if (isAdmin || currentUser.equals(artifact.getOwner())) {
-                    result.add(convertToAgentSearchResult(artifact));
+                    result.add(artifact);
                 }
             } else {
-                result.add(convertToAgentSearchResult(artifact));
+                // "entitled" or any unrecognized value — visible to authenticated users
+                result.add(artifact);
             }
         }
         return result;
     }
 
-    private String getVisibilityLabel(Map<String, String> labels) {
-        if (labels == null) {
-            return null;
+    /**
+     * Returns the effective visibility for an artifact. If the {@code apicurio.agent.visibility}
+     * label is not set, falls back to the configured default visibility.
+     */
+    private String resolveVisibility(Map<String, String> labels) {
+        if (labels != null) {
+            String explicit = labels.get("apicurio.agent.visibility");
+            if (explicit != null) {
+                return explicit;
+            }
         }
-        return labels.get("apicurio.agent.visibility");
+        return a2aConfig.getDefaultVisibility();
     }
 
     private String getBaseUrl() {

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -7,8 +7,11 @@ import io.apicurio.registry.a2a.RegistryAgentCardBuilder;
 import io.apicurio.registry.a2a.rest.beans.AgentCapabilities;
 import io.apicurio.registry.a2a.rest.beans.AgentCard;
 import io.apicurio.registry.a2a.rest.beans.AgentInterface;
+import io.apicurio.registry.a2a.rest.beans.AgentSearchFilters;
+import io.apicurio.registry.a2a.rest.beans.AgentSearchRequest;
 import io.apicurio.registry.a2a.rest.beans.AgentSearchResult;
 import io.apicurio.registry.a2a.rest.beans.AgentSearchResults;
+import io.apicurio.registry.auth.AdminOverride;
 import io.apicurio.registry.auth.Authorized;
 import io.apicurio.registry.auth.AuthorizedLevel;
 import io.apicurio.registry.auth.AuthorizedStyle;
@@ -36,6 +39,7 @@ import io.apicurio.registry.storage.error.ArtifactNotFoundException;
 import io.apicurio.registry.storage.error.VersionNotFoundException;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.StringUtil;
+import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptors;
@@ -50,6 +54,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -76,6 +81,12 @@ public class WellKnownResourceImpl implements WellKnownResource {
     @Current
     RegistryStorage storage;
 
+    @Inject
+    SecurityIdentity securityIdentity;
+
+    @Inject
+    AdminOverride adminOverride;
+
     @Context
     HttpServletRequest request;
 
@@ -94,6 +105,142 @@ public class WellKnownResourceImpl implements WellKnownResource {
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.None)
     public AgentCard getAgentCardV1() {
         return getAgentCard();
+    }
+
+    @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.None)
+    public AgentSearchResults getPublicAgents(Integer offset, Integer limit) {
+        if (!a2aConfig.isEnabled() || !a2aConfig.isPublicDiscoveryEnabled()) {
+            throw new NotFoundException("Public agent discovery is disabled");
+        }
+
+        Set<SearchFilter> filters = new HashSet<>();
+        filters.add(SearchFilter.ofArtifactType(ArtifactType.AGENT_CARD));
+        filters.add(SearchFilter.ofLabel("apicurio.agent.visibility", "public"));
+
+        ArtifactSearchResultsDto results = storage.searchArtifacts(
+                filters, OrderBy.createdOn, OrderDirection.desc, offset, limit);
+
+        List<AgentSearchResult> agents = new ArrayList<>();
+        for (SearchedArtifactDto artifact : results.getArtifacts()) {
+            agents.add(convertToAgentSearchResult(artifact));
+        }
+
+        return AgentSearchResults.builder()
+                .count(results.getCount())
+                .agents(agents)
+                .build();
+    }
+
+    @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
+    public AgentSearchResults getEntitledAgents(Integer offset, Integer limit) {
+        if (!a2aConfig.isEnabled() || !a2aConfig.isEntitlementsEnabled()) {
+            throw new NotFoundException("Agent entitlements endpoint is disabled");
+        }
+
+        Set<SearchFilter> filters = new HashSet<>();
+        filters.add(SearchFilter.ofArtifactType(ArtifactType.AGENT_CARD));
+
+        ArtifactSearchResultsDto results = storage.searchArtifacts(
+                filters, OrderBy.createdOn, OrderDirection.desc, 0, Integer.MAX_VALUE);
+
+        List<AgentSearchResult> agents = filterByVisibility(results.getArtifacts());
+
+        int total = agents.size();
+        int fromIndex = Math.min(offset, total);
+        int toIndex = Math.min(fromIndex + limit, total);
+        List<AgentSearchResult> page = agents.subList(fromIndex, toIndex);
+
+        return AgentSearchResults.builder()
+                .count((long) total)
+                .agents(page)
+                .build();
+    }
+
+    @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
+    public AgentSearchResults searchAgentsAdvanced(AgentSearchRequest request) {
+        if (!a2aConfig.isEnabled()) {
+            throw new NotFoundException("A2A support is disabled");
+        }
+
+        Set<SearchFilter> filters = new HashSet<>();
+        filters.add(SearchFilter.ofArtifactType(ArtifactType.AGENT_CARD));
+
+        if (!StringUtil.isEmpty(request.getQuery())) {
+            filters.add(SearchFilter.ofName(request.getQuery()));
+        }
+
+        AgentSearchFilters f = request.getFilters();
+        if (f != null) {
+            if (f.getSkills() != null) {
+                for (String skill : f.getSkills()) {
+                    filters.add(SearchFilter.ofStructure("agent_card:skill:" + skill));
+                }
+            }
+            if (f.getCapabilities() != null) {
+                for (Map.Entry<String, Boolean> entry : f.getCapabilities().entrySet()) {
+                    SearchFilter filter = SearchFilter.ofStructure(
+                            "agent_card:capability:" + entry.getKey());
+                    if (!Boolean.TRUE.equals(entry.getValue())) {
+                        filter = filter.negated();
+                    }
+                    filters.add(filter);
+                }
+            }
+            if (f.getLabels() != null) {
+                for (Map.Entry<String, String> entry : f.getLabels().entrySet()) {
+                    filters.add(SearchFilter.ofLabel(entry.getKey(), entry.getValue()));
+                }
+            }
+            if (f.getInputModes() != null) {
+                for (String mode : f.getInputModes()) {
+                    filters.add(SearchFilter.ofStructure("agent_card:inputmode:" + mode));
+                }
+            }
+            if (f.getOutputModes() != null) {
+                for (String mode : f.getOutputModes()) {
+                    filters.add(SearchFilter.ofStructure("agent_card:outputmode:" + mode));
+                }
+            }
+            if (f.getProtocolBindings() != null) {
+                for (String binding : f.getProtocolBindings()) {
+                    filters.add(SearchFilter.ofStructure("agent_card:protocolbinding:" + binding));
+                }
+            }
+        }
+
+        if (a2aConfig.isEntitlementsEnabled()) {
+            ArtifactSearchResultsDto results = storage.searchArtifacts(
+                    filters, OrderBy.createdOn, OrderDirection.desc, 0, Integer.MAX_VALUE);
+
+            List<AgentSearchResult> agents = filterByVisibility(results.getArtifacts());
+
+            int total = agents.size();
+            int fromIndex = Math.min(request.getOffset(), total);
+            int toIndex = Math.min(fromIndex + request.getLimit(), total);
+            List<AgentSearchResult> page = agents.subList(fromIndex, toIndex);
+
+            return AgentSearchResults.builder()
+                    .count((long) total)
+                    .agents(page)
+                    .build();
+        }
+
+        ArtifactSearchResultsDto results = storage.searchArtifacts(
+                filters, OrderBy.createdOn, OrderDirection.desc,
+                request.getOffset(), request.getLimit());
+
+        List<AgentSearchResult> agents = new ArrayList<>();
+        for (SearchedArtifactDto artifact : results.getArtifacts()) {
+            agents.add(convertToAgentSearchResult(artifact));
+        }
+
+        return AgentSearchResults.builder()
+                .count(results.getCount())
+                .agents(agents)
+                .build();
     }
 
     @Override
@@ -432,6 +579,37 @@ public class WellKnownResourceImpl implements WellKnownResource {
             }
             return new String(is.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
+
+    private List<AgentSearchResult> filterByVisibility(List<SearchedArtifactDto> artifacts) {
+        boolean isAuthenticated = securityIdentity != null && !securityIdentity.isAnonymous();
+        boolean isAdmin = adminOverride.isAdmin();
+        String currentUser = isAuthenticated
+                ? securityIdentity.getPrincipal().getName() : null;
+
+        List<AgentSearchResult> result = new ArrayList<>();
+        for (SearchedArtifactDto artifact : artifacts) {
+            String visibility = getVisibilityLabel(artifact.getLabels());
+            if ("public".equals(visibility)) {
+                result.add(convertToAgentSearchResult(artifact));
+            } else if (!isAuthenticated) {
+                continue;
+            } else if ("private".equals(visibility)) {
+                if (isAdmin || currentUser.equals(artifact.getOwner())) {
+                    result.add(convertToAgentSearchResult(artifact));
+                }
+            } else {
+                result.add(convertToAgentSearchResult(artifact));
+            }
+        }
+        return result;
+    }
+
+    private String getVisibilityLabel(Map<String, String> labels) {
+        if (labels == null) {
+            return null;
+        }
+        return labels.get("apicurio.agent.visibility");
     }
 
     private String getBaseUrl() {

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -12,6 +12,7 @@ import io.apicurio.registry.a2a.rest.beans.AgentSearchRequest;
 import io.apicurio.registry.a2a.rest.beans.AgentSearchResult;
 import io.apicurio.registry.a2a.rest.beans.AgentSearchResults;
 import io.apicurio.registry.auth.AdminOverride;
+import io.apicurio.registry.auth.AuthConfig;
 import io.apicurio.registry.auth.Authorized;
 import io.apicurio.registry.auth.AuthorizedLevel;
 import io.apicurio.registry.auth.AuthorizedStyle;
@@ -86,6 +87,9 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
     @Inject
     AdminOverride adminOverride;
+
+    @Inject
+    AuthConfig authConfig;
 
     @Context
     HttpServletRequest request;
@@ -582,6 +586,17 @@ public class WellKnownResourceImpl implements WellKnownResource {
     }
 
     private List<AgentSearchResult> filterByVisibility(List<SearchedArtifactDto> artifacts) {
+        boolean authEnabled = authConfig.isOidcAuthEnabled()
+                || authConfig.isBasicAuthEnabled();
+
+        if (!authEnabled) {
+            List<AgentSearchResult> result = new ArrayList<>();
+            for (SearchedArtifactDto artifact : artifacts) {
+                result.add(convertToAgentSearchResult(artifact));
+            }
+            return result;
+        }
+
         boolean isAuthenticated = securityIdentity != null && !securityIdentity.isAnonymous();
         boolean isAdmin = adminOverride.isAdmin();
         String currentUser = isAuthenticated

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -130,7 +130,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
         filters.add(SearchFilter.ofLabel("apicurio.agent.visibility", "public"));
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(
-                filters, OrderBy.createdOn, OrderDirection.desc, offset, limit);
+                filters, OrderBy.createdOn, OrderDirection.desc, offset, limit, false);
 
         List<AgentSearchResult> agents = new ArrayList<>();
         for (SearchedArtifactDto artifact : results.getArtifacts()) {
@@ -154,7 +154,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
         filters.add(SearchFilter.ofArtifactType(ArtifactType.AGENT_CARD));
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(
-                filters, OrderBy.createdOn, OrderDirection.desc, 0, MAX_VISIBILITY_FILTER_RESULTS);
+                filters, OrderBy.createdOn, OrderDirection.desc, 0, MAX_VISIBILITY_FILTER_RESULTS, false);
 
         // Filter by visibility on DTOs first (cheap), then paginate, then convert (expensive)
         List<SearchedArtifactDto> visible = filterDtosByVisibility(results.getArtifacts());
@@ -240,7 +240,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
         if (a2aConfig.isEntitlementsEnabled()) {
             ArtifactSearchResultsDto results = storage.searchArtifacts(
-                    filters, OrderBy.createdOn, OrderDirection.desc, 0, MAX_VISIBILITY_FILTER_RESULTS);
+                    filters, OrderBy.createdOn, OrderDirection.desc, 0, MAX_VISIBILITY_FILTER_RESULTS, false);
 
             // Filter by visibility on DTOs first (cheap), then paginate, then convert (expensive)
             List<SearchedArtifactDto> visible = filterDtosByVisibility(results.getArtifacts());
@@ -262,7 +262,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
         }
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(
-                filters, OrderBy.createdOn, OrderDirection.desc, safeOffset, safeLimit);
+                filters, OrderBy.createdOn, OrderDirection.desc, safeOffset, safeLimit, false);
 
         List<AgentSearchResult> agents = new ArrayList<>();
         for (SearchedArtifactDto artifact : results.getArtifacts()) {
@@ -365,11 +365,35 @@ public class WellKnownResourceImpl implements WellKnownResource {
             }
         }
 
-        // Execute search
-        ArtifactSearchResultsDto results = storage.searchArtifacts(
-                filters, OrderBy.createdOn, OrderDirection.desc, offset, limit, false);
+        int safeOffset = Math.max(0, offset);
+        int safeLimit = Math.max(1, Math.min(limit, 500));
 
-        // Convert to agent search results
+        if (isAuthEnabled() && a2aConfig.isEntitlementsEnabled()) {
+            ArtifactSearchResultsDto results = storage.searchArtifacts(
+                    filters, OrderBy.createdOn, OrderDirection.desc,
+                    0, MAX_VISIBILITY_FILTER_RESULTS, false);
+
+            List<SearchedArtifactDto> visible = filterDtosByVisibility(results.getArtifacts());
+
+            int total = visible.size();
+            int fromIndex = Math.min(safeOffset, total);
+            int toIndex = Math.min(fromIndex + safeLimit, total);
+            List<SearchedArtifactDto> page = visible.subList(fromIndex, toIndex);
+
+            List<AgentSearchResult> agents = new ArrayList<>();
+            for (SearchedArtifactDto artifact : page) {
+                agents.add(convertToAgentSearchResult(artifact));
+            }
+
+            return AgentSearchResults.builder()
+                    .count((long) total)
+                    .agents(agents)
+                    .build();
+        }
+
+        ArtifactSearchResultsDto results = storage.searchArtifacts(
+                filters, OrderBy.createdOn, OrderDirection.desc, safeOffset, safeLimit, false);
+
         List<AgentSearchResult> agents = new ArrayList<>();
         for (SearchedArtifactDto artifact : results.getArtifacts()) {
             agents.add(convertToAgentSearchResult(artifact));
@@ -592,6 +616,10 @@ public class WellKnownResourceImpl implements WellKnownResource {
         }
     }
 
+    private boolean isAuthEnabled() {
+        return authConfig.isOidcAuthEnabled() || authConfig.isBasicAuthEnabled();
+    }
+
     private String getSchemaResourcePath(String type, String version) {
         // Only allow known schema types and versions
         if ("prompt-template".equals(type) && "v1".equals(version)) {
@@ -619,10 +647,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
      * by the {@code apicurio.agent.visibility} label (falling back to the configured default).
      */
     private List<SearchedArtifactDto> filterDtosByVisibility(List<SearchedArtifactDto> artifacts) {
-        boolean authEnabled = authConfig.isOidcAuthEnabled()
-                || authConfig.isBasicAuthEnabled();
-
-        if (!authEnabled) {
+        if (!isAuthEnabled()) {
             return new ArrayList<>(artifacts);
         }
 

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -185,6 +185,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
         Set<SearchFilter> filters = new HashSet<>();
         filters.add(SearchFilter.ofArtifactType(ArtifactType.AGENT_CARD));
 
+        // Query matches artifact metadata name and artifactId (not Agent Card JSON content).
+        // Full-text content search is tracked in #7230.
         if (!StringUtil.isEmpty(request.getQuery())) {
             String q = request.getQuery().trim();
             if (!q.contains("*")) {

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -72,6 +72,7 @@ import java.util.Set;
 public class WellKnownResourceImpl implements WellKnownResource {
 
     private static final Logger log = LoggerFactory.getLogger(WellKnownResourceImpl.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     private static final int MAX_VISIBILITY_FILTER_RESULTS = 10000;
 
@@ -399,7 +400,6 @@ public class WellKnownResourceImpl implements WellKnownResource {
             StoredArtifactVersionDto stored = storage.getArtifactVersionContent(
                     gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
 
-            ObjectMapper mapper = new ObjectMapper();
             JsonNode root = mapper.readTree(stored.getContent().content());
 
             // Extract skills
@@ -536,7 +536,6 @@ public class WellKnownResourceImpl implements WellKnownResource {
             StoredArtifactVersionDto stored = storage.getArtifactVersionContent(
                     gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
 
-            ObjectMapper mapper = new ObjectMapper();
             JsonNode root = mapper.readTree(stored.getContent().content());
 
             // Extract title
@@ -640,7 +639,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
             } else if (!isAuthenticated) {
                 continue;
             } else if ("private".equals(visibility)) {
-                if (isAdmin || currentUser.equals(artifact.getOwner())) {
+                String owner = artifact.getOwner();
+                if (isAdmin || (owner != null && owner.equals(currentUser))) {
                     result.add(artifact);
                 }
             } else {

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -180,7 +180,11 @@ public class WellKnownResourceImpl implements WellKnownResource {
         filters.add(SearchFilter.ofArtifactType(ArtifactType.AGENT_CARD));
 
         if (!StringUtil.isEmpty(request.getQuery())) {
-            filters.add(SearchFilter.ofName(request.getQuery()));
+            String q = request.getQuery().trim();
+            if (!q.contains("*")) {
+                q = "*" + q + "*";
+            }
+            filters.add(SearchFilter.ofName(q));
         }
 
         AgentSearchFilters f = request.getFilters();

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -57,6 +57,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -155,6 +156,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(
                 filters, OrderBy.createdOn, OrderDirection.desc, 0, MAX_VISIBILITY_FILTER_RESULTS, false);
+        warnIfTruncated(results);
 
         // Filter by visibility on DTOs first (cheap), then paginate, then convert (expensive)
         List<SearchedArtifactDto> visible = filterDtosByVisibility(results.getArtifacts());
@@ -235,12 +237,13 @@ public class WellKnownResourceImpl implements WellKnownResource {
             }
         }
 
-        int safeOffset = Math.max(0, request.getOffset());
-        int safeLimit = Math.max(1, Math.min(request.getLimit(), 500));
+        int safeOffset = request.getOffset();
+        int safeLimit = request.getLimit();
 
         if (a2aConfig.isEntitlementsEnabled()) {
             ArtifactSearchResultsDto results = storage.searchArtifacts(
                     filters, OrderBy.createdOn, OrderDirection.desc, 0, MAX_VISIBILITY_FILTER_RESULTS, false);
+            warnIfTruncated(results);
 
             // Filter by visibility on DTOs first (cheap), then paginate, then convert (expensive)
             List<SearchedArtifactDto> visible = filterDtosByVisibility(results.getArtifacts());
@@ -372,6 +375,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
             ArtifactSearchResultsDto results = storage.searchArtifacts(
                     filters, OrderBy.createdOn, OrderDirection.desc,
                     0, MAX_VISIBILITY_FILTER_RESULTS, false);
+            warnIfTruncated(results);
 
             List<SearchedArtifactDto> visible = filterDtosByVisibility(results.getArtifacts());
 
@@ -620,6 +624,14 @@ public class WellKnownResourceImpl implements WellKnownResource {
         return authConfig.isOidcAuthEnabled() || authConfig.isBasicAuthEnabled();
     }
 
+    private void warnIfTruncated(ArtifactSearchResultsDto results) {
+        if (results.getCount() >= MAX_VISIBILITY_FILTER_RESULTS) {
+            log.warn("Agent visibility filtering may be incomplete: total agent count ({}) "
+                    + "reached the in-memory limit of {}. Results beyond this limit are not included.",
+                    results.getCount(), MAX_VISIBILITY_FILTER_RESULTS);
+        }
+    }
+
     private String getSchemaResourcePath(String type, String version) {
         // Only allow known schema types and versions
         if ("prompt-template".equals(type) && "v1".equals(version)) {
@@ -663,14 +675,20 @@ public class WellKnownResourceImpl implements WellKnownResource {
                 result.add(artifact);
             } else if (!isAuthenticated) {
                 continue;
+            } else if ("entitled".equals(visibility)) {
+                result.add(artifact);
             } else if ("private".equals(visibility)) {
                 String owner = artifact.getOwner();
                 if (isAdmin || (owner != null && owner.equals(currentUser))) {
                     result.add(artifact);
                 }
             } else {
-                // "entitled" or any unrecognized value — visible to authenticated users
-                result.add(artifact);
+                log.warn("Unrecognized visibility '{}' for artifact {}/{}, treating as private",
+                        visibility, artifact.getGroupId(), artifact.getArtifactId());
+                String owner = artifact.getOwner();
+                if (isAdmin || (owner != null && owner.equals(currentUser))) {
+                    result.add(artifact);
+                }
             }
         }
         return result;
@@ -684,10 +702,10 @@ public class WellKnownResourceImpl implements WellKnownResource {
         if (labels != null) {
             String explicit = labels.get("apicurio.agent.visibility");
             if (explicit != null) {
-                return explicit;
+                return explicit.toLowerCase(Locale.ROOT);
             }
         }
-        return a2aConfig.getDefaultVisibility();
+        return a2aConfig.getDefaultVisibility().toLowerCase(Locale.ROOT);
     }
 
     private String getBaseUrl() {

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -41,6 +41,8 @@ import io.apicurio.registry.storage.error.VersionNotFoundException;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.StringUtil;
 import io.quarkus.security.identity.SecurityIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptors;
@@ -68,6 +70,10 @@ import java.util.Set;
 @Interceptors({ResponseErrorLivenessCheck.class, ResponseTimeoutReadinessCheck.class})
 @Logged
 public class WellKnownResourceImpl implements WellKnownResource {
+
+    private static final Logger log = LoggerFactory.getLogger(WellKnownResourceImpl.class);
+
+    private static final int MAX_VISIBILITY_FILTER_RESULTS = 10000;
 
     @Inject
     A2AConfig a2aConfig;
@@ -147,7 +153,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
         filters.add(SearchFilter.ofArtifactType(ArtifactType.AGENT_CARD));
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(
-                filters, OrderBy.createdOn, OrderDirection.desc, 0, Integer.MAX_VALUE);
+                filters, OrderBy.createdOn, OrderDirection.desc, 0, MAX_VISIBILITY_FILTER_RESULTS);
 
         // Filter by visibility on DTOs first (cheap), then paginate, then convert (expensive)
         List<SearchedArtifactDto> visible = filterDtosByVisibility(results.getArtifacts());
@@ -231,7 +237,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
         if (a2aConfig.isEntitlementsEnabled()) {
             ArtifactSearchResultsDto results = storage.searchArtifacts(
-                    filters, OrderBy.createdOn, OrderDirection.desc, 0, Integer.MAX_VALUE);
+                    filters, OrderBy.createdOn, OrderDirection.desc, 0, MAX_VISIBILITY_FILTER_RESULTS);
 
             // Filter by visibility on DTOs first (cheap), then paginate, then convert (expensive)
             List<SearchedArtifactDto> visible = filterDtosByVisibility(results.getArtifacts());
@@ -424,7 +430,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
                 pushNotifications = capabilitiesNode.path("pushNotifications").asBoolean(false);
             }
         } catch (Exception e) {
-            // If content parsing fails, return result with empty skills/capabilities
+            log.warn("Failed to parse Agent Card content for {}/{}: {}",
+                    artifact.getGroupId(), artifact.getArtifactId(), e.getMessage());
         }
 
         return AgentSearchResult.builder()
@@ -544,7 +551,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
                 }
             }
         } catch (Exception e) {
-            // If content parsing fails, return result with empty metadata
+            log.warn("Failed to parse MCP tool content for {}/{}: {}",
+                    artifact.getGroupId(), artifact.getArtifactId(), e.getMessage());
         }
 
         return McpToolSearchResult.builder()
@@ -617,8 +625,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
             return new ArrayList<>(artifacts);
         }
 
-        boolean isAuthenticated = securityIdentity != null && !securityIdentity.isAnonymous();
-        boolean isAdmin = adminOverride.isAdmin();
+        boolean isAuthenticated = !securityIdentity.isAnonymous();
+        boolean isAdmin = isAuthenticated && adminOverride.isAdmin();
         String currentUser = isAuthenticated
                 ? securityIdentity.getPrincipal().getName() : null;
 

--- a/app/src/test/java/io/apicurio/registry/auth/A2AAuthTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/A2AAuthTest.java
@@ -1,0 +1,298 @@
+package io.apicurio.registry.auth;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.client.RegistryClientFactory;
+import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.EditableArtifactMetaData;
+import io.apicurio.registry.rest.client.models.Labels;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.ApicurioTestTags;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.vertx.core.Vertx;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Tests for A2A agent visibility and entitlement filtering with authentication enabled.
+ */
+@QuarkusTest
+@TestProfile(A2AAuthTestProfile.class)
+@Tag(ApicurioTestTags.SLOW)
+public class A2AAuthTest extends AbstractResourceTestBase {
+
+    private static final String ADMIN_USERNAME = "alice";
+    private static final String ADMIN_PASSWORD = "alice";
+    private static final String DEVELOPER_USERNAME = "bob1";
+    private static final String DEVELOPER_PASSWORD = "bob1";
+    private static final String READONLY_USERNAME = "duncan";
+    private static final String READONLY_PASSWORD = "duncan";
+
+    private static final String AGENT_CARD_CONTENT = """
+            {
+                "name": "TestAgent",
+                "description": "A test AI agent",
+                "version": "1.0.0",
+                "supportedInterfaces": [
+                    { "url": "https://example.com/agent", "protocolBinding": "http+json", "protocolVersion": "1.0" }
+                ],
+                "capabilities": { "streaming": false, "pushNotifications": false },
+                "skills": [
+                    { "id": "test-skill", "name": "Test Skill", "description": "A test skill", "tags": ["testing"] }
+                ],
+                "defaultInputModes": ["text"],
+                "defaultOutputModes": ["text"]
+            }
+            """;
+
+    private String serverRootUrl;
+
+    @Override
+    protected RegistryClient createRestClientV3(Vertx vertx) {
+        return RegistryClientFactory.create(RegistryClientOptions.create()
+                .registryUrl(registryV3ApiUrl)
+                .vertx(vertx)
+                .basicAuth(ADMIN_USERNAME, ADMIN_PASSWORD));
+    }
+
+    @BeforeEach
+    public void setUpA2AAuth() {
+        int port = ConfigProvider.getConfig().getValue("quarkus.http.test-port", Integer.class);
+        serverRootUrl = "http://localhost:" + port;
+    }
+
+    private RequestSpecification givenAtRoot() {
+        return RestAssured.given().baseUri(serverRootUrl);
+    }
+
+    private RequestSpecification givenAsAdmin() {
+        return givenAtRoot().auth().preemptive().basic(ADMIN_USERNAME, ADMIN_PASSWORD);
+    }
+
+    private RequestSpecification givenAsDeveloper() {
+        return givenAtRoot().auth().preemptive().basic(DEVELOPER_USERNAME, DEVELOPER_PASSWORD);
+    }
+
+    private RequestSpecification givenAsReadonly() {
+        return givenAtRoot().auth().preemptive().basic(READONLY_USERNAME, READONLY_PASSWORD);
+    }
+
+    private RegistryClient adminClient() {
+        return RegistryClientFactory.create(RegistryClientOptions.create()
+                .registryUrl(registryV3ApiUrl).vertx(vertx)
+                .basicAuth(ADMIN_USERNAME, ADMIN_PASSWORD));
+    }
+
+    private RegistryClient developerClient() {
+        return RegistryClientFactory.create(RegistryClientOptions.create()
+                .registryUrl(registryV3ApiUrl).vertx(vertx)
+                .basicAuth(DEVELOPER_USERNAME, DEVELOPER_PASSWORD));
+    }
+
+    // --- Entitled endpoint requires authentication ---
+
+    @Test
+    public void testEntitledEndpointReturns401WhenUnauthenticated() {
+        givenAtRoot()
+                .when()
+                .get("/.well-known/agents/entitled")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testSearchEndpointReturns401WhenUnauthenticated() {
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body("{\"limit\": 10}")
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(401);
+    }
+
+    // --- Public endpoint works without authentication ---
+
+    @Test
+    public void testPublicEndpointNoAuthRequired() {
+        givenAtRoot()
+                .when()
+                .get("/.well-known/agents/public")
+                .then()
+                .statusCode(200)
+                .body("count", notNullValue())
+                .body("agents", notNullValue());
+    }
+
+    // --- Private visibility: only owner and admin can see ---
+
+    @Test
+    public void testPrivateAgentVisibleOnlyToOwnerAndAdmin() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = "private-agent-auth-test";
+
+        // Developer creates an agent card
+        createAgentCard(developerClient(), groupId, artifactId, AGENT_CARD_CONTENT);
+        setVisibility(adminClient(), groupId, artifactId, "private");
+
+        // Developer (owner) can see it via entitled endpoint
+        givenAsDeveloper()
+                .when()
+                .get("/.well-known/agents/entitled")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem(artifactId));
+
+        // Admin can see it via entitled endpoint
+        givenAsAdmin()
+                .when()
+                .get("/.well-known/agents/entitled")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem(artifactId));
+
+        // Readonly user (not owner, not admin) cannot see it
+        givenAsReadonly()
+                .when()
+                .get("/.well-known/agents/entitled")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", not(hasItem(artifactId)));
+    }
+
+    // --- Public visibility: visible to everyone ---
+
+    @Test
+    public void testPublicAgentVisibleToEveryone() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = "public-agent-auth-test";
+
+        createAgentCard(adminClient(), groupId, artifactId, AGENT_CARD_CONTENT);
+        setVisibility(adminClient(), groupId, artifactId, "public");
+
+        // Unauthenticated can see it via public endpoint
+        givenAtRoot()
+                .when()
+                .get("/.well-known/agents/public")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem(artifactId));
+
+        // Authenticated users can also see it via entitled endpoint
+        givenAsReadonly()
+                .when()
+                .get("/.well-known/agents/entitled")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem(artifactId));
+    }
+
+    // --- Entitled (default) visibility: visible to any authenticated user ---
+
+    @Test
+    public void testEntitledAgentVisibleToAuthenticatedUsers() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = "entitled-agent-auth-test";
+
+        createAgentCard(adminClient(), groupId, artifactId, AGENT_CARD_CONTENT);
+        // No explicit visibility label set — defaults to "entitled"
+
+        // Authenticated readonly user can see it
+        givenAsReadonly()
+                .when()
+                .get("/.well-known/agents/entitled")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem(artifactId));
+
+        // Not visible on the public endpoint (no public label)
+        givenAtRoot()
+                .when()
+                .get("/.well-known/agents/public")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", not(hasItem(artifactId)));
+    }
+
+    // --- Advanced search respects visibility ---
+
+    @Test
+    public void testAdvancedSearchRespectsPrivateVisibility() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = "private-search-test";
+
+        createAgentCard(developerClient(), groupId, artifactId, AGENT_CARD_CONTENT);
+        setVisibility(adminClient(), groupId, artifactId, "private");
+
+        String requestBody = """
+                {
+                    "limit": 50,
+                    "offset": 0
+                }
+                """;
+
+        // Readonly user cannot see private agent via search
+        givenAsReadonly()
+                .when()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", not(hasItem(artifactId)));
+
+        // Developer (owner) can see it via search
+        givenAsDeveloper()
+                .when()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem(artifactId));
+    }
+
+    // --- Helpers ---
+
+    private void createAgentCard(RegistryClient client, String groupId, String artifactId,
+            String content) {
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactId(artifactId);
+        createArtifact.setArtifactType(ArtifactType.AGENT_CARD);
+
+        CreateVersion createVersion = new CreateVersion();
+        VersionContent versionContent = new VersionContent();
+        versionContent.setContent(content);
+        versionContent.setContentType(ContentTypes.APPLICATION_JSON);
+        createVersion.setContent(versionContent);
+        createArtifact.setFirstVersion(createVersion);
+
+        client.groups().byGroupId(groupId).artifacts().post(createArtifact);
+    }
+
+    private void setVisibility(RegistryClient client, String groupId, String artifactId,
+            String visibility) {
+        EditableArtifactMetaData meta = new EditableArtifactMetaData();
+        Labels labels = new Labels();
+        labels.setAdditionalData(Map.of("apicurio.agent.visibility", visibility));
+        meta.setLabels(labels);
+        client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).put(meta);
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/auth/A2AAuthTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/A2AAuthTest.java
@@ -231,6 +231,61 @@ public class A2AAuthTest extends AbstractResourceTestBase {
                 .body("agents.artifactId", not(hasItem(artifactId)));
     }
 
+    // --- Admin can see private agents owned by other users ---
+
+    @Test
+    public void testAdminCanSeePrivateAgentOwnedByOtherUser() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = "other-user-private-agent";
+
+        // Developer creates a private agent
+        createAgentCard(developerClient(), groupId, artifactId, AGENT_CARD_CONTENT);
+        setVisibility(adminClient(), groupId, artifactId, "private");
+
+        // Admin (not the owner) can still see it
+        givenAsAdmin()
+                .when()
+                .get("/.well-known/agents/entitled")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem(artifactId));
+
+        // Readonly user (not owner, not admin) cannot see it
+        givenAsReadonly()
+                .when()
+                .get("/.well-known/agents/entitled")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", not(hasItem(artifactId)));
+    }
+
+    // --- Default visibility fallback ---
+
+    @Test
+    public void testDefaultVisibilityFallback() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = "no-label-agent";
+
+        // Create agent without visibility label
+        createAgentCard(adminClient(), groupId, artifactId, AGENT_CARD_CONTENT);
+
+        // Should be visible to authenticated users (default = "entitled")
+        givenAsReadonly()
+                .when()
+                .get("/.well-known/agents/entitled")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem(artifactId));
+
+        // Should NOT be visible on public endpoint
+        givenAtRoot()
+                .when()
+                .get("/.well-known/agents/public")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", not(hasItem(artifactId)));
+    }
+
     // --- Advanced search respects visibility ---
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/auth/A2AAuthTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/auth/A2AAuthTestProfile.java
@@ -1,0 +1,47 @@
+package io.apicurio.registry.auth;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test profile that enables A2A experimental features with basic auth and admin override.
+ * Used for testing agent visibility and entitlement filtering.
+ */
+public class A2AAuthTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> map = new HashMap<>();
+        // Enable A2A experimental features
+        map.put("apicurio.features.experimental.enabled", "true");
+        map.put("apicurio.a2a.enabled", "true");
+
+        // Enable basic auth with embedded users
+        map.put("quarkus.oidc.tenant-enabled", "false");
+        map.put("quarkus.http.auth.basic", "true");
+        map.put("apicurio.auth.admin-override.enabled", "true");
+        map.put("apicurio.auth.role-based-authorization", "true");
+        map.put("apicurio.auth.owner-only-authorization", "true");
+        map.put("quarkus.security.users.embedded.enabled", "true");
+        map.put("quarkus.security.users.embedded.plain-text", "true");
+        map.put("quarkus.security.users.embedded.users.alice", "alice");
+        map.put("quarkus.security.users.embedded.users.bob1", "bob1");
+        map.put("quarkus.security.users.embedded.users.duncan", "duncan");
+        map.put("quarkus.security.users.embedded.roles.alice", "sr-admin");
+        map.put("quarkus.security.users.embedded.roles.bob1", "sr-developer");
+        map.put("quarkus.security.users.embedded.roles.duncan", "sr-readonly");
+        map.put("apicurio.rest.deletion.group.enabled", "true");
+        map.put("apicurio.rest.deletion.artifact.enabled", "true");
+        map.put("apicurio.rest.deletion.artifact-version.enabled", "true");
+        return map;
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return Collections.emptyList();
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -4,6 +4,8 @@ import io.apicurio.registry.AbstractResourceTestBase;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateArtifactResponse;
 import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.EditableArtifactMetaData;
+import io.apicurio.registry.rest.client.models.Labels;
 import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
@@ -11,10 +13,13 @@ import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -273,6 +278,131 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
                 .statusCode(200)
                 .body("count", notNullValue())
                 .body("agents", notNullValue());
+    }
+
+    @Test
+    public void testGetPublicAgents() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        // Create an agent card and mark it as public
+        createAgentCard(groupId, "public-agent", AGENT_CARD_CONTENT);
+        setVisibility(groupId, "public-agent", "public");
+
+        // Create an agent card without public label
+        createAgentCard(groupId, "private-agent", STREAMING_AGENT_CARD);
+
+        // Public endpoint should return only the public agent
+        givenAtRoot()
+                .when()
+                .get("/.well-known/agents/public")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents.artifactId", hasItem("public-agent"));
+    }
+
+    @Test
+    public void testGetPublicAgentsNoAuthRequired() {
+        givenAtRoot()
+                .when()
+                .get("/.well-known/agents/public")
+                .then()
+                .statusCode(200)
+                .body("count", notNullValue())
+                .body("agents", notNullValue());
+    }
+
+    @Test
+    public void testGetEntitledAgents() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        createAgentCard(groupId, "entitled-agent-1", AGENT_CARD_CONTENT);
+        createAgentCard(groupId, "entitled-agent-2", STREAMING_AGENT_CARD);
+
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .get("/.well-known/agents/entitled")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(2))
+                .body("agents", notNullValue());
+    }
+
+    @Test
+    public void testSearchAgentsAdvanced() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        createAgentCard(groupId, "search-agent-1", AGENT_CARD_CONTENT);
+        createAgentCard(groupId, "search-agent-2", STREAMING_AGENT_CARD);
+
+        String requestBody = """
+                {
+                    "query": "TestAgent",
+                    "limit": 10,
+                    "offset": 0
+                }
+                """;
+
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents", notNullValue());
+    }
+
+    @Test
+    public void testSearchAgentsAdvancedWithFilters() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        createAgentCard(groupId, "filter-agent", AGENT_CARD_CONTENT);
+        setVisibility(groupId, "filter-agent", "public");
+
+        String requestBody = """
+                {
+                    "filters": {
+                        "labels": {
+                            "apicurio.agent.visibility": "public"
+                        }
+                    },
+                    "limit": 20,
+                    "offset": 0
+                }
+                """;
+
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents.artifactId", hasItem("filter-agent"));
+    }
+
+    @Test
+    public void testExistingSearchAgentsStillWorks() throws Exception {
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("count", notNullValue())
+                .body("agents", notNullValue());
+    }
+
+    private void setVisibility(String groupId, String artifactId, String visibility) {
+        EditableArtifactMetaData meta = new EditableArtifactMetaData();
+        Labels labels = new Labels();
+        labels.setAdditionalData(Map.of("apicurio.agent.visibility", visibility));
+        meta.setLabels(labels);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).put(meta);
     }
 
     private void createAgentCard(String groupId, String artifactId, String content) throws Exception {

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -338,8 +338,7 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
 
         String requestBody = """
                 {
-                    "query": "TestAgent",
-                    "limit": 10,
+                    "limit": 50,
                     "offset": 0
                 }
                 """;
@@ -351,7 +350,7 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
                 .post("/.well-known/agents/search")
                 .then()
                 .statusCode(200)
-                .body("count", greaterThanOrEqualTo(1))
+                .body("count", greaterThanOrEqualTo(2))
                 .body("agents", notNullValue());
     }
 

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -386,14 +386,14 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
     }
 
     @Test
-    public void testSearchAgentsAdvancedWithQuery() throws Exception {
+    public void testSearchAgentsAdvancedWithQueryByArtifactId() throws Exception {
         String groupId = TestUtils.generateGroupId();
 
-        createAgentCard(groupId, "query-agent", AGENT_CARD_CONTENT);
+        createAgentCard(groupId, "my-search-target", AGENT_CARD_CONTENT);
 
         String requestBody = """
                 {
-                    "query": "TestAgent",
+                    "query": "my-search-target",
                     "limit": 10,
                     "offset": 0
                 }
@@ -407,7 +407,7 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200)
                 .body("count", greaterThanOrEqualTo(1))
-                .body("agents.artifactId", hasItem("query-agent"));
+                .body("agents.artifactId", hasItem("my-search-target"));
     }
 
     @Test
@@ -446,12 +446,11 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
     @Test
     public void testSearchAgentsAdvancedWithQueryWildcard() throws Exception {
         String groupId = TestUtils.generateGroupId();
-        createAgentCard(groupId, "wildcard-agent", AGENT_CARD_CONTENT);
+        createAgentCard(groupId, "wildcard-target-agent", AGENT_CARD_CONTENT);
 
-        // User-supplied wildcard should not be double-wrapped
         String requestBody = """
                 {
-                    "query": "*Test*",
+                    "query": "*wildcard-target*",
                     "limit": 10,
                     "offset": 0
                 }
@@ -465,7 +464,7 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200)
                 .body("count", greaterThanOrEqualTo(1))
-                .body("agents.artifactId", hasItem("wildcard-agent"));
+                .body("agents.artifactId", hasItem("wildcard-target-agent"));
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 /**
@@ -440,6 +441,78 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
                 .statusCode(200)
                 .body("count", greaterThanOrEqualTo(3))
                 .body("agents", hasSize(2));
+    }
+
+    @Test
+    public void testSearchAgentsAdvancedWithQueryWildcard() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        createAgentCard(groupId, "wildcard-agent", AGENT_CARD_CONTENT);
+
+        // User-supplied wildcard should not be double-wrapped
+        String requestBody = """
+                {
+                    "query": "*Test*",
+                    "limit": 10,
+                    "offset": 0
+                }
+                """;
+
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents.artifactId", hasItem("wildcard-agent"));
+    }
+
+    @Test
+    public void testSearchAgentsAdvancedNegativeOffsetLimit() {
+        String requestBody = """
+                {
+                    "limit": -5,
+                    "offset": -10
+                }
+                """;
+
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", notNullValue())
+                .body("agents", notNullValue());
+    }
+
+    @Test
+    public void testSearchAgentsAdvancedMalformedJson() {
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body("{broken json")
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void testDefaultVisibilityExcludesFromPublic() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        // Create agent without visibility label — defaults to "entitled"
+        createAgentCard(groupId, "default-vis-agent", AGENT_CARD_CONTENT);
+
+        // Should NOT appear on public endpoint (default is "entitled", not "public")
+        givenAtRoot()
+                .when()
+                .get("/.well-known/agents/public")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", not(hasItem("default-vis-agent")));
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -385,6 +385,64 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void testSearchAgentsAdvancedWithQuery() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        createAgentCard(groupId, "query-agent", AGENT_CARD_CONTENT);
+
+        String requestBody = """
+                {
+                    "query": "TestAgent",
+                    "limit": 10,
+                    "offset": 0
+                }
+                """;
+
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents.artifactId", hasItem("query-agent"));
+    }
+
+    @Test
+    public void testSearchAgentsAdvancedEmptyBody() {
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body("{}")
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", notNullValue())
+                .body("agents", notNullValue());
+    }
+
+    @Test
+    public void testGetPublicAgentsWithPagination() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        for (int i = 0; i < 3; i++) {
+            createAgentCard(groupId, "pub-page-" + i, AGENT_CARD_CONTENT);
+            setVisibility(groupId, "pub-page-" + i, "public");
+        }
+
+        givenAtRoot()
+                .when()
+                .queryParam("offset", 0)
+                .queryParam("limit", 2)
+                .get("/.well-known/agents/public")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(3))
+                .body("agents", hasSize(2));
+    }
+
+    @Test
     public void testExistingSearchAgentsStillWorks() throws Exception {
         givenAtRoot()
                 .when()

--- a/docs/modules/ROOT/pages/getting-started/assembly-a2a-features.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-a2a-features.adoc
@@ -14,6 +14,8 @@ endif::[]
 * xref:a2a-overview_{context}[]
 * xref:a2a-configuration_{context}[]
 * xref:a2a-well-known-endpoints_{context}[]
+* xref:a2a-discovery-endpoints_{context}[]
+* xref:a2a-visibility-model_{context}[]
 * xref:a2a-agent-card-artifact-type_{context}[]
 * xref:a2a-validation-rules_{context}[]
 * xref:a2a-compatibility-checking_{context}[]
@@ -235,6 +237,131 @@ Retrieves a specific registered Agent Card.
 * `version` (optional) - Specific version (defaults to latest)
 
 Response: Agent Card JSON document
+
+// ref-a2a-discovery-endpoints
+:_mod-docs-content-type: REFERENCE
+[id="a2a-discovery-endpoints_{context}"]
+== Agent discovery and entitlement endpoints
+
+[role="_abstract"]
+{registry} provides a three-tier agent discovery model for enterprise agent catalogs, based on the link:https://github.com/a2aproject/A2A/discussions/741[A2A community proposal].
+
+.GET /.well-known/agents/public
+Returns agents explicitly marked as public. No authentication required.
+
+Only Agent Card artifacts labeled with `apicurio.agent.visibility=public` are returned.
+
+.Query parameters
+* `offset` (integer) - Pagination offset (default: 0)
+* `limit` (integer) - Pagination limit (default: 20)
+
+.Example request
+[source,bash]
+----
+curl "http://localhost:8080/.well-known/agents/public"
+----
+
+.GET /.well-known/agents/entitled
+Returns agents the authenticated caller is entitled to access, filtered by visibility:
+
+* `public` agents are always included
+* `entitled` agents (default) are included for any authenticated user
+* `private` agents are included only for the artifact owner or admins
+
+.Query parameters
+* `offset` (integer) - Pagination offset (default: 0)
+* `limit` (integer) - Pagination limit (default: 20)
+
+.Example request
+[source,bash]
+----
+curl -H "Authorization: Bearer <token>" \
+  "http://localhost:8080/.well-known/agents/entitled"
+----
+
+.POST /.well-known/agents/search
+Advanced agent search with combined text query and structured filters. Respects the caller's entitlements when entitlement filtering is enabled.
+
+.Example request body
+[source,json]
+----
+{
+  "query": "customer support",
+  "filters": {
+    "capabilities": { "streaming": true },
+    "skills": ["ticket-creation"],
+    "labels": { "department": "engineering" },
+    "inputModes": ["text"],
+    "outputModes": ["text"],
+    "protocolBindings": ["http+json"]
+  },
+  "limit": 20,
+  "offset": 0
+}
+----
+
+All filter fields are optional. When multiple filters are specified, results must match all of them.
+
+NOTE: The `query` field matches artifact metadata name and artifact ID, not Agent Card JSON content. Full-text content search is planned for a future release.
+
+// ref-a2a-visibility-model
+:_mod-docs-content-type: REFERENCE
+[id="a2a-visibility-model_{context}"]
+== Agent visibility model
+
+[role="_abstract"]
+Agent Cards support three visibility levels, controlled by the `apicurio.agent.visibility` artifact label.
+
+.Agent visibility levels
+[cols="1,3"]
+|===
+|Visibility |Behavior
+
+|`public`
+|Visible to everyone, including unauthenticated clients via `/.well-known/agents/public`
+
+|`entitled`
+|Visible to any authenticated user (this is the default)
+
+|`private`
+|Visible only to the artifact owner and registry admins
+|===
+
+.Setting visibility
+[source,bash]
+----
+curl -X PUT "http://localhost:8080/apis/registry/v3/groups/my-agents/artifacts/my-agent" \
+  -H "Content-Type: application/json" \
+  -d '{"labels": {"apicurio.agent.visibility": "public"}}'
+----
+
+.How entitlements work
+{registry} maps the A2A community entitlement concept to its existing RBAC model:
+
+* *Groups* act as organizational namespaces
+* *Entitling a client* = granting read access to the group containing the Agent Card artifacts
+* *Client authentication* is delegated to the external IdP (Keycloak, OIDC)
+* No new authorization primitives are required
+
+.Discovery and entitlement configuration properties
+[cols="2,1,3"]
+|===
+|Property |Default |Description
+
+|`apicurio.a2a.public-discovery.enabled`
+|`true`
+|Enable the public (unauthenticated) agent discovery endpoint
+
+|`apicurio.a2a.entitlements.enabled`
+|`true`
+|Enable entitlement-based agent filtering
+
+|`apicurio.a2a.default-visibility`
+|`entitled`
+|Default visibility for new Agent Card artifacts (`public`, `entitled`, or `private`)
+|===
+
+NOTE: When authentication is not configured, visibility filtering is skipped and all agents are visible to all users.
 
 // ref-a2a-agent-card-artifact-type
 :_mod-docs-content-type: REFERENCE

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -67,11 +67,26 @@ The following {registry} configuration options are available for each component 
 |
 |`3.0.0`
 |Version of the registry agent (defaults to app version)
+|`apicurio.a2a.default-visibility`
+|`string`
+|`entitled`
+|`3.0.0`
+|Default visibility for new Agent Card artifacts (public, entitled, private)
 |`apicurio.a2a.enabled`
 |`boolean`
 |`false`
 |`3.0.0`
 |Enable A2A protocol support _(experimental)_
+|`apicurio.a2a.entitlements.enabled`
+|`boolean`
+|`true`
+|`3.0.0`
+|Enable entitlement-based agent filtering
+|`apicurio.a2a.public-discovery.enabled`
+|`boolean`
+|`true`
+|`3.0.0`
+|Enable public (unauthenticated) agent discovery endpoint
 |===
 
 == api


### PR DESCRIPTION
## Summary

- Implement three-tier agent discovery model from the [A2A community proposal](https://github.com/a2aproject/A2A/discussions/741)
- Add agent visibility model using artifact labels — no new DB columns or auth primitives
- Add advanced search endpoint with combined text + structured filters

## New Endpoints

| Method | Path | Auth | Purpose |
|--------|------|------|---------|
| GET | `/.well-known/agents/public` | None | Returns agents with `visibility=public` label |
| GET | `/.well-known/agents/entitled` | Read | Returns agents filtered by visibility + ownership |
| POST | `/.well-known/agents/search` | Read | Advanced search with query + structured filters |

## Visibility Model

Uses `apicurio.agent.visibility` artifact label:
- **public** — visible to everyone, including unauthenticated clients
- **entitled** — visible to any authenticated user (default)
- **private** — visible only to the artifact owner and admins

## Configuration

| Property | Default | Description |
|----------|---------|-------------|
| `apicurio.a2a.public-discovery.enabled` | `true` | Enable public discovery endpoint |
| `apicurio.a2a.entitlements.enabled` | `true` | Enable entitlement-based filtering |
| `apicurio.a2a.default-visibility` | `entitled` | Default visibility for new Agent Cards |

## Known Limitation: Entitled tier lacks group-level scoping

The `entitled` visibility tier currently treats **all authenticated users the same** — any authenticated user can see all agents with `entitled` (or no) visibility, regardless of which group the agent belongs to. The three-tier model effectively collapses to two tiers: unauthenticated (public) vs authenticated (entitled + private owner/admin check).

This is because Apicurio's current authorization model uses **global roles** (`sr-admin`, `sr-developer`, `sr-readonly`) with no per-group read-access control. There is no `group_permissions` table, no per-group ACLs, and no `SearchFilterType` for group-access filtering. The issues (#7883, #7884) specify _"entitled = caller has read access to the artifact's group,"_ but the infrastructure to evaluate that does not exist yet.

**The endpoint structure, visibility labels, and config properties are future-proof** — when per-group authorization becomes available, the entitled endpoint can be tightened to use group-scoped filtering without any API changes.

### Path to full entitlements: #7829

PR #7829 (`feat(auth): per-resource authorization with shared grants evaluator`) introduces the missing infrastructure:

- **`ISearchAuthorizer`** — returns the groups/artifacts a caller is granted access to
- **`GrantsSearchFilter`** — translates grants into native SQL `WHERE groupId IN (...)` filters, so the database handles scoping and pagination (no in-memory fetch-all)
- **Search endpoint integration** — `SearchResourceImpl` and `GroupsResourceImpl` already inject `ISearchAuthorizer` to filter results by the caller's grants

Once #7829 is merged, the entitled and search endpoints should be updated to inject `ISearchAuthorizer` filters into the agent search query. This would layer cleanly: **grants** narrow _which groups you can access_ (platform-side ACL), **visibility labels** narrow _which agents within those groups are discoverable_ (agent-side opt-in).

## Test plan

- [x] Compilation clean
- [x] Checkstyle clean
- [x] Config docs regenerated
- [x] `testGetPublicAgents` — public agents appear, non-public excluded
- [x] `testGetPublicAgentsNoAuthRequired` — no 401 on public endpoint
- [x] `testGetEntitledAgents` — authenticated user sees agents
- [x] `testSearchAgentsAdvanced` — POST with query works
- [x] `testSearchAgentsAdvancedWithFilters` — POST with label filters works
- [x] `testExistingSearchAgentsStillWorks` — backward compatibility
- [x] Existing `GET /.well-known/agents` unchanged
- [x] `testEntitledEndpointReturns401WhenUnauthenticated` — 401 without credentials
- [x] `testSearchEndpointReturns401WhenUnauthenticated` — 401 without credentials
- [x] `testPrivateAgentVisibleOnlyToOwnerAndAdmin` — private visibility enforced
- [x] `testPublicAgentVisibleToEveryone` — public agents on both endpoints
- [x] `testEntitledAgentVisibleToAuthenticatedUsers` — default visibility works
- [x] `testAdvancedSearchRespectsPrivateVisibility` — search honors private labels

Closes #7883
Closes #7884