### PR TITLE
feat(ci): test plan comment and auto-merge review warning

### DIFF
--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -940,9 +940,17 @@ async function handleTestResult({ github, context, core }) {
 }
 
 async function postDecisionSummary(github, owner, repo, workflowRun, prNumber, core) {
+  const DECISION_KEYS = new Set([
+    'lifecycle-ready', 'run-build', 'run-unit-tests',
+    'run-integration', 'run-extras', 'run-sdk', 'run-cli',
+  ]);
+  const CHANGES_KEYS = new Set(['java', 'ui', 'integration', 'sdk', 'cli', 'ci']);
+  const ALLOWED_VALUES = new Set(['true', 'false', 'skip']);
+  const EXPECTED_FILES = new Set(['verify-decisions.json', 'verify-changes.json']);
+  const MAX_ARTIFACT_BYTES = 10240;
 
   try {
-    // Find the decisions artifact from the workflow run
+    // ── Load decisions from artifact (hardened) ───────────────────────
     const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
       owner, repo, run_id: workflowRun.id,
     });
@@ -951,31 +959,63 @@ async function postDecisionSummary(github, owner, repo, workflowRun, prNumber, c
       core.info(`No verify-decisions artifact found for run ${workflowRun.id}, skipping summary`);
       return;
     }
+    if (artifact.size_in_bytes > MAX_ARTIFACT_BYTES) {
+      core.warning(`Decision artifact too large (${artifact.size_in_bytes} bytes), skipping`);
+      return;
+    }
 
-    // Download and extract artifact
     const { data: zip } = await github.rest.actions.downloadArtifact({
       owner, repo, artifact_id: artifact.id, archive_format: 'zip',
     });
 
-    // Extract zip using Node built-ins
     const os = require('os');
     const { execSync } = require('child_process');
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-decisions-'));
     const zipPath = path.join(tmpDir, 'artifact.zip');
     fs.writeFileSync(zipPath, Buffer.from(zip));
+
+    // Validate zip entries before extracting
+    const listing = execSync(`unzip -l "${zipPath}"`, { encoding: 'utf8' });
+    const entryLines = listing.split('\n').filter(l => l.includes('.json'));
+    for (const line of entryLines) {
+      const entry = line.trim().split(/\s+/).pop();
+      if (entry.includes('..') || path.isAbsolute(entry)) {
+        core.warning(`Suspicious path in artifact: ${entry}, skipping`);
+        return;
+      }
+    }
+
     execSync(`unzip -o "${zipPath}" -d "${tmpDir}"`, { stdio: 'ignore' });
 
-    const decisionsPath = path.join(tmpDir, 'verify-decisions.json');
-    const changesPath = path.join(tmpDir, 'verify-changes.json');
-    if (!fs.existsSync(decisionsPath) || !fs.existsSync(changesPath)) {
-      core.info('Decision artifact missing expected files, skipping summary');
+    // Validate extracted files
+    const jsonFiles = fs.readdirSync(tmpDir).filter(f => f.endsWith('.json') && f !== 'artifact.zip');
+    for (const f of jsonFiles) {
+      if (!EXPECTED_FILES.has(f)) {
+        core.warning(`Unexpected file in artifact: ${f}, skipping`);
+        return;
+      }
+    }
+
+    function parseAndValidate(filePath, allowedKeys) {
+      if (!fs.existsSync(filePath)) return null;
+      const raw = fs.readFileSync(filePath, 'utf8');
+      if (raw.length > 1024) return null;
+      const obj = JSON.parse(raw);
+      if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) return null;
+      for (const [key, value] of Object.entries(obj)) {
+        if (!allowedKeys.has(key) || !ALLOWED_VALUES.has(String(value))) return null;
+      }
+      return obj;
+    }
+
+    const decisions = parseAndValidate(path.join(tmpDir, 'verify-decisions.json'), DECISION_KEYS);
+    const changes = parseAndValidate(path.join(tmpDir, 'verify-changes.json'), CHANGES_KEYS);
+    if (!decisions) {
+      core.warning('Decision JSON missing or invalid, skipping summary');
       return;
     }
 
-    const decisions = JSON.parse(fs.readFileSync(decisionsPath, 'utf8'));
-    const changes = JSON.parse(fs.readFileSync(changesPath, 'utf8'));
-
-    // Fetch actual job results from the workflow run
+    // ── Fetch actual job results ──────────────────────────────────────
     const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
       owner, repo, run_id: workflowRun.id, per_page: 100,
     });
@@ -1012,25 +1052,31 @@ async function postDecisionSummary(github, owner, repo, workflowRun, prNumber, c
       `| ${label} | ${icon(decisions[key], jobResult(jobPrefix))} |`
     );
 
-    const body = [
+    const bodyParts = [
       '<!-- verify-decide-summary -->',
       `**Verify — ${conclusion}** ([run](${workflowRun.html_url}))`,
       '',
       '| Phase | Status |',
       '|-------|--------|',
       ...rows,
-      '',
-      '<details><summary>Change detection</summary>',
-      '',
-      Object.entries(changes)
-        .filter(([k]) => ['java', 'ui', 'integration', 'sdk', 'cli', 'ci'].includes(k))
-        .map(([k, v]) => `${k}: \`${v}\``)
-        .join(', '),
-      '</details>',
-    ].join('\n');
+    ];
 
-    // Update existing comment or create new one
-    const { data: comments } = await github.rest.issues.listComments({
+    if (changes) {
+      bodyParts.push(
+        '',
+        '<details><summary>Change detection</summary>',
+        '',
+        Object.entries(changes)
+          .map(([k, v]) => `${k}: \`${v}\``)
+          .join(', '),
+        '</details>',
+      );
+    }
+
+    const body = bodyParts.join('\n');
+
+    // ── Post or update comment (paginated lookup) ────────────────────
+    const comments = await github.paginate(github.rest.issues.listComments, {
       owner, repo, issue_number: prNumber, per_page: 100,
     });
     const existing = comments.find(c => c.body?.includes('<!-- verify-decide-summary -->'));

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -933,6 +933,116 @@ async function handleTestResult({ github, context, core }) {
       );
       core.info(`PR #${pr.number} tests failed`);
     }
+
+    // Post or update the decision summary comment
+    await postDecisionSummary(github, owner, repo, workflowRun, pr.number, core);
+  }
+}
+
+async function postDecisionSummary(github, owner, repo, workflowRun, prNumber, core) {
+
+  try {
+    // Find the decisions artifact from the workflow run
+    const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
+      owner, repo, run_id: workflowRun.id,
+    });
+    const artifact = artifacts.find(a => a.name === 'verify-decisions');
+    if (!artifact) {
+      core.info(`No verify-decisions artifact found for run ${workflowRun.id}, skipping summary`);
+      return;
+    }
+
+    // Download and extract artifact
+    const { data: zip } = await github.rest.actions.downloadArtifact({
+      owner, repo, artifact_id: artifact.id, archive_format: 'zip',
+    });
+
+    // Extract zip using Node built-ins
+    const os = require('os');
+    const { execSync } = require('child_process');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-decisions-'));
+    const zipPath = path.join(tmpDir, 'artifact.zip');
+    fs.writeFileSync(zipPath, Buffer.from(zip));
+    execSync(`unzip -o "${zipPath}" -d "${tmpDir}"`, { stdio: 'ignore' });
+
+    const decisionsPath = path.join(tmpDir, 'verify-decisions.json');
+    const changesPath = path.join(tmpDir, 'verify-changes.json');
+    if (!fs.existsSync(decisionsPath) || !fs.existsSync(changesPath)) {
+      core.info('Decision artifact missing expected files, skipping summary');
+      return;
+    }
+
+    const decisions = JSON.parse(fs.readFileSync(decisionsPath, 'utf8'));
+    const changes = JSON.parse(fs.readFileSync(changesPath, 'utf8'));
+
+    // Fetch actual job results from the workflow run
+    const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+      owner, repo, run_id: workflowRun.id, per_page: 100,
+    });
+
+    const jobResult = (namePrefix) => {
+      const matching = jobs.filter(j => j.name.startsWith(namePrefix));
+      if (!matching.length) return 'skipped';
+      if (matching.some(j => j.conclusion === 'failure')) return 'failure';
+      if (matching.every(j => j.conclusion === 'success')) return 'success';
+      if (matching.every(j => j.conclusion === 'skipped')) return 'skipped';
+      return 'mixed';
+    };
+
+    const icon = (planned, result) => {
+      if (planned !== 'true') return '➖';
+      if (result === 'success') return '🟢';
+      if (result === 'failure') return '🔴';
+      return '🟡';
+    };
+
+    const conclusion = workflowRun.conclusion === 'success' ? '✅ passed' : '❌ failed';
+
+    const phases = [
+      ['Lint and Validate', 'lifecycle-ready', 'Lint and Validate'],
+      ['Build', 'run-build', 'Build /'],
+      ['Unit Tests', 'run-unit-tests', 'Unit Tests /'],
+      ['Integration Tests', 'run-integration', 'Integration Tests /'],
+      ['Extra Tests', 'run-extras', 'Extra Tests /'],
+      ['SDK Verification', 'run-sdk', 'SDK Verification /'],
+      ['CLI Verification', 'run-cli', 'CLI Verification'],
+    ];
+
+    const rows = phases.map(([label, key, jobPrefix]) =>
+      `| ${label} | ${icon(decisions[key], jobResult(jobPrefix))} |`
+    );
+
+    const body = [
+      '<!-- verify-decide-summary -->',
+      `**Verify — ${conclusion}** ([run](${workflowRun.html_url}))`,
+      '',
+      '| Phase | Status |',
+      '|-------|--------|',
+      ...rows,
+      '',
+      '<details><summary>Change detection</summary>',
+      '',
+      Object.entries(changes)
+        .filter(([k]) => ['java', 'ui', 'integration', 'sdk', 'cli', 'ci'].includes(k))
+        .map(([k, v]) => `${k}: \`${v}\``)
+        .join(', '),
+      '</details>',
+    ].join('\n');
+
+    // Update existing comment or create new one
+    const { data: comments } = await github.rest.issues.listComments({
+      owner, repo, issue_number: prNumber, per_page: 100,
+    });
+    const existing = comments.find(c => c.body?.includes('<!-- verify-decide-summary -->'));
+
+    if (existing) {
+      await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+    } else {
+      await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+    }
+    core.info(`PR #${prNumber} decision summary posted`);
+  } catch (err) {
+    core.warning(`Failed to post decision summary: ${err.message}`);
   }
 }
 

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -652,9 +652,15 @@ async function cmdAutoMerge(api, config, core, pr, actor, maintainer, commentId)
   await api.addLabel(pr.number, LABELS.AUTO_MERGE);
   await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
   await api.addReaction(commentId, '+1');
+
+  const approved = isApproved(await api.getReviews(pr.number));
+  const reviewSkipped = hasLabel(pr, LABELS.REVIEW_SKIPPED);
+  const needsReview = !approved && !reviewSkipped;
+
   await api.postComment(pr.number,
     `Auto-merge enabled by @${actor}. This PR will be merged automatically ` +
-    `when it reaches \`lifecycle/ready-to-merge\` state. Use \`/auto-merge\` again to disable.`
+    `when it reaches \`lifecycle/ready-to-merge\` state. Use \`/auto-merge\` again to disable.` +
+    (needsReview ? `\n\n**Note:** A review or \`/skip-review\` is still required before auto-merge can proceed.` : '')
   );
 
   if (state === LABELS.READY_TO_MERGE) {

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -295,30 +295,10 @@ function isApproved(reviews) {
   return hasApproval && !hasChangesRequested;
 }
 
-function isForkPr(pr) {
-  return pr.head?.repo?.full_name !== pr.base?.repo?.full_name;
-}
-
-function mergeHint(pr) {
-  return isForkPr(pr)
-    ? 'This is a fork PR — a maintainer must merge manually via the GitHub UI.'
-    : 'A maintainer can use `/merge` to merge, or `/auto-merge` to merge automatically once approved and tested.';
-}
-
 async function performMerge(api, config, pr, core) {
   const freshPr = await api.getPr(pr.number);
   if (!hasLabel(freshPr, LABELS.TESTED) || !hasLabel(freshPr, LABELS.READY_TO_MERGE)) {
     core.warning(`PR #${pr.number} merge aborted: state changed since merge was initiated`);
-    return false;
-  }
-
-  if (isForkPr(freshPr)) {
-    await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-    await api.postComment(pr.number,
-      `This PR is from a fork and cannot be auto-merged due to GitHub token restrictions. ` +
-      `A maintainer must merge it manually.`
-    );
-    core.info(`PR #${pr.number} is from a fork, skipping auto-merge`);
     return false;
   }
 
@@ -331,13 +311,16 @@ async function performMerge(api, config, pr, core) {
     core.info(`PR #${pr.number} merged using ${strategy}`);
     return true;
   } catch (e) {
+    const workflowHint = e.message?.includes('workflow')
+      ? ' This PR modifies workflow files and requires manual merge via the GitHub UI (the `workflow` token scope is not available to GitHub Actions).'
+      : '';
     await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
     await api.removeLabel(pr.number, LABELS.TESTED);
     await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
     await api.postComment(pr.number,
       `Merge failed: ${e.message}\n\n` +
-      `Reverted to \`lifecycle/ready-for-review\`. The branch may need to be rebased. ` +
-      `Use \`/auto-merge\` to merge automatically once approved and tested.`
+      `Reverted to \`lifecycle/ready-for-review\`.${workflowHint}` +
+      (workflowHint ? '' : ` The branch may need to be rebased. Use \`/auto-merge\` to merge automatically once approved and tested.`)
     );
     core.error(`PR #${pr.number} merge failed: ${e.message}`);
     return false;
@@ -356,9 +339,7 @@ async function checkAndTransitionToReady(api, pr, core) {
     await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
     await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
 
-    const fork = isForkPr(pr);
-
-    if (!fork && hasLabel(pr, LABELS.AUTO_MERGE)) {
+    if (hasLabel(pr, LABELS.AUTO_MERGE)) {
       core.info(`PR #${pr.number} auto-merge enabled, will merge`);
       return 'auto-merge';
     }
@@ -375,7 +356,8 @@ async function checkAndTransitionToReady(api, pr, core) {
     const mentionSuffix = mentions ? ` ${mentions}` : '';
 
     await api.postComment(pr.number,
-      `This PR is approved and tested.${mentionSuffix} ${mergeHint(pr)}`
+      `This PR is approved and tested.${mentionSuffix} A maintainer can merge it with \`/merge\`, ` +
+      `or enable auto-merge with \`/auto-merge\`.`
     );
     core.info(`PR #${pr.number} is ready to merge`);
     return 'ready-to-merge';
@@ -397,8 +379,8 @@ async function handlePrOpened({ github, context, core }) {
     const initialState = pr.draft ? LABELS.WIP : LABELS.READY_FOR_REVIEW;
     await api.addLabel(pr.number, initialState);
     const maintainerHint = isMaintainer(config, pr.user.login)
-      ? `\n\nA maintainer can use \`/skip-review\` to skip the review requirement for small changes. ` +
-        mergeHint(pr)
+      ? `\n\nA maintainer can use \`/skip-review\` to skip the review requirement for small changes, ` +
+        `or \`/auto-merge\` to merge automatically once approved and tested.`
       : '';
     if (pr.draft) {
       await api.postComment(pr.number,
@@ -499,7 +481,7 @@ async function handlePrReadyForReview({ github, context, core }) {
   await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
   await api.postComment(pr.number,
     `PR is now ready for review. The full test suite will run.\n\n` +
-    mergeHint(pr)
+    `A maintainer can use \`/auto-merge\` to merge automatically once approved and tested.`
   );
   core.info(`PR #${pr.number} transitioned to ready-for-review (draft->ready)`);
   await retriggerVerify(api, pr, core);
@@ -632,7 +614,7 @@ async function cmdReady(api, config, core, pr, actor, isAuthor, maintainer, comm
   await api.addReaction(commentId, '+1');
   await api.postComment(pr.number,
     `PR marked as ready for review. The full test suite will run.\n\n` +
-    mergeHint(pr)
+    `A maintainer can use \`/auto-merge\` to merge automatically once approved and tested.`
   );
   core.info(`PR #${pr.number} marked ready by ${actor}`);
   await retriggerVerify(api, pr, core);
@@ -642,15 +624,6 @@ async function cmdMerge(api, config, core, pr, actor, maintainer, commentId) {
   if (!maintainer) {
     await api.addReaction(commentId, '-1');
     await api.postComment(pr.number, `@${actor} Only maintainers can merge PRs.`);
-    return;
-  }
-
-  if (isForkPr(pr)) {
-    await api.addReaction(commentId, 'confused');
-    await api.postComment(pr.number,
-      `@${actor} The \`/merge\` command is not available for fork PRs due to GitHub token restrictions. ` +
-      `Please merge manually via the GitHub UI.`
-    );
     return;
   }
 
@@ -680,15 +653,6 @@ async function cmdAutoMerge(api, config, core, pr, actor, maintainer, commentId)
     await api.addReaction(commentId, 'confused');
     await api.postComment(pr.number,
       `@${actor} Cannot enable auto-merge: PR must be accepted first.`
-    );
-    return;
-  }
-
-  if (isForkPr(pr)) {
-    await api.addReaction(commentId, 'confused');
-    await api.postComment(pr.number,
-      `@${actor} Auto-merge is not available for fork PRs due to GitHub token restrictions. ` +
-      `A maintainer must merge manually via the GitHub UI once the PR reaches \`lifecycle/ready-to-merge\`.`
     );
     return;
   }

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -295,12 +295,33 @@ function isApproved(reviews) {
   return hasApproval && !hasChangesRequested;
 }
 
+function isForkPr(pr) {
+  return pr.head?.repo?.full_name !== pr.base?.repo?.full_name;
+}
+
+function mergeHint(pr) {
+  return isForkPr(pr)
+    ? 'This is a fork PR — a maintainer must merge manually via the GitHub UI.'
+    : 'A maintainer can use `/merge` to merge, or `/auto-merge` to merge automatically once approved and tested.';
+}
+
 async function performMerge(api, config, pr, core) {
   const freshPr = await api.getPr(pr.number);
   if (!hasLabel(freshPr, LABELS.TESTED) || !hasLabel(freshPr, LABELS.READY_TO_MERGE)) {
     core.warning(`PR #${pr.number} merge aborted: state changed since merge was initiated`);
     return false;
   }
+
+  if (isForkPr(freshPr)) {
+    await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+    await api.postComment(pr.number,
+      `This PR is from a fork and cannot be auto-merged due to GitHub token restrictions. ` +
+      `A maintainer must merge it manually.`
+    );
+    core.info(`PR #${pr.number} is from a fork, skipping auto-merge`);
+    return false;
+  }
+
   const strategy = config.merge?.strategy || 'rebase';
   try {
     await api.mergePr(pr.number, strategy, freshPr.title);
@@ -335,13 +356,26 @@ async function checkAndTransitionToReady(api, pr, core) {
     await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
     await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
 
-    if (hasLabel(pr, LABELS.AUTO_MERGE)) {
+    const fork = isForkPr(pr);
+
+    if (!fork && hasLabel(pr, LABELS.AUTO_MERGE)) {
       core.info(`PR #${pr.number} auto-merge enabled, will merge`);
       return 'auto-merge';
     }
+
+    // Ping reviewers/requested reviewers so they know the PR is ready
+    const reviews = await api.getReviews(pr.number);
+    const reviewerLogins = [...new Set(reviews.map(r => r.user.login))];
+    const requestedLogins = (pr.requested_reviewers || []).map(r => r.login);
+    const allReviewers = [...new Set([...reviewerLogins, ...requestedLogins])];
+    const mentions = allReviewers
+      .filter(login => login !== pr.user.login)
+      .map(login => `@${login}`)
+      .join(' ');
+    const mentionSuffix = mentions ? ` ${mentions}` : '';
+
     await api.postComment(pr.number,
-      `This PR is approved and tested. A maintainer can merge it with \`/merge\`, ` +
-      `or enable auto-merge with \`/auto-merge\`.`
+      `This PR is approved and tested.${mentionSuffix} ${mergeHint(pr)}`
     );
     core.info(`PR #${pr.number} is ready to merge`);
     return 'ready-to-merge';
@@ -363,8 +397,8 @@ async function handlePrOpened({ github, context, core }) {
     const initialState = pr.draft ? LABELS.WIP : LABELS.READY_FOR_REVIEW;
     await api.addLabel(pr.number, initialState);
     const maintainerHint = isMaintainer(config, pr.user.login)
-      ? `\n\nA maintainer can use \`/skip-review\` to skip the review requirement for small changes, ` +
-        `or \`/auto-merge\` to merge automatically once approved and tested.`
+      ? `\n\nA maintainer can use \`/skip-review\` to skip the review requirement for small changes. ` +
+        mergeHint(pr)
       : '';
     if (pr.draft) {
       await api.postComment(pr.number,
@@ -465,7 +499,7 @@ async function handlePrReadyForReview({ github, context, core }) {
   await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
   await api.postComment(pr.number,
     `PR is now ready for review. The full test suite will run.\n\n` +
-    `A maintainer can use \`/auto-merge\` to merge automatically once approved and tested.`
+    mergeHint(pr)
   );
   core.info(`PR #${pr.number} transitioned to ready-for-review (draft->ready)`);
   await retriggerVerify(api, pr, core);
@@ -598,7 +632,7 @@ async function cmdReady(api, config, core, pr, actor, isAuthor, maintainer, comm
   await api.addReaction(commentId, '+1');
   await api.postComment(pr.number,
     `PR marked as ready for review. The full test suite will run.\n\n` +
-    `A maintainer can use \`/auto-merge\` to merge automatically once approved and tested.`
+    mergeHint(pr)
   );
   core.info(`PR #${pr.number} marked ready by ${actor}`);
   await retriggerVerify(api, pr, core);
@@ -608,6 +642,15 @@ async function cmdMerge(api, config, core, pr, actor, maintainer, commentId) {
   if (!maintainer) {
     await api.addReaction(commentId, '-1');
     await api.postComment(pr.number, `@${actor} Only maintainers can merge PRs.`);
+    return;
+  }
+
+  if (isForkPr(pr)) {
+    await api.addReaction(commentId, 'confused');
+    await api.postComment(pr.number,
+      `@${actor} The \`/merge\` command is not available for fork PRs due to GitHub token restrictions. ` +
+      `Please merge manually via the GitHub UI.`
+    );
     return;
   }
 
@@ -637,6 +680,15 @@ async function cmdAutoMerge(api, config, core, pr, actor, maintainer, commentId)
     await api.addReaction(commentId, 'confused');
     await api.postComment(pr.number,
       `@${actor} Cannot enable auto-merge: PR must be accepted first.`
+    );
+    return;
+  }
+
+  if (isForkPr(pr)) {
+    await api.addReaction(commentId, 'confused');
+    await api.postComment(pr.number,
+      `@${actor} Auto-merge is not available for fork PRs due to GitHub token restrictions. ` +
+      `A maintainer must merge manually via the GitHub UI once the PR reaches \`lifecycle/ready-to-merge\`.`
     );
     return;
   }

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -169,7 +169,7 @@ jobs:
           decide run-cli         "$run_full"  "$CLI"
 
       - name: Save decision summary
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.decide.outputs.lifecycle-ready != 'skip'
         run: |
           cat > /tmp/verify-decisions.json <<'DECISIONS_EOF'
           ${{ toJSON(steps.decide.outputs) }}
@@ -179,7 +179,7 @@ jobs:
           CHANGES_EOF
 
       - name: Upload decision summary
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.decide.outputs.lifecycle-ready != 'skip'
         uses: actions/upload-artifact@v4
         with:
           name: verify-decisions

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -168,46 +168,25 @@ jobs:
           decide run-sdk         "$run_full"  "$IS_PUSH" "$SDK" "$JAVA" "$CI"
           decide run-cli         "$run_full"  "$CLI"
 
-      - name: Post decision summary
+      - name: Save decision summary
         if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          icon() { if [ "$1" = "true" ]; then echo "🟢"; else echo "➖"; fi; }
+          cat > /tmp/verify-decisions.json <<'DECISIONS_EOF'
+          ${{ toJSON(steps.decide.outputs) }}
+          DECISIONS_EOF
+          cat > /tmp/verify-changes.json <<'CHANGES_EOF'
+          ${{ toJSON(steps.filter.outputs) }}
+          CHANGES_EOF
 
-          BODY=$(cat <<EOF
-          <!-- verify-decide-summary -->
-          **Verify — test plan for this run:**
-
-          | Phase | Status |
-          |-------|--------|
-          | Lint and Validate | $(icon "${{ steps.decide.outputs.lifecycle-ready }}") |
-          | Build | $(icon "${{ steps.decide.outputs.run-build }}") |
-          | Unit Tests | $(icon "${{ steps.decide.outputs.run-unit-tests }}") |
-          | Integration Tests | $(icon "${{ steps.decide.outputs.run-integration }}") |
-          | Extra Tests | $(icon "${{ steps.decide.outputs.run-extras }}") |
-          | SDK Verification | $(icon "${{ steps.decide.outputs.run-sdk }}") |
-          | CLI Verification | $(icon "${{ steps.decide.outputs.run-cli }}") |
-
-          <details><summary>Change detection</summary>
-
-          java: \`${{ steps.filter.outputs.java }}\`, ui: \`${{ steps.filter.outputs.ui }}\`, integration: \`${{ steps.filter.outputs.integration }}\`, sdk: \`${{ steps.filter.outputs.sdk }}\`, cli: \`${{ steps.filter.outputs.cli }}\`, ci: \`${{ steps.filter.outputs.ci }}\`
-          </details>
-          EOF
-          )
-
-          # Update existing comment or create new one
-          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --paginate --jq '.[] | select(.body | contains("<!-- verify-decide-summary -->")) | .id' | tail -1)
-
-          if [ -n "$COMMENT_ID" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
-              -X PATCH -f body="$BODY" > /dev/null
-          else
-            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-              -f body="$BODY" > /dev/null
-          fi
+      - name: Upload decision summary
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-decisions
+          retention-days: 1
+          path: |
+            /tmp/verify-decisions.json
+            /tmp/verify-changes.json
 
   # ============================================================================
   # PHASE 1: Fast Checks (fail early)

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -174,7 +174,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          icon() { if [ "$1" = "true" ]; then echo "🟢"; else echo "⚪"; fi; }
+          icon() { if [ "$1" = "true" ]; then echo "🟢"; else echo "➖"; fi; }
 
           BODY=$(cat <<EOF
           <!-- verify-decide-summary -->

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -171,12 +171,27 @@ jobs:
       - name: Save decision summary
         if: github.event_name == 'pull_request' && steps.decide.outputs.lifecycle-ready != 'skip'
         run: |
-          cat > /tmp/verify-decisions.json <<'DECISIONS_EOF'
-          ${{ toJSON(steps.decide.outputs) }}
-          DECISIONS_EOF
-          cat > /tmp/verify-changes.json <<'CHANGES_EOF'
-          ${{ toJSON(steps.filter.outputs) }}
-          CHANGES_EOF
+          cat > /tmp/verify-decisions.json << 'ARTIFACT_EOF'
+          {
+            "lifecycle-ready": "${{ steps.decide.outputs.lifecycle-ready }}",
+            "run-build": "${{ steps.decide.outputs.run-build }}",
+            "run-unit-tests": "${{ steps.decide.outputs.run-unit-tests }}",
+            "run-integration": "${{ steps.decide.outputs.run-integration }}",
+            "run-extras": "${{ steps.decide.outputs.run-extras }}",
+            "run-sdk": "${{ steps.decide.outputs.run-sdk }}",
+            "run-cli": "${{ steps.decide.outputs.run-cli }}"
+          }
+          ARTIFACT_EOF
+          cat > /tmp/verify-changes.json << 'ARTIFACT_EOF'
+          {
+            "java": "${{ steps.filter.outputs.java }}",
+            "ui": "${{ steps.filter.outputs.ui }}",
+            "integration": "${{ steps.filter.outputs.integration }}",
+            "sdk": "${{ steps.filter.outputs.sdk }}",
+            "cli": "${{ steps.filter.outputs.cli }}",
+            "ci": "${{ steps.filter.outputs.ci }}"
+          }
+          ARTIFACT_EOF
 
       - name: Upload decision summary
         if: github.event_name == 'pull_request' && steps.decide.outputs.lifecycle-ready != 'skip'

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -168,6 +168,47 @@ jobs:
           decide run-sdk         "$run_full"  "$IS_PUSH" "$SDK" "$JAVA" "$CI"
           decide run-cli         "$run_full"  "$CLI"
 
+      - name: Post decision summary
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          icon() { if [ "$1" = "true" ]; then echo "🟢"; else echo "⚪"; fi; }
+
+          BODY=$(cat <<EOF
+          <!-- verify-decide-summary -->
+          **Verify — test plan for this run:**
+
+          | Phase | Status |
+          |-------|--------|
+          | Lint and Validate | $(icon "${{ steps.decide.outputs.lifecycle-ready }}") |
+          | Build | $(icon "${{ steps.decide.outputs.run-build }}") |
+          | Unit Tests | $(icon "${{ steps.decide.outputs.run-unit-tests }}") |
+          | Integration Tests | $(icon "${{ steps.decide.outputs.run-integration }}") |
+          | Extra Tests | $(icon "${{ steps.decide.outputs.run-extras }}") |
+          | SDK Verification | $(icon "${{ steps.decide.outputs.run-sdk }}") |
+          | CLI Verification | $(icon "${{ steps.decide.outputs.run-cli }}") |
+
+          <details><summary>Change detection</summary>
+
+          java: \`${{ steps.filter.outputs.java }}\`, ui: \`${{ steps.filter.outputs.ui }}\`, integration: \`${{ steps.filter.outputs.integration }}\`, sdk: \`${{ steps.filter.outputs.sdk }}\`, cli: \`${{ steps.filter.outputs.cli }}\`, ci: \`${{ steps.filter.outputs.ci }}\`
+          </details>
+          EOF
+          )
+
+          # Update existing comment or create new one
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq '.[] | select(.body | contains("<!-- verify-decide-summary -->")) | .id' | tail -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$BODY" > /dev/null
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              -f body="$BODY" > /dev/null
+          fi
+
   # ============================================================================
   # PHASE 1: Fast Checks (fail early)
   # ============================================================================


### PR DESCRIPTION
## Summary

- Post a test plan summary comment on PRs showing which phases ran (🟢), failed (🔴), were planned but blocked (🟡), or skipped (➖), with change detection details in a collapsible section. The comment is updated in-place on subsequent pushes.
- Uses hardened artifact relay: the `decide` job uploads decisions + change detection as JSON artifacts, and `handleTestResult` (triggered by `workflow_run` with write access) downloads, validates strictly, fetches actual job results, and posts the comment. Works for both fork and non-fork PRs.
- Warn when `/auto-merge` is enabled without a review or `/skip-review`, so the maintainer knows auto-merge can't proceed yet.

Artifact hardening: size limits, zip path traversal checks, strict file name allowlist, JSON schema validation (key/value allowlists), paginated comment lookup.

Follow-up to #7937. Fixes #7933.

## Test plan

- [ ] PR with Java changes: summary comment shows unit tests, integration, extras, SDK as 🟢
- [ ] PR with only UI changes: summary comment shows most phases as ➖
- [ ] Fork PR: summary comment appears (via workflow_run artifact relay)
- [ ] Failed test phase: shows 🔴 in the summary
- [ ] `/auto-merge` without review: comment includes note about needing `/skip-review`
- [ ] `/auto-merge` with review: no extra note
- [ ] New push updates the existing summary comment instead of creating a new one
- [ ] Non-lifecycle label event: no artifact uploaded, existing summary not overwritten