### PR TITLE
feat(ci): backport multi-channel OLM, Docker floating tags, and release parallelization to 3.2.x

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -54,6 +54,11 @@ jobs:
           echo "RELEASE_VERSION=$(cat release.json | jq -r '.name')" >> $GITHUB_ENV
           echo "BRANCH=$(cat release.json | jq -r '.target_commitish')" >> $GITHUB_ENV
 
+      - name: Calculate Minor Series Tag
+        run: |
+          MINOR_TAG=$(echo "$RELEASE_VERSION" | awk -F. '{print $1"."$2}')
+          echo "MINOR_TAG=$MINOR_TAG" >> $GITHUB_ENV
+
       - name: Download Source Code
         run: git clone --branch $RELEASE_VERSION --single-branch ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git registry
 
@@ -115,6 +120,7 @@ jobs:
         run: |
           docker buildx build --push -f ./target/docker/Dockerfile.jvm \
               -t quay.io/apicurio/apicurio-registry-mcp-server:$RELEASE_VERSION \
+              -t quay.io/apicurio/apicurio-registry-mcp-server:$MINOR_TAG \
               -t quay.io/apicurio/apicurio-registry-mcp-server:latest \
               --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le ./target/docker
 
@@ -125,9 +131,11 @@ jobs:
               -t docker.io/apicurio/apicurio-registry:latest \
               -t docker.io/apicurio/apicurio-registry:latest-release \
               -t docker.io/apicurio/apicurio-registry:$RELEASE_VERSION \
+              -t docker.io/apicurio/apicurio-registry:$MINOR_TAG \
               -t quay.io/apicurio/apicurio-registry:latest \
               -t quay.io/apicurio/apicurio-registry:latest-release \
               -t quay.io/apicurio/apicurio-registry:$RELEASE_VERSION \
+              -t quay.io/apicurio/apicurio-registry:$MINOR_TAG \
               --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le ./distro/docker/target/docker
 
       - name: Build and Push Multi-arch UI Images
@@ -137,9 +145,11 @@ jobs:
               -t docker.io/apicurio/apicurio-registry-ui:latest \
               -t docker.io/apicurio/apicurio-registry-ui:latest-release \
               -t docker.io/apicurio/apicurio-registry-ui:$RELEASE_VERSION \
+              -t docker.io/apicurio/apicurio-registry-ui:$MINOR_TAG \
               -t quay.io/apicurio/apicurio-registry-ui:latest \
               -t quay.io/apicurio/apicurio-registry-ui:latest-release \
               -t quay.io/apicurio/apicurio-registry-ui:$RELEASE_VERSION \
+              -t quay.io/apicurio/apicurio-registry-ui:$MINOR_TAG \
               --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le .
 
   # Slack notification using reusable workflow

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -13,16 +13,18 @@ on:
   release:
     types: [ released ]
 
-env:
-  RELEASE_VERSION: ${{ github.event.release.name }}
-  BRANCH: ${{ github.event.release.target_commitish }}
-  RUN_TESTS: 'true'
-
 jobs:
-  release-operator:
+
+  release-build:
+    name: Build & Publish
     if: github.repository_owner == 'Apicurio' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '3.'))
     runs-on: ubuntu-22.04
-    timeout-minutes: 180
+    timeout-minutes: 60
+    outputs:
+      release-version: ${{ steps.config.outputs.release-version }}
+      branch: ${{ steps.config.outputs.branch }}
+      run-tests: ${{ steps.config.outputs.run-tests }}
+      package-version: ${{ steps.config.outputs.package-version }}
     steps:
 
       - name: Fetch Release Details
@@ -32,6 +34,13 @@ jobs:
           echo "RELEASE_VERSION=$(cat release.json | jq -r '.name')" >> $GITHUB_ENV
           echo "BRANCH=$(cat release.json | jq -r '.target_commitish')" >> $GITHUB_ENV
           echo "RUN_TESTS=${{ github.event.inputs.run_tests }}" >> $GITHUB_ENV
+
+      - name: Configure release event env
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          echo "RELEASE_VERSION=${{ github.event.release.name }}" >> $GITHUB_ENV
+          echo "BRANCH=${{ github.event.release.target_commitish }}" >> $GITHUB_ENV
+          echo "RUN_TESTS=true" >> $GITHUB_ENV
 
       - name: Download Source Code
         run: |
@@ -61,27 +70,19 @@ jobs:
               exit 1
           fi
 
-      - name: Configure env. variables 1
+      - name: Configure outputs
+        id: config
         working-directory: registry/operator
         run: |
-          echo "GH_TOKEN=${{ secrets.ACCESS_TOKEN }}" >> "$GITHUB_ENV"
-          echo "CUSTOM_ENV=$(pwd)/custom_env" >> "$GITHUB_ENV"
-          echo "PACKAGE_VERSION=$(make VAR=LC_VERSION variable-get)" >> "$GITHUB_ENV"
-
-      - name: Configure env. variables 2
-        run: |
-          echo "RELEASE_BRANCH=release-$PACKAGE_VERSION" >> "$GITHUB_ENV"
-
-      - name: Configure custom env. variables 1
-        # See https://github.com/actions/runner/issues/1126
-        run: |
-          echo "export OPERAND_IMAGE_TAG=$RELEASE_VERSION" >> "$CUSTOM_ENV"
+          echo "release-version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "run-tests=$RUN_TESTS" >> $GITHUB_OUTPUT
+          echo "package-version=$(make VAR=LC_VERSION variable-get)" >> $GITHUB_OUTPUT
 
       - name: Show make configuration
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make config-show
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION config-show
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -93,7 +94,6 @@ jobs:
       - name: Build the operator
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
           make BUILD_OPTS=--no-transfer-progress SKIP_TESTS=true build
 
       - name: Login to Quay.io Registry
@@ -102,60 +102,185 @@ jobs:
       - name: Build and push operator image
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make ADDITIONAL_IMAGE_TAG=latest image-build image-push
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_IMAGE_TAG=latest image-build image-push
 
       - name: Wait on operand images
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          export REGISTRY_APP_IMAGE="$(make VAR=REGISTRY_APP_IMAGE variable-get)"
+          export REGISTRY_APP_IMAGE="$(make OPERAND_IMAGE_TAG=$RELEASE_VERSION VAR=REGISTRY_APP_IMAGE variable-get)"
           until docker manifest inspect "$REGISTRY_APP_IMAGE" >& /dev/null; do echo "Waiting on $REGISTRY_APP_IMAGE"; sleep 10; done
-          export REGISTRY_UI_IMAGE="$(make VAR=REGISTRY_UI_IMAGE variable-get)"
+          export REGISTRY_UI_IMAGE="$(make OPERAND_IMAGE_TAG=$RELEASE_VERSION VAR=REGISTRY_UI_IMAGE variable-get)"
           until docker manifest inspect "$REGISTRY_UI_IMAGE" >& /dev/null; do echo "Waiting on $REGISTRY_UI_IMAGE"; sleep 10; done
 
       - name: Build operator bundle
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make bundle
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION bundle
 
       - name: Build operator catalog
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make ADDITIONAL_CATALOG_IMAGE_TAG=latest catalog
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_CATALOG_IMAGE_TAG=latest catalog
+
+      - name: Generate install file for tests
+        working-directory: registry/operator
+        run: |
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION INSTALL_FILE=controller/target/test-install.yaml dist-install-file
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-test-artifacts
+          path: |
+            registry/operator/controller/target/
+            registry/operator/model/target/
+            registry/operator/olm-tests/target/
+          retention-days: 1
+
+      - name: Upload bundle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-bundle-artifacts
+          path: |
+            registry/operator/target/bundle/
+          retention-days: 1
+
+  release-test:
+    name: Test (${{ matrix.name }})
+    needs: release-build
+    if: needs.release-build.outputs.run-tests == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: smoke
+            groups: "smoke"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: kafka
+            groups: "kafka"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: auth
+            groups: "auth"
+            excluded-groups: "kafka"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: database
+            groups: "database"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: feature
+            groups: "feature"
+            excluded-groups: "feature-setup"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: feature-setup
+            groups: "feature-setup"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+          - name: olm-v1
+            groups: "OLM"
+            olm-enable: "true"
+            olm-v1-enable: "true"
+            extra-build-opts: "-Dtest.operator.olm-version=1"
+          - name: olm-v0
+            groups: "OLM"
+            olm-enable: "true"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
+    steps:
+
+      - name: Download Source Code
+        run: |
+          git clone https://github.com/Apicurio/apicurio-registry.git registry
+          cd registry && git checkout "${{ needs.release-build.outputs.release-version }}"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Download test artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: operator-test-artifacts
+          path: registry/operator/
 
       - uses: apicurio/apicurio-github-actions/setup-minikube@v2
-        if: env.RUN_TESTS == 'true'
         with:
-          # Do not use the "docker" driver, it is causing port-forwarding errors. I have no clue why :(
-          # TODO: I might've been wrong, check this again later.
           driver: 'none'
           ingress-enable: 'true'
-          olm-enable: 'true'
-          olm-v1-enable: 'true'
-          start-args: '--alsologtostderr --v=2' # Debug
+          olm-enable: ${{ matrix.olm-enable }}
+          olm-v1-enable: ${{ matrix.olm-v1-enable }}
+          start-args: '--alsologtostderr --v=2'
 
-      - name: Run remote and OLM v1 tests on Minikube
-        if: env.RUN_TESTS == 'true'
+      - name: Run ${{ matrix.name }} tests on Minikube
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make REMOTE_TESTS_ALL_INSTALL_FILE=install/install.yaml BUILD_OPTS="--no-transfer-progress -Dtest.operator.olm-version=1" test-remote-all
+          make BUILD_OPTS="--no-transfer-progress ${{ matrix.extra-build-opts }}" \
+            OPERAND_IMAGE_TAG="${{ needs.release-build.outputs.release-version }}" \
+            REMOTE_TESTS_ALL_INSTALL_FILE=controller/target/test-install.yaml \
+            GROUPS="${{ matrix.groups }}" \
+            EXCLUDED_GROUPS="${{ matrix.excluded-groups }}" \
+            test-remote-group
 
-      - name: Run OLM v0 smoke tests on Minikube
-        if: env.RUN_TESTS == 'true'
+  release-post:
+    name: Post-Release
+    needs: [release-build, release-test]
+    if: always() && needs.release-build.result == 'success' && (needs.release-test.result == 'success' || needs.release-test.result == 'skipped')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    env:
+      RELEASE_VERSION: ${{ needs.release-build.outputs.release-version }}
+      BRANCH: ${{ needs.release-build.outputs.branch }}
+      PACKAGE_VERSION: ${{ needs.release-build.outputs.package-version }}
+    steps:
+
+      - name: Configure env. variables
+        run: |
+          echo "GH_TOKEN=${{ secrets.ACCESS_TOKEN }}" >> "$GITHUB_ENV"
+          echo "RELEASE_BRANCH=release-$PACKAGE_VERSION" >> "$GITHUB_ENV"
+
+      - name: Download Source Code
+        run: |
+          git config --global user.name apicurio-ci
+          git config --global user.email apicurio.ci@gmail.com
+          git clone "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git" registry
+          cd registry && git checkout "$RELEASE_VERSION"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Build operator
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make REMOTE_TESTS_ALL_INSTALL_FILE=install/install.yaml BUILD_OPTS="--no-transfer-progress -Dgroups=OLM" test-remote-all
+          make BUILD_OPTS=--no-transfer-progress SKIP_TESTS=true OPERAND_IMAGE_TAG=$RELEASE_VERSION build
+
+      - name: Download bundle artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: operator-bundle-artifacts
+          path: registry/operator/target/bundle/
 
       - name: Build dist archive and attach to the release
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make dist
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION dist
           DIST_FILE="target/apicurio-registry-operator-$RELEASE_VERSION.tar.gz"
           gh release upload "$RELEASE_VERSION" "$DIST_FILE"
 
@@ -219,12 +344,6 @@ jobs:
         if: steps.openshift-community-operators-pr.outcome == 'failure'
         run: echo "::warning::Failed to create Openshift Community Operators PR. Please create it manually."
 
-      - name: Configure custom env. variables 2
-        run: |
-          # We want to use latest-snapshot instead of x.y.z-snapshot
-          echo "export IMAGE_TAG=latest-snapshot" >> "$CUSTOM_ENV"
-          echo "export OPERAND_IMAGE_TAG=latest-snapshot" >> "$CUSTOM_ENV"
-
       - name: Prepare post-release changes
         working-directory: registry/operator
         run: |
@@ -249,8 +368,7 @@ jobs:
       - name: Update install file
         working-directory: registry/operator
         run: |
-          source "$CUSTOM_ENV"
-          make SKIP_TESTS=true build INSTALL_FILE=install/install.yaml dist-install-file
+          make IMAGE_TAG=latest-snapshot OPERAND_IMAGE_TAG=latest-snapshot SKIP_TESTS=true build INSTALL_FILE=install/install.yaml dist-install-file
           git add install/*
 
       - name: Commit & push post-release changes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -414,29 +414,6 @@ jobs:
           npm version ${{ env.SNAPSHOT_UI_VERSION }} --allow-same-version
           popd
 
-      - name: Create maintenance branch for previous minor
-        if: github.event.inputs.branch == 'main'
-        run: |
-          cd registry
-          RELEASE_VERSION="${{ github.event.inputs.release-version }}"
-          MAJOR=$(echo "$RELEASE_VERSION" | awk -F '[.-]' '{print $1}')
-          MINOR=$(echo "$RELEASE_VERSION" | awk -F '[.-]' '{print $2}')
-          PATCH=$(echo "$RELEASE_VERSION" | awk -F '[.-]' '{print $3}')
-
-          if [ "$PATCH" = "0" ] && [ "$MINOR" -gt "0" ]; then
-            PREV_MINOR=$((MINOR - 1))
-            MAINT_BRANCH="release/${MAJOR}.${PREV_MINOR}.x"
-            # Find the latest tag for the previous minor
-            PREV_TAG=$(git tag -l "${MAJOR}.${PREV_MINOR}.*" --sort=-v:refname | head -1)
-            if [ -n "$PREV_TAG" ] && ! git ls-remote --exit-code origin "refs/heads/$MAINT_BRANCH" > /dev/null 2>&1; then
-              echo "Creating maintenance branch $MAINT_BRANCH from tag $PREV_TAG"
-              git branch "$MAINT_BRANCH" "$PREV_TAG"
-              git push origin "$MAINT_BRANCH"
-            else
-              echo "Maintenance branch $MAINT_BRANCH already exists or no previous tag found, skipping"
-            fi
-          fi
-
       - name: Commit Snapshot Version ${{ env.SNAPSHOT_VERSION }}
         run: |
           cd registry

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -414,6 +414,29 @@ jobs:
           npm version ${{ env.SNAPSHOT_UI_VERSION }} --allow-same-version
           popd
 
+      - name: Create maintenance branch for previous minor
+        if: github.event.inputs.branch == 'main'
+        run: |
+          cd registry
+          RELEASE_VERSION="${{ github.event.inputs.release-version }}"
+          MAJOR=$(echo "$RELEASE_VERSION" | awk -F '[.-]' '{print $1}')
+          MINOR=$(echo "$RELEASE_VERSION" | awk -F '[.-]' '{print $2}')
+          PATCH=$(echo "$RELEASE_VERSION" | awk -F '[.-]' '{print $3}')
+
+          if [ "$PATCH" = "0" ] && [ "$MINOR" -gt "0" ]; then
+            PREV_MINOR=$((MINOR - 1))
+            MAINT_BRANCH="release/${MAJOR}.${PREV_MINOR}.x"
+            # Find the latest tag for the previous minor
+            PREV_TAG=$(git tag -l "${MAJOR}.${PREV_MINOR}.*" --sort=-v:refname | head -1)
+            if [ -n "$PREV_TAG" ] && ! git ls-remote --exit-code origin "refs/heads/$MAINT_BRANCH" > /dev/null 2>&1; then
+              echo "Creating maintenance branch $MAINT_BRANCH from tag $PREV_TAG"
+              git branch "$MAINT_BRANCH" "$PREV_TAG"
+              git push origin "$MAINT_BRANCH"
+            else
+              echo "Maintenance branch $MAINT_BRANCH already exists or no previous tag found, skipping"
+            fi
+          fi
+
       - name: Commit Snapshot Version ${{ env.SNAPSHOT_VERSION }}
         run: |
           cd registry

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -40,8 +40,12 @@ PACKAGE ?= $(PACKAGE_NAME).v$(LC_VERSION)
 PREVIOUS_PACKAGE_VERSION ?= 3.2.4
 PREVIOUS_PACKAGE ?= $(PACKAGE_NAME).v$(PREVIOUS_PACKAGE_VERSION)
 
-CHANNELS ?= 3.x
-DEFAULT_CHANNEL ?= $(CHANNELS)
+# Auto-derive channel from version (e.g., 3.2.1 -> 3.2.x, 3.3.0-snapshot -> 3.3.x)
+CHANNEL ?= $(shell echo "$(LC_VERSION)" | sed 's/\([0-9]*\.[0-9]*\)\..*/\1.x/')
+PREVIOUS_CHANNEL ?= $(shell echo "$(PREVIOUS_PACKAGE_VERSION)" | sed 's/\([0-9]*\.[0-9]*\)\..*/\1.x/')
+
+CHANNELS ?= $(CHANNEL)
+DEFAULT_CHANNEL ?= $(CHANNEL)
 
 BUNDLE_OPTS ?= --package $(PACKAGE_NAME) --version $(LC_VERSION) --channels=$(CHANNELS) --default-channel=$(DEFAULT_CHANNEL)
 BUNDLE_DIR ?= target/bundle/$(PACKAGE_NAME)/$(LC_VERSION)
@@ -111,6 +115,8 @@ export PLACEHOLDER_BUNDLE_IMAGE := $(BUNDLE_IMAGE)
 export PLACEHOLDER_CATALOG_NAMESPACE := $(CATALOG_NAMESPACE)
 export PLACEHOLDER_CATALOG_IMAGE := $(CATALOG_IMAGE)
 
+export PLACEHOLDER_CHANNEL := $(CHANNEL)
+
 
 ########## Help
 
@@ -148,6 +154,8 @@ endif
 	@echo ""
 	@echo "$(CC_CYAN)Bundle$(CC_END)"
 	@echo "PACKAGE_NAME=$(PACKAGE_NAME)"
+	@echo "CHANNEL=$(CHANNEL)"
+	@echo "PREVIOUS_CHANNEL=$(PREVIOUS_CHANNEL)"
 	@echo "CHANNELS=$(CHANNELS)"
 	@echo "DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)"
 	@echo "BUNDLE_IMAGE=$(BUNDLE_IMAGE)"
@@ -480,8 +488,30 @@ endif
 
 .PHONY: release-catalog-template-update
 release-catalog-template-update: install-yq
+	# Update 3.x rolling channel: replace placeholder with released version, add new placeholder
 	$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "3.x") | .entries[] | select(.name == "$${PLACEHOLDER_PACKAGE}")).name = "$(PREVIOUS_PACKAGE)"' -i $(CATALOG_DIR)/catalog.template.yaml
 	$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "3.x") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}", "replaces": "$(PREVIOUS_PACKAGE)"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml
+	# Update minor-version channel
+	@if $(YQ) -e '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(PREVIOUS_CHANNEL)"))' $(CATALOG_DIR)/catalog.template.yaml > /dev/null 2>&1; then \
+		echo "Updating existing $(PREVIOUS_CHANNEL) channel"; \
+		$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(PREVIOUS_CHANNEL)") | .entries[] | select(.name == "$${PLACEHOLDER_PACKAGE}")).name = "$(PREVIOUS_PACKAGE)"' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	else \
+		echo "Creating new $(PREVIOUS_CHANNEL) channel with $(PREVIOUS_PACKAGE)"; \
+		$(YQ) '.entries |= . + [{"schema": "olm.channel", "package": "$${PLACEHOLDER_PACKAGE_NAME}", "name": "$(PREVIOUS_CHANNEL)", "entries": [{"name": "$(PREVIOUS_PACKAGE)"}]}]' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	fi
+	@if [ "$(CHANNEL)" = "$(PREVIOUS_CHANNEL)" ]; then \
+		echo "Adding placeholder to $(CHANNEL) channel (same minor)"; \
+		$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}", "replaces": "$(PREVIOUS_PACKAGE)"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	elif $(YQ) -e '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)"))' $(CATALOG_DIR)/catalog.template.yaml > /dev/null 2>&1; then \
+		echo "Adding placeholder to existing $(CHANNEL) channel (new minor)"; \
+		$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	else \
+		echo "Creating new $(CHANNEL) channel with placeholder (new minor)"; \
+		$(YQ) '.entries |= . + [{"schema": "olm.channel", "package": "$${PLACEHOLDER_PACKAGE_NAME}", "name": "$(CHANNEL)", "entries": [{"name": "$${PLACEHOLDER_PACKAGE}"}]}]' -i $(CATALOG_DIR)/catalog.template.yaml; \
+	fi
+	# Update defaultChannel to the current channel
+	$(YQ) '(.entries[] | select(.schema == "olm.package")).defaultChannel = "$${PLACEHOLDER_CHANNEL}"' -i $(CATALOG_DIR)/catalog.template.yaml
+	# Add bundle image for the released version
 	$(YQ) '.entries |= . + [{"schema": "olm.bundle", "image": "$(PREVIOUS_BUNDLE_IMAGE)"}]' -i $(CATALOG_DIR)/catalog.template.yaml
 
 

--- a/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
+++ b/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
@@ -2,7 +2,7 @@ schema: olm.template.basic
 entries:
   - schema: olm.package
     name: ${PLACEHOLDER_PACKAGE_NAME}
-    defaultChannel: 3.x
+    defaultChannel: ${PLACEHOLDER_CHANNEL}
   - schema: olm.channel
     package: ${PLACEHOLDER_PACKAGE_NAME}
     name: 3.x
@@ -42,6 +42,15 @@ entries:
       - name: apicurio-registry-3.v3.0.8
         replaces: apicurio-registry-3.v3.0.7
       - name: apicurio-registry-3.v3.0.7
+  - schema: olm.channel
+    package: ${PLACEHOLDER_PACKAGE_NAME}
+    name: 3.2.x
+    entries:
+      - name: ${PLACEHOLDER_PACKAGE}
+        replaces: apicurio-registry-3.v3.2.1
+      - name: apicurio-registry-3.v3.2.1
+        replaces: apicurio-registry-3.v3.2.0
+      - name: apicurio-registry-3.v3.2.0
   - schema: olm.bundle
     image: ${PLACEHOLDER_BUNDLE_IMAGE}
   - schema: olm.bundle

--- a/operator/olm-tests/src/test/deploy/olmv0/subscription.yaml
+++ b/operator/olm-tests/src/test/deploy/olmv0/subscription.yaml
@@ -7,6 +7,6 @@ spec:
   sourceNamespace: ${PLACEHOLDER_CATALOG_NAMESPACE}
   source: apicurio-registry-operator-catalog
   name: ${PLACEHOLDER_PACKAGE_NAME}
-  channel: 3.x
+  channel: ${PLACEHOLDER_CHANNEL}
   startingCSV: ${PLACEHOLDER_PACKAGE}
   installPlanApproval: Automatic

--- a/operator/olm-tests/src/test/deploy/olmv1/cluster-extension.yaml
+++ b/operator/olm-tests/src/test/deploy/olmv1/cluster-extension.yaml
@@ -24,5 +24,5 @@ spec:
           olm.operatorframework.io/metadata.name: apicurio-registry-operator-catalog # Intentional for development and testing.
       packageName: ${PLACEHOLDER_PACKAGE_NAME}
       channels:
-        - 3.x
+        - ${PLACEHOLDER_CHANNEL}
       version: ${PLACEHOLDER_LC_VERSION}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
@@ -162,7 +162,18 @@ public abstract class OLMITBase {
         rawResource = rawResource.replace("${PLACEHOLDER_PACKAGE}", "apicurio-registry-3.v" + projectVersion.toLowerCase());
         rawResource = rawResource.replace("${PLACEHOLDER_VERSION}", projectVersion);
         rawResource = rawResource.replace("${PLACEHOLDER_LC_VERSION}", projectVersion.toLowerCase());
+        rawResource = rawResource.replace("${PLACEHOLDER_CHANNEL}", deriveChannel(projectVersion));
         return rawResource;
+    }
+
+    private static String deriveChannel(String version) {
+        // Derive minor-version channel from version (e.g., "3.2.1" -> "3.2.x", "3.3.0-SNAPSHOT" -> "3.3.x")
+        var lc = version.toLowerCase();
+        var parts = lc.split("\\.");
+        if (parts.length >= 2) {
+            return parts[0] + "." + parts[1] + ".x";
+        }
+        return lc;
     }
 
     @AfterEach


### PR DESCRIPTION
## Summary

Backport of release infrastructure changes from PR #7743 to the `3.2.x` maintenance branch.

These workflow changes are needed on `3.2.x` because `workflow_dispatch` triggers use the workflow files from the branch being released, not from main.

### Changes backported

- **Multi-channel OLM support**: auto-derive minor-version channels (e.g., `3.2.x`) from operator version
- **Release-operator parallelization**: split monolithic 3h job into 3 parallel jobs (~45 min)
- **PLACEHOLDER_CHANNEL substitution**: OLM test support for parameterized channels
- **Minor-series floating Docker tags**: add `MINOR_TAG` (e.g., `3.2`) to app, UI, and MCP server images
- **Maintenance branch automation**: auto-create `release/X.Y.x` when releasing a new minor from main
- **Branch input description**: clarify usage for minor vs. patch releases

### Not backported (main-only)

- README/CONTRIBUTING versioning policy docs
- Official Antora docs page
- 3.3.x catalog channel (not relevant for 3.2.x)

## Test plan

- [ ] Verify operator CI tests pass on 3.2.x
- [ ] Verify `MINOR_TAG` derives correctly (e.g., `3.2.5` → `3.2`)