### PR TITLE
fix(test): add throws Exception to prepareRestAssured for retry()

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
@@ -90,7 +90,7 @@ public class ApicurioRegistryBaseIT implements TestSeparator, Constants {
     }
 
     @BeforeAll
-    void prepareRestAssured() {
+    void prepareRestAssured() throws Exception {
         vertx = Vertx.vertx();
         authServerUrlConfigured = Optional
                 .ofNullable(ConfigProvider.getConfig().getConfigValue("quarkus.oidc.token-path").getValue())


### PR DESCRIPTION
## Summary

**Hotfix** — PR #8145 (merged earlier today) added `retry(() -> registryClient.admin().rules().delete())` to `prepareRestAssured()` but didn't add `throws Exception` to the method signature. The `retry()` method declares `throws Exception`, causing a compilation error in all integration tests.

This is blocking CI on main and all open PRs.

## Changes

- `ApicurioRegistryBaseIT.java`: `void prepareRestAssured()` → `void prepareRestAssured() throws Exception`

## Test plan

- [x] `ReadOnlyRegistryBaseIT` override is compatible (Java allows overrides to declare fewer exceptions)
- [ ] Integration tests compile and pass (CI will verify)