### PR TITLE
fix(ci): add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/generate-go-sdk.yaml
+++ b/.github/workflows/generate-go-sdk.yaml
@@ -6,6 +6,9 @@ on:
       - common/src/main/resources/META-INF/openapi-v2.json
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   generate-go-sdk:
     name: Generate Go SDK

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 6 * * *"
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   vulnerability-scan:
     name: Container vulnerability scan

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -7,6 +7,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 env:
   REGISTRY_APP_IMAGE: ttl.sh/apicurio-registry-${{ github.sha }}:8h
   REGISTRY_GITOPS_SYNC_IMAGE: ttl.sh/apicurio-registry-gitops-sync-${{ github.sha }}:8h

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -6,6 +6,9 @@ on:
       - 'docs/**'
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   publish-docs:
     if: github.repository_owner == 'Apicurio'

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -8,6 +8,8 @@ on:
   release:
     types: [ released ]
 
+permissions:
+  contents: read
 
 env:
   # The values are extracted from the github.event context,

--- a/.github/workflows/release-milestones.yaml
+++ b/.github/workflows/release-milestones.yaml
@@ -8,6 +8,8 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
 
 env:
   # The values are extracted from the github.event context,

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -13,6 +13,9 @@ on:
   release:
     types: [ released ]
 
+permissions:
+  contents: read
+
 jobs:
 
   release-build:

--- a/.github/workflows/release-release-notes.yaml
+++ b/.github/workflows/release-release-notes.yaml
@@ -8,6 +8,8 @@ on:
   release:
     types: [ released ]
 
+permissions:
+  contents: write
 
 env:
   # The values are extracted from the github.event context,

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,9 @@ on:
         type: boolean
         description: I will notify jsenko if the operator release workflow fails!
 
+permissions:
+  contents: read
+
 jobs:
   # Phase 1: Bump version, commit, push. Fast job that gates all parallel builds.
   release-prepare:

--- a/.github/workflows/reusable-docker-build.yaml
+++ b/.github/workflows/reusable-docker-build.yaml
@@ -90,6 +90,9 @@ on:
       QUAY_PASSWORD:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   docker-build:
     name: Build and Push Docker Image

--- a/.github/workflows/reusable-notify-slack.yaml
+++ b/.github/workflows/reusable-notify-slack.yaml
@@ -21,6 +21,8 @@ on:
       SLACK_ERROR_WEBHOOK:
         required: true
 
+permissions: {}
+
 jobs:
   notify:
     name: Send Slack Notification

--- a/.github/workflows/update-openapi.yaml
+++ b/.github/workflows/update-openapi.yaml
@@ -7,6 +7,9 @@ on:
       - utils/tools/src/main/java/io/apicurio/registry/utils/tools/TransformOpenApiForClientGen.java
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   update-openapi:
     name: Update OpenAPI

--- a/.github/workflows/update-website.yaml
+++ b/.github/workflows/update-website.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 jobs:
   update-website:
     if: github.repository_owner == 'Apicurio' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '3.'))

--- a/.github/workflows/validate-docs.yaml
+++ b/.github/workflows/validate-docs.yaml
@@ -7,6 +7,9 @@ on:
       - 'docs/**'
       - 'docs-playbook/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Docs

--- a/.github/workflows/validate-openapi.yaml
+++ b/.github/workflows/validate-openapi.yaml
@@ -6,6 +6,9 @@ on:
     paths:
       - common/src/main/resources/META-INF/openapi.json
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate

--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -14,6 +14,9 @@ on:
         description: 'Docker image tag (commit SHA)'
         value: ${{ jobs.build-java.outputs.image-tag }}
 
+permissions:
+  contents: read
+
 jobs:
   build-java:
     name: Build Java Application (no tests)

--- a/.github/workflows/verify-cli.yaml
+++ b/.github/workflows/verify-cli.yaml
@@ -8,6 +8,9 @@ on:
         required: true
         description: 'Build artifact identifier (commit SHA)'
 
+permissions:
+  contents: read
+
 jobs:
   cli-verify:
     name: CLI (${{ matrix.os-name }})

--- a/.github/workflows/verify-extras.yaml
+++ b/.github/workflows/verify-extras.yaml
@@ -14,6 +14,9 @@ on:
         required: true
         description: 'Docker image tag to test'
 
+permissions:
+  contents: read
+
 jobs:
   extra-tests:
     name: Extra Tests

--- a/.github/workflows/verify-integration-tests.yaml
+++ b/.github/workflows/verify-integration-tests.yaml
@@ -11,6 +11,9 @@ on:
         required: true
         description: 'Docker image tag to test'
 
+permissions:
+  contents: read
+
 jobs:
   integration-tests:
     name: Integration Tests (${{ matrix.storage }}-${{ matrix.name || matrix.groups }})

--- a/.github/workflows/verify-publish.yaml
+++ b/.github/workflows/verify-publish.yaml
@@ -18,6 +18,9 @@ on:
       QUAY_PASSWORD:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish-app-image:
     name: Publish App Docker Image

--- a/.github/workflows/verify-sdk.yaml
+++ b/.github/workflows/verify-sdk.yaml
@@ -11,6 +11,9 @@ on:
         required: true
         description: 'Docker image tag to test'
 
+permissions:
+  contents: read
+
 jobs:
   verify-python-sdk:
     name: Verify Python SDK

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -11,6 +11,9 @@ on:
         required: true
         description: 'Build artifact identifier (commit SHA)'
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit Tests (${{ matrix.shard.name }})

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # ============================================================================
   # DECIDE: Centralized decision on what to run


### PR DESCRIPTION
## Summary

- Add explicit top-level `permissions:` blocks to all 23 GitHub Actions workflow files that were
  missing them, following the principle of least privilege (CWE-250, OpenSSF Scorecard
  `Token-Permissions`)
- Default to `permissions: contents: read` for most workflows; elevate only where the `GITHUB_TOKEN`
  is actually used for write operations (`security-events: write` for SARIF uploads,
  `contents: write` for release note editing)
- Workflows that use `secrets.ACCESS_TOKEN` (a PAT) for write operations only need `contents: read`
  for the `GITHUB_TOKEN` since the PAT carries its own scopes

## Related Issue

Fixes #8196

## Test Plan

- [x] All 27 workflow files now have a `permissions:` block (verified via script)
- [x] All modified YAML files pass `yaml.safe_load()` validation
- [ ] Verify CI passes on the PR (the `verify.yaml` workflow itself is updated)
- [ ] Spot-check that image publish, release, and notification workflows still function correctly
  on the next push to main or release event