### PR TITLE
fix(serdes): use property-aware Schema keys in DatumReader/Writer cache. Fixes #8129 [backport 3.2.x]

### DIFF
--- a/serdes/generic/serde-common-avro/src/main/java/io/apicurio/registry/serde/avro/DefaultAvroDatumProvider.java
+++ b/serdes/generic/serde-common-avro/src/main/java/io/apicurio/registry/serde/avro/DefaultAvroDatumProvider.java
@@ -1,7 +1,6 @@
 package io.apicurio.registry.serde.avro;
 
 import org.apache.avro.Schema;
-import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.DatumReader;
@@ -24,22 +23,11 @@ public class DefaultAvroDatumProvider<T> implements AvroDatumProvider<T> {
      */
     private final ConcurrentHashMap<String, Schema> readerSchemas = new ConcurrentHashMap<>();
 
-    /**
-     * Cache for DatumWriter instances keyed by schema fingerprint + type.
-     * DatumWriter is thread-safe and can be reused across serializations.
-     */
     private final ConcurrentHashMap<WriterCacheKey, DatumWriter<T>> writerCache = new ConcurrentHashMap<>();
 
-    /**
-     * Cache for DatumReader instances keyed by schema fingerprint.
-     * DatumReader is thread-safe and can be reused across deserializations.
-     */
-    private final ConcurrentHashMap<Long, DatumReader<T>> readerCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Schema, DatumReader<T>> readerCache = new ConcurrentHashMap<>();
 
-    /**
-     * Cache key for DatumWriter that includes schema fingerprint and whether it's specific or generic.
-     */
-    private record WriterCacheKey(long schemaFingerprint, boolean isSpecific) {}
+    private record WriterCacheKey(Schema schema, boolean isSpecific) {}
 
     public DefaultAvroDatumProvider() {
     }
@@ -79,19 +67,10 @@ public class DefaultAvroDatumProvider<T> implements AvroDatumProvider<T> {
         });
     }
 
-    /**
-     * Gets a fingerprint for the schema to use as a cache key.
-     * Uses Avro's parsing fingerprint which is based on the schema content,
-     * ensuring different schema versions (with same name but different fields) get different cache entries.
-     */
-    private long getSchemaFingerprint(Schema schema) {
-        return SchemaNormalization.parsingFingerprint64(schema);
-    }
-
     @Override
     public DatumWriter<T> createDatumWriter(T data, Schema schema) {
         boolean isSpecific = data instanceof SpecificRecord;
-        WriterCacheKey key = new WriterCacheKey(getSchemaFingerprint(schema), isSpecific);
+        WriterCacheKey key = new WriterCacheKey(schema, isSpecific);
 
         return writerCache.computeIfAbsent(key, k -> {
             if (k.isSpecific()) {
@@ -104,9 +83,7 @@ public class DefaultAvroDatumProvider<T> implements AvroDatumProvider<T> {
 
     @Override
     public DatumReader<T> createDatumReader(Schema schema) {
-        long fingerprint = getSchemaFingerprint(schema);
-
-        return readerCache.computeIfAbsent(fingerprint, k -> {
+        return readerCache.computeIfAbsent(schema, k -> {
             // do not use SpecificDatumReader if schema is a primitive
             if (useSpecificAvroReader != null && useSpecificAvroReader) {
                 if (!AvroSchemaUtils.isPrimitive(schema)) {

--- a/serdes/generic/serde-common-avro/src/test/java/io/apicurio/registry/serde/avro/DefaultAvroDatumProviderTest.java
+++ b/serdes/generic/serde-common-avro/src/test/java/io/apicurio/registry/serde/avro/DefaultAvroDatumProviderTest.java
@@ -1,0 +1,87 @@
+package io.apicurio.registry.serde.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class DefaultAvroDatumProviderTest {
+
+    private DefaultAvroDatumProvider<GenericRecord> provider;
+
+    @BeforeEach
+    public void setup() {
+        provider = new DefaultAvroDatumProvider<>();
+        provider.configure(new AvroSerdeConfig(Collections.emptyMap()));
+    }
+
+    @Test
+    public void testReaderCacheDistinguishesSchemasDifferingOnlyInProperties() {
+        Schema v1 = new Schema.Parser().parse(
+                "{\"type\":\"record\",\"name\":\"Value\",\"namespace\":\"test\",\"fields\":["
+                        + "{\"name\":\"type\",\"type\":{\"type\":\"string\","
+                        + "\"connect.parameters\":{\"allowed\":\"station,post_office\"},"
+                        + "\"connect.name\":\"io.debezium.data.Enum\"}}"
+                        + "]}");
+
+        Schema v2 = new Schema.Parser().parse(
+                "{\"type\":\"record\",\"name\":\"Value\",\"namespace\":\"test\",\"fields\":["
+                        + "{\"name\":\"type\",\"type\":{\"type\":\"string\","
+                        + "\"connect.parameters\":{\"allowed\":\"station,post_office,plane\"},"
+                        + "\"connect.name\":\"io.debezium.data.Enum\"}}"
+                        + "]}");
+
+        DatumReader<GenericRecord> reader1 = provider.createDatumReader(v1);
+        DatumReader<GenericRecord> reader2 = provider.createDatumReader(v2);
+
+        assertNotSame(reader1, reader2,
+                "Schemas differing only in connect.parameters must produce different DatumReaders");
+    }
+
+    @Test
+    public void testWriterCacheDistinguishesSchemasDifferingOnlyInProperties() {
+        Schema v1 = new Schema.Parser().parse(
+                "{\"type\":\"record\",\"name\":\"Value\",\"namespace\":\"test\",\"fields\":["
+                        + "{\"name\":\"col\",\"type\":{\"type\":\"string\","
+                        + "\"connect.default\":\"-6\"}}"
+                        + "]}");
+
+        Schema v2 = new Schema.Parser().parse(
+                "{\"type\":\"record\",\"name\":\"Value\",\"namespace\":\"test\",\"fields\":["
+                        + "{\"name\":\"col\",\"type\":{\"type\":\"string\","
+                        + "\"connect.default\":\"-9\"}}"
+                        + "]}");
+
+        GenericRecord record1 = new GenericData.Record(v1);
+        record1.put("col", "x");
+        GenericRecord record2 = new GenericData.Record(v2);
+        record2.put("col", "x");
+
+        DatumWriter<GenericRecord> writer1 = provider.createDatumWriter(record1, v1);
+        DatumWriter<GenericRecord> writer2 = provider.createDatumWriter(record2, v2);
+
+        assertNotSame(writer1, writer2,
+                "Schemas differing only in connect.default must produce different DatumWriters");
+    }
+
+    @Test
+    public void testCacheReturnsExistingInstanceForIdenticalSchema() {
+        Schema schema = new Schema.Parser().parse(
+                "{\"type\":\"record\",\"name\":\"Value\",\"namespace\":\"test\",\"fields\":["
+                        + "{\"name\":\"id\",\"type\":\"long\"}"
+                        + "]}");
+
+        DatumReader<GenericRecord> reader1 = provider.createDatumReader(schema);
+        DatumReader<GenericRecord> reader2 = provider.createDatumReader(schema);
+
+        assertSame(reader1, reader2, "Same schema instance should return cached DatumReader");
+    }
+}


### PR DESCRIPTION
## Summary

Backport of #8135 to 3.2.x.

- Fix stale schema metadata returned during Avro round-trips when schemas differ only in JSON properties (`connect.parameters`, `connect.default`, etc.)
- Replace `SchemaNormalization.parsingFingerprint64()` cache keys with `Schema` objects directly, whose `equals()`/`hashCode()` include JSON properties
- Add unit tests verifying correct cache behavior for property-differing schemas

## Test plan

- [x] New `DefaultAvroDatumProviderTest` with 3 tests covering:
  - Schemas differing only in `connect.parameters` produce different `DatumReader` instances
  - Schemas differing only in `connect.default` produce different `DatumWriter` instances
  - Same schema instance returns cached `DatumReader`
- [x] All existing `serde-common-avro` tests pass

Fixes #8129