### PR TITLE
Harden SAXParser in ContentTypeUtil.isParsableXml() to prevent XXE

### DIFF
--- a/schema-util/common/pom.xml
+++ b/schema-util/common/pom.xml
@@ -76,6 +76,12 @@
       <artifactId>jackson-datatype-json-org</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
@@ -9,6 +9,7 @@ import io.apicurio.registry.types.ContentTypes;
 import org.xml.sax.InputSource;
 import org.xml.sax.helpers.DefaultHandler;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
@@ -124,6 +125,10 @@ public final class ContentTypeUtil {
     public static boolean isParsableXml(ContentHandle content) {
         try {
             SAXParserFactory factory = SAXParserFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             SAXParser saxParser = factory.newSAXParser();
             saxParser.parse(new InputSource(new StringReader(content.content())), new DefaultHandler());
             // If no exception is thrown, the XML is valid

--- a/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
@@ -1,0 +1,48 @@
+package io.apicurio.registry.content.util;
+
+import io.apicurio.registry.content.ContentHandle;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ContentTypeUtilTest {
+
+    @Test
+    public void testIsParsableXml_validXml() {
+        ContentHandle content = ContentHandle.create("<root><child>text</child></root>");
+        Assertions.assertTrue(ContentTypeUtil.isParsableXml(content));
+    }
+
+    @Test
+    public void testIsParsableXml_malformedXml() {
+        ContentHandle content = ContentHandle.create("<root><unclosed>");
+        Assertions.assertFalse(ContentTypeUtil.isParsableXml(content));
+    }
+
+    @Test
+    public void testIsParsableXml_nonXml() {
+        ContentHandle content = ContentHandle.create("this is not xml at all");
+        Assertions.assertFalse(ContentTypeUtil.isParsableXml(content));
+    }
+
+    @Test
+    public void testIsParsableXml_rejectsDoctypeDeclaration() {
+        String xxePayload = "<?xml version=\"1.0\"?>\n"
+                + "<!DOCTYPE foo [\n"
+                + "  <!ENTITY xxe SYSTEM \"file:///etc/passwd\">\n"
+                + "]>\n"
+                + "<root>&xxe;</root>";
+        ContentHandle content = ContentHandle.create(xxePayload);
+        Assertions.assertFalse(ContentTypeUtil.isParsableXml(content));
+    }
+
+    @Test
+    public void testIsParsableXml_rejectsEntityExpansion() {
+        String billionLaughs = "<?xml version=\"1.0\"?>\n"
+                + "<!DOCTYPE lolz [\n"
+                + "  <!ENTITY lol \"lol\">\n"
+                + "]>\n"
+                + "<root>&lol;</root>";
+        ContentHandle content = ContentHandle.create(billionLaughs);
+        Assertions.assertFalse(ContentTypeUtil.isParsableXml(content));
+    }
+}


### PR DESCRIPTION
## Summary
- Added XXE/SSRF/entity-expansion DoS protections to `ContentTypeUtil.isParsableXml()` by enabling
  `FEATURE_SECURE_PROCESSING`, `disallow-doctype-decl`, and disabling external entity resolution on
  the `SAXParserFactory`
- Added unit tests covering valid XML, malformed XML, and DOCTYPE-bearing payloads (XXE, entity expansion)
- Added JUnit 5 test dependency to `schema-util/common` module

## Related Issue
Fixes #8187

## Test Plan
- [ ] Run `./mvnw test -pl schema-util/common` to verify new unit tests pass
- [ ] Run `./mvnw checkstyle:check -pl schema-util/common` to verify code style compliance
- [ ] Full build with `./mvnw clean install -DskipTests` to confirm no compilation issues
- [ ] Verify XML/XSD/WSDL artifact uploads still work (content type detection unchanged for valid XML)