### PR TITLE
fix(deps): update json-schema-validator to 3.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
 
     <!-- Schema types -->
     <avro.version>1.12.1</avro.version>
-    <json-schema-validator.version>1.5.9</json-schema-validator.version>
+    <json-schema-validator.version>3.0.2</json-schema-validator.version>
     <wire-schema.version>5.3.3</wire-schema.version>
     <okhttp.version>4.12.0</okhttp.version>
     <okio.version>3.17.0</okio.version>


### PR DESCRIPTION
## Summary
- Update com.networknt:json-schema-validator from 1.5.9 to 3.0.2

## Context
This dependency upgrade was split from Renovate PR #7898 for easier review and testing.

Note: This is a major version bump (1.x → 3.x). Review for API compatibility.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected