### PR TITLE
fix(deps): update pulsar clients to 4.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
     <kafka-clients.version>3.9.2</kafka-clients.version>
     <kafka-oauth-client.version>0.17.1</kafka-oauth-client.version>
     <debezium.version>2.7.4.Final</debezium.version>
-    <pulsar-clients.version>3.3.9</pulsar-clients.version>
+    <pulsar-clients.version>4.2.1</pulsar-clients.version>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
 
     <nats.version>2.25.2</nats.version>


### PR DESCRIPTION
## Summary
- Update org.apache.pulsar:pulsar-client and pulsar-functions-api from 3.3.9 to 4.2.1

## Context
This dependency upgrade was split from Renovate PR #7898 for easier review and testing.

Note: This is a major version bump (3.x → 4.x). Apache Pulsar 4.x includes breaking
changes to the client API. Review for compatibility.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected