### PR TITLE
Centralize ProblemDetails error handling in the CLI. Fixes #8026 and #8031

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/BrandedCommandLineProducer.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/BrandedCommandLineProducer.java
@@ -5,11 +5,10 @@ import io.quarkus.picocli.runtime.PicocliCommandLineFactory;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
-import org.jboss.logging.Logger;
-import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
-
 import java.util.LinkedHashMap;
+import org.jboss.logging.Logger;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine;
 
 @ApplicationScoped
 public class BrandedCommandLineProducer {

--- a/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
@@ -6,14 +6,13 @@ import io.apicurio.registry.cli.config.ConfigModel;
 import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.Mapper;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import org.jboss.logging.Logger;
-import picocli.CommandLine.Command;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import org.jboss.logging.Logger;
+import picocli.CommandLine.Command;
 
 import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
 import static io.apicurio.registry.cli.utils.Utils.isBlank;

--- a/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
@@ -7,18 +7,17 @@ import io.apicurio.registry.cli.services.Update;
 import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import jakarta.inject.Inject;
-import org.jboss.logging.Logger;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
-import picocli.CommandLine.ParentCommand;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import org.jboss.logging.Logger;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 

--- a/cli/src/main/java/io/apicurio/registry/cli/VersionCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/VersionCommand.java
@@ -9,14 +9,13 @@ import io.apicurio.registry.cli.utils.TableBuilder;
 import io.apicurio.registry.rest.client.RegistryClient;
 import io.apicurio.registry.rest.client.models.ArtifactTypeInfo;
 import io.apicurio.registry.rest.client.models.ProblemDetails;
+import java.util.Date;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
-
-import java.util.Date;
-import java.util.List;
 
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPES;
 import static io.apicurio.registry.cli.utils.Columns.CLI_VERSION;
@@ -53,8 +52,10 @@ public class VersionCommand extends AbstractCommand {
 
         try {
             final var registryClient = client.getRegistryClient();
-            fetchSystemInfo(registryClient, builder, output);
-            fetchArtifactTypes(registryClient, builder, output);
+            fetchSystemInfo(registryClient, builder);
+            fetchArtifactTypes(registryClient, builder);
+        } catch (ProblemDetails ex) {
+            handleProblemDetails(output, ex);
         } catch (Exception ex) {
             output.writeStdErrChunk(err ->
                     err.append("Could not connect to server: ").append(ex.getMessage()).append('\n'));
@@ -64,29 +65,19 @@ public class VersionCommand extends AbstractCommand {
     }
 
     // Fetches server name, version, and build timestamp from /system/info.
-    private void fetchSystemInfo(final RegistryClient client, final VersionOutput.VersionOutputBuilder builder, final OutputBuffer output) {
-        try {
-            final var systemInfo = client.system().info().get();
-            builder.serverName(systemInfo.getName());
-            builder.serverVersion(systemInfo.getVersion());
-            builder.serverBuiltOn(systemInfo.getBuiltOn() != null ? convert(systemInfo.getBuiltOn()) : null);
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err ->
-                    err.append("Error retrieving system info: ").append(ex.getDetail()).append('\n'));
-        }
+    private void fetchSystemInfo(final RegistryClient client, final VersionOutput.VersionOutputBuilder builder) {
+        final var systemInfo = client.system().info().get();
+        builder.serverName(systemInfo.getName());
+        builder.serverVersion(systemInfo.getVersion());
+        builder.serverBuiltOn(systemInfo.getBuiltOn() != null ? convert(systemInfo.getBuiltOn()) : null);
     }
 
     // Fetches supported artifact types from /admin/config/artifactTypes.
-    private void fetchArtifactTypes(final RegistryClient client, final VersionOutput.VersionOutputBuilder builder, final OutputBuffer output) {
-        try {
-            final var artifactTypes = client.admin().config().artifactTypes().get();
-            builder.artifactTypes(artifactTypes != null ? artifactTypes.stream()
-                    .map(ArtifactTypeInfo::getName)
-                    .toList() : null);
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err ->
-                    err.append("Error retrieving artifact types: ").append(ex.getDetail()).append('\n'));
-        }
+    private void fetchArtifactTypes(final RegistryClient client, final VersionOutput.VersionOutputBuilder builder) {
+        final var artifactTypes = client.admin().config().artifactTypes().get();
+        builder.artifactTypes(artifactTypes != null ? artifactTypes.stream()
+                .map(ArtifactTypeInfo::getName)
+                .toList() : null);
     }
 
     private static void printVersion(final OutputBuffer output, final VersionOutput versionOutput, final OutputTypeMixin outputType) throws JsonProcessingException {

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCommand.java
@@ -1,24 +1,21 @@
 package io.apicurio.registry.cli.artifact;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.Acr;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.ArtifactOrderMixin;
 import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.common.PaginationMixin;
-import io.apicurio.registry.cli.version.VersionCommand;
 import io.apicurio.registry.cli.utils.Mapper;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.cli.version.VersionCommand;
 import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPE;
 import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
@@ -71,68 +68,57 @@ public class ArtifactCommand extends AbstractCommand {
     private Acr parent;
 
     @Override
-    public void run(final OutputBuffer output) throws JsonProcessingException {
+    public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            //noinspection ConstantConditions
-            final var artifacts = convert(registryClient
-                    .groups().byGroupId(resolvedGroupId).artifacts().get(r -> {
-                        //noinspection ConstantConditions
-                        r.queryParameters.offset = (pagination.getPage() - 1) * pagination.getSize();
-                        r.queryParameters.limit = pagination.getSize();
-                        r.queryParameters.orderby = ordering.getOrderBy();
-                        r.queryParameters.order = ordering.getOrder();
-                    }));
-            output.writeStdOutChunkWithException(out -> {
-                switch (outputType.getOutputType()) {
-                    case json -> {
-                        out.append(Mapper.MAPPER.writeValueAsString(artifacts));
-                        out.append('\n');
-                    }
-                    case table -> {
-                        final var table = new TableBuilder();
-                        table.addColumns(
-                                GROUP_ID,
-                                ARTIFACT_ID,
-                                NAME,
-                                ARTIFACT_TYPE,
-                                DESCRIPTION,
-                                CREATED_ON,
-                                OWNER,
-                                MODIFIED_ON,
-                                MODIFIED_BY,
-                                LABELS
-                        );
-                        artifacts.getArtifacts().forEach(a -> {
-                            table.addRow(
-                                    a.getGroupId(),
-                                    a.getArtifactId(),
-                                    a.getName(),
-                                    a.getArtifactType(),
-                                    a.getDescription(),
-                                    convertToString(a.getCreatedOn()),
-                                    a.getOwner(),
-                                    convertToString(a.getModifiedOn()),
-                                    a.getModifiedBy(),
-                                    convertToString(a.getLabels())
-                            );
-                        });
-                        table.setPagination(pagination.getPage(), pagination.getSize(), artifacts.getCount());
-                        table.print(out);
-                    }
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        //noinspection ConstantConditions
+        final var artifacts = convert(registryClient
+                .groups().byGroupId(resolvedGroupId).artifacts().get(r -> {
+                    //noinspection ConstantConditions
+                    r.queryParameters.offset = (pagination.getPage() - 1) * pagination.getSize();
+                    r.queryParameters.limit = pagination.getSize();
+                    r.queryParameters.orderby = ordering.getOrderBy();
+                    r.queryParameters.order = ordering.getOrder();
+                }));
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(Mapper.MAPPER.writeValueAsString(artifacts));
+                    out.append('\n');
                 }
-            });
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error listing artifacts in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(
+                            GROUP_ID,
+                            ARTIFACT_ID,
+                            NAME,
+                            ARTIFACT_TYPE,
+                            DESCRIPTION,
+                            CREATED_ON,
+                            OWNER,
+                            MODIFIED_ON,
+                            MODIFIED_BY,
+                            LABELS
+                    );
+                    artifacts.getArtifacts().forEach(a -> {
+                        table.addRow(
+                                a.getGroupId(),
+                                a.getArtifactId(),
+                                a.getName(),
+                                a.getArtifactType(),
+                                a.getDescription(),
+                                convertToString(a.getCreatedOn()),
+                                a.getOwner(),
+                                convertToString(a.getModifiedOn()),
+                                a.getModifiedBy(),
+                                convertToString(a.getLabels())
+                        );
+                    });
+                    table.setPagination(pagination.getPage(), pagination.getSize(), artifacts.getCount());
+                    table.print(out);
+                }
+            }
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
@@ -9,18 +9,15 @@ import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.Labels;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.models.VersionContent;
+import java.util.HashMap;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import java.util.HashMap;
-import java.util.List;
-
 import static io.apicurio.registry.cli.artifact.ArtifactGetCommand.printArtifact;
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Conversions.convert;
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
 
@@ -128,28 +125,15 @@ public class ArtifactCreateCommand extends AbstractCommand {
             newArtifact.setFirstVersion(firstVersion);
         }
 
-        try {
-            final var result = client.getRegistryClient()
-                    .groups().byGroupId(resolvedGroupId).artifacts().post(newArtifact);
-            //noinspection ConstantConditions
-            final var artifact = convert(result.getArtifact());
-            switch (outputType.getOutputType()) {
-                case json -> output.writeStdErrChunk(out -> successMessage(out, resolvedGroupId, artifact.getArtifactId()));
-                case table -> output.writeStdOutChunk(out -> successMessage(out, resolvedGroupId, artifact.getArtifactId()));
-            }
-            printArtifact(output, artifact, outputType.getOutputType());
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error creating artifact '")
-                        .append(artifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+        final var result = client.getRegistryClient()
+                .groups().byGroupId(resolvedGroupId).artifacts().post(newArtifact);
+        //noinspection ConstantConditions
+        final var artifact = convert(result.getArtifact());
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, resolvedGroupId, artifact.getArtifactId()));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, resolvedGroupId, artifact.getArtifactId()));
         }
+        printArtifact(output, artifact, outputType.getOutputType());
     }
 
     private static void successMessage(final StringBuilder out, final String groupId, final String artifactId) {

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactDeleteCommand.java
@@ -1,14 +1,11 @@
 package io.apicurio.registry.cli.artifact;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 
 /** Deletes an existing artifact from a group. */
 @Command(
@@ -34,25 +31,12 @@ public class ArtifactDeleteCommand extends AbstractCommand {
     @Override
     public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            registryClient.groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId).delete();
-            output.writeStdOutChunk(out -> {
-                out.append("Artifact '").append(artifactId).append("' in group '")
-                        .append(resolvedGroupId).append("' deleted successfully.\n");
-            });
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error deleting artifact '")
-                        .append(artifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        registryClient.groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId).delete();
+        output.writeStdOutChunk(out -> {
+            out.append("Artifact '").append(artifactId).append("' in group '")
+                    .append(resolvedGroupId).append("' deleted successfully.\n");
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactGetCommand.java
@@ -1,25 +1,22 @@
 package io.apicurio.registry.cli.artifact;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputType;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
 import io.apicurio.registry.rest.client.RegistryClient;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.v3.beans.ArtifactMetaData;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
 import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPE;
 import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
@@ -75,25 +72,12 @@ public class ArtifactGetCommand extends AbstractCommand {
     @Override
     public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            if (outputOptions != null && outputOptions.content) {
-                fetchContent(registryClient, resolvedGroupId, output);
-            } else {
-                fetchMetadata(registryClient, resolvedGroupId, output);
-            }
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error retrieving artifact '")
-                        .append(artifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        if (outputOptions != null && outputOptions.content) {
+            fetchContent(registryClient, resolvedGroupId, output);
+        } else {
+            fetchMetadata(registryClient, resolvedGroupId, output);
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactRuleCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactRuleCommand.java
@@ -1,16 +1,13 @@
 package io.apicurio.registry.cli.artifact;
 
-import io.apicurio.registry.cli.common.IdUtil;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRuleTypes;
 
 @Command(
@@ -42,26 +39,13 @@ public class ArtifactRuleCommand extends AbstractCommand {
     private OutputTypeMixin outputType;
 
     @Override
-    public void run(final OutputBuffer output) throws JsonProcessingException {
+    public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            final var ruleTypes = registryClient.groups().byGroupId(resolvedGroupId)
-                    .artifacts().byArtifactId(resolvedArtifactId).rules().get();
-            printRuleTypes(ruleTypes, output, outputType);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error listing rules for artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        final var ruleTypes = registryClient.groups().byGroupId(resolvedGroupId)
+                .artifacts().byArtifactId(resolvedArtifactId).rules().get();
+        printRuleTypes(ruleTypes, output, outputType);
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactRuleCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactRuleCreateCommand.java
@@ -1,7 +1,7 @@
 package io.apicurio.registry.cli.artifact;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.CreateRule;
@@ -12,7 +12,6 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRule;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleConfig;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
@@ -63,43 +62,24 @@ public class ArtifactRuleCreateCommand extends AbstractCommand {
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
         validateRuleType(ruleType);
         validateRuleConfig(ruleType, ruleConfig);
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        final var newRule = new CreateRule();
+        newRule.setRuleType(RuleType.forValue(ruleType));
+        newRule.setConfig(ruleConfig);
+        registryClient.groups().byGroupId(resolvedGroupId)
+                .artifacts().byArtifactId(resolvedArtifactId).rules().post(newRule);
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType, resolvedArtifactId, resolvedGroupId));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType, resolvedArtifactId, resolvedGroupId));
+        }
         try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            final var newRule = new CreateRule();
-            newRule.setRuleType(RuleType.forValue(ruleType));
-            newRule.setConfig(ruleConfig);
-            registryClient.groups().byGroupId(resolvedGroupId)
-                    .artifacts().byArtifactId(resolvedArtifactId).rules().post(newRule);
-            switch (outputType.getOutputType()) {
-                case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType, resolvedArtifactId, resolvedGroupId));
-                case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType, resolvedArtifactId, resolvedGroupId));
-            }
-            try {
-                //noinspection ConstantConditions
-                final var rule = convert(registryClient.groups().byGroupId(resolvedGroupId)
-                        .artifacts().byArtifactId(resolvedArtifactId).rules().byRuleType(ruleType).get());
-                printRule(output, rule, outputType);
-            } catch (final ProblemDetails ex) {
-                output.writeStdErrChunk(err -> {
-                    err.append("Warning: Artifact rule was created but failed to retrieve details: ")
-                            .append(ex.getDetail())
-                            .append('\n');
-                });
-            }
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error creating rule '")
-                        .append(ruleType)
-                        .append("' for artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+            //noinspection ConstantConditions
+            final var rule = convert(registryClient.groups().byGroupId(resolvedGroupId)
+                    .artifacts().byArtifactId(resolvedArtifactId).rules().byRuleType(ruleType).get());
+            printRule(output, rule, outputType);
+        } catch (ProblemDetails ex) {
+            handleProblemDetails(output, ex);
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactRuleDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactRuleDeleteCommand.java
@@ -1,16 +1,14 @@
 package io.apicurio.registry.cli.artifact;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
 
 @Command(
@@ -65,39 +63,24 @@ public class ArtifactRuleDeleteCommand extends AbstractCommand {
         if (!all) {
             validateRuleType(ruleType);
         }
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            if (all) {
-                registryClient.groups().byGroupId(resolvedGroupId)
-                        .artifacts().byArtifactId(resolvedArtifactId).rules().delete();
-                output.writeStdOutChunk(out -> {
-                    out.append("All rules deleted successfully for artifact '")
-                            .append(resolvedArtifactId).append("' in group '")
-                            .append(resolvedGroupId).append("'.\n");
-                });
-            } else {
-                registryClient.groups().byGroupId(resolvedGroupId)
-                        .artifacts().byArtifactId(resolvedArtifactId).rules().byRuleType(ruleType).delete();
-                output.writeStdOutChunk(out -> {
-                    out.append("Rule '").append(ruleType).append("' deleted successfully for artifact '")
-                            .append(resolvedArtifactId).append("' in group '")
-                            .append(resolvedGroupId).append("'.\n");
-                });
-            }
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error deleting rule")
-                        .append(ruleType != null ? " '" + ruleType + "'" : "s")
-                        .append(" for artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        if (all) {
+            registryClient.groups().byGroupId(resolvedGroupId)
+                    .artifacts().byArtifactId(resolvedArtifactId).rules().delete();
+            output.writeStdOutChunk(out -> {
+                out.append("All rules deleted successfully for artifact '")
+                        .append(resolvedArtifactId).append("' in group '")
+                        .append(resolvedGroupId).append("'.\n");
             });
-            exitQuietServerError();
+        } else {
+            registryClient.groups().byGroupId(resolvedGroupId)
+                    .artifacts().byArtifactId(resolvedArtifactId).rules().byRuleType(ruleType).delete();
+            output.writeStdOutChunk(out -> {
+                out.append("Rule '").append(ruleType).append("' deleted successfully for artifact '")
+                        .append(resolvedArtifactId).append("' in group '")
+                        .append(resolvedGroupId).append("'.\n");
+            });
         }
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactRuleGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactRuleGetCommand.java
@@ -1,17 +1,14 @@
 package io.apicurio.registry.cli.artifact;
 
-import io.apicurio.registry.cli.common.IdUtil;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRule;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
 import static io.apicurio.registry.cli.utils.Conversions.convert;
@@ -44,30 +41,15 @@ public class ArtifactRuleGetCommand extends AbstractCommand {
     private OutputTypeMixin outputType;
 
     @Override
-    public void run(final OutputBuffer output) throws JsonProcessingException {
+    public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
         validateRuleType(ruleType);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            //noinspection ConstantConditions
-            final var rule = convert(registryClient.groups().byGroupId(resolvedGroupId)
-                    .artifacts().byArtifactId(resolvedArtifactId).rules().byRuleType(ruleType).get());
-            printRule(output, rule, outputType);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error retrieving rule '")
-                        .append(ruleType)
-                        .append("' for artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        //noinspection ConstantConditions
+        final var rule = convert(registryClient.groups().byGroupId(resolvedGroupId)
+                .artifacts().byArtifactId(resolvedArtifactId).rules().byRuleType(ruleType).get());
+        printRule(output, rule, outputType);
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactRuleUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactRuleUpdateCommand.java
@@ -1,16 +1,14 @@
 package io.apicurio.registry.cli.artifact;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRule;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleConfig;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
@@ -60,33 +58,18 @@ public class ArtifactRuleUpdateCommand extends AbstractCommand {
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
         validateRuleType(ruleType);
         validateRuleConfig(ruleType, ruleConfig);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            final var rule = new io.apicurio.registry.rest.client.models.Rule();
-            rule.setConfig(ruleConfig);
-            //noinspection ConstantConditions
-            final var updatedRule = convert(registryClient.groups().byGroupId(resolvedGroupId)
-                    .artifacts().byArtifactId(resolvedArtifactId).rules().byRuleType(ruleType).put(rule));
-            switch (outputType.getOutputType()) {
-                case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType, resolvedArtifactId, resolvedGroupId));
-                case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType, resolvedArtifactId, resolvedGroupId));
-            }
-            printRule(output, updatedRule, outputType);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error updating rule '")
-                        .append(ruleType)
-                        .append("' for artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        final var rule = new io.apicurio.registry.rest.client.models.Rule();
+        rule.setConfig(ruleConfig);
+        //noinspection ConstantConditions
+        final var updatedRule = convert(registryClient.groups().byGroupId(resolvedGroupId)
+                .artifacts().byArtifactId(resolvedArtifactId).rules().byRuleType(ruleType).put(rule));
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType, resolvedArtifactId, resolvedGroupId));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType, resolvedArtifactId, resolvedGroupId));
         }
+        printRule(output, updatedRule, outputType);
     }
 
     private static void successMessage(final StringBuilder out, final String ruleType,

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactUpdateCommand.java
@@ -1,21 +1,16 @@
 package io.apicurio.registry.cli.artifact;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.EditableArtifactMetaData;
 import io.apicurio.registry.rest.client.models.Labels;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
-
-import java.util.List;
-
-import io.apicurio.registry.cli.common.CliException;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 
 /**
  * Updates an existing artifact's metadata (name, description, labels).
@@ -70,51 +65,38 @@ public class ArtifactUpdateCommand extends AbstractCommand {
                     CliException.VALIDATION_ERROR_RETURN_CODE);
         }
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            final var existing = registryClient
-                    .groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId).get();
-            final var updatedArtifact = new EditableArtifactMetaData();
-            //noinspection ConstantConditions
-            updatedArtifact.setName(existing.getName());
-            updatedArtifact.setDescription(existing.getDescription());
-            updatedArtifact.setLabels(existing.getLabels());
-            if (name != null) {
-                updatedArtifact.setName(name);
-            }
-            if (description != null) {
-                updatedArtifact.setDescription(description);
-            }
-            if (setLabels != null) {
-                if (updatedArtifact.getLabels() == null) {
-                    updatedArtifact.setLabels(new Labels());
-                }
-                updatedArtifact.getLabels().getAdditionalData().putAll(Conversions.parseLabels(setLabels));
-            }
-            if (deleteLabels != null) {
-                if (updatedArtifact.getLabels() != null) {
-                    deleteLabels.forEach(key -> {
-                        updatedArtifact.getLabels().getAdditionalData().remove(key);
-                    });
-                }
-            }
-            registryClient.groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId).put(updatedArtifact);
-            output.writeStdOutChunk(out -> {
-                out.append("Artifact '").append(artifactId).append("' in group '")
-                        .append(resolvedGroupId).append("' updated successfully.\n");
-            });
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error updating artifact '")
-                        .append(artifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        final var existing = registryClient
+                .groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId).get();
+        final var updatedArtifact = new EditableArtifactMetaData();
+        //noinspection ConstantConditions
+        updatedArtifact.setName(existing.getName());
+        updatedArtifact.setDescription(existing.getDescription());
+        updatedArtifact.setLabels(existing.getLabels());
+        if (name != null) {
+            updatedArtifact.setName(name);
         }
+        if (description != null) {
+            updatedArtifact.setDescription(description);
+        }
+        if (setLabels != null) {
+            if (updatedArtifact.getLabels() == null) {
+                updatedArtifact.setLabels(new Labels());
+            }
+            updatedArtifact.getLabels().getAdditionalData().putAll(Conversions.parseLabels(setLabels));
+        }
+        if (deleteLabels != null) {
+            if (updatedArtifact.getLabels() != null) {
+                deleteLabels.forEach(key -> {
+                    updatedArtifact.getLabels().getAdditionalData().remove(key);
+                });
+            }
+        }
+        registryClient.groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId).put(updatedArtifact);
+        output.writeStdOutChunk(out -> {
+            out.append("Artifact '").append(artifactId).append("' in group '")
+                    .append(resolvedGroupId).append("' updated successfully.\n");
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -5,21 +5,26 @@ import io.apicurio.registry.cli.config.Config;
 import io.apicurio.registry.cli.services.Client;
 import io.apicurio.registry.cli.services.UpdateNotifier;
 import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.client.models.RuleViolationProblemDetails;
 import jakarta.inject.Inject;
+import java.util.Optional;
+import java.util.concurrent.Callable;
 import org.jboss.logging.Logger;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
-import java.util.concurrent.Callable;
-
 import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
 import static io.apicurio.registry.cli.common.CliException.OK_RETURN_CODE;
+import static io.apicurio.registry.cli.common.CliException.SERVER_ERROR_RETURN_CODE;
 
 @Command
 public abstract class AbstractCommand implements Callable<Integer> {
 
     private static final Logger log = Logger.getLogger(AbstractCommand.class);
+
+    private static final String ERROR_PREFIX = "Error: ";
 
     @Spec
     protected CommandSpec spec;
@@ -42,18 +47,14 @@ public abstract class AbstractCommand implements Callable<Integer> {
             run(output);
             return OK_RETURN_CODE;
         } catch (CliException ex) {
-            if (!ex.isQuiet()) {
-                if (log.isDebugEnabled()) {
-                    log.error("Error", ex); // Force printing of stack trace.
-                } else {
-                    output.writeStdErrChunk(out -> {
-                        out.append("Error: ")
-                                .append(ex.getMessage())
-                                .append("\n");
-                    });
-                }
-            }
+            handleCliException(output, ex);
             return ex.getCode();
+        } catch (RuleViolationProblemDetails ex) {
+            handleRuleViolation(output, ex);
+            return SERVER_ERROR_RETURN_CODE;
+        } catch (ProblemDetails ex) {
+            handleProblemDetails(output, ex);
+            return SERVER_ERROR_RETURN_CODE;
         } catch (Exception ex) {
             log.error("Unexpected error", ex);
             output.writeStdErrChunk(out -> out.append("Unexpected error: ").append(ex.getMessage()).append("\n"));
@@ -61,10 +62,31 @@ public abstract class AbstractCommand implements Callable<Integer> {
         } finally {
             output.print();
         }
-        // TODO: Move handling of `ProblemDetails` exceptions here.
     }
 
     public abstract void run(OutputBuffer output) throws Exception;
+
+    private static void handleCliException(final OutputBuffer output, final CliException ex) {
+        if (!ex.isQuiet()) {
+            output.writeStdErrChunk(out -> out.append(ERROR_PREFIX).append(ex.getMessage()).append("\n"));
+        }
+    }
+
+    private static void handleRuleViolation(final OutputBuffer output, final RuleViolationProblemDetails ex) {
+        output.writeStdErrChunk(err -> {
+            err.append(ERROR_PREFIX).append(Optional.ofNullable(ex.getDetail()).orElse(ex.getMessage())).append('\n');
+            Optional.ofNullable(ex.getCauses()).ifPresent(causes ->
+                    causes.forEach(cause ->
+                            err.append("  -> ").append(Optional.ofNullable(cause.getContext()).orElse(""))
+                                    .append(": ").append(Optional.ofNullable(cause.getDescription()).orElse("")).append('\n')));
+        });
+    }
+
+    protected static void handleProblemDetails(final OutputBuffer output, final ProblemDetails ex) {
+        output.writeStdErrChunk(err -> {
+            err.append(ERROR_PREFIX).append(Optional.ofNullable(ex.getDetail()).orElse(ex.getMessage())).append('\n');
+        });
+    }
 
     private String getTopLevelCommandName() {
         var current = spec;

--- a/cli/src/main/java/io/apicurio/registry/cli/common/PositiveIntegerValidator.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/PositiveIntegerValidator.java
@@ -1,11 +1,10 @@
 package io.apicurio.registry.cli.common;
 
+import java.util.Stack;
 import picocli.CommandLine.IParameterConsumer;
 import picocli.CommandLine.Model.ArgSpec;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.ParameterException;
-
-import java.util.Stack;
 
 public class PositiveIntegerValidator implements IParameterConsumer {
 

--- a/cli/src/main/java/io/apicurio/registry/cli/config/AcrHomeConfigSource.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/AcrHomeConfigSource.java
@@ -1,11 +1,10 @@
 package io.apicurio.registry.cli.config;
 
 import io.apicurio.registry.cli.common.CliException;
-import org.eclipse.microprofile.config.spi.ConfigSource;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import org.eclipse.microprofile.config.spi.ConfigSource;
 
 /**
  * Custom ConfigSource that loads properties from "$ACR_HOME/config.json".

--- a/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
@@ -7,14 +7,13 @@ import io.apicurio.registry.cli.utils.Output;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
-import lombok.Getter;
-import lombok.Setter;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
 import static io.apicurio.registry.cli.utils.Mapper.copy;

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
@@ -2,14 +2,13 @@ package io.apicurio.registry.cli.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @SuperBuilder
 @NoArgsConstructor

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyDeleteCommand.java
@@ -3,10 +3,9 @@ package io.apicurio.registry.cli.config;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.utils.OutputBuffer;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
-
-import java.util.List;
 
 import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
 

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertySetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertySetCommand.java
@@ -3,10 +3,9 @@ package io.apicurio.registry.cli.config;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.utils.OutputBuffer;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
-
-import java.util.List;
 
 import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
 

--- a/cli/src/main/java/io/apicurio/registry/cli/context/ContextCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/context/ContextCommand.java
@@ -3,9 +3,8 @@ package io.apicurio.registry.cli.context;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
-import picocli.CommandLine.Command;
-
 import java.util.Objects;
+import picocli.CommandLine.Command;
 
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
 import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;

--- a/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleCommand.java
@@ -1,17 +1,14 @@
 package io.apicurio.registry.cli.globalrule;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.Acr;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.ParentCommand;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRuleTypes;
 
 @Command(
@@ -35,17 +32,8 @@ public class GlobalRuleCommand extends AbstractCommand {
     private Acr parent;
 
     @Override
-    public void run(final OutputBuffer output) throws JsonProcessingException {
-        try {
-            final var ruleTypes = client.getRegistryClient().admin().rules().get();
-            printRuleTypes(ruleTypes, output, outputType);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error listing global rules: ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+    public void run(final OutputBuffer output) throws Exception {
+        final var ruleTypes = client.getRegistryClient().admin().rules().get();
+        printRuleTypes(ruleTypes, output, outputType);
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleCreateCommand.java
@@ -11,7 +11,6 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRule;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleConfig;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
@@ -48,35 +47,20 @@ public class GlobalRuleCreateCommand extends AbstractCommand {
     public void run(final OutputBuffer output) throws Exception {
         validateRuleType(ruleType);
         validateRuleConfig(ruleType, ruleConfig);
+        final var newRule = new CreateRule();
+        newRule.setRuleType(RuleType.forValue(ruleType));
+        newRule.setConfig(ruleConfig);
+        client.getRegistryClient().admin().rules().post(newRule);
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType));
+        }
         try {
-            final var newRule = new CreateRule();
-            newRule.setRuleType(RuleType.forValue(ruleType));
-            newRule.setConfig(ruleConfig);
-            client.getRegistryClient().admin().rules().post(newRule);
-            switch (outputType.getOutputType()) {
-                case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType));
-                case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType));
-            }
-            try {
-                //noinspection ConstantConditions
-                final var rule = convert(client.getRegistryClient().admin().rules().byRuleType(ruleType).get());
-                printRule(output, rule, outputType);
-            } catch (final ProblemDetails ex) {
-                output.writeStdErrChunk(err -> {
-                    err.append("Warning: Global rule was created but failed to retrieve details: ")
-                            .append(ex.getDetail())
-                            .append('\n');
-                });
-            }
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error creating global rule '")
-                        .append(ruleType)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+            //noinspection ConstantConditions
+            final var rule = convert(client.getRegistryClient().admin().rules().byRuleType(ruleType).get());
+            printRule(output, rule, outputType);
+        } catch (ProblemDetails ex) {
+            handleProblemDetails(output, ex);
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleDeleteCommand.java
@@ -3,13 +3,11 @@ package io.apicurio.registry.cli.globalrule;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
 
 @Command(
@@ -56,36 +54,16 @@ public class GlobalRuleDeleteCommand extends AbstractCommand {
     }
 
     private void deleteAllRules(final OutputBuffer output) {
-        try {
-            client.getRegistryClient().admin().rules().delete();
-            output.writeStdOutChunk(out -> {
-                out.append("All global rules deleted successfully.\n");
-            });
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error deleting all global rules: ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+        client.getRegistryClient().admin().rules().delete();
+        output.writeStdOutChunk(out -> {
+            out.append("All global rules deleted successfully.\n");
+        });
     }
 
     private void deleteSingleRule(final OutputBuffer output) {
-        try {
-            client.getRegistryClient().admin().rules().byRuleType(ruleType).delete();
-            output.writeStdOutChunk(out -> {
-                out.append("Global rule '").append(ruleType).append("' deleted successfully.\n");
-            });
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error deleting global rule '")
-                        .append(ruleType)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+        client.getRegistryClient().admin().rules().byRuleType(ruleType).delete();
+        output.writeStdOutChunk(out -> {
+            out.append("Global rule '").append(ruleType).append("' deleted successfully.\n");
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleGetCommand.java
@@ -1,15 +1,12 @@
 package io.apicurio.registry.cli.globalrule;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Parameters;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRule;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
 import static io.apicurio.registry.cli.utils.Conversions.convert;
@@ -30,21 +27,10 @@ public class GlobalRuleGetCommand extends AbstractCommand {
     private OutputTypeMixin outputType;
 
     @Override
-    public void run(final OutputBuffer output) throws JsonProcessingException {
+    public void run(final OutputBuffer output) throws Exception {
         validateRuleType(ruleType);
-        try {
-            //noinspection ConstantConditions
-            final var rule = convert(client.getRegistryClient().admin().rules().byRuleType(ruleType).get());
-            printRule(output, rule, outputType);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error retrieving global rule '")
-                        .append(ruleType)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+        //noinspection ConstantConditions
+        final var rule = convert(client.getRegistryClient().admin().rules().byRuleType(ruleType).get());
+        printRule(output, rule, outputType);
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/globalrule/GlobalRuleUpdateCommand.java
@@ -3,13 +3,11 @@ package io.apicurio.registry.cli.globalrule;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRule;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleConfig;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
@@ -45,26 +43,15 @@ public class GlobalRuleUpdateCommand extends AbstractCommand {
     public void run(final OutputBuffer output) throws Exception {
         validateRuleType(ruleType);
         validateRuleConfig(ruleType, ruleConfig);
-        try {
-            final var rule = new io.apicurio.registry.rest.client.models.Rule();
-            rule.setConfig(ruleConfig);
-            //noinspection ConstantConditions
-            final var updatedRule = convert(client.getRegistryClient().admin().rules().byRuleType(ruleType).put(rule));
-            switch (outputType.getOutputType()) {
-                case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType));
-                case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType));
-            }
-            printRule(output, updatedRule, outputType);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error updating global rule '")
-                        .append(ruleType)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+        final var rule = new io.apicurio.registry.rest.client.models.Rule();
+        rule.setConfig(ruleConfig);
+        //noinspection ConstantConditions
+        final var updatedRule = convert(client.getRegistryClient().admin().rules().byRuleType(ruleType).put(rule));
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType));
         }
+        printRule(output, updatedRule, outputType);
     }
 
     private static void successMessage(final StringBuilder out, final String ruleType) {

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupCreateCommand.java
@@ -6,16 +6,13 @@ import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.CreateGroup;
 import io.apicurio.registry.rest.client.models.Labels;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
+import java.util.HashMap;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Parameters;
 
-import java.util.HashMap;
-import java.util.List;
-
 import static io.apicurio.registry.cli.group.GroupGetCommand.printGroup;
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Conversions.convert;
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
 import static picocli.CommandLine.Option;
@@ -60,23 +57,12 @@ public class GroupCreateCommand extends AbstractCommand {
             newLabels.setAdditionalData(new HashMap<>(Conversions.parseLabels(labels)));
             newGroup.setLabels(newLabels);
         }
-        try {
-            var group = convert(client.getRegistryClient().groups().post(newGroup));
-            switch (outputType.getOutputType()) {
-                case json -> output.writeStdErrChunk(out -> successMessage(out, group.getGroupId()));
-                case table -> output.writeStdOutChunk(out -> successMessage(out, group.getGroupId()));
-            }
-            printGroup(output, group, outputType);
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error creating a new group '")
-                        .append(groupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+        var group = convert(client.getRegistryClient().groups().post(newGroup));
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, group.getGroupId()));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, group.getGroupId()));
         }
+        printGroup(output, group, outputType);
     }
 
     private static void successMessage(StringBuilder out, String groupId) {

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupDeleteCommand.java
@@ -4,7 +4,6 @@ import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.ArtifactSortBy;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.models.SortOrder;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -12,7 +11,6 @@ import picocli.CommandLine.Parameters;
 
 import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
 import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static java.util.Optional.ofNullable;
 
 @Command(
@@ -37,52 +35,41 @@ public class GroupDeleteCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
-        try {
-            // Check if the group exists
-            client.getRegistryClient().groups().byGroupId(groupId).get();
+        // Check if the group exists
+        client.getRegistryClient().groups().byGroupId(groupId).get();
 
-            // Check if the group has artifacts
-            var artifacts = client.getRegistryClient().groups().byGroupId(groupId).artifacts().get(r -> {
-                //noinspection ConstantConditions
-                r.queryParameters.offset = 0;
-                r.queryParameters.limit = 1;
-                r.queryParameters.orderby = ArtifactSortBy.ArtifactId;
-                r.queryParameters.order = SortOrder.Asc;
-            });
+        // Check if the group has artifacts
+        var artifacts = client.getRegistryClient().groups().byGroupId(groupId).artifacts().get(r -> {
             //noinspection ConstantConditions
-            var artifactCount = ofNullable(artifacts.getCount()).orElseThrow(
-                    () -> new CliException(
-                            "Invalid response from server. Unable to determine artifact count for group '" + groupId + "'.",
-                            APPLICATION_ERROR_RETURN_CODE
-                    )
+            r.queryParameters.offset = 0;
+            r.queryParameters.limit = 1;
+            r.queryParameters.orderby = ArtifactSortBy.ArtifactId;
+            r.queryParameters.order = SortOrder.Asc;
+        });
+        //noinspection ConstantConditions
+        var artifactCount = ofNullable(artifacts.getCount()).orElseThrow(
+                () -> new CliException(
+                        "Invalid response from server. Unable to determine artifact count for group '" + groupId + "'.",
+                        APPLICATION_ERROR_RETURN_CODE
+                )
+        );
+        if (artifactCount > 0 && !force) {
+            throw new CliException(
+                    "Group '" + groupId + "' is not empty (contains " + artifactCount + " artifact(s)). " +
+                            "Use --force to delete the group and all its artifacts.",
+                    VALIDATION_ERROR_RETURN_CODE
             );
-            if (artifactCount > 0 && !force) {
-                throw new CliException(
-                        "Group '" + groupId + "' is not empty (contains " + artifactCount + " artifact(s)). " +
-                                "Use --force to delete the group and all its artifacts.",
-                        VALIDATION_ERROR_RETURN_CODE
-                );
-            }
-
-            // Delete the group
-            client.getRegistryClient().groups().byGroupId(groupId).delete();
-
-            output.writeStdOutChunk(out -> {
-                out.append("Group '").append(groupId).append("' deleted successfully");
-                if (artifactCount > 0) {
-                    out.append(" (including ").append(artifactCount).append(" artifact(s))");
-                }
-                out.append(".\n");
-            });
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err ->
-                    err.append("Error deleting group '")
-                            .append(groupId)
-                            .append("': ")
-                            .append(ex.getDetail())
-                            .append('\n')
-            );
-            exitQuietServerError();
         }
+
+        // Delete the group
+        client.getRegistryClient().groups().byGroupId(groupId).delete();
+
+        output.writeStdOutChunk(out -> {
+            out.append("Group '").append(groupId).append("' deleted successfully");
+            if (artifactCount > 0) {
+                out.append(" (including ").append(artifactCount).append(" artifact(s))");
+            }
+            out.append(".\n");
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupGetCommand.java
@@ -5,7 +5,6 @@ import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.v3.beans.GroupMetaData;
 import lombok.Getter;
 import picocli.CommandLine.Command;
@@ -13,7 +12,6 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParentCommand;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
 import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
 import static io.apicurio.registry.cli.utils.Columns.FIELD;
@@ -46,22 +44,11 @@ public class GroupGetCommand extends AbstractCommand {
     private GroupCommand parent;
 
     @Override
-    public void run(OutputBuffer output) throws JsonProcessingException {
-        try {
-            //noinspection ConstantConditions
-            var group = convert(client.getRegistryClient().groups().byGroupId(groupId).get());
-            // TODO: Should we include the `default` group in the list?
-            printGroup(output, group, outputType);
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error retrieving group '")
-                        .append(groupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+    public void run(OutputBuffer output) throws Exception {
+        //noinspection ConstantConditions
+        var group = convert(client.getRegistryClient().groups().byGroupId(groupId).get());
+        // TODO: Should we include the `default` group in the list?
+        printGroup(output, group, outputType);
     }
 
     static void printGroup(OutputBuffer output, GroupMetaData group, OutputTypeMixin outputType) throws JsonProcessingException {

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupRuleCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupRuleCommand.java
@@ -1,16 +1,13 @@
 package io.apicurio.registry.cli.group;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRuleTypes;
 import static io.apicurio.registry.cli.common.RuleUtil.rejectDefaultGroup;
 
@@ -37,21 +34,10 @@ public class GroupRuleCommand extends AbstractCommand {
     private OutputTypeMixin outputType;
 
     @Override
-    public void run(final OutputBuffer output) throws JsonProcessingException {
+    public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         rejectDefaultGroup(resolvedGroupId);
-        try {
-            final var ruleTypes = client.getRegistryClient().groups().byGroupId(resolvedGroupId).rules().get();
-            printRuleTypes(ruleTypes, output, outputType);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error listing rules for group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+        final var ruleTypes = client.getRegistryClient().groups().byGroupId(resolvedGroupId).rules().get();
+        printRuleTypes(ruleTypes, output, outputType);
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupRuleCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupRuleCreateCommand.java
@@ -1,7 +1,7 @@
 package io.apicurio.registry.cli.group;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.CreateRule;
@@ -12,7 +12,6 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRule;
 import static io.apicurio.registry.cli.common.RuleUtil.rejectDefaultGroup;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleConfig;
@@ -58,38 +57,21 @@ public class GroupRuleCreateCommand extends AbstractCommand {
         rejectDefaultGroup(resolvedGroupId);
         validateRuleType(ruleType);
         validateRuleConfig(ruleType, ruleConfig);
+        final var registryClient = client.getRegistryClient();
+        final var newRule = new CreateRule();
+        newRule.setRuleType(RuleType.forValue(ruleType));
+        newRule.setConfig(ruleConfig);
+        registryClient.groups().byGroupId(resolvedGroupId).rules().post(newRule);
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType, resolvedGroupId));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType, resolvedGroupId));
+        }
         try {
-            final var registryClient = client.getRegistryClient();
-            final var newRule = new CreateRule();
-            newRule.setRuleType(RuleType.forValue(ruleType));
-            newRule.setConfig(ruleConfig);
-            registryClient.groups().byGroupId(resolvedGroupId).rules().post(newRule);
-            switch (outputType.getOutputType()) {
-                case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType, resolvedGroupId));
-                case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType, resolvedGroupId));
-            }
-            try {
-                //noinspection ConstantConditions
-                final var rule = convert(registryClient.groups().byGroupId(resolvedGroupId).rules().byRuleType(ruleType).get());
-                printRule(output, rule, outputType);
-            } catch (final ProblemDetails ex) {
-                output.writeStdErrChunk(err -> {
-                    err.append("Warning: Group rule was created but failed to retrieve details: ")
-                            .append(ex.getDetail())
-                            .append('\n');
-                });
-            }
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error creating rule '")
-                        .append(ruleType)
-                        .append("' for group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+            //noinspection ConstantConditions
+            final var rule = convert(registryClient.groups().byGroupId(resolvedGroupId).rules().byRuleType(ruleType).get());
+            printRule(output, rule, outputType);
+        } catch (ProblemDetails ex) {
+            handleProblemDetails(output, ex);
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupRuleDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupRuleDeleteCommand.java
@@ -1,16 +1,14 @@
 package io.apicurio.registry.cli.group;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.rejectDefaultGroup;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
 
@@ -60,31 +58,18 @@ public class GroupRuleDeleteCommand extends AbstractCommand {
         if (!all) {
             validateRuleType(ruleType);
         }
-        try {
-            final var registryClient = client.getRegistryClient();
-            if (all) {
-                registryClient.groups().byGroupId(resolvedGroupId).rules().delete();
-                output.writeStdOutChunk(out -> {
-                    out.append("All rules deleted successfully for group '").append(resolvedGroupId).append("'.\n");
-                });
-            } else {
-                registryClient.groups().byGroupId(resolvedGroupId).rules().byRuleType(ruleType).delete();
-                output.writeStdOutChunk(out -> {
-                    out.append("Rule '").append(ruleType).append("' deleted successfully for group '")
-                            .append(resolvedGroupId).append("'.\n");
-                });
-            }
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error deleting rule")
-                        .append(ruleType != null ? " '" + ruleType + "'" : "s")
-                        .append(" for group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
+        final var registryClient = client.getRegistryClient();
+        if (all) {
+            registryClient.groups().byGroupId(resolvedGroupId).rules().delete();
+            output.writeStdOutChunk(out -> {
+                out.append("All rules deleted successfully for group '").append(resolvedGroupId).append("'.\n");
             });
-            exitQuietServerError();
+        } else {
+            registryClient.groups().byGroupId(resolvedGroupId).rules().byRuleType(ruleType).delete();
+            output.writeStdOutChunk(out -> {
+                out.append("Rule '").append(ruleType).append("' deleted successfully for group '")
+                        .append(resolvedGroupId).append("'.\n");
+            });
         }
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupRuleGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupRuleGetCommand.java
@@ -1,17 +1,14 @@
 package io.apicurio.registry.cli.group;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRule;
 import static io.apicurio.registry.cli.common.RuleUtil.rejectDefaultGroup;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleType;
@@ -39,25 +36,12 @@ public class GroupRuleGetCommand extends AbstractCommand {
     private OutputTypeMixin outputType;
 
     @Override
-    public void run(final OutputBuffer output) throws JsonProcessingException {
+    public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         rejectDefaultGroup(resolvedGroupId);
         validateRuleType(ruleType);
-        try {
-            //noinspection ConstantConditions
-            final var rule = convert(client.getRegistryClient().groups().byGroupId(resolvedGroupId).rules().byRuleType(ruleType).get());
-            printRule(output, rule, outputType);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error retrieving rule '")
-                        .append(ruleType)
-                        .append("' for group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+        //noinspection ConstantConditions
+        final var rule = convert(client.getRegistryClient().groups().byGroupId(resolvedGroupId).rules().byRuleType(ruleType).get());
+        printRule(output, rule, outputType);
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupRuleUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupRuleUpdateCommand.java
@@ -1,16 +1,14 @@
 package io.apicurio.registry.cli.group;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.common.RuleUtil.printRule;
 import static io.apicurio.registry.cli.common.RuleUtil.rejectDefaultGroup;
 import static io.apicurio.registry.cli.common.RuleUtil.validateRuleConfig;
@@ -55,28 +53,15 @@ public class GroupRuleUpdateCommand extends AbstractCommand {
         rejectDefaultGroup(resolvedGroupId);
         validateRuleType(ruleType);
         validateRuleConfig(ruleType, ruleConfig);
-        try {
-            final var rule = new io.apicurio.registry.rest.client.models.Rule();
-            rule.setConfig(ruleConfig);
-            //noinspection ConstantConditions
-            final var updatedRule = convert(client.getRegistryClient().groups().byGroupId(resolvedGroupId).rules().byRuleType(ruleType).put(rule));
-            switch (outputType.getOutputType()) {
-                case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType, resolvedGroupId));
-                case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType, resolvedGroupId));
-            }
-            printRule(output, updatedRule, outputType);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error updating rule '")
-                        .append(ruleType)
-                        .append("' for group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+        final var rule = new io.apicurio.registry.rest.client.models.Rule();
+        rule.setConfig(ruleConfig);
+        //noinspection ConstantConditions
+        final var updatedRule = convert(client.getRegistryClient().groups().byGroupId(resolvedGroupId).rules().byRuleType(ruleType).put(rule));
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, ruleType, resolvedGroupId));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, ruleType, resolvedGroupId));
         }
+        printRule(output, updatedRule, outputType);
     }
 
     private static void successMessage(final StringBuilder out, final String ruleType, final String groupId) {

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupUpdateCommand.java
@@ -5,13 +5,10 @@ import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.EditableGroupMetaData;
 import io.apicurio.registry.rest.client.models.Labels;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
-import java.util.List;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
 import static picocli.CommandLine.Option;
 
@@ -47,38 +44,27 @@ public class GroupUpdateCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
-        try {
-            var group = client.getRegistryClient().groups().byGroupId(groupId).get();
-            var updatedGroup = new EditableGroupMetaData();
-            updatedGroup.setDescription(group.getDescription());
-            updatedGroup.setLabels(group.getLabels());
-            if (!isBlank(description)) {
-                updatedGroup.setDescription(description);
-            }
-            if (setLabels != null) {
-                if (updatedGroup.getLabels() == null) {
-                    updatedGroup.setLabels(new Labels());
-                }
-                updatedGroup.getLabels().getAdditionalData().putAll(Conversions.parseLabels(setLabels));
-            }
-            if (deleteLabels != null && updatedGroup.getLabels() != null) {
-                deleteLabels.forEach(key -> {
-                    updatedGroup.getLabels().getAdditionalData().remove(key);
-                });
-            }
-            client.getRegistryClient().groups().byGroupId(groupId).put(updatedGroup);
-            output.writeStdOutChunk(out -> {
-                out.append("Group '").append(group.getGroupId()).append("' updated successfully.\n");
-            });
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error updating group '")
-                        .append(groupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+        var group = client.getRegistryClient().groups().byGroupId(groupId).get();
+        var updatedGroup = new EditableGroupMetaData();
+        updatedGroup.setDescription(group.getDescription());
+        updatedGroup.setLabels(group.getLabels());
+        if (!isBlank(description)) {
+            updatedGroup.setDescription(description);
         }
+        if (setLabels != null) {
+            if (updatedGroup.getLabels() == null) {
+                updatedGroup.setLabels(new Labels());
+            }
+            updatedGroup.getLabels().getAdditionalData().putAll(Conversions.parseLabels(setLabels));
+        }
+        if (deleteLabels != null && updatedGroup.getLabels() != null) {
+            deleteLabels.forEach(key -> {
+                updatedGroup.getLabels().getAdditionalData().remove(key);
+            });
+        }
+        client.getRegistryClient().groups().byGroupId(groupId).put(updatedGroup);
+        output.writeStdOutChunk(out -> {
+            out.append("Group '").append(group.getGroupId()).append("' updated successfully.\n");
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchArtifactsCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchArtifactsCommand.java
@@ -8,16 +8,13 @@ import io.apicurio.registry.cli.common.PaginationMixin;
 import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.search.artifacts.ArtifactsRequestBuilder;
 import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-import java.util.List;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPE;
 import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
@@ -97,22 +94,13 @@ public class SearchArtifactsCommand extends AbstractCommand {
     private OutputTypeMixin outputType;
 
     @Override
-    public void run(final OutputBuffer output) throws JsonProcessingException {
-        try {
+    public void run(final OutputBuffer output) throws Exception {
+        //noinspection ConstantConditions
+        final var results = convert(client.getRegistryClient().search().artifacts().get(r -> {
             //noinspection ConstantConditions
-            final var results = convert(client.getRegistryClient().search().artifacts().get(r -> {
-                //noinspection ConstantConditions
-                applyFilters(r.queryParameters);
-            }));
-            printResults(output, results);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error searching for artifacts: ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+            applyFilters(r.queryParameters);
+        }));
+        printResults(output, results);
     }
 
     private void applyFilters(final ArtifactsRequestBuilder.GetQueryParameters params) {

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchGroupsCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchGroupsCommand.java
@@ -8,16 +8,13 @@ import io.apicurio.registry.cli.common.PaginationMixin;
 import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.search.groups.GroupsRequestBuilder;
 import io.apicurio.registry.rest.v3.beans.GroupSearchResults;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-import java.util.List;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
 import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
 import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
@@ -64,22 +61,13 @@ public class SearchGroupsCommand extends AbstractCommand {
     private OutputTypeMixin outputType;
 
     @Override
-    public void run(final OutputBuffer output) throws JsonProcessingException {
-        try {
+    public void run(final OutputBuffer output) throws Exception {
+        //noinspection ConstantConditions
+        final var results = convert(client.getRegistryClient().search().groups().get(r -> {
             //noinspection ConstantConditions
-            final var results = convert(client.getRegistryClient().search().groups().get(r -> {
-                //noinspection ConstantConditions
-                applyFilters(r.queryParameters);
-            }));
-            printResults(output, results);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error searching for groups: ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+            applyFilters(r.queryParameters);
+        }));
+        printResults(output, results);
     }
 
     private void applyFilters(final GroupsRequestBuilder.GetQueryParameters params) {

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchVersionsCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchVersionsCommand.java
@@ -8,17 +8,14 @@ import io.apicurio.registry.cli.common.VersionOrderMixin;
 import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.models.VersionState;
 import io.apicurio.registry.rest.client.search.versions.VersionsRequestBuilder;
 import io.apicurio.registry.rest.v3.beans.VersionSearchResults;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-import java.util.List;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPE;
 import static io.apicurio.registry.cli.utils.Columns.CONTENT_ID;
@@ -111,22 +108,13 @@ public class SearchVersionsCommand extends AbstractCommand {
     private OutputTypeMixin outputType;
 
     @Override
-    public void run(final OutputBuffer output) throws JsonProcessingException {
-        try {
+    public void run(final OutputBuffer output) throws Exception {
+        //noinspection ConstantConditions
+        final var results = convert(client.getRegistryClient().search().versions().get(r -> {
             //noinspection ConstantConditions
-            final var results = convert(client.getRegistryClient().search().versions().get(r -> {
-                //noinspection ConstantConditions
-                applyFilters(r.queryParameters);
-            }));
-            printResults(output, results);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error searching for versions: ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+            applyFilters(r.queryParameters);
+        }));
+        printResults(output, results);
     }
 
     private void applyFilters(final VersionsRequestBuilder.GetQueryParameters params) {

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
@@ -6,12 +6,6 @@ import io.apicurio.registry.cli.utils.PlatformUtils;
 import io.vertx.core.http.HttpMethod;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
-
-import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.nio.file.Files;
@@ -23,6 +17,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 
 import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
 

--- a/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
@@ -3,11 +3,10 @@ package io.apicurio.registry.cli.services;
 import io.apicurio.registry.cli.config.Config;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.jboss.logging.Logger;
-
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Set;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class UpdateNotifier {

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
@@ -2,18 +2,17 @@ package io.apicurio.registry.cli.utils;
 
 import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.rest.client.models.Labels;
-import io.apicurio.registry.rest.v3.beans.Comment;
-import io.apicurio.registry.rest.v3.beans.Rule;
 import io.apicurio.registry.rest.v3.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
+import io.apicurio.registry.rest.v3.beans.Comment;
 import io.apicurio.registry.rest.v3.beans.GroupMetaData;
 import io.apicurio.registry.rest.v3.beans.GroupSearchResults;
+import io.apicurio.registry.rest.v3.beans.Rule;
 import io.apicurio.registry.rest.v3.beans.SearchedArtifact;
 import io.apicurio.registry.rest.v3.beans.SearchedGroup;
 import io.apicurio.registry.rest.v3.beans.SearchedVersion;
 import io.apicurio.registry.rest.v3.beans.VersionMetaData;
 import io.apicurio.registry.rest.v3.beans.VersionSearchResults;
-
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/FileUtils.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/FileUtils.java
@@ -1,8 +1,6 @@
 package io.apicurio.registry.cli.utils;
 
 import io.apicurio.registry.cli.common.CliException;
-import org.jboss.logging.Logger;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -10,6 +8,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import org.jboss.logging.Logger;
 
 import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
 import static java.util.Comparator.reverseOrder;

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/OutputBuffer.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/OutputBuffer.java
@@ -1,12 +1,11 @@
 package io.apicurio.registry.cli.utils;
 
 import io.apicurio.registry.cli.utils.Utils.Function0Ex;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 public class OutputBuffer {
 

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/TableBuilder.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/TableBuilder.java
@@ -1,10 +1,9 @@
 package io.apicurio.registry.cli.utils;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;

--- a/cli/src/main/java/io/apicurio/registry/cli/version/CommentCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/CommentCreateCommand.java
@@ -7,13 +7,11 @@ import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
 import io.apicurio.registry.rest.client.models.NewComment;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.v3.beans.Comment;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Columns.COMMENT;
 import static io.apicurio.registry.cli.utils.Columns.COMMENT_ID;
 import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
@@ -64,39 +62,24 @@ public class CommentCreateCommand extends AbstractCommand {
     public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
-            final var resolvedText = "-".equals(commentText)
-                    ? new String(System.in.readAllBytes()).trim()
-                    : commentText;
-            final var newComment = new NewComment();
-            newComment.setValue(resolvedText);
-            //noinspection ConstantConditions
-            final var created = convert(registryClient.groups().byGroupId(resolvedGroupId)
-                    .artifacts().byArtifactId(resolvedArtifactId)
-                    .versions().byVersionExpression(versionExpression)
-                    .comments().post(newComment));
-            switch (outputType.getOutputType()) {
-                case json -> output.writeStdErrChunk(out -> out.append("Comment added successfully.\n"));
-                case table -> output.writeStdOutChunk(out -> out.append("Comment added successfully.\n"));
-            }
-            printComment(output, created, outputType);
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error adding comment to version '")
-                        .append(versionExpression)
-                        .append("' of artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+        final var resolvedText = "-".equals(commentText)
+                ? new String(System.in.readAllBytes()).trim()
+                : commentText;
+        final var newComment = new NewComment();
+        newComment.setValue(resolvedText);
+        //noinspection ConstantConditions
+        final var created = convert(registryClient.groups().byGroupId(resolvedGroupId)
+                .artifacts().byArtifactId(resolvedArtifactId)
+                .versions().byVersionExpression(versionExpression)
+                .comments().post(newComment));
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> out.append("Comment added successfully.\n"));
+            case table -> output.writeStdOutChunk(out -> out.append("Comment added successfully.\n"));
         }
+        printComment(output, created, outputType);
     }
 
     static void printComment(final OutputBuffer output, final Comment comment,

--- a/cli/src/main/java/io/apicurio/registry/cli/version/CommentDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/CommentDeleteCommand.java
@@ -3,12 +3,9 @@ package io.apicurio.registry.cli.version;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 
 @Command(
         name = "delete",
@@ -46,33 +43,16 @@ public class CommentDeleteCommand extends AbstractCommand {
     public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
-            registryClient.groups().byGroupId(resolvedGroupId)
-                    .artifacts().byArtifactId(resolvedArtifactId)
-                    .versions().byVersionExpression(versionExpression)
-                    .comments().byCommentId(commentId)
-                    .delete();
-            output.writeStdOutChunk(out -> {
-                out.append("Comment '").append(commentId).append("' deleted successfully.\n");
-            });
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error deleting comment '")
-                        .append(commentId)
-                        .append("' on version '")
-                        .append(versionExpression)
-                        .append("' of artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+        registryClient.groups().byGroupId(resolvedGroupId)
+                .artifacts().byArtifactId(resolvedArtifactId)
+                .versions().byVersionExpression(versionExpression)
+                .comments().byCommentId(commentId)
+                .delete();
+        output.writeStdOutChunk(out -> {
+            out.append("Comment '").append(commentId).append("' deleted successfully.\n");
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/version/CommentListCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/CommentListCommand.java
@@ -4,18 +4,15 @@ import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.Conversions;
-import io.apicurio.registry.rest.v3.beans.Comment;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.v3.beans.Comment;
+import java.util.List;
+import java.util.stream.Collectors;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Columns.COMMENT;
 import static io.apicurio.registry.cli.utils.Columns.COMMENT_ID;
 import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
@@ -56,52 +53,37 @@ public class CommentListCommand extends AbstractCommand {
     public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
-            IdUtil.validateVersion(registryClient, resolvedGroupId, resolvedArtifactId, versionExpression);
-            final var comments = registryClient.groups().byGroupId(resolvedGroupId)
-                    .artifacts().byArtifactId(resolvedArtifactId)
-                    .versions().byVersionExpression(versionExpression)
-                    .comments().get();
-            final List<Comment> convertedComments = comments != null
-                    ? comments.stream().map(Conversions::convert).collect(Collectors.toList())
-                    : List.of();
-            output.writeStdOutChunkWithException(out -> {
-                switch (outputType.getOutputType()) {
-                    case json -> {
-                        out.append(MAPPER.writeValueAsString(convertedComments));
-                        out.append('\n');
-                    }
-                    case table -> {
-                        final var table = new TableBuilder();
-                        table.addColumns(COMMENT_ID, COMMENT, OWNER, CREATED_ON);
-                        convertedComments.forEach(c -> {
-                            table.addRow(
-                                    c.getCommentId(),
-                                    c.getValue(),
-                                    c.getOwner(),
-                                    convertToString(c.getCreatedOn())
-                            );
-                        });
-                        table.print(out);
-                    }
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+        IdUtil.validateVersion(registryClient, resolvedGroupId, resolvedArtifactId, versionExpression);
+        final var comments = registryClient.groups().byGroupId(resolvedGroupId)
+                .artifacts().byArtifactId(resolvedArtifactId)
+                .versions().byVersionExpression(versionExpression)
+                .comments().get();
+        final List<Comment> convertedComments = comments != null
+                ? comments.stream().map(Conversions::convert).collect(Collectors.toList())
+                : List.of();
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(convertedComments));
+                    out.append('\n');
                 }
-            });
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error listing comments for version '")
-                        .append(versionExpression)
-                        .append("' of artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(COMMENT_ID, COMMENT, OWNER, CREATED_ON);
+                    convertedComments.forEach(c -> {
+                        table.addRow(
+                                c.getCommentId(),
+                                c.getValue(),
+                                c.getOwner(),
+                                convertToString(c.getCreatedOn())
+                        );
+                    });
+                    table.print(out);
+                }
+            }
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/version/CommentUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/CommentUpdateCommand.java
@@ -4,12 +4,9 @@ import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.NewComment;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 
 @Command(
         name = "update",
@@ -53,38 +50,21 @@ public class CommentUpdateCommand extends AbstractCommand {
     public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
-            final var resolvedText = "-".equals(commentText)
-                    ? new String(System.in.readAllBytes()).trim()
-                    : commentText;
-            final var updatedComment = new NewComment();
-            updatedComment.setValue(resolvedText);
-            registryClient.groups().byGroupId(resolvedGroupId)
-                    .artifacts().byArtifactId(resolvedArtifactId)
-                    .versions().byVersionExpression(versionExpression)
-                    .comments().byCommentId(commentId)
-                    .put(updatedComment);
-            output.writeStdOutChunk(out -> {
-                out.append("Comment '").append(commentId).append("' updated successfully.\n");
-            });
-        } catch (final ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error updating comment '")
-                        .append(commentId)
-                        .append("' on version '")
-                        .append(versionExpression)
-                        .append("' of artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+        final var resolvedText = "-".equals(commentText)
+                ? new String(System.in.readAllBytes()).trim()
+                : commentText;
+        final var updatedComment = new NewComment();
+        updatedComment.setValue(resolvedText);
+        registryClient.groups().byGroupId(resolvedGroupId)
+                .artifacts().byArtifactId(resolvedArtifactId)
+                .versions().byVersionExpression(versionExpression)
+                .comments().byCommentId(commentId)
+                .put(updatedComment);
+        output.writeStdOutChunk(out -> {
+            out.append("Comment '").append(commentId).append("' updated successfully.\n");
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionCommand.java
@@ -1,6 +1,5 @@
 package io.apicurio.registry.cli.version;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
@@ -9,12 +8,10 @@ import io.apicurio.registry.cli.common.VersionOrderMixin;
 import io.apicurio.registry.cli.utils.Mapper;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
 import static io.apicurio.registry.cli.utils.Columns.CONTENT_ID;
 import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
@@ -65,72 +62,59 @@ public class VersionCommand extends AbstractCommand {
     private OutputTypeMixin outputType;
 
     @Override
-    public void run(final OutputBuffer output) throws JsonProcessingException {
+    public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            //noinspection ConstantConditions
-            final var versions = convert(registryClient
-                    .groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(resolvedArtifactId)
-                    .versions().get(r -> {
-                        //noinspection ConstantConditions
-                        r.queryParameters.offset = (pagination.getPage() - 1) * pagination.getSize();
-                        r.queryParameters.limit = pagination.getSize();
-                        r.queryParameters.orderby = ordering.getOrderBy();
-                        r.queryParameters.order = ordering.getOrder();
-                    }));
-            output.writeStdOutChunkWithException(out -> {
-                switch (outputType.getOutputType()) {
-                    case json -> {
-                        out.append(Mapper.MAPPER.writeValueAsString(versions));
-                        out.append('\n');
-                    }
-                    case table -> {
-                        final var table = new TableBuilder();
-                        table.addColumns(
-                                GROUP_ID,
-                                ARTIFACT_ID,
-                                VERSION,
-                                NAME,
-                                DESCRIPTION,
-                                STATE,
-                                GLOBAL_ID,
-                                CONTENT_ID,
-                                CREATED_ON,
-                                OWNER
-                        );
-                        versions.getVersions().forEach(v -> {
-                            table.addRow(
-                                    v.getGroupId(),
-                                    v.getArtifactId(),
-                                    v.getVersion(),
-                                    v.getName(),
-                                    v.getDescription(),
-                                    convertToString(v.getState()),
-                                    convertToString(v.getGlobalId()),
-                                    convertToString(v.getContentId()),
-                                    convertToString(v.getCreatedOn()),
-                                    v.getOwner()
-                            );
-                        });
-                        table.setPagination(pagination.getPage(), pagination.getSize(), versions.getCount());
-                        table.print(out);
-                    }
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        //noinspection ConstantConditions
+        final var versions = convert(registryClient
+                .groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(resolvedArtifactId)
+                .versions().get(r -> {
+                    //noinspection ConstantConditions
+                    r.queryParameters.offset = (pagination.getPage() - 1) * pagination.getSize();
+                    r.queryParameters.limit = pagination.getSize();
+                    r.queryParameters.orderby = ordering.getOrderBy();
+                    r.queryParameters.order = ordering.getOrder();
+                }));
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(Mapper.MAPPER.writeValueAsString(versions));
+                    out.append('\n');
                 }
-            });
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error listing versions for artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(
+                            GROUP_ID,
+                            ARTIFACT_ID,
+                            VERSION,
+                            NAME,
+                            DESCRIPTION,
+                            STATE,
+                            GLOBAL_ID,
+                            CONTENT_ID,
+                            CREATED_ON,
+                            OWNER
+                    );
+                    versions.getVersions().forEach(v -> {
+                        table.addRow(
+                                v.getGroupId(),
+                                v.getArtifactId(),
+                                v.getVersion(),
+                                v.getName(),
+                                v.getDescription(),
+                                convertToString(v.getState()),
+                                convertToString(v.getGlobalId()),
+                                convertToString(v.getContentId()),
+                                convertToString(v.getCreatedOn()),
+                                v.getOwner()
+                        );
+                    });
+                    table.setPagination(pagination.getPage(), pagination.getSize(), versions.getCount());
+                    table.print(out);
+                }
+            }
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionCreateCommand.java
@@ -8,17 +8,14 @@ import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.Labels;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.models.VersionContent;
+import java.util.HashMap;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import java.util.HashMap;
-import java.util.List;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Conversions.convert;
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
 import static io.apicurio.registry.cli.version.VersionGetCommand.printVersion;
@@ -122,30 +119,17 @@ public class VersionCreateCommand extends AbstractCommand {
         versionContent.setContentType(!isBlank(contentType) ? contentType : "application/json");
         newVersion.setContent(versionContent);
 
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            //noinspection ConstantConditions
-            final var result = convert(registryClient
-                    .groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(resolvedArtifactId)
-                    .versions().post(newVersion));
-            switch (outputType.getOutputType()) {
-                case json -> output.writeStdErrChunk(out -> successMessage(out, resolvedGroupId, resolvedArtifactId, result.getVersion()));
-                case table -> output.writeStdOutChunk(out -> successMessage(out, resolvedGroupId, resolvedArtifactId, result.getVersion()));
-            }
-            printVersion(output, result, outputType.getOutputType());
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error creating version for artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        //noinspection ConstantConditions
+        final var result = convert(registryClient
+                .groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(resolvedArtifactId)
+                .versions().post(newVersion));
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, resolvedGroupId, resolvedArtifactId, result.getVersion()));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, resolvedGroupId, resolvedArtifactId, result.getVersion()));
         }
+        printVersion(output, result, outputType.getOutputType());
     }
 
     private static void successMessage(final StringBuilder out, final String groupId,

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionDeleteCommand.java
@@ -1,14 +1,11 @@
 package io.apicurio.registry.cli.version;
 
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 
 /** Deletes a version from an artifact. */
 @Command(
@@ -41,30 +38,15 @@ public class VersionDeleteCommand extends AbstractCommand {
     public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
-            registryClient.groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(resolvedArtifactId)
-                    .versions().byVersionExpression(versionExpression).delete();
-            output.writeStdOutChunk(out -> {
-                out.append("Version '").append(versionExpression).append("' for artifact '")
-                        .append(resolvedArtifactId).append("' in group '")
-                        .append(resolvedGroupId).append("' deleted successfully.\n");
-            });
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error deleting version '")
-                        .append(versionExpression)
-                        .append("' for artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
-        }
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+        registryClient.groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(resolvedArtifactId)
+                .versions().byVersionExpression(versionExpression).delete();
+        output.writeStdOutChunk(out -> {
+            out.append("Version '").append(versionExpression).append("' for artifact '")
+                    .append(resolvedArtifactId).append("' in group '")
+                    .append(resolvedGroupId).append("' deleted successfully.\n");
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionGetCommand.java
@@ -1,25 +1,22 @@
 package io.apicurio.registry.cli.version;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputType;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
 import io.apicurio.registry.rest.client.RegistryClient;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.v3.beans.VersionMetaData;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
 import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
 import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPE;
 import static io.apicurio.registry.cli.utils.Columns.CONTENT_ID;
@@ -86,28 +83,13 @@ public class VersionGetCommand extends AbstractCommand {
     public void run(final OutputBuffer output) throws Exception {
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
-            if (outputOptions != null && outputOptions.content) {
-                fetchContent(registryClient, resolvedGroupId, resolvedArtifactId, output);
-            } else {
-                fetchMetadata(registryClient, resolvedGroupId, resolvedArtifactId, output);
-            }
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error retrieving version '")
-                        .append(versionExpression)
-                        .append("' for artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+        if (outputOptions != null && outputOptions.content) {
+            fetchContent(registryClient, resolvedGroupId, resolvedArtifactId, output);
+        } else {
+            fetchMetadata(registryClient, resolvedGroupId, resolvedArtifactId, output);
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionUpdateCommand.java
@@ -1,24 +1,20 @@
 package io.apicurio.registry.cli.version;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
-import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.EditableVersionMetaData;
 import io.apicurio.registry.rest.client.models.Labels;
-import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.rest.client.models.VersionState;
 import io.apicurio.registry.rest.client.models.WrappedVersionState;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
-
-import java.util.List;
-
-import static io.apicurio.registry.cli.common.CliException.exitQuietServerError;
 
 /**
  * Updates a version's metadata (name, description, labels), state, and content.
@@ -101,78 +97,63 @@ public class VersionUpdateCommand extends AbstractCommand {
         }
         final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
         final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
-        try {
-            final var registryClient = client.getRegistryClient();
-            IdUtil.validateGroup(registryClient, resolvedGroupId);
-            IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
-            final var versionPath = registryClient
-                    .groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(resolvedArtifactId)
-                    .versions().byVersionExpression(versionExpression);
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+        final var versionPath = registryClient
+                .groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(resolvedArtifactId)
+                .versions().byVersionExpression(versionExpression);
 
-            // Update metadata if any metadata options are provided
-            if (name != null || description != null || setLabels != null || deleteLabels != null) {
-                final var existing = versionPath.get();
-                final var updatedVersion = new EditableVersionMetaData();
-                //noinspection ConstantConditions
-                updatedVersion.setName(existing.getName());
-                updatedVersion.setDescription(existing.getDescription());
-                updatedVersion.setLabels(existing.getLabels());
-                if (name != null) {
-                    updatedVersion.setName(name);
-                }
-                if (description != null) {
-                    updatedVersion.setDescription(description);
-                }
-                if (setLabels != null) {
-                    if (updatedVersion.getLabels() == null) {
-                        updatedVersion.setLabels(new Labels());
-                    }
-                    updatedVersion.getLabels().getAdditionalData().putAll(Conversions.parseLabels(setLabels));
-                }
-                if (deleteLabels != null) {
-                    if (updatedVersion.getLabels() != null) {
-                        deleteLabels.forEach(key -> {
-                            updatedVersion.getLabels().getAdditionalData().remove(key);
-                        });
-                    }
-                }
-                versionPath.put(updatedVersion);
+        // Update metadata if any metadata options are provided
+        if (name != null || description != null || setLabels != null || deleteLabels != null) {
+            final var existing = versionPath.get();
+            final var updatedVersion = new EditableVersionMetaData();
+            //noinspection ConstantConditions
+            updatedVersion.setName(existing.getName());
+            updatedVersion.setDescription(existing.getDescription());
+            updatedVersion.setLabels(existing.getLabels());
+            if (name != null) {
+                updatedVersion.setName(name);
             }
-
-            // Update state if provided (separate API endpoint)
-            if (state != null) {
-                final var wrappedState = new WrappedVersionState();
-                wrappedState.setState(state);
-                versionPath.state().put(wrappedState);
+            if (description != null) {
+                updatedVersion.setDescription(description);
             }
-
-            // Update content if provided (only works for draft versions)
-            if (file != null) {
-                final var content = FileUtils.readContent(file);
-                final var versionContent = new VersionContent();
-                versionContent.setContent(content);
-                versionContent.setContentType(contentType != null ? contentType : "application/json");
-                versionPath.content().put(versionContent);
+            if (setLabels != null) {
+                if (updatedVersion.getLabels() == null) {
+                    updatedVersion.setLabels(new Labels());
+                }
+                updatedVersion.getLabels().getAdditionalData().putAll(Conversions.parseLabels(setLabels));
             }
-
-            output.writeStdOutChunk(out -> {
-                out.append("Version '").append(versionExpression).append("' for artifact '")
-                        .append(resolvedArtifactId).append("' in group '")
-                        .append(resolvedGroupId).append("' updated successfully.\n");
-            });
-        } catch (ProblemDetails ex) {
-            output.writeStdErrChunk(err -> {
-                err.append("Error updating version '")
-                        .append(versionExpression)
-                        .append("' for artifact '")
-                        .append(resolvedArtifactId)
-                        .append("' in group '")
-                        .append(resolvedGroupId)
-                        .append("': ")
-                        .append(ex.getDetail())
-                        .append('\n');
-            });
-            exitQuietServerError();
+            if (deleteLabels != null) {
+                if (updatedVersion.getLabels() != null) {
+                    deleteLabels.forEach(key -> {
+                        updatedVersion.getLabels().getAdditionalData().remove(key);
+                    });
+                }
+            }
+            versionPath.put(updatedVersion);
         }
+
+        // Update state if provided (separate API endpoint)
+        if (state != null) {
+            final var wrappedState = new WrappedVersionState();
+            wrappedState.setState(state);
+            versionPath.state().put(wrappedState);
+        }
+
+        // Update content if provided (only works for draft versions)
+        if (file != null) {
+            final var content = FileUtils.readContent(file);
+            final var versionContent = new VersionContent();
+            versionContent.setContent(content);
+            versionContent.setContentType(contentType != null ? contentType : "application/json");
+            versionPath.content().put(versionContent);
+        }
+
+        output.writeStdOutChunk(out -> {
+            out.append("Version '").append(versionExpression).append("' for artifact '")
+                    .append(resolvedArtifactId).append("' in group '")
+                    .append(resolvedGroupId).append("' updated successfully.\n");
+        });
     }
 }


### PR DESCRIPTION
## Summary

Centralizes `ProblemDetails` and `RuleViolationProblemDetails` exception handling in `AbstractCommand.call()`, removing 42 duplicated catch blocks across 33 command files. Also sorts imports across all CLI files.

## Changes

- Add `RuleViolationProblemDetails` and `ProblemDetails` catch blocks in `AbstractCommand.call()`, fulfilling the existing TODO comment
- Extract error handling into helper methods (`handleCliException`, `handleRuleViolation`, `handleProblemDetails`)
- Extract `ERROR_PREFIX` constant to avoid duplicated string literal
- `RuleViolationProblemDetails` displays rule violation causes (context + description)
- Falls back to `ex.getMessage()` when `ex.getDetail()` is null
- Remove all individual `catch (ProblemDetails)` blocks from command files
- Remove unused `ProblemDetails` and `exitQuietServerError` imports
- Remove unused `output` parameter from `VersionCommand.fetchSystemInfo()` and `fetchArtifactTypes()`
- Sort imports alphabetically across all CLI files

## Before / After

**Before (RuleViolationProblemDetails — unhandled):**
```
ERROR: Unexpected error: io.apicurio.registry.rest.client.models.RuleViolationProblemDetails
    at io.kiota.serialization.json.JsonParseNode...
```

**After (clean error with causes):**
```
Error: Rule violation
  -> /fields/0: Incompatible change: field type changed
  -> /fields/2: Missing required field
```

## Testing

- [x] Build succeeds
- [x] Checkstyle passes with 0 violations
- [x] All CLI tests pass (196 tests, 0 failures)
- [x] Only `AbstractCommand.java` contains ProblemDetails catches
- [x] No leftover `exitQuietServerError` or `ProblemDetails` imports in command files
- [x] All CLI imports sorted alphabetically

Fixes #8026, #8031