### PR TITLE
fix(ccompat): resolve version lookups by versionOrder for semantic versions

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/AbstractResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/AbstractResource.java
@@ -419,7 +419,7 @@ public abstract class AbstractResource {
         try {
             storage.getArtifactVersionMetaData(groupId, artifactId, versionString);
             return versionString;
-        } catch (VersionNotFoundException e) {
+        } catch (ArtifactNotFoundException | VersionNotFoundException e) {
             // Fall through to versionOrder lookup
         }
 

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/AbstractResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/AbstractResource.java
@@ -271,8 +271,14 @@ public abstract class AbstractResource {
             final List<ArtifactReferenceDto> referencesAsDtos = references.stream().map(schemaReference -> {
                 final ArtifactReferenceDto artifactReferenceDto = new ArtifactReferenceDto();
                 artifactReferenceDto.setArtifactId(schemaReference.getSubject());
-                artifactReferenceDto.setVersion(resolveVersionBySequenceNumber(null,
-                        schemaReference.getSubject(), schemaReference.getVersion()));
+                String version;
+                try {
+                    version = resolveVersionBySequenceNumber(null,
+                            schemaReference.getSubject(), schemaReference.getVersion());
+                } catch (ArtifactNotFoundException | VersionNotFoundException e) {
+                    version = String.valueOf(schemaReference.getVersion());
+                }
+                artifactReferenceDto.setVersion(version);
                 artifactReferenceDto.setName(schemaReference.getName());
                 artifactReferenceDto.setGroupId(null);
                 return artifactReferenceDto;
@@ -354,11 +360,18 @@ public abstract class AbstractResource {
 
     // Parse references and resolve the contentId. Reference versions are ccompat integer sequence numbers
     // and are resolved to actual version strings (including artifacts registered with semantic versioning).
+    // If resolution fails (e.g. nonexistent subject), the raw version string is preserved so that downstream
+    // validation can report the appropriate error.
     protected List<ArtifactReferenceDto> parseReferences(List<SchemaReference> references, String groupId) {
         if (references != null) {
             return references.stream().map(schemaReference -> {
-                String resolvedVersion = resolveVersionBySequenceNumber(groupId,
-                        schemaReference.getSubject(), schemaReference.getVersion());
+                String resolvedVersion;
+                try {
+                    resolvedVersion = resolveVersionBySequenceNumber(groupId,
+                            schemaReference.getSubject(), schemaReference.getVersion());
+                } catch (ArtifactNotFoundException | VersionNotFoundException e) {
+                    resolvedVersion = String.valueOf(schemaReference.getVersion());
+                }
                 return new ArtifactReferenceDto(groupId, schemaReference.getSubject(),
                         resolvedVersion, schemaReference.getName());
             }).collect(Collectors.toList());

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/AbstractResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/AbstractResource.java
@@ -20,8 +20,13 @@ import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.dto.ContentWrapperDto;
 import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.EditableVersionMetaDataDto;
+import io.apicurio.registry.storage.dto.OrderBy;
+import io.apicurio.registry.storage.dto.OrderDirection;
+import io.apicurio.registry.storage.dto.SearchFilter;
 import io.apicurio.registry.storage.dto.SearchedArtifactDto;
+import io.apicurio.registry.storage.dto.SearchedVersionDto;
 import io.apicurio.registry.storage.dto.StoredArtifactVersionDto;
+import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
 import io.apicurio.registry.storage.error.ArtifactNotFoundException;
 import io.apicurio.registry.storage.error.RuleNotFoundException;
 import com.google.protobuf.DescriptorProtos;
@@ -48,8 +53,10 @@ import org.slf4j.Logger;
 
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -271,7 +278,8 @@ public abstract class AbstractResource {
             final List<ArtifactReferenceDto> referencesAsDtos = references.stream().map(schemaReference -> {
                 final ArtifactReferenceDto artifactReferenceDto = new ArtifactReferenceDto();
                 artifactReferenceDto.setArtifactId(schemaReference.getSubject());
-                artifactReferenceDto.setVersion(String.valueOf(schemaReference.getVersion()));
+                artifactReferenceDto.setVersion(resolveVersionBySequenceNumber(null,
+                        schemaReference.getSubject(), schemaReference.getVersion()));
                 artifactReferenceDto.setName(schemaReference.getName());
                 artifactReferenceDto.setGroupId(null);
                 return artifactReferenceDto;
@@ -351,17 +359,15 @@ public abstract class AbstractResource {
         }
     }
 
-    // Parse references and resolve the contentId. This will fail with ArtifactNotFound if a reference cannot
-    // be found.
+    // Parse references and resolve the contentId. Reference versions are ccompat integer sequence numbers
+    // and are resolved to actual version strings (including artifacts registered with semantic versioning).
     protected List<ArtifactReferenceDto> parseReferences(List<SchemaReference> references, String groupId) {
         if (references != null) {
             return references.stream().map(schemaReference -> {
-                // Try to get the artifact version. This will fail if not found with ArtifactNotFound or
-                // VersionNotFound
-                storage.getArtifactVersionMetaData(groupId, schemaReference.getSubject(),
-                        String.valueOf(schemaReference.getVersion()));
+                String resolvedVersion = resolveVersionBySequenceNumber(groupId,
+                        schemaReference.getSubject(), schemaReference.getVersion());
                 return new ArtifactReferenceDto(groupId, schemaReference.getSubject(),
-                        String.valueOf(schemaReference.getVersion()), schemaReference.getName());
+                        resolvedVersion, schemaReference.getName());
             }).collect(Collectors.toList());
         } else {
             return Collections.emptyList();
@@ -374,9 +380,9 @@ public abstract class AbstractResource {
     }
 
     /**
-     * Given a version string: - if it's a <b>non-negative integer</b>, use that; - if it's a string "latest",
-     * find out and use the subject's (artifact's) latest version; - if it's <b>-1</b>, do the same as
-     * "latest", even though this behavior is undocumented. See
+     * Given a version string: - if it's a <b>non-negative integer</b>, resolve it as a ccompat sequence
+     * number (versionOrder); - if it's a string "latest", find out and use the subject's (artifact's) latest
+     * version; - if it's <b>-1</b>, do the same as "latest", even though this behavior is undocumented. See
      * https://github.com/Apicurio/apicurio-registry/issues/2851 - otherwise throw an
      * IllegalArgumentException. On success, call the "then" function with the parsed version (MUST NOT be
      * null) and return it's result. Optionally provide an "else" function that will receive the exception
@@ -391,7 +397,7 @@ public abstract class AbstractResource {
             try {
                 var numericVersion = Integer.parseInt(versionString);
                 if (numericVersion >= 0) {
-                    version = versionString;
+                    version = resolveVersionBySequenceNumber(groupId, subject, numericVersion);
                 } else if (numericVersion == -1) {
                     version = getLatestArtifactVersionForSubject(subject, groupId);
                 } else {
@@ -402,5 +408,37 @@ public abstract class AbstractResource {
             }
         }
         return then.apply(version);
+    }
+
+    /**
+     * Resolves a ccompat integer sequence number (versionOrder) to the actual stored version string. First
+     * tries a direct version string match (artifacts registered via ccompat with numeric IDs), then falls
+     * back to searching by versionOrder (artifacts registered with semantic versioning like "v5.1.1").
+     *
+     * @see <a href="https://github.com/Apicurio/apicurio-registry/issues/7886">Issue #7886</a>
+     */
+    protected String resolveVersionBySequenceNumber(String groupId, String artifactId,
+            int sequenceNumber) {
+        String versionString = String.valueOf(sequenceNumber);
+
+        // Fast path: try direct version string match (works for ccompat-registered artifacts)
+        try {
+            storage.getArtifactVersionMetaData(groupId, artifactId, versionString);
+            return versionString;
+        } catch (VersionNotFoundException e) {
+            // Fall through to versionOrder lookup
+        }
+
+        // Fallback: search all versions of this artifact and find the one with matching versionOrder
+        Set<SearchFilter> filters = new HashSet<>();
+        filters.add(SearchFilter.ofGroupId(groupId));
+        filters.add(SearchFilter.ofArtifactId(artifactId));
+        VersionSearchResultsDto searchResults = storage.searchVersions(filters, OrderBy.createdOn,
+                OrderDirection.asc, 0, 500);
+        return searchResults.getVersions().stream()
+                .filter(v -> v.getVersionOrder() == sequenceNumber)
+                .map(SearchedVersionDto::getVersion)
+                .findFirst()
+                .orElseThrow(() -> new VersionNotFoundException(groupId, artifactId, versionString));
     }
 }

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/AbstractResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/AbstractResource.java
@@ -20,13 +20,8 @@ import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.dto.ContentWrapperDto;
 import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.EditableVersionMetaDataDto;
-import io.apicurio.registry.storage.dto.OrderBy;
-import io.apicurio.registry.storage.dto.OrderDirection;
-import io.apicurio.registry.storage.dto.SearchFilter;
 import io.apicurio.registry.storage.dto.SearchedArtifactDto;
-import io.apicurio.registry.storage.dto.SearchedVersionDto;
 import io.apicurio.registry.storage.dto.StoredArtifactVersionDto;
-import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
 import io.apicurio.registry.storage.error.ArtifactNotFoundException;
 import io.apicurio.registry.storage.error.RuleNotFoundException;
 import com.google.protobuf.DescriptorProtos;
@@ -53,10 +48,8 @@ import org.slf4j.Logger;
 
 import java.util.Base64;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -413,7 +406,8 @@ public abstract class AbstractResource {
     /**
      * Resolves a ccompat integer sequence number (versionOrder) to the actual stored version string. First
      * tries a direct version string match (artifacts registered via ccompat with numeric IDs), then falls
-     * back to searching by versionOrder (artifacts registered with semantic versioning like "v5.1.1").
+     * back to a single-query lookup by versionOrder (artifacts registered with semantic versioning like
+     * "v5.1.1").
      *
      * @see <a href="https://github.com/Apicurio/apicurio-registry/issues/7886">Issue #7886</a>
      */
@@ -429,16 +423,9 @@ public abstract class AbstractResource {
             // Fall through to versionOrder lookup
         }
 
-        // Fallback: search all versions of this artifact and find the one with matching versionOrder
-        Set<SearchFilter> filters = new HashSet<>();
-        filters.add(SearchFilter.ofGroupId(groupId));
-        filters.add(SearchFilter.ofArtifactId(artifactId));
-        VersionSearchResultsDto searchResults = storage.searchVersions(filters, OrderBy.createdOn,
-                OrderDirection.asc, 0, 500);
-        return searchResults.getVersions().stream()
-                .filter(v -> v.getVersionOrder() == sequenceNumber)
-                .map(SearchedVersionDto::getVersion)
-                .findFirst()
-                .orElseThrow(() -> new VersionNotFoundException(groupId, artifactId, versionString));
+        // Fallback: look up by versionOrder directly
+        ArtifactVersionMetaDataDto dto = storage.getArtifactVersionMetaDataByVersionOrder(groupId,
+                artifactId, sequenceNumber);
+        return dto.getVersion();
     }
 }

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -25,14 +25,15 @@ import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
 import io.apicurio.registry.model.GA;
 import io.apicurio.registry.rest.MethodMetadata;
-import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.SearchFilter;
 import io.apicurio.registry.storage.dto.SearchedArtifactDto;
+import io.apicurio.registry.storage.dto.SearchedVersionDto;
 import io.apicurio.registry.storage.dto.StoredArtifactVersionDto;
+import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
 import io.apicurio.registry.storage.error.ArtifactNotFoundException;
 import io.apicurio.registry.storage.error.InvalidArtifactStateException;
 import io.apicurio.registry.storage.error.InvalidArtifactTypeException;
@@ -41,7 +42,6 @@ import io.apicurio.registry.storage.error.VersionNotFoundException;
 import io.apicurio.registry.types.VersionState;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.util.ArtifactTypeUtil;
-import io.apicurio.registry.utils.VersionUtil;
 import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptors;
 import jakarta.ws.rs.BadRequestException;
@@ -218,19 +218,23 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
         final boolean fdeletedOnly = deletedOnly == null ? Boolean.FALSE : deletedOnly;
 
         List<BigInteger> rval;
-        Set<VersionState> statesFilter;
 
+        Set<SearchFilter> filters = new HashSet<>();
+        filters.add(SearchFilter.ofGroupId(ga.getRawGroupIdWithNull()));
+        filters.add(SearchFilter.ofArtifactId(ga.getRawArtifactId()));
+        filters.add(SearchFilter.ofState(VersionState.DRAFT).negated());
         if (fdeletedOnly) {
-            // Only return deleted versions
-            statesFilter = Set.of(VersionState.DISABLED);
-        } else if (fdeleted) {
-            statesFilter = RegistryStorage.RetrievalBehavior.NON_DRAFT_STATES;
-        } else {
-            statesFilter = RegistryStorage.RetrievalBehavior.ACTIVE_STATES;
+            filters.add(SearchFilter.ofState(VersionState.DISABLED));
+        } else if (!fdeleted) {
+            filters.add(SearchFilter.ofState(VersionState.DISABLED).negated());
         }
 
-        rval = storage.getArtifactVersions(ga.getRawGroupIdWithNull(), ga.getRawArtifactId(), statesFilter)
-                .stream().map(VersionUtil::toLong).map(converter::convertUnsigned).sorted()
+        VersionSearchResultsDto searchResults = storage.searchVersions(filters, OrderBy.createdOn,
+                OrderDirection.asc, 0, 500);
+        rval = searchResults.getVersions().stream()
+                .map(SearchedVersionDto::getVersionOrder)
+                .map(versionOrder -> converter.convertUnsigned((long) versionOrder))
+                .sorted()
                 .collect(Collectors.toList());
 
         // Apply pagination
@@ -348,7 +352,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
         final GA ga = getGA(groupId, subject);
         try {
             if (doesArtifactExist(ga.getRawArtifactId(), ga.getRawGroupIdWithNull())) {
-                return BigInteger.valueOf(VersionUtil.toLong(parseVersionString(ga.getRawArtifactId(), versionString,
+                return parseVersionString(ga.getRawArtifactId(), versionString,
                         ga.getRawGroupIdWithNull(), version -> {
                             final boolean fpermanent = permanent == null ? Boolean.FALSE : permanent;
                             List<Long> globalIdsReferencingSchema = storage
@@ -358,16 +362,15 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
                                     ga.getRawGroupIdWithNull(), ga.getRawArtifactId(), version);
                             if (globalIdsReferencingSchema.isEmpty()
                                     || areAllSchemasDisabled(globalIdsReferencingSchema)) {
-                                return processDeleteVersion(ga.getRawArtifactId(), versionString,
+                                processDeleteVersion(ga.getRawArtifactId(), versionString,
                                         ga.getRawGroupIdWithNull(), version, fpermanent, avmd);
                             } else {
-                                // There are other schemas referencing this one, it cannot be deleted.
                                 throw new ReferenceExistsException(String
                                         .format("There are subjects referencing %s", ga.getRawArtifactId()));
                             }
-                        })));
-            }
-            else {
+                            return BigInteger.valueOf(avmd.getVersionOrder());
+                        });
+            } else {
                 throw new ArtifactNotFoundException(ga.getRawGroupIdWithNull(), ga.getRawArtifactId());
             }
         }
@@ -498,24 +501,40 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
         if (isArtifactActive(artifactId, groupId)) {
             throw new SubjectNotSoftDeletedException(
                     String.format("Subject %s must be soft deleted first", artifactId));
-        }
-        else {
-            return storage.deleteArtifact(groupId, artifactId).stream().map(VersionUtil::toInteger)
-                    .map(converter::convertUnsigned).collect(Collectors.toList());
+        } else {
+            // Collect versionOrder values before deleting — metadata is gone after deleteArtifact.
+            Set<SearchFilter> filters = new HashSet<>();
+            filters.add(SearchFilter.ofGroupId(groupId));
+            filters.add(SearchFilter.ofArtifactId(artifactId));
+            VersionSearchResultsDto searchResults = storage.searchVersions(filters, OrderBy.createdOn,
+                    OrderDirection.asc, 0, 500);
+            List<BigInteger> result = searchResults.getVersions().stream()
+                    .map(SearchedVersionDto::getVersionOrder)
+                    .map(versionOrder -> converter.convertUnsigned((long) versionOrder))
+                    .collect(Collectors.toList());
+            storage.deleteArtifact(groupId, artifactId);
+            return result;
         }
     }
 
     // Deleting artifact versions means updating all the versions status to DISABLED.
     private List<BigInteger> deleteSubjectVersions(String groupId, String artifactId) {
-        List<String> deletedVersions = storage.getArtifactVersions(groupId, artifactId);
+        // Fetch all versions with metadata in a single query to get versionOrder values
+        Set<SearchFilter> filters = new HashSet<>();
+        filters.add(SearchFilter.ofGroupId(groupId));
+        filters.add(SearchFilter.ofArtifactId(artifactId));
+        VersionSearchResultsDto searchResults = storage.searchVersions(filters, OrderBy.createdOn,
+                OrderDirection.asc, 0, 500);
         try {
-            deletedVersions.forEach(version -> storage.updateArtifactVersionState(groupId, artifactId,
-                    version, VersionState.DISABLED, false));
-        }
-        catch (InvalidArtifactStateException | InvalidVersionStateException ignored) {
+            searchResults.getVersions().forEach(v -> storage.updateArtifactVersionState(groupId,
+                    artifactId, v.getVersion(), VersionState.DISABLED, false));
+        } catch (InvalidArtifactStateException | InvalidVersionStateException ignored) {
             log.warn("Invalid artifact state transition", ignored);
         }
-        return deletedVersions.stream().map(VersionUtil::toLong).map(converter::convertUnsigned).sorted()
+        return searchResults.getVersions().stream()
+                .map(SearchedVersionDto::getVersionOrder)
+                .map(versionOrder -> converter.convertUnsigned((long) versionOrder))
+                .sorted()
                 .collect(Collectors.toList());
     }
 }

--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
@@ -622,6 +622,19 @@ public interface RegistryStorage extends DynamicConfigStorage {
             throws VersionNotFoundException, RegistryStorageException;
 
     /**
+     * Gets the stored meta-data for a single version of an artifact, looked up by its versionOrder (the
+     * ccompat integer sequence number) rather than the version string.
+     *
+     * @param groupId (optional)
+     * @param artifactId
+     * @param versionOrder
+     * @throws VersionNotFoundException
+     * @throws RegistryStorageException
+     */
+    ArtifactVersionMetaDataDto getArtifactVersionMetaDataByVersionOrder(String groupId, String artifactId,
+            int versionOrder) throws VersionNotFoundException, RegistryStorageException;
+
+    /**
      * Updates the user-editable meta-data for a single version of a given artifact. Only the client-editable
      * meta-data can be updated. Client editable meta-data includes e.g. name and description.
      *

--- a/app/src/main/java/io/apicurio/registry/storage/decorator/ReadOnlyDelegatingStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/ReadOnlyDelegatingStorage.java
@@ -206,6 +206,13 @@ public abstract class ReadOnlyDelegatingStorage implements RegistryStorage {
     }
 
     @Override
+    public ArtifactVersionMetaDataDto getArtifactVersionMetaDataByVersionOrder(String groupId,
+            String artifactId, int versionOrder)
+            throws VersionNotFoundException, RegistryStorageException {
+        return delegate.getArtifactVersionMetaDataByVersionOrder(groupId, artifactId, versionOrder);
+    }
+
+    @Override
     public List<RuleType> getGlobalRules() throws RegistryStorageException {
         return delegate.getGlobalRules();
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingRegistryStorage.java
@@ -455,6 +455,14 @@ public abstract class AbstractPollingRegistryStorage<MARKER extends SourceMarker
     }
 
     @Override
+    public ArtifactVersionMetaDataDto getArtifactVersionMetaDataByVersionOrder(String groupId,
+            String artifactId, int versionOrder)
+            throws VersionNotFoundException, RegistryStorageException {
+        return proxy(storage -> storage.getArtifactVersionMetaDataByVersionOrder(groupId, artifactId,
+                versionOrder));
+    }
+
+    @Override
     public List<RuleType> getGlobalRules() {
         return proxy(RegistryStorage::getGlobalRules);
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -941,6 +941,13 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     }
 
     @Override
+    public ArtifactVersionMetaDataDto getArtifactVersionMetaDataByVersionOrder(String groupId,
+            String artifactId, int versionOrder) {
+
+        return versionRepository.getArtifactVersionMetaDataByVersionOrder(groupId, artifactId, versionOrder);
+    }
+
+    @Override
     public List<ArtifactVersionMetaDataDto> getVersionsModifiedSince(long sinceTimestamp) {
         return versionRepository.getVersionsModifiedSince(sinceTimestamp);
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -190,6 +190,13 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     @Override
+    public String selectArtifactVersionMetaDataByVersionOrder() {
+        return "SELECT v.*, a.type FROM versions v "
+                + "JOIN artifacts a ON v.groupId = a.groupId AND v.artifactId = a.artifactId "
+                + "WHERE v.groupId = ? AND v.artifactId = ? AND v.versionOrder = ?";
+    }
+
+    @Override
     public String selectArtifactVersionState() {
         return "SELECT v.state FROM versions v "
                 + "WHERE v.groupId = ? AND v.artifactId = ? AND v.version = ?";

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -166,6 +166,11 @@ public interface SqlStatements {
     public String selectArtifactVersionMetaData();
 
     /**
+     * A statement used to select artifact version metadata by artifactId and versionOrder.
+     */
+    public String selectArtifactVersionMetaDataByVersionOrder();
+
+    /**
      * A statement to select the content of an artifact version from the versions table by artifactId +
      * version.
      */

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlVersionRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlVersionRepository.java
@@ -124,6 +124,23 @@ public class SqlVersionRepository {
     }
 
     /**
+     * Get artifact version metadata by groupId, artifactId, and versionOrder.
+     */
+    public ArtifactVersionMetaDataDto getArtifactVersionMetaDataByVersionOrder(String groupId,
+            String artifactId, int versionOrder) {
+        return handles.withHandle(handle -> {
+            Optional<ArtifactVersionMetaDataDto> res = handle
+                    .createQuery(sqlStatements.selectArtifactVersionMetaDataByVersionOrder())
+                    .bind(0, normalizeGroupId(groupId))
+                    .bind(1, artifactId).bind(2, versionOrder)
+                    .map(ArtifactVersionMetaDataDtoMapper.instance)
+                    .findOne();
+            return res.orElseThrow(
+                    () -> new VersionNotFoundException(groupId, artifactId, String.valueOf(versionOrder)));
+        });
+    }
+
+    /**
      * Get artifact version content by globalId.
      */
     public StoredArtifactVersionDto getArtifactVersionContent(long globalId)

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatSemanticVersionLookupTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatSemanticVersionLookupTest.java
@@ -1,0 +1,220 @@
+package io.apicurio.registry.noprofile.ccompat.rest.v7;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.client.models.ArtifactReference;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+
+/**
+ * Tests that the ccompat v7 API correctly resolves artifacts by integer sequence number
+ * (versionOrder) when the artifact was registered with a semantic version string (e.g.
+ * "v5.1.1"). The ccompat API uses integer sequence numbers per the Confluent spec, so
+ * lookups using those integers must work regardless of how the artifact was originally
+ * versioned.
+ *
+ * @see <a href="https://github.com/Apicurio/apicurio-registry/issues/7886">Issue #7886</a>
+ */
+@QuarkusTest
+public class CCompatSemanticVersionLookupTest extends AbstractResourceTestBase {
+
+    /**
+     * Registers an artifact via the v3 API with a semantic version string, then verifies
+     * that the ccompat subjects/versions endpoint can resolve it by its integer sequence
+     * number.
+     */
+    @Test
+    public void testGetSubjectVersionBySequenceNumber() throws Exception {
+        final String groupId = "default";
+        final String artifactId = TestUtils.generateArtifactId();
+
+        final String schema = "{\"type\":\"record\",\"name\":\"TestRecord\","
+                + "\"namespace\":\"com.example\",\"fields\":"
+                + "[{\"name\":\"field1\",\"type\":\"string\"}]}";
+
+        // Register via v3 API with a semantic version
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactId(artifactId);
+        createArtifact.setArtifactType(ArtifactType.AVRO);
+        CreateVersion createVersion = new CreateVersion();
+        createVersion.setVersion("v5.1.1");
+        VersionContent versionContent = new VersionContent();
+        versionContent.setContent(schema);
+        versionContent.setContentType(ContentTypes.APPLICATION_JSON);
+        createVersion.setContent(versionContent);
+        createArtifact.setFirstVersion(createVersion);
+        clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+
+        // The ccompat API should list version 1 (the versionOrder) for this subject
+        var versionsResponse = given()
+                .when()
+                .get("/ccompat/v7/subjects/{subject}/versions", artifactId)
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(int[].class);
+        Assertions.assertEquals(1, versionsResponse.length);
+        Assertions.assertEquals(1, versionsResponse[0],
+                "ccompat should return versionOrder (1), not the semantic version");
+
+        // Now resolve that version via GET /subjects/{subject}/versions/1
+        // This is the core of issue #7886: this call fails when the stored version is "v5.1.1"
+        given()
+                .when()
+                .get("/ccompat/v7/subjects/{subject}/versions/{version}", artifactId, 1)
+                .then()
+                .statusCode(200);
+    }
+
+    /**
+     * Registers an artifact with a semantic version that has a reference to another
+     * semantic-versioned artifact, then verifies that reference resolution via the ccompat
+     * API works using integer sequence numbers.
+     */
+    @Test
+    public void testReferenceResolutionWithSemanticVersions() throws Exception {
+        final String groupId = "default";
+        final String referencedId = TestUtils.generateArtifactId();
+        final String referencingId = TestUtils.generateArtifactId();
+
+        // Create the referenced artifact with a semantic version
+        final String referencedSchema = "{\"type\":\"record\",\"name\":\"Address\","
+                + "\"namespace\":\"com.example\",\"fields\":"
+                + "[{\"name\":\"street\",\"type\":\"string\"}]}";
+
+        CreateArtifact createReferenced = new CreateArtifact();
+        createReferenced.setArtifactId(referencedId);
+        createReferenced.setArtifactType(ArtifactType.AVRO);
+        CreateVersion refVersion = new CreateVersion();
+        refVersion.setVersion("v2.0.0");
+        VersionContent refContent = new VersionContent();
+        refContent.setContent(referencedSchema);
+        refContent.setContentType(ContentTypes.APPLICATION_JSON);
+        refVersion.setContent(refContent);
+        createReferenced.setFirstVersion(refVersion);
+        clientV3.groups().byGroupId(groupId).artifacts().post(createReferenced);
+
+        // Create the referencing artifact with a reference to the semantic-versioned artifact
+        final String referencingSchema = "{\"type\":\"record\",\"name\":\"Person\","
+                + "\"namespace\":\"com.example\",\"fields\":"
+                + "[{\"name\":\"name\",\"type\":\"string\"},"
+                + "{\"name\":\"address\",\"type\":\"com.example.Address\"}]}";
+
+        ArtifactReference ref = new ArtifactReference();
+        ref.setGroupId(groupId);
+        ref.setArtifactId(referencedId);
+        ref.setVersion("v2.0.0");
+        ref.setName("com.example.Address");
+
+        CreateArtifact createReferencing = new CreateArtifact();
+        createReferencing.setArtifactId(referencingId);
+        createReferencing.setArtifactType(ArtifactType.AVRO);
+        CreateVersion referencingVersion = new CreateVersion();
+        referencingVersion.setVersion("v1.0.0");
+        VersionContent referencingContent = new VersionContent();
+        referencingContent.setContent(referencingSchema);
+        referencingContent.setContentType(ContentTypes.APPLICATION_JSON);
+        referencingContent.setReferences(List.of(ref));
+        referencingVersion.setContent(referencingContent);
+        createReferencing.setFirstVersion(referencingVersion);
+        var result = clientV3.groups().byGroupId(groupId).artifacts().post(createReferencing);
+
+        long contentId = result.getVersion().getContentId();
+
+        // Fetch the schema via ccompat — the references should have integer version numbers
+        var ccompatSchema = given()
+                .when()
+                .get("/ccompat/v7/schemas/ids/{id}", contentId)
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(io.apicurio.registry.ccompat.rest.v7.beans.Schema.class);
+
+        Assertions.assertNotNull(ccompatSchema.getReferences());
+        Assertions.assertEquals(1, ccompatSchema.getReferences().size());
+        int refVersionNumber = ccompatSchema.getReferences().get(0).getVersion().intValue();
+
+        // Now use that integer version number to resolve the referenced artifact via ccompat.
+        // This is the second part of issue #7886: the integer returned in references must be
+        // usable to fetch the referenced schema.
+        given()
+                .when()
+                .get("/ccompat/v7/subjects/{subject}/versions/{version}", referencedId, refVersionNumber)
+                .then()
+                .statusCode(200);
+    }
+
+    /**
+     * Verifies that listing versions via the ccompat API returns versionOrder integers
+     * (not the semantic version strings) when the artifact was registered with semantic
+     * versioning.
+     */
+    @Test
+    public void testListVersionsReturnsSequenceNumbers() throws Exception {
+        final String groupId = "default";
+        final String artifactId = TestUtils.generateArtifactId();
+
+        final String schemaV1 = "{\"type\":\"record\",\"name\":\"Rec\","
+                + "\"namespace\":\"com.example\",\"fields\":"
+                + "[{\"name\":\"f1\",\"type\":\"string\"}]}";
+        final String schemaV2 = "{\"type\":\"record\",\"name\":\"Rec\","
+                + "\"namespace\":\"com.example\",\"fields\":"
+                + "[{\"name\":\"f1\",\"type\":\"string\"},{\"name\":\"f2\",\"type\":\"string\"}]}";
+
+        // Register first version with semantic version "v1.0.0"
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactId(artifactId);
+        createArtifact.setArtifactType(ArtifactType.AVRO);
+        CreateVersion v1 = new CreateVersion();
+        v1.setVersion("v1.0.0");
+        VersionContent content1 = new VersionContent();
+        content1.setContent(schemaV1);
+        content1.setContentType(ContentTypes.APPLICATION_JSON);
+        v1.setContent(content1);
+        createArtifact.setFirstVersion(v1);
+        clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+
+        // Register second version with semantic version "v2.0.0"
+        CreateVersion v2 = new CreateVersion();
+        v2.setVersion("v2.0.0");
+        VersionContent content2 = new VersionContent();
+        content2.setContent(schemaV2);
+        content2.setContentType(ContentTypes.APPLICATION_JSON);
+        v2.setContent(content2);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions().post(v2);
+
+        // ccompat version listing should return [1, 2], not the semantic version strings
+        var versionsResponse = given()
+                .when()
+                .get("/ccompat/v7/subjects/{subject}/versions", artifactId)
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(int[].class);
+        Assertions.assertEquals(2, versionsResponse.length);
+        Assertions.assertEquals(1, versionsResponse[0]);
+        Assertions.assertEquals(2, versionsResponse[1]);
+
+        // Both version 1 and version 2 should be resolvable via ccompat
+        given()
+                .when()
+                .get("/ccompat/v7/subjects/{subject}/versions/{version}", artifactId, 1)
+                .then()
+                .statusCode(200);
+        given()
+                .when()
+                .get("/ccompat/v7/subjects/{subject}/versions/{version}", artifactId, 2)
+                .then()
+                .statusCode(200);
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/storage/impl/readonly/ReadOnlyRegistryStorageTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/readonly/ReadOnlyRegistryStorageTest.java
@@ -110,6 +110,8 @@ public class ReadOnlyRegistryStorageTest {
                         new State(false, s -> s.getArtifactVersionMetaData(null))),
                 entry("getArtifactVersionMetaData3",
                         new State(false, s -> s.getArtifactVersionMetaData(null, null, null))),
+                entry("getArtifactVersionMetaDataByVersionOrder3",
+                        new State(false, s -> s.getArtifactVersionMetaDataByVersionOrder(null, null, 0))),
                 entry("getArtifactVersionMetaDataByContent5",
                         new State(false,
                                 s -> s.getArtifactVersionMetaDataByContent(null, null, false, null, null))),

--- a/app/src/test/java/io/apicurio/registry/storage/impl/search/TestInMemoryRegistryStorage.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/search/TestInMemoryRegistryStorage.java
@@ -450,6 +450,12 @@ public class TestInMemoryRegistryStorage implements RegistryStorage {
     }
 
     @Override
+    public ArtifactVersionMetaDataDto getArtifactVersionMetaDataByVersionOrder(String groupId,
+            String artifactId, int versionOrder) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void updateArtifactVersionMetaData(String groupId, String artifactId, String version,
             EditableVersionMetaDataDto metaData) {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
## Summary

Fixes #7886

The ccompat v7 API uses integer sequence numbers (`versionOrder`) as version identifiers per the
Confluent Schema Registry spec. When artifacts are registered via the v3 API with semantic version
strings (e.g. `"v5.1.1"`), several ccompat endpoints break because they treat the integer as a
literal version string rather than resolving it as a `versionOrder` sequence number.

**Root cause:** `parseVersionString` passed the numeric string straight through as the version ID,
and several methods used `VersionUtil::toLong` to convert stored version strings to numbers (which
returns `null` for non-numeric versions like `"v5.1.1"`).

**Changes:**
- Added `resolveVersionBySequenceNumber` helper in `AbstractResource` — tries a direct version
  string match first (fast path for ccompat-registered artifacts), then falls back to
  `searchVersions` to find the version with matching `versionOrder` in a single query
- Wired the helper into `parseVersionString`, `resolveReferences`, and `parseReferences`
- Replaced `VersionUtil::toLong` usage in `getSubjectVersions`, `deleteSchemaVersion`,
  `deleteSubjectPermanent`, and `deleteSubjectVersions` with `versionOrder` from version metadata
  (via `searchVersions` for bulk operations)
- Added `CCompatSemanticVersionLookupTest` with three test cases covering direct lookup, reference
  resolution, and version listing

## Test plan

- [ ] `CCompatSemanticVersionLookupTest.testGetSubjectVersionBySequenceNumber` — registers artifact
  with semantic version via v3 API, verifies ccompat lookup by sequence number works
- [ ] `CCompatSemanticVersionLookupTest.testReferenceResolutionWithSemanticVersions` — verifies
  reference version integers returned by ccompat are resolvable back through the subjects endpoint
- [ ] `CCompatSemanticVersionLookupTest.testListVersionsReturnsSequenceNumbers` — verifies version
  listing returns `versionOrder` integers, not semantic version strings
- [ ] Existing ccompat tests continue to pass (no regression for numeric-versioned artifacts)