### PR TITLE
fix(ui): reset pagination to page 1 when search filters change

### DIFF
--- a/ui/ui-app/src/app/pages/explore/ExplorePage.tsx
+++ b/ui/ui-app/src/app/pages/explore/ExplorePage.tsx
@@ -83,7 +83,9 @@ export const ExplorePage: FunctionComponent<ExplorePageProps> = () => {
 
     const onFilterCriteriaChange = (newCriteria: ExplorePageToolbarFilterCriteria): void => {
         setCriteria(newCriteria);
-        search(newCriteria, paging);
+        const resetPaging: Paging = { page: 1, pageSize: paging.pageSize };
+        setPaging(resetPaging);
+        search(newCriteria, resetPaging);
     };
 
     const isFiltered = (): boolean => {

--- a/ui/ui-app/src/app/pages/search/SearchPage.tsx
+++ b/ui/ui-app/src/app/pages/search/SearchPage.tsx
@@ -101,7 +101,9 @@ export const SearchPage: FunctionComponent<PageProperties> = () => {
 
     const onFilterChange = (filters: SearchFilter[]): void => {
         setFilters(filters);
-        search(searchType, filters, sortBy, sortOrder, paging);
+        const resetPaging: Paging = { page: 1, pageSize: paging.pageSize };
+        setPaging(resetPaging);
+        search(searchType, filters, sortBy, sortOrder, resetPaging);
     };
 
     const onFilterByLabel = (key: string, value: string | undefined): void => {
@@ -127,7 +129,9 @@ export const SearchPage: FunctionComponent<PageProperties> = () => {
             newFilters.push(dsf);
         }
         setFilters(newFilters);
-        search(searchType, newFilters, sortBy, sortOrder, paging);
+        const resetPaging: Paging = { page: 1, pageSize: paging.pageSize };
+        setPaging(resetPaging);
+        search(searchType, newFilters, sortBy, sortOrder, resetPaging);
     };
 
     const isFiltered = (): boolean => {


### PR DESCRIPTION
## Summary

- Reset pagination offset to page 1 when search filters change in `SearchPage.tsx` and `ExplorePage.tsx`
- Previously, searching from page 2+ would keep the stale offset, showing broken results like "21 - 1 of 1"
- Preserves the current `pageSize` when resetting

Fixes #8110
Related Jira: APICURIO-37

## Test plan

- [ ] Open the web console with 20+ artifacts
- [ ] Navigate to page 2 of the artifacts list
- [ ] Apply a search filter for an artifact on page 1
- [ ] Verify pagination resets to page 1 and the result is displayed correctly
- [ ] Repeat on the Explore page with groups
- [ ] Verify that normal page navigation (clicking page 2, changing page size) still works