### PR TITLE
fix(operator): include rolling 3.x channel in OLM bundle annotations (3.2.x)

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -44,7 +44,8 @@ PREVIOUS_PACKAGE ?= $(PACKAGE_NAME).v$(PREVIOUS_PACKAGE_VERSION)
 CHANNEL ?= $(shell echo "$(LC_VERSION)" | sed 's/\([0-9]*\.[0-9]*\)\..*/\1.x/')
 PREVIOUS_CHANNEL ?= $(shell echo "$(PREVIOUS_PACKAGE_VERSION)" | sed 's/\([0-9]*\.[0-9]*\)\..*/\1.x/')
 
-CHANNELS ?= $(CHANNEL)
+MAJOR_CHANNEL ?= $(shell echo "$(LC_VERSION)" | sed 's/\([0-9]*\)\..*/\1.x/')
+CHANNELS ?= $(MAJOR_CHANNEL),$(CHANNEL)
 DEFAULT_CHANNEL ?= $(CHANNEL)
 
 BUNDLE_OPTS ?= --package $(PACKAGE_NAME) --version $(LC_VERSION) --channels=$(CHANNELS) --default-channel=$(DEFAULT_CHANNEL)
@@ -155,6 +156,7 @@ endif
 	@echo "$(CC_CYAN)Bundle$(CC_END)"
 	@echo "PACKAGE_NAME=$(PACKAGE_NAME)"
 	@echo "CHANNEL=$(CHANNEL)"
+	@echo "MAJOR_CHANNEL=$(MAJOR_CHANNEL)"
 	@echo "PREVIOUS_CHANNEL=$(PREVIOUS_CHANNEL)"
 	@echo "CHANNELS=$(CHANNELS)"
 	@echo "DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)"


### PR DESCRIPTION
## Summary

Backport of #8173 to 3.2.x.

The OLM bundle annotations only included the minor channel (e.g., `3.2.x`) but not the rolling `3.x` channel. Future 3.2.x patch releases would not appear in the `3.x` channel on OperatorHub.

### Fix

Add `MAJOR_CHANNEL` (e.g., `3.x`) derived from the version and set `CHANNELS` to include both.

**Before:** `CHANNELS = 3.2.x`
**After:** `CHANNELS = 3.x,3.2.x`