### PR TITLE
fix(operator): include rolling 3.x channel in OLM bundle annotations

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -45,7 +45,8 @@ PREVIOUS_PACKAGE ?= $(PACKAGE_NAME).v$(PREVIOUS_PACKAGE_VERSION)
 CHANNEL ?= $(shell echo "$(LC_VERSION)" | sed 's/\([0-9]*\.[0-9]*\)\..*/\1.x/')
 PREVIOUS_CHANNEL ?= $(shell echo "$(PREVIOUS_PACKAGE_VERSION)" | sed 's/\([0-9]*\.[0-9]*\)\..*/\1.x/')
 
-CHANNELS ?= $(CHANNEL)
+MAJOR_CHANNEL ?= $(shell echo "$(LC_VERSION)" | sed 's/\([0-9]*\)\..*/\1.x/')
+CHANNELS ?= $(MAJOR_CHANNEL),$(CHANNEL)
 DEFAULT_CHANNEL ?= $(CHANNEL)
 
 BUNDLE_OPTS ?= --package $(PACKAGE_NAME) --version $(LC_VERSION) --channels=$(CHANNELS) --default-channel=$(DEFAULT_CHANNEL)
@@ -158,6 +159,7 @@ endif
 	@echo "$(CC_CYAN)Bundle$(CC_END)"
 	@echo "PACKAGE_NAME=$(PACKAGE_NAME)"
 	@echo "CHANNEL=$(CHANNEL)"
+	@echo "MAJOR_CHANNEL=$(MAJOR_CHANNEL)"
 	@echo "PREVIOUS_CHANNEL=$(PREVIOUS_CHANNEL)"
 	@echo "CHANNELS=$(CHANNELS)"
 	@echo "DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)"


### PR DESCRIPTION
## Summary

The OLM bundle annotations only included the minor channel (e.g., `3.3.x`) but not the rolling `3.x` channel. This means users subscribed to the `3.x` channel would not see new releases appear.

Spotted in: https://github.com/k8s-operatorhub/community-operators/pull/8314

### Root cause

`CHANNELS` in the Makefile was set to `$(CHANNEL)` which only resolves to the minor channel (e.g., `3.3.x`). The bundle annotations need to list all channels the bundle belongs to.

### Fix

Add `MAJOR_CHANNEL` derived from the version (e.g., `3.3.0` → `3.x`) and set `CHANNELS` to `$(MAJOR_CHANNEL),$(CHANNEL)` so the bundle is registered in both channels.

**Before:** `operators.operatorframework.io.bundle.channels.v1: 3.3.x`
**After:** `operators.operatorframework.io.bundle.channels.v1: 3.x,3.3.x`

## Changes

| File | Change |
|------|--------|
| `operator/Makefile` | Add `MAJOR_CHANNEL`, update `CHANNELS` to include both, add to `config-show` |

## Test plan

- [x] Verify `make variable-get VAR=CHANNELS` outputs `3.x,3.3.x`
- [x] Verify `make bundle` generates annotations with both channels
- [x] Verify OLM tests pass with multi-channel bundle