### PR TITLE
fix(test): fix flaky BlueGreenStorageIsolationTest

### DIFF
--- a/app/src/test/java/io/apicurio/registry/storage/impl/gitops/GitTestRepository.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/gitops/GitTestRepository.java
@@ -30,6 +30,9 @@ public class GitTestRepository implements AutoCloseable {
             gitRepoBranch = "main";
             git = Git.init().setDirectory(gitDir.toFile()).setInitialBranch(gitRepoBranch).call();
             Files.write(gitDir.resolve(".init"), "init".getBytes(StandardCharsets.UTF_8));
+            Files.write(gitDir.resolve("registry.registry.yaml"),
+                    "$type: registry-v0\nregistryId: test\nglobalRules: []\nproperties: []\n"
+                            .getBytes(StandardCharsets.UTF_8));
             git.add().addFilepattern(".").call();
             git.commit().setMessage("Initial commit").call();
             gitRepoUrl = git.getRepository().getWorkTree().getAbsolutePath();


### PR DESCRIPTION
## Summary

Fixes a race condition causing `BlueGreenStorageIsolationTest` to fail intermittently in CI.

**Root cause:** The gitops scheduler starts polling on Quarkus boot, before any test method runs. `GitTestRepository.initialize()` created a git repo with only a `.init` file — no `registry.registry.yaml`. The scheduler's first poll failed with *"Data source does not contain a registry configuration matching ID 'test'"*, then concurrently called `deleteAllUserData()` on the same `BlueSqlStorage`/`GreenSqlStorage` beans the test was using.

**Fix:** Add a minimal `registry.registry.yaml` (with `registryId: test`) to the initial commit in `GitTestRepository.initialize()`. This makes the first poll succeed with an empty-but-valid dataset, eliminating the race.

Fixes #8138

## Changes

- `GitTestRepository.java`: 3 lines added — write `registry.registry.yaml` alongside `.init` in the initial commit

## Test plan

- [x] `BlueGreenStorageIsolationTest` — passes
- [x] `GitOpsSmokeTest` — passes (overwrites repo contents via `load()`, unaffected)
- [x] `GitOpsStatusTest` — passes (asserts `syncState` is `notNullValue()`, accepts any state)
- [x] All 11 gitops tests run 5 times consecutively with zero failures