### PR TITLE
feat(operator): add test retry and cluster diagnostics on failure

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -15,6 +15,8 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.apicurio.registry.operator.utils.OperatorTestContext;
+import io.apicurio.registry.operator.utils.OperatorTestExtension;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +57,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 
-public abstract class ITBase {
+@ExtendWith(OperatorTestExtension.class)
+public abstract class ITBase implements OperatorTestContext {
 
     private static final Logger log = LoggerFactory.getLogger(ITBase.class);
 
@@ -90,6 +94,16 @@ public abstract class ITBase {
     private static App app;
     protected static JobManager jobManager;
     protected static HostAliasManager hostAliasManager;
+
+    @Override
+    public KubernetesClient getClient() {
+        return client;
+    }
+
+    @Override
+    public String getNamespace() {
+        return namespace;
+    }
 
     @BeforeAll
     public static void before() throws Exception {

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/ClusterDiagnostics.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/ClusterDiagnostics.java
@@ -1,0 +1,256 @@
+package io.apicurio.registry.operator.utils;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
+
+import static io.apicurio.registry.operator.utils.Mapper.toYAML;
+
+/**
+ * Dumps Kubernetes cluster state to the log on test failure. Called automatically by
+ * {@link OperatorTestExtension} when a test fails.
+ *
+ * <p>
+ * Dumps full YAML for: ApicurioRegistry3 CRs, Deployments, Services, Ingresses, Routes, and
+ * NetworkPolicies. Dumps status only for Pods (phase, conditions, container statuses) and Events (last 50,
+ * sorted by timestamp). For OLM tests, also dumps Subscriptions, InstallPlans, CSVs (v0) and
+ * ClusterExtensions, ClusterCatalogs (v1).
+ *
+ * <p>
+ * Each resource type is dumped in its own try-catch, so a failure to list one type (e.g. Routes on
+ * non-OpenShift clusters) does not prevent other diagnostics from being collected.
+ */
+public final class ClusterDiagnostics {
+
+    private static final Logger log = LoggerFactory.getLogger(ClusterDiagnostics.class);
+
+    private static final int MAX_EVENTS = 50;
+
+    private ClusterDiagnostics() {
+    }
+
+    public static void dump(KubernetesClient client, String namespace, boolean isOLM) {
+        log.error("==================== CLUSTER DIAGNOSTICS ====================");
+        log.error("Namespace: {}", namespace);
+
+        dumpApicurioRegistryCRs(client, namespace);
+        dumpDeployments(client, namespace);
+        dumpServices(client, namespace);
+        dumpIngresses(client, namespace);
+        dumpRoutes(client, namespace);
+        dumpNetworkPolicies(client, namespace);
+        dumpPods(client, namespace);
+        dumpEvents(client, namespace);
+
+        if (isOLM) {
+            dumpOLMResources(client, namespace);
+        }
+
+        log.error("================ END CLUSTER DIAGNOSTICS =================");
+    }
+
+    private static void dumpApicurioRegistryCRs(KubernetesClient client, String namespace) {
+        log.error("--- ApicurioRegistry3 CRs ---");
+        try {
+            var crs = client.resources(ApicurioRegistry3.class).inNamespace(namespace).list().getItems();
+            if (crs.isEmpty()) {
+                log.error("  (none)");
+                return;
+            }
+            for (var cr : crs) {
+                log.error("  {}:\n{}", cr.getMetadata().getName(), toYAML(cr));
+            }
+        } catch (Exception e) {
+            log.error("  Failed to list ApicurioRegistry3 CRs: {}", e.getMessage());
+        }
+    }
+
+    private static void dumpDeployments(KubernetesClient client, String namespace) {
+        log.error("--- Deployments ---");
+        try {
+            var deployments = client.apps().deployments().inNamespace(namespace).list().getItems();
+            if (deployments.isEmpty()) {
+                log.error("  (none)");
+                return;
+            }
+            for (var d : deployments) {
+                log.error("  {}:\n{}", d.getMetadata().getName(), toYAML(d));
+            }
+        } catch (Exception e) {
+            log.error("  Failed to list Deployments: {}", e.getMessage());
+        }
+    }
+
+    private static void dumpServices(KubernetesClient client, String namespace) {
+        log.error("--- Services ---");
+        try {
+            var services = client.services().inNamespace(namespace).list().getItems();
+            if (services.isEmpty()) {
+                log.error("  (none)");
+                return;
+            }
+            for (var s : services) {
+                log.error("  {}:\n{}", s.getMetadata().getName(), toYAML(s));
+            }
+        } catch (Exception e) {
+            log.error("  Failed to list Services: {}", e.getMessage());
+        }
+    }
+
+    private static void dumpIngresses(KubernetesClient client, String namespace) {
+        log.error("--- Ingresses ---");
+        try {
+            var ingresses = client.network().v1().ingresses().inNamespace(namespace).list().getItems();
+            if (ingresses.isEmpty()) {
+                log.error("  (none)");
+                return;
+            }
+            for (var i : ingresses) {
+                log.error("  {}:\n{}", i.getMetadata().getName(), toYAML(i));
+            }
+        } catch (Exception e) {
+            log.error("  Failed to list Ingresses: {}", e.getMessage());
+        }
+    }
+
+    private static void dumpRoutes(KubernetesClient client, String namespace) {
+        log.error("--- Routes ---");
+        try {
+            var routes = client.genericKubernetesResources("route.openshift.io/v1", "Route")
+                    .inNamespace(namespace).list().getItems();
+            if (routes.isEmpty()) {
+                log.error("  (none)");
+                return;
+            }
+            for (var r : routes) {
+                log.error("  {}:\n{}", r.getMetadata().getName(), toYAML(r));
+            }
+        } catch (Exception e) {
+            log.error("  Routes not available: {}", e.getMessage());
+        }
+    }
+
+    private static void dumpNetworkPolicies(KubernetesClient client, String namespace) {
+        log.error("--- NetworkPolicies ---");
+        try {
+            var policies = client.network().v1().networkPolicies().inNamespace(namespace).list().getItems();
+            if (policies.isEmpty()) {
+                log.error("  (none)");
+                return;
+            }
+            for (var p : policies) {
+                log.error("  {}:\n{}", p.getMetadata().getName(), toYAML(p));
+            }
+        } catch (Exception e) {
+            log.error("  Failed to list NetworkPolicies: {}", e.getMessage());
+        }
+    }
+
+    private static void dumpPods(KubernetesClient client, String namespace) {
+        log.error("--- Pods (status) ---");
+        try {
+            var pods = client.pods().inNamespace(namespace).list().getItems();
+            if (pods.isEmpty()) {
+                log.error("  (none)");
+                return;
+            }
+            for (var pod : pods) {
+                log.error("  Pod: {} | Phase: {}", pod.getMetadata().getName(),
+                        pod.getStatus().getPhase());
+                dumpPodStatus(pod);
+            }
+        } catch (Exception e) {
+            log.error("  Failed to list Pods: {}", e.getMessage());
+        }
+    }
+
+    private static void dumpPodStatus(Pod pod) {
+        var status = pod.getStatus();
+        if (status.getConditions() != null && !status.getConditions().isEmpty()) {
+            log.error("    Conditions:\n{}", toYAML(status.getConditions()));
+        }
+        if (status.getContainerStatuses() != null) {
+            for (var cs : status.getContainerStatuses()) {
+                log.error("    Container {}: ready={}, restarts={}, state={}",
+                        cs.getName(), cs.getReady(), cs.getRestartCount(),
+                        toYAML(cs.getState()));
+            }
+        }
+    }
+
+    private static void dumpEvents(KubernetesClient client, String namespace) {
+        log.error("--- Events (last {}) ---", MAX_EVENTS);
+        try {
+            var events = client.v1().events().inNamespace(namespace).list().getItems();
+            events.sort(Comparator.comparing(
+                    (Event e) -> e.getLastTimestamp() != null ? e.getLastTimestamp() : "",
+                    Comparator.reverseOrder()));
+
+            if (events.isEmpty()) {
+                log.error("  (none)");
+                return;
+            }
+
+            var limited = events.subList(0, Math.min(events.size(), MAX_EVENTS));
+            for (var event : limited) {
+                log.error("  {} | {} | {} | {}/{} | {}",
+                        event.getLastTimestamp(),
+                        event.getType(),
+                        event.getReason(),
+                        event.getInvolvedObject().getKind(),
+                        event.getInvolvedObject().getName(),
+                        event.getMessage());
+            }
+        } catch (Exception e) {
+            log.error("  Failed to list Events: {}", e.getMessage());
+        }
+    }
+
+    private static void dumpOLMResources(KubernetesClient client, String namespace) {
+        log.error("--- OLM Resources ---");
+
+        dumpGenericResources(client, "operators.coreos.com/v1alpha1", "Subscription", namespace);
+        dumpGenericResources(client, "operators.coreos.com/v1alpha1", "InstallPlan", namespace);
+        dumpGenericResources(client, "operators.coreos.com/v1alpha1", "ClusterServiceVersion", namespace);
+
+        dumpGenericClusterResources(client, "olm.operatorframework.io/v1", "ClusterExtension");
+        dumpGenericClusterResources(client, "olm.operatorframework.io/v1", "ClusterCatalog");
+    }
+
+    private static void dumpGenericResources(KubernetesClient client, String apiVersion, String kind,
+            String namespace) {
+        try {
+            var resources = client.genericKubernetesResources(apiVersion, kind)
+                    .inNamespace(namespace).list().getItems();
+            if (resources.isEmpty()) {
+                log.error("  {} (none)", kind);
+                return;
+            }
+            for (var r : resources) {
+                log.error("  {} {}:\n{}", kind, r.getMetadata().getName(), toYAML(r));
+            }
+        } catch (Exception e) {
+            log.error("  {} not available: {}", kind, e.getMessage());
+        }
+    }
+
+    private static void dumpGenericClusterResources(KubernetesClient client, String apiVersion, String kind) {
+        try {
+            var resources = client.genericKubernetesResources(apiVersion, kind).list().getItems();
+            if (resources.isEmpty()) {
+                log.error("  {} (none)", kind);
+                return;
+            }
+            for (var r : resources) {
+                log.error("  {} {}:\n{}", kind, r.getMetadata().getName(), toYAML(r));
+            }
+        } catch (Exception e) {
+            log.error("  {} not available: {}", kind, e.getMessage());
+        }
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestContext.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestContext.java
@@ -1,0 +1,23 @@
+package io.apicurio.registry.operator.utils;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+/**
+ * Implemented by operator test base classes ({@code ITBase}, {@code OLMITBase}) to expose the Kubernetes
+ * client and namespace to the {@link OperatorTestExtension}. This avoids reflection for accessing test
+ * infrastructure and allows the extension to dump cluster diagnostics on failure.
+ */
+public interface OperatorTestContext {
+
+    KubernetesClient getClient();
+
+    String getNamespace();
+
+    /**
+     * Returns {@code true} if this test runs against an OLM-installed operator. OLM tests get additional
+     * diagnostics (Subscriptions, InstallPlans, CSVs, ClusterExtensions, ClusterCatalogs).
+     */
+    default boolean isOLMTest() {
+        return false;
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestExtension.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestExtension.java
@@ -1,0 +1,129 @@
+package io.apicurio.registry.operator.utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * JUnit 5 extension that provides two capabilities for operator integration tests:
+ *
+ * <p>
+ * <b>Retry on failure</b> ({@link InvocationInterceptor}): Test methods annotated with {@link RetryTest} are
+ * automatically retried on failure. The {@code @AfterEach} cleanup is called between attempts to reset state.
+ * Each retry is logged with the attempt number and the triggering exception.
+ *
+ * <p>
+ * <b>Cluster diagnostics on failure</b> ({@link TestWatcher}): When a test fails (after all retries are
+ * exhausted, or immediately for non-retried tests), the extension dumps the Kubernetes cluster state to the
+ * log. This includes CRs, Deployments, Pods, Services, Ingresses, Events, and OLM resources (for OLM tests).
+ * The test class must implement {@link OperatorTestContext} to provide the client and namespace.
+ *
+ * <p>
+ * Register on test base classes with {@code @ExtendWith(OperatorTestExtension.class)} — all subclasses
+ * inherit it automatically.
+ */
+public class OperatorTestExtension implements InvocationInterceptor, TestWatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(OperatorTestExtension.class);
+
+    @Override
+    public void interceptTestMethod(Invocation<Void> invocation,
+            ReflectiveInvocationContext<Method> invocationContext,
+            ExtensionContext extensionContext) throws Throwable {
+
+        Method method = invocationContext.getExecutable();
+        RetryTest retryTest = method.getAnnotation(RetryTest.class);
+
+        if (retryTest == null) {
+            invocation.proceed();
+            return;
+        }
+
+        int totalAttempts = retryTest.maxRetries() + 1;
+        Throwable lastException = null;
+
+        for (int attempt = 1; attempt <= totalAttempts; attempt++) {
+            try {
+                if (attempt == 1) {
+                    invocation.proceed();
+                } else {
+                    method.invoke(invocationContext.getTarget().orElseThrow());
+                }
+                if (attempt > 1) {
+                    log.info("========================================");
+                    log.info("TEST PASSED on attempt {}/{}: {}", attempt, totalAttempts, method.getName());
+                    log.info("========================================");
+                }
+                return;
+            } catch (InvocationTargetException e) {
+                lastException = e.getCause();
+            } catch (Throwable e) {
+                lastException = e;
+            }
+
+            if (attempt < totalAttempts) {
+                log.warn("========================================");
+                log.warn("RETRY {}/{} for test: {}", attempt + 1, totalAttempts, method.getName());
+                log.warn("Failed with: {} - {}", lastException.getClass().getSimpleName(),
+                        lastException.getMessage());
+                log.warn("========================================");
+                runCleanupBetweenRetries(invocationContext);
+            }
+        }
+
+        log.error("========================================");
+        log.error("TEST FAILED after {} attempts: {}", totalAttempts, method.getName());
+        log.error("========================================");
+        throw lastException;
+    }
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        Object testInstance = context.getRequiredTestInstance();
+        if (testInstance instanceof OperatorTestContext ctx) {
+            var client = ctx.getClient();
+            var namespace = ctx.getNamespace();
+            if (client != null && namespace != null) {
+                ClusterDiagnostics.dump(client, namespace, ctx.isOLMTest());
+            } else {
+                log.warn("Cannot dump cluster diagnostics: client={}, namespace={}", client, namespace);
+            }
+        } else {
+            log.warn("Test class does not implement OperatorTestContext, skipping cluster diagnostics");
+        }
+    }
+
+    private void runCleanupBetweenRetries(ReflectiveInvocationContext<Method> invocationContext) {
+        invocationContext.getTarget().ifPresent(testInstance -> {
+            Method afterEach = findAfterEachMethod(testInstance.getClass());
+            if (afterEach == null) {
+                return;
+            }
+            try {
+                log.info("Running @AfterEach cleanup between retry attempts");
+                afterEach.setAccessible(true);
+                afterEach.invoke(testInstance);
+            } catch (Exception e) {
+                log.warn("Cleanup between retries failed: {}", e.getMessage());
+            }
+        });
+    }
+
+    private Method findAfterEachMethod(Class<?> clazz) {
+        for (Class<?> c = clazz; c != null; c = c.getSuperclass()) {
+            for (Method m : c.getDeclaredMethods()) {
+                if (m.isAnnotationPresent(AfterEach.class)) {
+                    return m;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestExtension.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestExtension.java
@@ -54,6 +54,7 @@ public class OperatorTestExtension implements InvocationInterceptor, TestWatcher
                 if (attempt == 1) {
                     invocation.proceed();
                 } else {
+                    method.setAccessible(true);
                     method.invoke(invocationContext.getTarget().orElseThrow());
                 }
                 if (attempt > 1) {
@@ -111,7 +112,7 @@ public class OperatorTestExtension implements InvocationInterceptor, TestWatcher
                 afterEach.setAccessible(true);
                 afterEach.invoke(testInstance);
             } catch (Exception e) {
-                log.warn("Cleanup between retries failed: {}", e.getMessage());
+                log.warn("Cleanup between retries failed", e);
             }
         });
     }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/RetryTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/RetryTest.java
@@ -1,0 +1,45 @@
+package io.apicurio.registry.operator.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a test method for automatic retry on failure. This is a drop-in replacement for {@link Test @Test}
+ * — do not use both annotations on the same method.
+ *
+ * <p>
+ * When a test annotated with {@code @RetryTest} fails, the {@link OperatorTestExtension} will re-invoke it
+ * up to {@link #maxRetries()} additional times. Between retry attempts, the {@code @AfterEach} cleanup method
+ * is called to reset test state (e.g. delete CRs). Each retry is logged clearly with the attempt number and
+ * the exception that triggered it.
+ *
+ * <p>
+ * If the test passes on any attempt, the overall test result is a pass. If all attempts are exhausted, the
+ * last exception is thrown and {@link ClusterDiagnostics} dumps the cluster state for debugging.
+ *
+ * <p>
+ * Example usage:
+ *
+ * <pre>
+ * &#64;RetryTest // 3 total attempts (1 + 2 retries)
+ * void smoke() { ... }
+ *
+ * &#64;RetryTest(maxRetries = 4) // 5 total attempts
+ * void flakyTest() { ... }
+ * </pre>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Test
+public @interface RetryTest {
+
+    /**
+     * Maximum number of retry attempts after the initial failure. The total number of attempts is
+     * {@code maxRetries + 1}. Defaults to 2 (3 total attempts).
+     */
+    int maxRetries() default 2;
+}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
@@ -2,6 +2,8 @@ package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.OperatorException;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.utils.OperatorTestContext;
+import io.apicurio.registry.operator.utils.OperatorTestExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.NamespaceableResource;
@@ -10,6 +12,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +31,8 @@ import static io.apicurio.registry.operator.utils.K8sCell.k8sCell;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-public abstract class OLMITBase {
+@ExtendWith(OperatorTestExtension.class)
+public abstract class OLMITBase implements OperatorTestContext {
 
     private static final Logger log = LoggerFactory.getLogger(OLMITBase.class);
 
@@ -41,6 +45,21 @@ public abstract class OLMITBase {
     protected static String namespace;
     protected static IngressManager ingressManager;
     protected static boolean cleanup;
+
+    @Override
+    public KubernetesClient getClient() {
+        return client;
+    }
+
+    @Override
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public boolean isOLMTest() {
+        return true;
+    }
 
     @BeforeAll
     public static void beforeAll() throws Exception {

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/SmokeOLMITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/SmokeOLMITTest.java
@@ -1,9 +1,9 @@
 package io.apicurio.registry.operator.it;
 
+import io.apicurio.registry.operator.utils.RetryTest;
 import io.quarkus.test.junit.QuarkusTest;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +17,7 @@ public class SmokeOLMITTest extends OLMITBase {
 
     private static final Logger log = LoggerFactory.getLogger(SmokeOLMITTest.class);
 
-    @Test
+    @RetryTest
     void smoke() {
         // Wait for the operator to deploy
         var projectVersion = ConfigProvider.getConfig().getValue(PROJECT_VERSION_PROP, String.class);


### PR DESCRIPTION
## Summary
- Add `@RetryTest` annotation as a drop-in `@Test` replacement that automatically retries flaky operator tests (default: up to 3 total attempts), with clear logging on each retry
- Add `OperatorTestExtension` (JUnit 5) that dumps full cluster state (CRs, Deployments, Services, Ingresses, Routes, NetworkPolicies, Pods, Events, and OLM resources) to logs on final test failure
- Add `OperatorTestContext` interface implemented by `ITBase` and `OLMITBase` to provide client/namespace to the extension without reflection
- Apply `@RetryTest` to `SmokeOLMITTest.smoke()` as the primary use case

## Test plan
- [x] `./mvnw clean install -f operator/controller/pom.xml -DskipTests` compiles
- [x] `./mvnw clean install -f operator/olm-tests/pom.xml -DskipTests` compiles
- [x] Checkstyle passes on both modules
- [x] Full operator test suite passes on OCP 4.16 and 4.20 ([run](https://github.com/ApicurioTesting/apicurio-testing/actions/runs/26771149228))