### PR TITLE
feat: add Apitomy Data Models JSON Schema compatibility checker

### DIFF
--- a/app/src/main/java/io/apicurio/registry/types/provider/configured/ArtifactTypeUtilProviderImpl.java
+++ b/app/src/main/java/io/apicurio/registry/types/provider/configured/ArtifactTypeUtilProviderImpl.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.types.provider.configured;
 
+import io.apicurio.registry.types.provider.AbstractArtifactTypeUtilProvider;
 import io.apicurio.registry.types.provider.DefaultArtifactTypeUtilProviderImpl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -7,6 +8,8 @@ import io.apicurio.common.apps.config.ConfigPropertyCategory;
 import io.apicurio.common.apps.config.Info;
 import io.apicurio.registry.config.artifactTypes.ArtifactTypesConfiguration;
 import io.apicurio.registry.http.HttpClientService;
+import io.apicurio.registry.json.rules.compatibility.ApitomyJsonSchemaCompatibilityChecker;
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.IoUtil;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -36,17 +39,34 @@ public class ArtifactTypeUtilProviderImpl extends DefaultArtifactTypeUtilProvide
     @Getter
     private String configFile;
 
+    @ConfigProperty(name = "apicurio.compat.json-schema.use-apitomy", defaultValue = "false")
+    @Info(category = ConfigPropertyCategory.CATEGORY_TYPES, description = "Use the Apitomy Data Models JSON Schema compatibility checker instead of the everit-based one.", availableSince = "3.3.1", experimental = true)
+    boolean useApitomyJsonSchemaChecker;
+
     @PostConstruct
     public void init() {
         // Try to load from external config file for user-defined custom types
         ArtifactTypesConfiguration config = loadArtifactTypeConfiguration();
         if (config != null) {
             loadConfiguredProviders(config);
-            return;
+        } else {
+            // No external config — use standard providers (includes all built-in types)
+            loadStandardProviders();
         }
 
-        // No external config — use standard providers (includes all built-in types)
-        loadStandardProviders();
+        applyExperimentalOverrides();
+    }
+
+    private void applyExperimentalOverrides() {
+        if (useApitomyJsonSchemaChecker) {
+            log.info("Using Apitomy Data Models JSON Schema compatibility checker (experimental).");
+            providers.stream()
+                    .filter(p -> ArtifactType.JSON.equals(p.getArtifactType()))
+                    .filter(AbstractArtifactTypeUtilProvider.class::isInstance)
+                    .map(AbstractArtifactTypeUtilProvider.class::cast)
+                    .findFirst()
+                    .ifPresent(p -> p.setCompatibilityChecker(new ApitomyJsonSchemaCompatibilityChecker()));
+        }
     }
 
     private ArtifactTypesConfiguration loadArtifactTypeConfiguration() {

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -1398,6 +1398,11 @@ The following {registry} configuration options are available for each component 
 |`/tmp/apicurio-registry-artifact-types.json`
 |`3.1.0`
 |Path to a configuration file containing a list of supported artifact types.
+|`apicurio.compat.json-schema.use-apitomy`
+|`boolean`
+|`false`
+|`3.3.1`
+|Use the Apitomy Data Models JSON Schema compatibility checker instead of the everit-based one. _(experimental)_
 |===
 
 == ui

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
     <skipCommitIdPlugin>true</skipCommitIdPlugin>
 
     <!-- Apitomy Data Models (OpenAPI and AsyncAPI support) -->
-    <apitomy-data-models.version>3.1.0</apitomy-data-models.version>
+    <apitomy-data-models.version>3.1.1</apitomy-data-models.version>
 
     <!-- GraphQL -->
     <graphql.version>26.0</graphql.version>

--- a/schema-util/common/src/test/java/io/apicurio/registry/rules/compatibility/CompatibilityTestExecutor.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/rules/compatibility/CompatibilityTestExecutor.java
@@ -32,13 +32,16 @@ public class CompatibilityTestExecutor {
 
     private CompatibilityChecker checker;
 
-    public CompatibilityTestExecutor(CompatibilityChecker checker) {
+    private final Set<String> skipFields;
+
+    public CompatibilityTestExecutor(CompatibilityChecker checker, String... skipFields) {
         this.checker = checker;
+        this.skipFields = Set.of(skipFields);
     }
 
     public Set<String> execute(String testData) throws Exception {
 
-        Set<String> failed = new HashSet<>(); // TODO add diff
+        Set<String> failed = new HashSet<>();
 
         JSONObject testDataJson = MAPPER.readValue(testData, JSONObject.class);
         JSONArray testCasesData = testDataJson.getJSONArray("tests");
@@ -48,7 +51,16 @@ public class CompatibilityTestExecutor {
             String caseId = testCaseData.getString("id");
 
             if (!testCaseData.getBoolean("enabled")) {
-                log.warn("Skipping {}", caseId);
+                log.warn("Skipping disabled test case: {}", caseId);
+                continue;
+            }
+
+            var skipReason = skipFields.stream()
+                    .filter(testCaseData::has)
+                    .map(testCaseData::getString)
+                    .findFirst();
+            if (skipReason.isPresent()) {
+                log.warn("Skipping test case {}: {}", caseId, skipReason.get());
                 continue;
             }
 
@@ -62,46 +74,44 @@ public class CompatibilityTestExecutor {
                 ? testCaseData.get("updatedContentType").toString() : ContentTypes.APPLICATION_JSON;
             var updatedTypedContent = TypedContent.create(updated, updatedCT);
 
-            var resultBackward = checker.testCompatibility(CompatibilityLevel.BACKWARD,
-                    List.of(originalTypedContent), updatedTypedContent, Collections.emptyMap());
-            var resultForward = checker.testCompatibility(CompatibilityLevel.FORWARD,
-                    List.of(originalTypedContent), updatedTypedContent, Collections.emptyMap());
+            try {
+                var resultBackward = checker.testCompatibility(CompatibilityLevel.BACKWARD,
+                        List.of(originalTypedContent), updatedTypedContent, Collections.emptyMap());
+                var resultForward = checker.testCompatibility(CompatibilityLevel.FORWARD,
+                        List.of(originalTypedContent), updatedTypedContent, Collections.emptyMap());
 
-            switch (testCaseData.getString("compatibility")) {
-                case "backward":
-                    if (resultBackward.isCompatible() && !resultForward.isCompatible()) {
-                        // ok
-                        log.debug("OK caseId: {}", caseId);
-                    } else {
-                        // bad
-                        failed.add(caseId);
-                        logFail(caseId, resultBackward, resultForward);
-                    }
-                    break;
-
-                case "both":
-                    if (resultBackward.isCompatible() && resultForward.isCompatible()) {
-                        // ok
-                        log.debug("OK caseId: {}", caseId);
-                    } else {
-                        // bad
-                        failed.add(caseId);
-                        logFail(caseId, resultBackward, resultForward);
-                    }
-                    break;
-                case "none":
-                    if (!resultBackward.isCompatible() && !resultForward.isCompatible()) {
-                        // ok
-                        log.debug("OK caseId: {}", caseId);
-                    } else {
-                        // bad
-                        failed.add(caseId);
-                        logFail(caseId, resultBackward, resultForward);
-                    }
-                    break;
-                default:
-                    throw new IllegalArgumentException(
-                            "Unsupported compatibility type: " + testCaseData.getString("compatibility"));
+                switch (testCaseData.getString("compatibility")) {
+                    case "backward":
+                        if (resultBackward.isCompatible() && !resultForward.isCompatible()) {
+                            log.debug("OK caseId: {}", caseId);
+                        } else {
+                            failed.add(caseId);
+                            logFail(caseId, resultBackward, resultForward);
+                        }
+                        break;
+                    case "both":
+                        if (resultBackward.isCompatible() && resultForward.isCompatible()) {
+                            log.debug("OK caseId: {}", caseId);
+                        } else {
+                            failed.add(caseId);
+                            logFail(caseId, resultBackward, resultForward);
+                        }
+                        break;
+                    case "none":
+                        if (!resultBackward.isCompatible() && !resultForward.isCompatible()) {
+                            log.debug("OK caseId: {}", caseId);
+                        } else {
+                            failed.add(caseId);
+                            logFail(caseId, resultBackward, resultForward);
+                        }
+                        break;
+                    default:
+                        throw new IllegalArgumentException(
+                                "Unsupported compatibility type: " + testCaseData.getString("compatibility"));
+                }
+            } catch (Exception e) {
+                failed.add(caseId);
+                log.error("Test case {} threw exception: {}", caseId, e.getMessage(), e);
             }
         }
         return failed;

--- a/schema-util/json/pom.xml
+++ b/schema-util/json/pom.xml
@@ -24,6 +24,10 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apitomy</groupId>
+      <artifactId>apitomy-data-models</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-schema-util-common</artifactId>
       <version>${project.version}</version>

--- a/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/ApitomyCompatibilityDifference.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/ApitomyCompatibilityDifference.java
@@ -1,0 +1,33 @@
+package io.apicurio.registry.json.rules.compatibility;
+
+import io.apitomy.datamodels.jsonschema.compat.Difference;
+import io.apicurio.registry.rules.compatibility.CompatibilityDifference;
+import io.apicurio.registry.rules.violation.RuleViolation;
+
+import java.util.Objects;
+
+public class ApitomyCompatibilityDifference implements CompatibilityDifference {
+
+    private final Difference difference;
+
+    public ApitomyCompatibilityDifference(Difference difference) {
+        this.difference = Objects.requireNonNull(difference);
+    }
+
+    @Override
+    public RuleViolation asRuleViolation() {
+        return new RuleViolation(difference.getDiffType().name(), difference.getPathUpdated());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ApitomyCompatibilityDifference that)) return false;
+        return difference.equals(that.difference);
+    }
+
+    @Override
+    public int hashCode() {
+        return difference.hashCode();
+    }
+}

--- a/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/ApitomyJsonSchemaCompatibilityChecker.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/ApitomyJsonSchemaCompatibilityChecker.java
@@ -1,0 +1,41 @@
+package io.apicurio.registry.json.rules.compatibility;
+
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.rules.compatibility.AbstractCompatibilityChecker;
+import io.apicurio.registry.rules.compatibility.CompatibilityDifference;
+import io.apitomy.datamodels.jsonschema.compat.JsonSchemaCompatibilityChecker;
+import io.apitomy.datamodels.jsonschema.ref.AnchorFragmentResolver;
+import io.apitomy.datamodels.jsonschema.ref.JsonSchemaRefResolverChain;
+import io.apitomy.datamodels.jsonschema.ref.PointerFragmentResolver;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * JSON Schema compatibility checker using the Apitomy Data Models library
+ * instead of the everit-json-schema library.
+ */
+public class ApitomyJsonSchemaCompatibilityChecker extends AbstractCompatibilityChecker<ApitomyCompatibilityDifference> {
+
+    @Override
+    protected Set<ApitomyCompatibilityDifference> isBackwardsCompatibleWith(String existing, String proposed,
+            Map<String, TypedContent> resolvedReferences) {
+        var chain = JsonSchemaRefResolverChain.builder()
+                .addFragmentResolver(new PointerFragmentResolver())
+                .addFragmentResolver(new AnchorFragmentResolver())
+                .addResourceResolver(new RegistryResourceResolver(resolvedReferences))
+                .build();
+
+        return JsonSchemaCompatibilityChecker
+                .checkBackwardCompatibility(existing, proposed, chain)
+                .getIncompatibleDifferences().stream()
+                .map(ApitomyCompatibilityDifference::new)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    protected CompatibilityDifference transform(ApitomyCompatibilityDifference original) {
+        return original;
+    }
+}

--- a/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/RegistryResourceResolver.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/RegistryResourceResolver.java
@@ -1,0 +1,48 @@
+package io.apicurio.registry.json.rules.compatibility;
+
+import io.apicurio.registry.content.TypedContent;
+import io.apitomy.datamodels.Library;
+import io.apitomy.datamodels.jsonschema.ref.RefResolutionContext;
+import io.apitomy.datamodels.jsonschema.ref.ResourceResolver;
+import io.apitomy.datamodels.models.Node;
+import io.apitomy.datamodels.models.jsonschema.JsonSchemaDocument;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves external JSON Schema documents from the Registry's
+ * pre-resolved reference map ({@code Map<String, TypedContent>}).
+ */
+public class RegistryResourceResolver implements ResourceResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(RegistryResourceResolver.class);
+
+    private final Map<String, TypedContent> resolvedReferences;
+
+    public RegistryResourceResolver(Map<String, TypedContent> resolvedReferences) {
+        this.resolvedReferences = resolvedReferences != null ? resolvedReferences : Map.of();
+    }
+
+    @Override
+    public Optional<Node> resolveResource(String resource, RefResolutionContext context) {
+        var content = resolvedReferences.get(resource);
+        if (content == null) {
+            return Optional.empty();
+        }
+
+        try {
+            var doc = Library.readDocumentFromJSONString(content.getContent().content());
+            if (doc instanceof JsonSchemaDocument) {
+                return Optional.of(doc);
+            }
+            return Optional.empty();
+        } catch (Exception e) {
+            log.debug("Failed to parse referenced schema '{}': {}", resource, e.getMessage());
+            return Optional.empty();
+        }
+    }
+}

--- a/schema-util/json/src/test/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonSchemaCompatibilityCheckerTest.java
+++ b/schema-util/json/src/test/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonSchemaCompatibilityCheckerTest.java
@@ -2,14 +2,28 @@ package io.apicurio.registry.rules.compatibility.jsonschema;
 
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.TypedContent;
-import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
+import io.apicurio.registry.json.rules.compatibility.ApitomyJsonSchemaCompatibilityChecker;
 import io.apicurio.registry.json.rules.compatibility.JsonSchemaCompatibilityChecker;
+import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
+import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
 import io.apicurio.registry.types.ContentTypes;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JsonSchemaCompatibilityCheckerTest {
+
+    static Stream<CompatibilityChecker> checkers() {
+        return Stream.of(
+                new JsonSchemaCompatibilityChecker(),
+                new ApitomyJsonSchemaCompatibilityChecker()
+        );
+    }
 
     private TypedContent toTypedContent(String content) {
         return TypedContent.create(ContentHandle.create(content), ContentTypes.APPLICATION_JSON);
@@ -40,22 +54,23 @@ public class JsonSchemaCompatibilityCheckerTest {
             + "            \"type\": \"integer\",\r\n" + "            \"minimum\": 0\r\n" + "        }\r\n"
             + "    }\r\n" + "}";
 
-    @Test
-    public void testJsonSchemaCompatibilityChecker() {
-        JsonSchemaCompatibilityChecker checker = new JsonSchemaCompatibilityChecker();
-        TypedContent existing = toTypedContent(BEFORE);
-        TypedContent proposed = toTypedContent(AFTER_VALID);
-        checker.testCompatibility(CompatibilityLevel.BACKWARD, Collections.singletonList(existing), proposed,
-                Collections.emptyMap());
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("checkers")
+    void testCompatible(CompatibilityChecker checker) {
+        var existing = toTypedContent(BEFORE);
+        var proposed = toTypedContent(AFTER_VALID);
+        var result = checker.testCompatibility(CompatibilityLevel.BACKWARD,
+                Collections.singletonList(existing), proposed, Collections.emptyMap());
+        assertTrue(result.isCompatible(), "Adding a description should be backward compatible");
     }
 
-    @Test
-    public void testJsonSchemaCompatibilityChecker_Fail() {
-        JsonSchemaCompatibilityChecker checker = new JsonSchemaCompatibilityChecker();
-        TypedContent existing = toTypedContent(BEFORE);
-        TypedContent proposed = toTypedContent(AFTER_INVALID);
-        checker.testCompatibility(CompatibilityLevel.BACKWARD, Collections.singletonList(existing), proposed,
-                Collections.emptyMap());
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("checkers")
+    void testIncompatible(CompatibilityChecker checker) {
+        var existing = toTypedContent(BEFORE);
+        var proposed = toTypedContent(AFTER_INVALID);
+        var result = checker.testCompatibility(CompatibilityLevel.BACKWARD,
+                Collections.singletonList(existing), proposed, Collections.emptyMap());
+        assertFalse(result.isCompatible(), "Adding required properties should not be backward compatible");
     }
-
 }

--- a/schema-util/json/src/test/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonSchemaSmokeTest.java
+++ b/schema-util/json/src/test/java/io/apicurio/registry/rules/compatibility/jsonschema/JsonSchemaSmokeTest.java
@@ -1,7 +1,8 @@
 package io.apicurio.registry.rules.compatibility.jsonschema;
 
-import io.apicurio.registry.rules.compatibility.CompatibilityTestExecutor;
+import io.apicurio.registry.json.rules.compatibility.ApitomyJsonSchemaCompatibilityChecker;
 import io.apicurio.registry.json.rules.compatibility.JsonSchemaCompatibilityChecker;
+import io.apicurio.registry.rules.compatibility.CompatibilityTestExecutor;
 import org.junit.jupiter.api.Test;
 
 import static io.apicurio.registry.rules.compatibility.CompatibilityTestExecutor.readResource;
@@ -10,8 +11,14 @@ import static io.apicurio.registry.rules.compatibility.CompatibilityTestExecutor
 class JsonSchemaSmokeTest {
 
     @Test
-    void testCompatibility() throws Exception {
+    void testCompatibilityLegacy() throws Exception {
         var executor = new CompatibilityTestExecutor(new JsonSchemaCompatibilityChecker());
+        throwOnFailure(executor.execute(readResource(this.getClass(), "compatibility-test-data.json")));
+    }
+
+    @Test
+    void testCompatibilityApitomy() throws Exception {
+        var executor = new CompatibilityTestExecutor(new ApitomyJsonSchemaCompatibilityChecker(), "skipApitomy");
         throwOnFailure(executor.execute(readResource(this.getClass(), "compatibility-test-data.json")));
     }
 }

--- a/schema-util/json/src/test/resources/io/apicurio/registry/rules/compatibility/jsonschema/compatibility-test-data.json
+++ b/schema-util/json/src/test/resources/io/apicurio/registry/rules/compatibility/jsonschema/compatibility-test-data.json
@@ -20,7 +20,8 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "string"
       },
-      "updated": true
+      "updated": true,
+      "skipApitomy": "Boolean root schema not supported until union-as-root (G1)"
     },
     {
       "enabled": true,
@@ -2041,8 +2042,7 @@
       "original": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "string",
-        "enum": [
-        ]
+        "enum": []
       },
       "updated": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -2088,7 +2088,7 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "string",
         "const": [
-          "π"
+          "\u03c0"
         ]
       }
     },
@@ -3438,7 +3438,10 @@
         "type": "object",
         "properties": {
           "test": {
-            "type": ["string", "number"]
+            "type": [
+              "string",
+              "number"
+            ]
           }
         }
       }
@@ -3451,20 +3454,34 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
-          "foo": { "type": "string" }
+          "foo": {
+            "type": "string"
+          }
         },
-        "required":["foo"],
-        "additionalProperties": { "type": "string" }
+        "required": [
+          "foo"
+        ],
+        "additionalProperties": {
+          "type": "string"
+        }
       },
       "updated": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
-          "foo": { "type": "string" },
-          "bar": { "type": "string" }
+          "foo": {
+            "type": "string"
+          },
+          "bar": {
+            "type": "string"
+          }
         },
-        "required":["foo"],
-        "additionalProperties": { "type": "string" }
+        "required": [
+          "foo"
+        ],
+        "additionalProperties": {
+          "type": "string"
+        }
       }
     },
     {
@@ -3475,18 +3492,28 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
-          "foo": { "type": "string" },
-          "bar":{ "type": "string" }
+          "foo": {
+            "type": "string"
+          },
+          "bar": {
+            "type": "string"
+          }
         },
-        "required":["foo"]
+        "required": [
+          "foo"
+        ]
       },
       "updated": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
-          "foo": { "type": "string" }
+          "foo": {
+            "type": "string"
+          }
         },
-        "required":["foo"]
+        "required": [
+          "foo"
+        ]
       }
     },
     {
@@ -3497,16 +3524,24 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
-          "foo": { "type": "string" }
+          "foo": {
+            "type": "string"
+          }
         },
-        "additionalProperties": { "type": "number" }
+        "additionalProperties": {
+          "type": "number"
+        }
       },
       "updated": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
-          "foo": { "type": "string" },
-          "bar": { "type": "number" }
+          "foo": {
+            "type": "string"
+          },
+          "bar": {
+            "type": "number"
+          }
         },
         "additionalProperties": true
       }
@@ -3519,8 +3554,12 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
-          "foo": { "type": "string" },
-          "bar": { "type": "number" }
+          "foo": {
+            "type": "string"
+          },
+          "bar": {
+            "type": "number"
+          }
         },
         "additionalProperties": false
       },
@@ -3528,9 +3567,13 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
-          "foo": { "type": "string" }
+          "foo": {
+            "type": "string"
+          }
         },
-        "additionalProperties": { "type": "number" }
+        "additionalProperties": {
+          "type": "number"
+        }
       }
     },
     {
@@ -3541,8 +3584,12 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
-          "foo": { "type": "string" },
-          "bar": { "type": "number" }
+          "foo": {
+            "type": "string"
+          },
+          "bar": {
+            "type": "number"
+          }
         },
         "additionalProperties": false
       },
@@ -3550,7 +3597,9 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
-          "foo": { "type": "string" }
+          "foo": {
+            "type": "string"
+          }
         },
         "additionalProperties": {
           "type": "number",
@@ -3573,7 +3622,9 @@
             "type": "string"
           }
         ],
-        "additionalItems": { "type": "string" }
+        "additionalItems": {
+          "type": "string"
+        }
       },
       "updated": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -3583,7 +3634,9 @@
             "type": "string"
           }
         ],
-        "additionalItems": { "type": "string" }
+        "additionalItems": {
+          "type": "string"
+        }
       }
     },
     {
@@ -3624,7 +3677,9 @@
             "type": "string"
           }
         ],
-        "additionalItems": { "type": "number" }
+        "additionalItems": {
+          "type": "number"
+        }
       },
       "updated": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -3665,7 +3720,9 @@
             "type": "string"
           }
         ],
-        "additionalItems": { "type": "number" }
+        "additionalItems": {
+          "type": "number"
+        }
       }
     },
     {

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/AbstractArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/AbstractArtifactTypeUtilProvider.java
@@ -33,6 +33,10 @@ public abstract class AbstractArtifactTypeUtilProvider implements ArtifactTypeUt
 
     protected abstract ContentAccepter createContentAccepter();
 
+    public void setCompatibilityChecker(CompatibilityChecker checker) {
+        this.compatibilityChecker = checker;
+    }
+
     @Override
     public CompatibilityChecker getCompatibilityChecker() {
         if (compatibilityChecker == null) {


### PR DESCRIPTION
## Summary

Add an alternative JSON Schema compatibility checker using the Apitomy Data Models library (3.1.1) instead of the everit-json-schema library. The legacy checker remains the default — users opt in via experimental feature flags.

## Activation

```properties
apicurio.features.experimental.enabled=true
apicurio.compat.json-schema.use-apitomy=true
```

## Changes

**New files:**
- `ApitomyJsonSchemaCompatibilityChecker` — extends `AbstractCompatibilityChecker`, delegates to data-models checker
- `ApitomyCompatibilityDifference` — wraps data-models `Difference` as `CompatibilityDifference`
- `RegistryResourceResolver` — resolves external `$ref` from Registry's pre-resolved `Map<String, TypedContent>`

**Modified files:**
- `pom.xml` — bump `apitomy-data-models` from 3.1.0 to 3.1.1
- `schema-util/json/pom.xml` — add `apitomy-data-models` dependency
- `AbstractArtifactTypeUtilProvider` — add `setCompatibilityChecker()` for runtime override
- `ArtifactTypeUtilProviderImpl` — config property + provider switching logic
- `CompatibilityTestExecutor` — per-case exception handling + `skipFields` support for test data
- Tests — both checkers run the same test suites via parameterized tests

## Test plan

- [x] All existing JSON Schema compatibility tests pass with legacy checker (default)
- [x] Same tests pass with Apitomy checker (1 known skip: boolean root schema, tracked as G1)
- [x] Skip mechanism uses `skipApitomy` field in test data — data-driven, not hardcoded

## Related

- Data-models epic: Apitomy/apitomy-data-models#1042
- Generator improvements: Apitomy/apitomy-data-models#1041
- Compat checker type hierarchy refactoring: #8184