### PR TITLE
fix(ui): correct masthead logo filename and operator precedence in test [backport 3.2.x]

### DIFF
--- a/ui/tests/specs/masthead.spec.ts
+++ b/ui/tests/specs/masthead.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from "@playwright/test";
 
 const REGISTRY_UI_URL: string = process.env["REGISTRY_UI_URL"] || "http://localhost:8888/";
 const IS_DOWNSTREAM: boolean = process.env["IS_DOWNSTREAM"] === "true";
-const EXPECTED_ALT: string = process.env["EXPECTED_ALT"] || IS_DOWNSTREAM ? "Red Hat build of Apicurio Registry" : "Apicurio Registry";
-const EXPECTED_LOGO_SRC: string = process.env["EXPECTED_LOGO_SRC"] || IS_DOWNSTREAM ? "/red-hat-logo-default-transparent-100px.png" : "/apicurio_registry_logo_default.svg";
+const EXPECTED_ALT: string = process.env["EXPECTED_ALT"] || (IS_DOWNSTREAM ? "Red Hat build of Apicurio Registry" : "Apicurio Registry");
+const EXPECTED_LOGO_SRC: string = process.env["EXPECTED_LOGO_SRC"] || (IS_DOWNSTREAM ? "/red-hat-logo-reverse-transparent-100px.png" : "/apicurio_registry_logo_default.svg");
 
 test("Masthead - Logo verification", async ({ page }) => {
     await page.goto(REGISTRY_UI_URL);


### PR DESCRIPTION
## Summary
Backport of #8043 to `3.2.x`.

- Update the downstream logo filename from `red-hat-logo-default-transparent-100px.png` to `red-hat-logo-reverse-transparent-100px.png`
- Fix operator precedence bug on `EXPECTED_ALT` and `EXPECTED_LOGO_SRC` by adding parentheses around the ternary expressions, so that env var overrides work correctly

## Related Issue
Fixes #8042