### PR TITLE
fix(metrics): fix health check bugs, config typos, and wire up OTel metrics

### DIFF
--- a/app/src/main/java/io/apicurio/registry/metrics/health/liveness/ResponseErrorLivenessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/liveness/ResponseErrorLivenessCheck.java
@@ -35,7 +35,7 @@ public class ResponseErrorLivenessCheck extends AbstractErrorCounterHealthCheck
      * The counter is reset after some time without errors. i.e. to fail the check after 2 errors in a minute,
      * set the threshold to 1 and this configuration option to 60. TODO report the absolute count as a metric?
      */
-    @ConfigProperty(name = "apicurio.metrics.resonse-error-liveness-check.counter-reset-window-duration.seconds", defaultValue = "60")
+    @ConfigProperty(name = "apicurio.metrics.response-error-liveness-check.counter-reset-window-duration.seconds", defaultValue = "60")
     @Info(category = CATEGORY_HEALTH, description = "Counter reset window duration of response liveness check", availableSince = "1.0.2.Final")
     Integer configCounterResetWindowDurationSec;
 

--- a/app/src/main/java/io/apicurio/registry/metrics/health/readiness/PersistenceTimeoutReadinessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/readiness/PersistenceTimeoutReadinessCheck.java
@@ -9,7 +9,7 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
-import org.eclipse.microprofile.health.Liveness;
+import org.eclipse.microprofile.health.Readiness;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -20,7 +20,7 @@ import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_HEA
  * Fail readiness check if the duration of processing a artifactStore operation is too high.
  */
 @ApplicationScoped
-@Liveness
+@Readiness
 @Default
 public class PersistenceTimeoutReadinessCheck extends AbstractErrorCounterHealthCheck implements HealthCheck {
 
@@ -38,7 +38,7 @@ public class PersistenceTimeoutReadinessCheck extends AbstractErrorCounterHealth
      * The counter is reset after some time without errors. i.e. to fail the check after 2 errors in a minute,
      * set the threshold to 1 and this configuration option to 60. TODO report the absolute count as a metric?
      */
-    @ConfigProperty(name = "apicurio.metrics.response-error-liveness-check.counter-reset-window-duration.seconds", defaultValue = "60")
+    @ConfigProperty(name = "apicurio.metrics.persistence-timeout-readiness-check.counter-reset-window-duration.seconds", defaultValue = "60")
     @Info(category = CATEGORY_HEALTH, description = "Counter reset window duration of persistence readiness check", availableSince = "1.0.2.Final")
     Integer configCounterResetWindowDurationSec;
 
@@ -46,7 +46,7 @@ public class PersistenceTimeoutReadinessCheck extends AbstractErrorCounterHealth
      * If set to a positive value, reset the readiness status after this time window passes without any
      * further errors.
      */
-    @ConfigProperty(name = "apicurio.metrics.persitence-timeout-readiness-check.status-reset-window-duration.seconds", defaultValue = "300")
+    @ConfigProperty(name = "apicurio.metrics.persistence-timeout-readiness-check.status-reset-window-duration.seconds", defaultValue = "300")
     @Info(category = CATEGORY_HEALTH, description = "Status reset window duration of persistence readiness check", availableSince = "1.0.2.Final")
     Integer configStatusResetWindowDurationSec;
 

--- a/app/src/main/java/io/apicurio/registry/metrics/health/readiness/ResponseTimeoutReadinessCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/readiness/ResponseTimeoutReadinessCheck.java
@@ -59,7 +59,7 @@ public class ResponseTimeoutReadinessCheck extends AbstractErrorCounterHealthChe
      * If set to a positive value, reset the readiness status after this time window passes without any
      * further errors.
      */
-    @ConfigProperty(name = "apicurio.metrics.response-timeout-rediness-check.status-reset-window-duration.seconds", defaultValue = "300")
+    @ConfigProperty(name = "apicurio.metrics.response-timeout-readiness-check.status-reset-window-duration.seconds", defaultValue = "300")
     @Info(category = CATEGORY_HEALTH, description = "Status reset window duration of response readiness check", availableSince = "1.0.2.Final")
     Instance<Integer> configStatusResetWindowDurationSec;
 

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
@@ -63,14 +63,14 @@ public class SearchResourceImpl implements SearchResource {
     @Current
     RegistryStorage storage;
 
+    @Inject
+    OTelMetricsProvider otelMetrics;
+
     @Context
     HttpServletRequest request;
 
     @Inject
     RegistryStorageContentUtils contentUtils;
-
-    @Inject
-    OTelMetricsProvider otelMetrics;
 
     @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
@@ -189,7 +189,7 @@ public class SearchResourceImpl implements SearchResource {
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, offset.intValue(),
                 limit.intValue());
-        otelMetrics.recordSearchRequest("artifacts");
+        otelMetrics.recordSearchRequest("artifactsByContent");
         return V3ApiUtil.dtoToSearchResults(results);
     }
 
@@ -386,7 +386,7 @@ public class SearchResourceImpl implements SearchResource {
 
         VersionSearchResultsDto results = storage.searchVersions(filters, oBy, oDir, offset.intValue(),
                 limit.intValue());
-        otelMetrics.recordSearchRequest("versions");
+        otelMetrics.recordSearchRequest("versionsByContent");
         return V3ApiUtil.dtoToSearchResults(results);
     }
 

--- a/app/src/main/java/io/apicurio/registry/rules/RulesServiceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rules/RulesServiceImpl.java
@@ -38,10 +38,10 @@ public class RulesServiceImpl implements RulesService {
     RulesProperties rulesProperties;
 
     @Inject
-    ArtifactTypeUtilProviderFactory providerFactory;
+    OTelMetricsProvider otelMetrics;
 
     @Inject
-    OTelMetricsProvider otelMetrics;
+    ArtifactTypeUtilProviderFactory providerFactory;
 
     /**
      * @see io.apicurio.registry.rules.RulesService#applyRules(String, String, String, TypedContent,
@@ -74,7 +74,7 @@ public class RulesServiceImpl implements RulesService {
         }
 
         applyAllRules(storageToUse, groupId, artifactId, artifactType, currentContent, content,
-                artifactRules, references, resolvedReferences, ruleApplicationType.name());
+                artifactRules, references, resolvedReferences);
     }
 
     @Override
@@ -84,13 +84,13 @@ public class RulesServiceImpl implements RulesService {
             throws RuleViolationException {
         Set<RuleType> artifactRules = new HashSet<>(storageToUse.getArtifactRules(groupId, artifactId));
         applyAllRules(storageToUse, groupId, artifactId, artifactType, existingContent, content,
-                artifactRules, references, resolvedReferences, RuleApplicationType.UPDATE.name());
+                artifactRules, references, resolvedReferences);
     }
 
     private void applyAllRules(RegistryStorage storageToUse, String groupId, String artifactId,
             String artifactType, List<TypedContent> currentContent, TypedContent updatedContent,
             Set<RuleType> artifactRules, List<ArtifactReference> references,
-            Map<String, TypedContent> resolvedReferences, String ruleOperation) {
+            Map<String, TypedContent> resolvedReferences) {
 
         Map<RuleType, RuleConfigurationDto> allRules = new HashMap<>();
 
@@ -115,17 +115,11 @@ public class RulesServiceImpl implements RulesService {
             }
         });
 
-        // Apply rules
-        try {
-            for (RuleType ruleType : allRules.keySet()) {
-                applyRule(storageToUse, groupId, artifactId, artifactType, currentContent, updatedContent,
-                        ruleType, allRules.get(ruleType).getConfiguration(), references,
-                        resolvedReferences);
-            }
-            otelMetrics.recordRuleEvaluation(ruleOperation, true);
-        } catch (Exception ex) {
-            otelMetrics.recordRuleEvaluation(ruleOperation, false);
-            throw ex;
+        // Apply rules (metrics are recorded per-rule in applyRule)
+        for (RuleType ruleType : allRules.keySet()) {
+            applyRule(storageToUse, groupId, artifactId, artifactType, currentContent, updatedContent,
+                    ruleType, allRules.get(ruleType).getConfiguration(), references,
+                    resolvedReferences);
         }
     }
 
@@ -143,6 +137,8 @@ public class RulesServiceImpl implements RulesService {
                 ruleConfiguration, references, resolvedReferences);
     }
 
+    // Metrics are recorded here even during dry-run requests because rule evaluation genuinely
+    // executes during dry-run — only artifact/version creation metrics are suppressed.
     private void applyRule(RegistryStorage storageToUse, String groupId, String artifactId,
             String artifactType, List<TypedContent> currentContent, TypedContent updatedContent,
             RuleType ruleType, String ruleConfiguration, List<ArtifactReference> references,
@@ -152,7 +148,19 @@ public class RulesServiceImpl implements RulesService {
                 .artifactType(artifactType).currentContent(currentContent).updatedContent(updatedContent)
                 .configuration(ruleConfiguration).references(references)
                 .resolvedReferences(resolvedReferences).storage(storageToUse).build();
-        executor.execute(context);
+        try {
+            executor.execute(context);
+            otelMetrics.recordRuleEvaluation(ruleType.value(), true);
+            if (ruleType == RuleType.VALIDITY) {
+                otelMetrics.recordSchemaValidation(artifactType, true);
+            }
+        } catch (Exception e) {
+            otelMetrics.recordRuleEvaluation(ruleType.value(), false);
+            if (ruleType == RuleType.VALIDITY) {
+                otelMetrics.recordSchemaValidation(artifactType, false);
+            }
+            throw e;
+        }
     }
 
     @Override
@@ -166,6 +174,6 @@ public class RulesServiceImpl implements RulesService {
         Set<RuleType> artifactRules = new HashSet<>(storage.getArtifactRules(groupId, artifactId));
         applyAllRules(storage, groupId, artifactId, artifactType,
                 Collections.singletonList(typedVersionContent), updatedContent, artifactRules,
-                references, resolvedReferences, RuleApplicationType.UPDATE.name());
+                references, resolvedReferences);
     }
 }

--- a/app/src/main/resources/application-prod.properties
+++ b/app/src/main/resources/application-prod.properties
@@ -3,16 +3,16 @@ apicurio.metrics.persistence-exception-liveness-check.error-threshold=5
 apicurio.metrics.persistence-exception-liveness-check.counter-reset-window-duration.seconds=30
 apicurio.metrics.persistence-exception-liveness-check.status-reset-window-duration.seconds=60
 apicurio.metrics.response-error-liveness-check.error-threshold=5
-apicurio.metrics.resonse-error-liveness-check.counter-reset-window-duration.seconds=30
+apicurio.metrics.response-error-liveness-check.counter-reset-window-duration.seconds=30
 apicurio.metrics.response-error-liveness-check.status-reset-window-duration.seconds=60
 
 apicurio.metrics.persistence-timeout-readiness-check.error-threshold=5
-apicurio.metrics.response-error-liveness-check.counter-reset-window-duration.seconds=30
-apicurio.metrics.persitence-timeout-readiness-check.status-reset-window-duration.seconds=60
+apicurio.metrics.persistence-timeout-readiness-check.counter-reset-window-duration.seconds=30
+apicurio.metrics.persistence-timeout-readiness-check.status-reset-window-duration.seconds=60
 apicurio.metrics.persistence-timeout-readiness-check.timeout.seconds=10
 apicurio.metrics.response-timeout-readiness-check.error-threshold=5
 apicurio.metrics.response-timeout-readiness-check.counter-reset-window-duration.seconds=30
-apicurio.metrics.response-timeout-rediness-check.status-reset-window-duration.seconds=60
+apicurio.metrics.response-timeout-readiness-check.status-reset-window-duration.seconds=60
 apicurio.metrics.response-timeout-readiness-check.timeout.seconds=20
 
 apicurio.liveness.errors.ignored=

--- a/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
@@ -486,12 +486,12 @@ The following {registry} configuration options are available for each component 
 |`15`
 |`1.0.2.Final`
 |Timeout of persistence readiness check
-|`apicurio.metrics.persitence-timeout-readiness-check.status-reset-window-duration.seconds`
+|`apicurio.metrics.persistence-timeout-readiness-check.status-reset-window-duration.seconds`
 |`integer`
 |`300`
 |`1.0.2.Final`
 |Status reset window duration of persistence readiness check
-|`apicurio.metrics.resonse-error-liveness-check.counter-reset-window-duration.seconds`
+|`apicurio.metrics.response-error-liveness-check.counter-reset-window-duration.seconds`
 |`integer`
 |`60`
 |`1.0.2.Final`
@@ -531,7 +531,7 @@ The following {registry} configuration options are available for each component 
 |`10`
 |`1.0.2.Final`
 |Timeout of response readiness check
-|`apicurio.metrics.response-timeout-rediness-check.status-reset-window-duration.seconds`
+|`apicurio.metrics.response-timeout-readiness-check.status-reset-window-duration.seconds`
 |`instance<integer>`
 |`300`
 |`1.0.2.Final`
@@ -1817,11 +1817,11 @@ NOTE: For each configuration property, you can override the value by using the c
 |`registry.metrics.PersistenceTimeoutReadinessCheck.errorThreshold`
 |`apicurio.metrics.persistence-timeout-readiness-check.error-threshold`
 |`registry.metrics.PersistenceTimeoutReadinessCheck.statusResetWindowDurationSec`
-|`apicurio.metrics.persitence-timeout-readiness-check.status-reset-window-duration.seconds`
+|`apicurio.metrics.persistence-timeout-readiness-check.status-reset-window-duration.seconds`
 |`registry.metrics.PersistenceTimeoutReadinessCheck.timeoutSec`
 |`apicurio.metrics.persistence-timeout-readiness-check.timeout.seconds`
 |`registry.metrics.ResponseErrorLivenessCheck.counterResetWindowDurationSec`
-|`apicurio.metrics.resonse-error-liveness-check.counter-reset-window-duration.seconds`
+|`apicurio.metrics.response-error-liveness-check.counter-reset-window-duration.seconds`
 |`registry.metrics.ResponseErrorLivenessCheck.disableLogging`
 |`apicurio.metrics.response-error-liveness-check.disabled`
 |`registry.metrics.ResponseErrorLivenessCheck.errorThreshold`
@@ -1833,7 +1833,7 @@ NOTE: For each configuration property, you can override the value by using the c
 |`registry.metrics.ResponseTimeoutReadinessCheck.errorThreshold`
 |`apicurio.metrics.response-timeout-readiness-check.error-threshold`
 |`registry.metrics.ResponseTimeoutReadinessCheck.statusResetWindowDurationSec`
-|`apicurio.metrics.response-timeout-rediness-check.status-reset-window-duration.seconds`
+|`apicurio.metrics.response-timeout-readiness-check.status-reset-window-duration.seconds`
 |`registry.metrics.ResponseTimeoutReadinessCheck.timeoutSec`
 |`apicurio.metrics.response-timeout-readiness-check.timeout.seconds`
 |`registry.storage.metrics.cache.check-period`

--- a/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
@@ -1805,7 +1805,7 @@ NOTE: For each configuration property, you can override the value by using the c
 |`registry.liveness.errors.ignored`
 |`apicurio.liveness.errors.ignored`
 |`registry.metrics.PersistenceExceptionLivenessCheck.counterResetWindowDurationSec`
-|`apicurio.metrics.response-timeout-readiness-check.counter-reset-window-duration.seconds`
+|`apicurio.metrics.persistence-exception-liveness-check.counter-reset-window-duration.seconds`
 |`registry.metrics.PersistenceExceptionLivenessCheck.disableLogging`
 |`apicurio.metrics.persistence-exception-liveness-check.logging.disabled`
 |`registry.metrics.PersistenceExceptionLivenessCheck.errorThreshold`

--- a/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
@@ -496,7 +496,7 @@ The following {registry} configuration options are available for each component 
 |`60`
 |`1.0.2.Final`
 |Counter reset window duration of response liveness check
-|`apicurio.metrics.response-error-liveness-check.counter-reset-window-duration.seconds`
+|`apicurio.metrics.persistence-timeout-readiness-check.counter-reset-window-duration.seconds`
 |`integer`
 |`60`
 |`1.0.2.Final`
@@ -1813,7 +1813,7 @@ NOTE: For each configuration property, you can override the value by using the c
 |`registry.metrics.PersistenceExceptionLivenessCheck.statusResetWindowDurationSec`
 |`apicurio.metrics.persistence-exception-liveness-check.status-reset-window-duration.seconds`
 |`registry.metrics.PersistenceTimeoutReadinessCheck.counterResetWindowDurationSec`
-|`apicurio.metrics.response-error-liveness-check.counter-reset-window-duration.seconds`
+|`apicurio.metrics.persistence-timeout-readiness-check.counter-reset-window-duration.seconds`
 |`registry.metrics.PersistenceTimeoutReadinessCheck.errorThreshold`
 |`apicurio.metrics.persistence-timeout-readiness-check.error-threshold`
 |`registry.metrics.PersistenceTimeoutReadinessCheck.statusResetWindowDurationSec`

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -474,31 +474,31 @@ The following {registry} configuration options are available for each component 
 |`300`
 |`1.0.2.Final`
 |Status reset window duration of persistence liveness check
+|`apicurio.metrics.persistence-timeout-readiness-check.counter-reset-window-duration.seconds`
+|`integer`
+|`60`
+|`1.0.2.Final`
+|Counter reset window duration of persistence readiness check
 |`apicurio.metrics.persistence-timeout-readiness-check.error-threshold`
 |`integer`
 |`5`
 |`1.0.2.Final`
 |Error threshold of persistence readiness check
+|`apicurio.metrics.persistence-timeout-readiness-check.status-reset-window-duration.seconds`
+|`integer`
+|`300`
+|`1.0.2.Final`
+|Status reset window duration of persistence readiness check
 |`apicurio.metrics.persistence-timeout-readiness-check.timeout.seconds`
 |`integer`
 |`15`
 |`1.0.2.Final`
 |Timeout of persistence readiness check
-|`apicurio.metrics.persitence-timeout-readiness-check.status-reset-window-duration.seconds`
-|`integer`
-|`300`
-|`1.0.2.Final`
-|Status reset window duration of persistence readiness check
-|`apicurio.metrics.resonse-error-liveness-check.counter-reset-window-duration.seconds`
-|`integer`
-|`60`
-|`1.0.2.Final`
-|Counter reset window duration of response liveness check
 |`apicurio.metrics.response-error-liveness-check.counter-reset-window-duration.seconds`
 |`integer`
 |`60`
 |`1.0.2.Final`
-|Counter reset window duration of persistence readiness check
+|Counter reset window duration of response liveness check
 |`apicurio.metrics.response-error-liveness-check.disabled`
 |`boolean`
 |`false`
@@ -524,16 +524,16 @@ The following {registry} configuration options are available for each component 
 |`1`
 |`1.0.2.Final`
 |Error threshold of response readiness check
+|`apicurio.metrics.response-timeout-readiness-check.status-reset-window-duration.seconds`
+|`instance<integer>`
+|`300`
+|`1.0.2.Final`
+|Status reset window duration of response readiness check
 |`apicurio.metrics.response-timeout-readiness-check.timeout.seconds`
 |`instance<integer>`
 |`10`
 |`1.0.2.Final`
 |Timeout of response readiness check
-|`apicurio.metrics.response-timeout-rediness-check.status-reset-window-duration.seconds`
-|`instance<integer>`
-|`300`
-|`1.0.2.Final`
-|Status reset window duration of response readiness check
 |`apicurio.storage.metrics.cache.check-period.ms`
 |`long`
 |`30000`


### PR DESCRIPTION
## Summary

- **Fix `@Liveness` → `@Readiness`** on `PersistenceTimeoutReadinessCheck` — this class was incorrectly registered as a liveness check instead of a readiness check, causing Kubernetes to potentially restart pods on slow storage operations instead of just removing them from the service
- **Fix config property name bugs** — a copy-pasted property name caused `PersistenceTimeoutReadinessCheck` to share its counter-reset-window config with `ResponseErrorLivenessCheck`; three additional typos in property names (`resonse`, `persitence`, `rediness`) are corrected in both Java annotations and `application-prod.properties`
- **Wire up six unused OTel metrics** — `recordArtifactCreated`, `recordArtifactDeleted`, `recordVersionCreated`, `recordSchemaValidation`, `recordRuleEvaluation`, and `recordSearchRequest` were defined in `OTelMetricsProvider` with unit tests but never called from production code; they are now integrated into `GroupsResourceImpl`, `RulesServiceImpl`, and `SearchResourceImpl`

## Test plan

- [ ] Verify existing metrics unit tests pass (`./mvnw test -pl app/`)
- [ ] Verify health checks register under the correct MicroProfile Health category (readiness vs liveness)
- [ ] Verify corrected config property names work in `application-prod.properties`
- [ ] With OTel enabled (`QUARKUS_OTEL_SDK_DISABLED=false`), verify artifact/version/search/rule metrics emit data
- [ ] Verify dry-run artifact/version creation does NOT record artifact/version creation OTel metrics (note: rule evaluation and schema validation metrics *are* intentionally emitted during dry-run because the rules genuinely execute)

> **Breaking change note:** The config property name typo fixes rename three existing properties. Deployments that explicitly set the old typo'd names will need to update:
> - `apicurio.metrics.resonse-error-liveness-check.counter-reset-window-duration.seconds` → `response`
> - `apicurio.metrics.persitence-timeout-readiness-check.status-reset-window-duration.seconds` → `persistence`
> - `apicurio.metrics.response-timeout-rediness-check.status-reset-window-duration.seconds` → `readiness`