### PR TITLE
fix(avro): resolve namespaced enum/fixed types as internal references (#7970)

### DIFF
--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/refs/AvroReferenceFinder.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/refs/AvroReferenceFinder.java
@@ -132,8 +132,10 @@ public class AvroReferenceFinder implements ReferenceFinder {
                     findExternalTypesIn(values, internalTypes, externalTypes, namespace);
                 }
                 case "enum", "fixed" -> {
-                    String enumName = schema.get("name").asText();
-                    String qualifiedType = qualifyTypeName(enumName, namespace);
+                    String typeNamespace = extractNamespace(schema);
+                    String effectiveNamespace = typeNamespace != null ? typeNamespace : namespace;
+                    String typeName = schema.get("name").asText();
+                    String qualifiedType = qualifyTypeName(typeName, effectiveNamespace);
                     internalTypes.add(qualifiedType);
                     externalTypes.remove(qualifiedType);
                 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/content/refs/AvroReferenceFinderTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/content/refs/AvroReferenceFinderTest.java
@@ -13,7 +13,7 @@ public class AvroReferenceFinderTest extends ArtifactUtilProviderTestBase {
 
     /**
      * Test method for
-     * {@link AsyncApiReferenceFinder#findExternalReferences(io.apicurio.registry.content.ContentHandle)}.
+     * {@link AsyncApiReferenceFinder#findExternalReferences(io.apicurio.registry.content.TypedContent)}.
      */
     @Test
     public void testFindExternalReferences() {
@@ -57,6 +57,21 @@ public class AvroReferenceFinderTest extends ArtifactUtilProviderTestBase {
         Assertions.assertEquals(2, foundReferences.size());
         Assertions.assertEquals(Set.of(new ExternalReference("com.kubetrade.schema.trade.TradeKey"),
                 new ExternalReference("com.kubetrade.schema.trade.TradeValue")), foundReferences);
+    }
+
+    /**
+     * Test that inline enum, fixed, and record types with their own namespace are correctly
+     * identified as internal references when reused by fully qualified name.
+     * This addresses issue #7970.
+     */
+    @Test
+    public void testNamespacedEnumFixedRefsAreNotReturnedAsExternal() {
+        TypedContent content = resourceToTypedContentHandle("avro-with-namespaced-enum-refs.avsc");
+        AvroReferenceFinder finder = new AvroReferenceFinder();
+        Set<ExternalReference> foundReferences = finder.findExternalReferences(content);
+        Assertions.assertNotNull(foundReferences);
+        Assertions.assertEquals(1, foundReferences.size());
+        Assertions.assertEquals(Set.of(new ExternalReference("com.example.TradeKey")), foundReferences);
     }
 
 }

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/content/refs/avro-with-namespaced-enum-refs.avsc
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/content/refs/avro-with-namespaced-enum-refs.avsc
@@ -1,0 +1,58 @@
+{
+  "namespace": "com.example",
+  "type": "record",
+  "name": "User",
+  "fields": [
+    {
+      "name": "tradeKey",
+      "type": "TradeKey"
+    },
+    {
+      "name": "addressType",
+      "type": {
+        "type": "enum",
+        "name": "AddressType",
+        "namespace": "com.example.adr",
+        "symbols": [
+          "HOME",
+          "WORK"
+        ]
+      }
+    },
+    {
+      "name": "billingAddressType",
+      "type": "com.example.adr.AddressType"
+    },
+    {
+      "name": "hash1",
+      "type": {
+        "type": "fixed",
+        "name": "MD5",
+        "namespace": "com.example.hash",
+        "size": 16
+      }
+    },
+    {
+      "name": "hash2",
+      "type": "com.example.hash.MD5"
+    },
+    {
+      "name": "homeAddress",
+      "type": {
+        "type": "record",
+        "name": "Address",
+        "namespace": "com.example.adr",
+        "fields": [
+          {
+            "name": "street",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "workAddress",
+      "type": "com.example.adr.Address"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Fix `AvroReferenceFinder` to extract the `namespace` property from inline `enum` and `fixed` type
  definitions, matching how `record` types already handle this.
- Previously, reusing an enum/fixed type with its own namespace (e.g. `com.example.adr.AddressType`)
  would incorrectly flag it as an external reference because the type was registered under the parent
  namespace (e.g. `com.example.AddressType`).
- Add test coverage with a new Avro schema containing namespaced enum, fixed, and record types all
  reused by fully qualified name.

## Related Issue
Fixes #7970

## Test Plan
- [ ] Run `AvroReferenceFinderTest` — all 4 tests should pass, including the new
  `testNamespacedEnumFixedRefsAreNotReturnedAsExternal` test
- [ ] Run `AvroContentValidatorTest` — verify no regressions in Avro validation
- [ ] Verify the user's exact schema from the issue (enum with `namespace: "com.example.adr"` reused
  by fully qualified name) no longer triggers "Missing reference detected"