### PR TITLE
fix(ci): add -Dfull flag to flink-only deploy step

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -9,6 +9,10 @@ on:
         description: 'Artifacts to release (comma-separated: maven,sboms,site,all)'
         required: true
         default: 'all'
+      maven-modules:
+        description: 'Maven modules to deploy (e.g. "utils/flink"). Leave empty to deploy all.'
+        required: false
+        default: ''
   release:
     types: [released]
 
@@ -116,21 +120,18 @@ jobs:
             --pattern "apicurio-registry-cli-${RELEASE_VERSION}-osx-aarch_64.zip" \
             --dir cli/target/
 
-      - name: Maven Deploy (excluding flink)
+      - name: Maven Deploy
         working-directory: registry
-        continue-on-error: true
         run: |
-          mvn -B --settings /home/runner/.m2/settings.xml deploy \
-            -Pprod -Prelease -Dfull -DskipTests -DcliAttachArtifacts \
-            -pl '!utils/flink'
-
-      - name: Maven Deploy (flink only)
-        working-directory: registry
-        continue-on-error: true
-        run: |
-          mvn -B --settings /home/runner/.m2/settings.xml deploy \
-            -Pprod -Prelease -Dfull -DskipTests \
-            -pl utils/flink
+          MODULES="${{ github.event.inputs.maven-modules }}"
+          if [ -n "$MODULES" ]; then
+            mvn -B --settings /home/runner/.m2/settings.xml deploy \
+              -Pprod -Prelease -Dfull -DskipTests \
+              -pl "$MODULES"
+          else
+            mvn -B --settings /home/runner/.m2/settings.xml deploy \
+              -Pprod -Prelease -Dfull -DskipTests -DcliAttachArtifacts
+          fi
 
   # SBOMs Generation
   release-sboms:

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -128,7 +128,7 @@ jobs:
         continue-on-error: true
         run: |
           mvn -B --settings /home/runner/.m2/settings.xml deploy \
-            -Pprod -Prelease -DskipTests \
+            -Pprod -Prelease -Dfull -DskipTests \
             -pl utils/flink
 
   # SBOMs Generation

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -118,6 +118,7 @@ jobs:
 
       - name: Maven Deploy (excluding flink)
         working-directory: registry
+        continue-on-error: true
         run: |
           mvn -B --settings /home/runner/.m2/settings.xml deploy \
             -Pprod -Prelease -Dfull -DskipTests -DcliAttachArtifacts \


### PR DESCRIPTION
## Summary

- Adds missing `-Dfull` flag to the flink-only deploy step in `release-artifacts.yaml`
- The flink module lives in the `full` profile, so without `-Dfull` Maven can't find it in the reactor (`Could not find the selected project in the reactor: utils/flink`)

## Context

During the 3.2.5 release, the main deploy (excluding flink) succeeded and all other modules are now on Maven Central. The flink-only follow-up step failed because of this missing flag.

## Test plan
- [ ] After merging, re-trigger "Release Artifacts" workflow from `3.2.x` branch with tag `3.2.5` and artifacts `maven`
- [ ] Verify `apicurio-registry-utils-flink:3.2.5` appears on repo1.maven.org