### PR TITLE
feat(search): support wildcard matching for artifactId, groupId, and labels

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
@@ -197,11 +197,10 @@ public class ElasticsearchSearchService {
         case groupId:
             String groupValue = filter.getStringValue() == null ? "default"
                     : filter.getStringValue();
-            return Query.of(q -> q.term(t -> t.field("groupId").value(groupValue)));
+            return buildTermOrWildcardQuery("groupId", groupValue);
 
         case artifactId:
-            return Query.of(q -> q.term(t -> t
-                    .field("artifactId").value(filter.getStringValue())));
+            return buildTermOrWildcardQuery("artifactId", filter.getStringValue());
 
         case version:
             return Query.of(q -> q.term(t -> t
@@ -247,6 +246,16 @@ public class ElasticsearchSearchService {
             log.warn("Unknown filter type: {}", filter.getType());
             return null;
         }
+    }
+
+    /**
+     * Builds a term query for exact match, or a wildcard query if the value contains '*'.
+     */
+    private Query buildTermOrWildcardQuery(String field, String value) {
+        if (value != null && value.contains("*")) {
+            return Query.of(q -> q.wildcard(w -> w.field(field).value(value)));
+        }
+        return Query.of(q -> q.term(t -> t.field(field).value(value)));
     }
 
     /**
@@ -322,23 +331,18 @@ public class ElasticsearchSearchService {
         String labelValue = labelPair.getRight();
 
         if (labelValue == null || labelValue.isBlank()) {
-            // Key-only filter
             return Query.of(q -> q.nested(n -> n
                     .path("labels")
                     .scoreMode(ChildScoreMode.None)
-                    .query(Query.of(nq -> nq.match(m -> m
-                            .field("labels.key").query(key))))));
+                    .query(buildTermOrWildcardQuery("labels.key", key))));
         }
 
-        // Key + value filter
         return Query.of(q -> q.nested(n -> n
                 .path("labels")
                 .scoreMode(ChildScoreMode.None)
                 .query(Query.of(nq -> nq.bool(b -> b
-                        .must(Query.of(mq -> mq.match(m -> m
-                                .field("labels.key").query(key))))
-                        .must(Query.of(mq -> mq.match(m -> m
-                                .field("labels.value").query(labelValue)))))))));
+                        .must(buildTermOrWildcardQuery("labels.key", key))
+                        .must(buildTermOrWildcardQuery("labels.value", labelValue)))))));
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlGroupRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlGroupRepository.java
@@ -297,28 +297,19 @@ public class SqlGroupRepository {
                         });
                         break;
                     case groupId:
-                        op = filter.isNot() ? "!=" : "=";
-                        where.append("g.groupId ");
-                        where.append(op);
-                        where.append(" ?");
-                        binders.add((query, idx) -> {
-                            query.bind(idx, filter.getStringValue());
-                        });
+                        buildWildcardClause(where, "g.groupId",
+                                filter.getStringValue(), filter.isNot(), binders);
                         break;
                     case labels:
-                        op = filter.isNot() ? "!=" : "=";
                         Pair<String, String> label = filter.getLabelFilterValue();
                         String labelKey = label.getKey().toLowerCase();
-                        where.append("EXISTS(SELECT l.* FROM group_labels l WHERE l.labelKey " + op + " ?");
-                        binders.add((query, idx) -> {
-                            query.bind(idx, labelKey);
-                        });
+                        where.append("EXISTS(SELECT l.* FROM group_labels l WHERE ");
+                        buildWildcardClause(where, "l.labelKey", labelKey, filter.isNot(), binders);
                         if (label.getValue() != null) {
                             String labelValue = label.getValue().toLowerCase();
-                            where.append(" AND l.labelValue " + op + " ?");
-                            binders.add((query, idx) -> {
-                                query.bind(idx, labelValue);
-                            });
+                            where.append(" AND ");
+                            buildWildcardClause(where, "l.labelValue", labelValue, filter.isNot(),
+                                    binders);
                         }
                         where.append(" AND l.groupId = g.groupId)");
                         break;
@@ -425,6 +416,24 @@ public class SqlGroupRepository {
 
             return null;
         });
+    }
+
+    private void buildWildcardClause(StringBuilder where, String column, String value, boolean not,
+            List<SqlStatementVariableBinder> binders) {
+        if (value.contains("*")) {
+            String op = not ? "NOT LIKE" : "LIKE";
+            where.append(column).append(" ").append(op).append(" ?");
+            String pattern = value.replace('*', '%');
+            binders.add((query, idx) -> {
+                query.bind(idx, pattern);
+            });
+        } else {
+            String op = not ? "!=" : "=";
+            where.append(column).append(" ").append(op).append(" ?");
+            binders.add((query, idx) -> {
+                query.bind(idx, value);
+            });
+        }
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
@@ -133,18 +133,12 @@ public class SqlSearchRepository {
                         }
                         break;
                     case groupId:
-                        op = filter.isNot() ? "!=" : "=";
-                        where.append("a.groupId " + op + " ?");
-                        binders.add((query, idx) -> {
-                            query.bind(idx, normalizeGroupId(filter.getStringValue()));
-                        });
+                        buildWildcardClause(where, "a.groupId",
+                                normalizeGroupId(filter.getStringValue()), filter.isNot(), binders);
                         break;
                     case artifactId:
-                        op = filter.isNot() ? "!=" : "=";
-                        where.append("a.artifactId " + op + " ?");
-                        binders.add((query, idx) -> {
-                            query.bind(idx, filter.getStringValue());
-                        });
+                        buildWildcardClause(where, "a.artifactId",
+                                filter.getStringValue(), filter.isNot(), binders);
                         break;
                     case artifactType:
                         op = filter.isNot() ? "!=" : "=";
@@ -174,22 +168,15 @@ public class SqlSearchRepository {
                         where.append(")");
                         break;
                     case labels:
-                        op = filter.isNot() ? "!=" : "=";
                         Pair<String, String> label = filter.getLabelFilterValue();
-                        // Note: convert search to lowercase when searching for labels (case-insensitivity
-                        // support).
                         String labelKey = label.getKey().toLowerCase();
-                        where.append(
-                                "EXISTS(SELECT l.* FROM artifact_labels l WHERE l.labelKey " + op + " ?");
-                        binders.add((query, idx) -> {
-                            query.bind(idx, labelKey);
-                        });
+                        where.append("EXISTS(SELECT l.* FROM artifact_labels l WHERE ");
+                        buildWildcardClause(where, "l.labelKey", labelKey, filter.isNot(), binders);
                         if (label.getValue() != null) {
                             String labelValue = label.getValue().toLowerCase();
-                            where.append(" AND l.labelValue " + op + " ?");
-                            binders.add((query, idx) -> {
-                                query.bind(idx, labelValue);
-                            });
+                            where.append(" AND ");
+                            buildWildcardClause(where, "l.labelValue", labelValue, filter.isNot(),
+                                    binders);
                         }
                         where.append(" AND l.groupId = a.groupId AND l.artifactId = a.artifactId)");
                         break;
@@ -314,11 +301,8 @@ public class SqlSearchRepository {
                 where.append(" AND (");
                 switch (filter.getType()) {
                     case groupId:
-                        op = filter.isNot() ? "!=" : "=";
-                        where.append("a.groupId " + op + " ?");
-                        binders.add((query, idx) -> {
-                            query.bind(idx, normalizeGroupId(filter.getStringValue()));
-                        });
+                        buildWildcardClause(where, "a.groupId",
+                                normalizeGroupId(filter.getStringValue()), filter.isNot(), binders);
                         break;
                     case artifactType:
                         op = filter.isNot() ? "!=" : "=";
@@ -328,6 +312,9 @@ public class SqlSearchRepository {
                         });
                         break;
                     case artifactId:
+                        buildWildcardClause(where, "v.artifactId",
+                                filter.getStringValue(), filter.isNot(), binders);
+                        break;
                     case contentId:
                     case globalId:
                     case state:
@@ -355,21 +342,15 @@ public class SqlSearchRepository {
                         });
                         break;
                     case labels:
-                        op = filter.isNot() ? "!=" : "=";
                         Pair<String, String> label = filter.getLabelFilterValue();
-                        // Note: convert search to lowercase when searching for labels (case-insensitivity
-                        // support).
                         String labelKey = label.getKey().toLowerCase();
-                        where.append("EXISTS(SELECT l.* FROM version_labels l WHERE l.labelKey " + op + " ?");
-                        binders.add((query, idx) -> {
-                            query.bind(idx, labelKey);
-                        });
+                        where.append("EXISTS(SELECT l.* FROM version_labels l WHERE ");
+                        buildWildcardClause(where, "l.labelKey", labelKey, filter.isNot(), binders);
                         if (label.getValue() != null) {
                             String labelValue = label.getValue().toLowerCase();
-                            where.append(" AND l.labelValue " + op + " ?");
-                            binders.add((query, idx) -> {
-                                query.bind(idx, labelValue);
-                            });
+                            where.append(" AND ");
+                            buildWildcardClause(where, "l.labelValue", labelValue, filter.isNot(),
+                                    binders);
                         }
                         where.append(" AND l.globalId = v.globalId)");
                         break;
@@ -461,6 +442,24 @@ public class SqlSearchRepository {
             results.setCount(count);
             return results;
         });
+    }
+
+    private void buildWildcardClause(StringBuilder where, String column, String value, boolean not,
+            List<SqlStatementVariableBinder> binders) {
+        if (value.contains("*")) {
+            String op = not ? "NOT LIKE" : "LIKE";
+            where.append(column).append(" ").append(op).append(" ?");
+            String pattern = value.replace('*', '%');
+            binders.add((query, idx) -> {
+                query.bind(idx, pattern);
+            });
+        } else {
+            String op = not ? "!=" : "=";
+            where.append(column).append(" ").append(op).append(" ?");
+            binders.add((query, idx) -> {
+                query.bind(idx, value);
+            });
+        }
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/noprofile/ArtifactSearchTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ArtifactSearchTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 
 @QuarkusTest
@@ -321,5 +322,138 @@ public class ArtifactSearchTest extends AbstractResourceTestBase {
         Assertions.assertNotNull(results);
         Assertions.assertEquals(1, results.getCount(),
                 "Wildcard '*test' should return 1 result (name-test)");
+    }
+
+    @Test
+    void testArtifactIdSearchWildcards() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        createArtifact(groupId, "user-profile-cli", ArtifactType.JSON, "{}", ContentTypes.APPLICATION_JSON);
+        createArtifact(groupId, "user-profile-web", ArtifactType.JSON, "{}", ContentTypes.APPLICATION_JSON);
+        createArtifact(groupId, "admin-profile-cli", ArtifactType.JSON, "{}", ContentTypes.APPLICATION_JSON);
+        createArtifact(groupId, "order-service", ArtifactType.JSON, "{}", ContentTypes.APPLICATION_JSON);
+
+        // Exact match
+        ArtifactSearchResults results = clientV3.search().artifacts().get(config -> {
+            config.queryParameters.groupId = groupId;
+            config.queryParameters.artifactId = "user-profile-cli";
+        });
+        Assertions.assertEquals(1, results.getCount(), "Exact match should return 1 result");
+
+        // Prefix wildcard
+        results = clientV3.search().artifacts().get(config -> {
+            config.queryParameters.groupId = groupId;
+            config.queryParameters.artifactId = "user*";
+        });
+        Assertions.assertEquals(2, results.getCount(), "Wildcard 'user*' should return 2 results");
+
+        // Suffix wildcard
+        results = clientV3.search().artifacts().get(config -> {
+            config.queryParameters.groupId = groupId;
+            config.queryParameters.artifactId = "*cli";
+        });
+        Assertions.assertEquals(2, results.getCount(), "Wildcard '*cli' should return 2 results");
+
+        // Substring wildcard
+        results = clientV3.search().artifacts().get(config -> {
+            config.queryParameters.groupId = groupId;
+            config.queryParameters.artifactId = "*profile*";
+        });
+        Assertions.assertEquals(3, results.getCount(), "Wildcard '*profile*' should return 3 results");
+
+        // No match
+        results = clientV3.search().artifacts().get(config -> {
+            config.queryParameters.groupId = groupId;
+            config.queryParameters.artifactId = "nonexistent*";
+        });
+        Assertions.assertEquals(0, results.getCount(), "Wildcard 'nonexistent*' should return 0 results");
+    }
+
+    @Test
+    void testGroupIdSearchWildcards() throws Exception {
+        String prefix = "WildcardGroupTest_" + UUID.randomUUID().toString().substring(0, 8);
+
+        createArtifact(prefix + "_alpha", "artifact-1", ArtifactType.JSON, "{}",
+                ContentTypes.APPLICATION_JSON);
+        createArtifact(prefix + "_beta", "artifact-2", ArtifactType.JSON, "{}",
+                ContentTypes.APPLICATION_JSON);
+        createArtifact(prefix + "_gamma", "artifact-3", ArtifactType.JSON, "{}",
+                ContentTypes.APPLICATION_JSON);
+
+        // Prefix wildcard on groupId
+        ArtifactSearchResults results = clientV3.search().artifacts().get(config -> {
+            config.queryParameters.groupId = prefix + "*";
+        });
+        Assertions.assertEquals(3, results.getCount(),
+                "Wildcard groupId prefix should return all 3 artifacts");
+
+        // Suffix wildcard
+        results = clientV3.search().artifacts().get(config -> {
+            config.queryParameters.groupId = "*_alpha";
+        });
+        Assertions.assertTrue(results.getCount() >= 1,
+                "Wildcard '*_alpha' should return at least 1 result");
+
+        // Exact match
+        results = clientV3.search().artifacts().get(config -> {
+            config.queryParameters.groupId = prefix + "_beta";
+        });
+        Assertions.assertEquals(1, results.getCount(), "Exact groupId match should return 1 result");
+    }
+
+    @Test
+    void testLabelSearchWildcards() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        String artifactId1 = "label-wildcard-1";
+        String artifactId2 = "label-wildcard-2";
+        String artifactId3 = "label-wildcard-3";
+
+        createArtifact(groupId, artifactId1, ArtifactType.JSON, "{}", ContentTypes.APPLICATION_JSON);
+        createArtifact(groupId, artifactId2, ArtifactType.JSON, "{}", ContentTypes.APPLICATION_JSON);
+        createArtifact(groupId, artifactId3, ArtifactType.JSON, "{}", ContentTypes.APPLICATION_JSON);
+
+        // Set labels on each artifact
+        EditableArtifactMetaData meta1 = new EditableArtifactMetaData();
+        Labels labels1 = new Labels();
+        labels1.setAdditionalData(Map.of("contract.status", "active", "team", "platform"));
+        meta1.setLabels(labels1);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId1).put(meta1);
+
+        EditableArtifactMetaData meta2 = new EditableArtifactMetaData();
+        Labels labels2 = new Labels();
+        labels2.setAdditionalData(Map.of("contract.owner", "team-a", "team", "backend"));
+        meta2.setLabels(labels2);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId2).put(meta2);
+
+        EditableArtifactMetaData meta3 = new EditableArtifactMetaData();
+        Labels labels3 = new Labels();
+        labels3.setAdditionalData(Map.of("version", "v2", "team", "frontend"));
+        meta3.setLabels(labels3);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId3).put(meta3);
+
+        // Wildcard on label key: contract.* should match artifacts 1 and 2
+        ArtifactSearchResults results = clientV3.search().artifacts().get(config -> {
+            config.queryParameters.groupId = groupId;
+            config.queryParameters.labels = new String[] { "contract.*" };
+        });
+        Assertions.assertEquals(2, results.getCount(),
+                "Wildcard label key 'contract.*' should match 2 artifacts");
+
+        // Wildcard on label value: team:*end* should match backend and frontend
+        results = clientV3.search().artifacts().get(config -> {
+            config.queryParameters.groupId = groupId;
+            config.queryParameters.labels = new String[] { "team:*end*" };
+        });
+        Assertions.assertEquals(2, results.getCount(),
+                "Wildcard label value 'team:*end*' should match 2 artifacts");
+
+        // Exact label key without wildcard
+        results = clientV3.search().artifacts().get(config -> {
+            config.queryParameters.groupId = groupId;
+            config.queryParameters.labels = new String[] { "team" };
+        });
+        Assertions.assertEquals(3, results.getCount(),
+                "Exact label key 'team' should match all 3 artifacts");
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchGroupsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchGroupsTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.UUID;
 
 @QuarkusTest
 public class SearchGroupsTest extends AbstractResourceTestBase {
@@ -112,5 +113,73 @@ public class SearchGroupsTest extends AbstractResourceTestBase {
         });
         Assertions.assertEquals(1, results.getGroups().size());
         Assertions.assertEquals("testSearchGroupsByLabels3", results.getGroups().get(0).getGroupId());
+    }
+
+    @Test
+    public void testSearchGroupsByGroupIdWildcard() throws Exception {
+        String prefix = "WildcardGroupSearch_" + UUID.randomUUID().toString().substring(0, 8);
+
+        for (int idx = 0; idx < 3; idx++) {
+            CreateGroup createGroup = new CreateGroup();
+            createGroup.setGroupId(prefix + "_group_" + idx);
+            clientV3.groups().post(createGroup);
+        }
+
+        // Prefix wildcard
+        GroupSearchResults results = clientV3.search().groups().get(request -> {
+            request.queryParameters.groupId = prefix + "*";
+        });
+        Assertions.assertEquals(3, results.getGroups().size(),
+                "Wildcard groupId prefix should return all 3 groups");
+
+        // Substring wildcard
+        results = clientV3.search().groups().get(request -> {
+            request.queryParameters.groupId = "*" + prefix + "*";
+        });
+        Assertions.assertEquals(3, results.getGroups().size(),
+                "Wildcard substring should return all 3 groups");
+
+        // Exact match
+        results = clientV3.search().groups().get(request -> {
+            request.queryParameters.groupId = prefix + "_group_1";
+        });
+        Assertions.assertEquals(1, results.getGroups().size(),
+                "Exact match should return 1 group");
+    }
+
+    @Test
+    public void testSearchGroupsByLabelWildcard() throws Exception {
+        String prefix = "WildcardLabelGroup_" + UUID.randomUUID().toString().substring(0, 8);
+
+        for (int idx = 0; idx < 3; idx++) {
+            Labels labels = new Labels();
+            labels.setAdditionalData(
+                    Map.of("env.tier-" + idx, "value-" + idx, "common", "shared"));
+            CreateGroup createGroup = new CreateGroup();
+            createGroup.setGroupId(prefix + "_" + idx);
+            createGroup.setLabels(labels);
+            clientV3.groups().post(createGroup);
+        }
+
+        // Wildcard on label key
+        GroupSearchResults results = clientV3.search().groups().get(request -> {
+            request.queryParameters.labels = new String[] { "env.*" };
+        });
+        Assertions.assertEquals(3, results.getGroups().size(),
+                "Wildcard label key 'env.*' should match all 3 groups");
+
+        // Wildcard on label value
+        results = clientV3.search().groups().get(request -> {
+            request.queryParameters.labels = new String[] { "common:sha*" };
+        });
+        Assertions.assertEquals(3, results.getGroups().size(),
+                "Wildcard label value 'common:sha*' should match all 3 groups");
+
+        // Exact label key still works
+        results = clientV3.search().groups().get(request -> {
+            request.queryParameters.labels = new String[] { "env.tier-1" };
+        });
+        Assertions.assertEquals(1, results.getGroups().size(),
+                "Exact label key should return 1 group");
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchVersionsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchVersionsTest.java
@@ -303,4 +303,71 @@ public class SearchVersionsTest extends AbstractResourceTestBase {
                 results.getVersions().get(0).getLabels().getAdditionalData());
     }
 
+    @Test
+    public void testSearchVersionsByArtifactIdWildcard() throws Exception {
+        String artifactContent = resourceToString("openapi-empty.json");
+        String group = TestUtils.generateGroupId();
+
+        createArtifact(group, "user-profile-cli", ArtifactType.OPENAPI, artifactContent,
+                ContentTypes.APPLICATION_JSON);
+        createArtifact(group, "user-profile-web", ArtifactType.OPENAPI, artifactContent,
+                ContentTypes.APPLICATION_JSON);
+        createArtifact(group, "admin-profile-cli", ArtifactType.OPENAPI, artifactContent,
+                ContentTypes.APPLICATION_JSON);
+        createArtifact(group, "order-service", ArtifactType.OPENAPI, artifactContent,
+                ContentTypes.APPLICATION_JSON);
+
+        // Prefix wildcard
+        VersionSearchResults results = clientV3.search().versions().get(config -> {
+            config.queryParameters.groupId = group;
+            config.queryParameters.artifactId = "user*";
+        });
+        Assertions.assertEquals(2, results.getCount(), "Wildcard 'user*' should return 2 versions");
+
+        // Suffix wildcard
+        results = clientV3.search().versions().get(config -> {
+            config.queryParameters.groupId = group;
+            config.queryParameters.artifactId = "*cli";
+        });
+        Assertions.assertEquals(2, results.getCount(), "Wildcard '*cli' should return 2 versions");
+
+        // Substring wildcard
+        results = clientV3.search().versions().get(config -> {
+            config.queryParameters.groupId = group;
+            config.queryParameters.artifactId = "*profile*";
+        });
+        Assertions.assertEquals(3, results.getCount(), "Wildcard '*profile*' should return 3 versions");
+
+        // Exact match still works
+        results = clientV3.search().versions().get(config -> {
+            config.queryParameters.groupId = group;
+            config.queryParameters.artifactId = "order-service";
+        });
+        Assertions.assertEquals(1, results.getCount(), "Exact match should return 1 version");
+    }
+
+    @Test
+    public void testSearchVersionsByGroupIdWildcard() throws Exception {
+        String artifactContent = resourceToString("openapi-empty.json");
+        String prefix = "WildcardGroupVersionTest_" + TestUtils.generateGroupId().substring(0, 8);
+
+        createArtifact(prefix + "_alpha", "artifact-1", ArtifactType.OPENAPI, artifactContent,
+                ContentTypes.APPLICATION_JSON);
+        createArtifact(prefix + "_beta", "artifact-2", ArtifactType.OPENAPI, artifactContent,
+                ContentTypes.APPLICATION_JSON);
+
+        // Prefix wildcard on groupId
+        VersionSearchResults results = clientV3.search().versions().get(config -> {
+            config.queryParameters.groupId = prefix + "*";
+        });
+        Assertions.assertEquals(2, results.getCount(),
+                "Wildcard groupId prefix should return 2 versions");
+
+        // Exact match
+        results = clientV3.search().versions().get(config -> {
+            config.queryParameters.groupId = prefix + "_alpha";
+        });
+        Assertions.assertEquals(1, results.getCount(), "Exact groupId should return 1 version");
+    }
+
 }

--- a/app/src/test/java/io/apicurio/registry/search/SearchVersionsViaIndexTest.java
+++ b/app/src/test/java/io/apicurio/registry/search/SearchVersionsViaIndexTest.java
@@ -230,4 +230,52 @@ public class SearchVersionsViaIndexTest extends AbstractResourceTestBase {
         });
         Assertions.assertEquals(0, results.getCount());
     }
+
+    @Test
+    public void testSearchByContentWithArtifactIdWildcard() throws Exception {
+        String group = TestUtils.generateGroupId();
+
+        String content1 = "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"Pet Store API\","
+                + "\"description\":\"An API for managing pets\"}}";
+        String content2 = "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"Pet Clinic API\","
+                + "\"description\":\"An API for pet clinics\"}}";
+        String content3 = "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"User API\","
+                + "\"description\":\"An API for managing users\"}}";
+
+        createArtifact(group, "pet-store-api", ArtifactType.OPENAPI,
+                content1, ContentTypes.APPLICATION_JSON);
+        createArtifact(group, "pet-clinic-api", ArtifactType.OPENAPI,
+                content2, ContentTypes.APPLICATION_JSON);
+        createArtifact(group, "user-api", ArtifactType.OPENAPI,
+                content3, ContentTypes.APPLICATION_JSON);
+
+        indexUpdater.awaitIdle(10, TimeUnit.SECONDS);
+
+        // Content filter "pets" forces ES path; artifactId wildcard "pet*" narrows results
+        VersionSearchResults results = clientV3.search().versions().get(config -> {
+            config.queryParameters.groupId = group;
+            config.queryParameters.content = "pets";
+            config.queryParameters.artifactId = "pet*";
+        });
+        Assertions.assertEquals(2, results.getCount(),
+                "Content 'pets' + artifactId 'pet*' should return 2 results");
+
+        // Content filter "pets" + exact artifactId
+        results = clientV3.search().versions().get(config -> {
+            config.queryParameters.groupId = group;
+            config.queryParameters.content = "pets";
+            config.queryParameters.artifactId = "pet-store-api";
+        });
+        Assertions.assertEquals(1, results.getCount(),
+                "Content 'pets' + exact artifactId should return 1 result");
+
+        // Content filter "pets" + non-matching wildcard artifactId
+        results = clientV3.search().versions().get(config -> {
+            config.queryParameters.groupId = group;
+            config.queryParameters.content = "pets";
+            config.queryParameters.artifactId = "user*";
+        });
+        Assertions.assertEquals(0, results.getCount(),
+                "Content 'pets' + artifactId 'user*' should return 0 results");
+    }
 }

--- a/app/src/test/java/io/apicurio/registry/search/SearchVersionsViaIndexTest.java
+++ b/app/src/test/java/io/apicurio/registry/search/SearchVersionsViaIndexTest.java
@@ -238,7 +238,7 @@ public class SearchVersionsViaIndexTest extends AbstractResourceTestBase {
         String content1 = "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"Pet Store API\","
                 + "\"description\":\"An API for managing pets\"}}";
         String content2 = "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"Pet Clinic API\","
-                + "\"description\":\"An API for pet clinics\"}}";
+                + "\"description\":\"An API for pets at clinics\"}}";
         String content3 = "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"User API\","
                 + "\"description\":\"An API for managing users\"}}";
 


### PR DESCRIPTION
## Summary

- Add `*` wildcard support to `artifactId`, `groupId`, and `labels` (key and value) search filters
- Without `*` behavior is unchanged (exact match); with `*` it acts as a pattern wildcard
- Applied across all three search endpoints: artifacts, versions, and groups
- Covers both SQL and Elasticsearch code paths

Fixes #8107
Related Jira: APICURIO-36

## Test plan

- [x] Unit tests pass locally (20 tests, 0 failures)
- [ ] `ArtifactSearchTest`: new tests for artifactId, groupId, and label wildcard matching
- [ ] `SearchVersionsTest`: new tests for artifactId and groupId wildcard matching
- [ ] `SearchGroupsTest`: new tests for groupId and label wildcard matching
- [ ] `SearchVersionsViaIndexTest`: new test combining content filter (ES path) with artifactId wildcard
- [ ] CI passes