### PR TITLE
fix(ui): convert globalId and contentId to numbers in search queries

### DIFF
--- a/ui/ui-app/src/services/useSearchService.ts
+++ b/ui/ui-app/src/services/useSearchService.ts
@@ -59,7 +59,11 @@ const searchArtifacts = async (config: ConfigService, auth: AuthService, filters
         orderby: sortBy
     };
     filters?.forEach(filter => {
-        queryParams[filter.by] = filter.value;
+        if (filter.by === FilterBy.globalId || filter.by === FilterBy.contentId) {
+            queryParams[filter.by] = Number(filter.value);
+        } else {
+            queryParams[filter.by] = filter.value;
+        }
     });
 
     return getRegistryClient(config, auth).search.artifacts.get({
@@ -81,7 +85,13 @@ const searchVersions = async (config: ConfigService, auth: AuthService, filters:
     // users can type whatever they want when filtering by state, but if they don't enter a valid
     // state name, the REST call will fail.  So make sure to coerce the filter value to something valid.
     filters?.forEach(filter => {
-        queryParams[filter.by] = filter.by === "state" ? filter.value.toUpperCase() : filter.value;
+        if (filter.by === FilterBy.globalId || filter.by === FilterBy.contentId) {
+            queryParams[filter.by] = Number(filter.value);
+        } else if (filter.by === FilterBy.state) {
+            queryParams[filter.by] = filter.value.toUpperCase();
+        } else {
+            queryParams[filter.by] = filter.value;
+        }
     });
 
     if (queryParams["state"]) {


### PR DESCRIPTION
## Summary

- Convert `globalId` and `contentId` filter values from string to number before passing to the API
- The REST API expects these as `int64` parameters; sending strings caused a 404 error
- Applied to both `searchArtifacts()` and `searchVersions()` in `useSearchService.ts`

Fixes #8112
Related Jira: APICURIO-38

## Test plan

- [ ] Open the web console Search page
- [ ] Select "Global Id" from the search criteria dropdown
- [ ] Enter a valid numeric Global ID and search
- [ ] Verify the result is displayed correctly (no 404 error)
- [ ] Repeat with "Content Id" filter
- [ ] Verify other filter types (Name, Artifact Id, etc.) still work