### PR TITLE
ci: integrate operator tests into verification gate

### DIFF
--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -1067,8 +1067,9 @@ async function postDecisionSummary(github, owner, repo, workflowRun, prNumber, c
   const DECISION_KEYS = new Set([
     'lifecycle-ready', 'run-build', 'run-unit-tests',
     'run-integration', 'run-extras', 'run-sdk', 'run-cli',
+    'run-operator', 'run-go-sdk-freshness',
   ]);
-  const CHANGES_KEYS = new Set(['java', 'ui', 'integration', 'sdk', 'cli', 'ci']);
+  const CHANGES_KEYS = new Set(['java', 'ui', 'integration', 'sdk', 'cli', 'operator', 'go-sdk-gen', 'ci']);
   const ALLOWED_VALUES = new Set(['true', 'false', 'skip']);
   const EXPECTED_FILES = new Set(['verify-decisions.json', 'verify-changes.json']);
   const MAX_ARTIFACT_BYTES = 10240;
@@ -1170,6 +1171,7 @@ async function postDecisionSummary(github, owner, repo, workflowRun, prNumber, c
       ['Extra Tests', 'run-extras', 'Extra Tests /'],
       ['SDK Verification', 'run-sdk', 'SDK Verification /'],
       ['CLI Verification', 'run-cli', 'CLI Verification'],
+      ['Operator Tests', 'run-operator', 'Operator Tests /'],
     ];
 
     const rows = phases.map(([label, key, jobPrefix]) =>

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -1,19 +1,11 @@
 name: Operator Test Workflow
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - operator/**
-  pull_request:
-    branches:
-      - main
-    paths:
-      - operator/**
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call:
+    inputs:
+      publish:
+        description: Whether to publish operator images (only on push to main)
+        type: boolean
+        default: false
 
 env:
   REGISTRY_APP_IMAGE: ttl.sh/apicurio-registry-${{ github.sha }}:8h
@@ -86,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: operator-build
     # Only run local tests on push to main
-    if: github.event_name == 'push'
+    if: inputs.publish
     steps:
 
       - name: Checkout ${{ github.ref }}
@@ -240,7 +232,7 @@ jobs:
     name: Publish Operator
     runs-on: ubuntu-latest
     needs: [operator-test, operator-check-install]
-    if: github.event_name == 'push'
+    if: inputs.publish
     steps:
 
       - name: Configure env. variables
@@ -289,7 +281,7 @@ jobs:
   notify-slack:
     name: Slack Notification
     needs: operator-publish
-    if: always() && github.event_name == 'push'
+    if: always() && inputs.publish
     uses: ./.github/workflows/reusable-notify-slack.yaml
     with:
       workflow-name: ${{ github.workflow }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -31,6 +31,7 @@ jobs:
       run-sdk: ${{ steps.decide.outputs.run-sdk }}
       run-cli: ${{ steps.decide.outputs.run-cli }}
       run-go-sdk-freshness: ${{ steps.decide.outputs.run-go-sdk-freshness }}
+      run-operator: ${{ steps.decide.outputs.run-operator }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -77,6 +78,8 @@ jobs:
               - 'cli/**'
               - 'java-sdk/**'
               - '.github/workflows/verify-cli.yaml'
+            operator:
+              - 'operator/**'
             ci:
               - '.github/workflows/**'
 
@@ -105,7 +108,7 @@ jobs:
               LABEL='${{ github.event.label.name }}'
               if [[ "$LABEL" != lifecycle/* ]]; then
                 echo "lifecycle-ready=skip" >> "$GITHUB_OUTPUT"
-                for out in run-build run-unit-tests run-integration run-extras run-sdk run-cli; do
+                for out in run-build run-unit-tests run-integration run-extras run-sdk run-cli run-operator; do
                   echo "$out=false" >> "$GITHUB_OUTPUT"
                 done
                 exit 0
@@ -145,6 +148,7 @@ jobs:
           INTEGRATION='${{ steps.filter.outputs.integration }}'
           SDK='${{ steps.filter.outputs.sdk }}'
           CLI='${{ steps.filter.outputs.cli }}'
+          OPERATOR='${{ steps.filter.outputs.operator }}'
           GO_SDK_GEN='${{ steps.filter.outputs.go-sdk-gen }}'
           CI='${{ steps.filter.outputs.ci }}'
 
@@ -173,6 +177,7 @@ jobs:
           decide run-extras      "$run_full"  "$IS_PUSH" "$JAVA" "$UI" "$CI"
           decide run-sdk         "$run_full"  "$IS_PUSH" "$SDK" "$JAVA" "$CI"
           decide run-cli         "$run_full"  "$CLI"
+          decide run-operator   "$run_full"  "$IS_PUSH" "$OPERATOR" "$CI"
           decide run-go-sdk-freshness "$run_smoke" "$GO_SDK_GEN" "$CI"
 
       - name: Save decision summary
@@ -187,6 +192,7 @@ jobs:
             "run-extras": "${{ steps.decide.outputs.run-extras }}",
             "run-sdk": "${{ steps.decide.outputs.run-sdk }}",
             "run-cli": "${{ steps.decide.outputs.run-cli }}",
+            "run-operator": "${{ steps.decide.outputs.run-operator }}",
             "run-go-sdk-freshness": "${{ steps.decide.outputs.run-go-sdk-freshness }}"
           }
           ARTIFACT_EOF
@@ -198,6 +204,7 @@ jobs:
             "sdk": "${{ steps.filter.outputs.sdk }}",
             "cli": "${{ steps.filter.outputs.cli }}",
             "go-sdk-gen": "${{ steps.filter.outputs.go-sdk-gen }}",
+            "operator": "${{ steps.filter.outputs.operator }}",
             "ci": "${{ steps.filter.outputs.ci }}"
           }
           ARTIFACT_EOF
@@ -329,6 +336,18 @@ jobs:
       image-tag: ${{ github.sha }}
 
   # ============================================================================
+  # Operator Tests
+  # ============================================================================
+  operator:
+    name: Operator Tests
+    needs: [decide]
+    if: needs.decide.outputs.run-operator == 'true'
+    uses: ./.github/workflows/operator.yaml
+    with:
+      publish: ${{ github.event_name == 'push' }}
+    secrets: inherit
+
+  # ============================================================================
   # VERIFICATION GATE: Single required check for branch protection
   #
   # Aggregates results from all test phases.  Passes when every upstream job
@@ -340,7 +359,7 @@ jobs:
     name: Verification Gate
     if: always()
     needs: [decide, lint-and-validate, build, unit-tests, cli-verify,
-            integration-tests, extras, sdk, go-sdk-freshness]
+            integration-tests, extras, sdk, go-sdk-freshness, operator]
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate gate
@@ -389,13 +408,13 @@ jobs:
   # ============================================================================
   notify-slack:
     name: Slack Notification
-    needs: [unit-tests, integration-tests, publish]
+    needs: [unit-tests, integration-tests, publish, operator]
     if: github.event_name == 'push' && always()
     uses: ./.github/workflows/reusable-notify-slack.yaml
     with:
       workflow-name: ${{ github.workflow }}
       job-name: 'verification'
-      job-status: ${{ (needs.unit-tests.result == 'failure' || needs.integration-tests.result == 'failure' || needs.publish.result == 'failure') && 'failure' || 'success' }}
+      job-status: ${{ (needs.unit-tests.result == 'failure' || needs.integration-tests.result == 'failure' || needs.publish.result == 'failure' || needs.operator.result == 'failure') && 'failure' || 'success' }}
     secrets:
       SLACK_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
       SLACK_ERROR_WEBHOOK: ${{ secrets.SLACK_ERROR_WEBHOOK }}

--- a/app/src/test/java/io/apicurio/registry/storage/impl/gitops/GitOpsSmokeTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/gitops/GitOpsSmokeTest.java
@@ -153,12 +153,14 @@ public class GitOpsSmokeTest {
         });
 
         // Verify status shows ERROR with the expected rule type
-        get("/apis/registry/v3/admin/gitops/status")
-                .then()
-                .statusCode(200)
-                .body("syncState", equalTo("ERROR"))
-                .body("errors", hasSize(1))
-                .body("errors[0].detail", containsString("Rule " + expectedRuleType + " violation"));
+        await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            get("/apis/registry/v3/admin/gitops/status")
+                    .then()
+                    .statusCode(200)
+                    .body("syncState", equalTo("ERROR"))
+                    .body("errors", hasSize(1))
+                    .body("errors[0].detail", containsString("Rule " + expectedRuleType + " violation"));
+        });
     }
 
     @Test

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/ConfigMapConfigSource.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/ConfigMapConfigSource.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static io.apicurio.registry.operator.resource.Labels.getMinimalOperatorSelectorLabels;
+import static io.apicurio.registry.operator.utils.Utils.isBlank;
 import static io.fabric8.kubernetes.client.Config.autoConfigure;
 
 public class ConfigMapConfigSource implements ConfigSource {
@@ -27,9 +28,11 @@ public class ConfigMapConfigSource implements ConfigSource {
     private void init() {
         if (!initExecuted) {
             initExecuted = true;
-            var namespaceOpt = Configuration.getControllerNamespace();
-            if (namespaceOpt.isPresent()) {
-                var namespace = namespaceOpt.get();
+            // Read POD_NAMESPACE directly instead of using Configuration.getControllerNamespace(),
+            // because Configuration's static initializer calls ConfigProvider.getConfig(),
+            // which would re-enter Config initialization from this ConfigSource.
+            var namespace = System.getenv("POD_NAMESPACE");
+            if (!isBlank(namespace)) {
                 try (KubernetesClient client = new KubernetesClientBuilder()
                         .withConfig(new ConfigBuilder(autoConfigure(null)).withNamespace(namespace).build())
                         .build()) {


### PR DESCRIPTION
## Summary
- Convert `operator.yaml` from a standalone workflow into a reusable workflow (`workflow_call`)
- Call it from `verify.yaml` with path-based change detection (`operator/**`)
- Add operator test results to the Verification Gate's `needs`, so the gate blocks merging until operator tests complete
- Pass `publish` input to control image publishing (only on push to main)

Fixes the issue where PR #8040 was auto-merged before operator tests finished (and failed), because operator tests ran in a separate workflow outside the Verification Gate.

## Test plan
- [ ] PR touching `operator/` files triggers operator tests within the Verify workflow
- [ ] Verification Gate waits for operator test results before passing
- [ ] PR not touching `operator/` files skips operator tests (job shows as skipped)
- [ ] Push to main triggers operator tests with publish enabled