### PR TITLE
feat(operator): expose management port 9000 on the app Service

### DIFF
--- a/operator/controller/src/main/java/io/apicurio/registry/operator/resource/app/AppServiceResource.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/resource/app/AppServiceResource.java
@@ -48,10 +48,16 @@ public class AppServiceResource extends CRUDKubernetesDependentResource<Service,
                             .withTargetPort(new IntOrStringBuilder().withValue(8443).build())
                             .build();
 
+                    var managementPort = new ServicePortBuilder()
+                            .withName("management")
+                            .withPort(9000)
+                            .withTargetPort(new IntOrStringBuilder().withValue(9000).build())
+                            .build();
+
                     if (TLS.insecureRequestsEnabled(tls)) {
-                        s.getSpec().setPorts(List.of(httpsPort, httpPort));
+                        s.getSpec().setPorts(List.of(httpsPort, httpPort, managementPort));
                     } else {
-                        s.getSpec().setPorts(List.of(httpsPort));
+                        s.getSpec().setPorts(List.of(httpsPort, managementPort));
                     }
                 });
 

--- a/operator/controller/src/main/resources/k8s/default/app.service.yaml
+++ b/operator/controller/src/main/resources/k8s/default/app.service.yaml
@@ -7,4 +7,8 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: http
+    - name: management
+      port: 9000
+      protocol: TCP
+      targetPort: management
   selector: { }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/TlsITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/TlsITTest.java
@@ -77,8 +77,9 @@ public class TlsITTest extends ITBase {
                     .withName(registry.getMetadata().getName() + "-app-service").get().getSpec();
 
             assertThat(service.getClusterIP()).isNotBlank();
-            Assertions.assertEquals(1, service.getPorts().size());
+            Assertions.assertEquals(2, service.getPorts().size());
             assertThat(service.getPorts().get(0).getPort()).isEqualTo(443);
+            assertThat(service.getPorts().get(1).getPort()).isEqualTo(9000);
             assertThat(service.getClusterIP()).isNotBlank();
             return true;
         });
@@ -324,8 +325,9 @@ public class TlsITTest extends ITBase {
             assertThat(service.getClusterIP()).isNotBlank();
             assertThat(service.getPorts().get(0).getPort()).isEqualTo(443);
             assertThat(service.getPorts().get(1).getPort()).isEqualTo(8080);
+            assertThat(service.getPorts().get(2).getPort()).isEqualTo(9000);
 
-            Assertions.assertEquals(2, service.getPorts().size());
+            Assertions.assertEquals(3, service.getPorts().size());
 
             assertThat(service.getClusterIP()).isNotBlank();
             return true;


### PR DESCRIPTION
## Summary

The operator-generated Kubernetes Service for the registry app component only exposes the HTTP port (8080, or 443/8443 when TLS is configured). However, the app container also declares a **management port (9000)** used for health endpoints (`/health/live`, `/health/ready`) and metrics. This port is already present on the container spec, health probes, and NetworkPolicy, but was missing from the Service.

Without the management port on the Service, any infrastructure that performs health checks or routing through the Service's port list cannot reach the management endpoints. This affects:

- **Ingress controllers** (e.g. AWS ALB, GCP NEG) that validate health check target ports against the Service's `spec.ports`
- **Service mesh sidecars** that discover upstream ports from the Service definition
- **Monitoring tools** that scrape metrics by enumerating Service ports

This PR adds the management port (9000) to the app Service across all configurations:

- **Non-TLS (default)**: Added to the `app.service.yaml` template with named `targetPort: management` matching the container port
- **TLS / TLS+insecure**: Added to the programmatic port list in `AppServiceResource` that replaces template ports when TLS is configured

### Files changed

- `operator/controller/src/main/resources/k8s/default/app.service.yaml` -- added management port entry
- `operator/controller/src/main/java/.../AppServiceResource.java` -- included management port in TLS code path
- `operator/controller/src/test/java/.../TlsITTest.java` -- updated port count and port number assertions

### Not affected

- **UI Service**: The UI container has no management port (health checks use `/config.js` on port 8080), so no change is needed
- **CRD/model**: Port 9000 is a fixed management port, not user-configurable, so no CRD changes are required
- **Reconciliation lifecycle**: The Service is a leaf dependency (only the Ingress depends on it, and it uses the Service name, not port list). Adding a static port does not introduce reconcile loops

## Test plan

- [ ] Verify `TlsITTest.testPassthroughTLS()` passes with updated assertion (2 ports: 443, 9000)
- [ ] Verify `TlsITTest.testPassthroughTLSWithInsecureTraffic()` passes with updated assertion (3 ports: 443, 8080, 9000)
- [ ] Verify `SmokeITTest` passes (non-TLS path, service template now includes management port)
- [ ] Manually confirm generated Service YAML includes `management` port on 9000


Made with [Cursor](https://cursor.com)