### PR TITLE
fix(ci): poll for workflow completion before re-run in retriggerVerify

### DIFF
--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -240,6 +240,13 @@ function createApi(github, owner, repo) {
         if (e.status !== 409) throw e;
       }
     },
+
+    getWorkflowRun: async (runId) => {
+      const { data } = await github.rest.actions.getWorkflowRun({
+        owner, repo, run_id: runId,
+      });
+      return data;
+    },
   };
 }
 
@@ -264,7 +271,14 @@ async function retriggerVerify(api, pr, core, { waitForRun = false } = {}) {
   if (run.status === 'in_progress' || run.status === 'queued') {
     core.info(`PR #${pr.number} cancelling in-progress Verify run ${run.id}`);
     await api.cancelWorkflowRun(run.id);
-    await new Promise(r => setTimeout(r, 3000));
+
+    // Wait for the run to fully complete — the Verification Gate job
+    // has `if: always()` and keeps the run alive after cancellation.
+    for (let attempt = 0; attempt < 10; attempt++) {
+      await new Promise(r => setTimeout(r, 3000));
+      const fresh = await api.getWorkflowRun(run.id);
+      if (fresh.status === 'completed') break;
+    }
   }
 
   // Allow label changes to propagate through GitHub's eventually-consistent API


### PR DESCRIPTION
## Summary

- Fix a race condition in `retriggerVerify` where the `reRunWorkflow` API call fails silently
  because the cancelled Verify workflow run hasn't fully completed yet (the Verification Gate
  job with `if: always()` keeps the run alive after cancellation).
- Replace the fixed 3-second post-cancel wait with a polling loop (up to 30 seconds) that
  checks the run status before attempting the re-run.
- Add a `getWorkflowRun` API helper for precise run-by-ID status checking.

## Test plan

- [ ] Open a test PR from a trusted author to trigger the `handlePrOpened` → `retriggerVerify`
  flow
- [ ] Verify the PR Lifecycle `PR Opened` job logs show "re-triggered Verify run" instead of
  the warning about a failed re-trigger
- [ ] Verify the Verify workflow re-runs successfully and the Verification Gate passes