### PR TITLE
fix(deps): update graphql-java to 26.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
     <apicurio-data-models.version>3.0.1</apicurio-data-models.version>
 
     <!-- GraphQL -->
-    <graphql.version>22.4</graphql.version>
+    <graphql.version>26.0</graphql.version>
 
     <!-- JSON Schema Validator -->
     <org.everit.json.schema.version>1.14.6</org.everit.json.schema.version>


### PR DESCRIPTION
## Summary
- Update com.graphql-java:graphql-java from 22.4 to 26.0

## Context
This dependency upgrade was split from Renovate PR #7898 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected