### PR TITLE
fix(deps): override Netty and PostgreSQL JDBC versions to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,10 @@
     /WARNING
     -->
 
+    <!-- Quarkus BOM overrides (CVE fixes) -->
+    <netty.version>4.1.133.Final</netty.version>
+    <postgresql-jdbc.version>42.7.11</postgresql-jdbc.version>
+
     <!-- Jandex -->
     <jandex.version>3.5.3</jandex.version>
 
@@ -550,6 +554,15 @@
         <version>${project.version}</version>
       </dependency>
 
+      <!-- Netty BOM override (before Quarkus BOM so it takes precedence) -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <!-- Quarkus Dependencies -->
       <dependency>
         <groupId>io.quarkus.platform</groupId>
@@ -570,6 +583,11 @@
       </dependency>
 
       <!-- Overrides of versions from the Quarkus BOM -->
+      <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>${postgresql-jdbc.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>


### PR DESCRIPTION
## Summary

- Override Netty to **4.1.133.Final** (from 4.1.130.Final) via Netty BOM import before the Quarkus BOM
- Override PostgreSQL JDBC to **42.7.11** (from 42.7.7) via explicit dependencyManagement entry
- Stays on Quarkus 3.27.2 (no Red Hat build available for 3.27.4)

## CVEs Fixed (11 total)

### HIGH (7)
| CVE | Component | Description |
|-----|-----------|-------------|
| CVE-2026-33870 | netty-codec-http | Request smuggling via chunked extension parsing |
| CVE-2026-33871 | netty-codec-http2 | DoS via HTTP/2 CONTINUATION frames |
| CVE-2026-42583 | netty-codec | Lz4FrameDecoder resource exhaustion DoS |
| CVE-2026-42579 | netty-codec-dns | Improper DNS record handling |
| CVE-2026-42584 | netty-codec-http | Incorrect HTTP header validation |
| CVE-2026-42587 | netty-codec-http/http2 | HTTP request smuggling |
| CVE-2026-42198 | postgresql JDBC | SCRAM auth unbounded PBKDF2 iterations DoS |

### MEDIUM (4)
| CVE | Component | Description |
|-----|-----------|-------------|
| CVE-2026-41417 | netty-codec-http | HTTP request smuggling via URI manipulation |
| CVE-2026-42580 | netty-codec-http | Request smuggling via chunk size parser |
| CVE-2026-42581 | netty-codec-http | HTTP request smuggling |
| CVE-2026-42585 | netty-codec-http | Request smuggling |

## Not addressed (require Quarkus bump to 3.27.3.1+)
- CVE-2026-39852 (quarkus-vertx-http auth bypass) — fix is in Quarkus's own code
- CVE-2026-1002 / CVE-2026-6860 (vertx-core) — coupled to Quarkus version

## Test plan
- [ ] Verify build succeeds with `./mvnw clean install -DskipTests`
- [ ] Run unit tests with `./mvnw test -pl app`
- [ ] Verify resolved Netty version is 4.1.133.Final and PostgreSQL JDBC is 42.7.11
- [ ] Scan rebuilt image with Trivy to confirm CVE count reduction