### PR TITLE
fix(operator): prevent duplicate placeholder in catalog template channel

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -506,8 +506,12 @@ release-catalog-template-update: install-yq
 		echo "Adding placeholder to $(CHANNEL) channel (same minor)"; \
 		$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}", "replaces": "$(PREVIOUS_PACKAGE)"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml; \
 	elif $(YQ) -e '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)"))' $(CATALOG_DIR)/catalog.template.yaml > /dev/null 2>&1; then \
-		echo "Adding placeholder to existing $(CHANNEL) channel (new minor)"; \
-		$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml; \
+		if $(YQ) -e '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)") | .entries[] | select(.name == "$${PLACEHOLDER_PACKAGE}"))' $(CATALOG_DIR)/catalog.template.yaml > /dev/null 2>&1; then \
+			echo "$(CHANNEL) channel already has a placeholder entry, skipping"; \
+		else \
+			echo "Adding placeholder to existing $(CHANNEL) channel (new minor)"; \
+			$(YQ) '(.entries[] | select(.schema == "olm.channel") | select(.name == "$(CHANNEL)") | .entries) |= [{"name": "$${PLACEHOLDER_PACKAGE}"}] + .' -i $(CATALOG_DIR)/catalog.template.yaml; \
+		fi; \
 	else \
 		echo "Creating new $(CHANNEL) channel with placeholder (new minor)"; \
 		$(YQ) '.entries |= . + [{"schema": "olm.channel", "package": "$${PLACEHOLDER_PACKAGE_NAME}", "name": "$(CHANNEL)", "entries": [{"name": "$${PLACEHOLDER_PACKAGE}"}]}]' -i $(CATALOG_DIR)/catalog.template.yaml; \

--- a/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
+++ b/operator/olm-tests/src/test/deploy/catalog/catalog.template.yaml
@@ -58,7 +58,6 @@ entries:
     name: 3.3.x
     entries:
       - name: ${PLACEHOLDER_PACKAGE}
-      - name: ${PLACEHOLDER_PACKAGE}
   - schema: olm.bundle
     image: ${PLACEHOLDER_BUNDLE_IMAGE}
   - schema: olm.bundle


### PR DESCRIPTION
## Summary

Fixes a bug in the `release-catalog-template-update` Makefile target that caused duplicate `${PLACEHOLDER_PACKAGE}` entries in the catalog template.

### Root cause

When releasing from a maintenance branch (e.g., 3.2.5 from `3.2.x`), the post-release "Sync to main" step runs `make release-catalog-template-update` on main. At that point:

- `CHANNEL = 3.3.x` (derived from main's `3.3.0-SNAPSHOT`)
- `PREVIOUS_CHANNEL = 3.2.x` (derived from `PREVIOUS_PACKAGE_VERSION = 3.2.5`)

The target correctly updates the `3.2.x` and `3.x` channels, but then hits the `elif` branch for the `3.3.x` channel ("Adding placeholder to existing channel"). This branch unconditionally prepends a `${PLACEHOLDER_PACKAGE}` entry — even though the `3.3.x` channel already had one, producing a duplicate.

### Fix

Add a guard that checks whether the channel already contains a `${PLACEHOLDER_PACKAGE}` entry before adding one. If a placeholder already exists, the step is skipped with a log message.

## Changes

| File | Change |
|------|--------|
| `operator/Makefile` | Add placeholder existence check in `release-catalog-template-update` |

## Test plan

- [ ] Release 3.2.6 from `3.2.x` branch and verify the sync-to-main step does not duplicate the `3.3.x` channel placeholder
- [ ] Release 3.3.0 from `main` and verify the `3.3.x` channel is correctly finalized and a `3.4.x` channel is created
- [ ] Verify `make catalog` builds successfully with no duplicate entries