### PR TITLE
fix(otel): add @Priority to StorageTracingInterceptor

### DIFF
--- a/app/src/main/java/io/apicurio/registry/metrics/StorageTracingInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/StorageTracingInterceptor.java
@@ -6,6 +6,7 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
+import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
@@ -22,13 +23,15 @@ import java.lang.reflect.Method;
  */
 @Interceptor
 @StorageMetricsApply
+@Priority(Interceptor.Priority.PLATFORM_BEFORE + 10)
 public class StorageTracingInterceptor {
 
     private static final String INSTRUMENTATION_NAME = "io.apicurio.registry.storage";
+    private static final String INSTRUMENTATION_VERSION = "3.x";
 
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
-        Tracer tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
+        Tracer tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION);
         String spanName = "storage." + context.getMethod().getName();
 
         Span span = tracer.spanBuilder(spanName)


### PR DESCRIPTION
## Summary

- Add explicit `@Priority(Interceptor.Priority.PLATFORM_BEFORE + 10)` annotation to `StorageTracingInterceptor` to ensure deterministic interceptor ordering
- Add instrumentation version to `getTracer()` call for proper OTel scope metadata

## Related Issues

- Fixes items 2 and 3 from #7150

## Changes

- `app/src/main/java/io/apicurio/registry/metrics/StorageTracingInterceptor.java`
  - Added `@Priority(Interceptor.Priority.PLATFORM_BEFORE + 10)` annotation
  - Added `INSTRUMENTATION_VERSION` constant (`"3.x"`)
  - Changed `getTracer(INSTRUMENTATION_NAME)` → `getTracer(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION)`

## Testing

- All 6 existing `StorageTracingInterceptorTest` tests pass (span creation, attributes, error recording, multi-parameter signatures, no-parameter signatures, span timing)
- Checkstyle passes with 0 violations
- No behavioral change: `getTracer(name, version)` returns the same `Tracer` — the version is metadata-only