### PR TITLE
feat(cli): add file-based credential fallback with --allow-unsafe-credential-storage

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -249,9 +249,16 @@ acr logout
 
 Authentication is per-context — each context can use different credentials.
 
+**Headless/CI environments (no OS keychain):**
+```bash
+acr login --username <username> --password <password> --allow-unsafe-credential-storage
+```
+Credentials are stored in a local file instead of the OS keychain. A warning is printed. The preference is saved so subsequent commands don't need the flag again.
+
 **Prerequisites for credential storage:**
 - macOS: No prerequisites (uses Keychain)
 - Linux: `secret-tool` required (`sudo apt install libsecret-tools` or `sudo dnf install libsecret`)
+- Headless/CI: Use `--allow-unsafe-credential-storage` if no keychain is available
 
 ### Working with Groups
 

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialStore.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialStore.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli.auth;
 
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.config.Config;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -8,7 +9,7 @@ import org.jboss.logging.Logger;
 import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
 
 /**
- * Stores and retrieves credentials per context using the OS keychain.
+ * Stores and retrieves credentials per context using the OS keychain or file-based fallback.
  */
 @ApplicationScoped
 public class CredentialStore {
@@ -18,16 +19,43 @@ public class CredentialStore {
     @Inject
     CredentialProvider provider;
 
-    public void store(final String contextName, final String key, final String secret) {
+    @Inject
+    Config config;
+
+    private FileCredentialProvider fileProvider;
+
+    /**
+     * @return true if file-based fallback was used
+     */
+    public boolean store(final String contextName, final String key, final String secret,
+                         final boolean allowUnsafe) {
         try {
             provider.store(credentialKey(contextName, key), secret);
+            cleanupStaleFileCredential(contextName, key);
+            return false;
         } catch (CredentialStoreException ex) {
-            throw new CliException("Failed to store credentials. Ensure the system keychain is available.",
-                    APPLICATION_ERROR_RETURN_CODE);
+            if (allowUnsafe) {
+                log.debug("OS keychain not available, using file-based credential storage.");
+                getFileProvider().store(credentialKey(contextName, key), secret);
+                return true;
+            } else {
+                throw new CliException(
+                        "Failed to store credentials. Ensure the system keychain is available, "
+                                + "or use --allow-unsafe-credential-storage to store credentials in a file.",
+                        APPLICATION_ERROR_RETURN_CODE);
+            }
         }
     }
 
-    public String retrieve(final String contextName, final String key) {
+    public void store(final String contextName, final String key, final String secret) {
+        store(contextName, key, secret, false);
+    }
+
+    public String retrieve(final String contextName, final String key,
+                           final boolean unsafeStorage) {
+        if (unsafeStorage) {
+            return getFileProvider().retrieve(credentialKey(contextName, key));
+        }
         try {
             return provider.retrieve(credentialKey(contextName, key));
         } catch (CredentialStoreException ex) {
@@ -36,8 +64,32 @@ public class CredentialStore {
         }
     }
 
+    public String retrieve(final String contextName, final String key) {
+        return retrieve(contextName, key, false);
+    }
+
     public void delete(final String contextName, final String key) {
-        provider.delete(credentialKey(contextName, key));
+        try {
+            provider.delete(credentialKey(contextName, key));
+        } catch (CredentialStoreException ex) {
+            // Ignore — credential may not exist in OS keychain
+        }
+        getFileProvider().delete(credentialKey(contextName, key));
+    }
+
+    private void cleanupStaleFileCredential(final String contextName, final String key) {
+        try {
+            getFileProvider().delete(credentialKey(contextName, key));
+        } catch (CredentialStoreException ex) {
+            log.debugf("Could not clean up stale file credentials: %s", ex.getMessage());
+        }
+    }
+
+    private FileCredentialProvider getFileProvider() {
+        if (fileProvider == null) {
+            fileProvider = new FileCredentialProvider(config);
+        }
+        return fileProvider;
     }
 
     private static String credentialKey(final String contextName, final String key) {

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialStoreException.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialStoreException.java
@@ -1,8 +1,8 @@
 package io.apicurio.registry.cli.auth;
 
-class CredentialStoreException extends RuntimeException {
+public class CredentialStoreException extends RuntimeException {
 
-    CredentialStoreException(final String message) {
+    public CredentialStoreException(final String message) {
         super(message);
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
@@ -1,0 +1,118 @@
+package io.apicurio.registry.cli.auth;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.apicurio.registry.cli.config.Config;
+import io.apicurio.registry.cli.utils.Mapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+/**
+ * File-based credential provider for environments without an OS keychain.
+ * Stores credentials in a separate JSON file alongside config.json.
+ */
+class FileCredentialProvider implements CredentialProvider {
+
+    private static final Logger log = Logger.getLogger(FileCredentialProvider.class);
+
+    private static final String CREDENTIALS_FILE = "credentials.json";
+
+    private final Config config;
+
+    FileCredentialProvider(final Config config) {
+        this.config = config;
+    }
+
+    @Override
+    public void store(final String account, final String secret) {
+        final var credentials = readCredentials();
+        credentials.put(account, secret);
+        writeCredentials(credentials);
+    }
+
+    @Override
+    public String retrieve(final String account) {
+        return readCredentials().get(account);
+    }
+
+    @Override
+    public void delete(final String account) {
+        final var credentials = readCredentials();
+        credentials.remove(account);
+        if (credentials.isEmpty()) {
+            try {
+                Files.deleteIfExists(credentialsPath());
+            } catch (IOException ex) {
+                // Non-critical — empty file is harmless
+            }
+        } else {
+            writeCredentials(credentials);
+        }
+    }
+
+    private Map<String, String> readCredentials() {
+        final Path path = credentialsPath();
+        if (!Files.exists(path)) {
+            return new HashMap<>();
+        }
+        try {
+            return Mapper.MAPPER.readValue(path.toFile(), new TypeReference<>() {});
+        } catch (IOException ex) {
+            log.debugf("Could not read credentials file (%s).", ex.getClass().getSimpleName());
+            return new HashMap<>();
+        }
+    }
+
+    private void writeCredentials(final Map<String, String> credentials) {
+        final Path path = credentialsPath();
+        Path temp = null;
+        try {
+            temp = Files.createTempFile(path.getParent(), "credentials", ".tmp");
+            Mapper.MAPPER.writeValue(temp.toFile(), credentials);
+            restrictFilePermissions(temp);
+            moveFile(temp, path);
+        } catch (IOException ex) {
+            cleanupTempFile(temp);
+            throw new CredentialStoreException("Failed to write credentials file: " + ex.getMessage(), ex);
+        }
+    }
+
+    private static void moveFile(final Path source, final Path target) throws IOException {
+        try {
+            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException ex) {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private static void cleanupTempFile(final Path temp) {
+        if (temp != null) {
+            try {
+                Files.deleteIfExists(temp);
+            } catch (IOException ignored) {
+                // Non-critical — OS will clean up temp files
+            }
+        }
+    }
+
+    private static void restrictFilePermissions(final Path path) {
+        try {
+            Files.setPosixFilePermissions(path, EnumSet.of(
+                    PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+        } catch (UnsupportedOperationException | IOException ex) {
+            log.warnf("Could not restrict file permissions on %s"
+                    + " — credentials may be readable by other users.", CREDENTIALS_FILE);
+        }
+    }
+
+    private Path credentialsPath() {
+        return config.getAcrCurrentHomePath().resolve(CREDENTIALS_FILE);
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
@@ -22,6 +22,9 @@ import static io.apicurio.registry.cli.utils.Utils.isBlank;
 )
 public class LoginCommand extends AbstractCommand {
 
+    private static final String UNSAFE_STORAGE_WARNING =
+            "Warning: Credentials stored in a file. This is not recommended for production use.\n";
+
     @Option(
             names = {"-u", "--username"},
             description = "Username for basic authentication."
@@ -62,6 +65,13 @@ public class LoginCommand extends AbstractCommand {
     )
     private String scope;
 
+    @Option(
+            names = {"--allow-unsafe-credential-storage"},
+            description = "Allow storing credentials in a file when the OS keychain is not available.",
+            defaultValue = "false"
+    )
+    private boolean allowUnsafeCredentialStorage;
+
     @Inject
     CredentialStore credentialStore;
 
@@ -99,13 +109,21 @@ public class LoginCommand extends AbstractCommand {
                     "Password cannot be empty.");
         }
 
-        credentialStore.store(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD, resolvedPassword);
+        final var allowUnsafe = allowUnsafeCredentialStorage || context.isUnsafeCredentialStorage();
+        final var usedFileFallback = credentialStore.store(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD,
+                resolvedPassword, allowUnsafe);
         credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET);
 
         context.clearAuth();
         context.setAuthType(ConfigModel.AUTH_TYPE_BASIC);
         context.setUsername(username);
+        context.setUnsafeCredentialStorage(usedFileFallback);
         config.write(configModel);
+
+        if (usedFileFallback) {
+            output.writeStdOutChunk(out ->
+                    out.append(UNSAFE_STORAGE_WARNING));
+        }
 
         client.reset();
 
@@ -130,7 +148,9 @@ public class LoginCommand extends AbstractCommand {
                     "Client secret cannot be empty.");
         }
 
-        credentialStore.store(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET, resolvedSecret);
+        final var allowUnsafe = allowUnsafeCredentialStorage || context.isUnsafeCredentialStorage();
+        final var usedFileFallback = credentialStore.store(contextName,
+                ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET, resolvedSecret, allowUnsafe);
         credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD);
 
         context.clearAuth();
@@ -138,7 +158,13 @@ public class LoginCommand extends AbstractCommand {
         context.setTokenEndpoint(tokenEndpoint);
         context.setClientId(clientId);
         context.setScope(scope);
+        context.setUnsafeCredentialStorage(usedFileFallback);
         config.write(configModel);
+
+        if (usedFileFallback) {
+            output.writeStdOutChunk(out ->
+                    out.append(UNSAFE_STORAGE_WARNING));
+        }
 
         client.reset();
 

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
@@ -75,12 +75,16 @@ public class ConfigModel {
         @JsonProperty("scope")
         private String scope;
 
+        @JsonProperty("unsafeCredentialStorage")
+        private boolean unsafeCredentialStorage;
+
         public void clearAuth() {
             authType = null;
             username = null;
             tokenEndpoint = null;
             clientId = null;
             scope = null;
+            unsafeCredentialStorage = false;
         }
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
@@ -75,10 +75,12 @@ public class Client {
                                final ConfigModel.Context context,
                                final String contextName) {
         if (ConfigModel.AUTH_TYPE_BASIC.equals(context.getAuthType())) {
-            final var password = requireCredential(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD);
+            final var password = requireCredential(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD,
+                    context.isUnsafeCredentialStorage());
             options.basicAuth(context.getUsername(), password);
         } else if (ConfigModel.AUTH_TYPE_OAUTH2.equals(context.getAuthType())) {
-            final var clientSecret = requireCredential(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET);
+            final var clientSecret = requireCredential(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET,
+                    context.isUnsafeCredentialStorage());
             options.oauth2(context.getTokenEndpoint(), context.getClientId(), clientSecret, context.getScope());
         } else if (!isBlank(context.getAuthType())) {
             throw new CliException("Unsupported auth type '" + context.getAuthType()
@@ -86,8 +88,9 @@ public class Client {
         }
     }
 
-    private String requireCredential(final String contextName, final String key) {
-        final var value = credentialStore.retrieve(contextName, key);
+    private String requireCredential(final String contextName, final String key,
+                                     final boolean unsafeStorage) {
+        final var value = credentialStore.retrieve(contextName, key, unsafeStorage);
         if (isBlank(value)) {
             throw new CliException("Credentials not found for context '" + contextName
                     + "'. Run 'acr login' to authenticate.", APPLICATION_ERROR_RETURN_CODE);

--- a/cli/src/test/java/io/apicurio/registry/cli/AuthCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/AuthCommandTest.java
@@ -1,13 +1,18 @@
 package io.apicurio.registry.cli;
 
+import io.apicurio.registry.cli.auth.CredentialProvider;
 import io.apicurio.registry.cli.config.ConfigModel;
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 public class AuthCommandTest extends AbstractCLITest {
+
+    @Inject
+    CredentialProvider credentialProvider;
 
     private static final String TOKEN_PATH = "/token";
     private static final String TEST_CONTEXT = "test";
@@ -189,6 +194,137 @@ public class AuthCommandTest extends AbstractCLITest {
 
         var context = getTestContext();
         assertThat(context.getUsername()).isEqualTo("user2");
+    }
+
+    // -- Unsafe credential storage --
+
+    @Test
+    public void testLoginBasicWithUnsafeFlagKeychainAvailable() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD,
+                "--allow-unsafe-credential-storage");
+        assertThat(out.toString())
+                .as(withCliOutput("Should login without warning when keychain works"))
+                .contains("Logged in to context")
+                .doesNotContain("not recommended for production");
+
+        var context = getTestContext();
+        assertThat(context.isUnsafeCredentialStorage())
+                .as("Should be false — keychain succeeded, fallback not used")
+                .isFalse();
+    }
+
+    @Test
+    public void testLoginOAuth2WithUnsafeFlagKeychainAvailable() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("login", "--token-endpoint", tokenEndpoint(),
+                "--client-id", TEST_CLIENT_ID, "--client-secret", TEST_CLIENT_SECRET,
+                "--allow-unsafe-credential-storage");
+        assertThat(out.toString())
+                .as(withCliOutput("Should login without warning when keychain works"))
+                .contains("Logged in to context")
+                .doesNotContain("not recommended for production");
+
+        var context = getTestContext();
+        assertThat(context.isUnsafeCredentialStorage())
+                .as("Should be false — keychain succeeded, fallback not used")
+                .isFalse();
+    }
+
+    @Test
+    public void testLogoutClearsUnsafeFlag() {
+        executeAndAssertSuccess("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD,
+                "--allow-unsafe-credential-storage");
+
+        executeAndAssertSuccess("logout");
+
+        var context = getTestContext();
+        assertThat(context.isUnsafeCredentialStorage())
+                .as("Logout should clear unsafeCredentialStorage flag")
+                .isFalse();
+    }
+
+    @Test
+    public void testLoginFallsBackToFileWhenKeychainFails() {
+        final var testProvider = (TestCredentialProvider) credentialProvider;
+        try {
+            testProvider.setFailOnStore(true);
+
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD,
+                    "--allow-unsafe-credential-storage");
+            assertThat(out.toString())
+                    .as(withCliOutput("Should warn about file storage"))
+                    .contains("not recommended for production");
+
+            var context = getTestContext();
+            assertThat(context.isUnsafeCredentialStorage())
+                    .as("Should be true — file fallback was used")
+                    .isTrue();
+        } finally {
+            testProvider.setFailOnStore(false);
+        }
+    }
+
+    @Test
+    public void testLoginOAuth2FallsBackToFileWhenKeychainFails() {
+        final var testProvider = (TestCredentialProvider) credentialProvider;
+        try {
+            testProvider.setFailOnStore(true);
+
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("login", "--token-endpoint", tokenEndpoint(),
+                    "--client-id", TEST_CLIENT_ID, "--client-secret", TEST_CLIENT_SECRET,
+                    "--allow-unsafe-credential-storage");
+            assertThat(out.toString())
+                    .as(withCliOutput("Should warn about file storage"))
+                    .contains("not recommended for production");
+
+            var context = getTestContext();
+            assertThat(context.isUnsafeCredentialStorage())
+                    .as("Should be true — file fallback was used")
+                    .isTrue();
+        } finally {
+            testProvider.setFailOnStore(false);
+        }
+    }
+
+    @Test
+    public void testLoginFailsWithoutFlagWhenKeychainFails() {
+        final var testProvider = (TestCredentialProvider) credentialProvider;
+        try {
+            testProvider.setFailOnStore(true);
+
+            out.getBuffer().setLength(0);
+            executeAndAssertFailure("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD);
+            assertThat(err.toString())
+                    .as(withCliOutput("Should suggest --allow-unsafe-credential-storage"))
+                    .contains("allow-unsafe-credential-storage");
+        } finally {
+            testProvider.setFailOnStore(false);
+        }
+    }
+
+    @Test
+    public void testReloginHonorsSavedUnsafePreference() {
+        final var testProvider = (TestCredentialProvider) credentialProvider;
+        try {
+            testProvider.setFailOnStore(true);
+
+            // First login — file fallback used, preference saved
+            executeAndAssertSuccess("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD,
+                    "--allow-unsafe-credential-storage");
+            assertThat(getTestContext().isUnsafeCredentialStorage()).isTrue();
+
+            // Re-login without flag — should succeed via saved preference
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD);
+            assertThat(out.toString())
+                    .as(withCliOutput("Re-login should succeed without flag"))
+                    .contains("Logged in to context");
+        } finally {
+            testProvider.setFailOnStore(false);
+        }
     }
 
     // -- Helpers --

--- a/cli/src/test/java/io/apicurio/registry/cli/TestCredentialProvider.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/TestCredentialProvider.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli;
 
 import io.apicurio.registry.cli.auth.CredentialProvider;
+import io.apicurio.registry.cli.auth.CredentialStoreException;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
@@ -17,9 +18,17 @@ import java.util.concurrent.ConcurrentMap;
 public class TestCredentialProvider implements CredentialProvider {
 
     private final ConcurrentMap<String, String> store = new ConcurrentHashMap<>();
+    private boolean failOnStore;
+
+    public void setFailOnStore(final boolean fail) {
+        this.failOnStore = fail;
+    }
 
     @Override
     public void store(final String account, final String secret) {
+        if (failOnStore) {
+            throw new CredentialStoreException("Simulated keychain failure");
+        }
         store.put(account, secret);
     }
 


### PR DESCRIPTION
## Summary

Adds a file-based credential fallback for CLI environments without an OS keychain (UBI images, GitHub Actions runners, headless servers). Implements the `--allow-unsafe-credential-storage` flag discussed in #8134.

## Behavior

| Scenario | Result |
|----------|--------|
| Keychain available (default) | Uses OS keychain |
| Keychain available + `--allow-unsafe-credential-storage` | Uses OS keychain (flag is a fallback, not a force) |
| No keychain + no flag | Error: suggests `--allow-unsafe-credential-storage` |
| No keychain + flag | Stores in `credentials.json` with warning |

The preference is stored in config — subsequent commands auto-use file storage without needing the flag again.

## Security

- `credentials.json` written atomically (temp file + rename) to prevent corruption
- File permissions set to `0600` (owner read/write only)
- Warning printed: "Credentials stored in a file. This is not recommended for production use."
- Explicit opt-in required — never silently falls back to file
- `unsafeCredentialStorage` only set to `true` when file fallback was actually used
- Logout clears the preference and deletes `credentials.json`
- Empty credentials file deleted on last credential removal

## Changes

| File | Purpose |
|------|---------|
| `FileCredentialProvider.java` | New — reads/writes `credentials.json` with atomic writes and 0600 permissions |
| `CredentialStore.java` | Tries OS keychain first, falls back to file when flag set. Returns whether fallback was used |
| `LoginCommand.java` | Added `--allow-unsafe-credential-storage` flag, `UNSAFE_STORAGE_WARNING` constant |
| `ConfigModel.java` | Added `unsafeCredentialStorage` boolean to Context, cleared on `clearAuth()` |
| `Client.java` | Passes `unsafeCredentialStorage` preference when retrieving credentials |
| `AuthCommandTest.java` | 3 new tests: basic with flag, OAuth2 with flag, logout clears flag |
| `README.md` | Added headless/CI section to authentication docs |

## Test Plan

- [x] 19 unit tests pass (231 total CLI tests)
- [x] macOS E2E: keychain available + flag → uses keychain, `unsafeCredentialStorage: false`, no warning
- [x] macOS E2E: keychain login/logout flow works
- [x] Linux E2E: no keychain + no flag → error with suggestion
- [x] Linux E2E: no keychain + flag → file storage with warning, `unsafeCredentialStorage: true`
- [x] Linux E2E: authenticated API call works with file-based credentials
- [x] Linux E2E: logout clears credentials.json
- [x] File permissions verified as 0600
- [x] Logout clears unsafeCredentialStorage flag

## Follow-up from

- #8134 (CLI auth support) — discussion with @jsenko about headless environments