### PR TITLE
Add search capabilities to the CLI. Fixes #7786

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -3,8 +3,9 @@ package io.apicurio.registry.cli;
 import io.apicurio.registry.cli.artifact.ArtifactCommand;
 import io.apicurio.registry.cli.config.ConfigPropertyCommand;
 import io.apicurio.registry.cli.context.ContextCommand;
-import io.apicurio.registry.cli.group.GroupCommand;
 import io.apicurio.registry.cli.globalrule.GlobalRuleCommand;
+import io.apicurio.registry.cli.group.GroupCommand;
+import io.apicurio.registry.cli.search.SearchCommand;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import lombok.Getter;
 import picocli.CommandLine.Command;
@@ -30,6 +31,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
                 GlobalRuleCommand.class,
                 GroupCommand.class,
                 InstallCommand.class,
+                SearchCommand.class,
                 UpdateCommand.class,
                 VersionCommand.class
         },

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCommand.java
@@ -1,18 +1,17 @@
 package io.apicurio.registry.cli.artifact;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.Acr;
 import io.apicurio.registry.cli.common.AbstractCommand;
-import io.apicurio.registry.cli.version.VersionCommand;
+import io.apicurio.registry.cli.common.ArtifactOrderMixin;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.common.PaginationMixin;
+import io.apicurio.registry.cli.version.VersionCommand;
 import io.apicurio.registry.cli.utils.Mapper;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
-import io.apicurio.registry.rest.client.models.ArtifactSortBy;
 import io.apicurio.registry.rest.client.models.ProblemDetails;
-import io.apicurio.registry.rest.client.models.SortOrder;
 import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -59,6 +58,9 @@ public class ArtifactCommand extends AbstractCommand {
     private String groupId;
 
     @Mixin
+    private ArtifactOrderMixin ordering;
+
+    @Mixin
     private PaginationMixin pagination;
 
     @Mixin
@@ -80,8 +82,8 @@ public class ArtifactCommand extends AbstractCommand {
                         //noinspection ConstantConditions
                         r.queryParameters.offset = (pagination.getPage() - 1) * pagination.getSize();
                         r.queryParameters.limit = pagination.getSize();
-                        r.queryParameters.orderby = ArtifactSortBy.ArtifactId;
-                        r.queryParameters.order = SortOrder.Asc;
+                        r.queryParameters.orderby = ordering.getOrderBy();
+                        r.queryParameters.order = ordering.getOrder();
                     }));
             output.writeStdOutChunkWithException(out -> {
                 switch (outputType.getOutputType()) {

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
@@ -1,8 +1,9 @@
 package io.apicurio.registry.cli.artifact;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
@@ -16,7 +17,7 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 import static io.apicurio.registry.cli.artifact.ArtifactGetCommand.printArtifact;
 import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
@@ -73,10 +74,9 @@ public class ArtifactCreateCommand extends AbstractCommand {
 
     @Option(
             names = {"-l", "--label"},
-            description = "Provide a list of artifact labels.",
-            mapFallbackValue = ""
+            description = "Provide a list of artifact labels (format: key=value or key). Use \\= to include = in a key."
     )
-    private Map<String, String> labels;
+    private List<String> labels;
 
     @Option(
             names = {"--version"},
@@ -111,7 +111,7 @@ public class ArtifactCreateCommand extends AbstractCommand {
         }
         if (labels != null) {
             final var newLabels = new Labels();
-            newLabels.setAdditionalData(new HashMap<>(labels));
+            newLabels.setAdditionalData(new HashMap<>(Conversions.parseLabels(labels)));
             newArtifact.setLabels(newLabels);
         }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactUpdateCommand.java
@@ -1,7 +1,8 @@
 package io.apicurio.registry.cli.artifact;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
+import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.EditableArtifactMetaData;
 import io.apicurio.registry.rest.client.models.Labels;
@@ -11,7 +12,6 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 import java.util.List;
-import java.util.Map;
 
 import io.apicurio.registry.cli.common.CliException;
 
@@ -53,10 +53,9 @@ public class ArtifactUpdateCommand extends AbstractCommand {
 
     @Option(
             names = {"-l", "--sl", "--set-label"},
-            description = "Add or update an artifact label.",
-            mapFallbackValue = ""
+            description = "Add or update an artifact label (format: key=value or key). Use \\= to include = in a key."
     )
-    private Map<String, String> setLabels;
+    private List<String> setLabels;
 
     @Option(
             names = {"--dl", "--delete-label"},
@@ -91,7 +90,7 @@ public class ArtifactUpdateCommand extends AbstractCommand {
                 if (updatedArtifact.getLabels() == null) {
                     updatedArtifact.setLabels(new Labels());
                 }
-                updatedArtifact.getLabels().getAdditionalData().putAll(setLabels);
+                updatedArtifact.getLabels().getAdditionalData().putAll(Conversions.parseLabels(setLabels));
             }
             if (deleteLabels != null) {
                 if (updatedArtifact.getLabels() != null) {

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -22,7 +22,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
     private static final Logger log = Logger.getLogger(AbstractCommand.class);
 
     @Spec
-    CommandSpec spec;
+    protected CommandSpec spec;
 
     @Inject
     protected Config config;

--- a/cli/src/main/java/io/apicurio/registry/cli/common/ArtifactOrderMixin.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/ArtifactOrderMixin.java
@@ -1,0 +1,25 @@
+package io.apicurio.registry.cli.common;
+
+import io.apicurio.registry.rest.client.models.ArtifactSortBy;
+import io.apicurio.registry.rest.client.models.SortOrder;
+import lombok.Getter;
+import picocli.CommandLine.Option;
+
+public class ArtifactOrderMixin {
+
+    @Option(
+            names = {"--order-by"},
+            description = "Sort field (GroupId, ArtifactId, CreatedOn, ModifiedOn, ArtifactType, Name). Default: ArtifactId.",
+            defaultValue = "ArtifactId"
+    )
+    @Getter
+    private ArtifactSortBy orderBy;
+
+    @Option(
+            names = {"--order"},
+            description = "Sort order (Asc, Desc). Default: Asc.",
+            defaultValue = "Asc"
+    )
+    @Getter
+    private SortOrder order;
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/common/GroupOrderMixin.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/GroupOrderMixin.java
@@ -1,0 +1,25 @@
+package io.apicurio.registry.cli.common;
+
+import io.apicurio.registry.rest.client.models.GroupSortBy;
+import io.apicurio.registry.rest.client.models.SortOrder;
+import lombok.Getter;
+import picocli.CommandLine.Option;
+
+public class GroupOrderMixin {
+
+    @Option(
+            names = {"--order-by"},
+            description = "Sort field (GroupId, CreatedOn, ModifiedOn). Default: GroupId.",
+            defaultValue = "GroupId"
+    )
+    @Getter
+    private GroupSortBy orderBy;
+
+    @Option(
+            names = {"--order"},
+            description = "Sort order (Asc, Desc). Default: Asc.",
+            defaultValue = "Asc"
+    )
+    @Getter
+    private SortOrder order;
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/common/VersionOrderMixin.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/VersionOrderMixin.java
@@ -1,0 +1,25 @@
+package io.apicurio.registry.cli.common;
+
+import io.apicurio.registry.rest.client.models.SortOrder;
+import io.apicurio.registry.rest.client.models.VersionSortBy;
+import lombok.Getter;
+import picocli.CommandLine.Option;
+
+public class VersionOrderMixin {
+
+    @Option(
+            names = {"--order-by"},
+            description = "Sort field (GroupId, ArtifactId, Version, Name, CreatedOn, ModifiedOn, GlobalId). Default: Version.",
+            defaultValue = "Version"
+    )
+    @Getter
+    private VersionSortBy orderBy;
+
+    @Option(
+            names = {"--order"},
+            description = "Sort order (Asc, Desc). Default: Asc.",
+            defaultValue = "Asc"
+    )
+    @Getter
+    private SortOrder order;
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupCommand.java
@@ -3,13 +3,12 @@ package io.apicurio.registry.cli.group;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.Acr;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.GroupOrderMixin;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.common.PaginationMixin;
 import io.apicurio.registry.cli.utils.Mapper;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
-import io.apicurio.registry.rest.client.models.GroupSortBy;
-import io.apicurio.registry.rest.client.models.SortOrder;
 import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -40,6 +39,9 @@ import static io.apicurio.registry.cli.utils.Conversions.convertToString;
 public class GroupCommand extends AbstractCommand {
 
     @Mixin
+    private GroupOrderMixin ordering;
+
+    @Mixin
     private PaginationMixin pagination;
 
     @Mixin
@@ -56,8 +58,8 @@ public class GroupCommand extends AbstractCommand {
             //noinspection ConstantConditions
             r.queryParameters.offset = (pagination.getPage() - 1) * pagination.getSize();
             r.queryParameters.limit = pagination.getSize();
-            r.queryParameters.orderby = GroupSortBy.GroupId;
-            r.queryParameters.order = SortOrder.Asc;
+            r.queryParameters.orderby = ordering.getOrderBy();
+            r.queryParameters.order = ordering.getOrder();
         }));
         output.writeStdOutChunkWithException(out -> {
             switch (outputType.getOutputType()) {

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupCreateCommand.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.cli.group;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.CreateGroup;
 import io.apicurio.registry.rest.client.models.Labels;
@@ -10,7 +11,8 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Parameters;
 
-import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
 
 import static io.apicurio.registry.cli.group.GroupGetCommand.printGroup;
 import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
@@ -26,7 +28,8 @@ import static picocli.CommandLine.Option;
 public class GroupCreateCommand extends AbstractCommand {
 
     @Parameters(
-            index = "0"
+            index = "0",
+            description = "The group ID."
     )
     private String groupId;
 
@@ -38,16 +41,14 @@ public class GroupCreateCommand extends AbstractCommand {
 
     @Option(
             names = {"-l", "--label"},
-            description = "Provide a list of group labels.",
-            mapFallbackValue = ""
+            description = "Provide a list of group labels (format: key=value or key). Use \\= to include = in a key."
     )
-    private Map<String, String> labels;
+    private List<String> labels;
 
     @Mixin
     private OutputTypeMixin outputType;
 
     @Override
-    @SuppressWarnings("unchecked")
     public void run(OutputBuffer output) throws Exception {
         var newGroup = new CreateGroup();
         newGroup.setGroupId(groupId);
@@ -56,7 +57,7 @@ public class GroupCreateCommand extends AbstractCommand {
         }
         if (labels != null) {
             var newLabels = new Labels();
-            newLabels.setAdditionalData((Map<String, Object>) (Map<String, ?>) labels);
+            newLabels.setAdditionalData(new HashMap<>(Conversions.parseLabels(labels)));
             newGroup.setLabels(newLabels);
         }
         try {

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupUpdateCommand.java
@@ -1,14 +1,15 @@
 package io.apicurio.registry.cli.group;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.EditableGroupMetaData;
+import io.apicurio.registry.rest.client.models.Labels;
 import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
 import java.util.List;
-import java.util.Map;
 
 import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
@@ -21,7 +22,8 @@ import static picocli.CommandLine.Option;
 public class GroupUpdateCommand extends AbstractCommand {
 
     @Parameters(
-            index = "0"
+            index = "0",
+            description = "The group ID."
     )
     private String groupId;
 
@@ -33,10 +35,9 @@ public class GroupUpdateCommand extends AbstractCommand {
 
     @Option(
             names = {"-l", "--sl", "--set-label"},
-            description = "Add or update a group label.",
-            mapFallbackValue = ""
+            description = "Add or update a group label (format: key=value or key). Use \\= to include = in a key."
     )
-    private Map<String, String> setLabels;
+    private List<String> setLabels;
 
     @Option(
             names = {"--dl", "--delete-label"},
@@ -55,9 +56,12 @@ public class GroupUpdateCommand extends AbstractCommand {
                 updatedGroup.setDescription(description);
             }
             if (setLabels != null) {
-                updatedGroup.getLabels().getAdditionalData().putAll(setLabels);
+                if (updatedGroup.getLabels() == null) {
+                    updatedGroup.setLabels(new Labels());
+                }
+                updatedGroup.getLabels().getAdditionalData().putAll(Conversions.parseLabels(setLabels));
             }
-            if (deleteLabels != null) {
+            if (deleteLabels != null && updatedGroup.getLabels() != null) {
                 deleteLabels.forEach(key -> {
                     updatedGroup.getLabels().getAdditionalData().remove(key);
                 });

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchArtifactsCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchArtifactsCommand.java
@@ -1,0 +1,180 @@
+package io.apicurio.registry.cli.search;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.ArtifactOrderMixin;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.common.PaginationMixin;
+import io.apicurio.registry.cli.utils.Conversions;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.client.search.artifacts.ArtifactsRequestBuilder;
+import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import java.util.List;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPE;
+import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
+import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
+import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
+import static io.apicurio.registry.cli.utils.Columns.LABELS;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_BY;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_ON;
+import static io.apicurio.registry.cli.utils.Columns.NAME;
+import static io.apicurio.registry.cli.utils.Columns.OWNER;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Conversions.convertToString;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+@Command(
+        name = "artifact",
+        aliases = {"artifacts"},
+        description = "Search for artifacts"
+)
+public class SearchArtifactsCommand extends AbstractCommand {
+
+    @Option(
+            names = {"--name"},
+            description = "Filter by artifact name. Searches both the name and artifactId fields. Use * as prefix/suffix wildcard, otherwise matches exactly."
+    )
+    private String name;
+
+    @Option(
+            names = {"--description"},
+            description = "Filter by description (substring match)."
+    )
+    private String description;
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Filter by group ID (exact match)."
+    )
+    private String groupId;
+
+    @Option(
+            names = {"-a", "--artifact"},
+            description = "Filter by artifact ID (exact match)."
+    )
+    private String artifactId;
+
+    @Option(
+            names = {"--type"},
+            description = "Filter by artifact type, exact match (e.g. AVRO, JSON, PROTOBUF, OPENAPI, ASYNCAPI). Use 'acr version' to see all supported types."
+    )
+    private String artifactType;
+
+    @Option(
+            names = {"-l", "--label"},
+            description = "Filter by label (format: key=value or key). Exact match on key and value. Can be specified multiple times."
+    )
+    private List<String> labels;
+
+    @Option(
+            names = {"--global-id"},
+            description = "Filter by global ID"
+    )
+    private Long globalId;
+
+    @Option(
+            names = {"--content-id"},
+            description = "Filter by content ID"
+    )
+    private Long contentId;
+
+    @Mixin
+    private ArtifactOrderMixin ordering;
+
+    @Mixin
+    private PaginationMixin pagination;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws JsonProcessingException {
+        try {
+            //noinspection ConstantConditions
+            final var results = convert(client.getRegistryClient().search().artifacts().get(r -> {
+                //noinspection ConstantConditions
+                applyFilters(r.queryParameters);
+            }));
+            printResults(output, results);
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error searching for artifacts: ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+
+    private void applyFilters(final ArtifactsRequestBuilder.GetQueryParameters params) {
+        params.offset = (pagination.getPage() - 1) * pagination.getSize();
+        params.limit = pagination.getSize();
+        params.orderby = ordering.getOrderBy();
+        params.order = ordering.getOrder();
+        if (name != null) {
+            params.name = name;
+        }
+        if (description != null) {
+            params.description = description;
+        }
+        if (groupId != null) {
+            params.groupId = groupId;
+        }
+        if (artifactId != null) {
+            params.artifactId = artifactId;
+        }
+        if (artifactType != null) {
+            params.artifactType = artifactType;
+        }
+        if (labels != null) {
+            params.labels = Conversions.convertLabelsForApi(labels);
+        }
+        if (globalId != null) {
+            params.globalId = globalId;
+        }
+        if (contentId != null) {
+            params.contentId = contentId;
+        }
+    }
+
+    private void printResults(final OutputBuffer output, final ArtifactSearchResults results) throws JsonProcessingException {
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(results));
+                    out.append('\n');
+                }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(GROUP_ID, ARTIFACT_ID, NAME, ARTIFACT_TYPE, DESCRIPTION,
+                            CREATED_ON, OWNER, MODIFIED_ON, MODIFIED_BY, LABELS);
+                    results.getArtifacts().forEach(a -> {
+                        table.addRow(
+                                a.getGroupId(),
+                                a.getArtifactId(),
+                                a.getName(),
+                                a.getArtifactType(),
+                                a.getDescription(),
+                                convertToString(a.getCreatedOn()),
+                                a.getOwner(),
+                                convertToString(a.getModifiedOn()),
+                                a.getModifiedBy(),
+                                convertToString(a.getLabels())
+                        );
+                    });
+                    table.setPagination(pagination.getPage(), pagination.getSize(), results.getCount());
+                    table.print(out);
+                }
+            }
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchCommand.java
@@ -1,0 +1,22 @@
+package io.apicurio.registry.cli.search;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+
+@Command(
+        name = "search",
+        description = "Search for groups, artifacts, and versions",
+        subcommands = {
+                SearchArtifactsCommand.class,
+                SearchGroupsCommand.class,
+                SearchVersionsCommand.class
+        }
+)
+public class SearchCommand extends AbstractCommand {
+
+    @Override
+    public void run(final OutputBuffer output) {
+        spec.commandLine().usage(spec.commandLine().getOut());
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchGroupsCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchGroupsCommand.java
@@ -1,0 +1,128 @@
+package io.apicurio.registry.cli.search;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.GroupOrderMixin;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.common.PaginationMixin;
+import io.apicurio.registry.cli.utils.Conversions;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.client.search.groups.GroupsRequestBuilder;
+import io.apicurio.registry.rest.v3.beans.GroupSearchResults;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import java.util.List;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
+import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
+import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
+import static io.apicurio.registry.cli.utils.Columns.LABELS;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_BY;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_ON;
+import static io.apicurio.registry.cli.utils.Columns.OWNER;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Conversions.convertToString;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+@Command(
+        name = "group",
+        aliases = {"groups"},
+        description = "Search for groups"
+)
+public class SearchGroupsCommand extends AbstractCommand {
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Filter by group ID (exact match)."
+    )
+    private String groupId;
+
+    @Option(
+            names = {"--description"},
+            description = "Filter by description (substring match)."
+    )
+    private String description;
+
+    @Option(
+            names = {"-l", "--label"},
+            description = "Filter by label (format: key=value or key). Exact match on key and value. Can be specified multiple times."
+    )
+    private List<String> labels;
+
+    @Mixin
+    private GroupOrderMixin ordering;
+
+    @Mixin
+    private PaginationMixin pagination;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws JsonProcessingException {
+        try {
+            //noinspection ConstantConditions
+            final var results = convert(client.getRegistryClient().search().groups().get(r -> {
+                //noinspection ConstantConditions
+                applyFilters(r.queryParameters);
+            }));
+            printResults(output, results);
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error searching for groups: ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+
+    private void applyFilters(final GroupsRequestBuilder.GetQueryParameters params) {
+        params.offset = (pagination.getPage() - 1) * pagination.getSize();
+        params.limit = pagination.getSize();
+        params.orderby = ordering.getOrderBy();
+        params.order = ordering.getOrder();
+        if (groupId != null) {
+            params.groupId = groupId;
+        }
+        if (description != null) {
+            params.description = description;
+        }
+        if (labels != null) {
+            params.labels = Conversions.convertLabelsForApi(labels);
+        }
+    }
+
+    private void printResults(final OutputBuffer output, final GroupSearchResults results) throws JsonProcessingException {
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(results));
+                    out.append('\n');
+                }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(GROUP_ID, DESCRIPTION, CREATED_ON, OWNER, MODIFIED_ON, MODIFIED_BY, LABELS);
+                    results.getGroups().forEach(g -> {
+                        table.addRow(
+                                g.getGroupId(),
+                                g.getDescription(),
+                                convertToString(g.getCreatedOn()),
+                                g.getOwner(),
+                                convertToString(g.getModifiedOn()),
+                                g.getModifiedBy(),
+                                convertToString(g.getLabels())
+                        );
+                    });
+                    table.setPagination(pagination.getPage(), pagination.getSize(), results.getCount());
+                    table.print(out);
+                }
+            }
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchVersionsCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchVersionsCommand.java
@@ -1,0 +1,201 @@
+package io.apicurio.registry.cli.search;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.common.PaginationMixin;
+import io.apicurio.registry.cli.common.VersionOrderMixin;
+import io.apicurio.registry.cli.utils.Conversions;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.client.models.VersionState;
+import io.apicurio.registry.rest.client.search.versions.VersionsRequestBuilder;
+import io.apicurio.registry.rest.v3.beans.VersionSearchResults;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import java.util.List;
+
+import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPE;
+import static io.apicurio.registry.cli.utils.Columns.CONTENT_ID;
+import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
+import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
+import static io.apicurio.registry.cli.utils.Columns.GLOBAL_ID;
+import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
+import static io.apicurio.registry.cli.utils.Columns.NAME;
+import static io.apicurio.registry.cli.utils.Columns.OWNER;
+import static io.apicurio.registry.cli.utils.Columns.STATE;
+import static io.apicurio.registry.cli.utils.Columns.VERSION;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Conversions.convertToString;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+@Command(
+        name = "version",
+        aliases = {"versions"},
+        description = "Search for versions"
+)
+public class SearchVersionsCommand extends AbstractCommand {
+
+    @Option(
+            names = {"--name"},
+            description = "Filter by version name (substring match)."
+    )
+    private String name;
+
+    @Option(
+            names = {"--description"},
+            description = "Filter by description (substring match)."
+    )
+    private String description;
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Filter by group ID (exact match)."
+    )
+    private String groupId;
+
+    @Option(
+            names = {"-a", "--artifact"},
+            description = "Filter by artifact ID (exact match)."
+    )
+    private String artifactId;
+
+    @Option(
+            names = {"-v", "--version"},
+            description = "Filter by version expression (exact match)."
+    )
+    private String version;
+
+    @Option(
+            names = {"--type"},
+            description = "Filter by artifact type, exact match (e.g. AVRO, JSON, PROTOBUF, OPENAPI, ASYNCAPI). Use 'acr version' to see all supported types."
+    )
+    private String artifactType;
+
+    @Option(
+            names = {"--state"},
+            description = "Filter by version state (ENABLED, DISABLED, DEPRECATED)."
+    )
+    private VersionState state;
+
+    @Option(
+            names = {"-l", "--label"},
+            description = "Filter by label (format: key=value or key). Exact match on key and value. Can be specified multiple times."
+    )
+    private List<String> labels;
+
+    @Option(
+            names = {"--global-id"},
+            description = "Filter by global ID"
+    )
+    private Long globalId;
+
+    @Option(
+            names = {"--content-id"},
+            description = "Filter by content ID"
+    )
+    private Long contentId;
+
+    @Mixin
+    private VersionOrderMixin ordering;
+
+    @Mixin
+    private PaginationMixin pagination;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws JsonProcessingException {
+        try {
+            //noinspection ConstantConditions
+            final var results = convert(client.getRegistryClient().search().versions().get(r -> {
+                //noinspection ConstantConditions
+                applyFilters(r.queryParameters);
+            }));
+            printResults(output, results);
+        } catch (final ProblemDetails ex) {
+            output.writeStdErrChunk(err -> {
+                err.append("Error searching for versions: ")
+                        .append(ex.getDetail())
+                        .append('\n');
+            });
+            exitQuietServerError();
+        }
+    }
+
+    private void applyFilters(final VersionsRequestBuilder.GetQueryParameters params) {
+        params.offset = (pagination.getPage() - 1) * pagination.getSize();
+        params.limit = pagination.getSize();
+        params.orderby = ordering.getOrderBy();
+        params.order = ordering.getOrder();
+        if (name != null) {
+            params.name = name;
+        }
+        if (description != null) {
+            params.description = description;
+        }
+        if (groupId != null) {
+            params.groupId = groupId;
+        }
+        if (artifactId != null) {
+            params.artifactId = artifactId;
+        }
+        if (version != null) {
+            params.version = version;
+        }
+        if (artifactType != null) {
+            params.artifactType = artifactType;
+        }
+        if (state != null) {
+            params.state = state;
+        }
+        if (labels != null) {
+            params.labels = Conversions.convertLabelsForApi(labels);
+        }
+        if (globalId != null) {
+            params.globalId = globalId;
+        }
+        if (contentId != null) {
+            params.contentId = contentId;
+        }
+    }
+
+    private void printResults(final OutputBuffer output, final VersionSearchResults results) throws JsonProcessingException {
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(results));
+                    out.append('\n');
+                }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(GROUP_ID, ARTIFACT_ID, VERSION, NAME, ARTIFACT_TYPE,
+                            STATE, GLOBAL_ID, CONTENT_ID, DESCRIPTION, CREATED_ON, OWNER);
+                    results.getVersions().forEach(v -> {
+                        table.addRow(
+                                v.getGroupId(),
+                                v.getArtifactId(),
+                                v.getVersion(),
+                                v.getName(),
+                                v.getArtifactType(),
+                                convertToString(v.getState()),
+                                convertToString(v.getGlobalId()),
+                                convertToString(v.getContentId()),
+                                v.getDescription(),
+                                convertToString(v.getCreatedOn()),
+                                v.getOwner()
+                        );
+                    });
+                    table.setPagination(pagination.getPage(), pagination.getSize(), results.getCount());
+                    table.print(out);
+                }
+            }
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.cli.utils;
 
+import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.rest.client.models.Labels;
 import io.apicurio.registry.rest.v3.beans.Comment;
 import io.apicurio.registry.rest.v3.beans.Rule;
@@ -17,6 +18,8 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -24,6 +27,10 @@ import static java.util.Optional.ofNullable;
 
 // TODO: Move some of these to the Java SDK.
 public final class Conversions {
+
+    private static final char ESCAPE_CHAR = '\\';
+    private static final char LABEL_SEPARATOR = '=';
+    private static final String API_LABEL_SEPARATOR = ":";
 
     private Conversions() {
     }
@@ -213,5 +220,79 @@ public final class Conversions {
 
     public static String convertToString(Long value) {
         return ofNullable(value).map(String::valueOf).orElse("");
+    }
+
+    public static Map<String, String> parseLabels(final List<String> labels) {
+        final Map<String, String> result = new LinkedHashMap<>();
+        for (final String label : labels) {
+            final LabelParts parts = splitLabel(label);
+            result.put(parts.key(), parts.value());
+        }
+        return result;
+    }
+
+    public static String[] convertLabelsForApi(final List<String> labels) {
+        return labels.stream()
+                .map(Conversions::convertLabelForApi)
+                .toArray(String[]::new);
+    }
+
+    private record LabelParts(String key, String value) {}
+
+    private static String convertLabelForApi(final String label) {
+        final LabelParts parts = splitLabel(label);
+        if (parts.key().contains(API_LABEL_SEPARATOR)) {
+            throw new CliException("Label key '" + parts.key() + "' must not contain colons. Colons are reserved by the REST API.",
+                    CliException.VALIDATION_ERROR_RETURN_CODE);
+        }
+        if (parts.value().isEmpty()) {
+            return parts.key();
+        }
+        return parts.key() + API_LABEL_SEPARATOR + parts.value();
+    }
+
+    private static LabelParts splitLabel(final String label) {
+        final int separatorIndex = findUnescapedEquals(label);
+        if (separatorIndex < 0) {
+            return new LabelParts(unescape(label), "");
+        }
+        final String key = unescape(label.substring(0, separatorIndex));
+        final String value = label.substring(separatorIndex + 1);
+        return new LabelParts(key, value);
+    }
+
+    private static String unescape(final String input) {
+        final StringBuilder result = new StringBuilder(input.length());
+        boolean escaped = false;
+        for (int index = 0; index < input.length(); index++) {
+            final char ch = input.charAt(index);
+            if (escaped) {
+                result.append(ch);
+                escaped = false;
+            } else if (ch == ESCAPE_CHAR) {
+                escaped = true;
+            } else {
+                result.append(ch);
+            }
+        }
+        if (escaped) {
+            result.append(ESCAPE_CHAR);
+        }
+        return result.toString();
+    }
+
+    private static int findUnescapedEquals(final String label) {
+        boolean escaped = false;
+        for (int index = 0; index < label.length(); index++) {
+            final char ch = label.charAt(index);
+            if (escaped) {
+                escaped = false;
+            } else if (ch == ESCAPE_CHAR) {
+                escaped = true;
+            } else if (ch == LABEL_SEPARATOR) {
+                return index;
+            }
+        }
+        return -1;
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/version/CommentCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/CommentCommand.java
@@ -1,8 +1,8 @@
 package io.apicurio.registry.cli.version;
 
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.utils.OutputBuffer;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
 
 @Command(
         name = "comment",
@@ -15,13 +15,10 @@ import picocli.CommandLine.Spec;
                 CommentUpdateCommand.class
         }
 )
-public class CommentCommand implements Runnable {
-
-    @Spec
-    CommandSpec spec;
+public class CommentCommand extends AbstractCommand {
 
     @Override
-    public void run() {
+    public void run(final OutputBuffer output) {
         spec.commandLine().usage(spec.commandLine().getOut());
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionCommand.java
@@ -1,16 +1,15 @@
 package io.apicurio.registry.cli.version;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.common.PaginationMixin;
+import io.apicurio.registry.cli.common.VersionOrderMixin;
 import io.apicurio.registry.cli.utils.Mapper;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
 import io.apicurio.registry.rest.client.models.ProblemDetails;
-import io.apicurio.registry.rest.client.models.SortOrder;
-import io.apicurio.registry.rest.client.models.VersionSortBy;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -57,6 +56,9 @@ public class VersionCommand extends AbstractCommand {
     private String artifactId;
 
     @Mixin
+    private VersionOrderMixin ordering;
+
+    @Mixin
     private PaginationMixin pagination;
 
     @Mixin
@@ -76,8 +78,8 @@ public class VersionCommand extends AbstractCommand {
                         //noinspection ConstantConditions
                         r.queryParameters.offset = (pagination.getPage() - 1) * pagination.getSize();
                         r.queryParameters.limit = pagination.getSize();
-                        r.queryParameters.orderby = VersionSortBy.Version;
-                        r.queryParameters.order = SortOrder.Asc;
+                        r.queryParameters.orderby = ordering.getOrderBy();
+                        r.queryParameters.order = ordering.getOrder();
                     }));
             output.writeStdOutChunkWithException(out -> {
                 switch (outputType.getOutputType()) {

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionCreateCommand.java
@@ -1,8 +1,9 @@
 package io.apicurio.registry.cli.version;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.CreateVersion;
@@ -15,7 +16,7 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Conversions.convert;
@@ -70,10 +71,9 @@ public class VersionCreateCommand extends AbstractCommand {
 
     @Option(
             names = {"-l", "--label"},
-            description = "Provide a list of version labels.",
-            mapFallbackValue = ""
+            description = "Provide a list of version labels (format: key=value or key). Use \\= to include = in a key."
     )
-    private Map<String, String> labels;
+    private List<String> labels;
 
     @Option(
             names = {"--content-type"},
@@ -109,7 +109,7 @@ public class VersionCreateCommand extends AbstractCommand {
         }
         if (labels != null) {
             final var newLabels = new Labels();
-            newLabels.setAdditionalData(new HashMap<>(labels));
+            newLabels.setAdditionalData(new HashMap<>(Conversions.parseLabels(labels)));
             newVersion.setLabels(newLabels);
         }
         if (draft) {

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionUpdateCommand.java
@@ -1,8 +1,9 @@
 package io.apicurio.registry.cli.version;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.EditableVersionMetaData;
@@ -16,7 +17,6 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 import java.util.List;
-import java.util.Map;
 
 import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 
@@ -69,10 +69,9 @@ public class VersionUpdateCommand extends AbstractCommand {
 
     @Option(
             names = {"-l", "--sl", "--set-label"},
-            description = "Add or update a version label.",
-            mapFallbackValue = ""
+            description = "Add or update a version label (format: key=value or key). Use \\= to include = in a key."
     )
-    private Map<String, String> setLabels;
+    private List<String> setLabels;
 
     @Option(
             names = {"--dl", "--delete-label"},
@@ -128,7 +127,7 @@ public class VersionUpdateCommand extends AbstractCommand {
                     if (updatedVersion.getLabels() == null) {
                         updatedVersion.setLabels(new Labels());
                     }
-                    updatedVersion.getLabels().getAdditionalData().putAll(setLabels);
+                    updatedVersion.getLabels().getAdditionalData().putAll(Conversions.parseLabels(setLabels));
                 }
                 if (deleteLabels != null) {
                     if (updatedVersion.getLabels() != null) {

--- a/cli/src/test/java/io/apicurio/registry/cli/SearchCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/SearchCommandTest.java
@@ -1,0 +1,334 @@
+package io.apicurio.registry.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
+import io.apicurio.registry.rest.v3.beans.GroupSearchResults;
+import io.apicurio.registry.rest.v3.beans.VersionSearchResults;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestMethodOrder(OrderAnnotation.class)
+public class SearchCommandTest extends AbstractCLITest {
+
+    private static final String TEST_GROUP = "search-test-group";
+    private static final String TEST_ARTIFACT = "search-test-artifact";
+
+    @Test
+    @Order(0)
+    public void testSetup() throws Exception {
+        executeAndAssertSuccess("group", "create", TEST_GROUP);
+        final Path tempFile = Files.createTempFile("search-test", ".json");
+        Files.writeString(tempFile, "{\"type\": \"string\"}");
+        try {
+            executeAndAssertSuccess("artifact", "create", "-g", TEST_GROUP,
+                    "--type", "JSON", "--file", tempFile.toString(),
+                    "-l", "env=test", TEST_ARTIFACT);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    @Order(1)
+    public void testSearchHelp() {
+        testHelpCommand("search");
+        testHelpCommand("search", "group");
+        testHelpCommand("search", "artifact");
+        testHelpCommand("search", "version");
+    }
+
+    @Test
+    @Order(2)
+    public void testSearchGroups() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "groups", "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), GroupSearchResults.class);
+
+        assertThat(results.getGroups())
+                .as(withCliOutput("Search should return at least the test group"))
+                .isNotEmpty();
+    }
+
+    @Test
+    @Order(3)
+    public void testSearchGroupsWithFilter() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "groups", "-g", TEST_GROUP, "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), GroupSearchResults.class);
+
+        assertThat(results.getGroups())
+                .as(withCliOutput("Filtered search should return only matching groups"))
+                .isNotEmpty()
+                .allMatch(g -> g.getGroupId().contains(TEST_GROUP));
+    }
+
+    @Test
+    @Order(4)
+    public void testSearchGroupsNoResults() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "groups", "-g", "non-existent-group-xyz", "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), GroupSearchResults.class);
+
+        assertThat(results.getGroups())
+                .as(withCliOutput("Search for non-existent group should return empty"))
+                .isEmpty();
+    }
+
+    @Test
+    @Order(5)
+    public void testSearchGroupsTableOutput() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "groups");
+        assertThat(out.toString())
+                .as(withCliOutput("Table output should contain column headers"))
+                .contains("Group ID");
+    }
+
+    @Test
+    @Order(6)
+    public void testSearchGroupsPagination() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "groups", "-p", "1", "-s", "1", "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), GroupSearchResults.class);
+
+        assertThat(results.getGroups())
+                .as(withCliOutput("Paginated search should return at most 1 result"))
+                .hasSizeLessThanOrEqualTo(1);
+    }
+
+    @Test
+    @Order(7)
+    public void testSearchGroupsOrderBy() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "groups", "--order-by", "CreatedOn", "--order", "Desc",
+                "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), GroupSearchResults.class);
+
+        assertThat(results.getGroups())
+                .as(withCliOutput("Order by should return results"))
+                .isNotEmpty();
+    }
+
+    @Test
+    @Order(8)
+    public void testSearchGroupsInvalidOrderBy() {
+        executeAndAssertFailure("search", "groups", "--order-by", "INVALID");
+    }
+
+    @Test
+    @Order(9)
+    public void testSearchGroupsInvalidOrder() {
+        executeAndAssertFailure("search", "groups", "--order", "INVALID");
+    }
+
+    @Test
+    @Order(10)
+    public void testSearchArtifacts() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "artifacts", "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+        assertThat(results.getArtifacts())
+                .as(withCliOutput("Search should return at least the test artifact"))
+                .isNotEmpty();
+    }
+
+    @Test
+    @Order(11)
+    public void testSearchArtifactsWithFilter() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "artifacts", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+        assertThat(results.getArtifacts())
+                .as(withCliOutput("Filtered search should return only matching artifacts"))
+                .isNotEmpty()
+                .allMatch(a -> TEST_ARTIFACT.equals(a.getArtifactId()));
+    }
+
+    @Test
+    @Order(12)
+    public void testSearchArtifactsNoResults() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "artifacts", "-a", "non-existent-artifact-xyz",
+                "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+        assertThat(results.getArtifacts())
+                .as(withCliOutput("Search for non-existent artifact should return empty"))
+                .isEmpty();
+    }
+
+    @Test
+    @Order(13)
+    public void testSearchArtifactsTableOutput() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "artifacts");
+        assertThat(out.toString())
+                .as(withCliOutput("Table output should contain column headers"))
+                .contains("Group ID")
+                .contains("Artifact ID");
+    }
+
+    @Test
+    @Order(14)
+    public void testSearchArtifactsByType() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "artifacts", "--type", "JSON", "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+        assertThat(results.getArtifacts())
+                .as(withCliOutput("Type-filtered search should return JSON artifacts"))
+                .allMatch(a -> "JSON".equals(a.getArtifactType()));
+    }
+
+    @Test
+    @Order(15)
+    public void testSearchArtifactsOrderBy() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "artifacts", "--order-by", "CreatedOn", "--order", "Desc",
+                "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+        assertThat(results.getArtifacts())
+                .as(withCliOutput("Order by should return results"))
+                .isNotEmpty();
+    }
+
+    @Test
+    @Order(16)
+    public void testSearchVersions() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "versions", "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), VersionSearchResults.class);
+
+        assertThat(results.getVersions())
+                .as(withCliOutput("Search should return at least the test version"))
+                .isNotEmpty();
+    }
+
+    @Test
+    @Order(17)
+    public void testSearchVersionsWithFilter() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "versions", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), VersionSearchResults.class);
+
+        assertThat(results.getVersions())
+                .as(withCliOutput("Filtered search should return only matching versions"))
+                .isNotEmpty()
+                .allMatch(v -> TEST_ARTIFACT.equals(v.getArtifactId()));
+    }
+
+    @Test
+    @Order(18)
+    public void testSearchVersionsNoResults() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "versions", "-a", "non-existent-artifact-xyz",
+                "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), VersionSearchResults.class);
+
+        assertThat(results.getVersions())
+                .as(withCliOutput("Search for non-existent artifact versions should return empty"))
+                .isEmpty();
+    }
+
+    @Test
+    @Order(19)
+    public void testSearchVersionsTableOutput() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "versions");
+        assertThat(out.toString())
+                .as(withCliOutput("Table output should contain column headers"))
+                .contains("Group ID")
+                .contains("Artifact ID")
+                .contains("Version");
+    }
+
+    @Test
+    @Order(20)
+    public void testSearchVersionsByState() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "versions", "--state", "ENABLED", "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), VersionSearchResults.class);
+
+        assertThat(results.getVersions())
+                .as(withCliOutput("State-filtered search should return only ENABLED versions"))
+                .isNotEmpty()
+                .allMatch(v -> io.apicurio.registry.types.VersionState.ENABLED.equals(v.getState()));
+    }
+
+    @Test
+    @Order(21)
+    public void testSearchVersionsByVersion() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "versions", "-v", "1", "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), VersionSearchResults.class);
+
+        assertThat(results.getVersions())
+                .as(withCliOutput("Version filter should return results"))
+                .isNotEmpty();
+    }
+
+    @Test
+    @Order(22)
+    public void testSearchVersionsPagination() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "versions", "-p", "1", "-s", "1", "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), VersionSearchResults.class);
+
+        assertThat(results.getVersions())
+                .as(withCliOutput("Paginated search should return at most 1 result"))
+                .hasSizeLessThanOrEqualTo(1);
+    }
+
+    @Test
+    @Order(23)
+    public void testSearchVersionsOrderBy() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "versions", "--order-by", "CreatedOn", "--order", "Desc",
+                "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), VersionSearchResults.class);
+
+        assertThat(results.getVersions())
+                .as(withCliOutput("Order by should return results"))
+                .isNotEmpty();
+    }
+
+    @Test
+    @Order(24)
+    public void testSearchArtifactsByLabel() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("search", "artifacts", "-l", "env=test", "--output-type", "json");
+        var results = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+        assertThat(results.getArtifacts())
+                .as(withCliOutput("Label-filtered search should return matching artifacts"))
+                .isNotEmpty()
+                .anyMatch(a -> TEST_ARTIFACT.equals(a.getArtifactId()));
+    }
+
+    @Test
+    @Order(25)
+    public void testSearchArtifactsInvalidLabel() {
+        executeAndAssertFailure("search", "artifacts", "-l", ":foo");
+    }
+
+    @Test
+    @Order(26)
+    public void testSearchVersionsInvalidState() {
+        executeAndAssertFailure("search", "versions", "--state", "INVALID");
+    }
+}


### PR DESCRIPTION
## Summary

Add search commands to the Apicurio Registry CLI for searching groups, artifacts, and versions with filtering, pagination, sorting, and JSON/table output.

## Changes

### Search commands
- Add `SearchCommand` (parent, shows help), `SearchGroupsCommand`, `SearchArtifactsCommand`, `SearchVersionsCommand` in the `search` package
- Register `SearchCommand` as top-level subcommand in `Acr.java`
- Support both singular and plural subcommand names (e.g., `acr search group` / `acr search groups`)
- Remove `-d`, `-n`, `-t` short options from search commands to use short options sparingly
- Update search field descriptions to specify matching behavior (exact, substring, wildcard)

### Order mixins
- Extract `ArtifactOrderMixin`, `GroupOrderMixin`, `VersionOrderMixin` for reusable `--order-by` and `--order` options
- Replace hardcoded sort values in `ArtifactCommand`, `GroupCommand`, `VersionCommand` with the shared mixins

### Label handling
- Use `key=value` format for labels across all CLI commands (search, create, update), converting to `key:value` internally for the API
- Support `\=` escaping in label keys (e.g., `key\=name=value` creates label `key=name` with value `value`)
- Validate that label keys don't contain colons (reserved by the REST API) with a clean error message
- Change `--set-label` / `--label` from `Map<String, String>` to `List<String>` with manual parsing in all create and update commands

### Bug fixes & cleanup
- Fix potential NPE in `GroupUpdateCommand` when group has no labels
- Add missing `@Parameters` descriptions in `GroupCreateCommand` and `GroupUpdateCommand`
- Fix import ordering in artifact and version command files
- Remove unnecessary `@SuppressWarnings("unchecked")` from `GroupCreateCommand`
- Fix `CommentCommand` to extend `AbstractCommand` instead of `Runnable` for consistency
- Make `AbstractCommand.spec` protected for cross-package access

## Usage

```bash
acr search groups                                           # list all groups
acr search groups -g myGroup -o json                        # filter by group ID
acr search groups -l "env=prod" -l "team=platform"          # filter by labels
acr search groups --order-by CreatedOn --order Desc         # sort by creation date

acr search artifacts -g myGroup --type JSON                 # filter by group and type
acr search artifacts --name "my-schema" -o json             # filter by name
acr search artifacts --global-id 123                        # filter by global ID

acr search versions -g myGroup -a myArtifact                # filter by group and artifact
acr search versions --state ENABLED -v 1.0.0                # filter by state and version
acr search versions --order-by CreatedOn --order Desc -p 1 -s 5  # sort and paginate
```

## Filters Supported

| Filter | Groups | Artifacts | Versions |
|--------|--------|-----------|----------|
| `-g` / `--group` | ✓ | ✓ | ✓ |
| `-a` / `--artifact` | — | ✓ | ✓ |
| `--name` | — | ✓ | ✓ |
| `--description` | ✓ | ✓ | ✓ |
| `--type` | — | ✓ | ✓ |
| `-l` / `--label` | ✓ | ✓ | ✓ |
| `-v` / `--version` | — | — | ✓ |
| `--state` | — | — | ✓ |
| `--global-id` | — | ✓ | ✓ |
| `--content-id` | — | ✓ | ✓ |
| `--order-by` | ✓ | ✓ | ✓ |
| `--order` | ✓ | ✓ | ✓ |
| `-p` / `--page` | ✓ | ✓ | ✓ |
| `-s` / `--size` | ✓ | ✓ | ✓ |

## Related Issues

- Closes #7786
- Fixes #8005 (CLI exception when searching with label `:foo`)
- #8002 (Registry search API: inconsistent matching behavior across name fields)

## Testing

- [x] Build succeeds
- [x] Checkstyle passes with 0 violations
- [x] All CLI tests pass (193 tests, 0 failures)
- [x] Search groups — all, filtered, no results, table, pagination, order-by, invalid inputs
- [x] Search artifacts — all, filtered, no results, table, type filter, order-by, label filter, invalid label
- [x] Search versions — all, filtered, no results, table, state filter, version filter, order-by, pagination, invalid state