### PR TITLE
feat(ci): add reconciler, /retry command, and failure notification to PR lifecycle

### DIFF
--- a/.github/pr-lifecycle.yml
+++ b/.github/pr-lifecycle.yml
@@ -38,6 +38,7 @@ welcome_message: |
   | `/disable-tests` | Disable smoke tests during development |
   | `/enable-tests` | Re-enable smoke tests |
   | `/unstale` | Remove the stale label |
+  | `/retry` | Re-run the lifecycle orchestrator and retry failed tests |
 
   **Maintainer commands:**
   | Command | Description |

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -380,6 +380,54 @@ async function checkAndTransitionToReady(api, pr, core) {
 }
 
 // ---------------------------------------------------------------------------
+// Reconciler
+// ---------------------------------------------------------------------------
+
+async function reconcile(github, api, pr, core) {
+  const config = loadConfig();
+  const state = getLifecycleState(pr);
+
+  // 1. No lifecycle label at all → initialize as new PR
+  if (!state) {
+    if (hasLabel(pr, LABELS.DISABLED)) return;
+
+    if (isAutoAccepted(config, pr.user.login)) {
+      const initialState = pr.draft ? LABELS.WIP : LABELS.READY_FOR_REVIEW;
+      await api.addLabel(pr.number, initialState);
+      if (!pr.draft) {
+        await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+      }
+      core.warning(`PR #${pr.number} had no lifecycle label — initialized as ${initialState} (auto-accepted)`);
+    } else {
+      await api.addLabel(pr.number, LABELS.NEW);
+      if (!pr.draft) {
+        await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+      }
+      core.warning(`PR #${pr.number} had no lifecycle label — initialized as lifecycle/new`);
+    }
+
+    await api.postComment(pr.number,
+      `**Warning:** This PR was missing a lifecycle label, which indicates the ` +
+      `PR lifecycle orchestrator may have failed during initial processing. ` +
+      `The label has been restored automatically. If this PR was already accepted, ` +
+      `a maintainer may need to re-run the appropriate command (e.g. \`/accept\`).`
+    );
+    return;
+  }
+
+  // 2. Ready-for-review with all conditions met but not transitioned
+  if (state === LABELS.READY_FOR_REVIEW) {
+    const freshPr = await api.getPr(pr.number);
+    const result = await checkAndTransitionToReady(api, freshPr, core);
+    if (result === 'auto-merge') {
+      await performMerge(api, config, freshPr, core);
+    } else if (result === 'ready-to-merge') {
+      core.info(`PR #${pr.number} reconciler transitioned to ready-to-merge`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Event Handlers
 // ---------------------------------------------------------------------------
 
@@ -468,6 +516,9 @@ async function handlePrSynchronize({ github, context, core }) {
       rerunHints.map(h => `- ${h}`).join('\n')
     );
   }
+
+  const freshPr = await api.getPr(pr.number);
+  await reconcile(github, api, freshPr, core);
 }
 
 async function handlePrReadyForReview({ github, context, core }) {
@@ -499,6 +550,9 @@ async function handlePrReadyForReview({ github, context, core }) {
   );
   core.info(`PR #${pr.number} transitioned to ready-for-review (draft->ready)`);
   await retriggerVerify(api, pr, core);
+
+  const reconPr = await api.getPr(pr.number);
+  await reconcile(github, api, reconPr, core);
 }
 
 async function handleComment({ github, context, core }) {
@@ -825,6 +879,9 @@ async function handleReview({ github, context, core }) {
       await performMerge(api, config, freshPr, core);
     }
   }
+
+  const freshPr = await api.getPr(pr.number);
+  await reconcile(github, api, freshPr, core);
 }
 
 // ---------------------------------------------------------------------------
@@ -962,6 +1019,9 @@ async function handleTestResult({ github, context, core }) {
 
     // Post or update the decision summary comment
     await postDecisionSummary(github, owner, repo, workflowRun, pr.number, core);
+
+    const reconPr = await api.getPr(pr.number);
+    await reconcile(github, api, reconPr, core);
   }
 }
 
@@ -1198,5 +1258,6 @@ module.exports = {
   handleLabelChange,
   handleTestResult,
   handleStale,
+  reconcile,
   LABELS,
 };

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -325,8 +325,8 @@ async function performMerge(api, config, pr, core) {
     core.info(`PR #${pr.number} merged using ${strategy}`);
     return true;
   } catch (e) {
-    const workflowHint = e.message?.includes('workflow')
-      ? ' This PR modifies workflow files and requires manual merge via the GitHub UI (the `workflow` token scope is not available to GitHub Actions).'
+    const workflowHint = e.message?.includes('Resource not accessible')
+      ? ' This may be because the PR modifies workflow files, which requires manual merge via the GitHub UI (the `workflow` token scope is not available to GitHub Actions).'
       : '';
     await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
     await api.removeLabel(pr.number, LABELS.TESTED);

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -582,6 +582,7 @@ async function handleComment({ github, context, core }) {
     'disable-tests': () => cmdDisableTests(api, core, pr, actor, isAuthor, maintainer, comment.id),
     'enable-tests': () => cmdEnableTests(api, core, pr, actor, isAuthor, maintainer, comment.id),
     'unstale': () => cmdUnstale(api, config, core, pr, actor, isAuthor, maintainer, comment.id),
+    'retry': () => cmdRetry(github, api, config, core, pr, actor, isAuthor, maintainer, comment.id),
   };
 
   const handler = handlers[parsed.command];
@@ -843,6 +844,43 @@ async function cmdUnstale(api, config, core, pr, actor, isAuthor, maintainer, co
   await api.removeLabel(pr.number, LABELS.STALE);
   await api.addReaction(commentId, '+1');
   core.info(`PR #${pr.number} unstaled by ${actor}`);
+}
+
+async function cmdRetry(github, api, config, core, pr, actor, isAuthor, maintainer, commentId) {
+  if (!isAuthor && !maintainer) {
+    await api.addReaction(commentId, '-1');
+    await api.postComment(pr.number,
+      `@${actor} Only the PR author or a maintainer can retry.`
+    );
+    return;
+  }
+
+  await api.addReaction(commentId, '+1');
+
+  // Run the reconciler to fix any label inconsistencies
+  const freshPr = await api.getPr(pr.number);
+  await reconcile(github, api, freshPr, core);
+
+  // Check if the latest Verify run failed or was cancelled, and rerun if so
+  const latestRun = await api.findLatestVerifyRun(freshPr.head.sha);
+  if (latestRun && (latestRun.conclusion === 'failure' || latestRun.conclusion === 'cancelled')) {
+    await api.postComment(pr.number,
+      `Retrying: reconciled PR state and re-triggering the Verify workflow ` +
+      `(previous run [${latestRun.conclusion}](${latestRun.html_url})).`
+    );
+    await retriggerVerify(api, freshPr, core);
+    core.info(`PR #${pr.number} retry: reconciled + re-triggered Verify by ${actor}`);
+  } else if (latestRun && latestRun.status !== 'completed') {
+    await api.postComment(pr.number,
+      `Retrying: reconciled PR state. The Verify workflow is already running.`
+    );
+    core.info(`PR #${pr.number} retry: reconciled (Verify already running) by ${actor}`);
+  } else {
+    await api.postComment(pr.number,
+      `Retrying: reconciled PR state. No failed Verify run to re-trigger.`
+    );
+    core.info(`PR #${pr.number} retry: reconciled (no failed run) by ${actor}`);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -397,6 +397,7 @@ async function reconcile(github, api, pr, core) {
       if (!pr.draft) {
         await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
       }
+      await retriggerVerify(api, pr, core);
       core.warning(`PR #${pr.number} had no lifecycle label — initialized as ${initialState} (auto-accepted)`);
     } else {
       await api.addLabel(pr.number, LABELS.NEW);
@@ -417,10 +418,9 @@ async function reconcile(github, api, pr, core) {
 
   // 2. Ready-for-review with all conditions met but not transitioned
   if (state === LABELS.READY_FOR_REVIEW) {
-    const freshPr = await api.getPr(pr.number);
-    const result = await checkAndTransitionToReady(api, freshPr, core);
+    const result = await checkAndTransitionToReady(api, pr, core);
     if (result === 'auto-merge') {
-      await performMerge(api, config, freshPr, core);
+      await performMerge(api, config, pr, core);
     } else if (result === 'ready-to-merge') {
       core.info(`PR #${pr.number} reconciler transitioned to ready-to-merge`);
     }
@@ -582,7 +582,7 @@ async function handleComment({ github, context, core }) {
     'disable-tests': () => cmdDisableTests(api, core, pr, actor, isAuthor, maintainer, comment.id),
     'enable-tests': () => cmdEnableTests(api, core, pr, actor, isAuthor, maintainer, comment.id),
     'unstale': () => cmdUnstale(api, config, core, pr, actor, isAuthor, maintainer, comment.id),
-    'retry': () => cmdRetry(github, api, config, core, pr, actor, isAuthor, maintainer, comment.id),
+    'retry': () => cmdRetry(github, api, core, pr, actor, isAuthor, maintainer, comment.id),
   };
 
   const handler = handlers[parsed.command];
@@ -846,7 +846,7 @@ async function cmdUnstale(api, config, core, pr, actor, isAuthor, maintainer, co
   core.info(`PR #${pr.number} unstaled by ${actor}`);
 }
 
-async function cmdRetry(github, api, config, core, pr, actor, isAuthor, maintainer, commentId) {
+async function cmdRetry(github, api, core, pr, actor, isAuthor, maintainer, commentId) {
   if (!isAuthor && !maintainer) {
     await api.addReaction(commentId, '-1');
     await api.postComment(pr.number,
@@ -1235,6 +1235,15 @@ async function handleStale({ github, context, core }) {
   for (const pr of prs) {
     if (hasLabel(pr, LABELS.DISABLED)) continue;
 
+    // Reconcile all PRs targeting main
+    if (pr.base?.ref === 'main') {
+      try {
+        await reconcile(github, api, pr, core);
+      } catch (err) {
+        core.warning(`PR #${pr.number} reconcile failed: ${err.message}`);
+      }
+    }
+
     const state = getLifecycleState(pr);
     if (!state) continue;
     if (state === LABELS.READY_TO_MERGE) continue;
@@ -1282,17 +1291,6 @@ async function handleStale({ github, context, core }) {
     }
   }
 
-  // Reconcile all open PRs targeting main to catch any with missing/inconsistent state
-  core.info('Running reconciler on all open PRs...');
-  for (const pr of prs) {
-    if (hasLabel(pr, LABELS.DISABLED)) continue;
-    if (pr.base?.ref !== 'main') continue;
-    try {
-      await reconcile(github, api, pr, core);
-    } catch (err) {
-      core.warning(`PR #${pr.number} reconcile failed: ${err.message}`);
-    }
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -1281,6 +1281,18 @@ async function handleStale({ github, context, core }) {
       core.info(`PR #${pr.number} marked as stale`);
     }
   }
+
+  // Reconcile all open PRs targeting main to catch any with missing/inconsistent state
+  core.info('Running reconciler on all open PRs...');
+  for (const pr of prs) {
+    if (hasLabel(pr, LABELS.DISABLED)) continue;
+    if (pr.base?.ref !== 'main') continue;
+    try {
+      await reconcile(github, api, pr, core);
+    } catch (err) {
+      core.warning(`PR #${pr.number} reconcile failed: ${err.message}`);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -161,7 +161,7 @@ and tags starting with `3.`.
 
 | Workflow | Trigger | Purpose | Duration |
 |----------|---------|---------|----------|
-| `pr-lifecycle.yml` | PR events, comments, reviews, workflow_run, daily schedule | Label-driven PR state machine. States: `new` -> `wip` -> `ready-for-review` -> `ready-to-merge`. Comment commands: `/accept`, `/reject`, `/ready`, `/merge`, `/auto-merge`. Auto-accepts maintainers. Stale detection (7-day warning, 14-day auto-close). Label protection (reverts unauthorized changes). 838 lines of JS logic in `.github/scripts/pr-lifecycle.js` | 2-5 min per event |
+| `pr-lifecycle.yml` | PR events, comments, reviews, workflow_run, every 4 hours | Label-driven PR state machine. States: `new` -> `wip` -> `ready-for-review` -> `ready-to-merge`. Comment commands: `/accept`, `/reject`, `/ready`, `/merge`, `/auto-merge`, `/retry`. Auto-accepts maintainers. Reconciler runs after each event and on cron to fix inconsistent state. Stale detection (7-day warning, 14-day auto-close). Label protection (reverts unauthorized changes). Failure notification posts a warning comment when any lifecycle job fails. | 2-5 min per event |
 | `update-openapi.yaml` | Push to main (openapi.json changes) | Auto-copies v3 OpenAPI spec to v2 path, commits if changed, then validates via `validate-openapi.yaml` | 10-15 min |
 | `update-website.yaml` | Release event, workflow_dispatch | Updates `latestRelease.json` on apicurio.github.io with release metadata | 5-10 min |
 | `publish-docs.yaml` | Push to main (docs/**), workflow_dispatch | Builds documentation via Antora playbook and publishes to apicurio.github.io | 15-30 min |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -161,7 +161,7 @@ and tags starting with `3.`.
 
 | Workflow | Trigger | Purpose | Duration |
 |----------|---------|---------|----------|
-| `pr-lifecycle.yml` | PR events, comments, reviews, workflow_run, every 4 hours | Label-driven PR state machine. States: `new` -> `wip` -> `ready-for-review` -> `ready-to-merge`. Comment commands: `/accept`, `/reject`, `/ready`, `/merge`, `/auto-merge`, `/retry`. Auto-accepts maintainers. Reconciler runs after each event and on cron to fix inconsistent state. Stale detection (7-day warning, 14-day auto-close). Label protection (reverts unauthorized changes). Failure notification posts a warning comment when any lifecycle job fails. | 2-5 min per event |
+| `pr-lifecycle.yml` | PR events, comments, reviews, workflow_run, every 6 hours | Label-driven PR state machine. States: `new` -> `wip` -> `ready-for-review` -> `ready-to-merge`. Comment commands: `/accept`, `/reject`, `/ready`, `/merge`, `/auto-merge`, `/retry`. Auto-accepts maintainers. Reconciler runs after each event and on cron to fix inconsistent state. Stale detection (7-day warning, 14-day auto-close). Label protection (reverts unauthorized changes). Failure notification posts a warning comment when any lifecycle job fails. | 2-5 min per event |
 | `update-openapi.yaml` | Push to main (openapi.json changes) | Auto-copies v3 OpenAPI spec to v2 path, commits if changed, then validates via `validate-openapi.yaml` | 10-15 min |
 | `update-website.yaml` | Release event, workflow_dispatch | Updates `latestRelease.json` on apicurio.github.io with release metadata | 5-10 min |
 | `publish-docs.yaml` | Push to main (docs/**), workflow_dispatch | Builds documentation via Antora playbook and publishes to apicurio.github.io | 15-30 min |

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -196,6 +196,33 @@ jobs:
             await handler.handleTestResult({ github, context, core });
 
   # ==========================================================================
+  # Failure Notification
+  # ==========================================================================
+  failure-notify:
+    name: Failure Notification
+    runs-on: ubuntu-latest
+    if: >-
+      failure() &&
+      github.event_name != 'schedule' &&
+      (github.event.pull_request.number || github.event.issue.number)
+    needs: [pr-opened, pr-synchronize, pr-ready-for-review, command, review, label-guard, test-result]
+    steps:
+      - name: Post warning comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request?.number || context.payload.issue?.number;
+            if (!prNumber) return;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `**Warning:** The PR lifecycle orchestrator encountered an error while processing ` +
+                `an event for this PR. Some labels or state transitions may be incorrect.\n\n` +
+                `A maintainer or the PR author can use \`/retry\` to re-run the orchestrator.`
+            });
+
+  # ==========================================================================
   # Stale Detection (daily cron)
   # ==========================================================================
   stale:

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -12,7 +12,7 @@ on:
     workflows: ["Verify"]
     types: [completed]
   schedule:
-    - cron: '17 8 * * *'
+    - cron: '17 */4 * * *'
 
 permissions:
   actions: write

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -12,7 +12,7 @@ on:
     workflows: ["Verify"]
     types: [completed]
   schedule:
-    - cron: '17 */4 * * *'
+    - cron: '17 */6 * * *'
 
 permissions:
   actions: write
@@ -203,27 +203,41 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       failure() &&
-      github.event_name != 'schedule' &&
-      (github.event.pull_request.number || github.event.issue.number)
+      github.event_name != 'schedule'
     needs: [pr-opened, pr-synchronize, pr-ready-for-review, command, review, label-guard, test-result]
     steps:
       - name: Post warning comment
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = context.payload.pull_request?.number || context.payload.issue?.number;
+            const { owner, repo } = context.repo;
+            let prNumber = context.payload.pull_request?.number || context.payload.issue?.number;
+
+            // For workflow_run events, resolve PR from the triggering run
+            if (!prNumber && context.payload.workflow_run) {
+              const run = context.payload.workflow_run;
+              let prs = run.pull_requests || [];
+              if (!prs.length) {
+                const headOwner = run.head_repository?.owner?.login || owner;
+                const { data: found } = await github.rest.pulls.list({
+                  owner, repo, state: 'open',
+                  head: `${headOwner}:${run.head_branch}`, per_page: 5,
+                });
+                prs = found.filter(p => p.head.sha === run.head_sha);
+              }
+              if (prs.length) prNumber = prs[0].number;
+            }
+
             if (!prNumber) return;
             await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
+              owner, repo, issue_number: prNumber,
               body: `**Warning:** The PR lifecycle orchestrator encountered an error while processing ` +
                 `an event for this PR. Some labels or state transitions may be incorrect.\n\n` +
                 `A maintainer or the PR author can use \`/retry\` to re-run the orchestrator.`
             });
 
   # ==========================================================================
-  # Stale Detection (daily cron)
+  # Stale Detection and Reconciliation (every 6 hours)
   # ==========================================================================
   stale:
     name: Stale Detection


### PR DESCRIPTION
## Summary

Add self-healing capabilities to the PR lifecycle orchestrator:

- **Reconciler** — Idempotent `reconcile()` function that runs after each event handler and fixes inconsistent state (missing lifecycle labels, missed state transitions). Posts a warning comment when it detects a problem. Also triggers Verify for auto-accepted PRs with missing labels.
- **`/retry` command** — Available to authors and maintainers. Runs the reconciler to fix labels, then re-triggers the Verify workflow if the latest run failed or was cancelled.
- **Failure notification** — Catch-all job that posts a warning comment when any lifecycle job fails (including workflow_run events), suggesting `/retry`.
- **6-hour cron reconciliation** — Runs `reconcile()` on all open PRs targeting main every 6 hours (integrated into the stale detection loop) to catch runner timeouts and dropped events.

Fixes the issue where Renovate PRs (#8007, #8008) were left without lifecycle labels because the `PR Opened` handler failed due to runner exhaustion.

## Test plan

- [ ] Open a new PR → `PR Opened` handler runs, reconciler is a no-op
- [ ] Push to a PR that has no lifecycle label → reconciler initializes it and posts a warning
- [ ] Comment `/retry` on a PR with failed Verify → reconciles state and re-triggers tests
- [ ] Comment `/retry` on a healthy PR → reconciles (no-op) and reports no failed run
- [ ] Lifecycle job fails (e.g., API error) → failure notification job posts a warning comment
- [ ] Cron runs → stale detection + reconciler pass on all open PRs