### PR TITLE
fix(ci): use X.Y.x branch naming for maintenance branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
         description: Version being released
         required: true
       branch:
-        description: Branch to release from (main for minor releases, release/X.Y.x for patches)
+        description: Branch to release from (main for minor releases, X.Y.x for patches)
         required: true
         default: main
       no-more-minor-releases:
@@ -425,7 +425,7 @@ jobs:
 
           if [ "$PATCH" = "0" ] && [ "$MINOR" -gt "0" ]; then
             PREV_MINOR=$((MINOR - 1))
-            MAINT_BRANCH="release/${MAJOR}.${PREV_MINOR}.x"
+            MAINT_BRANCH="${MAJOR}.${PREV_MINOR}.x"
             # Find the latest tag for the previous minor
             PREV_TAG=$(git tag -l "${MAJOR}.${PREV_MINOR}.*" --sort=-v:refname | head -1)
             if [ -n "$PREV_TAG" ] && ! git ls-remote --exit-code origin "refs/heads/$MAINT_BRANCH" > /dev/null 2>&1; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,12 +112,12 @@ We maintain the **latest two minor versions** with security patches. Once a new 
 | Branch | Purpose |
 |--------|---------|
 | `main` | Active development — next minor release |
-| `release/3.3.x` | Maintenance branch for 3.3 patch releases (created when 3.4.0 development starts) |
+| `3.3.x` | Maintenance branch for 3.3 patch releases (created when 3.4.0 development starts) |
 
 ### Where to target your PR
 
 - **Features and bug fixes** → target `main`
-- **CVE / security backports for N-1** → target the maintenance branch (e.g., `release/3.3.x`), cherry-picked from the fix on `main`
+- **CVE / security backports for N-1** → target the maintenance branch (e.g., `3.3.x`), cherry-picked from the fix on `main`
 - Bug fix backports are **not** accepted on maintenance branches — patches are strictly CVE-only
 
 ## The small print


### PR DESCRIPTION
## Summary

The maintenance branch automation in release.yaml was creating branches with `release/X.Y.x` prefix, but the existing convention uses `X.Y.x` (e.g., `3.2.x`). The 3.3.0 release created a stale `release/3.2.x` branch alongside the existing `3.2.x` — the stale branch has been deleted.

### Changes

- Update `release.yaml`: maintenance branch naming from `release/${MAJOR}.${PREV_MINOR}.x` to `${MAJOR}.${PREV_MINOR}.x`
- Update `release.yaml`: branch input description to reference `X.Y.x` instead of `release/X.Y.x`
- Update `CONTRIBUTING.md`: branch naming examples from `release/3.3.x` to `3.3.x`