### PR TITLE
Add context switching to the CLI. Fixes #8020

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/context/ContextCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/context/ContextCommand.java
@@ -19,6 +19,7 @@ import static io.apicurio.registry.cli.utils.Utils.isBlank;
                 ContextCreateCommand.class,
                 ContextUpdateCommand.class,
                 ContextDeleteCommand.class,
+                ContextUseCommand.class,
         }
 )
 public class ContextCommand extends AbstractCommand {

--- a/cli/src/main/java/io/apicurio/registry/cli/context/ContextUseCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/context/ContextUseCommand.java
@@ -1,0 +1,46 @@
+package io.apicurio.registry.cli.context;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(
+        name = "use",
+        aliases = {"set", "switch"},
+        description = "Switch to a different context"
+)
+public class ContextUseCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The context name to switch to."
+    )
+    private String name;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var configModel = config.read();
+        if (!configModel.getContext().containsKey(name)) {
+            throw new CliException("Context '" + name + "' does not exist.",
+                    CliException.VALIDATION_ERROR_RETURN_CODE);
+        }
+        if (name.equals(configModel.getCurrentContext())) {
+            output.writeStdOutChunk(out -> {
+                out.append("Context '").append(name).append("' is already the current context.\n");
+            });
+            return;
+        }
+        final var previousContext = configModel.getCurrentContext();
+        configModel.setCurrentContext(name);
+        config.write(configModel);
+        output.writeStdOutChunk(out -> {
+            out.append("Switched to context '").append(name).append("'");
+            if (previousContext != null) {
+                out.append(" from '").append(previousContext).append("'");
+            }
+            out.append(".\n");
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
@@ -32,8 +32,8 @@ public class Client {
         var currentContext = config.read();
         if (isBlank(currentContext.getCurrentContext())) {
             throw new CliException("No current context is set. " +
-                    "Run `acr context set <context>` " +
-                    "or `acr context add example http://localhost:8080`.", APPLICATION_ERROR_RETURN_CODE);
+                    "Run `acr context use <context>` " +
+                    "or `acr context create <name> <url>`.", APPLICATION_ERROR_RETURN_CODE);
         } else {
             if (registryClient == null) {
                 try {

--- a/cli/src/test/java/io/apicurio/registry/cli/ContextCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ContextCommandTest.java
@@ -14,6 +14,7 @@ public class ContextCommandTest extends AbstractCLITest {
         testHelpCommand("context", "create");
         testHelpCommand("context", "update");
         testHelpCommand("context", "delete");
+        testHelpCommand("context", "use");
     }
 
     @Test
@@ -81,5 +82,40 @@ public class ContextCommandTest extends AbstractCLITest {
         assertThat(out.toString())
                 .as(withCliOutput("Named context should show updated group"))
                 .contains("named-group");
+    }
+
+    @Test
+    public void testContextUse() {
+        // Create a second context
+        executeAndAssertSuccess("context", "create", "--no-switch-current", "second", registryUrl);
+
+        // Switch to the second context
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("context", "use", "second");
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm context switch with previous context"))
+                .contains("Switched to context 'second'")
+                .contains("from 'test'");
+
+        // Verify it is now the active context
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("context");
+        assertThat(out.toString())
+                .as(withCliOutput("Second context should be active"))
+                .contains("second*");
+    }
+
+    @Test
+    public void testContextUseAlreadyCurrent() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("context", "use", "test");
+        assertThat(out.toString())
+                .as(withCliOutput("Should indicate context is already active"))
+                .contains("already the current context");
+    }
+
+    @Test
+    public void testContextUseNonExistent() {
+        executeAndAssertFailure("context", "use", "non-existent");
     }
 }


### PR DESCRIPTION
## Summary

Adds `acr context use <name>` command to switch the active context without modifying its properties. Also available as `acr context set` and `acr context switch`.

## Usage

```bash
acr context use staging              # Switched to context 'staging' from 'dev'.
acr context use staging              # Context 'staging' is already the current context.
acr context use non-existent         # Error: Context 'non-existent' does not exist.
```

## Testing

- [x] Build succeeds, checkstyle passes
- [x] All CLI tests pass (193 tests, 0 failures)
- [x] Manual end-to-end testing passed

Fixes #8020