### PR TITLE
fix(deps): update json-unit-assertj to 5.1.1

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
-            <version>4.1.1</version>
+            <version>5.1.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -308,5 +308,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>


### PR DESCRIPTION
## Summary
- Update net.javacrumbs.json-unit:json-unit-assertj from 4.1.1 to 5.1.1

## Context
This dependency upgrade was split from Renovate PR #7898 for easier review and testing.
This is a test-scoped dependency in the CLI module.

## Test Plan
- [x] Build passes
- [x] CLI tests pass
- [ ] No breaking changes detected