### PR TITLE
fix(security): harden XML parsers against entity expansion attacks

### DIFF
--- a/schema-util/xml/pom.xml
+++ b/schema-util/xml/pom.xml
@@ -28,6 +28,12 @@
       <artifactId>xmlsec</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/schema-util/xml/src/main/java/io/apicurio/registry/xml/util/DocumentBuilderAccessor.java
+++ b/schema-util/xml/src/main/java/io/apicurio/registry/xml/util/DocumentBuilderAccessor.java
@@ -18,6 +18,8 @@ public final class DocumentBuilderAccessor {
                 DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
                 factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
                 factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
                 factory.setNamespaceAware(true);
                 builder = factory.newDocumentBuilder();
             } catch (ParserConfigurationException e) {

--- a/schema-util/xml/src/test/java/io/apicurio/registry/xml/util/DocumentBuilderAccessorTest.java
+++ b/schema-util/xml/src/test/java/io/apicurio/registry/xml/util/DocumentBuilderAccessorTest.java
@@ -1,0 +1,47 @@
+package io.apicurio.registry.xml.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXParseException;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.parsers.DocumentBuilder;
+
+/**
+ * Tests for {@link DocumentBuilderAccessor}.
+ */
+public class DocumentBuilderAccessorTest {
+
+    @Test
+    void testRejectsXmlWithDoctypeDeclaration() {
+        String xmlWithDoctype = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE foo [
+                  <!ENTITY xxe "test">
+                ]>
+                <root>&xxe;</root>
+                """;
+
+        DocumentBuilder builder = DocumentBuilderAccessor.getDocumentBuilder();
+        Assertions.assertThrows(SAXParseException.class, () -> {
+            builder.parse(new ByteArrayInputStream(xmlWithDoctype.getBytes(StandardCharsets.UTF_8)));
+        });
+    }
+
+    @Test
+    void testParsesWellFormedXmlWithoutDoctype() throws Exception {
+        String validXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <root><child>text</child></root>
+                """;
+
+        DocumentBuilder builder = DocumentBuilderAccessor.getDocumentBuilder();
+        var document = builder.parse(
+                new ByteArrayInputStream(validXml.getBytes(StandardCharsets.UTF_8)));
+        Assertions.assertNotNull(document);
+        Assertions.assertEquals("root", document.getDocumentElement().getTagName());
+    }
+
+}

--- a/schema-util/xsd/src/main/java/io/apicurio/registry/xsd/util/SchemaFactoryAccessor.java
+++ b/schema-util/xsd/src/main/java/io/apicurio/registry/xsd/util/SchemaFactoryAccessor.java
@@ -15,8 +15,9 @@ public class SchemaFactoryAccessor {
             try {
                 factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
                 factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
-                // Don't care.
+                throw new RuntimeException(e);
             }
             return factory;
         }

--- a/schema-util/xsd/src/test/java/io/apicurio/registry/xsd/util/SchemaFactoryAccessorTest.java
+++ b/schema-util/xsd/src/test/java/io/apicurio/registry/xsd/util/SchemaFactoryAccessorTest.java
@@ -1,0 +1,27 @@
+package io.apicurio.registry.xsd.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.validation.SchemaFactory;
+
+/**
+ * Tests for {@link SchemaFactoryAccessor}.
+ */
+public class SchemaFactoryAccessorTest {
+
+    @Test
+    void testReturnsNonNullFactory() {
+        SchemaFactory factory = SchemaFactoryAccessor.getSchemaFactory();
+        Assertions.assertNotNull(factory);
+    }
+
+    @Test
+    void testFactoryHasSecureProcessingEnabled() throws Exception {
+        SchemaFactory factory = SchemaFactoryAccessor.getSchemaFactory();
+        boolean secureProcessing = factory
+                .getFeature("http://javax.xml.XMLConstants/feature/secure-processing");
+        Assertions.assertTrue(secureProcessing);
+    }
+
+}


### PR DESCRIPTION
## Summary
- Add `disallow-doctype-decl=true` and `FEATURE_SECURE_PROCESSING` to `DocumentBuilderAccessor` to prevent billion-laughs XML entity expansion attacks
- Add `FEATURE_SECURE_PROCESSING` to `SchemaFactoryAccessor` and fail closed (throw) instead of silently swallowing `SAXNotRecognizedException` when security properties are rejected
- Add unit tests for both classes verifying the hardening is effective

## Related Issue
Fixes #8189

## Test Plan
- [ ] Run `./mvnw test -pl schema-util/xml` — verify `DocumentBuilderAccessorTest` passes (rejects DOCTYPE, parses clean XML)
- [ ] Run `./mvnw test -pl schema-util/xsd` — verify `SchemaFactoryAccessorTest` passes (secure processing enabled)
- [ ] Run `./mvnw checkstyle:check -pl schema-util/xml,schema-util/xsd` — verify no style violations
- [ ] Run `./mvnw test -pl schema-util/wsdl` — verify existing WSDL tests still pass (downstream consumer of `DocumentBuilderAccessor`)