### PR TITLE
ci: shard unit tests by storage variant for isolation

### DIFF
--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -19,11 +19,27 @@ jobs:
       fail-fast: false
       matrix:
         shard:
-          - name: app-shard1
+          - name: app-rest
             modules: "-pl app -am -Dfull -DcliSkipNative"
-            test-filter: "-Dtest=io.apicurio.registry.noprofile.rest.**,io.apicurio.registry.noprofile.ccompat.**,io.apicurio.registry.storage.**,io.apicurio.registry.event.**"
+            test-filter: "-Dtest=io.apicurio.registry.noprofile.rest.**,io.apicurio.registry.noprofile.ccompat.**"
             maven-opts: "-Xmx4g"
-          - name: app-shard2
+          - name: app-sql
+            modules: "-pl app -am -Dfull -DcliSkipNative"
+            test-filter: "-Dtest=io.apicurio.registry.storage.impl.sql.**,io.apicurio.registry.storage.impl.search.**,io.apicurio.registry.storage.impl.polling.**,io.apicurio.registry.storage.impl.readonly.**,io.apicurio.registry.storage.decorator.**,io.apicurio.registry.storage.dto.**,io.apicurio.registry.event.sql.**"
+            maven-opts: "-Xmx4g"
+          - name: app-kafkasql
+            modules: "-pl app -am -Dfull -DcliSkipNative"
+            test-filter: "-Dtest=io.apicurio.registry.storage.impl.kafkasql.**,io.apicurio.registry.event.kafkasql.**"
+            maven-opts: "-Xmx4g"
+          - name: app-gitops
+            modules: "-pl app -am -Dfull -DcliSkipNative"
+            test-filter: "-Dtest=io.apicurio.registry.storage.impl.gitops.**"
+            maven-opts: "-Xmx2g"
+          - name: app-kubernetesops
+            modules: "-pl app -am -Dfull -DcliSkipNative"
+            test-filter: "-Dtest=io.apicurio.registry.storage.impl.kubernetesops.**"
+            maven-opts: "-Xmx2g"
+          - name: app-other
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=!io.apicurio.registry.noprofile.rest.**,!io.apicurio.registry.noprofile.ccompat.**,!io.apicurio.registry.storage.**,!io.apicurio.registry.event.**"
             maven-opts: "-Xmx4g"


### PR DESCRIPTION
## Summary
- Split the monolithic `app-shard1` unit test job into separate shards per storage variant: `app-rest`, `app-sql`, `app-kafkasql`, `app-gitops`, `app-kubernetesops`, and `app-other`
- Each storage variant now runs in its own JVM process, preventing interference from shared Kafka containers, topic pollution, and resource contention
- Renamed `app-shard2` to `app-other` for clarity

## Test plan
- [ ] Verify all 7 shards pass in CI
- [ ] Confirm no tests are missed (every test that ran before still runs)
- [ ] Check that KafkaSQL tests no longer show "unknown records" warnings from other shards' activity