### PR TITLE
fix(ccompat): address remaining Confluent Schema Registry compatibility gaps

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/ApiConverter.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/ApiConverter.java
@@ -10,6 +10,7 @@ import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.dto.StoredArtifactVersionDto;
+import io.apicurio.registry.types.ArtifactType;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -42,16 +43,13 @@ public class ApiConverter {
         Schema schema = new Schema();
         schema.setId(convertUnsigned(cconfig.legacyIdModeEnabled.get() ? storedArtifact.getGlobalId()
                 : storedArtifact.getContentId()).intValue());
-        // Only set schemaType if it's not AVRO (AVRO is the default, so omit it for Confluent compatibility)
         if (artifactType != null && !artifactType.equalsIgnoreCase("AVRO")) {
             schema.setSchemaType(artifactType);
         }
         schema.setSubject(subject);
         schema.setVersion(convertUnsigned(storedArtifact.getVersionOrder()).intValue());
-        schema.setSchema(storedArtifact.getContent().content());
+        schema.setSchema(compactIfAvro(storedArtifact.getContent().content(), artifactType));
         List<SchemaReference> refs = storedArtifact.getReferences().stream().map(this::convert).collect(Collectors.toList());
-        // Only set refs if there are some - if not then set to "null" so the 'references' property
-        // is not included in the JSON response
         schema.setReferences(refs.isEmpty() ? null : refs);
         return schema;
     }
@@ -59,16 +57,25 @@ public class ApiConverter {
     public Schema convert(ContentHandle content, String artifactType,
                           List<ArtifactReferenceDto> references) {
         Schema schema = new Schema();
-        schema.setSchema(content.content());
-        // Only set schemaType if it's not AVRO (AVRO is the default, so omit it for Confluent compatibility)
+        schema.setSchema(compactIfAvro(content.content(), artifactType));
         if (artifactType != null && !artifactType.equalsIgnoreCase("AVRO")) {
             schema.setSchemaType(artifactType);
         }
         List<SchemaReference> refs = references.stream().map(this::convert).collect(Collectors.toList());
-        // Only set refs if there are some - if not then set to "null" so the 'references' property
-        // is not included in the JSON response
         schema.setReferences(refs.isEmpty() ? null : refs);
         return schema;
+    }
+
+    private String compactIfAvro(String content, String artifactType) {
+        if (content == null || !ArtifactType.AVRO.equals(artifactType)) {
+            return content;
+        }
+        try {
+            org.apache.avro.Schema parsed = new org.apache.avro.Schema.Parser().parse(content);
+            return parsed.toString();
+        } catch (Exception e) {
+            return content;
+        }
     }
 
     public SubjectVersion convert(String artifactId, Number version) {

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/ConfigResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/ConfigResourceImpl.java
@@ -95,6 +95,7 @@ public class ConfigResourceImpl extends AbstractResource implements ConfigResour
 
         ConfigUpdateResponse response = new ConfigUpdateResponse();
         response.setCompatibility(request.getCompatibility());
+        response.setNormalize(request.getNormalize() != null ? request.getNormalize() : false);
         return response;
     }
 
@@ -133,6 +134,7 @@ public class ConfigResourceImpl extends AbstractResource implements ConfigResour
 
         ConfigUpdateResponse response = new ConfigUpdateResponse();
         response.setCompatibility(request.getCompatibility());
+        response.setNormalize(request.getNormalize() != null ? request.getNormalize() : false);
         return response;
     }
 

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -431,6 +431,48 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
     }
 
     @Override
+    @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Read)
+    public Schema lookupSchemaByVersion(String subject, String versionString, Boolean normalize,
+                                        String format, String groupId, Boolean deleted,
+                                        RegisterSchemaRequest request) {
+        final GA ga = getGA(groupId, subject);
+        final boolean fdeleted = deleted == null ? Boolean.FALSE : deleted;
+        final boolean fnormalize = normalize == null ? Boolean.FALSE : normalize;
+
+        if (!doesArtifactExist(ga.getRawArtifactId(), ga.getRawGroupIdWithNull())) {
+            throw new ArtifactNotFoundException(ga.getRawGroupIdWithNull(), ga.getRawArtifactId());
+        }
+
+        return parseVersionString(ga.getRawArtifactId(), versionString, ga.getRawGroupIdWithNull(),
+                version -> {
+                    ArtifactVersionMetaDataDto amd = storage.getArtifactVersionMetaData(
+                            ga.getRawGroupIdWithNull(), ga.getRawArtifactId(), version);
+                    if (amd.getState() == VersionState.DISABLED && !fdeleted) {
+                        throw new VersionNotFoundException(ga.getRawGroupIdWithNull(),
+                                ga.getRawArtifactId(), version);
+                    }
+
+                    try {
+                        ArtifactVersionMetaDataDto matched = lookupSchema(
+                                ga.getRawGroupIdWithNull(), ga.getRawArtifactId(),
+                                request.getSchema(), request.getReferences(),
+                                request.getSchemaType(), fnormalize);
+                        if (matched.getVersionOrder() != amd.getVersionOrder()) {
+                            throw new SchemaNotFoundException(
+                                    "Schema not found at version " + versionString);
+                        }
+                    } catch (ArtifactNotFoundException e) {
+                        throw new SchemaNotFoundException(
+                                "Schema not found under subject " + ga.getRawArtifactId());
+                    }
+
+                    StoredArtifactVersionDto storedArtifact = storage.getArtifactVersionContent(
+                            ga.getRawGroupIdWithNull(), ga.getRawArtifactId(), amd.getVersion());
+                    return converter.convert(ga.getRawArtifactId(), storedArtifact, amd.getArtifactType());
+                });
+    }
+
+    @Override
     public Schema getSubjectMetadata(String subject, String key, String value, String format, Boolean deleted, String xRegistryGroupId) {
         //TODO not implemented
         return null;

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v8/impl/ConfigResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v8/impl/ConfigResourceImpl.java
@@ -71,6 +71,7 @@ public class ConfigResourceImpl implements ConfigResource {
         io.apicurio.registry.ccompat.rest.v7.beans.ConfigUpdateRequest v7Request =
                 new io.apicurio.registry.ccompat.rest.v7.beans.ConfigUpdateRequest();
         v7Request.setCompatibility(data.getCompatibility());
+        v7Request.setNormalize(data.getNormalize());
         return v7Request;
     }
 
@@ -83,6 +84,7 @@ public class ConfigResourceImpl implements ConfigResource {
     private ConfigUpdateResponse convertConfigUpdateResponse(io.apicurio.registry.ccompat.rest.v7.beans.ConfigUpdateResponse v7Response) {
         ConfigUpdateResponse response = new ConfigUpdateResponse();
         response.setCompatibility(v7Response.getCompatibility());
+        response.setNormalize(v7Response.getNormalize());
         return response;
     }
 

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v8/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v8/impl/SubjectsResourceImpl.java
@@ -88,6 +88,16 @@ public class SubjectsResourceImpl implements SubjectsResource {
     }
 
     @Override
+    public Schema lookupSchemaByVersion(String subject, String version, Boolean normalize,
+            String format, String xRegistryGroupId, Boolean deleted, RegisterSchemaRequest data) {
+        io.apicurio.registry.ccompat.rest.v7.beans.RegisterSchemaRequest v7Request = convertToV7Request(data);
+        io.apicurio.registry.ccompat.rest.v7.beans.Schema v7Schema =
+                v7SubjectsResource.lookupSchemaByVersion(subject, version, normalize, format,
+                        xRegistryGroupId, deleted, v7Request);
+        return convertSchema(v7Schema);
+    }
+
+    @Override
     public Schema getSubjectMetadata(String subject, String key, String value, String format,
             Boolean deleted, String xRegistryGroupId) {
         io.apicurio.registry.ccompat.rest.v7.beans.Schema v7Schema =

--- a/app/src/main/java/io/apicurio/registry/rest/config/JacksonDateTimeCustomizer.java
+++ b/app/src/main/java/io/apicurio/registry/rest/config/JacksonDateTimeCustomizer.java
@@ -1,6 +1,5 @@
 package io.apicurio.registry.rest.config;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.apicurio.common.apps.config.Info;
@@ -82,7 +81,6 @@ public class JacksonDateTimeCustomizer implements ObjectMapperCustomizer {
      */
     @Override
     public void customize(ObjectMapper mapper) {
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         try {
             configureDateFormat(mapper, dateFormat, timezone);
         } catch (Exception e) {

--- a/app/src/main/java/io/apicurio/registry/rest/config/JacksonDateTimeCustomizer.java
+++ b/app/src/main/java/io/apicurio/registry/rest/config/JacksonDateTimeCustomizer.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.rest.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.apicurio.common.apps.config.Info;
@@ -81,6 +82,7 @@ public class JacksonDateTimeCustomizer implements ObjectMapperCustomizer {
      */
     @Override
     public void customize(ObjectMapper mapper) {
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         try {
             configureDateFormat(mapper, dateFormat, timezone);
         } catch (Exception e) {

--- a/app/src/main/java/io/apicurio/registry/services/http/CCompatExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/CCompatExceptionMapperService.java
@@ -133,6 +133,12 @@ public class CCompatExceptionMapperService {
             }
             return "Subject not found";
         }
+        if (t instanceof VersionNotFoundException vnfe) {
+            if (vnfe.getVersion() != null) {
+                return "Version " + vnfe.getVersion() + " not found.";
+            }
+            return "Version not found.";
+        }
         if (t instanceof ContentNotFoundException cnfe) {
             if (cnfe.getContentId() != null) {
                 return "Schema " + cnfe.getContentId() + " not found";
@@ -141,6 +147,12 @@ public class CCompatExceptionMapperService {
         }
         if (t instanceof RuleNotFoundException) {
             return "Subject does not have subject-level compatibility configured";
+        }
+        if (t instanceof UnprocessableEntityException) {
+            return t.getMessage();
+        }
+        if (t instanceof SchemaNotFoundException) {
+            return t.getMessage();
         }
         return t.getLocalizedMessage();
     }

--- a/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/ccompat/v7/openapi.json
+++ b/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/ccompat/v7/openapi.json
@@ -1206,6 +1206,126 @@
             "$ref": "#/components/responses/Error"
           }
         }
+      },
+      "post": {
+        "operationId": "lookupSchemaByVersion",
+        "description": "Checks if a given schema matches the schema at the specified version. Returns the schema details if it matches, or 404 if it does not.",
+        "tags": [
+          "Subjects"
+        ],
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "description": "Name of the subject.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "description": "Version of the schema to check against.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "normalize",
+            "in": "query",
+            "required": false,
+            "description": "Normalize the schema content before comparing.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "description": "Desired output format.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Registry-GroupId",
+            "in": "header",
+            "required": false,
+            "description": "Group id in Apicurio Registry.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "deleted",
+            "in": "query",
+            "required": false,
+            "description": "Lookup for soft-deleted values.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Schema to check against the version.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterSchemaRequest"
+              }
+            },
+            "application/octet-stream": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterSchemaRequest"
+              }
+            },
+            "application/vnd.schemaregistry.v1+json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterSchemaRequest"
+              }
+            },
+            "application/vnd.schemaregistry+json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterSchemaRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Schema version data if the given schema matches.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Schema"
+                }
+              },
+              "application/vnd.schemaregistry.v1+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Schema"
+                }
+              },
+              "application/vnd.schemaregistry+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Schema"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "422": {
+            "$ref": "#/components/responses/Error"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
       }
     },
     "/subjects/{subject}/versions/{version}/schema": {
@@ -3671,6 +3791,10 @@
           "compatibility": {
             "type": "string",
             "description": "The compatibility level that was set."
+          },
+          "normalize": {
+            "type": "boolean",
+            "description": "Whether schemas are normalized during registration and lookups."
           }
         },
         "example": {

--- a/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/ccompat/v8/openapi.json
+++ b/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/ccompat/v8/openapi.json
@@ -1206,6 +1206,126 @@
             "$ref": "#/components/responses/Error"
           }
         }
+      },
+      "post": {
+        "operationId": "lookupSchemaByVersion",
+        "description": "Checks if a given schema matches the schema at the specified version. Returns the schema details if it matches, or 404 if it does not.",
+        "tags": [
+          "Subjects"
+        ],
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "description": "Name of the subject.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "description": "Version of the schema to check against.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "normalize",
+            "in": "query",
+            "required": false,
+            "description": "Normalize the schema content before comparing.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "description": "Desired output format.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Registry-GroupId",
+            "in": "header",
+            "required": false,
+            "description": "Group id in Apicurio Registry.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "deleted",
+            "in": "query",
+            "required": false,
+            "description": "Lookup for soft-deleted values.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Schema to check against the version.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterSchemaRequest"
+              }
+            },
+            "application/octet-stream": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterSchemaRequest"
+              }
+            },
+            "application/vnd.schemaregistry.v1+json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterSchemaRequest"
+              }
+            },
+            "application/vnd.schemaregistry+json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterSchemaRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Schema version data if the given schema matches.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Schema"
+                }
+              },
+              "application/vnd.schemaregistry.v1+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Schema"
+                }
+              },
+              "application/vnd.schemaregistry+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Schema"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "422": {
+            "$ref": "#/components/responses/Error"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
       }
     },
     "/subjects/{subject}/versions/{version}/schema": {
@@ -3683,6 +3803,10 @@
           "compatibility": {
             "type": "string",
             "description": "The compatibility level that was set."
+          },
+          "normalize": {
+            "type": "boolean",
+            "description": "Whether schemas are normalized during registration and lookups."
           }
         },
         "example": {

--- a/app/src/test/java/io/apicurio/registry/ccompat/rest/CCompatCanonicalModeTest.java
+++ b/app/src/test/java/io/apicurio/registry/ccompat/rest/CCompatCanonicalModeTest.java
@@ -85,7 +85,9 @@ public class CCompatCanonicalModeTest extends AbstractResourceTestBase {
                 .get("/ccompat/v7/subjects/{subject}/versions/latest", subject1).then().statusCode(200)
                 .extract().as(Schema.class);
 
-        assertEquals(schemaString1, schema1R.getSchema());
+        // Avro schemas are compacted to canonical JSON in ccompat responses
+        org.apache.avro.Schema expectedSchema = new org.apache.avro.Schema.Parser().parse(schemaString1);
+        assertEquals(expectedSchema.toString(), schema1R.getSchema());
         assertEquals(schemaId1.getId(), schema1R.getId());
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/SubjectVersionStringTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/SubjectVersionStringTest.java
@@ -64,11 +64,11 @@ public class SubjectVersionStringTest extends AbstractResourceTestBase {
         versions2.removeAll(versions1);
         var version2 = versions2.get(0);
 
-        // Get latest and compare
-        Assertions.assertEquals(schema1, getSubjectVersion(SUBJECT, String.valueOf(version1)).getSchema());
-        Assertions.assertEquals(schema2, getSubjectVersion(SUBJECT, String.valueOf(version2)).getSchema());
-        Assertions.assertEquals(schema2, getSubjectVersion(SUBJECT, "latest").getSchema());
-        Assertions.assertEquals(schema2, getSubjectVersion(SUBJECT, "-1").getSchema());
+        // Get latest and compare (Avro compacts primitive types: {"type":"string"} -> "string")
+        Assertions.assertEquals("\"string\"", getSubjectVersion(SUBJECT, String.valueOf(version1)).getSchema());
+        Assertions.assertEquals("\"int\"", getSubjectVersion(SUBJECT, String.valueOf(version2)).getSchema());
+        Assertions.assertEquals("\"int\"", getSubjectVersion(SUBJECT, "latest").getSchema());
+        Assertions.assertEquals("\"int\"", getSubjectVersion(SUBJECT, "-1").getSchema());
         getSubjectVersionFail(SUBJECT, "-2", 404);
         getSubjectVersionFail(SUBJECT, "foo", 404);
     }

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/VersionNumberingTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/VersionNumberingTest.java
@@ -88,7 +88,7 @@ public class VersionNumberingTest extends AbstractResourceTestBase {
             confluentClient.getByVersion(subject, 0, false);
         });
         Throwable rootCause = TestUtils.getRootCause(exception);
-        Assertions.assertTrue(rootCause.getMessage().contains("No version '0' found"));
+        Assertions.assertTrue(rootCause.getMessage().contains("Version 0 not found"));
     }
 
 }


### PR DESCRIPTION
## Summary

Follow-up to #7971. Addresses additional Confluent Schema Registry compatibility gaps identified by the [compatibility harness](https://www.apicur.io/apicurio-compatibility-harness/):

- **Avro schema compaction**: Parse and re-serialize Avro schemas to compact single-line JSON in ccompat API responses, matching Confluent's formatting
- **POST /subjects/{subject}/versions/{version}** (lookupVersion): New endpoint that checks whether a given schema matches the schema at a specific version, returning schema details or 404
- **Config response normalize field**: Add `normalize` boolean to `ConfigUpdateResponse` in v7/v8 OpenAPI specs and implementations
- **Error message alignment**: Improve `VersionNotFoundException` and `SchemaNotFoundException` messages to match Confluent's exact format

## Test plan

- [x] All 25 ccompat enhancement/config tests pass (CCompatV7EnhancementsTest, CCompatV8BasicTest, ConfluentCompatibilityConfigTest)
- [x] All 63 ConfluentClientTest tests pass
- [x] Checkstyle clean
- [ ] Run the [compatibility harness](https://github.com/Apicurio/apicurio-compatibility-harness) against a build with these changes

Ref #7962