### PR TITLE
fix(wsdl): disable wsdl4j import dereference to prevent SSRF (#8188)

### DIFF
--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/WsdlContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/WsdlContentValidatorTest.java
@@ -35,6 +35,14 @@ public class WsdlContentValidatorTest extends ArtifactUtilProviderTestBase {
     }
 
     @Test
+    public void testImportsNotFetched() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("wsdl-with-import.wsdl");
+        WsdlContentValidator validator = new WsdlContentValidator();
+        // Must not throw — if the import were fetched, the unreachable URL would cause a timeout/error
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+    }
+
+    @Test
     public void testinValidSemantics() throws Exception {
         TypedContent content = resourceToTypedContentHandle("wsdl-invalid-semantics.wsdl");
         WsdlContentValidator validator = new WsdlContentValidator();

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/wsdl-with-import.wsdl
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/wsdl-with-import.wsdl
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<definitions name="StockQuoteWithImport"
+             targetNamespace="http://example.com/stockquote-with-import.wsdl"
+             xmlns:tns="http://example.com/stockquote-with-import.wsdl"
+             xmlns:ext="http://192.0.2.1/unreachable.wsdl"
+             xmlns:xsd1="http://example.com/stockquote.xsd"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns="http://schemas.xmlsoap.org/wsdl/">
+
+    <import namespace="http://192.0.2.1/unreachable.wsdl"
+            location="http://192.0.2.1/unreachable.wsdl"/>
+
+    <types>
+       <schema targetNamespace="http://example.com/stockquote.xsd"
+              xmlns="http://www.w3.org/2000/10/XMLSchema">
+           <element name="TradePriceRequest">
+              <complexType>
+                  <all>
+                      <element name="tickerSymbol" type="string"/>
+                  </all>
+              </complexType>
+           </element>
+           <element name="TradePrice">
+              <complexType>
+                  <all>
+                      <element name="price" type="float"/>
+                  </all>
+              </complexType>
+           </element>
+       </schema>
+    </types>
+
+    <message name="GetLastTradePriceInput">
+        <part name="body" element="xsd1:TradePriceRequest"/>
+    </message>
+
+    <message name="GetLastTradePriceOutput">
+        <part name="body" element="xsd1:TradePrice"/>
+    </message>
+
+    <portType name="StockQuotePortType">
+        <operation name="GetLastTradePrice">
+           <input message="tns:GetLastTradePriceInput"/>
+           <output message="tns:GetLastTradePriceOutput"/>
+        </operation>
+    </portType>
+
+    <binding name="StockQuoteSoapBinding" type="tns:StockQuotePortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="GetLastTradePrice">
+           <soap:operation soapAction="http://example.com/GetLastTradePrice"/>
+           <input>
+               <soap:body use="literal"/>
+           </input>
+           <output>
+               <soap:body use="literal"/>
+           </output>
+        </operation>
+    </binding>
+
+    <service name="StockQuoteService">
+        <documentation>Service with an import that must not be fetched</documentation>
+        <port name="StockQuotePort" binding="tns:StockQuoteBinding">
+           <soap:address location="http://example.com/stockquote"/>
+        </port>
+    </service>
+
+</definitions>

--- a/schema-util/wsdl/src/main/java/io/apicurio/registry/wsdl/util/WSDLReaderAccessor.java
+++ b/schema-util/wsdl/src/main/java/io/apicurio/registry/wsdl/util/WSDLReaderAccessor.java
@@ -13,6 +13,8 @@ public class WSDLReaderAccessor {
             try {
                 WSDLFactory wsdlFactory = WSDLFactory.newInstance();
                 wsdlReader = wsdlFactory.newWSDLReader();
+                wsdlReader.setFeature("javax.wsdl.importDocuments", false);
+                wsdlReader.setFeature("com.ibm.wsdl.parseXMLSchemas", false);
             } catch (WSDLException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
## Summary

- Disable `javax.wsdl.importDocuments` and `com.ibm.wsdl.parseXMLSchemas` features in
  `WSDLReaderAccessor` to prevent wsdl4j from recursively fetching attacker-controlled URLs
  in `<wsdl:import>` and `<xsd:import>` elements (CWE-918 SSRF)
- Add unit test with a WSDL containing an import pointing to an unreachable RFC 5737 TEST-NET
  address, verifying that FULL validation succeeds without network access

## Related Issue

Fixes #8188

## Test Plan

- [ ] Run `./mvnw test -pl schema-util/util-provider -Dtest=WsdlContentValidatorTest` — all tests pass
- [ ] Verify `testImportsNotFetched` completes instantly (no network timeout)
- [ ] Verify existing `testValidSemantics` and `testValidSyntax` tests still pass (no regression)