### PR TITLE
fix(test): wrap initial rules cleanup in retry for auth flakiness

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
@@ -103,7 +103,7 @@ public class ApicurioRegistryBaseIT implements TestSeparator, Constants {
 
         // Make sure all global rules are deleted, anything else should be isolated
         // within a group or artifact on a per-test basis.
-        registryClient.admin().rules().delete();
+        retry(() -> registryClient.admin().rules().delete());
     }
 
     @AfterAll


### PR DESCRIPTION
## Summary

Fixes flaky `SimpleAuthIT` by wrapping the initial `registryClient.admin().rules().delete()` call in the existing `retry()` method.

**Root cause:** `ApicurioRegistryBaseIT.prepareRestAssured()` (line 106) makes the first HTTP request without retry. This triggers a lazy OAuth2 token exchange with Keycloak. If Keycloak's OIDC endpoint isn't fully ready after testcontainer startup, the connection is closed with `HttpClosedException`.

**Fix:** One-line change — `retry(() -> registryClient.admin().rules().delete())`. The `retry()` method is already defined in the same class (20 attempts, exponential backoff).

Fixes #8141

## Changes

- `ApicurioRegistryBaseIT.java`: 1 line changed — wrap `delete()` in `retry()`

## Test plan

- [x] Compiles without errors
- [ ] Integration tests pass (CI will verify)