### PR TITLE
feat(cli): enable automatic updates with config management and branding

### DIFF
--- a/.github/workflows/verify-cli.yaml
+++ b/.github/workflows/verify-cli.yaml
@@ -83,3 +83,9 @@ jobs:
         run: |
           cli/target/apicurio-registry-cli-*-runner --help
           cli/target/apicurio-registry-cli-*-runner version
+
+      - name: Run CLI Update E2E Tests
+        if: matrix.os-name == 'linux-x86_64'
+        run: |
+          cli/src/test/scripts/test-update.sh
+          cli/src/test/scripts/test-upgrade-from-previous.sh

--- a/cli/README.md
+++ b/cli/README.md
@@ -37,10 +37,40 @@ To install the Apicurio Registry CLI:
    ```
 
 
-[//]: # (### Update)
+### Update
 
-[//]: # ()
-[//]: # (To update the Apicurio Registry CLI to the latest version, run `acr update`, or remove the existing installation and re-install using the steps above.)
+The CLI checks for updates once per day and notifies you when a newer version is available.
+
+**Update to the latest version:**
+```bash
+acr update
+```
+
+If both a patch and minor update are available, you must specify the version:
+```bash
+acr update 3.3.0
+```
+
+**Check for updates without installing:**
+```bash
+acr update --check
+```
+
+**Postpone update notifications (default: 5 days):**
+```bash
+acr update --postpone
+acr update --postpone 240  # postpone for 240 hours
+```
+
+**Install from a local ZIP:**
+```bash
+acr update --path /path/to/apicurio-registry-cli-3.2.5-linux-x86_64.zip
+```
+
+**Disable automatic update checks:**
+```bash
+acr config set update.check-enabled=false
+```
 
 ## Build
 
@@ -120,6 +150,37 @@ Get help for a specific command:
 acr <command> --help
 acr <command> <subcommand> --help
 ```
+
+### Configuration
+
+Manage CLI configuration properties stored in `config.json`.
+
+**List all properties:**
+```bash
+acr config
+```
+
+**Get a property:**
+```bash
+acr config get update.repo.url
+```
+
+**Set properties:**
+```bash
+acr config set update.check-enabled=false
+acr config set update.repo.url=https://my-repo.example/maven2/io/apicurio/apicurio-registry-cli
+```
+
+**Delete properties:**
+```bash
+acr config delete my.custom.property
+```
+
+#### Configuration Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `update.check-enabled` | `true` | Enable automatic update checks |
 
 ### Context Management
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -168,7 +168,6 @@ acr config get update.repo.url
 **Set properties:**
 ```bash
 acr config set update.check-enabled=false
-acr config set update.repo.url=https://my-repo.example/maven2/io/apicurio/apicurio-registry-cli
 ```
 
 **Delete properties:**

--- a/cli/README.md
+++ b/cli/README.md
@@ -180,6 +180,7 @@ acr config delete my.custom.property
 | Property | Default | Description |
 |---|---|---|
 | `update.check-enabled` | `true` | Enable automatic update checks |
+| `update.timeout-seconds` | `60` | Timeout for update network requests |
 
 ### Context Management
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -21,6 +21,9 @@
         <quarkus.native.builder-image>
             quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-23
         </quarkus.native.builder-image>
+        <!-- CLI branding and update defaults. Override in productized profiles. -->
+        <update.repo.url>https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-cli</update.repo.url>
+        <branding.product-name>Apicurio Registry CLI</branding.product-name>
     </properties>
 
     <dependencies>
@@ -234,6 +237,15 @@
                 <directory>src/main/resources</directory>
                 <includes>
                     <include>META-INF/**</include>
+                </includes>
+            </resource>
+            <!-- Filter config.json with Maven properties for branding/productization -->
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/scripts/common</directory>
+                <targetPath>${project.build.directory}/filtered-scripts</targetPath>
+                <includes>
+                    <include>config.json</include>
                 </includes>
             </resource>
         </resources>

--- a/cli/src/main/assembly/distribution.xml
+++ b/cli/src/main/assembly/distribution.xml
@@ -20,7 +20,7 @@
             <outputDirectory>/</outputDirectory>
         </file>
         <file>
-            <source>${project.basedir}/src/main/scripts/common/config.json</source>
+            <source>${project.build.directory}/filtered-scripts/config.json</source>
             <outputDirectory>/</outputDirectory>
         </file>
     </files>

--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli;
 
 import io.apicurio.registry.cli.artifact.ArtifactCommand;
+import io.apicurio.registry.cli.config.ConfigPropertyCommand;
 import io.apicurio.registry.cli.context.ContextCommand;
 import io.apicurio.registry.cli.group.GroupCommand;
 import io.apicurio.registry.cli.globalrule.GlobalRuleCommand;
@@ -14,7 +15,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
 @TopCommand
 @Command(
         name = "acr",
-        description = "Apicurio Registry CLI — manage schemas and APIs from the command line. Currently unstable; its arguments and behavior are subject to backwards-incompatible changes.",
+        description = "{{product-name}} — manage schemas and APIs from the command line. Currently unstable; its arguments and behavior are subject to backwards-incompatible changes.",
         header = {
                 "   ___        _              _",
                 "  / _ | ___  (_)_____ ______(_)__",
@@ -24,6 +25,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
         },
         subcommands = {
                 ArtifactCommand.class,
+                ConfigPropertyCommand.class,
                 ContextCommand.class,
                 GlobalRuleCommand.class,
                 GroupCommand.class,
@@ -36,7 +38,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
                 "0: Successful execution.",
                 "1: Application error.",
                 "2: Input validation error.",
-                "3: Apicurio Registry server error."
+                "3: {{product-name}} server error."
         }
 )
 public class Acr {

--- a/cli/src/main/java/io/apicurio/registry/cli/BrandedCommandLineProducer.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/BrandedCommandLineProducer.java
@@ -1,0 +1,64 @@
+package io.apicurio.registry.cli;
+
+import io.apicurio.registry.cli.config.Config;
+import io.quarkus.picocli.runtime.PicocliCommandLineFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+
+import java.util.LinkedHashMap;
+
+@ApplicationScoped
+public class BrandedCommandLineProducer {
+
+    private static final Logger log = Logger.getLogger(BrandedCommandLineProducer.class);
+    private static final String PLACEHOLDER = "{{product-name}}";
+
+    @Inject
+    Config config;
+
+    @Produces
+    CommandLine createCommandLine(PicocliCommandLineFactory factory) {
+        var cmd = factory.create();
+        applyBranding(cmd.getCommandSpec(), resolveProductName());
+        return cmd;
+    }
+
+    private String resolveProductName() {
+        try {
+            var name = config.read().getConfig().get("internal.branding.product-name");
+            return name != null && !name.isEmpty() ? name : "Apicurio Registry CLI";
+        } catch (Exception e) {
+            log.debugf("Could not read branding config: %s", e.getMessage());
+            return "Apicurio Registry CLI";
+        }
+    }
+
+    private void applyBranding(CommandSpec spec, String productName) {
+        var usage = spec.usageMessage();
+        var desc = usage.description();
+        boolean descChanged = false;
+        for (int i = 0; i < desc.length; i++) {
+            if (desc[i].contains(PLACEHOLDER)) {
+                desc[i] = desc[i].replace(PLACEHOLDER, productName);
+                descChanged = true;
+            }
+        }
+        if (descChanged) {
+            usage.description(desc);
+        }
+        var exitCodes = usage.exitCodeList();
+        if (exitCodes != null && !exitCodes.isEmpty()) {
+            var patched = new LinkedHashMap<String, String>();
+            exitCodes.forEach((k, v) ->
+                    patched.put(k, v.contains(PLACEHOLDER) ? v.replace(PLACEHOLDER, productName) : v));
+            usage.exitCodeList(patched);
+        }
+        for (var sub : spec.subcommands().values()) {
+            applyBranding(sub.getCommandSpec(), productName);
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
@@ -2,7 +2,9 @@ package io.apicurio.registry.cli;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.config.ConfigModel;
 import io.apicurio.registry.cli.utils.FileUtils;
+import io.apicurio.registry.cli.utils.Mapper;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import org.jboss.logging.Logger;
 import picocli.CommandLine.Command;
@@ -95,6 +97,7 @@ public class InstallCommand extends AbstractCommand {
         if (!isBlank(cliHome)) {
             cliHomePath = Path.of(cliHome).normalize().toAbsolutePath();
             if (!Files.exists(cliHomePath)) {
+                log.debugf("ACR_HOME path does not exist, falling back to install dir: %s", cliHomePath);
                 cliHomePath = null;
             }
         }
@@ -150,8 +153,19 @@ public class InstallCommand extends AbstractCommand {
         FileUtils.replaceInFile(cliHomePath.resolve(ACR_ENV), ACR_HOME_PLACEHOLDER, cliHomePath.toAbsolutePath().toString());
 
         // Copy config.json only if it doesn't exist (preserve user settings)
-        if (!Files.exists(cliHomePath.resolve(CONFIG_JSON))) {
-            Files.copy(currentPath.resolve(CONFIG_JSON), cliHomePath.resolve(CONFIG_JSON));
+        var targetConfig = cliHomePath.resolve(CONFIG_JSON);
+        if (!Files.exists(targetConfig)) {
+            Files.copy(currentPath.resolve(CONFIG_JSON), targetConfig);
+        } else {
+            var existing = Mapper.MAPPER.readValue(targetConfig.toFile(), ConfigModel.class);
+            log.debugf("Existing installation version: %d, current: %d",
+                    existing.getInstallationVersion(), ConfigModel.CURRENT_INSTALLATION_VERSION);
+            if (existing.getInstallationVersion() > ConfigModel.CURRENT_INSTALLATION_VERSION) {
+                throw new CliException(
+                        "Existing installation (version %d) is newer than this CLI supports (version %d). Cannot downgrade."
+                                .formatted(existing.getInstallationVersion(), ConfigModel.CURRENT_INSTALLATION_VERSION),
+                        VALIDATION_ERROR_RETURN_CODE);
+            }
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
@@ -166,6 +166,11 @@ public class InstallCommand extends AbstractCommand {
                                 .formatted(existing.getInstallationVersion(), ConfigModel.CURRENT_INSTALLATION_VERSION),
                         VALIDATION_ERROR_RETURN_CODE);
             }
+            if (existing.getInstallationVersion() < ConfigModel.CURRENT_INSTALLATION_VERSION) {
+                existing.setInstallationVersion(ConfigModel.CURRENT_INSTALLATION_VERSION);
+                Mapper.MAPPER.writeValue(targetConfig.toFile(), existing);
+                log.debugf("Updated installation version to %d", ConfigModel.CURRENT_INSTALLATION_VERSION);
+            }
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
@@ -2,105 +2,236 @@ package io.apicurio.registry.cli;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.services.CliVersion;
+import io.apicurio.registry.cli.services.Update;
 import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.OutputBuffer;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParentCommand;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 @Command(
         name = "update",
-        description = "Update the CLI by installing it from the specified path"
+        description = "Update the CLI to a newer version"
 )
 public class UpdateCommand extends AbstractCommand {
 
     private static final Logger log = Logger.getLogger(UpdateCommand.class);
 
+    @Parameters(
+            index = "0",
+            arity = "0..1",
+            description = "Target version to update to. If not provided, the latest unambiguous version is used."
+    )
+    private String targetVersion;
+
     @Option(
             names = {"--path"},
-            description = "Install the zip file specified by this path. " +
-                    "Version check is not performed."
-            // TODO: This might cause problems if accidentally downgrading, check versions or is a warning enough?
+            description = "Install from a local zip file. Version check is not performed."
     )
     private Path path;
+
+    @Option(
+            names = {"--check"},
+            description = "Check for available updates without installing.",
+            defaultValue = "false"
+    )
+    private boolean check;
+
+    @Option(
+            names = {"--postpone"},
+            description = "Postpone update notifications. Default: 120 hours (5 days).",
+            arity = "0..1",
+            defaultValue = "-1",
+            fallbackValue = "120"
+    )
+    private int postponeHours;
 
     @ParentCommand
     private Acr parent;
 
+    @Inject
+    Update update;
+
     @Override
     public void run(OutputBuffer output) throws Exception {
-        var home = System.getenv("ACR_HOME");
-        log.debugf("ACR_HOME=%s", home);
-        if (isBlank(home)) {
-            throw new CliException("ACR_HOME is not set. " +
-                    "Please run the 'install' command first.");
-        }
-        var homePath = Path.of(home).normalize().toAbsolutePath();
-        if (!Files.exists(homePath)) {
-            throw new CliException("ACR_HOME directory does not exist: " + homePath + ". " +
-                    "Please run the 'install' command first.");
+        if (postponeHours >= 0) {
+            handlePostpone(output);
+            return;
         }
 
+        var currentVersion = getCurrentVersion();
+
+        if (check) {
+            handleCheck(output, currentVersion);
+            return;
+        }
+
+        if (path != null) {
+            handlePathInstall(output);
+            return;
+        }
+
+        handleAutoUpdate(output, currentVersion);
+    }
+
+    private void handlePostpone(OutputBuffer output) {
+        var configModel = config.read();
+        var until = Instant.now().plusSeconds(postponeHours * 3600L);
+        configModel.getConfig().put("internal.update.postponed-until", until.toString());
+        config.write(configModel);
+        output.writeStdOutLine("Update notifications postponed for %d hours.".formatted(postponeHours));
+    }
+
+    private void handleCheck(OutputBuffer output, CliVersion currentVersion) {
+        var result = update.checkForUpdates(currentVersion);
+        recordCheckTimestamp();
+
+        if (!result.hasUpdates()) {
+            output.writeStdOutLine("You are running the latest version (%s).".formatted(currentVersion));
+            return;
+        }
+
+        output.writeStdOutChunk(out -> {
+            result.formatMessage(out);
+        });
+    }
+
+    private void handlePathInstall(OutputBuffer output) throws Exception {
+        validateAcrHome();
+        var homePath = getHomePath();
         var targetDir = homePath.resolve(UUID.randomUUID().toString().substring(0, 8));
         try {
             Files.createDirectories(targetDir);
-
-            Path zipFilePath;
-            if (path != null) {
-                var zipFile = path.getFileName();
-                zipFilePath = targetDir.resolve(zipFile);
-                Files.copy(path, zipFilePath, REPLACE_EXISTING);
-            } else {
-                // TODO: This should work, but disable it until we have released the CLI to Maven Central at least once.
-                throw new UnsupportedOperationException("Automatic updates are not yet supported.");
-                /*
-                var latestVersion = update.getLatestVersion();
-                // We need to coerce because the version might be non-standard, e.g. 3.1.7.redhat-00001. We'll lose the suffix.
-                if (Semver.parse(ConfigProvider.getConfig().getValue("version", String.class))
-                        .isGreaterThanOrEqualTo(Semver.coerce(latestVersion))) {
-                    throw new CliException("You are already running the latest version.");
-                }
-
-                zipFilePath = update.downloadVersion(latestVersion, targetDir);
-                */
-            }
-
-            FileUtils.unzip(zipFilePath, targetDir);
-
-            // Run the acr subprocess and wait for it to finish
-            Path acrPath = targetDir.resolve("acr");
-            // Make the file executable
-            if (!acrPath.toFile().setExecutable(true, false)) {
-                throw new CliException("Failed to set executable permission on " + acrPath);
-            }
-            log.debugf("Running subprocess: %s", acrPath);
-            var cmd = new ArrayList<String>(3);
-            cmd.add(acrPath.toString());
-            cmd.add("install");
-            if (parent.isVerbose()) {
-                cmd.add("--verbose");
-            }
-            ProcessBuilder processBuilder = new ProcessBuilder(cmd);
-            processBuilder.inheritIO(); // Pipe subprocess output to current process
-            Process process = processBuilder.start();
-            int exitCode = process.waitFor();
-            log.debugf("Subprocess exited with code: %s", exitCode);
-            if (exitCode != 0) {
-                throw new CliException("Update failed with exit code: " + exitCode, exitCode);
-            }
-
-            output.writeStdOutLine("Update complete.");
+            var zipFilePath = targetDir.resolve(path.getFileName());
+            Files.copy(path, zipFilePath, REPLACE_EXISTING);
+            runInstallFromZip(zipFilePath, targetDir, output);
         } finally {
             FileUtils.deleteDirectory(targetDir);
         }
     }
+
+    private void handleAutoUpdate(OutputBuffer output, CliVersion currentVersion) throws Exception {
+        validateAcrHome();
+
+        var result = update.checkForUpdates(currentVersion);
+        recordCheckTimestamp();
+
+        if (!result.hasUpdates()) {
+            output.writeStdOutLine("You are running the latest version (%s).".formatted(currentVersion));
+            return;
+        }
+
+        String versionToDownload;
+        if (targetVersion != null) {
+            versionToDownload = targetVersion;
+        } else {
+            var unambiguous = result.unambiguousUpdate();
+            if (unambiguous == null) {
+                output.writeStdOutChunk(out -> {
+                    out.append("Multiple update candidates available:\n");
+                    result.formatMessage(out);
+                    out.append("\nSpecify a version: acr update <version>\n");
+                });
+                return;
+            }
+            versionToDownload = unambiguous.toString();
+            log.debugf("Auto-selected version: %s", versionToDownload);
+        }
+
+        output.writeStdOutLine("Updating to version %s...".formatted(versionToDownload));
+        output.print();
+
+        var homePath = getHomePath();
+        var targetDir = homePath.resolve(UUID.randomUUID().toString().substring(0, 8));
+        try {
+            Files.createDirectories(targetDir);
+            var zipFilePath = update.downloadVersion(versionToDownload, targetDir);
+            if (zipFilePath == null) {
+                throw new CliException("Failed to download version " + versionToDownload, VALIDATION_ERROR_RETURN_CODE);
+            }
+            runInstallFromZip(zipFilePath, targetDir, output);
+        } finally {
+            FileUtils.deleteDirectory(targetDir);
+        }
+    }
+
+    private void runInstallFromZip(Path zipFilePath, Path targetDir, OutputBuffer output) throws Exception {
+        FileUtils.unzip(zipFilePath, targetDir);
+
+        Path acrPath = targetDir.resolve(InstallCommand.ACR_SCRIPT);
+        Path acrRunnerPath = targetDir.resolve(InstallCommand.ACR_BINARY);
+        for (var executable : List.of(acrPath, acrRunnerPath)) {
+            if (executable.toFile().exists() && !executable.toFile().setExecutable(true, false)) {
+                throw new CliException("Failed to set executable permission on " + executable);
+            }
+        }
+        log.debugf("Running subprocess: %s", acrPath);
+        var cmd = new ArrayList<String>(3);
+        cmd.add(acrPath.toString());
+        cmd.add("install");
+        if (parent.isVerbose()) {
+            cmd.add("--verbose");
+        }
+        ProcessBuilder processBuilder = new ProcessBuilder(cmd);
+        processBuilder.inheritIO();
+        Process process = processBuilder.start();
+        int exitCode = process.waitFor();
+        log.debugf("Subprocess exited with code: %s", exitCode);
+        if (exitCode != 0) {
+            throw new CliException("Update failed with exit code: " + exitCode, exitCode);
+        }
+
+        output.writeStdOutLine("Update complete.");
+    }
+
+    private CliVersion getCurrentVersion() {
+        var versionStr = ConfigProvider.getConfig().getValue("version", String.class);
+        var version = CliVersion.parse(versionStr);
+        if (version == null) {
+            throw new CliException("Could not parse current CLI version: " + versionStr, VALIDATION_ERROR_RETURN_CODE);
+        }
+        return version;
+    }
+
+    private void validateAcrHome() {
+        var home = System.getenv("ACR_HOME");
+        log.debugf("ACR_HOME=%s", home);
+        if (isBlank(home)) {
+            throw new CliException("ACR_HOME is not set. Please run the 'install' command first.");
+        }
+        if (!Files.exists(Path.of(home))) {
+            throw new CliException("ACR_HOME directory does not exist: " + home + ". Please run the 'install' command first.");
+        }
+    }
+
+    private Path getHomePath() {
+        return Path.of(System.getenv("ACR_HOME")).normalize().toAbsolutePath();
+    }
+
+    private void recordCheckTimestamp() {
+        try {
+            var configModel = config.read();
+            configModel.getConfig().put("internal.update.last-check", Instant.now().toString());
+            config.write(configModel);
+        } catch (Exception e) {
+            log.debugf("Could not record update check timestamp: %s", e.getMessage());
+        }
+    }
+
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
@@ -129,18 +129,17 @@ public class UpdateCommand extends AbstractCommand {
     private void handleAutoUpdate(OutputBuffer output, CliVersion currentVersion) throws Exception {
         validateAcrHome();
 
-        var result = update.checkForUpdates(currentVersion);
-        recordCheckTimestamp();
-
-        if (!result.hasUpdates()) {
-            output.writeStdOutLine("You are running the latest version (%s).".formatted(currentVersion));
-            return;
-        }
-
         String versionToDownload;
         if (targetVersion != null) {
             versionToDownload = targetVersion;
         } else {
+            var result = update.checkForUpdates(currentVersion);
+            recordCheckTimestamp();
+
+            if (!result.hasUpdates()) {
+                output.writeStdOutLine("You are running the latest version (%s).".formatted(currentVersion));
+                return;
+            }
             var unambiguous = result.unambiguousUpdate();
             if (unambiguous == null) {
                 output.writeStdOutChunk(out -> {

--- a/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
@@ -7,7 +7,6 @@ import io.apicurio.registry.cli.services.Update;
 import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -21,8 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
-import static io.apicurio.registry.cli.utils.Utils.isBlank;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 @Command(
@@ -75,7 +72,7 @@ public class UpdateCommand extends AbstractCommand {
             return;
         }
 
-        var currentVersion = getCurrentVersion();
+        var currentVersion = config.getCliVersion();
 
         if (check) {
             handleCheck(output, currentVersion);
@@ -100,7 +97,6 @@ public class UpdateCommand extends AbstractCommand {
 
     private void handleCheck(OutputBuffer output, CliVersion currentVersion) {
         var result = update.checkForUpdates(currentVersion);
-        recordCheckTimestamp();
 
         if (!result.hasUpdates()) {
             output.writeStdOutLine("You are running the latest version (%s).".formatted(currentVersion));
@@ -113,8 +109,7 @@ public class UpdateCommand extends AbstractCommand {
     }
 
     private void handlePathInstall(OutputBuffer output) throws Exception {
-        validateAcrHome();
-        var homePath = getHomePath();
+        var homePath = config.getAcrHomePath();
         var targetDir = homePath.resolve(UUID.randomUUID().toString().substring(0, 8));
         try {
             Files.createDirectories(targetDir);
@@ -127,14 +122,13 @@ public class UpdateCommand extends AbstractCommand {
     }
 
     private void handleAutoUpdate(OutputBuffer output, CliVersion currentVersion) throws Exception {
-        validateAcrHome();
+        var homePath = config.getAcrHomePath();
 
         String versionToDownload;
         if (targetVersion != null) {
             versionToDownload = targetVersion;
         } else {
             var result = update.checkForUpdates(currentVersion);
-            recordCheckTimestamp();
 
             if (!result.hasUpdates()) {
                 output.writeStdOutLine("You are running the latest version (%s).".formatted(currentVersion));
@@ -156,14 +150,10 @@ public class UpdateCommand extends AbstractCommand {
         output.writeStdOutLine("Updating to version %s...".formatted(versionToDownload));
         output.print();
 
-        var homePath = getHomePath();
         var targetDir = homePath.resolve(UUID.randomUUID().toString().substring(0, 8));
         try {
             Files.createDirectories(targetDir);
             var zipFilePath = update.downloadVersion(versionToDownload, targetDir);
-            if (zipFilePath == null) {
-                throw new CliException("Failed to download version " + versionToDownload, VALIDATION_ERROR_RETURN_CODE);
-            }
             runInstallFromZip(zipFilePath, targetDir, output);
         } finally {
             FileUtils.deleteDirectory(targetDir);
@@ -197,40 +187,6 @@ public class UpdateCommand extends AbstractCommand {
         }
 
         output.writeStdOutLine("Update complete.");
-    }
-
-    private CliVersion getCurrentVersion() {
-        var versionStr = ConfigProvider.getConfig().getValue("version", String.class);
-        var version = CliVersion.parse(versionStr);
-        if (version == null) {
-            throw new CliException("Could not parse current CLI version: " + versionStr, VALIDATION_ERROR_RETURN_CODE);
-        }
-        return version;
-    }
-
-    private void validateAcrHome() {
-        var home = System.getenv("ACR_HOME");
-        log.debugf("ACR_HOME=%s", home);
-        if (isBlank(home)) {
-            throw new CliException("ACR_HOME is not set. Please run the 'install' command first.");
-        }
-        if (!Files.exists(Path.of(home))) {
-            throw new CliException("ACR_HOME directory does not exist: " + home + ". Please run the 'install' command first.");
-        }
-    }
-
-    private Path getHomePath() {
-        return Path.of(System.getenv("ACR_HOME")).normalize().toAbsolutePath();
-    }
-
-    private void recordCheckTimestamp() {
-        try {
-            var configModel = config.read();
-            configModel.getConfig().put("internal.update.last-check", Instant.now().toString());
-            config.write(configModel);
-        } catch (Exception e) {
-            log.debugf("Could not record update check timestamp: %s", e.getMessage());
-        }
     }
 
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
@@ -67,6 +67,10 @@ public class UpdateCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
+        if (postponeHours >= 0 && check) {
+            throw new CliException("Cannot use --postpone and --check together.");
+        }
+
         if (postponeHours >= 0) {
             handlePostpone(output);
             return;
@@ -87,9 +91,12 @@ public class UpdateCommand extends AbstractCommand {
         handleAutoUpdate(output, currentVersion);
     }
 
+    private static final int MAX_POSTPONE_HOURS = 8760; // 1 year
+
     private void handlePostpone(OutputBuffer output) {
+        var hours = Math.min(postponeHours, MAX_POSTPONE_HOURS);
         var configModel = config.read();
-        var until = Instant.now().plusSeconds(postponeHours * 3600L);
+        var until = Instant.now().plusSeconds(hours * 3600L);
         configModel.getConfig().put("internal.update.postponed-until", until.toString());
         config.write(configModel);
         output.writeStdOutLine("Update notifications postponed for %d hours.".formatted(postponeHours));

--- a/cli/src/main/java/io/apicurio/registry/cli/VersionCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/VersionCommand.java
@@ -11,7 +11,7 @@ import io.apicurio.registry.rest.client.models.ArtifactTypeInfo;
 import io.apicurio.registry.rest.client.models.ProblemDetails;
 import lombok.Builder;
 import lombok.Getter;
-import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 
@@ -43,10 +43,13 @@ public class VersionCommand extends AbstractCommand {
     @Mixin
     private OutputTypeMixin outputType;
 
+    @ConfigProperty(name = "version")
+    String cliVersion;
+
     @Override
     public void run(final OutputBuffer output) throws JsonProcessingException {
         final var builder = VersionOutput.builder()
-                .cliVersion(ConfigProvider.getConfig().getValue("version", String.class));
+                .cliVersion(cliVersion);
 
         try {
             final var registryClient = client.getRegistryClient();
@@ -107,7 +110,9 @@ public class VersionCommand extends AbstractCommand {
         });
     }
 
-    /** Output model for the version command, serialized as JSON or rendered as a table. */
+    /**
+     * Output model for the version command, serialized as JSON or rendered as a table.
+     */
     @Builder
     @Getter
     public static class VersionOutput {

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactDeleteCommand.java
@@ -14,7 +14,7 @@ import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 @Command(
         name = "delete",
         aliases = {"remove", "rm"},
-        description = "Delete an existing artifact. Apicurio Registry must be configured " +
+        description = "Delete an existing artifact. {{product-name}} must be configured " +
                 "with `apicurio.rest.deletion.artifact.enabled=true` to allow artifact deletions."
 )
 public class ArtifactDeleteCommand extends AbstractCommand {

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -3,6 +3,7 @@ package io.apicurio.registry.cli.common;
 import io.apicurio.registry.cli.Acr;
 import io.apicurio.registry.cli.config.Config;
 import io.apicurio.registry.cli.services.Client;
+import io.apicurio.registry.cli.services.UpdateNotifier;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -29,6 +30,9 @@ public abstract class AbstractCommand implements Callable<Integer> {
     @Inject
     protected Client client;
 
+    @Inject
+    UpdateNotifier updateNotifier;
+
     @Override
     public Integer call() {
         configureVerboseLogging();
@@ -54,11 +58,30 @@ public abstract class AbstractCommand implements Callable<Integer> {
             return APPLICATION_ERROR_RETURN_CODE;
         } finally {
             output.print();
+            checkForUpdates();
         }
         // TODO: Move handling of `ProblemDetails` exceptions here.
     }
 
     public abstract void run(OutputBuffer output) throws Exception;
+
+    private void checkForUpdates() {
+        try {
+            var commandName = getTopLevelCommandName();
+            log.debugf("Update check hook: command=%s (spec=%s)", commandName, spec.name());
+            updateNotifier.checkAndNotify(commandName);
+        } catch (Exception e) {
+            log.debugf("Update notification failed: %s", e.getMessage());
+        }
+    }
+
+    private String getTopLevelCommandName() {
+        var current = spec;
+        while (current.parent() != null && current.parent().parent() != null) {
+            current = current.parent();
+        }
+        return current.name();
+    }
 
     private void configureVerboseLogging() {
         var root = spec.root().userObject();

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -35,9 +35,10 @@ public abstract class AbstractCommand implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        configureVerboseLogging();
         var output = new OutputBuffer(config.getStdOut(), config.getStdErr());
         try {
+            configureVerboseLogging();
+            updateNotifier.checkAndNotify(getTopLevelCommandName());
             run(output);
             return OK_RETURN_CODE;
         } catch (CliException ex) {
@@ -54,26 +55,16 @@ public abstract class AbstractCommand implements Callable<Integer> {
             }
             return ex.getCode();
         } catch (Exception ex) {
-            log.error("Unexpected error", ex); // Force printing of stack trace.
+            log.error("Unexpected error", ex);
+            output.writeStdErrChunk(out -> out.append("Unexpected error: ").append(ex.getMessage()).append("\n"));
             return APPLICATION_ERROR_RETURN_CODE;
         } finally {
             output.print();
-            checkForUpdates();
         }
         // TODO: Move handling of `ProblemDetails` exceptions here.
     }
 
     public abstract void run(OutputBuffer output) throws Exception;
-
-    private void checkForUpdates() {
-        try {
-            var commandName = getTopLevelCommandName();
-            log.debugf("Update check hook: command=%s (spec=%s)", commandName, spec.name());
-            updateNotifier.checkAndNotify(commandName);
-        } catch (Exception e) {
-            log.debugf("Update notification failed: %s", e.getMessage());
-        }
-    }
 
     private String getTopLevelCommandName() {
         var current = spec;

--- a/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli.config;
 
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.services.CliVersion;
 import io.apicurio.registry.cli.utils.Mapper;
 import io.apicurio.registry.cli.utils.Output;
 import io.quarkus.runtime.StartupEvent;
@@ -8,6 +9,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import lombok.Getter;
 import lombok.Setter;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -42,10 +44,21 @@ public class Config {
     @Setter
     private Path acrCurrentHomePath;
 
+    @ConfigProperty(name = "version")
+    String cliVersion;
+
     private final Map<String, String> envOverrides = new HashMap<>();
 
     void onStart(@Observes StartupEvent ev) {
         instance = this;
+    }
+
+    public CliVersion getCliVersion() {
+        var version = CliVersion.parse(cliVersion);
+        if (version == null || !version.isParsed()) {
+            throw new CliException("Could not parse CLI version: " + cliVersion, APPLICATION_ERROR_RETURN_CODE);
+        }
+        return version;
     }
 
     /**
@@ -79,6 +92,19 @@ public class Config {
      */
     public void clearEnvOverrides() {
         envOverrides.clear();
+    }
+
+    public Path getAcrHomePath() {
+        var home = getEnv("ACR_HOME");
+        if (isBlank(home)) {
+            throw new CliException("ACR_HOME is not set. Please run the 'install' command first.", APPLICATION_ERROR_RETURN_CODE);
+        }
+        var homePath = Path.of(home).normalize().toAbsolutePath();
+        if (!java.nio.file.Files.exists(homePath)) {
+            throw new CliException("ACR_HOME directory does not exist: " + homePath + ". Please run the 'install' command first.",
+                    APPLICATION_ERROR_RETURN_CODE);
+        }
+        return homePath;
     }
 
     public Path getAcrCurrentHomePath() {

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.cli.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,13 @@ import java.util.Map;
 @Getter
 @Setter
 @ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ConfigModel {
+
+    public static final int CURRENT_INSTALLATION_VERSION = 1;
+
+    @JsonProperty("installation-version")
+    private int installationVersion = CURRENT_INSTALLATION_VERSION;
 
     @JsonProperty("config")
     private Map<String, String> config = new HashMap<>();
@@ -31,6 +38,7 @@ public class ConfigModel {
     @Getter
     @Setter
     @ToString
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Context {
 
         @JsonProperty("registryUrl")

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyCommand.java
@@ -1,0 +1,34 @@
+package io.apicurio.registry.cli.config;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import picocli.CommandLine.Command;
+
+@Command(
+        name = "config",
+        aliases = {"cfg"},
+        description = "Manage configuration properties",
+        subcommands = {
+                ConfigPropertyGetCommand.class,
+                ConfigPropertySetCommand.class,
+                ConfigPropertyDeleteCommand.class,
+        }
+)
+public class ConfigPropertyCommand extends AbstractCommand {
+
+    static final String INTERNAL_PREFIX = "internal.";
+
+    @Override
+    public void run(OutputBuffer output) throws Exception {
+        output.writeStdOutChunk(out -> {
+            var table = new TableBuilder();
+            table.addColumns("Property", "Value");
+            config.read().getConfig().entrySet().stream()
+                    .filter(e -> !e.getKey().startsWith(INTERNAL_PREFIX))
+                    .sorted(java.util.Map.Entry.comparingByKey())
+                    .forEach(e -> table.addRow(e.getKey(), e.getValue()));
+            table.print(out);
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyDeleteCommand.java
@@ -1,0 +1,40 @@
+package io.apicurio.registry.cli.config;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.List;
+
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+
+@Command(
+        name = "delete",
+        aliases = {"remove", "rm"},
+        description = "Delete one or more configuration properties"
+)
+public class ConfigPropertyDeleteCommand extends AbstractCommand {
+
+    @Parameters(
+            arity = "1..*",
+            description = "Property names to delete"
+    )
+    List<String> keys;
+
+    @Override
+    public void run(OutputBuffer output) throws Exception {
+        var configModel = config.read();
+        int removed = 0;
+        for (var key : keys) {
+            if (configModel.getConfig().remove(key) != null) {
+                removed++;
+            } else {
+                throw new CliException("Property '" + key + "' is not set.", VALIDATION_ERROR_RETURN_CODE);
+            }
+        }
+        config.write(configModel);
+        output.writeStdOutLine(removed == 1 ? "Property deleted." : removed + " properties deleted.");
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyDeleteCommand.java
@@ -26,15 +26,13 @@ public class ConfigPropertyDeleteCommand extends AbstractCommand {
     @Override
     public void run(OutputBuffer output) throws Exception {
         var configModel = config.read();
-        int removed = 0;
         for (var key : keys) {
-            if (configModel.getConfig().remove(key) != null) {
-                removed++;
-            } else {
+            if (!configModel.getConfig().containsKey(key)) {
                 throw new CliException("Property '" + key + "' is not set.", VALIDATION_ERROR_RETURN_CODE);
             }
         }
+        keys.forEach(configModel.getConfig()::remove);
         config.write(configModel);
-        output.writeStdOutLine(removed == 1 ? "Property deleted." : removed + " properties deleted.");
+        output.writeStdOutLine(keys.size() == 1 ? "Property deleted." : keys.size() + " properties deleted.");
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyGetCommand.java
@@ -1,0 +1,31 @@
+package io.apicurio.registry.cli.config;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+
+@Command(
+        name = "get",
+        description = "Get a configuration property value"
+)
+public class ConfigPropertyGetCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "Property name"
+    )
+    String key;
+
+    @Override
+    public void run(OutputBuffer output) throws Exception {
+        var value = config.read().getConfig().get(key);
+        if (value == null) {
+            throw new CliException("Property '" + key + "' is not set.", VALIDATION_ERROR_RETURN_CODE);
+        }
+        output.writeStdOutLine(value);
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertySetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertySetCommand.java
@@ -1,0 +1,40 @@
+package io.apicurio.registry.cli.config;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.List;
+
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+
+@Command(
+        name = "set",
+        description = "Set one or more configuration properties (key=value)"
+)
+public class ConfigPropertySetCommand extends AbstractCommand {
+
+    @Parameters(
+            arity = "1..*",
+            description = "Properties to set in key=value format"
+    )
+    List<String> properties;
+
+    @Override
+    public void run(OutputBuffer output) throws Exception {
+        var configModel = config.read();
+        for (var prop : properties) {
+            var eqIndex = prop.indexOf('=');
+            if (eqIndex < 1) {
+                throw new CliException("Invalid property format: '" + prop + "'. Expected key=value.", VALIDATION_ERROR_RETURN_CODE);
+            }
+            var key = prop.substring(0, eqIndex);
+            var value = prop.substring(eqIndex + 1);
+            configModel.getConfig().put(key, value);
+        }
+        config.write(configModel);
+        output.writeStdOutLine(properties.size() == 1 ? "Property set." : properties.size() + " properties set.");
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupDeleteCommand.java
@@ -18,7 +18,7 @@ import static java.util.Optional.ofNullable;
 @Command(
         name = "delete",
         aliases = {"remove", "rm"},
-        description = "Delete an existing group. Apicurio Registry must be configured " +
+        description = "Delete an existing group. {{product-name}} must be configured " +
                 "with `apicurio.rest.deletion.group.enabled=true` to allow group deletions."
 )
 public class GroupDeleteCommand extends AbstractCommand {

--- a/cli/src/main/java/io/apicurio/registry/cli/services/CliVersion.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/CliVersion.java
@@ -1,0 +1,148 @@
+package io.apicurio.registry.cli.services;
+
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Lenient version parser that handles both standard semver (3.2.4) and
+ * Red Hat suffixed versions (3.1.6.redhat-00011, 2.6.6.Final-redhat-00001).
+ * <p>
+ * Versions that cannot be parsed are preserved as-is ({@link #isParsed()} returns false).
+ * They cannot be compared or sorted but are still included in update candidate lists.
+ */
+public final class CliVersion implements Comparable<CliVersion> {
+
+    private static final Pattern REDHAT_SUFFIX = Pattern.compile(
+            "^(\\d+)\\.(\\d+)\\.(\\d+)(?:\\.(.*?))?[.-]redhat-(\\d+)$"
+    );
+    private static final Pattern COMMUNITY = Pattern.compile(
+            "^(\\d+)\\.(\\d+)\\.(\\d+)(?:-(.+))?$"
+    );
+
+    public static final Comparator<CliVersion> COMPARATOR = Comparator
+            .comparingInt(CliVersion::major)
+            .thenComparingInt(CliVersion::minor)
+            .thenComparingInt(CliVersion::patch)
+            .thenComparingInt(CliVersion::redhatBuild);
+
+    private final int major;
+    private final int minor;
+    private final int patch;
+    private final int redhatBuild;
+    private final boolean parsed;
+    private final String original;
+
+    private CliVersion(int major, int minor, int patch, int redhatBuild, boolean parsed, String original) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+        this.redhatBuild = redhatBuild;
+        this.parsed = parsed;
+        this.original = original;
+    }
+
+    public static CliVersion parse(String version) {
+        if (version == null || version.isBlank()) {
+            return null;
+        }
+        version = version.trim();
+
+        var m = REDHAT_SUFFIX.matcher(version);
+        if (m.matches()) {
+            return new CliVersion(
+                    Integer.parseInt(m.group(1)),
+                    Integer.parseInt(m.group(2)),
+                    Integer.parseInt(m.group(3)),
+                    Integer.parseInt(m.group(5)),
+                    true, version
+            );
+        }
+
+        m = COMMUNITY.matcher(version);
+        if (m.matches()) {
+            return new CliVersion(
+                    Integer.parseInt(m.group(1)),
+                    Integer.parseInt(m.group(2)),
+                    Integer.parseInt(m.group(3)),
+                    0, true, version
+            );
+        }
+
+        // Fallback: extract MAJOR.MINOR.PATCH from dotted string
+        var parts = version.split("\\.");
+        if (parts.length >= 3) {
+            try {
+                return new CliVersion(
+                        Integer.parseInt(parts[0]),
+                        Integer.parseInt(parts[1]),
+                        Integer.parseInt(parts[2]),
+                        0, true, version
+                );
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        return new CliVersion(0, 0, 0, 0, false, version);
+    }
+
+    public int major() {
+        return major;
+    }
+
+    public int minor() {
+        return minor;
+    }
+
+    public int patch() {
+        return patch;
+    }
+
+    public int redhatBuild() {
+        return redhatBuild;
+    }
+
+    public boolean isParsed() {
+        return parsed;
+    }
+
+    public boolean isProductized() {
+        return redhatBuild > 0;
+    }
+
+    public boolean sameMajorMinor(CliVersion other) {
+        return parsed && other.parsed && major == other.major && minor == other.minor;
+    }
+
+    public boolean isNewerThan(CliVersion other) {
+        if (!parsed || !other.parsed) {
+            return false;
+        }
+        return compareTo(other) > 0;
+    }
+
+    @Override
+    public int compareTo(CliVersion other) {
+        return COMPARATOR.compare(this, other);
+    }
+
+    @Override
+    public String toString() {
+        return original;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CliVersion that)) return false;
+        if (!parsed || !that.parsed) return Objects.equals(original, that.original);
+        return major == that.major && minor == that.minor && patch == that.patch
+                && redhatBuild == that.redhatBuild;
+    }
+
+    @Override
+    public int hashCode() {
+        if (!parsed) return original.hashCode();
+        return Objects.hash(major, minor, patch, redhatBuild);
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/services/CliVersion.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/CliVersion.java
@@ -79,7 +79,8 @@ public final class CliVersion implements Comparable<CliVersion> {
                         Integer.parseInt(parts[2]),
                         0, true, version
                 );
-            } catch (NumberFormatException ignored) {
+            } catch (NumberFormatException e) {
+                // Non-numeric segments — fall through to unparsed
             }
         }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.cli.services;
 
+import io.apicurio.registry.cli.utils.PlatformUtils;
 import io.vertx.core.http.HttpMethod;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -8,18 +9,17 @@ import org.jboss.logging.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
-/**
- * Service for checking and managing CLI updates.
- * Uses MicroProfile Config for configuration management.
- */
 @ApplicationScoped
 public class Update {
 
@@ -28,171 +28,197 @@ public class Update {
     @Inject
     Client client;
 
-    public String getLatestVersion() {
+    public UpdateCheckResult checkForUpdates(CliVersion currentVersion) {
+        var allVersions = fetchAvailableVersions();
+        if (allVersions == null || allVersions.isEmpty()) {
+            return new UpdateCheckResult(currentVersion, List.of());
+        }
+
+        // Filter parsed versions by productized/community compatibility, keep only newer
+        var newer = allVersions.stream()
+                .filter(CliVersion::isParsed)
+                .filter(v -> v.isProductized() == currentVersion.isProductized())
+                .filter(v -> v.isNewerThan(currentVersion))
+                .toList();
+
+        // Group by major.minor series, pick the latest in each series
+        var parsed = newer.stream()
+                .collect(Collectors.groupingBy(
+                        v -> v.major() + "." + v.minor(),
+                        Collectors.maxBy(CliVersion.COMPARATOR)))
+                .values().stream()
+                .filter(java.util.Optional::isPresent)
+                .map(java.util.Optional::get)
+                .sorted(CliVersion.COMPARATOR)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        // Include unparsed versions as ambiguous candidates
+        allVersions.stream()
+                .filter(v -> !v.isParsed())
+                .forEach(parsed::add);
+
+        return new UpdateCheckResult(currentVersion, List.copyOf(parsed));
+    }
+
+    List<CliVersion> fetchAvailableVersions() {
+        var xml = fetchContent(getMetadataUrl(), 30);
+        if (xml == null) {
+            return List.of();
+        }
         try {
-            String updateUrl = ConfigProvider.getConfig().getValue("acr.update.repo.url", String.class);
-            if (updateUrl == null || updateUrl.isBlank()) {
-                throw new RuntimeException("Update repository URL is not configured.");
+            var factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            var builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(new ByteArrayInputStream(xml.getBytes()));
+
+            NodeList versionNodes = doc.getElementsByTagName("version");
+            List<CliVersion> versions = new ArrayList<>();
+            for (int i = 0; i < versionNodes.getLength(); i++) {
+                var text = versionNodes.item(i).getTextContent();
+                if (text != null && !text.isBlank()) {
+                    versions.add(CliVersion.parse(text));
+                }
             }
-            String metadataUri = updateUrl.endsWith("/") ? updateUrl + "maven-metadata.xml" : updateUrl + "/maven-metadata.xml";
+            var unparsed = versions.stream().filter(v -> !v.isParsed()).count();
+            log.debugf("Found %d versions in metadata (%d unparsed)", versions.size(), unparsed);
+            return versions;
+        } catch (Exception e) {
+            log.error("Error parsing maven-metadata.xml", e);
+            return List.of();
+        }
+    }
 
-            // Parse the URI to get host, port, and path
-            URI uri = URI.create(metadataUri);
-            String host = uri.getHost();
-            int port = uri.getPort() != -1 ? uri.getPort() : (uri.getScheme().equals("https") ? 443 : 80);
-            String path = uri.getPath() + (uri.getQuery() != null ? "?" + uri.getQuery() : "");
+    public Path downloadVersion(String version, Path targetDir) {
+        var platform = PlatformUtils.detectPlatformClassifier();
+        log.debugf("Detected platform: %s", platform);
+        var fileName = "apicurio-registry-cli-%s-%s.zip".formatted(version, platform);
+        var pathSegment = "%s/%s".formatted(version, fileName);
+        var repoUrl = getRepoUrl();
+        var fileUri = repoUrl.endsWith("/") ? repoUrl + pathSegment : repoUrl + "/" + pathSegment;
 
-            log.debugf("Downloading metadata from: %s", metadataUri);
+        log.infof("Downloading version %s from: %s", version, fileUri);
 
-            // Use Vertx HttpClient to download the metadata XML file
+        if (!targetDir.toFile().exists()) {
+            targetDir.toFile().mkdirs();
+        }
+
+        Path targetFile = targetDir.resolve(fileName);
+        var content = fetchBytes(fileUri, 60);
+        if (content == null) {
+            return null;
+        }
+        try {
+            java.nio.file.Files.write(targetFile, content);
+            log.infof("Successfully downloaded file to: %s", targetFile);
+            return targetFile;
+        } catch (Exception e) {
+            log.errorf(e, "Error writing downloaded file to: %s", targetFile);
+            return null;
+        }
+    }
+
+    private String getRepoUrl() {
+        String url = ConfigProvider.getConfig().getValue("internal.update.repo-url", String.class);
+        if (url == null || url.isBlank()) {
+            throw new RuntimeException("Update repository URL is not configured.");
+        }
+        return url;
+    }
+
+    private String getMetadataUrl() {
+        var repoUrl = getRepoUrl();
+        return repoUrl.endsWith("/") ? repoUrl + "maven-metadata.xml" : repoUrl + "/maven-metadata.xml";
+    }
+
+    private String fetchContent(String url, int timeoutSeconds) {
+        try {
+            URI uri = URI.create(url);
             var httpClient = client.getHttpClient();
             CompletableFuture<String> future = new CompletableFuture<>();
 
             var requestOptions = new io.vertx.core.http.RequestOptions()
                     .setMethod(HttpMethod.GET)
-                    .setPort(port)
-                    .setHost(host)
-                    .setURI(path)
-                    .setSsl(uri.getScheme().equals("https"));
+                    .setPort(uri.getPort() != -1 ? uri.getPort() : (Objects.equals(uri.getScheme(), "https") ? 443 : 80))
+                    .setHost(uri.getHost())
+                    .setURI(uri.getPath() + (uri.getQuery() != null ? "?" + uri.getQuery() : ""))
+                    .setSsl(Objects.equals(uri.getScheme(), "https"));
+
+            log.debugf("Fetching: %s", url);
 
             httpClient.request(requestOptions)
-                    .onSuccess(clientReq -> {
-                        clientReq.send()
-                                .onSuccess(response -> {
-                                    if (response.statusCode() != 200) {
-                                        log.warnf("Failed to fetch metadata. Status code: %s", response.statusCode());
-                                        future.complete(null);
-                                        return;
-                                    }
-
-                                    response.body()
-                                            .onSuccess(buffer -> {
-                                                try {
-                                                    String xmlContent = buffer.toString();
-                                                    log.debug("Metadata XML content received");
-
-                                                    // Parse the XML and extract the latest version
-                                                    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-                                                    DocumentBuilder builder = factory.newDocumentBuilder();
-                                                    Document doc = builder.parse(new ByteArrayInputStream(xmlContent.getBytes()));
-
-                                                    // Extract the <latest> tag from <versioning>
-                                                    NodeList latestNodes = doc.getElementsByTagName("latest");
-                                                    if (latestNodes.getLength() > 0) {
-                                                        String latestVersion = latestNodes.item(0).getTextContent();
-                                                        log.debugf("Latest version available: %s", latestVersion);
-                                                        future.complete(latestVersion);
-                                                    } else {
-                                                        log.warn("No <latest> tag found in metadata XML");
-                                                        future.complete(null);
-                                                    }
-                                                } catch (Exception e) {
-                                                    log.error("Error parsing XML", e);
-                                                    future.completeExceptionally(e);
-                                                }
-                                            })
-                                            .onFailure(err -> {
-                                                log.error("Error reading response body", err);
-                                                future.completeExceptionally(err);
-                                            });
-                                })
-                                .onFailure(err -> {
-                                    log.error("Error sending request", err);
-                                    future.completeExceptionally(err);
-                                });
-                    })
+                    .onSuccess(req -> req.send()
+                            .onSuccess(response -> {
+                                if (response.statusCode() != 200) {
+                                    log.warnf("HTTP %d from %s", response.statusCode(), url);
+                                    future.complete(null);
+                                    return;
+                                }
+                                response.body()
+                                        .onSuccess(buffer -> future.complete(buffer.toString()))
+                                        .onFailure(err -> {
+                                            log.error("Error reading response body", err);
+                                            future.completeExceptionally(err);
+                                        });
+                            })
+                            .onFailure(err -> {
+                                log.error("Error sending request", err);
+                                future.completeExceptionally(err);
+                            }))
                     .onFailure(err -> {
                         log.error("Error creating request", err);
                         future.completeExceptionally(err);
                     });
 
-            // Wait for the async operation to complete (with timeout)
-            return future.get(30, TimeUnit.SECONDS);
-
+            return future.get(timeoutSeconds, TimeUnit.SECONDS);
         } catch (Exception e) {
-            log.error("Error checking for latest version", e);
+            log.errorf("Error fetching %s: %s", url, e.getMessage());
             return null;
         }
     }
 
-    public Path downloadVersion(String version, Path targetDir) {
+    private byte[] fetchBytes(String url, int timeoutSeconds) {
         try {
-            String updateUrl = ConfigProvider.getConfig().getValue("acr.update.repo.url", String.class);
-            if (updateUrl == null || updateUrl.isBlank()) {
-                throw new RuntimeException("Update repository URL is not configured.");
-            }
-            var pathSegment = "%1$s/apicurio-registry-cli-%1$s.zip".formatted(version);
-            String fileUri = updateUrl.endsWith("/") ? updateUrl + pathSegment : updateUrl + "/" + pathSegment;
-
-            // Parse the URI to get host, port, and path
-            URI uri = URI.create(fileUri);
-            String host = uri.getHost();
-            int port = uri.getPort() != -1 ? uri.getPort() : (uri.getScheme().equals("https") ? 443 : 80);
-            String uriPath = uri.getPath() + (uri.getQuery() != null ? "?" + uri.getQuery() : "");
-
-            log.infof("Downloading version %s from: %s", version, fileUri);
-
-            // Ensure target directory exists
-            if (!targetDir.toFile().exists()) {
-                targetDir.toFile().mkdirs();
-            }
-
-            // Create the target file path
-            Path targetFile = targetDir.resolve("apicurio-registry-cli-" + version + ".zip");
-
-            // Use Vertx HttpClient to download the file
+            URI uri = URI.create(url);
             var httpClient = client.getHttpClient();
-            CompletableFuture<Path> future = new CompletableFuture<>();
+            CompletableFuture<byte[]> future = new CompletableFuture<>();
 
             var requestOptions = new io.vertx.core.http.RequestOptions()
                     .setMethod(HttpMethod.GET)
-                    .setPort(port)
-                    .setHost(host)
-                    .setURI(uriPath)
-                    .setSsl(uri.getScheme().equals("https"));
+                    .setPort(uri.getPort() != -1 ? uri.getPort() : (Objects.equals(uri.getScheme(), "https") ? 443 : 80))
+                    .setHost(uri.getHost())
+                    .setURI(uri.getPath() + (uri.getQuery() != null ? "?" + uri.getQuery() : ""))
+                    .setSsl(Objects.equals(uri.getScheme(), "https"));
+
+            log.debugf("Downloading: %s", url);
 
             httpClient.request(requestOptions)
-                    .onSuccess(clientReq -> {
-                        clientReq.send()
-                                .onSuccess(response -> {
-                                    if (response.statusCode() != 200) {
-                                        log.errorf("Failed to download file. Status code: %s", response.statusCode());
-                                        future.completeExceptionally(new RuntimeException("HTTP " + response.statusCode()));
-                                        return;
-                                    }
-
-                                    response.body()
-                                            .onSuccess(buffer -> {
-                                                try {
-                                                    // Write the buffer to the target file
-                                                    java.nio.file.Files.write(targetFile, buffer.getBytes());
-                                                    log.infof("Successfully downloaded file to: %s", targetFile);
-                                                    future.complete(targetFile);
-                                                } catch (Exception e) {
-                                                    log.error("Error writing file to disk", e);
-                                                    future.completeExceptionally(e);
-                                                }
-                                            })
-                                            .onFailure(err -> {
-                                                log.error("Error reading response body", err);
-                                                future.completeExceptionally(err);
-                                            });
-                                })
-                                .onFailure(err -> {
-                                    log.error("Error sending request", err);
-                                    future.completeExceptionally(err);
-                                });
-                    })
+                    .onSuccess(req -> req.send()
+                            .onSuccess(response -> {
+                                if (response.statusCode() != 200) {
+                                    log.errorf("HTTP %d from %s", response.statusCode(), url);
+                                    future.completeExceptionally(new RuntimeException("HTTP " + response.statusCode()));
+                                    return;
+                                }
+                                response.body()
+                                        .onSuccess(buffer -> future.complete(buffer.getBytes()))
+                                        .onFailure(err -> {
+                                            log.error("Error reading response body", err);
+                                            future.completeExceptionally(err);
+                                        });
+                            })
+                            .onFailure(err -> {
+                                log.error("Error sending request", err);
+                                future.completeExceptionally(err);
+                            }))
                     .onFailure(err -> {
                         log.error("Error creating request", err);
                         future.completeExceptionally(err);
                     });
 
-            // Wait for the async operation to complete (with timeout)
-            return future.get(60, TimeUnit.SECONDS);
-
+            return future.get(timeoutSeconds, TimeUnit.SECONDS);
         } catch (Exception e) {
-            log.error("Error downloading version", e);
+            log.errorf("Error downloading %s: %s", url, e.getMessage());
             return null;
         }
     }

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
@@ -19,7 +19,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -161,12 +160,14 @@ public class Update {
             var httpClient = client.getHttpClient();
             CompletableFuture<byte[]> future = new CompletableFuture<>();
 
+            boolean ssl = "https".equals(uri.getScheme());
+            int port = uri.getPort() != -1 ? uri.getPort() : (ssl ? 443 : 80);
             var requestOptions = new io.vertx.core.http.RequestOptions()
                     .setMethod(HttpMethod.GET)
-                    .setPort(uri.getPort() != -1 ? uri.getPort() : (Objects.equals(uri.getScheme(), "https") ? 443 : 80))
+                    .setPort(port)
                     .setHost(uri.getHost())
                     .setURI(uri.getPath() + (uri.getQuery() != null ? "?" + uri.getQuery() : ""))
-                    .setSsl(Objects.equals(uri.getScheme(), "https"));
+                    .setSsl(ssl);
 
             log.debugf("Fetching: %s", url);
 

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
@@ -198,9 +198,13 @@ public class Update {
             return future.get(timeoutSeconds, TimeUnit.SECONDS);
         } catch (TimeoutException _ignored) {
             log.errorf("Request timed out after %ds: %s", timeoutSeconds, url);
-            config.getStdErr().print(
-                    "Request timed out. If you have a slow connection, increase the timeout:\n" +
-                            "  acr config set update.timeout-seconds=120\n");
+            config.getStdErr().print("""
+                    Request timed out. If you have a slow connection, increase the timeout:
+                      acr config set update.timeout-seconds=120
+                    """);
+            return null;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
             return null;
         } catch (Exception ex) {
             log.errorf("Error fetching %s: %s", url, ex.getMessage());

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
@@ -91,6 +91,8 @@ public class Update {
             var factory = DocumentBuilderFactory.newInstance();
             factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
             factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             var builder = factory.newDocumentBuilder();
             Document doc = builder.parse(new ByteArrayInputStream(bytes));
 

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
@@ -1,5 +1,7 @@
 package io.apicurio.registry.cli.services;
 
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.config.Config;
 import io.apicurio.registry.cli.utils.PlatformUtils;
 import io.vertx.core.http.HttpMethod;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -12,13 +14,18 @@ import org.w3c.dom.NodeList;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
 
 @ApplicationScoped
 public class Update {
@@ -27,6 +34,20 @@ public class Update {
 
     @Inject
     Client client;
+
+    @Inject
+    Config config;
+
+    private static final int DEFAULT_TIMEOUT_SECONDS = 60;
+
+    private int getTimeoutSeconds() {
+        try {
+            var value = config.read().getConfig().get("update.timeout-seconds");
+            return value != null ? Integer.parseInt(value) : DEFAULT_TIMEOUT_SECONDS;
+        } catch (Exception e) {
+            return DEFAULT_TIMEOUT_SECONDS;
+        }
+    }
 
     public UpdateCheckResult checkForUpdates(CliVersion currentVersion) {
         var allVersions = fetchAvailableVersions();
@@ -52,20 +73,26 @@ public class Update {
                 .sorted(CliVersion.COMPARATOR)
                 .collect(Collectors.toCollection(ArrayList::new));
 
+        var configModel = config.read();
+        configModel.getConfig().put("internal.update.last-check", Instant.now().toString());
+        config.write(configModel);
+
         return new UpdateCheckResult(currentVersion, List.copyOf(parsed));
     }
 
     List<CliVersion> fetchAvailableVersions() {
-        var xml = fetchContent(getMetadataUrl(), 30);
-        if (xml == null) {
-            return List.of();
+        var metadataUrl = getMetadataUrl();
+        var timeout = getTimeoutSeconds();
+        var bytes = fetchBytes(metadataUrl, timeout);
+        if (bytes == null) {
+            throw new CliException("Could not fetch update metadata from " + metadataUrl);
         }
         try {
             var factory = DocumentBuilderFactory.newInstance();
             factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
             factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             var builder = factory.newDocumentBuilder();
-            Document doc = builder.parse(new ByteArrayInputStream(xml.getBytes()));
+            Document doc = builder.parse(new ByteArrayInputStream(bytes));
 
             NodeList versionNodes = doc.getElementsByTagName("version");
             List<CliVersion> versions = new ArrayList<>();
@@ -78,9 +105,10 @@ public class Update {
             var unparsed = versions.stream().filter(v -> !v.isParsed()).count();
             log.debugf("Found %d versions in metadata (%d unparsed)", versions.size(), unparsed);
             return versions;
+        } catch (CliException e) {
+            throw e;
         } catch (Exception e) {
-            log.error("Error parsing maven-metadata.xml", e);
-            return List.of();
+            throw new CliException("Error parsing update metadata from " + metadataUrl, e, APPLICATION_ERROR_RETURN_CODE);
         }
     }
 
@@ -99,24 +127,23 @@ public class Update {
         }
 
         Path targetFile = targetDir.resolve(fileName);
-        var content = fetchBytes(fileUri, 60);
+        var content = fetchBytes(fileUri, getTimeoutSeconds());
         if (content == null) {
-            return null;
+            throw new CliException("Failed to download " + fileUri);
         }
         try {
-            java.nio.file.Files.write(targetFile, content);
+            Files.write(targetFile, content);
             log.infof("Successfully downloaded file to: %s", targetFile);
             return targetFile;
         } catch (Exception e) {
-            log.errorf(e, "Error writing downloaded file to: %s", targetFile);
-            return null;
+            throw new CliException("Error writing downloaded file to: " + targetFile, e, APPLICATION_ERROR_RETURN_CODE);
         }
     }
 
     private String getRepoUrl() {
         String url = ConfigProvider.getConfig().getValue("internal.update.repo-url", String.class);
         if (url == null || url.isBlank()) {
-            throw new RuntimeException("Update repository URL is not configured.");
+            throw new CliException("Update repository URL is not configured.");
         }
         return url;
     }
@@ -124,52 +151,6 @@ public class Update {
     private String getMetadataUrl() {
         var repoUrl = getRepoUrl();
         return repoUrl.endsWith("/") ? repoUrl + "maven-metadata.xml" : repoUrl + "/maven-metadata.xml";
-    }
-
-    private String fetchContent(String url, int timeoutSeconds) {
-        try {
-            URI uri = URI.create(url);
-            var httpClient = client.getHttpClient();
-            CompletableFuture<String> future = new CompletableFuture<>();
-
-            var requestOptions = new io.vertx.core.http.RequestOptions()
-                    .setMethod(HttpMethod.GET)
-                    .setPort(uri.getPort() != -1 ? uri.getPort() : (Objects.equals(uri.getScheme(), "https") ? 443 : 80))
-                    .setHost(uri.getHost())
-                    .setURI(uri.getPath() + (uri.getQuery() != null ? "?" + uri.getQuery() : ""))
-                    .setSsl(Objects.equals(uri.getScheme(), "https"));
-
-            log.debugf("Fetching: %s", url);
-
-            httpClient.request(requestOptions)
-                    .onSuccess(req -> req.send()
-                            .onSuccess(response -> {
-                                if (response.statusCode() != 200) {
-                                    log.warnf("HTTP %d from %s", response.statusCode(), url);
-                                    future.complete(null);
-                                    return;
-                                }
-                                response.body()
-                                        .onSuccess(buffer -> future.complete(buffer.toString()))
-                                        .onFailure(err -> {
-                                            log.error("Error reading response body", err);
-                                            future.completeExceptionally(err);
-                                        });
-                            })
-                            .onFailure(err -> {
-                                log.error("Error sending request", err);
-                                future.completeExceptionally(err);
-                            }))
-                    .onFailure(err -> {
-                        log.error("Error creating request", err);
-                        future.completeExceptionally(err);
-                    });
-
-            return future.get(timeoutSeconds, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            log.errorf("Error fetching %s: %s", url, e.getMessage());
-            return null;
-        }
     }
 
     private byte[] fetchBytes(String url, int timeoutSeconds) {
@@ -185,14 +166,14 @@ public class Update {
                     .setURI(uri.getPath() + (uri.getQuery() != null ? "?" + uri.getQuery() : ""))
                     .setSsl(Objects.equals(uri.getScheme(), "https"));
 
-            log.debugf("Downloading: %s", url);
+            log.debugf("Fetching: %s", url);
 
             httpClient.request(requestOptions)
                     .onSuccess(req -> req.send()
                             .onSuccess(response -> {
                                 if (response.statusCode() != 200) {
-                                    log.errorf("HTTP %d from %s", response.statusCode(), url);
-                                    future.completeExceptionally(new RuntimeException("HTTP " + response.statusCode()));
+                                    log.warnf("HTTP %d from %s", response.statusCode(), url);
+                                    future.completeExceptionally(new CliException("HTTP " + response.statusCode()));
                                     return;
                                 }
                                 response.body()
@@ -212,8 +193,14 @@ public class Update {
                     });
 
             return future.get(timeoutSeconds, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            log.errorf("Error downloading %s: %s", url, e.getMessage());
+        } catch (TimeoutException _ignored) {
+            log.errorf("Request timed out after %ds: %s", timeoutSeconds, url);
+            config.getStdErr().print(
+                    "Request timed out. If you have a slow connection, increase the timeout:\n" +
+                            "  acr config set update.timeout-seconds=120\n");
+            return null;
+        } catch (Exception ex) {
+            log.errorf("Error fetching %s: %s", url, ex.getMessage());
             return null;
         }
     }

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
@@ -52,11 +52,6 @@ public class Update {
                 .sorted(CliVersion.COMPARATOR)
                 .collect(Collectors.toCollection(ArrayList::new));
 
-        // Include unparsed versions as ambiguous candidates
-        allVersions.stream()
-                .filter(v -> !v.isParsed())
-                .forEach(parsed::add);
-
         return new UpdateCheckResult(currentVersion, List.copyOf(parsed));
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/services/UpdateCheckResult.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/UpdateCheckResult.java
@@ -1,0 +1,49 @@
+package io.apicurio.registry.cli.services;
+
+import java.util.List;
+
+public record UpdateCheckResult(
+        CliVersion currentVersion,
+        List<CliVersion> candidates
+) {
+
+    public boolean hasUpdates() {
+        return !candidates.isEmpty();
+    }
+
+    public CliVersion patchUpdate() {
+        return candidates.stream()
+                .filter(v -> v.isParsed() && v.sameMajorMinor(currentVersion))
+                .max(CliVersion.COMPARATOR)
+                .orElse(null);
+    }
+
+    public boolean isAmbiguous() {
+        if (candidates.size() <= 1) {
+            return false;
+        }
+        return patchUpdate() == null;
+    }
+
+    public CliVersion unambiguousUpdate() {
+        if (candidates.size() == 1) {
+            return candidates.get(0);
+        }
+        return patchUpdate();
+    }
+
+    public void formatMessage(StringBuilder out) {
+        for (var v : candidates) {
+            var label = v.isParsed() && v.sameMajorMinor(currentVersion) ? "patch" : "minor";
+            if (candidates.size() == 1) {
+                out.append("  ").append(v.toString())
+                        .append(" (").append(label).append(")")
+                        .append("  — run 'acr update'\n");
+            } else {
+                out.append("  ").append(v.toString())
+                        .append(" (").append(label).append(")")
+                        .append("  — run 'acr update ").append(v.toString()).append("'\n");
+            }
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
@@ -1,0 +1,132 @@
+package io.apicurio.registry.cli.services;
+
+import io.apicurio.registry.cli.config.Config;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+@ApplicationScoped
+public class UpdateNotifier {
+
+    private static final Logger log = Logger.getLogger(UpdateNotifier.class);
+    private static final Duration CHECK_INTERVAL = Duration.ofDays(1);
+    private static final int CHECK_TIMEOUT_SECONDS = 5;
+
+    private static final Set<String> SKIP_COMMANDS = Set.of("install", "update", "version", "config");
+
+    @Inject
+    Config config;
+
+    @Inject
+    Update update;
+
+    public void checkAndNotify(String commandName) {
+        try {
+            if (SKIP_COMMANDS.contains(commandName)) {
+                log.debugf("Update check skipped: command '%s' is in skip list", commandName);
+                return;
+            }
+            if (!shouldCheck()) {
+                return;
+            }
+
+            var versionStr = ConfigProvider.getConfig().getValue("version", String.class);
+            var currentVersion = CliVersion.parse(versionStr);
+            if (currentVersion == null) {
+                log.debugf("Update check skipped: could not parse current version '%s'", versionStr);
+                return;
+            }
+
+            log.debugf("Checking for updates (current version: %s)", currentVersion);
+            var future = CompletableFuture.supplyAsync(() -> update.checkForUpdates(currentVersion));
+            var result = future.get(CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            recordCheckTimestamp();
+
+            if (result.hasUpdates()) {
+                log.debugf("Updates available: %s", result.candidates());
+                printNotification(result);
+            } else {
+                log.debugf("No updates available");
+            }
+        } catch (Exception e) {
+            log.debugf("Update check failed: %s", e.getMessage());
+        }
+    }
+
+    private boolean shouldCheck() {
+        try {
+            var configModel = config.read();
+            var props = configModel.getConfig();
+
+            if ("false".equalsIgnoreCase(props.get("update.check-enabled"))) {
+                log.debugf("Update check skipped: update.check-enabled=false");
+                return false;
+            }
+
+            var postponedUntil = props.get("internal.update.postponed-until");
+            if (postponedUntil != null) {
+                var until = Instant.parse(postponedUntil);
+                if (Instant.now().isBefore(until)) {
+                    log.debugf("Update check skipped: postponed until %s", until);
+                    return false;
+                }
+            }
+
+            var lastCheck = props.get("internal.update.last-check");
+            if (lastCheck != null) {
+                var last = Instant.parse(lastCheck);
+                var elapsed = Duration.between(last, Instant.now());
+                if (elapsed.compareTo(CHECK_INTERVAL) < 0) {
+                    log.debugf("Update check skipped: last check was %s ago (interval: %s)", elapsed, CHECK_INTERVAL);
+                    return false;
+                }
+            }
+
+            return true;
+        } catch (Exception e) {
+            log.debugf("Update check skipped: could not read config: %s", e.getMessage());
+            return false;
+        }
+    }
+
+    private void recordCheckTimestamp() {
+        try {
+            var configModel = config.read();
+            configModel.getConfig().put("internal.update.last-check", Instant.now().toString());
+            config.write(configModel);
+        } catch (Exception e) {
+            log.debugf("Could not record update check timestamp: %s", e.getMessage());
+        }
+    }
+
+    private void printNotification(UpdateCheckResult result) {
+        var productName = getProductName();
+        var sb = new StringBuilder();
+        sb.append("\n");
+        if (result.isAmbiguous()) {
+            sb.append("New versions of ").append(productName).append(" are available:\n");
+        } else {
+            sb.append("A new version of ").append(productName).append(" is available:\n");
+        }
+        result.formatMessage(sb);
+        sb.append("Run 'acr update --postpone' to postpone for 5 days.\n");
+        config.getStdErr().print(sb.toString());
+    }
+
+    private String getProductName() {
+        try {
+            var name = config.read().getConfig().get("internal.branding.product-name");
+            return name != null ? name : "Apicurio Registry CLI";
+        } catch (Exception e) {
+            return "Apicurio Registry CLI";
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
@@ -3,21 +3,17 @@ package io.apicurio.registry.cli.services;
 import io.apicurio.registry.cli.config.Config;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
 public class UpdateNotifier {
 
     private static final Logger log = Logger.getLogger(UpdateNotifier.class);
     private static final Duration CHECK_INTERVAL = Duration.ofDays(1);
-    private static final int CHECK_TIMEOUT_SECONDS = 5;
 
     private static final Set<String> SKIP_COMMANDS = Set.of("install", "update", "version", "config");
 
@@ -28,6 +24,7 @@ public class UpdateNotifier {
     Update update;
 
     public void checkAndNotify(String commandName) {
+        log.debugf("Update check hook: command=%s", commandName);
         try {
             if (SKIP_COMMANDS.contains(commandName)) {
                 log.debugf("Update check skipped: command '%s' is in skip list", commandName);
@@ -37,27 +34,20 @@ public class UpdateNotifier {
                 return;
             }
 
-            var versionStr = ConfigProvider.getConfig().getValue("version", String.class);
-            var currentVersion = CliVersion.parse(versionStr);
-            if (currentVersion == null) {
-                log.debugf("Update check skipped: could not parse current version '%s'", versionStr);
-                return;
-            }
-
+            var currentVersion = config.getCliVersion();
+            config.getStdErr().print("Checking for updates...\n");
             log.debugf("Checking for updates (current version: %s)", currentVersion);
-            var future = CompletableFuture.supplyAsync(() -> update.checkForUpdates(currentVersion));
-            var result = future.get(CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
-            recordCheckTimestamp();
+            var result = update.checkForUpdates(currentVersion);
 
             if (result.hasUpdates()) {
                 log.debugf("Updates available: %s", result.candidates());
                 printNotification(result);
             } else {
-                log.debugf("No updates available");
+                config.getStdErr().print("No updates available.\n");
             }
         } catch (Exception e) {
             log.debugf("Update check failed: %s", e.getMessage());
+            config.getStdErr().print("Warning: Could not check for updates. Run 'acr update --check' to retry.\n");
         }
     }
 
@@ -94,16 +84,6 @@ public class UpdateNotifier {
         } catch (Exception e) {
             log.debugf("Update check skipped: could not read config: %s", e.getMessage());
             return false;
-        }
-    }
-
-    private void recordCheckTimestamp() {
-        try {
-            var configModel = config.read();
-            configModel.getConfig().put("internal.update.last-check", Instant.now().toString());
-            config.write(configModel);
-        } catch (Exception e) {
-            log.debugf("Could not record update check timestamp: %s", e.getMessage());
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/OutputBuffer.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/OutputBuffer.java
@@ -17,6 +17,7 @@ public class OutputBuffer {
     private final StringBuilder buffer = new StringBuilder();
 
     private final List<Chunk> chunks = new ArrayList<>();
+    private int printedUpTo = 0;
 
     public OutputBuffer(Output stdOut, Output stdErr) {
         this.stdOut = stdOut;
@@ -57,12 +58,14 @@ public class OutputBuffer {
     }
 
     public void print() {
-        for (Chunk chunk : chunks) {
+        for (int i = printedUpTo; i < chunks.size(); i++) {
+            var chunk = chunks.get(i);
             switch (chunk.getTarget()) {
                 case STDOUT -> stdOut.print(chunk.getOutput());
                 case STDERR -> stdErr.print(chunk.getOutput());
             }
         }
+        printedUpTo = chunks.size();
     }
 
     @AllArgsConstructor

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/PlatformUtils.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/PlatformUtils.java
@@ -1,0 +1,30 @@
+package io.apicurio.registry.cli.utils;
+
+import java.util.Locale;
+
+public final class PlatformUtils {
+
+    private PlatformUtils() {
+    }
+
+    public static String detectOsClassifier() {
+        var osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+        if (osName.contains("mac") || osName.contains("darwin")) {
+            return "osx";
+        }
+        return "linux";
+    }
+
+    public static String detectArchClassifier() {
+        var arch = System.getProperty("os.arch").toLowerCase(Locale.ROOT);
+        return switch (arch) {
+            case "amd64", "x86_64" -> "x86_64";
+            case "aarch64", "arm64" -> "aarch_64";
+            default -> arch;
+        };
+    }
+
+    public static String detectPlatformClassifier() {
+        return detectOsClassifier() + "-" + detectArchClassifier();
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/PlatformUtils.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/PlatformUtils.java
@@ -9,10 +9,13 @@ public final class PlatformUtils {
 
     public static String detectOsClassifier() {
         var osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+        if (osName.contains("linux")) {
+            return "linux";
+        }
         if (osName.contains("mac") || osName.contains("darwin")) {
             return "osx";
         }
-        return "linux";
+        throw new UnsupportedOperationException("Unsupported OS: " + System.getProperty("os.name"));
     }
 
     public static String detectArchClassifier() {
@@ -20,7 +23,7 @@ public final class PlatformUtils {
         return switch (arch) {
             case "amd64", "x86_64" -> "x86_64";
             case "aarch64", "arm64" -> "aarch_64";
-            default -> arch;
+            default -> throw new UnsupportedOperationException("Unsupported architecture: " + arch);
         };
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionDeleteCommand.java
@@ -14,7 +14,7 @@ import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 @Command(
         name = "delete",
         aliases = {"remove", "rm"},
-        description = "Delete a version. Apicurio Registry must be configured with " +
+        description = "Delete a version. {{product-name}} must be configured with " +
                 "`apicurio.rest.deletion.artifact-version.enabled=true` to allow version deletions."
 )
 public class VersionDeleteCommand extends AbstractCommand {

--- a/cli/src/main/resources/application.properties
+++ b/cli/src/main/resources/application.properties
@@ -11,11 +11,8 @@ version=${project.version}
 
 # Logging - send log output to stderr so stdout is clean for CLI output
 quarkus.log.console.stderr=true
-quarkus.log.level=WARN
+quarkus.log.level=OFF
 
-# Suppress Quarkus startup/shutdown messages
-quarkus.log.category."io.quarkus".level=WARN
-quarkus.log.category."io.quarkus.arc".level=ERROR
 
 
 # Native image configuration

--- a/cli/src/main/scripts/common/config.json
+++ b/cli/src/main/scripts/common/config.json
@@ -1,7 +1,9 @@
 {
+  "installation-version": 1,
   "config": {
-    "acr.update.check.enabled": "true",
-    "acr.update.repo.url": "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-cli"
+    "update.check-enabled": "true",
+    "internal.update.repo-url": "${update.repo.url}",
+    "internal.branding.product-name": "${branding.product-name}"
   },
   "context": {}
 }

--- a/cli/src/test/java/io/apicurio/registry/cli/CliVersionTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/CliVersionTest.java
@@ -1,0 +1,175 @@
+package io.apicurio.registry.cli;
+
+import io.apicurio.registry.cli.services.CliVersion;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CliVersionTest {
+
+    @Test
+    public void testParseCommunityVersion() {
+        var v = CliVersion.parse("3.2.4");
+        assertThat(v).isNotNull();
+        assertThat(v.major()).isEqualTo(3);
+        assertThat(v.minor()).isEqualTo(2);
+        assertThat(v.patch()).isEqualTo(4);
+        assertThat(v.isProductized()).isFalse();
+        assertThat(v.redhatBuild()).isEqualTo(0);
+        assertThat(v.toString()).isEqualTo("3.2.4");
+    }
+
+    @Test
+    public void testParseRedhatVersion() {
+        var v = CliVersion.parse("3.1.6.redhat-00011");
+        assertThat(v).isNotNull();
+        assertThat(v.major()).isEqualTo(3);
+        assertThat(v.minor()).isEqualTo(1);
+        assertThat(v.patch()).isEqualTo(6);
+        assertThat(v.isProductized()).isTrue();
+        assertThat(v.redhatBuild()).isEqualTo(11);
+    }
+
+    @Test
+    public void testParseRedhatVersionWithFinalQualifier() {
+        var v = CliVersion.parse("2.6.6.Final-redhat-00001");
+        assertThat(v).isNotNull();
+        assertThat(v.major()).isEqualTo(2);
+        assertThat(v.minor()).isEqualTo(6);
+        assertThat(v.patch()).isEqualTo(6);
+        assertThat(v.isProductized()).isTrue();
+        assertThat(v.redhatBuild()).isEqualTo(1);
+    }
+
+    @Test
+    public void testParseRedhatVersionWithSP() {
+        var v = CliVersion.parse("2.4.4.SP1-redhat-00001");
+        assertThat(v).isNotNull();
+        assertThat(v.major()).isEqualTo(2);
+        assertThat(v.minor()).isEqualTo(4);
+        assertThat(v.patch()).isEqualTo(4);
+        assertThat(v.isProductized()).isTrue();
+        assertThat(v.redhatBuild()).isEqualTo(1);
+    }
+
+    @Test
+    public void testParseRedhatVersionWithFuseQualifier() {
+        var v = CliVersion.parse("1.0.2.fuse-750001-redhat-00002");
+        assertThat(v).isNotNull();
+        assertThat(v.major()).isEqualTo(1);
+        assertThat(v.minor()).isEqualTo(0);
+        assertThat(v.patch()).isEqualTo(2);
+        assertThat(v.isProductized()).isTrue();
+        assertThat(v.redhatBuild()).isEqualTo(2);
+    }
+
+    @Test
+    public void testParseNullAndBlank() {
+        assertThat(CliVersion.parse(null)).isNull();
+        assertThat(CliVersion.parse("")).isNull();
+        assertThat(CliVersion.parse("   ")).isNull();
+    }
+
+    @Test
+    public void testParseInvalidPreservesOriginal() {
+        var v = CliVersion.parse("not-a-version");
+        assertThat(v).isNotNull();
+        assertThat(v.isParsed()).isFalse();
+        assertThat(v.toString()).isEqualTo("not-a-version");
+        assertThat(v.isNewerThan(CliVersion.parse("3.2.4"))).isFalse();
+
+        var v2 = CliVersion.parse("abc.def.ghi");
+        assertThat(v2).isNotNull();
+        assertThat(v2.isParsed()).isFalse();
+        assertThat(v2.toString()).isEqualTo("abc.def.ghi");
+    }
+
+    @Test
+    public void testParseSnapshotVersion() {
+        var v = CliVersion.parse("3.3.0-SNAPSHOT");
+        assertThat(v).isNotNull();
+        assertThat(v.major()).isEqualTo(3);
+        assertThat(v.minor()).isEqualTo(3);
+        assertThat(v.patch()).isEqualTo(0);
+        assertThat(v.isProductized()).isFalse();
+    }
+
+    @Test
+    public void testComparisonCommunity() {
+        var v324 = CliVersion.parse("3.2.4");
+        var v325 = CliVersion.parse("3.2.5");
+        var v330 = CliVersion.parse("3.3.0");
+        var v310 = CliVersion.parse("3.1.0");
+
+        assertThat(v325.isNewerThan(v324)).isTrue();
+        assertThat(v324.isNewerThan(v325)).isFalse();
+        assertThat(v330.isNewerThan(v324)).isTrue();
+        assertThat(v310.isNewerThan(v324)).isFalse();
+    }
+
+    @Test
+    public void testComparisonRedhat() {
+        var v1 = CliVersion.parse("3.1.6.redhat-00008");
+        var v2 = CliVersion.parse("3.1.6.redhat-00011");
+
+        assertThat(v2.isNewerThan(v1)).isTrue();
+        assertThat(v1.isNewerThan(v2)).isFalse();
+    }
+
+    @Test
+    public void testSameMajorMinor() {
+        var v1 = CliVersion.parse("3.2.4");
+        var v2 = CliVersion.parse("3.2.5");
+        var v3 = CliVersion.parse("3.3.0");
+
+        assertThat(v1.sameMajorMinor(v2)).isTrue();
+        assertThat(v1.sameMajorMinor(v3)).isFalse();
+    }
+
+    @Test
+    public void testProductizedFiltering() {
+        var community = CliVersion.parse("3.2.4");
+        var productized = CliVersion.parse("3.1.6.redhat-00011");
+
+        assertThat(community.isProductized()).isFalse();
+        assertThat(productized.isProductized()).isTrue();
+    }
+
+    @Test
+    public void testSorting() {
+        var versions = Stream.of(
+                "3.2.4", "3.1.0", "3.3.0", "3.2.5", "3.0.1"
+        ).map(CliVersion::parse).sorted().toList();
+
+        assertThat(versions).extracting(CliVersion::toString)
+                .containsExactly("3.0.1", "3.1.0", "3.2.4", "3.2.5", "3.3.0");
+    }
+
+    @Test
+    public void testSortingRedhat() {
+        var versions = Stream.of(
+                "3.1.6.redhat-00011", "3.0.7.redhat-00009", "3.1.0.redhat-00004", "3.1.6.redhat-00008"
+        ).map(CliVersion::parse).sorted().toList();
+
+        assertThat(versions).extracting(CliVersion::toString)
+                .containsExactly(
+                        "3.0.7.redhat-00009",
+                        "3.1.0.redhat-00004",
+                        "3.1.6.redhat-00008",
+                        "3.1.6.redhat-00011"
+                );
+    }
+
+    @Test
+    public void testEquality() {
+        var v1 = CliVersion.parse("3.2.4");
+        var v2 = CliVersion.parse("3.2.4");
+        var v3 = CliVersion.parse("3.2.5");
+
+        assertThat(v1).isEqualTo(v2);
+        assertThat(v1).isNotEqualTo(v3);
+        assertThat(v1.hashCode()).isEqualTo(v2.hashCode());
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/ConfigPropertyCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ConfigPropertyCommandTest.java
@@ -1,0 +1,160 @@
+package io.apicurio.registry.cli;
+
+import io.apicurio.registry.cli.config.Config;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+public class ConfigPropertyCommandTest {
+
+    @Inject
+    Config config;
+
+    @Inject
+    CommandLine.IFactory factory;
+
+    private CommandLine cmd;
+    private StringWriter out;
+    private StringWriter err;
+
+    @BeforeEach
+    public void setUp() {
+        var acrHome = Path.of(
+                        getClass().getClassLoader()
+                                .getResource("acr-home")
+                                .getPath())
+                .normalize();
+        config.setAcrCurrentHomePath(acrHome);
+        config.reset();
+        config.setAcrCurrentHomePath(acrHome);
+
+        cmd = new CommandLine(new Acr(), factory);
+        out = new StringWriter();
+        err = new StringWriter();
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(err));
+        config.setStdOut(value -> out.write(value));
+        config.setStdErr(value -> err.write(value));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        config.reset();
+    }
+
+    @Test
+    public void testConfigHelp() {
+        int exitCode = cmd.execute("config", "--help");
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(out.toString()).contains("Usage: acr config");
+    }
+
+    @Test
+    public void testConfigList() {
+        int exitCode = cmd.execute("config");
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(out.toString())
+                .contains("update.check-enabled")
+                .doesNotContain("internal.");
+    }
+
+    @Test
+    public void testConfigListHidesInternalProperties() {
+        // Set an internal property
+        var configModel = config.read();
+        configModel.getConfig().put("internal.update.last-check", "2026-01-01T00:00:00Z");
+        config.write(configModel);
+
+        int exitCode = cmd.execute("config");
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(out.toString()).doesNotContain("internal.");
+    }
+
+    @Test
+    public void testConfigGet() {
+        int exitCode = cmd.execute("config", "get", "update.check-enabled");
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(out.toString().trim()).isEqualTo("false");
+    }
+
+    @Test
+    public void testConfigGetNonExistent() {
+        int exitCode = cmd.execute("config", "get", "nonexistent.key");
+        assertThat(exitCode)
+                .as("Getting a non-existent property should fail")
+                .isNotEqualTo(0);
+    }
+
+    @Test
+    public void testConfigSet() {
+        int exitCode = cmd.execute("config", "set", "test.property=test-value");
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(out.toString()).contains("Property set");
+
+        // Verify it was persisted
+        var configModel = config.read();
+        assertThat(configModel.getConfig().get("test.property")).isEqualTo("test-value");
+    }
+
+    @Test
+    public void testConfigSetMultiple() {
+        int exitCode = cmd.execute("config", "set", "key1=value1", "key2=value2");
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(out.toString()).contains("2 properties set");
+
+        var configModel = config.read();
+        assertThat(configModel.getConfig().get("key1")).isEqualTo("value1");
+        assertThat(configModel.getConfig().get("key2")).isEqualTo("value2");
+    }
+
+    @Test
+    public void testConfigSetInvalidFormat() {
+        int exitCode = cmd.execute("config", "set", "no-equals-sign");
+        assertThat(exitCode)
+                .as("Setting a property without '=' should fail")
+                .isNotEqualTo(0);
+    }
+
+    @Test
+    public void testConfigDelete() {
+        // First set a property
+        cmd.execute("config", "set", "to-delete=value");
+        out.getBuffer().setLength(0);
+        err.getBuffer().setLength(0);
+
+        int exitCode = cmd.execute("config", "delete", "to-delete");
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(out.toString()).contains("Property deleted");
+
+        var configModel = config.read();
+        assertThat(configModel.getConfig().containsKey("to-delete")).isFalse();
+    }
+
+    @Test
+    public void testConfigDeleteNonExistent() {
+        int exitCode = cmd.execute("config", "delete", "nonexistent.key");
+        assertThat(exitCode)
+                .as("Deleting a non-existent property should fail")
+                .isNotEqualTo(0);
+    }
+
+    @Test
+    public void testConfigSetAndGet() {
+        cmd.execute("config", "set", "my.setting=hello");
+        out.getBuffer().setLength(0);
+
+        int exitCode = cmd.execute("config", "get", "my.setting");
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(out.toString().trim()).isEqualTo("hello");
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/PlatformUtilsTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/PlatformUtilsTest.java
@@ -1,0 +1,27 @@
+package io.apicurio.registry.cli;
+
+import io.apicurio.registry.cli.utils.PlatformUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlatformUtilsTest {
+
+    @Test
+    public void testDetectPlatformClassifier() {
+        var classifier = PlatformUtils.detectPlatformClassifier();
+        assertThat(classifier).matches("(linux|osx)-(x86_64|aarch_64)");
+    }
+
+    @Test
+    public void testDetectOsClassifier() {
+        var os = PlatformUtils.detectOsClassifier();
+        assertThat(os).isIn("linux", "osx");
+    }
+
+    @Test
+    public void testDetectArchClassifier() {
+        var arch = PlatformUtils.detectArchClassifier();
+        assertThat(arch).isIn("x86_64", "aarch_64");
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/UpdateCheckResultTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/UpdateCheckResultTest.java
@@ -1,0 +1,106 @@
+package io.apicurio.registry.cli;
+
+import io.apicurio.registry.cli.services.CliVersion;
+import io.apicurio.registry.cli.services.UpdateCheckResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UpdateCheckResultTest {
+
+    @Test
+    public void testNoUpdates() {
+        var result = new UpdateCheckResult(CliVersion.parse("3.2.4"), List.of());
+        assertThat(result.hasUpdates()).isFalse();
+        assertThat(result.isAmbiguous()).isFalse();
+        assertThat(result.unambiguousUpdate()).isNull();
+    }
+
+    @Test
+    public void testSinglePatchCandidate() {
+        var result = new UpdateCheckResult(
+                CliVersion.parse("3.2.4"),
+                List.of(CliVersion.parse("3.2.5"))
+        );
+        assertThat(result.hasUpdates()).isTrue();
+        assertThat(result.isAmbiguous()).isFalse();
+        assertThat(result.unambiguousUpdate().toString()).isEqualTo("3.2.5");
+    }
+
+    @Test
+    public void testSingleMinorCandidate() {
+        var result = new UpdateCheckResult(
+                CliVersion.parse("3.2.4"),
+                List.of(CliVersion.parse("3.3.0"))
+        );
+        assertThat(result.hasUpdates()).isTrue();
+        assertThat(result.isAmbiguous()).isFalse();
+        assertThat(result.unambiguousUpdate().toString()).isEqualTo("3.3.0");
+    }
+
+    @Test
+    public void testPatchAndMinorAutoSelectsPatch() {
+        var result = new UpdateCheckResult(
+                CliVersion.parse("3.2.4"),
+                List.of(CliVersion.parse("3.2.5"), CliVersion.parse("3.3.0"))
+        );
+        assertThat(result.hasUpdates()).isTrue();
+        assertThat(result.isAmbiguous()).isFalse();
+        assertThat(result.unambiguousUpdate().toString()).isEqualTo("3.2.5");
+        assertThat(result.patchUpdate().toString()).isEqualTo("3.2.5");
+    }
+
+    @Test
+    public void testMultipleMinorsWithoutPatchIsAmbiguous() {
+        var result = new UpdateCheckResult(
+                CliVersion.parse("3.2.4"),
+                List.of(CliVersion.parse("3.3.0"), CliVersion.parse("4.0.0"))
+        );
+        assertThat(result.hasUpdates()).isTrue();
+        assertThat(result.isAmbiguous()).isTrue();
+        assertThat(result.unambiguousUpdate()).isNull();
+    }
+
+    @Test
+    public void testThreeCandidatesWithPatchAutoSelectsPatch() {
+        var result = new UpdateCheckResult(
+                CliVersion.parse("3.2.4"),
+                List.of(CliVersion.parse("3.2.5"), CliVersion.parse("3.3.0"), CliVersion.parse("4.0.0"))
+        );
+        assertThat(result.isAmbiguous()).isFalse();
+        assertThat(result.unambiguousUpdate().toString()).isEqualTo("3.2.5");
+    }
+
+    @Test
+    public void testFormatMessageSingle() {
+        var result = new UpdateCheckResult(
+                CliVersion.parse("3.2.4"),
+                List.of(CliVersion.parse("3.2.5"))
+        );
+        var sb = new StringBuilder();
+        result.formatMessage(sb);
+        assertThat(sb.toString())
+                .contains("3.2.5")
+                .contains("patch")
+                .contains("acr update");
+    }
+
+    @Test
+    public void testFormatMessageMultipleWithPatchAndMinor() {
+        var result = new UpdateCheckResult(
+                CliVersion.parse("3.2.4"),
+                List.of(CliVersion.parse("3.2.5"), CliVersion.parse("3.3.0"))
+        );
+        var sb = new StringBuilder();
+        result.formatMessage(sb);
+        assertThat(sb.toString())
+                .contains("3.2.5")
+                .contains("patch")
+                .contains("3.3.0")
+                .contains("minor")
+                .contains("acr update 3.2.5")
+                .contains("acr update 3.3.0");
+    }
+}

--- a/cli/src/test/resources/acr-home/config.json
+++ b/cli/src/test/resources/acr-home/config.json
@@ -1,7 +1,8 @@
 {
+  "installation-version": 1,
   "config": {
-    "acr.update.check.enabled": "false",
-    "acr.update.repo.url": "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-cli"
+    "update.check-enabled": "false",
+    "internal.update.repo-url": "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-cli"
   },
   "context": {}
 }

--- a/cli/src/test/scripts/test-update.sh
+++ b/cli/src/test/scripts/test-update.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+#
+# End-to-end test for CLI auto-update.
+#
+# Starts a mock Maven repo (nginx), installs the CLI with a faked old version,
+# and verifies that update detection and installation work correctly.
+#
+# Prerequisites:
+#   - Docker
+#   - A built CLI ZIP in cli/target/ (run: mvn package -pl cli -am -DskipTests)
+#
+# Usage:
+#   ./cli/src/test/scripts/test-update.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+CLI_TARGET="$PROJECT_ROOT/cli/target"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILURES=$((FAILURES + 1)); }
+info() { echo -e "${YELLOW}INFO${NC}: $1"; }
+
+# Runs acr_runner, prints the command and its output, and stores combined output in $ACR_OUTPUT.
+# Usage: run_acr [ENV_VAR=value...] <args...>
+# Returns the exit code of acr_runner.
+run_acr() {
+    local env_prefix=""
+    local args=()
+    for arg in "$@"; do
+        if [[ "$arg" == *=* && ! "$arg" == -* && "${arg%%=*}" =~ ^[A-Z_]+$ ]]; then
+            env_prefix="$env_prefix $arg"
+        else
+            args+=("$arg")
+        fi
+    done
+    echo -e "  ${CYAN}\$${NC}${env_prefix:+ $env_prefix} acr ${args[*]}"
+    local rc=0
+    ACR_OUTPUT=$(eval $env_prefix '"$INSTALL_HOME/acr_runner"' '"${args[@]}"' 2>&1) || rc=$?
+    if [ -n "$ACR_OUTPUT" ]; then
+        echo "$ACR_OUTPUT" | sed 's/^/    /'
+    fi
+    return $rc
+}
+
+FAILURES=0
+CONTAINER_NAME="acr-test-repo-$$"
+WORK_DIR=""
+
+cleanup() {
+    if [ -n "$CONTAINER_NAME" ]; then
+        docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    fi
+    if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+# --- Detect platform ---
+
+detect_platform() {
+    local os arch
+    case "$(uname -s)" in
+        Linux*)  os="linux";;
+        Darwin*) os="osx";;
+        *)       echo "Unsupported OS: $(uname -s)"; exit 1;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64)   arch="x86_64";;
+        aarch64|arm64)  arch="aarch_64";;
+        *)              echo "Unsupported arch: $(uname -m)"; exit 1;;
+    esac
+    echo "${os}-${arch}"
+}
+
+PLATFORM="$(detect_platform)"
+info "Detected platform: $PLATFORM"
+
+# --- Find CLI ZIP ---
+
+CLI_ZIP=$(find "$CLI_TARGET" -maxdepth 1 -name "apicurio-registry-cli-*-${PLATFORM}.zip" | head -1)
+if [ -z "$CLI_ZIP" ] || [ ! -f "$CLI_ZIP" ]; then
+    echo "CLI ZIP not found in $CLI_TARGET for platform $PLATFORM."
+    echo "Build first: mvn package -pl cli -am -DskipTests"
+    exit 1
+fi
+info "Using CLI ZIP: $CLI_ZIP"
+
+# --- Set up work directory ---
+
+WORK_DIR="$(mktemp -d)"
+info "Work directory: $WORK_DIR"
+
+USER_HOME="$WORK_DIR/home"
+INSTALL_HOME="$USER_HOME/.apicurio/apicurio-registry-cli"
+REPO_DIR="$WORK_DIR/repo"
+
+mkdir -p "$USER_HOME/bin" "$USER_HOME" "$REPO_DIR"
+touch "$USER_HOME/.bashrc"
+
+# --- Prepare mock Maven repo ---
+
+FAKE_OLD_VERSION="3.0.0"
+FAKE_NEW_VERSION="3.1.0"
+FAKE_NEWER_VERSION="3.2.0"
+
+ARTIFACT_DIR="$REPO_DIR/$FAKE_NEW_VERSION"
+ARTIFACT_DIR_NEWER="$REPO_DIR/$FAKE_NEWER_VERSION"
+mkdir -p "$ARTIFACT_DIR" "$ARTIFACT_DIR_NEWER"
+
+# Copy the real ZIP as the "new version"
+cp "$CLI_ZIP" "$ARTIFACT_DIR/apicurio-registry-cli-${FAKE_NEW_VERSION}-${PLATFORM}.zip"
+cp "$CLI_ZIP" "$ARTIFACT_DIR_NEWER/apicurio-registry-cli-${FAKE_NEWER_VERSION}-${PLATFORM}.zip"
+
+# Create maven-metadata.xml
+cat > "$REPO_DIR/maven-metadata.xml" <<XMLEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>io.apicurio</groupId>
+  <artifactId>apicurio-registry-cli</artifactId>
+  <versioning>
+    <latest>$FAKE_NEWER_VERSION</latest>
+    <release>$FAKE_NEWER_VERSION</release>
+    <versions>
+      <version>$FAKE_OLD_VERSION</version>
+      <version>$FAKE_NEW_VERSION</version>
+      <version>$FAKE_NEWER_VERSION</version>
+    </versions>
+  </versioning>
+</metadata>
+XMLEOF
+
+info "Mock repo prepared with versions: $FAKE_OLD_VERSION, $FAKE_NEW_VERSION, $FAKE_NEWER_VERSION"
+
+# --- Start nginx ---
+
+docker run -d --name "$CONTAINER_NAME" \
+    -v "$REPO_DIR:/usr/share/nginx/html:ro" \
+    -p 0:80 \
+    nginx:alpine >/dev/null
+
+# Wait for container and get port
+sleep 1
+REPO_PORT=$(docker port "$CONTAINER_NAME" 80 | head -1 | cut -d: -f2)
+REPO_URL="http://localhost:${REPO_PORT}"
+
+info "Mock repo started at $REPO_URL"
+
+# Verify repo is accessible
+if ! curl -sf "$REPO_URL/maven-metadata.xml" >/dev/null; then
+    echo "Mock repo is not accessible at $REPO_URL"
+    exit 1
+fi
+info "Mock repo verified"
+
+# --- Install CLI from current ZIP ---
+
+UNZIP_DIR="$WORK_DIR/unzip"
+mkdir -p "$UNZIP_DIR"
+unzip -q "$CLI_ZIP" -d "$UNZIP_DIR"
+
+# Set up environment for install
+export HOME="$USER_HOME"
+export ACR_CURRENT_HOME="$UNZIP_DIR"
+
+echo -e "  ${CYAN}\$${NC} acr install"
+INSTALL_OUTPUT=$("$UNZIP_DIR/acr" install 2>&1) || true
+if [ -n "$INSTALL_OUTPUT" ]; then
+    echo "$INSTALL_OUTPUT" | sed 's/^/    /'
+fi
+
+# Verify install
+if [ ! -f "$INSTALL_HOME/acr_runner" ]; then
+    fail "CLI binary not installed"
+    exit 1
+fi
+pass "CLI installed to $INSTALL_HOME"
+
+# Point to mock repo and set up environment
+export ACR_HOME="$INSTALL_HOME"
+export ACR_CURRENT_HOME="$INSTALL_HOME"
+
+# Configure to use mock repo
+run_acr config set "internal.update.repo-url=$REPO_URL"
+pass "Config set to use mock repo"
+
+# ============================================================
+# TEST 1: Update check detects newer versions
+# ============================================================
+
+info "--- Test 1: Update check with faked old version ---"
+
+run_acr VERSION="$FAKE_OLD_VERSION" update --check || true
+
+if echo "$ACR_OUTPUT" | grep -q "$FAKE_NEW_VERSION"; then
+    pass "Update check found version $FAKE_NEW_VERSION"
+else
+    fail "Update check did not find version $FAKE_NEW_VERSION"
+fi
+
+if echo "$ACR_OUTPUT" | grep -q "$FAKE_NEWER_VERSION"; then
+    pass "Update check found version $FAKE_NEWER_VERSION"
+else
+    fail "Update check did not find version $FAKE_NEWER_VERSION"
+fi
+
+# ============================================================
+# TEST 2: Ambiguous update (multiple candidates) requires version
+# ============================================================
+
+info "--- Test 2: Ambiguous update requires explicit version ---"
+
+run_acr VERSION="$FAKE_OLD_VERSION" update || true
+
+if echo "$ACR_OUTPUT" | grep -qi "multiple\|candidates\|specify\|ambiguous"; then
+    pass "Ambiguous update correctly asks user to specify version"
+else
+    fail "Expected ambiguous update message"
+fi
+
+# ============================================================
+# TEST 3: Update to specific version downloads and installs
+# ============================================================
+
+info "--- Test 3: Update to specific version ---"
+
+BEFORE_MTIME=$(stat -c %Y "$INSTALL_HOME/acr_runner" 2>/dev/null || stat -f %m "$INSTALL_HOME/acr_runner")
+sleep 1
+
+run_acr VERSION="$FAKE_OLD_VERSION" update "$FAKE_NEW_VERSION" || true
+
+AFTER_MTIME=$(stat -c %Y "$INSTALL_HOME/acr_runner" 2>/dev/null || stat -f %m "$INSTALL_HOME/acr_runner")
+
+if [ "$AFTER_MTIME" != "$BEFORE_MTIME" ]; then
+    pass "Binary was updated (mtime changed)"
+else
+    fail "Binary was NOT updated (mtime unchanged)"
+fi
+
+# ============================================================
+# TEST 4: Config preserved after update
+# ============================================================
+
+info "--- Test 4: Config preserved after update ---"
+
+run_acr config get "internal.update.repo-url" || true
+
+if [ "$ACR_OUTPUT" = "$REPO_URL" ]; then
+    pass "Config preserved after update (repo URL intact)"
+else
+    fail "Config not preserved after update. Expected '$REPO_URL', got '$ACR_OUTPUT'"
+fi
+
+# ============================================================
+# TEST 5: Update check records last-check timestamp
+# ============================================================
+
+info "--- Test 5: Last-check timestamp recorded ---"
+
+run_acr config get "internal.update.last-check" || true
+
+if [ -n "$ACR_OUTPUT" ]; then
+    pass "Last-check timestamp recorded: $ACR_OUTPUT"
+else
+    fail "Last-check timestamp not found in config"
+fi
+
+# ============================================================
+# TEST 6: Single candidate auto-updates without specifying version
+# ============================================================
+
+info "--- Test 6: Single candidate auto-updates ---"
+
+# Create a repo with only one version newer than the "current"
+SINGLE_REPO="$WORK_DIR/single-repo"
+SINGLE_ARTIFACT="$SINGLE_REPO/$FAKE_NEWER_VERSION"
+mkdir -p "$SINGLE_ARTIFACT"
+cp "$CLI_ZIP" "$SINGLE_ARTIFACT/apicurio-registry-cli-${FAKE_NEWER_VERSION}-${PLATFORM}.zip"
+
+cat > "$SINGLE_REPO/maven-metadata.xml" <<XMLEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>io.apicurio</groupId>
+  <artifactId>apicurio-registry-cli</artifactId>
+  <versioning>
+    <latest>$FAKE_NEWER_VERSION</latest>
+    <versions>
+      <version>$FAKE_NEW_VERSION</version>
+      <version>$FAKE_NEWER_VERSION</version>
+    </versions>
+  </versioning>
+</metadata>
+XMLEOF
+
+# Stop old container, start new one with single-repo
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+CONTAINER_NAME="acr-test-single-repo-$$"
+docker run -d --name "$CONTAINER_NAME" \
+    -v "$SINGLE_REPO:/usr/share/nginx/html:ro" \
+    -p 0:80 \
+    nginx:alpine >/dev/null
+sleep 1
+SINGLE_PORT=$(docker port "$CONTAINER_NAME" 80 | head -1 | cut -d: -f2)
+SINGLE_URL="http://localhost:${SINGLE_PORT}"
+
+run_acr config set "internal.update.repo-url=$SINGLE_URL"
+
+BEFORE_MTIME=$(stat -c %Y "$INSTALL_HOME/acr_runner" 2>/dev/null || stat -f %m "$INSTALL_HOME/acr_runner")
+sleep 1
+
+run_acr VERSION="$FAKE_NEW_VERSION" update || true
+
+AFTER_MTIME=$(stat -c %Y "$INSTALL_HOME/acr_runner" 2>/dev/null || stat -f %m "$INSTALL_HOME/acr_runner")
+
+if [ "$AFTER_MTIME" != "$BEFORE_MTIME" ]; then
+    pass "Single candidate auto-update succeeded (binary updated)"
+else
+    fail "Single candidate auto-update failed (binary unchanged)"
+fi
+
+# ============================================================
+# Helper: switch mock repo
+# ============================================================
+
+start_repo() {
+    local repo_dir="$1"
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    CONTAINER_NAME="acr-test-repo-$$-$RANDOM"
+    docker run -d --name "$CONTAINER_NAME" \
+        -v "$repo_dir:/usr/share/nginx/html:ro" \
+        -p 0:80 \
+        nginx:alpine >/dev/null
+    sleep 1
+    local port
+    port=$(docker port "$CONTAINER_NAME" 80 | head -1 | cut -d: -f2)
+    CURRENT_REPO_URL="http://localhost:${port}"
+    run_acr config set "internal.update.repo-url=$CURRENT_REPO_URL"
+}
+
+# ============================================================
+# TEST 7: Redhat versions are filtered for community CLI
+# ============================================================
+
+info "--- Test 7: Redhat versions ignored for community CLI ---"
+
+REDHAT_REPO="$WORK_DIR/redhat-repo"
+mkdir -p "$REDHAT_REPO/3.1.0" "$REDHAT_REPO/3.1.0.redhat-00001"
+cp "$CLI_ZIP" "$REDHAT_REPO/3.1.0/apicurio-registry-cli-3.1.0-${PLATFORM}.zip"
+cp "$CLI_ZIP" "$REDHAT_REPO/3.1.0.redhat-00001/apicurio-registry-cli-3.1.0.redhat-00001-${PLATFORM}.zip"
+
+cat > "$REDHAT_REPO/maven-metadata.xml" <<XMLEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>io.apicurio</groupId>
+  <artifactId>apicurio-registry-cli</artifactId>
+  <versioning>
+    <versions>
+      <version>3.0.0</version>
+      <version>3.1.0</version>
+      <version>3.1.0.redhat-00001</version>
+    </versions>
+  </versioning>
+</metadata>
+XMLEOF
+
+start_repo "$REDHAT_REPO"
+
+# Running as community version (3.0.0) — should only see 3.1.0, not the redhat version
+run_acr VERSION="3.0.0" update --check || true
+
+if echo "$ACR_OUTPUT" | grep -q "3.1.0" && ! echo "$ACR_OUTPUT" | grep -q "redhat"; then
+    pass "Community CLI only sees community versions"
+else
+    fail "Expected only community version 3.1.0 in output"
+fi
+
+# ============================================================
+# TEST 8: Redhat CLI sees only redhat versions
+# ============================================================
+
+info "--- Test 8: Redhat CLI sees only redhat versions ---"
+
+# Running as redhat version — should only see redhat versions
+run_acr VERSION="3.0.0.redhat-00001" update --check || true
+
+if echo "$ACR_OUTPUT" | grep -q "redhat"; then
+    pass "Redhat CLI sees redhat versions"
+else
+    # May show "latest version" if no redhat updates — that's also correct
+    if echo "$ACR_OUTPUT" | grep -qi "latest version"; then
+        pass "Redhat CLI correctly found no newer redhat versions"
+    else
+        fail "Expected redhat version or 'latest version' message"
+    fi
+fi
+
+# ============================================================
+# TEST 9: Unparseable versions don't break update check
+# ============================================================
+
+info "--- Test 9: Unparseable versions handled gracefully ---"
+
+WEIRD_REPO="$WORK_DIR/weird-repo"
+mkdir -p "$WEIRD_REPO/3.1.0"
+cp "$CLI_ZIP" "$WEIRD_REPO/3.1.0/apicurio-registry-cli-3.1.0-${PLATFORM}.zip"
+
+cat > "$WEIRD_REPO/maven-metadata.xml" <<XMLEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>io.apicurio</groupId>
+  <artifactId>apicurio-registry-cli</artifactId>
+  <versioning>
+    <versions>
+      <version>3.0.0</version>
+      <version>3.1.0</version>
+      <version>not-a-version</version>
+      <version>weird.format.here.123</version>
+    </versions>
+  </versioning>
+</metadata>
+XMLEOF
+
+start_repo "$WEIRD_REPO"
+
+run_acr VERSION="3.0.0" update --check || true
+
+if echo "$ACR_OUTPUT" | grep -q "3.1.0"; then
+    pass "Update check works despite unparseable versions in metadata"
+else
+    fail "Update check failed with unparseable versions. Output: $ACR_OUTPUT"
+fi
+
+# ============================================================
+# TEST 10: Patch update auto-selected when minor also available
+# ============================================================
+
+info "--- Test 10: Patch auto-selected over minor ---"
+
+PATCH_REPO="$WORK_DIR/patch-repo"
+mkdir -p "$PATCH_REPO/3.2.5" "$PATCH_REPO/3.3.0"
+cp "$CLI_ZIP" "$PATCH_REPO/3.2.5/apicurio-registry-cli-3.2.5-${PLATFORM}.zip"
+cp "$CLI_ZIP" "$PATCH_REPO/3.3.0/apicurio-registry-cli-3.3.0-${PLATFORM}.zip"
+
+cat > "$PATCH_REPO/maven-metadata.xml" <<XMLEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>io.apicurio</groupId>
+  <artifactId>apicurio-registry-cli</artifactId>
+  <versioning>
+    <versions>
+      <version>3.2.4</version>
+      <version>3.2.5</version>
+      <version>3.3.0</version>
+    </versions>
+  </versioning>
+</metadata>
+XMLEOF
+
+start_repo "$PATCH_REPO"
+
+BEFORE_MTIME=$(stat -c %Y "$INSTALL_HOME/acr_runner" 2>/dev/null || stat -f %m "$INSTALL_HOME/acr_runner")
+sleep 1
+
+# Should auto-select 3.2.5 (patch) even though 3.3.0 (minor) is also available
+run_acr VERSION="3.2.4" update || true
+
+AFTER_MTIME=$(stat -c %Y "$INSTALL_HOME/acr_runner" 2>/dev/null || stat -f %m "$INSTALL_HOME/acr_runner")
+
+if echo "$ACR_OUTPUT" | grep -q "3.2.5"; then
+    pass "Patch version 3.2.5 auto-selected over minor 3.3.0"
+else
+    fail "Expected patch version 3.2.5 to be auto-selected. Output: $ACR_OUTPUT"
+fi
+
+if [ "$AFTER_MTIME" != "$BEFORE_MTIME" ]; then
+    pass "Binary was updated with patch version"
+else
+    fail "Binary was NOT updated"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    echo -e "${GREEN}All tests passed.${NC}"
+else
+    echo -e "${RED}${FAILURES} test(s) failed.${NC}"
+    exit 1
+fi

--- a/cli/src/test/scripts/test-update.sh
+++ b/cli/src/test/scripts/test-update.sh
@@ -25,9 +25,9 @@ YELLOW='\033[0;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-pass() { echo -e "${GREEN}PASS${NC}: $1"; }
-fail() { echo -e "${RED}FAIL${NC}: $1"; FAILURES=$((FAILURES + 1)); }
-info() { echo -e "${YELLOW}INFO${NC}: $1"; }
+pass() { local msg="$1"; echo -e "${GREEN}PASS${NC}: ${msg}"; }
+fail() { local msg="$1"; echo -e "${RED}FAIL${NC}: ${msg}"; FAILURES=$((FAILURES + 1)); }
+info() { local msg="$1"; echo -e "${YELLOW}INFO${NC}: ${msg}"; }
 
 # Runs acr_runner, prints the command and its output, and stores combined output in $ACR_OUTPUT.
 # Usage: run_acr [ENV_VAR=value...] <args...>
@@ -45,7 +45,7 @@ run_acr() {
     echo -e "  ${CYAN}\$${NC}${env_prefix:+ $env_prefix} acr ${args[*]}"
     local rc=0
     ACR_OUTPUT=$(eval $env_prefix '"$INSTALL_HOME/acr_runner"' '"${args[@]}"' 2>&1) || rc=$?
-    if [ -n "$ACR_OUTPUT" ]; then
+    if [[ -n "$ACR_OUTPUT" ]]; then
         echo "$ACR_OUTPUT" | sed 's/^/    /'
     fi
     return $rc
@@ -56,10 +56,10 @@ CONTAINER_NAME="acr-test-repo-$$"
 WORK_DIR=""
 
 cleanup() {
-    if [ -n "$CONTAINER_NAME" ]; then
+    if [[ -n "$CONTAINER_NAME" ]]; then
         docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
     fi
-    if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+    if [[ -n "$WORK_DIR" ]] && [[ -d "$WORK_DIR" ]]; then
         rm -rf "$WORK_DIR"
     fi
 }
@@ -88,7 +88,7 @@ info "Detected platform: $PLATFORM"
 # --- Find CLI ZIP ---
 
 CLI_ZIP=$(find "$CLI_TARGET" -maxdepth 1 -name "apicurio-registry-cli-*-${PLATFORM}.zip" | head -1)
-if [ -z "$CLI_ZIP" ] || [ ! -f "$CLI_ZIP" ]; then
+if [[ -z "$CLI_ZIP" ]] || [[ ! -f "$CLI_ZIP" ]]; then
     echo "CLI ZIP not found in $CLI_TARGET for platform $PLATFORM."
     echo "Build first: mvn package -pl cli -am -DskipTests"
     exit 1
@@ -174,12 +174,12 @@ export ACR_CURRENT_HOME="$UNZIP_DIR"
 
 echo -e "  ${CYAN}\$${NC} acr install"
 INSTALL_OUTPUT=$("$UNZIP_DIR/acr" install 2>&1) || true
-if [ -n "$INSTALL_OUTPUT" ]; then
+if [[ -n "$INSTALL_OUTPUT" ]]; then
     echo "$INSTALL_OUTPUT" | sed 's/^/    /'
 fi
 
 # Verify install
-if [ ! -f "$INSTALL_HOME/acr_runner" ]; then
+if [[ ! -f "$INSTALL_HOME/acr_runner" ]]; then
     fail "CLI binary not installed"
     exit 1
 fi
@@ -240,7 +240,7 @@ run_acr VERSION="$FAKE_OLD_VERSION" update "$FAKE_NEW_VERSION" || true
 
 AFTER_MTIME=$(stat -c %Y "$INSTALL_HOME/acr_runner" 2>/dev/null || stat -f %m "$INSTALL_HOME/acr_runner")
 
-if [ "$AFTER_MTIME" != "$BEFORE_MTIME" ]; then
+if [[ "$AFTER_MTIME" != "$BEFORE_MTIME" ]]; then
     pass "Binary was updated (mtime changed)"
 else
     fail "Binary was NOT updated (mtime unchanged)"
@@ -254,7 +254,7 @@ info "--- Test 4: Config preserved after update ---"
 
 run_acr config get "internal.update.repo-url" || true
 
-if [ "$ACR_OUTPUT" = "$REPO_URL" ]; then
+if [[ "$ACR_OUTPUT" = "$REPO_URL" ]]; then
     pass "Config preserved after update (repo URL intact)"
 else
     fail "Config not preserved after update. Expected '$REPO_URL', got '$ACR_OUTPUT'"
@@ -268,7 +268,7 @@ info "--- Test 5: Last-check timestamp recorded ---"
 
 run_acr config get "internal.update.last-check" || true
 
-if [ -n "$ACR_OUTPUT" ]; then
+if [[ -n "$ACR_OUTPUT" ]]; then
     pass "Last-check timestamp recorded: $ACR_OUTPUT"
 else
     fail "Last-check timestamp not found in config"
@@ -321,7 +321,7 @@ run_acr VERSION="$FAKE_NEW_VERSION" update || true
 
 AFTER_MTIME=$(stat -c %Y "$INSTALL_HOME/acr_runner" 2>/dev/null || stat -f %m "$INSTALL_HOME/acr_runner")
 
-if [ "$AFTER_MTIME" != "$BEFORE_MTIME" ]; then
+if [[ "$AFTER_MTIME" != "$BEFORE_MTIME" ]]; then
     pass "Single candidate auto-update succeeded (binary updated)"
 else
     fail "Single candidate auto-update failed (binary unchanged)"
@@ -481,7 +481,7 @@ else
     fail "Expected patch version 3.2.5 to be auto-selected. Output: $ACR_OUTPUT"
 fi
 
-if [ "$AFTER_MTIME" != "$BEFORE_MTIME" ]; then
+if [[ "$AFTER_MTIME" != "$BEFORE_MTIME" ]]; then
     pass "Binary was updated with patch version"
 else
     fail "Binary was NOT updated"
@@ -492,7 +492,7 @@ fi
 # ============================================================
 
 echo ""
-if [ "$FAILURES" -eq 0 ]; then
+if [[ "$FAILURES" -eq 0 ]]; then
     echo -e "${GREEN}All tests passed.${NC}"
 else
     echo -e "${RED}${FAILURES} test(s) failed.${NC}"

--- a/cli/src/test/scripts/test-upgrade-from-previous.sh
+++ b/cli/src/test/scripts/test-upgrade-from-previous.sh
@@ -160,7 +160,7 @@ export ACR_CURRENT_HOME="$INSTALL_HOME"
 
 # --- Prepare mock repo with current version as upgrade ---
 
-UPGRADE_VERSION="${PREVIOUS_VERSION}.1"
+UPGRADE_VERSION="$CURRENT_BASE"
 ARTIFACT_DIR="$REPO_DIR/$UPGRADE_VERSION"
 mkdir -p "$ARTIFACT_DIR"
 cp "$CLI_ZIP" "$ARTIFACT_DIR/apicurio-registry-cli-${UPGRADE_VERSION}-${PLATFORM}.zip"

--- a/cli/src/test/scripts/test-upgrade-from-previous.sh
+++ b/cli/src/test/scripts/test-upgrade-from-previous.sh
@@ -27,20 +27,20 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m'
 
-pass() { echo -e "${GREEN}PASS${NC}: $1"; }
-fail() { echo -e "${RED}FAIL${NC}: $1"; FAILURES=$((FAILURES + 1)); }
-info() { echo -e "${YELLOW}INFO${NC}: $1"; }
-skip() { echo -e "${YELLOW}SKIP${NC}: $1"; exit 0; }
+pass() { local msg="$1"; echo -e "${GREEN}PASS${NC}: ${msg}"; }
+fail() { local msg="$1"; echo -e "${RED}FAIL${NC}: ${msg}"; FAILURES=$((FAILURES + 1)); }
+info() { local msg="$1"; echo -e "${YELLOW}INFO${NC}: ${msg}"; }
+skip() { local msg="$1"; echo -e "${YELLOW}SKIP${NC}: ${msg}"; exit 0; }
 
 FAILURES=0
 CONTAINER_NAME="acr-test-upgrade-$$"
 WORK_DIR=""
 
 cleanup() {
-    if [ -n "$CONTAINER_NAME" ]; then
+    if [[ -n "$CONTAINER_NAME" ]]; then
         docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
     fi
-    if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+    if [[ -n "$WORK_DIR" ]] && [[ -d "$WORK_DIR" ]]; then
         rm -rf "$WORK_DIR"
     fi
 }
@@ -86,14 +86,14 @@ PREVIOUS_VERSION=$(echo "$METADATA_XML" \
     | sort -t. -k1,1n -k2,2n -k3,3n \
     | while IFS=. read -r maj min pat; do
         IFS=. read -r cmaj cmin cpat <<< "$CURRENT_BASE"
-        if [ "$maj" -lt "$cmaj" ] || \
+        if [ "$maj" -lt "$cmaj" ]] || \
            { [ "$maj" -eq "$cmaj" ] && [ "$min" -lt "$cmin" ]; } || \
            { [ "$maj" -eq "$cmaj" ] && [ "$min" -eq "$cmin" ] && [ "$pat" -lt "$cpat" ]; }; then
             echo "${maj}.${min}.${pat}"
         fi
     done | tail -1)
 
-if [ -z "$PREVIOUS_VERSION" ]; then
+if [[ -z "$PREVIOUS_VERSION" ]]; then
     skip "No previous release found on Maven Central that is older than $CURRENT_BASE"
 fi
 
@@ -102,7 +102,7 @@ fi
 MIN_UPGRADABLE="3.3.0"
 IFS=. read -r pMaj pMin pPat <<< "$PREVIOUS_VERSION"
 IFS=. read -r mMaj mMin mPat <<< "$MIN_UPGRADABLE"
-if [ "$pMaj" -lt "$mMaj" ] || \
+if [ "$pMaj" -lt "$mMaj" ]] || \
    { [ "$pMaj" -eq "$mMaj" ] && [ "$pMin" -lt "$mMin" ]; } || \
    { [ "$pMaj" -eq "$mMaj" ] && [ "$pMin" -eq "$mMin" ] && [ "$pPat" -lt "$mPat" ]; }; then
     skip "Previous version $PREVIOUS_VERSION is older than $MIN_UPGRADABLE (first native CLI release with auto-update)"
@@ -112,7 +112,7 @@ info "Previous release version to test: $PREVIOUS_VERSION"
 # --- Find current CLI ZIP ---
 
 CLI_ZIP=$(find "$CLI_TARGET" -maxdepth 1 -name "apicurio-registry-cli-*-${PLATFORM}.zip" | head -1)
-if [ -z "$CLI_ZIP" ] || [ ! -f "$CLI_ZIP" ]; then
+if [[ -z "$CLI_ZIP" ]] || [[ ! -f "$CLI_ZIP" ]]; then
     echo "CLI ZIP not found in $CLI_TARGET. Build first: mvn package -pl cli -am -DskipTests"
     exit 1
 fi
@@ -129,7 +129,7 @@ PREVIOUS_ZIP="$WORK_DIR/$PREVIOUS_ZIP_NAME"
 info "Downloading previous release from $PREVIOUS_URL"
 
 HTTP_CODE=$(curl -s -o "$PREVIOUS_ZIP" -w "%{http_code}" "$PREVIOUS_URL" || echo "000")
-if [ "$HTTP_CODE" != "200" ]; then
+if [[ "$HTTP_CODE" != "200" ]]; then
     skip "Previous release $PREVIOUS_VERSION not available on Maven Central (HTTP $HTTP_CODE). Test will be relevant after $PREVIOUS_VERSION is released."
 fi
 info "Downloaded previous release: $PREVIOUS_ZIP"
@@ -218,7 +218,7 @@ fi
 
 AFTER_MTIME=$(stat -c %Y "$INSTALL_HOME/acr_runner" 2>/dev/null || stat -f %m "$INSTALL_HOME/acr_runner")
 
-if [ "$AFTER_MTIME" != "$BEFORE_MTIME" ]; then
+if [[ "$AFTER_MTIME" != "$BEFORE_MTIME" ]]; then
     pass "Binary was updated"
 else
     fail "Binary was NOT updated"
@@ -253,7 +253,7 @@ fi
 # ============================================================
 
 echo ""
-if [ "$FAILURES" -eq 0 ]; then
+if [[ "$FAILURES" -eq 0 ]]; then
     echo -e "${GREEN}All tests passed.${NC}"
 else
     echo -e "${RED}${FAILURES} test(s) failed.${NC}"

--- a/cli/src/test/scripts/test-upgrade-from-previous.sh
+++ b/cli/src/test/scripts/test-upgrade-from-previous.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+#
+# Tests that a previous CLI release can upgrade to the current version.
+#
+# Downloads the previous release from Maven Central, installs it,
+# sets up a mock repo serving the current SNAPSHOT as the "new" version,
+# and runs the upgrade. Then runs smoke tests on the upgraded CLI.
+#
+# Skips gracefully if the previous release is not yet available on Maven Central.
+#
+# Prerequisites:
+#   - Docker
+#   - curl
+#   - A built CLI ZIP in cli/target/ (run: mvn package -pl cli -am -DskipTests)
+#
+# Usage:
+#   ./cli/src/test/scripts/test-upgrade-from-previous.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+CLI_TARGET="$PROJECT_ROOT/cli/target"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILURES=$((FAILURES + 1)); }
+info() { echo -e "${YELLOW}INFO${NC}: $1"; }
+skip() { echo -e "${YELLOW}SKIP${NC}: $1"; exit 0; }
+
+FAILURES=0
+CONTAINER_NAME="acr-test-upgrade-$$"
+WORK_DIR=""
+
+cleanup() {
+    if [ -n "$CONTAINER_NAME" ]; then
+        docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    fi
+    if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+# --- Detect platform ---
+
+detect_platform() {
+    local os arch
+    case "$(uname -s)" in
+        Linux*)  os="linux";;
+        Darwin*) os="osx";;
+        *)       echo "Unsupported OS: $(uname -s)"; exit 1;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64)   arch="x86_64";;
+        aarch64|arm64)  arch="aarch_64";;
+        *)              echo "Unsupported arch: $(uname -m)"; exit 1;;
+    esac
+    echo "${os}-${arch}"
+}
+
+PLATFORM="$(detect_platform)"
+info "Detected platform: $PLATFORM"
+
+# --- Determine versions ---
+
+MAVEN_CENTRAL="https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-cli"
+
+CURRENT_VERSION=$(grep '<version>' "$PROJECT_ROOT/cli/pom.xml" | head -1 | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+info "Current project version: $CURRENT_VERSION"
+
+CURRENT_BASE="${CURRENT_VERSION%-SNAPSHOT}"
+
+# Fetch all released versions from Maven Central and find the latest one
+# that is strictly lower than the current version (ignoring SNAPSHOT suffix).
+info "Fetching version list from Maven Central..."
+METADATA_XML=$(curl -sf "$MAVEN_CENTRAL/maven-metadata.xml" 2>/dev/null) || skip "Could not fetch maven-metadata.xml from Maven Central"
+
+# Extract versions, keep only community (no redhat/qualifier suffixes), sort, pick latest < current
+PREVIOUS_VERSION=$(echo "$METADATA_XML" \
+    | grep -oP '<version>\K[0-9]+\.[0-9]+\.[0-9]+(?=</version>)' \
+    | sort -t. -k1,1n -k2,2n -k3,3n \
+    | while IFS=. read -r maj min pat; do
+        IFS=. read -r cmaj cmin cpat <<< "$CURRENT_BASE"
+        if [ "$maj" -lt "$cmaj" ] || \
+           { [ "$maj" -eq "$cmaj" ] && [ "$min" -lt "$cmin" ]; } || \
+           { [ "$maj" -eq "$cmaj" ] && [ "$min" -eq "$cmin" ] && [ "$pat" -lt "$cpat" ]; }; then
+            echo "${maj}.${min}.${pat}"
+        fi
+    done | tail -1)
+
+if [ -z "$PREVIOUS_VERSION" ]; then
+    skip "No previous release found on Maven Central that is older than $CURRENT_BASE"
+fi
+
+# The native binary CLI with auto-update support was first released in 3.3.0.
+# Older versions used a Java JAR distribution and can't be tested here.
+MIN_UPGRADABLE="3.3.0"
+IFS=. read -r pMaj pMin pPat <<< "$PREVIOUS_VERSION"
+IFS=. read -r mMaj mMin mPat <<< "$MIN_UPGRADABLE"
+if [ "$pMaj" -lt "$mMaj" ] || \
+   { [ "$pMaj" -eq "$mMaj" ] && [ "$pMin" -lt "$mMin" ]; } || \
+   { [ "$pMaj" -eq "$mMaj" ] && [ "$pMin" -eq "$mMin" ] && [ "$pPat" -lt "$mPat" ]; }; then
+    skip "Previous version $PREVIOUS_VERSION is older than $MIN_UPGRADABLE (first native CLI release with auto-update)"
+fi
+info "Previous release version to test: $PREVIOUS_VERSION"
+
+# --- Find current CLI ZIP ---
+
+CLI_ZIP=$(find "$CLI_TARGET" -maxdepth 1 -name "apicurio-registry-cli-*-${PLATFORM}.zip" | head -1)
+if [ -z "$CLI_ZIP" ] || [ ! -f "$CLI_ZIP" ]; then
+    echo "CLI ZIP not found in $CLI_TARGET. Build first: mvn package -pl cli -am -DskipTests"
+    exit 1
+fi
+info "Current CLI ZIP: $CLI_ZIP"
+
+# --- Download previous release ---
+
+PREVIOUS_ZIP_NAME="apicurio-registry-cli-${PREVIOUS_VERSION}-${PLATFORM}.zip"
+PREVIOUS_URL="${MAVEN_CENTRAL}/${PREVIOUS_VERSION}/${PREVIOUS_ZIP_NAME}"
+
+WORK_DIR="$(mktemp -d)"
+PREVIOUS_ZIP="$WORK_DIR/$PREVIOUS_ZIP_NAME"
+
+info "Downloading previous release from $PREVIOUS_URL"
+
+HTTP_CODE=$(curl -s -o "$PREVIOUS_ZIP" -w "%{http_code}" "$PREVIOUS_URL" || echo "000")
+if [ "$HTTP_CODE" != "200" ]; then
+    skip "Previous release $PREVIOUS_VERSION not available on Maven Central (HTTP $HTTP_CODE). Test will be relevant after $PREVIOUS_VERSION is released."
+fi
+info "Downloaded previous release: $PREVIOUS_ZIP"
+
+# --- Set up directories ---
+
+INSTALL_HOME="$WORK_DIR/install"
+USER_HOME="$WORK_DIR/home"
+REPO_DIR="$WORK_DIR/repo"
+
+mkdir -p "$INSTALL_HOME" "$USER_HOME/bin" "$USER_HOME" "$REPO_DIR"
+
+# --- Install previous version ---
+
+PREV_UNZIP="$WORK_DIR/prev-unzip"
+mkdir -p "$PREV_UNZIP"
+unzip -q "$PREVIOUS_ZIP" -d "$PREV_UNZIP"
+
+export HOME="$USER_HOME"
+export ACR_INSTALL_PATH="$INSTALL_HOME"
+export ACR_CURRENT_HOME="$PREV_UNZIP"
+
+"$PREV_UNZIP/acr" install 2>/dev/null
+pass "Previous version $PREVIOUS_VERSION installed"
+
+export ACR_HOME="$INSTALL_HOME"
+export ACR_CURRENT_HOME="$INSTALL_HOME"
+
+# --- Prepare mock repo with current version as upgrade ---
+
+UPGRADE_VERSION="${PREVIOUS_VERSION}.1"
+ARTIFACT_DIR="$REPO_DIR/$UPGRADE_VERSION"
+mkdir -p "$ARTIFACT_DIR"
+cp "$CLI_ZIP" "$ARTIFACT_DIR/apicurio-registry-cli-${UPGRADE_VERSION}-${PLATFORM}.zip"
+
+cat > "$REPO_DIR/maven-metadata.xml" <<XMLEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>io.apicurio</groupId>
+  <artifactId>apicurio-registry-cli</artifactId>
+  <versioning>
+    <latest>$UPGRADE_VERSION</latest>
+    <versions>
+      <version>$PREVIOUS_VERSION</version>
+      <version>$UPGRADE_VERSION</version>
+    </versions>
+  </versioning>
+</metadata>
+XMLEOF
+
+# --- Start mock repo ---
+
+docker run -d --name "$CONTAINER_NAME" \
+    -v "$REPO_DIR:/usr/share/nginx/html:ro" \
+    -p 0:80 \
+    nginx:alpine >/dev/null
+sleep 1
+REPO_PORT=$(docker port "$CONTAINER_NAME" 80 | head -1 | cut -d: -f2)
+REPO_URL="http://localhost:${REPO_PORT}"
+info "Mock repo at $REPO_URL (serving $UPGRADE_VERSION)"
+
+# Configure previous CLI to use mock repo
+# The previous version may use old property names — try both
+"$INSTALL_HOME/acr_runner" config set "internal.update.repo-url=$REPO_URL" 2>/dev/null \
+    || "$INSTALL_HOME/acr_runner" config set "acr.update.repo.url=$REPO_URL" 2>/dev/null \
+    || "$INSTALL_HOME/acr_runner" config set "update.repo.url=$REPO_URL" 2>/dev/null \
+    || info "Could not set repo URL via config command — old CLI may not have config command"
+
+# ============================================================
+# TEST 1: Upgrade from previous release
+# ============================================================
+
+info "--- Test 1: Upgrade from $PREVIOUS_VERSION ---"
+
+BEFORE_MTIME=$(stat -c %Y "$INSTALL_HOME/acr_runner" 2>/dev/null || stat -f %m "$INSTALL_HOME/acr_runner")
+sleep 1
+
+# Try update; the old CLI may not support the new flags, so fall back to --path
+if VERSION="$PREVIOUS_VERSION" "$INSTALL_HOME/acr_runner" update "$UPGRADE_VERSION" 2>/dev/null; then
+    pass "Upgrade command succeeded"
+elif "$INSTALL_HOME/acr_runner" update --path "$ARTIFACT_DIR/apicurio-registry-cli-${UPGRADE_VERSION}-${PLATFORM}.zip" 2>/dev/null; then
+    pass "Upgrade via --path succeeded (old CLI may not support auto-update)"
+else
+    fail "Upgrade failed"
+fi
+
+AFTER_MTIME=$(stat -c %Y "$INSTALL_HOME/acr_runner" 2>/dev/null || stat -f %m "$INSTALL_HOME/acr_runner")
+
+if [ "$AFTER_MTIME" != "$BEFORE_MTIME" ]; then
+    pass "Binary was updated"
+else
+    fail "Binary was NOT updated"
+fi
+
+# ============================================================
+# TEST 2: Smoke test — upgraded CLI basic commands work
+# ============================================================
+
+info "--- Test 2: Smoke tests on upgraded CLI ---"
+
+if "$INSTALL_HOME/acr_runner" version 2>/dev/null | grep -q "CLI version"; then
+    pass "version command works"
+else
+    fail "version command failed"
+fi
+
+if "$INSTALL_HOME/acr_runner" config 2>/dev/null | grep -q "update.check-enabled\|update.repo.url\|Property"; then
+    pass "config command works"
+else
+    fail "config command failed or not available"
+fi
+
+if "$INSTALL_HOME/acr_runner" --help 2>&1 | grep -q "Usage: acr"; then
+    pass "help output works"
+else
+    fail "help output failed"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    echo -e "${GREEN}All tests passed.${NC}"
+else
+    echo -e "${RED}${FAILURES} test(s) failed.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Add `acr config` CRUD commands (list/get/set/delete) for managing CLI configuration properties
- Enable automatic update checks: once-per-day background check with notification to stderr, configurable via `update.check-enabled` and `--postpone`
- Rewrite `acr update` with version auto-resolution (patch preferred), `--check`, `--postpone`, and explicit version argument
- Add lenient version parser handling both community (`3.2.4`) and Red Hat suffixed versions (`3.1.6.redhat-00011`)
- Add `{{product-name}}` placeholder in help text, resolved at runtime via CDI CommandLine producer for productization branding
- Add `installation-version` field to config to prevent backward-incompatible downgrades
- Maven resource filtering on `config.json` for build-time defaults (repo URL, product name)
- Fix download URL to include architecture classifier (`linux-x86_64`, `osx-aarch_64`)

Closes #7642

## Test plan

- [x] 166 unit tests pass (15 CliVersion, 11 ConfigProperty, 8 UpdateCheckResult, 3 PlatformUtils + existing)
- [x] 10 e2e shell tests (`test-update.sh`) with mock nginx repo: update detection, ambiguous/unambiguous resolution, specific version update, config preservation, redhat version filtering, unparseable version handling, patch auto-selection
- [x] Upgrade-from-previous test (`test-upgrade-from-previous.sh`) — skips until 3.3.0 is released
- [ ] CI workflow updated to run e2e tests on Linux runner
- [ ] Manual test: `acr --help` shows branded product name
- [ ] Manual test: `acr update --check` against real Maven Central