### PR TITLE
fix: resolve SonarCloud reliability bugs failing quality gate

### DIFF
--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -158,6 +158,19 @@ public class RegistryClientRequestAdapterFactory {
      * Retries on transient network exceptions (connection reset, timeout, etc.) for both Vert.x and JDK adapters.
      */
     static class RetryInvocationHandler implements InvocationHandler {
+        private static final Class<?> VERTX_HTTP_CLOSED_EXCEPTION;
+
+        static {
+            Class<?> cls = null;
+            try {
+                cls = Class.forName("io.vertx.core.http.HttpClosedException", false,
+                        RetryInvocationHandler.class.getClassLoader());
+            } catch (ClassNotFoundException e) {
+                // Vert.x not on classpath
+            }
+            VERTX_HTTP_CLOSED_EXCEPTION = cls;
+        }
+
         private final RequestAdapter delegate;
         private final int maxRetryAttempts;
         private final long initialRetryDelayMs;
@@ -210,7 +223,7 @@ public class RegistryClientRequestAdapterFactory {
         private boolean isRetryable(Throwable cause) {
             Throwable current = cause;
             while (current != null) {
-                if ("io.vertx.core.http.HttpClosedException".equals(current.getClass().getName())) {
+                if (VERTX_HTTP_CLOSED_EXCEPTION != null && VERTX_HTTP_CLOSED_EXCEPTION.isInstance(current)) {
                     return true;
                 }
                 if (current instanceof java.net.ConnectException) {

--- a/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/jsonschema/diff/ArraySchemaDiffVisitor.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/jsonschema/diff/ArraySchemaDiffVisitor.java
@@ -92,7 +92,7 @@ public class ArraySchemaDiffVisitor extends JsonSchemaWrapperVisitor {
             visitItemSchema(i, itemSchemas.get(i));
         }
 
-        if (updatedSize > size) { // adding items
+        if (itemSchemas != null && updatedSize > size) { // adding items
             DiffUtil.diffSubSchemasAdded(ctx.sub("addItemSchema"), itemSchemas.subList(size, updatedSize),
                     original.permitsAdditionalItems(), wrap(original.getSchemaOfAdditionalItems()),
                     schema.permitsAdditionalItems(), DiffType.ARRAY_TYPE_ITEM_SCHEMAS_EXTENDED,


### PR DESCRIPTION
## Summary

- Fix two bugs in new code that cause the SonarCloud quality gate to fail on `main` with a **New Reliability Rating of C** (threshold: A)
- **`ArraySchemaDiffVisitor.java:96`** (`S2259`): add explicit null guard for `itemSchemas` parameter before `.subList()` call — logically unreachable but Sonar can't follow the `Optional.ofNullable` flow
- **`RegistryClientRequestAdapterFactory.java:213`** (`S1872`): replace string-based class name comparison with `Class.forName()` + `isInstance()` for the optional Vert.x `HttpClosedException` — follows the same pattern already used for OpenTelemetry in the same file

## Test plan

- [x] Both modules compile cleanly
- [x] Checkstyle passes on both modules
- [ ] SonarCloud quality gate passes after merge