### PR TITLE
feat(ci): centralize test decisions and add verification gate

### DIFF
--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -409,9 +409,9 @@ async function handlePrSynchronize({ github, context, core }) {
     await api.removeLabel(pr.number, LABELS.REVIEW_APPROVED);
     core.info(`PR #${pr.number} new push, removed lifecycle/review-approved`);
   }
-  if (hasLabel(pr, LABELS.REVIEW_SKIPPED)) {
-    await api.removeLabel(pr.number, LABELS.REVIEW_SKIPPED);
-    core.info(`PR #${pr.number} new push, removed orchestrator/review-skipped`);
+  if (hasLabel(pr, LABELS.AUTO_MERGE)) {
+    await api.removeLabel(pr.number, LABELS.AUTO_MERGE);
+    core.info(`PR #${pr.number} new push, removed orchestrator/auto-merge`);
   }
   if (hasLabel(pr, LABELS.STALE)) {
     await api.removeLabel(pr.number, LABELS.STALE);

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -856,11 +856,14 @@ async function handleTestResult({ github, context, core }) {
   const api = createApi(github, owner, repo);
 
   // Re-run attempts may lose the pull_requests array from the workflow_run
-  // payload. Fall back to searching for PRs by the head SHA.
+  // payload, and fork PRs always have an empty array. Fall back to
+  // searching for PRs by the head SHA, using the head repository owner
+  // (which differs from the base owner for fork PRs).
   let prRefs = workflowRun.pull_requests || [];
   if (!prRefs.length) {
+    const headOwner = workflowRun.head_repository?.owner?.login || owner;
     const { data: prs } = await github.rest.pulls.list({
-      owner, repo, state: 'open', head: `${owner}:${workflowRun.head_branch}`, per_page: 10,
+      owner, repo, state: 'open', head: `${headOwner}:${workflowRun.head_branch}`, per_page: 10,
     });
     prRefs = prs.filter(p => p.head.sha === workflowRun.head_sha);
     if (!prRefs.length) {

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -397,6 +397,8 @@ async function handlePrSynchronize({ github, context, core }) {
   const { owner, repo } = context.repo;
   const api = createApi(github, owner, repo);
 
+  const rerunHints = [];
+
   if (hasLabel(pr, LABELS.TESTED)) {
     await api.removeLabel(pr.number, LABELS.TESTED);
     core.info(`PR #${pr.number} new push, removed lifecycle/tested`);
@@ -407,10 +409,12 @@ async function handlePrSynchronize({ github, context, core }) {
   }
   if (hasLabel(pr, LABELS.REVIEW_APPROVED)) {
     await api.removeLabel(pr.number, LABELS.REVIEW_APPROVED);
+    rerunHints.push('Review approval has been reset — a new review is required.');
     core.info(`PR #${pr.number} new push, removed lifecycle/review-approved`);
   }
   if (hasLabel(pr, LABELS.AUTO_MERGE)) {
     await api.removeLabel(pr.number, LABELS.AUTO_MERGE);
+    rerunHints.push('Auto-merge has been disabled — use `/auto-merge` to re-enable after tests pass.');
     core.info(`PR #${pr.number} new push, removed orchestrator/auto-merge`);
   }
   if (hasLabel(pr, LABELS.STALE)) {
@@ -424,11 +428,14 @@ async function handlePrSynchronize({ github, context, core }) {
     await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
     await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
     await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-    await api.postComment(pr.number,
-      `New commits pushed. Reverting to \`lifecycle/ready-for-review\` — ` +
-      `the full test suite will re-run. Use \`/auto-merge\` to merge automatically once approved and tested.`
-    );
     core.info(`PR #${pr.number} reverted from ready-to-merge to ready-for-review`);
+  }
+
+  if (rerunHints.length > 0) {
+    await api.postComment(pr.number,
+      `New commits pushed. The test suite will re-run.\n\n` +
+      rerunHints.map(h => `- ${h}`).join('\n')
+    );
   }
 }
 

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -43,6 +43,7 @@ const COLORS = {
   SUCCESS_LIGHT: 'B5E8B5',
   SUCCESS: '5BB85B',
   ATTENTION: 'F7BF6A',
+  ATTENTION_STRONG: 'E8836B',
   INACTIVE: 'CCCCCC',
 };
 
@@ -54,7 +55,7 @@ const LABEL_DEFS = {
   [LABELS.TESTED]:               { color: COLORS.SUCCESS, description: 'Full test suite passed for current HEAD' },
   [LABELS.REVIEW_APPROVED]:      { color: COLORS.SUCCESS, description: 'PR has an approved review' },
   [LABELS.READY_TO_MERGE]:       { color: COLORS.INFO, description: 'Approved and tested, ready to merge' },
-  [LABELS.WAITING_ON_AUTHOR]:    { color: COLORS.ATTENTION, description: 'Blocked on contributor action' },
+  [LABELS.WAITING_ON_AUTHOR]:    { color: COLORS.ATTENTION_STRONG, description: 'Blocked on contributor action' },
   [LABELS.WAITING_ON_MAINTAINER]:{ color: COLORS.ATTENTION, description: 'Blocked on maintainer action' },
   [LABELS.STALE]:                { color: COLORS.INACTIVE, description: 'No activity for 7+ days' },
   [LABELS.DISABLED]:             { color: COLORS.INACTIVE, description: 'PR excluded from lifecycle orchestrator' },

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -642,6 +642,7 @@ async function cmdAutoMerge(api, config, core, pr, actor, maintainer, commentId)
   }
 
   await api.addLabel(pr.number, LABELS.AUTO_MERGE);
+  await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
   await api.addReaction(commentId, '+1');
   await api.postComment(pr.number,
     `Auto-merge enabled by @${actor}. This PR will be merged automatically ` +
@@ -676,11 +677,11 @@ async function cmdSkipReview(api, config, core, pr, actor, maintainer, commentId
     const freshPr = await api.getPr(pr.number);
     await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
     await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
-    await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
     await retriggerVerify(api, freshPr, core);
   }
 
   await api.addLabel(pr.number, LABELS.REVIEW_SKIPPED);
+  await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
   await api.addReaction(commentId, '+1');
 
   const freshPr = await api.getPr(pr.number);

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,37 +8,52 @@ It runs on pull requests to `main` and on pushes to `main`.
 ### Pipeline Phases
 
 ```
-determine-scope ──┐
-                   ├── lint-and-validate ── build ──┬── unit-tests (3 shards)
-detect-changes ───┘                                 ├── integration-tests (13 jobs)
-                                                    ├── extras (5 jobs)
-                                                    ├── sdk
-                                                    ├── cli-verify (conditional)
-                                                    └── publish (main only) ── notify-slack
+decide ── lint-and-validate ── build ──┬── unit-tests (3 shards)
+                                       ├── integration-tests (13 jobs)
+                                       ├── extras (5 jobs)
+                                       ├── sdk
+                                       ├── cli-verify (conditional)
+                                       ├── publish (main only) ── notify-slack
+                                       └── verification-gate (aggregates all results)
 ```
 
-### Two Gating Systems
+### Centralized Decision (`decide` job)
 
-Every test phase is gated by **both**:
+A single `decide` job combines **lifecycle scope** (PR labels) and **change
+detection** (path-based filtering) into one boolean output per test phase.
+Every downstream job uses a single `if:` condition.
 
-1. **Lifecycle scope** (`determine-scope`): driven by PR labels from the
-   PR lifecycle orchestrator. WIP PRs run smoke tests only; `ready-for-review`
-   PRs run the full suite. Push to main always runs everything.
+**Lifecycle scope** is driven by PR labels from the PR lifecycle orchestrator:
+- `lifecycle/new` or no label → no tests
+- `lifecycle/wip` → smoke tests only (build + unit tests)
+- `lifecycle/ready-for-review` / `lifecycle/ready-to-merge` → full suite
+- Push to main → always full suite
 
-2. **Change detection** (`detect-changes`): uses `dorny/paths-filter` to
-   detect which areas of the codebase changed. Outputs 6 flags:
+**Change detection** uses `dorny/paths-filter` to determine which areas changed:
 
-   | Flag | Paths | Gates |
-   |------|-------|-------|
-   | `java` | `app/`, `common/`, `schema-*/`, `serdes/`, `config-index/`, `java-sdk/`, `mcp/`, `distro/`, `pom.xml` | unit-tests, extras |
-   | `ui` | `ui/` | extras |
-   | `integration` | `app/`, `common/`, `integration-tests/`, `schema-*/`, `serdes/`, `distro/`, `pom.xml` | integration-tests |
-   | `sdk` | `java-sdk/`, `go-sdk/`, `python-sdk/`, `typescript-sdk/` | sdk |
-   | `cli` | `cli/`, `java-sdk/`, `verify-cli.yaml` | cli-verify |
-   | `ci` | `.github/workflows/**` | all test phases |
+| Flag | Paths | Phases |
+|------|-------|--------|
+| `java` | `app/`, `common/`, `schema-*/`, `serdes/`, `config-index/`, `java-sdk/`, `mcp/`, `distro/`, `pom.xml` | build, unit-tests, extras, sdk |
+| `ui` | `ui/` | build, extras |
+| `integration` | `app/`, `common/`, `integration-tests/`, `schema-*/`, `serdes/`, `distro/`, `pom.xml` | integration-tests |
+| `sdk` | `java-sdk/`, `go-sdk/`, `python-sdk/`, `typescript-sdk/` | build, sdk |
+| `cli` | `cli/`, `java-sdk/`, `verify-cli.yaml` | build, cli-verify |
+| `ci` | `.github/workflows/**` | all test phases |
 
-   Docs-only or UI-only PRs skip Java unit tests and integration tests entirely.
-   Push to main always runs everything regardless of change detection.
+Docs-only or UI-only PRs skip Java unit tests and integration tests entirely.
+Push to main always runs everything regardless of change detection.
+
+### Verification Gate
+
+The `verification-gate` job is the **single required check** for branch protection.
+It runs with `if: always()` and aggregates all upstream results:
+
+- Any job **failed** → gate fails
+- PR in non-testable lifecycle state (`lifecycle/new`, etc.) → gate fails
+- All jobs passed or appropriately skipped → gate passes
+
+This replaces the previous approach of configuring 24 individual jobs as required
+checks, which caused skipped jobs to show as permanently pending.
 
 ## Unit Test Sharding
 
@@ -110,7 +125,7 @@ non-Java changes (docs, UI).
 
 | Workflow | Trigger | Purpose | Duration |
 |----------|---------|---------|----------|
-| `verify.yaml` | PR, push to main | Main orchestrator: gates and coordinates all phases | N/A |
+| `verify.yaml` | PR, push to main | Main orchestrator: `decide` job determines what to run, `verification-gate` is the single required check | N/A |
 | `verify-build.yaml` | Called by verify | Parallel Java (`mvnw package -T 0.5C`) + UI (`npm build`) builds. Produces Docker images and build artifacts uploaded with 1-day retention | ~6 min |
 | `verify-unit-tests.yaml` | Called by verify | Unit tests in 3 parallel shards (see above) | ~16 min (critical path) |
 | `verify-integration-tests.yaml` | Called by verify | 13-job matrix across storage backends, each with Minikube | ~15 min per job |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -38,7 +38,7 @@ Every downstream job uses a single `if:` condition.
 | `integration` | `app/`, `common/`, `integration-tests/`, `schema-*/`, `serdes/`, `distro/`, `pom.xml` | integration-tests |
 | `sdk` | `java-sdk/`, `go-sdk/`, `python-sdk/`, `typescript-sdk/` | build, sdk |
 | `cli` | `cli/`, `java-sdk/`, `verify-cli.yaml` | build, cli-verify |
-| `ci` | `.github/workflows/**` | all test phases |
+| `ci` | `.github/workflows/**` | all test phases except cli-verify |
 
 Docs-only or UI-only PRs skip Java unit tests and integration tests entirely.
 Push to main always runs everything regardless of change detection.

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -91,11 +91,15 @@ jobs:
             run_smoke=true
             run_full=true
           else
-            # Labeled events: only react to lifecycle label changes
+            # Non-lifecycle label events: skip the workflow run entirely.
+            # Unlike other PR events, we do NOT need to evaluate lifecycle
+            # state here — the workflow already ran (or will run) for the
+            # synchronize/opened event on the same SHA, so the gate result
+            # from that run is authoritative.
             if [ "$ACTION" = "labeled" ]; then
               LABEL='${{ github.event.label.name }}'
               if [[ "$LABEL" != lifecycle/* ]]; then
-                echo "lifecycle-ready=false" >> "$GITHUB_OUTPUT"
+                echo "lifecycle-ready=skip" >> "$GITHUB_OUTPUT"
                 for out in run-build run-unit-tests run-integration run-extras run-sdk run-cli; do
                   echo "$out=false" >> "$GITHUB_OUTPUT"
                 done
@@ -281,8 +285,10 @@ jobs:
             exit 1
           fi
 
-          # On PRs, fail if lifecycle state does not allow merging
-          if [ "$EVENT" != "push" ] && [ "$LIFECYCLE_READY" != "true" ]; then
+          # On PRs, fail if lifecycle state does not allow merging.
+          # "skip" means this run was triggered by a non-lifecycle label and
+          # is not authoritative — let it pass without blocking.
+          if [ "$EVENT" != "push" ] && [ "$LIFECYCLE_READY" != "true" ] && [ "$LIFECYCLE_READY" != "skip" ]; then
             echo "::error::PR is not in a testable lifecycle state"
             exit 1
           fi

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,17 +1,9 @@
 name: Verify
 on:
   push:
-    paths-ignore:
-      - '.gitignore'
-      - 'LICENSE'
-      - 'README*'
     branches: [main]
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-    paths-ignore:
-      - '.gitignore'
-      - 'LICENSE'
-      - 'README*'
     branches: [main]
 
 concurrency:
@@ -20,91 +12,24 @@ concurrency:
 
 jobs:
   # ============================================================================
-  # SCOPE: Determine which test phases to run based on lifecycle labels
+  # DECIDE: Centralized decision on what to run
+  #
+  # Combines lifecycle-label evaluation (PR readiness) with path-based change
+  # detection into a single set of per-phase boolean outputs.  Every downstream
+  # job references exactly one output instead of combining two jobs.
   # ============================================================================
-  determine-scope:
-    name: Determine Test Scope
+  decide:
+    name: Decide
     runs-on: ubuntu-latest
     if: github.repository_owner == 'Apicurio'
     outputs:
-      run_smoke: ${{ steps.scope.outputs.run_smoke }}
-      run_full: ${{ steps.scope.outputs.run_full }}
-    steps:
-      - name: Evaluate scope
-        id: scope
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          EVENT="${{ github.event_name }}"
-          ACTION="${{ github.event.action }}"
-
-          # Push events: always run full
-          if [ "$EVENT" = "push" ]; then
-            echo "run_smoke=true" >> $GITHUB_OUTPUT
-            echo "run_full=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # Labeled events: only react to lifecycle label changes
-          if [ "$ACTION" = "labeled" ]; then
-            LABEL='${{ github.event.label.name }}'
-            if [[ "$LABEL" != lifecycle/* ]]; then
-              echo "run_smoke=false" >> $GITHUB_OUTPUT
-              echo "run_full=false" >> $GITHUB_OUTPUT
-              exit 0
-            fi
-          fi
-
-          # Fetch current labels from the API instead of the event payload.
-          # The event payload labels are stale when the orchestrator adds
-          # lifecycle labels after the workflow has already started.
-          PR_NUMBER='${{ github.event.pull_request.number }}'
-          LABELS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '[.labels[].name]')
-          has_label() { echo "$LABELS" | jq -e "index(\"$1\")" > /dev/null 2>&1; }
-
-          if has_label "orchestrator/disabled"; then
-            # Orchestrator disabled: full tests, DO NOT MERGE backward compat
-            if has_label "DO NOT MERGE"; then
-              echo "run_smoke=false" >> $GITHUB_OUTPUT
-              echo "run_full=false" >> $GITHUB_OUTPUT
-            else
-              echo "run_smoke=true" >> $GITHUB_OUTPUT
-              echo "run_full=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            # Orchestrated PR: scope based on lifecycle state
-            if has_label "lifecycle/ready-for-review" || has_label "lifecycle/ready-to-merge"; then
-              echo "run_smoke=true" >> $GITHUB_OUTPUT
-              echo "run_full=true" >> $GITHUB_OUTPUT
-            elif has_label "lifecycle/wip"; then
-              if has_label "orchestrator/tests-disabled"; then
-                echo "run_smoke=false" >> $GITHUB_OUTPUT
-                echo "run_full=false" >> $GITHUB_OUTPUT
-              else
-                echo "run_smoke=true" >> $GITHUB_OUTPUT
-                echo "run_full=false" >> $GITHUB_OUTPUT
-              fi
-            else
-              # lifecycle/new or no lifecycle label: skip tests
-              echo "run_smoke=false" >> $GITHUB_OUTPUT
-              echo "run_full=false" >> $GITHUB_OUTPUT
-            fi
-          fi
-
-  # ============================================================================
-  # CHANGE DETECTION: Determine which areas of code changed
-  # ============================================================================
-  detect-changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'Apicurio'
-    outputs:
-      java: ${{ steps.filter.outputs.java }}
-      ui: ${{ steps.filter.outputs.ui }}
-      integration: ${{ steps.filter.outputs.integration }}
-      sdk: ${{ steps.filter.outputs.sdk }}
-      cli: ${{ steps.filter.outputs.cli }}
-      ci: ${{ steps.filter.outputs.ci }}
+      lifecycle-ready: ${{ steps.decide.outputs.lifecycle-ready }}
+      run-build: ${{ steps.decide.outputs.run-build }}
+      run-unit-tests: ${{ steps.decide.outputs.run-unit-tests }}
+      run-integration: ${{ steps.decide.outputs.run-integration }}
+      run-extras: ${{ steps.decide.outputs.run-extras }}
+      run-sdk: ${{ steps.decide.outputs.run-sdk }}
+      run-cli: ${{ steps.decide.outputs.run-cli }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -150,14 +75,103 @@ jobs:
             ci:
               - '.github/workflows/**'
 
+      - name: Evaluate scope and decide
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EVENT="${{ github.event_name }}"
+          ACTION="${{ github.event.action }}"
+
+          # ── Phase 1: Lifecycle scope ──────────────────────────────────
+          run_smoke=false
+          run_full=false
+
+          if [ "$EVENT" = "push" ]; then
+            run_smoke=true
+            run_full=true
+          else
+            # Labeled events: only react to lifecycle label changes
+            if [ "$ACTION" = "labeled" ]; then
+              LABEL='${{ github.event.label.name }}'
+              if [[ "$LABEL" != lifecycle/* ]]; then
+                echo "lifecycle-ready=false" >> "$GITHUB_OUTPUT"
+                for out in run-build run-unit-tests run-integration run-extras run-sdk run-cli; do
+                  echo "$out=false" >> "$GITHUB_OUTPUT"
+                done
+                exit 0
+              fi
+            fi
+
+            # Fetch current labels from the API (event payload can be stale)
+            PR_NUMBER='${{ github.event.pull_request.number }}'
+            LABELS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '[.labels[].name]')
+            has_label() { echo "$LABELS" | jq -e "index(\"$1\")" > /dev/null 2>&1; }
+
+            if has_label "orchestrator/disabled"; then
+              if has_label "DO NOT MERGE"; then
+                run_smoke=false; run_full=false
+              else
+                run_smoke=true; run_full=true
+              fi
+            else
+              if has_label "lifecycle/ready-for-review" || has_label "lifecycle/ready-to-merge"; then
+                run_smoke=true; run_full=true
+              elif has_label "lifecycle/wip"; then
+                if has_label "orchestrator/tests-disabled"; then
+                  run_smoke=false; run_full=false
+                else
+                  run_smoke=true; run_full=false
+                fi
+              else
+                # lifecycle/new or no lifecycle label
+                run_smoke=false; run_full=false
+              fi
+            fi
+          fi
+
+          # ── Phase 2: Read change-detection results ────────────────────
+          JAVA='${{ steps.filter.outputs.java }}'
+          UI='${{ steps.filter.outputs.ui }}'
+          INTEGRATION='${{ steps.filter.outputs.integration }}'
+          SDK='${{ steps.filter.outputs.sdk }}'
+          CLI='${{ steps.filter.outputs.cli }}'
+          CI='${{ steps.filter.outputs.ci }}'
+
+          # ── Phase 3: Combine scope + changes into per-phase decisions ─
+          # decide <output-name> <scope-flag> <change-flags...>
+          # Outputs true when scope is active AND at least one flag is true.
+          decide() {
+            local name="$1" scope="$2"; shift 2
+            if [ "$scope" != "true" ]; then
+              echo "$name=false" >> "$GITHUB_OUTPUT"; return
+            fi
+            for flag in "$@"; do
+              if [ "$flag" = "true" ]; then
+                echo "$name=true" >> "$GITHUB_OUTPUT"; return
+              fi
+            done
+            echo "$name=false" >> "$GITHUB_OUTPUT"
+          }
+
+          IS_PUSH=$( [ "$EVENT" = "push" ] && echo true || echo false )
+
+          echo "lifecycle-ready=$run_smoke" >> "$GITHUB_OUTPUT"
+          decide run-build       "$run_smoke" "$IS_PUSH" "$JAVA" "$UI" "$SDK" "$CLI" "$CI"
+          decide run-unit-tests  "$run_smoke" "$IS_PUSH" "$JAVA" "$CI"
+          decide run-integration "$run_full"  "$IS_PUSH" "$INTEGRATION" "$CI"
+          decide run-extras      "$run_full"  "$IS_PUSH" "$JAVA" "$UI" "$CI"
+          decide run-sdk         "$run_full"  "$IS_PUSH" "$SDK" "$JAVA" "$CI"
+          decide run-cli         "$run_full"  "$CLI"
+
   # ============================================================================
   # PHASE 1: Fast Checks (fail early)
   # ============================================================================
   lint-and-validate:
     name: Lint and Validate
     runs-on: ubuntu-22.04
-    needs: determine-scope
-    if: needs.determine-scope.outputs.run_smoke == 'true'
+    needs: decide
+    if: needs.decide.outputs.lifecycle-ready == 'true'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -175,113 +189,108 @@ jobs:
 
   # ============================================================================
   # PHASE 2: Build (parallel Java + UI builds)
-  # Gated by lifecycle scope AND change detection.
   # ============================================================================
   build:
     name: Build
-    needs: [determine-scope, lint-and-validate, detect-changes]
-    if: >-
-      needs.determine-scope.outputs.run_smoke == 'true' &&
-      (
-        github.event_name == 'push' ||
-        needs.detect-changes.outputs.java == 'true' ||
-        needs.detect-changes.outputs.ui == 'true' ||
-        needs.detect-changes.outputs.sdk == 'true' ||
-        needs.detect-changes.outputs.cli == 'true' ||
-        needs.detect-changes.outputs.ci == 'true'
-      )
+    needs: [decide, lint-and-validate]
+    if: needs.decide.outputs.run-build == 'true'
     uses: ./.github/workflows/verify-build.yaml
 
   # ============================================================================
   # PHASE 3: Unit Tests
-  # Requires smoke scope. Skip when only docs/UI changed.
   # ============================================================================
   unit-tests:
     name: Unit Tests
-    needs: [determine-scope, build, detect-changes]
-    if: >-
-      needs.determine-scope.outputs.run_smoke == 'true' &&
-      (
-        github.event_name == 'push' ||
-        needs.detect-changes.outputs.java == 'true' ||
-        needs.detect-changes.outputs.ci == 'true'
-      )
+    needs: [decide, build]
+    if: needs.decide.outputs.run-unit-tests == 'true'
     uses: ./.github/workflows/verify-unit-tests.yaml
     with:
       image-tag: ${{ github.sha }}
 
   # ============================================================================
-  # CLI Verification (conditional on CLI/SDK changes + full scope)
+  # CLI Verification
   # ============================================================================
   cli-verify:
     name: CLI Verification
-    needs: [determine-scope, build, detect-changes]
-    if: >-
-      needs.determine-scope.outputs.run_full == 'true' &&
-      needs.detect-changes.outputs.cli == 'true'
+    needs: [decide, build]
+    if: needs.decide.outputs.run-cli == 'true'
     uses: ./.github/workflows/verify-cli.yaml
     with:
       image-tag: ${{ github.sha }}
 
   # ============================================================================
   # PHASE 4: Integration Tests (matrix-based parallel execution)
-  # Requires full scope. Skip when only docs/UI/SDK changed.
-  # Uses reduced matrix on PRs.
   # ============================================================================
   integration-tests:
     name: Integration Tests
-    needs: [determine-scope, build, detect-changes]
-    if: >-
-      needs.determine-scope.outputs.run_full == 'true' &&
-      (
-        github.event_name == 'push' ||
-        needs.detect-changes.outputs.integration == 'true' ||
-        needs.detect-changes.outputs.ci == 'true'
-      )
+    needs: [decide, build]
+    if: needs.decide.outputs.run-integration == 'true'
     uses: ./.github/workflows/verify-integration-tests.yaml
     with:
       image-tag: ${{ github.sha }}
 
   # ============================================================================
   # PHASE 5: Additional Tests (parallel)
-  # Requires full scope. Skip when only docs changed.
   # ============================================================================
   extras:
     name: Extra Tests
-    needs: [determine-scope, build, detect-changes]
-    if: >-
-      needs.determine-scope.outputs.run_full == 'true' &&
-      (
-        github.event_name == 'push' ||
-        needs.detect-changes.outputs.java == 'true' ||
-        needs.detect-changes.outputs.ui == 'true' ||
-        needs.detect-changes.outputs.ci == 'true'
-      )
+    needs: [decide, build]
+    if: needs.decide.outputs.run-extras == 'true'
     uses: ./.github/workflows/verify-extras.yaml
     with:
       image-tag: ${{ github.sha }}
 
   # ============================================================================
   # PHASE 6: SDK Verification (parallel)
-  # Requires full scope. Only when SDK/Java files changed.
   # ============================================================================
   sdk:
     name: SDK Verification
-    needs: [determine-scope, build, detect-changes]
-    if: >-
-      needs.determine-scope.outputs.run_full == 'true' &&
-      (
-        github.event_name == 'push' ||
-        needs.detect-changes.outputs.sdk == 'true' ||
-        needs.detect-changes.outputs.java == 'true' ||
-        needs.detect-changes.outputs.ci == 'true'
-      )
+    needs: [decide, build]
+    if: needs.decide.outputs.run-sdk == 'true'
     uses: ./.github/workflows/verify-sdk.yaml
     with:
       image-tag: ${{ github.sha }}
 
   # ============================================================================
-  # PHASE 7: Publish Images (only on push to main)
+  # VERIFICATION GATE: Single required check for branch protection
+  #
+  # Aggregates results from all test phases.  Passes when every upstream job
+  # either succeeded or was appropriately skipped by change detection.
+  # Fails when any job failed, or when the PR lifecycle state does not allow
+  # merging (lifecycle/new, DO NOT MERGE, etc.).
+  # ============================================================================
+  verification-gate:
+    name: Verification Gate
+    if: always()
+    needs: [decide, lint-and-validate, build, unit-tests, cli-verify,
+            integration-tests, extras, sdk]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate gate
+        env:
+          LIFECYCLE_READY: ${{ needs.decide.outputs.lifecycle-ready }}
+          EVENT: ${{ github.event_name }}
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          echo "Job results: $RESULTS"
+
+          # Fail if any upstream job failed or was cancelled
+          FAILED=$(echo "$RESULTS" | jq '[.[] | select(. != "success" and . != "skipped")] | length')
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::One or more required jobs failed or were cancelled"
+            exit 1
+          fi
+
+          # On PRs, fail if lifecycle state does not allow merging
+          if [ "$EVENT" != "push" ] && [ "$LIFECYCLE_READY" != "true" ]; then
+            echo "::error::PR is not in a testable lifecycle state"
+            exit 1
+          fi
+
+          echo "All checks passed"
+
+  # ============================================================================
+  # PUBLISH: Push images (only on push to main)
   # ============================================================================
   publish:
     name: Publish Images
@@ -297,7 +306,7 @@ jobs:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   # ============================================================================
-  # PHASE 8: Notifications (using reusable workflow)
+  # NOTIFICATIONS
   # ============================================================================
   notify-slack:
     name: Slack Notification


### PR DESCRIPTION
## Summary

- Merge `determine-scope` and `detect-changes` into a single `decide` job that outputs one boolean per test phase
- Add `verification-gate` job that aggregates all upstream results into a single required check for branch protection
- Remove `paths-ignore` so the gate always runs (the `decide` job handles all skip logic)
- Simplify all downstream `if:` conditions from compound expressions to single output references

Fixes #7933

## Rollout

1. Merge this PR — the Verification Gate job starts appearing
2. Add `Verification Gate` to required checks in branch protection (alongside existing 24)
3. Validate on a few PRs that skipping works correctly
4. Remove the 24 individual checks, keeping only `Verification Gate`

## Test plan

- [ ] PR touching only CLI files: unit-tests/integration/extras/sdk skipped, gate passes
- [ ] PR touching only README: all tests skipped, gate passes
- [ ] `lifecycle/new` PR: gate fails (blocks merge)
- [ ] `lifecycle/wip` PR: only smoke tests run, gate passes
- [ ] `lifecycle/ready-for-review` PR: full suite runs
- [ ] Push to main: everything runs