### PR TITLE
fix(app): remove extra quarkus-app wrapper directory from archives (#8039)

### DIFF
--- a/app/src/main/assembly/assembly.xml
+++ b/app/src/main/assembly/assembly.xml
@@ -10,7 +10,7 @@
     <!-- Quarkus fast-jar layout -->
     <fileSet>
       <directory>target/quarkus-app</directory>
-      <outputDirectory>/quarkus-app</outputDirectory>
+      <outputDirectory>/</outputDirectory>
       <filtered>false</filtered>
       <includes>
         <include>**/*</include>

--- a/distro/docker/src/main/docker/Dockerfile.jvm
+++ b/distro/docker/src/main/docker/Dockerfile.jvm
@@ -15,7 +15,3 @@ RUN chmod -R "ug=rwx" /deployments \
 USER 1001
 
 EXPOSE 8080 8443 9000
-
-# Quarkus fast-jar: run from quarkus-app directory
-WORKDIR /deployments/quarkus-app
-CMD ["sh", "-c", "exec java $JAVA_OPTIONS -jar quarkus-run.jar"]

--- a/mcp/src/main/assembly/assembly.xml
+++ b/mcp/src/main/assembly/assembly.xml
@@ -9,7 +9,7 @@
     <!-- Quarkus fast-jar layout -->
     <fileSet>
       <directory>target/quarkus-app</directory>
-      <outputDirectory>/quarkus-app</outputDirectory>
+      <outputDirectory>/</outputDirectory>
       <filtered>false</filtered>
       <includes>
         <include>**/*</include>

--- a/mcp/src/main/docker/Dockerfile.jvm
+++ b/mcp/src/main/docker/Dockerfile.jvm
@@ -10,7 +10,3 @@ USER root
 RUN chmod -R "ug=rwx" /deployments && chown -R 1001:0 /deployments
 
 USER 1001
-
-# Quarkus fast-jar: run from quarkus-app directory
-WORKDIR /deployments/quarkus-app
-CMD ["sh", "-c", "exec java $JAVA_OPTIONS -jar quarkus-run.jar"]

--- a/operator/controller/src/main/docker/Dockerfile.jvm
+++ b/operator/controller/src/main/docker/Dockerfile.jvm
@@ -13,6 +13,3 @@ RUN chmod -R "ug=rwx" /deployments \
 
 # Set user for running the container, according to OpenShift best practices
 USER 1001
-
-WORKDIR /deployments
-CMD ["sh", "-c", "exec java $JAVA_OPTIONS -jar quarkus-run.jar"]

--- a/support-chat/huggingface/Dockerfile
+++ b/support-chat/huggingface/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends supervisor && \
 
 RUN useradd -m -u 1001 appuser
 
-COPY --from=registry /deployments/quarkus-app /opt/registry/
+COPY --from=registry /deployments/ /opt/registry/
 COPY --from=support-chat /deployments/ /opt/support-chat/
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/utils/exportConfluent/src/main/assembly/exportConfluent.xml
+++ b/utils/exportConfluent/src/main/assembly/exportConfluent.xml
@@ -19,7 +19,7 @@
     <!-- Quarkus fast-jar layout -->
     <fileSet>
       <directory>${project.basedir}/target/quarkus-app</directory>
-      <outputDirectory>/quarkus-app</outputDirectory>
+      <outputDirectory>/</outputDirectory>
       <filtered>false</filtered>
       <includes>
         <include>**/*</include>


### PR DESCRIPTION
## Summary

- Remove the extra `quarkus-app/` wrapper directory from archive assembly descriptors (app, mcp, exportConfluent) so contents are output at the archive root, matching the operator module's approach
- Remove redundant `WORKDIR` and `CMD` directives from all Quarkus Dockerfiles (app, mcp, operator) since the base image handles entrypoint configuration
- Update the support-chat Dockerfile's `COPY` path to match the new archive layout

## Related Issue

Fixes #8039

## Test Plan

- [ ] Build the app archive: `./mvnw clean package -pl app -DskipTests`
- [ ] Verify archive structure: `tar -tzf app/target/apicurio-registry-app-*-all.tar.gz` — `quarkus-run.jar` should be at the root, not under `quarkus-app/`
- [ ] Build Docker images and verify they start correctly
- [ ] Compare archive structure with operator: `tar -tzf operator/controller/target/*-quarkus-app.tar.gz`