### PR TITLE
fix: issue 8014

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
@@ -1840,7 +1840,7 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .when().contentType(CT_JSON)
                 .body(createGroup)
                 .post("/registry/v3/groups")
-                .then().statusCode(204);
+                .then().statusCode(200);
 
         CreateRule createRule = new CreateRule();
         createRule.setRuleType(RuleType.INTEGRITY);

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
@@ -1829,6 +1829,43 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void testCreateArtifactWithoutReferencesFieldWithIntegrityRule() throws Exception {
+        String groupId = "testCreateArtifactWithoutReferencesFieldWithIntegrityRule";
+        String artifactId = "my-schema";
+        String artifactContent = resourceToString("jsonschema-valid.json");
+
+        CreateGroup createGroup = new CreateGroup();
+        createGroup.setGroupId(groupId);
+        given()
+                .when().contentType(CT_JSON)
+                .body(createGroup)
+                .post("/registry/v3/groups")
+                .then().statusCode(204);
+
+        CreateRule createRule = new CreateRule();
+        createRule.setRuleType(RuleType.INTEGRITY);
+        createRule.setConfig(IntegrityLevel.ALL_REFS_MAPPED.name());
+        given().when().contentType(CT_JSON)
+                .pathParam("groupId", groupId)
+                .body(createRule)
+                .post("/registry/v3/groups/{groupId}/rules")
+                .then().statusCode(204);
+
+        io.apicurio.registry.rest.v3.beans.CreateArtifact createArtifact = TestUtils.serverCreateArtifact(
+                artifactId, ArtifactType.JSON, artifactContent, ContentTypes.APPLICATION_JSON);
+
+        given().when().contentType(CT_JSON)
+                .pathParam("groupId", groupId)
+                .body(createArtifact)
+                .post("/registry/v3/groups/{groupId}/artifacts")
+                .then().statusCode(200)
+                .body("artifact.groupId", equalTo(groupId))
+                .body("artifact.artifactId", equalTo(artifactId))
+                .body("artifact.artifactType", equalTo(ArtifactType.JSON))
+                .body("version.version", equalTo("1"));
+    }
+
+    @Test
     public void testGetArtifactVersionWithReferences() throws Exception {
         String referencedTypesContent = resourceToString("referenced-types.json");
         String withExternalRefContent = resourceToString("openapi-with-external-ref.json");

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AbstractContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AbstractContentValidator.java
@@ -6,6 +6,7 @@ import io.apicurio.registry.rules.violation.RuleViolation;
 import io.apicurio.registry.rules.violation.RuleViolationException;
 import io.apicurio.registry.types.RuleType;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -27,6 +28,9 @@ public abstract class AbstractContentValidator implements ContentValidator {
      */
     protected void validateMappedReferences(List<ArtifactReference> references,
             Set<String> requiredReferences, String violationDescription) throws RuleViolationException {
+        if (references == null) {
+            references = Collections.emptyList();
+        }
 
         Set<String> mappedRefNames = references.stream()
         .map(ref -> extractReferenceName(ref))

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/JsonSchemaContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/JsonSchemaContentValidatorTest.java
@@ -121,4 +121,17 @@ public class JsonSchemaContentValidatorTest extends ArtifactUtilProviderTestBase
             validator.validateReferences(content, references);
         });
     }
+
+    @Test
+    public void testValidateReferencesWithNullReferenceList() throws Exception {
+        TypedContent contentWithoutRefs = resourceToTypedContentHandle("jsonschema-valid.json");
+        TypedContent contentWithRefs = resourceToTypedContentHandle("jsonschema-valid-with-refs.json");
+        JsonSchemaContentValidator validator = new JsonSchemaContentValidator();
+
+        validator.validateReferences(contentWithoutRefs, null);
+
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validateReferences(contentWithRefs, null);
+        });
+    }
 }


### PR DESCRIPTION
Fixes #8014 by treating omitted references as an empty list during integrity validation instead of throwing a NullPointerException.

-  shared reference-mapping validator path -> improved
- regression tests for both JSON schema validator and REST create-artifact flow added