### PR TITLE
fix(deps): update jakarta.annotation-api to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
     <connect.version>3.9.2</connect.version>
 
     <!-- Specifications -->
-    <annotation-api.version>1.3.5</annotation-api.version>
+    <annotation-api.version>3.0.0</annotation-api.version>
 
     <!-- Scala -->
     <version.scala-maven.plugin>4.9.10</version.scala-maven.plugin>


### PR DESCRIPTION
## Summary
- Update jakarta.annotation:jakarta.annotation-api from 1.3.5 to 3.0.0

## Context
This dependency upgrade was split from Renovate PR #7898 for easier review and testing.

Note: This is a major version bump (1.x → 3.0.0). Jakarta Annotations 3.0 is part of the
Jakarta EE 11 platform. Review for API compatibility.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected