### PR TITLE
fix(build): pin container base images to digest (CWE-1357)

### DIFF
--- a/distro/docker/src/main/docker/Dockerfile.jvm
+++ b/distro/docker/src/main/docker/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:latest
+FROM registry.access.redhat.com/ubi10/openjdk-21-runtime@sha256:5ee73448f86838eecff13f80512b49ff6ea0fa21aaf5d1fa8afe3402fc965e9e
 
 ENV APP_URL="${docker.app.file}" \
     JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"

--- a/distro/gitops/Dockerfile
+++ b/distro/gitops/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:2c20ac20ca1ecbbbd583603feabd9cc51e7e8ea5a82e5088e20a9494794b2574
 
 RUN microdnf install -y git-core openssh-clients openssh-server shadow-utils jq && \
     microdnf clean all

--- a/mcp/src/main/docker/Dockerfile.jvm
+++ b/mcp/src/main/docker/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:latest
+FROM registry.access.redhat.com/ubi10/openjdk-21-runtime@sha256:5ee73448f86838eecff13f80512b49ff6ea0fa21aaf5d1fa8afe3402fc965e9e
 
 ENV APP_URL="${docker.app.file}" \
     JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"

--- a/operator/controller/src/main/docker/Dockerfile.jvm
+++ b/operator/controller/src/main/docker/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:latest
+FROM registry.access.redhat.com/ubi10/openjdk-21-runtime@sha256:5ee73448f86838eecff13f80512b49ff6ea0fa21aaf5d1fa8afe3402fc965e9e
 
 ENV APP_URL="quarkus-app" \
     JAVA_OPTIONS="-Djava.util.logging.manager=org.jboss.logmanager.LogManager"

--- a/renovate.json
+++ b/renovate.json
@@ -9,14 +9,18 @@
   ],
   "enabledManagers": [
     "npm",
-    "maven"
+    "maven",
+    "dockerfile"
   ],
   "dependencyDashboard": true,
   "rangeStrategy": "bump",
   "ignorePaths": [
     "ui/deploy-examples/**",
     "ui/Dockerfile",
-    "distro/**",
+    "distro/connect-converter/**",
+    "distro/docker-compose/**",
+    "distro/metrics/**",
+    "distro/openshift-template/**",
     "docs/**",
     "docs-playbook/**",
     "examples/**",
@@ -398,6 +402,19 @@
       ],
       "schedule": [
         "* 0 15 * *"
+      ]
+    },
+
+    {
+      "groupName": "Dependencies: Docker Base Images",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "enabled": true,
+      "matchUpdateTypes": [
+        "digest",
+        "minor",
+        "patch"
       ]
     },
 

--- a/support-chat/src/main/docker/Dockerfile.jvm
+++ b/support-chat/src/main/docker/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:latest
+FROM registry.access.redhat.com/ubi10/openjdk-21-runtime@sha256:5ee73448f86838eecff13f80512b49ff6ea0fa21aaf5d1fa8afe3402fc965e9e
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
## Summary

- Pin all 5 production Dockerfiles from mutable `:latest` tags to `@sha256:<digest>` for reproducible builds and supply-chain integrity (CWE-1357)
- Enable Renovate `dockerfile` manager and add a package rule to auto-bump Docker base image digests
- Narrow `distro/**` in Renovate `ignorePaths` so the distro Dockerfiles are visible to the dockerfile manager

## Related Issue

Fixes #8194

## Test Plan

- [ ] Verify all 5 `FROM` lines in production Dockerfiles use `@sha256:` syntax (no `:latest`)
- [ ] Verify `renovate.json` is valid JSON with `dockerfile` in `enabledManagers`
- [ ] Verify CI Docker builds still succeed
- [ ] Verify Renovate dependency dashboard picks up the new Dockerfiles on next scan