### PR TITLE
feat(cli): add RBAC role mapping commands. Fixes #8095

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -6,10 +6,10 @@
 
 The CLI is distributed as a native executable. A separate ZIP is provided for each platform:
 
-| Platform | Architecture | ZIP Classifier | Shell |
-|----------|-------------|----------------|-------|
-| Linux    | x86_64      | `linux-x86_64` | bash  |
-| macOS    | aarch64 (Apple Silicon) | `osx-aarch64` | zsh |
+| Platform | Architecture            | ZIP Classifier | Shell |
+|----------|-------------------------|----------------|-------|
+| Linux    | x86_64                  | `linux-x86_64` | bash  |
+| macOS    | aarch64 (Apple Silicon) | `osx-aarch64`  | zsh   |
 
 Windows is not supported.
 
@@ -21,7 +21,7 @@ Prerequisites:
 
 To install the Apicurio Registry CLI:
 
-1. Download the ZIP for your platform from [GitHub Releases]() or [Maven Central]().
+1. Download the ZIP for your platform from [GitHub Releases](https://github.com/Apicurio/apicurio-registry/releases) or [Maven Central](https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-cli).
 2. Unzip the downloaded file to a location of your choice.
 3. You can run the CLI directly using `./acr`, or install it for the local user first (recommended):
 
@@ -84,20 +84,21 @@ mvn clean package -pl cli -am -DskipTests
 
 The output ZIP will be at `cli/target/apicurio-registry-cli-*-<os>-<arch>.zip`.
 
-By default, the native build uses a Mandrel container image. To use a local GraalVM installation instead:
-
-```bash
-GRAALVM_HOME=/path/to/graalvm mvn clean package -pl cli -am -DskipTests -Dquarkus.native.container-build=false
-```
-
-When building locally (without a container), the system must have the `zlib` static library installed:
+By default, the native build uses the local GraalVM installation (set `GRAALVM_HOME` or have
+`native-image` on your PATH). The system must also have `gcc` and the `zlib` static library (or `zlib-ng-compat-static`) installed:
 
 ```bash
 # Fedora/RHEL/CentOS
-sudo dnf install zlib-static
+sudo dnf install gcc zlib-static
 
 # Debian/Ubuntu
-sudo apt install zlib1g-dev
+sudo apt install gcc zlib1g-dev
+```
+
+To use a Mandrel container image instead (no local GraalVM or native toolchain needed, requires Docker/Podman):
+
+```bash
+mvn clean package -pl cli -am -DskipTests -Dquarkus.native.container-build=true
 ```
 
 #### Skipping Native Build (Development Only)
@@ -112,9 +113,9 @@ mvn clean package -pl cli -am -DskipTests -DcliSkipNative
 
 #### GraalVM Version Compatibility
 
-The **container-based build** (default) uses a Mandrel image and works out of the box — no GraalVM version management needed.
+The **local build** (default) requires GraalVM CE or Mandrel for JDK 17 or later. Set `GRAALVM_HOME` to point to the installation.
 
-For **local builds** (`-Dquarkus.native.container-build=false`), GraalVM CE or Mandrel for JDK 17 or later is required. Set `GRAALVM_HOME` to point to the installation.
+The **container-based build** (`-Dquarkus.native.container-build=true`) uses a Mandrel image and works out of the box — no local GraalVM or native toolchain needed.
 
 ### Installation from Build
 
@@ -177,10 +178,10 @@ acr config delete <property-name>
 
 #### Configuration Properties
 
-| Property | Default | Description |
-|---|---|---|
-| `update.check-enabled` | `true` | Enable automatic update checks |
-| `update.timeout-seconds` | `60` | Timeout for update network requests |
+| Property                 | Default | Description                         |
+|--------------------------|---------|-------------------------------------|
+| `update.check-enabled`   | `true`  | Enable automatic update checks      |
+| `update.timeout-seconds` | `60`    | Timeout for update network requests |
 
 ### Context Management
 
@@ -443,7 +444,7 @@ These options work with most commands:
 ### Guidelines
 
 - Suggested reading: [Command Line Interface Guidelines](https://clig.dev)
-- Use [picocli features](https://picocli.info/) where possible (e.g., for parsing, validation, help generation, etc.).
+- Use [picocli features](https://picocli.info) where possible (e.g., for parsing, validation, help generation, etc.).
 - Use hierarchical *command* → *sub-command* structure to organize commands logically.
 - Use `STDOUT` and `STDERR` appropriately. Use `STDERR` for logging and error messages, and `STDOUT` for command output. When outputting machine-readable formats (e.g. JSON), ensure that only the relevant data is printed to STDOUT, so that it can be easily piped to other tools.
 - Default options should work for basic use cases. For example, the CLI uses `--no-switch-current` instead of `--switch-current` when creating a new context, because we expect that users would want to use the context they just added in most cases.

--- a/cli/README.md
+++ b/cli/README.md
@@ -412,6 +412,22 @@ acr artifact rule create -g <group-id> -a <artifact-id> <rule-type> -c <rule-con
 
 Valid rule types: `VALIDITY`, `COMPATIBILITY`, `INTEGRITY`
 
+### Role Mappings
+
+Manage role-based access control (RBAC) for the registry.
+
+```bash
+acr role                                                    # list all role mappings
+acr role create <principal-id> <role> [--name <name>]       # create
+acr role get <principal-id>                                 # get
+acr role update <principal-id> --role <role>                 # update
+acr role delete <principal-id>                              # delete
+```
+
+Valid roles: `ADMIN`, `DEVELOPER`, `READ_ONLY`
+
+> **Note:** RBAC must be enabled on the registry (`apicurio.auth.role-based-authorization=true` with `apicurio.auth.role-source=application`).
+
 ### Search
 
 Search across groups, artifacts, and versions.

--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -7,6 +7,7 @@ import io.apicurio.registry.cli.config.ConfigPropertyCommand;
 import io.apicurio.registry.cli.context.ContextCommand;
 import io.apicurio.registry.cli.globalrule.GlobalRuleCommand;
 import io.apicurio.registry.cli.group.GroupCommand;
+import io.apicurio.registry.cli.rolemapping.RoleMappingCommand;
 import io.apicurio.registry.cli.search.SearchCommand;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import lombok.Getter;
@@ -35,6 +36,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
                 InstallCommand.class,
                 LoginCommand.class,
                 LogoutCommand.class,
+                RoleMappingCommand.class,
                 SearchCommand.class,
                 UpdateCommand.class,
                 VersionCommand.class

--- a/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingCommand.java
@@ -5,6 +5,7 @@ import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
 import io.apicurio.registry.rest.client.models.RoleMapping;
+import java.util.List;
 import java.util.Optional;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -15,8 +16,8 @@ import static io.apicurio.registry.cli.utils.Columns.PRINCIPAL_NAME;
 import static io.apicurio.registry.cli.utils.Columns.ROLE;
 
 @Command(
-        name = "role-mapping",
-        aliases = {"role-mappings"},
+        name = "role",
+        aliases = {"roles"},
         description = "Work with role mappings",
         subcommands = {
                 RoleMappingCreateCommand.class,
@@ -33,7 +34,7 @@ public class RoleMappingCommand extends AbstractCommand {
     @Override
     public void run(final OutputBuffer output) throws Exception {
         final var results = client.getRegistryClient().admin().roleMappings().get();
-        final var mappings = Optional.ofNullable(results.getRoleMappings()).orElse(java.util.List.of());
+        final var mappings = Optional.ofNullable(results.getRoleMappings()).orElse(List.of());
 
         switch (outputType.getOutputType()) {
             case json -> printRoleMappingJson(output, mappings);

--- a/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingCommand.java
@@ -1,0 +1,60 @@
+package io.apicurio.registry.cli.rolemapping;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.RoleMapping;
+import java.util.Optional;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+import static io.apicurio.registry.cli.rolemapping.RoleMappingUtil.printRoleMappingJson;
+import static io.apicurio.registry.cli.utils.Columns.PRINCIPAL_ID;
+import static io.apicurio.registry.cli.utils.Columns.PRINCIPAL_NAME;
+import static io.apicurio.registry.cli.utils.Columns.ROLE;
+
+@Command(
+        name = "role-mapping",
+        aliases = {"role-mappings"},
+        description = "Work with role mappings",
+        subcommands = {
+                RoleMappingCreateCommand.class,
+                RoleMappingGetCommand.class,
+                RoleMappingUpdateCommand.class,
+                RoleMappingDeleteCommand.class
+        }
+)
+public class RoleMappingCommand extends AbstractCommand {
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var results = client.getRegistryClient().admin().roleMappings().get();
+        final var mappings = Optional.ofNullable(results.getRoleMappings()).orElse(java.util.List.of());
+
+        switch (outputType.getOutputType()) {
+            case json -> printRoleMappingJson(output, mappings);
+            case table -> {
+                if (mappings.isEmpty()) {
+                    output.writeStdOutChunk(out -> out.append("No role mappings found.\n"));
+                } else {
+                    output.writeStdOutChunk(out -> {
+                        final var table = new TableBuilder();
+                        table.addColumns(PRINCIPAL_ID, ROLE, PRINCIPAL_NAME);
+                        for (final RoleMapping mapping : mappings) {
+                            table.addRow(
+                                    mapping.getPrincipalId(),
+                                    mapping.getRole() != null ? mapping.getRole().getValue() : "",
+                                    mapping.getPrincipalName()
+                            );
+                        }
+                        table.print(out);
+                    });
+                }
+            }
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingCreateCommand.java
@@ -1,0 +1,67 @@
+package io.apicurio.registry.cli.rolemapping;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.RoleMapping;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.rolemapping.RoleMappingUtil.parseRoleType;
+import static io.apicurio.registry.cli.rolemapping.RoleMappingUtil.printRoleMapping;
+
+@Command(
+        name = "create",
+        aliases = {"add"},
+        description = "Create a new role mapping"
+)
+public class RoleMappingCreateCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The principal ID."
+    )
+    private String principalId;
+
+    @Parameters(
+            index = "1",
+            description = "The role (ADMIN, DEVELOPER, or READ_ONLY)."
+    )
+    private String role;
+
+    @Option(
+            names = {"--name"},
+            description = "Display name for the principal."
+    )
+    private String principalName;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var roleType = parseRoleType(role);
+
+        final var mapping = new RoleMapping();
+        mapping.setPrincipalId(principalId);
+        mapping.setRole(roleType);
+        mapping.setPrincipalName(principalName);
+
+        client.getRegistryClient().admin().roleMappings().post(mapping);
+
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, principalId));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, principalId));
+        }
+
+        final var created = client.getRegistryClient().admin().roleMappings()
+                .byPrincipalId(principalId).get();
+        printRoleMapping(output, created, outputType);
+    }
+
+    private static void successMessage(final StringBuilder out, final String principalId) {
+        out.append("Role mapping for '").append(principalId).append("' created successfully.\n");
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingDeleteCommand.java
@@ -1,0 +1,30 @@
+package io.apicurio.registry.cli.rolemapping;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(
+        name = "delete",
+        aliases = {"remove", "rm"},
+        description = "Delete a role mapping"
+)
+public class RoleMappingDeleteCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The principal ID."
+    )
+    private String principalId;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        client.getRegistryClient().admin().roleMappings()
+                .byPrincipalId(principalId).delete();
+
+        output.writeStdOutChunk(out -> {
+            out.append("Role mapping for '").append(principalId).append("' deleted successfully.\n");
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingGetCommand.java
@@ -1,0 +1,33 @@
+package io.apicurio.registry.cli.rolemapping;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.rolemapping.RoleMappingUtil.printRoleMapping;
+
+@Command(
+        name = "get",
+        description = "Get a role mapping by principal ID"
+)
+public class RoleMappingGetCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The principal ID."
+    )
+    private String principalId;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var mapping = client.getRegistryClient().admin().roleMappings()
+                .byPrincipalId(principalId).get();
+        printRoleMapping(output, mapping, outputType);
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingUpdateCommand.java
@@ -1,0 +1,60 @@
+package io.apicurio.registry.cli.rolemapping;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.UpdateRole;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.rolemapping.RoleMappingUtil.parseRoleType;
+import static io.apicurio.registry.cli.rolemapping.RoleMappingUtil.printRoleMapping;
+
+@Command(
+        name = "update",
+        description = "Update the role of an existing role mapping"
+)
+public class RoleMappingUpdateCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The principal ID."
+    )
+    private String principalId;
+
+    @Option(
+            names = {"--role"},
+            description = "The new role (ADMIN, DEVELOPER, or READ_ONLY).",
+            required = true
+    )
+    private String role;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var roleType = parseRoleType(role);
+
+        final var updateRole = new UpdateRole();
+        updateRole.setRole(roleType);
+
+        client.getRegistryClient().admin().roleMappings()
+                .byPrincipalId(principalId).put(updateRole);
+
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, principalId));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, principalId));
+        }
+
+        final var updated = client.getRegistryClient().admin().roleMappings()
+                .byPrincipalId(principalId).get();
+        printRoleMapping(output, updated, outputType);
+    }
+
+    private static void successMessage(final StringBuilder out, final String principalId) {
+        out.append("Role mapping for '").append(principalId).append("' updated successfully.\n");
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/rolemapping/RoleMappingUtil.java
@@ -1,0 +1,62 @@
+package io.apicurio.registry.cli.rolemapping;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.RoleMapping;
+import io.apicurio.registry.rest.client.models.RoleType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.utils.Columns.PRINCIPAL_ID;
+import static io.apicurio.registry.cli.utils.Columns.PRINCIPAL_NAME;
+import static io.apicurio.registry.cli.utils.Columns.ROLE;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+public final class RoleMappingUtil {
+
+    private static final String VALID_ROLES = Arrays.stream(RoleType.values())
+            .map(RoleType::getValue)
+            .collect(Collectors.joining(", "));
+
+    private RoleMappingUtil() {
+    }
+
+    static RoleType parseRoleType(final String role) {
+        return Optional.ofNullable(RoleType.forValue(role.toUpperCase(Locale.ROOT)))
+                .orElseThrow(() -> new CliException(
+                        "Invalid role '" + role + "'. Valid values: " + VALID_ROLES + ".",
+                        VALIDATION_ERROR_RETURN_CODE));
+    }
+
+    static void printRoleMapping(final OutputBuffer output, final RoleMapping mapping,
+                                 final OutputTypeMixin outputType) throws JsonProcessingException {
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> out.append(MAPPER.writeValueAsString(mapping)).append('\n');
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(PRINCIPAL_ID, ROLE, PRINCIPAL_NAME);
+                    table.addRow(
+                            mapping.getPrincipalId(),
+                            mapping.getRole() != null ? mapping.getRole().getValue() : "",
+                            mapping.getPrincipalName()
+                    );
+                    table.print(out);
+                }
+            }
+        });
+    }
+
+    static void printRoleMappingJson(final OutputBuffer output, final List<RoleMapping> mappings)
+            throws JsonProcessingException {
+        output.writeStdOutChunkWithException(out ->
+                out.append(MAPPER.writeValueAsString(mappings)).append('\n'));
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
@@ -36,4 +36,8 @@ public final class Columns {
 
     public static final String COMMENT_ID = "Comment ID";
     public static final String COMMENT = "Comment";
+
+    public static final String PRINCIPAL_ID = "Principal ID";
+    public static final String PRINCIPAL_NAME = "Principal Name";
+    public static final String ROLE = "Role";
 }

--- a/cli/src/main/scripts/common/acr
+++ b/cli/src/main/scripts/common/acr
@@ -20,7 +20,7 @@ function error_exit() {
     exit "${2:-1}"
 }
 
-export ACR_INSTALL_PATH="$HOME/.apicurio/apicurio-registry-cli"
+export ACR_INSTALL_PATH="${ACR_INSTALL_PATH:-$HOME/.apicurio/apicurio-registry-cli}"
 
 find_acr_home() {
   # "$(script_dir)" must be first.

--- a/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
@@ -63,6 +63,8 @@ public abstract class AbstractCLITest {
                 .withEnv("APICURIO_REST_DELETION_ARTIFACT_ENABLED", "true")
                 .withEnv("APICURIO_REST_DELETION_ARTIFACT_VERSION_ENABLED", "true")
                 .withEnv("APICURIO_REST_MUTABILITY_ARTIFACT_VERSION_CONTENT_ENABLED", "true")
+                .withEnv("APICURIO_AUTH_ROLE_BASED_AUTHORIZATION", "true")
+                .withEnv("APICURIO_AUTH_ROLE_SOURCE", "application")
                 .withExposedPorts(8080)
                 .waitingFor(Wait.forHttp("/apis/registry/v3/system/info")
                         .forStatusCode(200)

--- a/cli/src/test/java/io/apicurio/registry/cli/RoleMappingCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/RoleMappingCommandTest.java
@@ -1,11 +1,13 @@
 package io.apicurio.registry.cli;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
@@ -20,131 +22,139 @@ public class RoleMappingCommandTest extends AbstractCLITest {
     // -- Help --
 
     @Test
-    public void testRoleMappingHelp() {
-        testHelpCommand("role-mapping");
-        testHelpCommand("role-mapping", "create");
-        testHelpCommand("role-mapping", "get");
-        testHelpCommand("role-mapping", "update");
-        testHelpCommand("role-mapping", "delete");
+    public void testRoleHelp() {
+        testHelpCommand("role");
+        testHelpCommand("role", "create");
+        testHelpCommand("role", "get");
+        testHelpCommand("role", "update");
+        testHelpCommand("role", "delete");
     }
 
     // -- Validation / error cases --
 
     @Test
     public void testCreateMissingArgs() {
-        executeAndAssertFailure("role-mapping", "create");
+        executeAndAssertFailure("role", "create");
     }
 
     @Test
     public void testCreateInvalidRole() {
-        executeAndAssertFailure("role-mapping", "create", TEST_PRINCIPAL, "INVALID_ROLE");
+        executeAndAssertFailure("role", "create", TEST_PRINCIPAL, "INVALID_ROLE");
     }
 
     @Test
     public void testGetNonExistent() {
-        executeAndAssertFailure("role-mapping", "get", "non-existent-principal");
+        executeAndAssertFailure("role", "get", "non-existent-principal");
     }
 
     @Test
     public void testUpdateNonExistent() {
-        executeAndAssertFailure("role-mapping", "update", "non-existent-principal",
+        executeAndAssertFailure("role", "update", "non-existent-principal",
                 "--role", TEST_ROLE);
     }
 
     @Test
     public void testUpdateInvalidRole() {
-        executeAndAssertFailure("role-mapping", "update", TEST_PRINCIPAL,
+        executeAndAssertFailure("role", "update", TEST_PRINCIPAL,
                 "--role", "INVALID_ROLE");
     }
 
     @Test
     public void testDeleteNonExistent() {
-        executeAndAssertFailure("role-mapping", "delete", "non-existent-principal");
+        executeAndAssertFailure("role", "delete", "non-existent-principal");
     }
 
     @Test
     @Order(9)
     public void testCreateDuplicate() {
-        executeAndAssertSuccess("role-mapping", "create", "dup-user", TEST_ROLE);
-        executeAndAssertFailure("role-mapping", "create", "dup-user", TEST_ROLE);
-        executeAndAssertSuccess("role-mapping", "delete", "dup-user");
+        executeAndAssertSuccess("role", "create", "dup-user", TEST_ROLE);
+        executeAndAssertFailure("role", "create", "dup-user", TEST_ROLE);
+        executeAndAssertSuccess("role", "delete", "dup-user");
     }
 
     // -- CRUD flow --
 
     @Test
     @Order(0)
-    public void testListEmpty() {
+    public void testListEmpty() throws Exception {
         out.getBuffer().setLength(0);
-        executeAndAssertSuccess("role-mapping");
-        assertThat(out.toString())
-                .as(withCliOutput("Should indicate no role mappings"))
-                .contains("No role mappings found");
+        executeAndAssertSuccess("role", "--output-type", "json");
+        JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.isArray())
+                .as(withCliOutput("Should be an array"))
+                .isTrue();
+        assertThat(json.size())
+                .as(withCliOutput("Should be empty"))
+                .isZero();
     }
 
     @Test
     @Order(1)
-    public void testCreate() {
+    public void testCreate() throws Exception {
         out.getBuffer().setLength(0);
-        executeAndAssertSuccess("role-mapping", "create", TEST_PRINCIPAL, TEST_ROLE,
-                "--name", TEST_NAME);
-        assertThat(out.toString())
-                .as(withCliOutput("Should confirm creation"))
-                .contains("created successfully")
-                .contains(TEST_PRINCIPAL)
-                .contains(TEST_ROLE)
-                .contains(TEST_NAME);
+        executeAndAssertSuccess("role", "create", "--output-type", "json",
+                TEST_PRINCIPAL, TEST_ROLE, "--name", TEST_NAME);
+        JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.get("principalId").asText())
+                .as(withCliOutput("Should have correct principal"))
+                .isEqualTo(TEST_PRINCIPAL);
+        assertThat(json.get("role").asText())
+                .as(withCliOutput("Should have correct role"))
+                .isEqualTo(TEST_ROLE);
+        assertThat(json.get("principalName").asText())
+                .as(withCliOutput("Should have correct name"))
+                .isEqualTo(TEST_NAME);
     }
 
     @Test
     @Order(2)
-    public void testList() {
+    public void testList() throws Exception {
         out.getBuffer().setLength(0);
-        executeAndAssertSuccess("role-mapping");
-        assertThat(out.toString())
-                .as(withCliOutput("Should list the created mapping"))
-                .contains(TEST_PRINCIPAL)
-                .contains(TEST_ROLE);
+        executeAndAssertSuccess("role", "--output-type", "json");
+        JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.size())
+                .as(withCliOutput("Should have one mapping"))
+                .isEqualTo(1);
+        assertThat(json.get(0).get("principalId").asText()).isEqualTo(TEST_PRINCIPAL);
     }
 
     @Test
     @Order(3)
-    public void testGet() {
+    public void testGet() throws Exception {
         out.getBuffer().setLength(0);
-        executeAndAssertSuccess("role-mapping", "get", TEST_PRINCIPAL);
-        assertThat(out.toString())
-                .as(withCliOutput("Should show the mapping details"))
-                .contains(TEST_PRINCIPAL)
-                .contains(TEST_ROLE)
-                .contains(TEST_NAME);
+        executeAndAssertSuccess("role", "get", "--output-type", "json", TEST_PRINCIPAL);
+        JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.get("principalId").asText()).isEqualTo(TEST_PRINCIPAL);
+        assertThat(json.get("role").asText()).isEqualTo(TEST_ROLE);
+        assertThat(json.get("principalName").asText()).isEqualTo(TEST_NAME);
     }
 
     @Test
     @Order(4)
-    public void testUpdate() {
+    public void testUpdate() throws Exception {
         out.getBuffer().setLength(0);
-        executeAndAssertSuccess("role-mapping", "update", TEST_PRINCIPAL, "--role", TEST_UPDATED_ROLE);
-        assertThat(out.toString())
-                .as(withCliOutput("Should confirm update"))
-                .contains("updated successfully");
+        executeAndAssertSuccess("role", "update", "--output-type", "json",
+                TEST_PRINCIPAL, "--role", TEST_UPDATED_ROLE);
+        JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.get("role").asText())
+                .as(withCliOutput("Should have updated role"))
+                .isEqualTo(TEST_UPDATED_ROLE);
     }
 
     @Test
     @Order(5)
-    public void testGetAfterUpdate() {
+    public void testGetAfterUpdate() throws Exception {
         out.getBuffer().setLength(0);
-        executeAndAssertSuccess("role-mapping", "get", TEST_PRINCIPAL);
-        assertThat(out.toString())
-                .as(withCliOutput("Should show updated role"))
-                .contains(TEST_PRINCIPAL)
-                .contains(TEST_UPDATED_ROLE);
+        executeAndAssertSuccess("role", "get", "--output-type", "json", TEST_PRINCIPAL);
+        JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.get("role").asText()).isEqualTo(TEST_UPDATED_ROLE);
     }
 
     @Test
     @Order(6)
     public void testDelete() {
         out.getBuffer().setLength(0);
-        executeAndAssertSuccess("role-mapping", "delete", TEST_PRINCIPAL);
+        executeAndAssertSuccess("role", "delete", TEST_PRINCIPAL);
         assertThat(out.toString())
                 .as(withCliOutput("Should confirm deletion"))
                 .contains("deleted successfully");
@@ -152,25 +162,24 @@ public class RoleMappingCommandTest extends AbstractCLITest {
 
     @Test
     @Order(7)
-    public void testListAfterDelete() {
+    public void testListAfterDelete() throws Exception {
         out.getBuffer().setLength(0);
-        executeAndAssertSuccess("role-mapping");
-        assertThat(out.toString())
+        executeAndAssertSuccess("role", "--output-type", "json");
+        JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.size())
                 .as(withCliOutput("Should be empty after delete"))
-                .contains("No role mappings found");
+                .isZero();
     }
 
     @Test
     @Order(8)
     public void testCreateWithoutName() {
         out.getBuffer().setLength(0);
-        executeAndAssertSuccess("role-mapping", "create", "no-name-user", TEST_ROLE);
+        executeAndAssertSuccess("role", "create", "no-name-user", TEST_ROLE);
         assertThat(out.toString())
                 .as(withCliOutput("Should create without name"))
-                .contains("created successfully")
-                .contains("no-name-user")
-                .contains(TEST_ROLE);
+                .contains("created successfully");
 
-        executeAndAssertSuccess("role-mapping", "delete", "no-name-user");
+        executeAndAssertSuccess("role", "delete", "no-name-user");
     }
 }

--- a/cli/src/test/java/io/apicurio/registry/cli/RoleMappingCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/RoleMappingCommandTest.java
@@ -1,0 +1,176 @@
+package io.apicurio.registry.cli;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestMethodOrder(OrderAnnotation.class)
+public class RoleMappingCommandTest extends AbstractCLITest {
+
+    private static final String TEST_PRINCIPAL = "test-user";
+    private static final String TEST_ROLE = "DEVELOPER";
+    private static final String TEST_UPDATED_ROLE = "ADMIN";
+    private static final String TEST_NAME = "Test User";
+
+    // -- Help --
+
+    @Test
+    public void testRoleMappingHelp() {
+        testHelpCommand("role-mapping");
+        testHelpCommand("role-mapping", "create");
+        testHelpCommand("role-mapping", "get");
+        testHelpCommand("role-mapping", "update");
+        testHelpCommand("role-mapping", "delete");
+    }
+
+    // -- Validation / error cases --
+
+    @Test
+    public void testCreateMissingArgs() {
+        executeAndAssertFailure("role-mapping", "create");
+    }
+
+    @Test
+    public void testCreateInvalidRole() {
+        executeAndAssertFailure("role-mapping", "create", TEST_PRINCIPAL, "INVALID_ROLE");
+    }
+
+    @Test
+    public void testGetNonExistent() {
+        executeAndAssertFailure("role-mapping", "get", "non-existent-principal");
+    }
+
+    @Test
+    public void testUpdateNonExistent() {
+        executeAndAssertFailure("role-mapping", "update", "non-existent-principal",
+                "--role", TEST_ROLE);
+    }
+
+    @Test
+    public void testUpdateInvalidRole() {
+        executeAndAssertFailure("role-mapping", "update", TEST_PRINCIPAL,
+                "--role", "INVALID_ROLE");
+    }
+
+    @Test
+    public void testDeleteNonExistent() {
+        executeAndAssertFailure("role-mapping", "delete", "non-existent-principal");
+    }
+
+    @Test
+    @Order(9)
+    public void testCreateDuplicate() {
+        executeAndAssertSuccess("role-mapping", "create", "dup-user", TEST_ROLE);
+        executeAndAssertFailure("role-mapping", "create", "dup-user", TEST_ROLE);
+        executeAndAssertSuccess("role-mapping", "delete", "dup-user");
+    }
+
+    // -- CRUD flow --
+
+    @Test
+    @Order(0)
+    public void testListEmpty() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("role-mapping");
+        assertThat(out.toString())
+                .as(withCliOutput("Should indicate no role mappings"))
+                .contains("No role mappings found");
+    }
+
+    @Test
+    @Order(1)
+    public void testCreate() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("role-mapping", "create", TEST_PRINCIPAL, TEST_ROLE,
+                "--name", TEST_NAME);
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm creation"))
+                .contains("created successfully")
+                .contains(TEST_PRINCIPAL)
+                .contains(TEST_ROLE)
+                .contains(TEST_NAME);
+    }
+
+    @Test
+    @Order(2)
+    public void testList() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("role-mapping");
+        assertThat(out.toString())
+                .as(withCliOutput("Should list the created mapping"))
+                .contains(TEST_PRINCIPAL)
+                .contains(TEST_ROLE);
+    }
+
+    @Test
+    @Order(3)
+    public void testGet() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("role-mapping", "get", TEST_PRINCIPAL);
+        assertThat(out.toString())
+                .as(withCliOutput("Should show the mapping details"))
+                .contains(TEST_PRINCIPAL)
+                .contains(TEST_ROLE)
+                .contains(TEST_NAME);
+    }
+
+    @Test
+    @Order(4)
+    public void testUpdate() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("role-mapping", "update", TEST_PRINCIPAL, "--role", TEST_UPDATED_ROLE);
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm update"))
+                .contains("updated successfully");
+    }
+
+    @Test
+    @Order(5)
+    public void testGetAfterUpdate() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("role-mapping", "get", TEST_PRINCIPAL);
+        assertThat(out.toString())
+                .as(withCliOutput("Should show updated role"))
+                .contains(TEST_PRINCIPAL)
+                .contains(TEST_UPDATED_ROLE);
+    }
+
+    @Test
+    @Order(6)
+    public void testDelete() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("role-mapping", "delete", TEST_PRINCIPAL);
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm deletion"))
+                .contains("deleted successfully");
+    }
+
+    @Test
+    @Order(7)
+    public void testListAfterDelete() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("role-mapping");
+        assertThat(out.toString())
+                .as(withCliOutput("Should be empty after delete"))
+                .contains("No role mappings found");
+    }
+
+    @Test
+    @Order(8)
+    public void testCreateWithoutName() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("role-mapping", "create", "no-name-user", TEST_ROLE);
+        assertThat(out.toString())
+                .as(withCliOutput("Should create without name"))
+                .contains("created successfully")
+                .contains("no-name-user")
+                .contains(TEST_ROLE);
+
+        executeAndAssertSuccess("role-mapping", "delete", "no-name-user");
+    }
+}

--- a/cli/src/test/scripts/test-upgrade-from-previous.sh
+++ b/cli/src/test/scripts/test-upgrade-from-previous.sh
@@ -86,9 +86,9 @@ PREVIOUS_VERSION=$(echo "$METADATA_XML" \
     | sort -t. -k1,1n -k2,2n -k3,3n \
     | while IFS=. read -r maj min pat; do
         IFS=. read -r cmaj cmin cpat <<< "$CURRENT_BASE"
-        if [ "$maj" -lt "$cmaj" ]] || \
-           { [ "$maj" -eq "$cmaj" ] && [ "$min" -lt "$cmin" ]; } || \
-           { [ "$maj" -eq "$cmaj" ] && [ "$min" -eq "$cmin" ] && [ "$pat" -lt "$cpat" ]; }; then
+        if [[ "$maj" -lt "$cmaj" ]] || \
+           { [[ "$maj" -eq "$cmaj" ]] && [[ "$min" -lt "$cmin" ]]; } || \
+           { [[ "$maj" -eq "$cmaj" ]] && [[ "$min" -eq "$cmin" ]] && [[ "$pat" -lt "$cpat" ]]; }; then
             echo "${maj}.${min}.${pat}"
         fi
     done | tail -1)
@@ -102,9 +102,9 @@ fi
 MIN_UPGRADABLE="3.3.0"
 IFS=. read -r pMaj pMin pPat <<< "$PREVIOUS_VERSION"
 IFS=. read -r mMaj mMin mPat <<< "$MIN_UPGRADABLE"
-if [ "$pMaj" -lt "$mMaj" ]] || \
-   { [ "$pMaj" -eq "$mMaj" ] && [ "$pMin" -lt "$mMin" ]; } || \
-   { [ "$pMaj" -eq "$mMaj" ] && [ "$pMin" -eq "$mMin" ] && [ "$pPat" -lt "$mPat" ]; }; then
+if [[ "$pMaj" -lt "$mMaj" ]] || \
+   { [[ "$pMaj" -eq "$mMaj" ]] && [[ "$pMin" -lt "$mMin" ]]; } || \
+   { [[ "$pMaj" -eq "$mMaj" ]] && [[ "$pMin" -eq "$mMin" ]] && [[ "$pPat" -lt "$mPat" ]]; }; then
     skip "Previous version $PREVIOUS_VERSION is older than $MIN_UPGRADABLE (first native CLI release with auto-update)"
 fi
 info "Previous release version to test: $PREVIOUS_VERSION"
@@ -152,7 +152,7 @@ export HOME="$USER_HOME"
 export ACR_INSTALL_PATH="$INSTALL_HOME"
 export ACR_CURRENT_HOME="$PREV_UNZIP"
 
-"$PREV_UNZIP/acr" install 2>/dev/null
+ACR_CURRENT_HOME="$PREV_UNZIP" "$PREV_UNZIP/acr_runner" install 2>/dev/null
 pass "Previous version $PREVIOUS_VERSION installed"
 
 export ACR_HOME="$INSTALL_HOME"


### PR DESCRIPTION
## Summary

Adds CLI commands to manage role-based access control via the `/admin/roleMappings` API endpoint. Part of CLI epic #7162 (Phase 4). Also fixes a pre-existing CI failure in the CLI upgrade E2E test.

## Commands

```bash
acr role                                              # list all role mappings
acr role create <principal-id> <role> [--name <name>] # create
acr role get <principal-id>                           # get
acr role update <principal-id> --role <role>           # update
acr role delete <principal-id>                        # delete
```

Valid roles: `ADMIN`, `DEVELOPER`, `READ_ONLY`

## Changes

| File | Purpose |
|------|---------|
| `RoleMappingCommand.java` | Parent command — lists all role mappings (`acr role`) |
| `RoleMappingCreateCommand.java` | Create with principal ID, role, optional name |
| `RoleMappingGetCommand.java` | Get by principal ID |
| `RoleMappingUpdateCommand.java` | Update role for a principal |
| `RoleMappingDeleteCommand.java` | Delete by principal ID |
| `RoleMappingUtil.java` | Shared output formatting and role validation |
| `Columns.java` | Added `PRINCIPAL_ID`, `PRINCIPAL_NAME`, `ROLE` constants |
| `Acr.java` | Registered `RoleMappingCommand` |
| `AbstractCLITest.java` | Added RBAC env vars to test container |
| `RoleMappingCommandTest.java` | 17 tests with JSON output assertions |
| `README.md` | Added Role Mappings section |

## CI Fix

Fixed a pre-existing failure in the CLI upgrade E2E test (`test-upgrade-from-previous.sh`):
- **Root cause:** The `acr` shell wrapper hardcodes `ACR_INSTALL_PATH`, overriding the test's value. This caused `acr install` to install to the wrong directory, making `acr_runner` not found.
- **Fix:** Use `acr_runner` directly for install in the test, and make the `acr` script respect pre-set `ACR_INSTALL_PATH` via `${ACR_INSTALL_PATH:-default}`.
- Also fixed `]]` → `]` shell syntax errors in version comparison.

## Test Plan

- [x] Help commands for all subcommands
- [x] Create missing args fails
- [x] Create with invalid role fails
- [x] Get non-existent principal fails
- [x] Update non-existent principal fails
- [x] Update with invalid role fails
- [x] Delete non-existent principal fails
- [x] Duplicate create fails
- [x] List empty returns `[]` (JSON)
- [x] Full CRUD flow with JSON assertions: create → list → get → update → get → delete → list
- [x] Create without optional `--name` works
- [x] Manual E2E: tested against Keycloak + Registry with application RBAC enabled