### PR TITLE
feat(cli): add authentication support (Basic auth and OAuth2). Fixes #8055

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -1,6 +1,8 @@
 package io.apicurio.registry.cli;
 
 import io.apicurio.registry.cli.artifact.ArtifactCommand;
+import io.apicurio.registry.cli.auth.LoginCommand;
+import io.apicurio.registry.cli.auth.LogoutCommand;
 import io.apicurio.registry.cli.config.ConfigPropertyCommand;
 import io.apicurio.registry.cli.context.ContextCommand;
 import io.apicurio.registry.cli.globalrule.GlobalRuleCommand;
@@ -31,6 +33,8 @@ import static picocli.CommandLine.ScopeType.INHERIT;
                 GlobalRuleCommand.class,
                 GroupCommand.class,
                 InstallCommand.class,
+                LoginCommand.class,
+                LogoutCommand.class,
                 SearchCommand.class,
                 UpdateCommand.class,
                 VersionCommand.class

--- a/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
@@ -6,6 +6,7 @@ import io.apicurio.registry.cli.config.ConfigModel;
 import io.apicurio.registry.cli.utils.FileUtils;
 import io.apicurio.registry.cli.utils.Mapper;
 import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.PlatformUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,11 +52,6 @@ public class InstallCommand extends AbstractCommand {
     public static final String ENV_ACR_INSTALL_PATH = "ACR_INSTALL_PATH";
     public static final String ENV_ACR_HOME = "ACR_HOME";
     public static final String ENV_HOME = "HOME";
-
-    // OS detection
-    public static final String OS_NAME_PROPERTY = "os.name";
-    public static final String OS_MAC_IDENTIFIER = "mac";
-    public static final String OS_DARWIN_IDENTIFIER = "darwin";
 
     @Override
     public void run(final OutputBuffer output) throws IOException {
@@ -112,22 +108,12 @@ public class InstallCommand extends AbstractCommand {
     }
 
     /**
-     * Detects if the current OS is macOS.
-     *
-     * @return true if running on macOS, false otherwise
-     */
-    public static boolean detectMacOS() {
-        final String osName = System.getProperty(OS_NAME_PROPERTY).toLowerCase();
-        return osName.contains(OS_MAC_IDENTIFIER) || osName.contains(OS_DARWIN_IDENTIFIER);
-    }
-
-    /**
      * Gets the appropriate shell configuration file name for the current OS.
      *
      * @return ZSHRC for macOS, BASHRC for Linux
      */
     public static String getShellConfigFile() {
-        return detectMacOS() ? ZSHRC : BASHRC;
+        return PlatformUtils.isMacOS() ? ZSHRC : BASHRC;
     }
 
     /**

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialProvider.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialProvider.java
@@ -1,0 +1,13 @@
+package io.apicurio.registry.cli.auth;
+
+/**
+ * Platform-specific credential storage provider (macOS Keychain, Linux Secret Service).
+ */
+public interface CredentialProvider {
+
+    void store(String account, String secret);
+
+    String retrieve(String account);
+
+    void delete(String account);
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialProviderProducer.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialProviderProducer.java
@@ -1,0 +1,23 @@
+package io.apicurio.registry.cli.auth;
+
+import io.apicurio.registry.cli.utils.PlatformUtils;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+/**
+ * Selects the platform-specific credential provider at runtime.
+ */
+@ApplicationScoped
+public class CredentialProviderProducer {
+
+    private static final String SERVICE_NAME = "apicurio-registry-cli";
+
+    @Produces
+    @ApplicationScoped
+    CredentialProvider createProvider() {
+        if (PlatformUtils.isMacOS()) {
+            return new MacOSCredentialProvider(SERVICE_NAME);
+        }
+        return new LinuxCredentialProvider(SERVICE_NAME);
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialStore.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialStore.java
@@ -1,0 +1,46 @@
+package io.apicurio.registry.cli.auth;
+
+import io.apicurio.registry.cli.common.CliException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
+
+/**
+ * Stores and retrieves credentials per context using the OS keychain.
+ */
+@ApplicationScoped
+public class CredentialStore {
+
+    private static final Logger log = Logger.getLogger(CredentialStore.class);
+
+    @Inject
+    CredentialProvider provider;
+
+    public void store(final String contextName, final String key, final String secret) {
+        try {
+            provider.store(credentialKey(contextName, key), secret);
+        } catch (CredentialStoreException ex) {
+            throw new CliException("Failed to store credentials. Ensure the system keychain is available.",
+                    APPLICATION_ERROR_RETURN_CODE);
+        }
+    }
+
+    public String retrieve(final String contextName, final String key) {
+        try {
+            return provider.retrieve(credentialKey(contextName, key));
+        } catch (CredentialStoreException ex) {
+            log.debugf("Could not retrieve credential (%s).", ex.getClass().getSimpleName());
+            return null;
+        }
+    }
+
+    public void delete(final String contextName, final String key) {
+        provider.delete(credentialKey(contextName, key));
+    }
+
+    private static String credentialKey(final String contextName, final String key) {
+        return contextName + "/" + key;
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialStoreException.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialStoreException.java
@@ -1,0 +1,12 @@
+package io.apicurio.registry.cli.auth;
+
+class CredentialStoreException extends RuntimeException {
+
+    CredentialStoreException(final String message) {
+        super(message);
+    }
+
+    CredentialStoreException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/LinuxCredentialProvider.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/LinuxCredentialProvider.java
@@ -1,0 +1,44 @@
+package io.apicurio.registry.cli.auth;
+
+import org.jboss.logging.Logger;
+
+class LinuxCredentialProvider implements CredentialProvider {
+
+    private static final Logger log = Logger.getLogger(LinuxCredentialProvider.class);
+
+    private static final String CMD = "secret-tool";
+    private static final String KEY_SERVICE = "service";
+    private static final String KEY_ACCOUNT = "account";
+
+    private final String serviceName;
+
+    LinuxCredentialProvider(final String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    @Override
+    public void store(final String account, final String secret) {
+        ProcessUtils.execWithStdin(secret, CMD, "store",
+                "--label", serviceName + " " + account,
+                KEY_SERVICE, serviceName,
+                KEY_ACCOUNT, account);
+    }
+
+    @Override
+    public String retrieve(final String account) {
+        return ProcessUtils.exec(CMD, "lookup",
+                KEY_SERVICE, serviceName,
+                KEY_ACCOUNT, account);
+    }
+
+    @Override
+    public void delete(final String account) {
+        try {
+            ProcessUtils.exec(CMD, "clear",
+                    KEY_SERVICE, serviceName,
+                    KEY_ACCOUNT, account);
+        } catch (RuntimeException ex) {
+            log.debugf("No existing secret-tool entry to delete.");
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
@@ -1,0 +1,166 @@
+package io.apicurio.registry.cli.auth;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.config.ConfigModel;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import jakarta.inject.Inject;
+import java.util.Arrays;
+import java.util.Optional;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.utils.Utils.isBlank;
+
+/**
+ * Authenticates with the registry using Basic auth or OAuth2 client credentials.
+ */
+@Command(
+        name = "login",
+        description = "Log in to the current registry context"
+)
+public class LoginCommand extends AbstractCommand {
+
+    @Option(
+            names = {"-u", "--username"},
+            description = "Username for basic authentication."
+    )
+    private String username;
+
+    @Option(
+            names = {"-p", "--password"},
+            description = "Password for basic authentication. If not provided, you will be prompted.",
+            interactive = true,
+            arity = "0..1"
+    )
+    private String password;
+
+    @Option(
+            names = {"--token-endpoint"},
+            description = "OAuth2 token endpoint URL."
+    )
+    private String tokenEndpoint;
+
+    @Option(
+            names = {"--client-id"},
+            description = "OAuth2 client ID."
+    )
+    private String clientId;
+
+    @Option(
+            names = {"--client-secret"},
+            description = "OAuth2 client secret. If not provided, you will be prompted.",
+            interactive = true,
+            arity = "0..1"
+    )
+    private String clientSecret;
+
+    @Option(
+            names = {"--scope"},
+            description = "OAuth2 scope (optional)."
+    )
+    private String scope;
+
+    @Inject
+    CredentialStore credentialStore;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var configModel = config.read();
+        final var contextName = configModel.getCurrentContext();
+        if (isBlank(contextName)) {
+            throw new CliException("No current context is set. Create a context first with 'acr context create'.",
+                    VALIDATION_ERROR_RETURN_CODE);
+        }
+        final var context = Optional.ofNullable(configModel.getContext().get(contextName))
+                .orElseThrow(() -> new CliException(
+                        "Context '" + contextName + "' not found. Create it with 'acr context create'.",
+                        VALIDATION_ERROR_RETURN_CODE));
+
+        if (!isBlank(username)) {
+            loginBasic(output, configModel, context, contextName);
+        } else if (!isBlank(tokenEndpoint)) {
+            loginOAuth2(output, configModel, context, contextName);
+        } else {
+            throw new CliException("Specify --username for basic auth or --token-endpoint for OAuth2.",
+                    VALIDATION_ERROR_RETURN_CODE);
+        }
+    }
+
+    private void loginBasic(final OutputBuffer output,
+                            final ConfigModel configModel,
+                            final ConfigModel.Context context,
+                            final String contextName) {
+        var resolvedPassword = password;
+        if (isBlank(resolvedPassword)) {
+            resolvedPassword = readSecret("Password: ",
+                    "No console available for interactive password input. Use --password.",
+                    "Password cannot be empty.");
+        }
+
+        credentialStore.store(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD, resolvedPassword);
+        credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET);
+
+        context.clearAuth();
+        context.setAuthType(ConfigModel.AUTH_TYPE_BASIC);
+        context.setUsername(username);
+        config.write(configModel);
+
+        client.reset();
+
+        output.writeStdOutChunk(out -> {
+            out.append("Logged in to context '").append(contextName)
+                    .append("' as '").append(username).append("'.\n");
+        });
+    }
+
+    private void loginOAuth2(final OutputBuffer output,
+                             final ConfigModel configModel,
+                             final ConfigModel.Context context,
+                             final String contextName) {
+        if (isBlank(clientId)) {
+            throw new CliException("--client-id is required for OAuth2 authentication.",
+                    VALIDATION_ERROR_RETURN_CODE);
+        }
+        var resolvedSecret = clientSecret;
+        if (isBlank(resolvedSecret)) {
+            resolvedSecret = readSecret("Client Secret: ",
+                    "No console available for interactive input. Use --client-secret.",
+                    "Client secret cannot be empty.");
+        }
+
+        credentialStore.store(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET, resolvedSecret);
+        credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD);
+
+        context.clearAuth();
+        context.setAuthType(ConfigModel.AUTH_TYPE_OAUTH2);
+        context.setTokenEndpoint(tokenEndpoint);
+        context.setClientId(clientId);
+        context.setScope(scope);
+        config.write(configModel);
+
+        client.reset();
+
+        output.writeStdOutChunk(out -> {
+            out.append("Logged in to context '").append(contextName).append("' via OAuth2.\n");
+        });
+    }
+
+    private static String readSecret(final String prompt, final String noConsoleMessage,
+                                     final String emptyMessage) {
+        final var console = Optional.ofNullable(System.console())
+                .orElseThrow(() -> new CliException(noConsoleMessage, VALIDATION_ERROR_RETURN_CODE));
+        final var chars = console.readPassword(prompt);
+        try {
+            if (chars == null || chars.length == 0) {
+                throw new CliException(emptyMessage, VALIDATION_ERROR_RETURN_CODE);
+            }
+            return new String(chars);
+        } finally {
+            if (chars != null) {
+                Arrays.fill(chars, '\0');
+            }
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/LogoutCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/LogoutCommand.java
@@ -1,0 +1,56 @@
+package io.apicurio.registry.cli.auth;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.config.ConfigModel;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import jakarta.inject.Inject;
+import java.util.Optional;
+import picocli.CommandLine.Command;
+
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.utils.Utils.isBlank;
+
+/**
+ * Clears credentials from the OS keychain and resets auth config for the current context.
+ */
+@Command(
+        name = "logout",
+        description = "Log out of the current registry context"
+)
+public class LogoutCommand extends AbstractCommand {
+
+    @Inject
+    CredentialStore credentialStore;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var configModel = config.read();
+        final var contextName = configModel.getCurrentContext();
+        if (isBlank(contextName)) {
+            throw new CliException("No current context is set.", VALIDATION_ERROR_RETURN_CODE);
+        }
+        final var context = Optional.ofNullable(configModel.getContext().get(contextName))
+                .orElseThrow(() -> new CliException(
+                        "Context '" + contextName + "' not found.", VALIDATION_ERROR_RETURN_CODE));
+
+        if (isBlank(context.getAuthType())) {
+            output.writeStdOutChunk(out -> {
+                out.append("Context '").append(contextName).append("' is not logged in.\n");
+            });
+            return;
+        }
+
+        credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD);
+        credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET);
+
+        context.clearAuth();
+        config.write(configModel);
+
+        client.reset();
+
+        output.writeStdOutChunk(out -> {
+            out.append("Logged out of context '").append(contextName).append("'.\n");
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/MacOSCredentialProvider.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/MacOSCredentialProvider.java
@@ -1,0 +1,46 @@
+package io.apicurio.registry.cli.auth;
+
+import org.jboss.logging.Logger;
+
+class MacOSCredentialProvider implements CredentialProvider {
+
+    private static final Logger log = Logger.getLogger(MacOSCredentialProvider.class);
+
+    private static final String CMD = "security";
+    private static final String FLAG_SERVICE = "-s";
+    private static final String FLAG_ACCOUNT = "-a";
+
+    private final String serviceName;
+
+    MacOSCredentialProvider(final String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    @Override
+    public void store(final String account, final String secret) {
+        delete(account);
+        ProcessUtils.exec(CMD, "add-generic-password",
+                FLAG_SERVICE, serviceName,
+                FLAG_ACCOUNT, account,
+                "-w", secret);
+    }
+
+    @Override
+    public String retrieve(final String account) {
+        return ProcessUtils.exec(CMD, "find-generic-password",
+                FLAG_SERVICE, serviceName,
+                FLAG_ACCOUNT, account,
+                "-w");
+    }
+
+    @Override
+    public void delete(final String account) {
+        try {
+            ProcessUtils.exec(CMD, "delete-generic-password",
+                    FLAG_SERVICE, serviceName,
+                    FLAG_ACCOUNT, account);
+        } catch (RuntimeException ex) {
+            log.debugf("No existing keychain entry to delete.");
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/ProcessUtils.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/ProcessUtils.java
@@ -1,0 +1,58 @@
+package io.apicurio.registry.cli.auth;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Executes OS commands with timeout handling, used by credential providers.
+ */
+final class ProcessUtils {
+
+    private static final int COMMAND_TIMEOUT_SECONDS = 10;
+
+    private ProcessUtils() {
+    }
+
+    static void execWithStdin(final String stdin, final String... command) {
+        try {
+            final Process process = new ProcessBuilder(command).start();
+            process.getOutputStream().write(stdin.getBytes(StandardCharsets.UTF_8));
+            process.getOutputStream().close();
+            if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                throw new CredentialStoreException(command[0] + " timed out.");
+            }
+            if (process.exitValue() != 0) {
+                final String error = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+                throw new CredentialStoreException(command[0] + " failed (exit code " + process.exitValue() + "): " + error);
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new CredentialStoreException("Failed to execute " + command[0] + ": " + ex.getMessage(), ex);
+        } catch (IOException ex) {
+            throw new CredentialStoreException("Failed to execute " + command[0] + ": " + ex.getMessage(), ex);
+        }
+    }
+
+    static String exec(final String... command) {
+        try {
+            final Process process = new ProcessBuilder(command).start();
+            if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                throw new CredentialStoreException("Command timed out: " + command[0]);
+            }
+            final String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+            if (process.exitValue() != 0) {
+                final String error = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+                throw new CredentialStoreException(command[0] + " failed (exit code " + process.exitValue() + "): " + error);
+            }
+            return output;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new CredentialStoreException("Failed to execute " + command[0] + ": " + ex.getMessage(), ex);
+        } catch (IOException ex) {
+            throw new CredentialStoreException("Failed to execute " + command[0] + ": " + ex.getMessage(), ex);
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
@@ -20,6 +20,12 @@ public class ConfigModel {
 
     public static final int CURRENT_INSTALLATION_VERSION = 1;
 
+    public static final String AUTH_TYPE_BASIC = "basic";
+    public static final String AUTH_TYPE_OAUTH2 = "oauth2";
+
+    public static final String CREDENTIAL_KEY_PASSWORD = "password";
+    public static final String CREDENTIAL_KEY_CLIENT_SECRET = "client-secret";
+
     @JsonProperty("installation-version")
     private int installationVersion = CURRENT_INSTALLATION_VERSION;
 
@@ -48,5 +54,33 @@ public class ConfigModel {
 
         @JsonProperty("artifactId")
         private String artifactId;
+
+        @ToString.Exclude
+        @JsonProperty("authType")
+        private String authType;
+
+        @ToString.Exclude
+        @JsonProperty("username")
+        private String username;
+
+        @ToString.Exclude
+        @JsonProperty("tokenEndpoint")
+        private String tokenEndpoint;
+
+        @ToString.Exclude
+        @JsonProperty("clientId")
+        private String clientId;
+
+        @ToString.Exclude
+        @JsonProperty("scope")
+        private String scope;
+
+        public void clearAuth() {
+            authType = null;
+            username = null;
+            tokenEndpoint = null;
+            clientId = null;
+            scope = null;
+        }
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
@@ -1,7 +1,9 @@
 package io.apicurio.registry.cli.services;
 
+import io.apicurio.registry.cli.auth.CredentialStore;
 import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.config.Config;
+import io.apicurio.registry.cli.config.ConfigModel;
 import io.apicurio.registry.client.RegistryClientFactory;
 import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.rest.client.RegistryClient;
@@ -24,6 +26,9 @@ public class Client {
     @Inject
     Config config;
 
+    @Inject
+    CredentialStore credentialStore;
+
     private RegistryClient registryClient;
 
     private HttpClient httpClient;
@@ -41,9 +46,10 @@ public class Client {
                     if (uri.getPath() == null) {
                         uri = uri.resolve("/apis/registry/v3");
                     }
-                    registryClient = RegistryClientFactory.create(
-                            RegistryClientOptions.create(uri.toString(), vertx)
-                    );
+                    final var options = RegistryClientOptions.create(uri.toString(), vertx);
+                    final var context = currentContext.getContext().get(currentContext.getCurrentContext());
+                    configureAuth(options, context, currentContext.getCurrentContext());
+                    registryClient = RegistryClientFactory.create(options);
                 } catch (Exception ex) {
                     throw new CliException("Could not create Registry client: " + ex.getMessage(),
                             APPLICATION_ERROR_RETURN_CODE);
@@ -63,6 +69,30 @@ public class Client {
             }
         }
         return httpClient;
+    }
+
+    private void configureAuth(final RegistryClientOptions options,
+                               final ConfigModel.Context context,
+                               final String contextName) {
+        if (ConfigModel.AUTH_TYPE_BASIC.equals(context.getAuthType())) {
+            final var password = requireCredential(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD);
+            options.basicAuth(context.getUsername(), password);
+        } else if (ConfigModel.AUTH_TYPE_OAUTH2.equals(context.getAuthType())) {
+            final var clientSecret = requireCredential(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET);
+            options.oauth2(context.getTokenEndpoint(), context.getClientId(), clientSecret, context.getScope());
+        } else if (!isBlank(context.getAuthType())) {
+            throw new CliException("Unsupported auth type '" + context.getAuthType()
+                    + "'. Run 'acr login' to reconfigure authentication.", APPLICATION_ERROR_RETURN_CODE);
+        }
+    }
+
+    private String requireCredential(final String contextName, final String key) {
+        final var value = credentialStore.retrieve(contextName, key);
+        if (isBlank(value)) {
+            throw new CliException("Credentials not found for context '" + contextName
+                    + "'. Run 'acr login' to authenticate.", APPLICATION_ERROR_RETURN_CODE);
+        }
+        return value;
     }
 
     /**

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/PlatformUtils.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/PlatformUtils.java
@@ -4,16 +4,21 @@ import java.util.Locale;
 
 public final class PlatformUtils {
 
+    public static final String OS_MAC = "osx";
+    public static final String OS_MAC_IDENTIFIER = "mac";
+    public static final String OS_DARWIN_IDENTIFIER = "darwin";
+    public static final String OS_LINUX = "linux";
+
     private PlatformUtils() {
     }
 
     public static String detectOsClassifier() {
         var osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
-        if (osName.contains("linux")) {
-            return "linux";
+        if (osName.contains(OS_LINUX)) {
+            return OS_LINUX;
         }
-        if (osName.contains("mac") || osName.contains("darwin")) {
-            return "osx";
+        if (osName.contains(OS_MAC_IDENTIFIER) || osName.contains(OS_DARWIN_IDENTIFIER)) {
+            return OS_MAC;
         }
         throw new UnsupportedOperationException("Unsupported OS: " + System.getProperty("os.name"));
     }
@@ -25,6 +30,10 @@ public final class PlatformUtils {
             case "aarch64", "arm64" -> "aarch_64";
             default -> throw new UnsupportedOperationException("Unsupported architecture: " + arch);
         };
+    }
+
+    public static boolean isMacOS() {
+        return OS_MAC.equals(detectOsClassifier());
     }
 
     public static String detectPlatformClassifier() {

--- a/cli/src/test/java/io/apicurio/registry/cli/AuthCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/AuthCommandTest.java
@@ -1,0 +1,212 @@
+package io.apicurio.registry.cli;
+
+import io.apicurio.registry.cli.config.ConfigModel;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+public class AuthCommandTest extends AbstractCLITest {
+
+    private static final String TOKEN_PATH = "/token";
+    private static final String TEST_CONTEXT = "test";
+    private static final String TEST_USERNAME = "testuser";
+    private static final String TEST_PASSWORD = "testpass";
+    private static final String TEST_CLIENT_ID = "test-client";
+    private static final String TEST_CLIENT_SECRET = "test-secret";
+    private static final String TEST_SCOPE = "openid profile";
+
+    // -- Help --
+
+    @Test
+    public void testLoginHelp() {
+        testHelpCommand("login");
+    }
+
+    @Test
+    public void testLogoutHelp() {
+        testHelpCommand("logout");
+    }
+
+    // -- Validation / error cases --
+
+    @Test
+    public void testLoginNoArgs() {
+        executeAndAssertFailure("login");
+    }
+
+    @Test
+    public void testLoginPasswordWithoutUsername() {
+        executeAndAssertFailure("login", "--password", TEST_PASSWORD);
+    }
+
+    @Test
+    public void testLoginOAuth2MissingClientId() {
+        executeAndAssertFailure("login", "--token-endpoint", tokenEndpoint());
+    }
+
+    @Test
+    public void testLoginNoContext() {
+        executeAndAssertSuccess("context", "delete", "--all");
+        executeAndAssertFailure("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD);
+    }
+
+    @Test
+    public void testLogoutNoContext() {
+        executeAndAssertSuccess("context", "delete", "--all");
+        executeAndAssertFailure("logout");
+    }
+
+    @Test
+    public void testLogoutWhenNotLoggedIn() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("logout");
+        assertThat(out.toString())
+                .as(withCliOutput("Should indicate not logged in"))
+                .contains("is not logged in");
+    }
+
+    // -- Basic auth --
+
+    @Test
+    public void testLoginBasicAuth() {
+        out.getBuffer().setLength(0);
+        loginBasic();
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm basic auth login"))
+                .contains("Logged in to context")
+                .contains(TEST_USERNAME);
+
+        var context = getTestContext();
+        assertThat(context.getAuthType()).isEqualTo(ConfigModel.AUTH_TYPE_BASIC);
+        assertThat(context.getUsername()).isEqualTo(TEST_USERNAME);
+        assertThat(context.getTokenEndpoint()).isNull();
+        assertThat(context.getClientId()).isNull();
+    }
+
+    @Test
+    public void testLogoutAfterLogin() {
+        loginBasic();
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("logout");
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm logout"))
+                .contains("Logged out of context");
+
+        var context = getTestContext();
+        assertThat(context.getAuthType()).isNull();
+        assertThat(context.getUsername()).isNull();
+    }
+
+    // -- OAuth2 --
+
+    @Test
+    public void testLoginOAuth2() {
+        out.getBuffer().setLength(0);
+        loginOAuth2();
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm OAuth2 login"))
+                .contains("Logged in to context")
+                .contains("OAuth2");
+
+        var context = getTestContext();
+        assertThat(context.getAuthType()).isEqualTo(ConfigModel.AUTH_TYPE_OAUTH2);
+        assertThat(context.getTokenEndpoint()).isEqualTo(tokenEndpoint());
+        assertThat(context.getClientId()).isEqualTo(TEST_CLIENT_ID);
+        assertThat(context.getUsername()).isNull();
+    }
+
+    @Test
+    public void testLoginOAuth2WithScope() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("login", "--token-endpoint", tokenEndpoint(),
+                "--client-id", TEST_CLIENT_ID, "--client-secret", TEST_CLIENT_SECRET,
+                "--scope", TEST_SCOPE);
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm OAuth2 login"))
+                .contains("Logged in to context")
+                .contains("OAuth2");
+
+        var context = getTestContext();
+        assertThat(context.getScope()).isEqualTo(TEST_SCOPE);
+    }
+
+    @Test
+    public void testLogoutAfterOAuth2Login() {
+        loginOAuth2();
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("logout");
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm logout"))
+                .contains("Logged out of context");
+
+        var context = getTestContext();
+        assertThat(context.getAuthType()).isNull();
+        assertThat(context.getTokenEndpoint()).isNull();
+        assertThat(context.getClientId()).isNull();
+        assertThat(context.getScope()).isNull();
+    }
+
+    // -- State transitions --
+
+    @Test
+    public void testLoginUsernameAndTokenEndpoint() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD,
+                "--token-endpoint", tokenEndpoint());
+
+        var context = getTestContext();
+        assertThat(context.getAuthType())
+                .as(withCliOutput("--username should take precedence over --token-endpoint"))
+                .isEqualTo(ConfigModel.AUTH_TYPE_BASIC);
+    }
+
+    @Test
+    public void testLoginOverwriteBasicWithOAuth2() {
+        loginBasic();
+
+        out.getBuffer().setLength(0);
+        loginOAuth2();
+
+        var context = getTestContext();
+        assertThat(context.getAuthType()).isEqualTo(ConfigModel.AUTH_TYPE_OAUTH2);
+        assertThat(context.getUsername()).isNull();
+        assertThat(context.getTokenEndpoint()).isEqualTo(tokenEndpoint());
+    }
+
+    @Test
+    public void testLoginReloginBasicDifferentUser() {
+        executeAndAssertSuccess("login", "--username", "user1", "--password", "pass1");
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("login", "--username", "user2", "--password", "pass2");
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm login as new user"))
+                .contains("user2");
+
+        var context = getTestContext();
+        assertThat(context.getUsername()).isEqualTo("user2");
+    }
+
+    // -- Helpers --
+
+    private void loginBasic() {
+        executeAndAssertSuccess("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD);
+    }
+
+    private void loginOAuth2() {
+        executeAndAssertSuccess("login", "--token-endpoint", tokenEndpoint(),
+                "--client-id", TEST_CLIENT_ID, "--client-secret", TEST_CLIENT_SECRET);
+    }
+
+    private String tokenEndpoint() {
+        return registryUrl + TOKEN_PATH;
+    }
+
+    private ConfigModel.Context getTestContext() {
+        return config.read().getContext().get(TEST_CONTEXT);
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/TestCredentialProvider.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/TestCredentialProvider.java
@@ -1,0 +1,35 @@
+package io.apicurio.registry.cli;
+
+import io.apicurio.registry.cli.auth.CredentialProvider;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Test credential provider using in-memory storage. Replaces the OS keychain
+ * provider so tests work in CI environments without secret-tool or macOS Keychain.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class TestCredentialProvider implements CredentialProvider {
+
+    private final ConcurrentMap<String, String> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void store(final String account, final String secret) {
+        store.put(account, secret);
+    }
+
+    @Override
+    public String retrieve(final String account) {
+        return store.get(account);
+    }
+
+    @Override
+    public void delete(final String account) {
+        store.remove(account);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `acr login` and `acr logout` commands to authenticate with secured registry instances using Basic auth or OAuth2 client credentials flow. Credentials are stored securely in the OS keychain (macOS Keychain / Linux Secret Service), never in config files.

## Architecture

```
┌──────────────────────────────────────────────────┐
│                   CLI Commands                   │
│  ┌──────────────┐         ┌───────────────┐      │
│  │ LoginCommand │         │ LogoutCommand │      │
│  └──────┬───────┘         └───────┬───────┘      │
│         │                         │              │
│         ▼                         ▼              │
│  ┌─────────────────────────────────────────┐     │
│  │           CredentialStore               │     │
│  │  (facade — per-context key management)  │     │
│  └──────────────────┬──────────────────────┘     │
│                     │ @Inject                    │
│  ┌──────────────────┴──────────────────────┐     │
│  │    CredentialProvider (interface)       │     │
│  │  selected by CredentialProviderProducer │     │
│  └──────────────────┬──────────────────────┘     │
│          ┌──────────┴──────────┐                 │
│          ▼                     ▼                 │
│  ┌───────────────┐   ┌────────────────┐          │
│  │ MacOSCred.    │   │ LinuxCred.     │          │
│  │ Provider      │   │ Provider       │          │
│  │ (security)    │   │ (secret-tool)  │          │
│  └───────────────┘   └────────────────┘          │
│                                                  │
│  Test: TestCredentialProvider (@Alternative)     │
│        in-memory — no OS keychain in CI          │
│                                                  │
│  ┌─────────────────────────────────────────┐     │
│  │        ConfigModel.Context              │     │
│  │  (authType, username, tokenEndpoint,    │     │
│  │   clientId, scope — stored in JSON)     │     │
│  └─────────────────────────────────────────┘     │
│                                                  │
│  ┌─────────────────────────────────────────┐     │
│  │              Client                     │     │
│  │  (configures SDK auth from stored creds)│     │
│  └─────────────────────────────────────────┘     │
└──────────────────────────────────────────────────┘
```

**Separation of concerns:**
- `CredentialProvider` — interface for platform-specific keychain operations
- `CredentialProviderProducer` — CDI producer that selects MacOS/Linux provider at runtime
- `CredentialStore` — public facade that maps context+key to keychain accounts
- `CredentialStoreException` — specific exception for credential operations (not generic RuntimeException)
- `LoginCommand` / `LogoutCommand` — CLI commands that orchestrate config + credential storage
- `Client` — reads stored credentials to configure the SDK for API calls
- `TestCredentialProvider` — `@Alternative` in-memory provider for CI tests (no OS keychain needed)

## Auth Flows

**Basic auth:**
```bash
acr login --username admin --password secret     # non-interactive (CI/CD)
acr login --username admin                        # prompts for password
```

**OAuth2 client credentials:**
```bash
acr login --token-endpoint <url> --client-id <id> --client-secret <secret> [--scope <scope>]
```

**Logout:**
```bash
acr logout   # clears credentials from keychain and config
```

## Security

- **Linux:** Secrets piped via stdin to `secret-tool` — never appear in process arguments
- **macOS:** Secrets passed as `-w` argument to `security` command (macOS `security` does not support stdin input; the process is short-lived)
- Passwords read via `Console.readPassword()` with `char[]` zeroed after use
- Auth fields excluded from Lombok `@ToString` to prevent log leakage
- Debug logs redacted — only exception class name logged, no raw OS command output
- Credentials stored only in OS keychain, config.json holds metadata only
- Fail-fast when credentials are missing — no silent unauthenticated requests
- Fail-fast on unknown auth type — no silent fallback to unauthenticated
- Credential store errors wrapped as `CliException` for clean CLI error output
- Login stores credentials before writing config — if keychain fails, config stays clean
- Login cleans up stale credentials from previous auth type
- Logout deletes all known credential keys regardless of current auth type

## Changes

| File | Purpose |
|------|---------|
| `CredentialProvider.java` | Platform-specific credential storage interface |
| `CredentialProviderProducer.java` | CDI producer — selects MacOS/Linux provider at runtime |
| `MacOSCredentialProvider.java` | macOS Keychain via `security` command |
| `LinuxCredentialProvider.java` | Linux Secret Service via `secret-tool` |
| `ProcessUtils.java` | Shared process execution with timeout handling |
| `CredentialStore.java` | Public facade over credential providers |
| `CredentialStoreException.java` | Specific exception for credential operations |
| `LoginCommand.java` | `acr login` command (Basic + OAuth2) |
| `LogoutCommand.java` | `acr logout` command |
| `ConfigModel.java` | Auth fields, constants, `clearAuth()`, `@ToString.Exclude` |
| `Client.java` | SDK auth configuration with `requireCredential()` |
| `PlatformUtils.java` | `OS_MAC` / `OS_LINUX` constants, `isMacOS()` helper |
| `InstallCommand.java` | Consolidated OS detection via `PlatformUtils.isMacOS()` |
| `Acr.java` | Register login/logout subcommands |
| `AuthCommandTest.java` | 16 unit tests |
| `TestCredentialProvider.java` | `@Alternative` in-memory provider for CI tests |

## Test Plan

- [x] `acr login --help` / `acr logout --help` display usage
- [x] `acr login` with no args fails with clear message
- [x] `acr login --password` without `--username` fails
- [x] `acr login --token-endpoint` without `--client-id` fails
- [x] Login/logout with no context set fails
- [x] Logout when not logged in shows informational message
- [x] Basic auth login stores correct config (authType, username)
- [x] OAuth2 login stores correct config (authType, tokenEndpoint, clientId)
- [x] OAuth2 with `--scope` stores scope in config
- [x] Logout clears all auth fields from config (Basic and OAuth2)
- [x] Login overwrites previous auth type (Basic → OAuth2)
- [x] Re-login with different user updates credentials
- [x] `--username` takes precedence when both `--username` and `--token-endpoint` provided
- [x] Manual: Basic auth end-to-end (macOS + Keycloak + Registry)
- [x] Manual: OAuth2 client credentials end-to-end (macOS + Keycloak + Registry)
- [x] Manual: macOS Keychain store/retrieve verified
- [x] Manual: Linux secret-tool storage

## Follow-up

- #8133 — Browser-based OAuth2/OIDC login and automatic token refresh
- #8161 — File-based credential fallback with `--allow-unsafe-credential-storage` for headless/CI environments