### PR TITLE
fix(ui): update expected downstream logo in masthead test

### DIFF
--- a/ui/tests/specs/masthead.spec.ts
+++ b/ui/tests/specs/masthead.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 const REGISTRY_UI_URL: string = process.env["REGISTRY_UI_URL"] || "http://localhost:8888/";
 const IS_DOWNSTREAM: boolean = process.env["IS_DOWNSTREAM"] === "true";
 const EXPECTED_ALT: string = process.env["EXPECTED_ALT"] || (IS_DOWNSTREAM ? "Red Hat build of Apicurio Registry" : "Apicurio Registry");
-const EXPECTED_LOGO_SRC: string = process.env["EXPECTED_LOGO_SRC"] || (IS_DOWNSTREAM ? "/red-hat-logo-reverse-transparent-100px.png" : "/apicurio_registry_logo_default.svg");
+const EXPECTED_LOGO_SRC: string = process.env["EXPECTED_LOGO_SRC"] || (IS_DOWNSTREAM ? "/red-hat-logo-default-transparent-36px.png" : "/apicurio_registry_logo_default.svg");
 
 test("Masthead - Logo verification", async ({ page }) => {
     await page.goto(REGISTRY_UI_URL);


### PR DESCRIPTION
## Summary
- Updates the expected downstream logo filename in the masthead Playwright test from `red-hat-logo-reverse-transparent-100px.png` to `red-hat-logo-default-transparent-36px.png` to match the PatternFly 6 branding changes.

## Test plan
- [ ] Verify downstream UI tests pass with the updated logo expectation