### PR TITLE
ci(go-sdk): move code generation to CI

### DIFF
--- a/.github/workflows/generate-go-sdk.yaml
+++ b/.github/workflows/generate-go-sdk.yaml
@@ -1,0 +1,47 @@
+name: Generate Go SDK
+on:
+  push:
+    paths:
+      - common/src/main/resources/META-INF/openapi.json
+      - common/src/main/resources/META-INF/openapi-v2.json
+    branches: [main]
+
+jobs:
+  generate-go-sdk:
+    name: Generate Go SDK
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Apicurio'
+    steps:
+      - name: Apicurio Registry Checkout
+        run: |
+          mkdir registry
+          cd registry
+          git init
+          git config --global user.name "apicurio-ci"
+          git config --global user.email "apicurio.ci@gmail.com"
+          git remote add origin "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git"
+          git fetch
+          git checkout main
+          git branch --set-upstream-to=origin/main
+          git pull
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Generate Go SDK
+        run: |
+          cd registry/go-sdk
+          make generate format
+
+      - name: Commit changes
+        run: |
+          cd registry
+          git add go-sdk/pkg/
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "chore(go-sdk): regenerate from updated OpenAPI spec"
+            git push
+          fi

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -30,6 +30,7 @@ jobs:
       run-extras: ${{ steps.decide.outputs.run-extras }}
       run-sdk: ${{ steps.decide.outputs.run-sdk }}
       run-cli: ${{ steps.decide.outputs.run-cli }}
+      run-go-sdk-freshness: ${{ steps.decide.outputs.run-go-sdk-freshness }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -68,6 +69,10 @@ jobs:
               - 'go-sdk/**'
               - 'python-sdk/**'
               - 'typescript-sdk/**'
+            go-sdk-gen:
+              - 'common/src/main/resources/META-INF/openapi.json'
+              - 'common/src/main/resources/META-INF/openapi-v2.json'
+              - 'go-sdk/**'
             cli:
               - 'cli/**'
               - 'java-sdk/**'
@@ -140,6 +145,7 @@ jobs:
           INTEGRATION='${{ steps.filter.outputs.integration }}'
           SDK='${{ steps.filter.outputs.sdk }}'
           CLI='${{ steps.filter.outputs.cli }}'
+          GO_SDK_GEN='${{ steps.filter.outputs.go-sdk-gen }}'
           CI='${{ steps.filter.outputs.ci }}'
 
           # ── Phase 3: Combine scope + changes into per-phase decisions ─
@@ -167,6 +173,7 @@ jobs:
           decide run-extras      "$run_full"  "$IS_PUSH" "$JAVA" "$UI" "$CI"
           decide run-sdk         "$run_full"  "$IS_PUSH" "$SDK" "$JAVA" "$CI"
           decide run-cli         "$run_full"  "$CLI"
+          decide run-go-sdk-freshness "$run_smoke" "$GO_SDK_GEN" "$CI"
 
       - name: Save decision summary
         if: github.event_name == 'pull_request' && steps.decide.outputs.lifecycle-ready != 'skip'
@@ -179,7 +186,8 @@ jobs:
             "run-integration": "${{ steps.decide.outputs.run-integration }}",
             "run-extras": "${{ steps.decide.outputs.run-extras }}",
             "run-sdk": "${{ steps.decide.outputs.run-sdk }}",
-            "run-cli": "${{ steps.decide.outputs.run-cli }}"
+            "run-cli": "${{ steps.decide.outputs.run-cli }}",
+            "run-go-sdk-freshness": "${{ steps.decide.outputs.run-go-sdk-freshness }}"
           }
           ARTIFACT_EOF
           cat > /tmp/verify-changes.json << 'ARTIFACT_EOF'
@@ -189,6 +197,7 @@ jobs:
             "integration": "${{ steps.filter.outputs.integration }}",
             "sdk": "${{ steps.filter.outputs.sdk }}",
             "cli": "${{ steps.filter.outputs.cli }}",
+            "go-sdk-gen": "${{ steps.filter.outputs.go-sdk-gen }}",
             "ci": "${{ steps.filter.outputs.ci }}"
           }
           ARTIFACT_EOF
@@ -280,6 +289,35 @@ jobs:
       image-tag: ${{ github.sha }}
 
   # ============================================================================
+  # Go SDK Freshness Check (no build dependency — runs early)
+  # ============================================================================
+  go-sdk-freshness:
+    name: Go SDK Freshness
+    runs-on: ubuntu-latest
+    needs: [decide]
+    if: needs.decide.outputs.run-go-sdk-freshness == 'true'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Regenerate Go SDK
+        run: |
+          cd go-sdk
+          make generate format
+
+      - name: Check for drift
+        run: |
+          if ! git diff --exit-code go-sdk/pkg/; then
+            echo "::error::Go SDK is out of date. Run 'cd go-sdk && make generate format' and commit the changes."
+            exit 1
+          fi
+
+  # ============================================================================
   # PHASE 6: SDK Verification (parallel)
   # ============================================================================
   sdk:
@@ -302,7 +340,7 @@ jobs:
     name: Verification Gate
     if: always()
     needs: [decide, lint-and-validate, build, unit-tests, cli-verify,
-            integration-tests, extras, sdk]
+            integration-tests, extras, sdk, go-sdk-freshness]
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate gate

--- a/go-sdk/pom.xml
+++ b/go-sdk/pom.xml
@@ -16,30 +16,35 @@
     <projectRoot>${project.basedir}/..</projectRoot>
   </properties>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>${version.exec-maven-plugin}</version>
-        <configuration>
-          <executable>make</executable>
-          <workingDirectory>${project.basedir}</workingDirectory>
-          <arguments>
-            <argument>generate</argument>
-            <argument>format</argument>
-          </arguments>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <phase>generate-sources</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+  <profiles>
+    <profile>
+      <id>generate-go-sdk</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>${version.exec-maven-plugin}</version>
+            <configuration>
+              <executable>make</executable>
+              <workingDirectory>${project.basedir}</workingDirectory>
+              <arguments>
+                <argument>generate</argument>
+                <argument>format</argument>
+              </arguments>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>generate-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
## Summary
- Add `generate-go-sdk.yaml` workflow that auto-regenerates and commits Go SDK code when OpenAPI specs change on `main` (mirrors `update-openapi.yaml` pattern)
- Add `go-sdk-freshness` check to `verify.yaml` that fails PRs if committed Go SDK code doesn't match what Kiota produces from current OpenAPI specs
- Gate Maven generation behind `-Pgenerate-go-sdk` profile so local builds no longer download OS-specific Kiota binaries

## Motivation
The current setup requires running Kiota locally to generate Go SDK code, which downloads platform-specific binaries (linux/osx, arm64/x64). This introduces OS-dependent differences in generated output and forces contributors to have Go + platform tooling installed. Moving generation to CI ensures deterministic output from a consistent Linux environment.

## Test plan
- [ ] Verify `generate-go-sdk.yaml` triggers when OpenAPI specs change on main
- [ ] Verify `go-sdk-freshness` job detects drift when Go SDK is out of date
- [ ] Verify `mvn install -pl go-sdk` skips generation without `-Pgenerate-go-sdk`
- [ ] Verify `mvn install -pl go-sdk -Pgenerate-go-sdk` still works for local generation