### PR TITLE
test(kafkasql): fix flaky snapshotting test assertions

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/tests/kafkasql/KafkaSqlSnapshottingIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/kafkasql/KafkaSqlSnapshottingIT.java
@@ -14,13 +14,17 @@ public class KafkaSqlSnapshottingIT extends ApicurioRegistryBaseIT {
     private static final String NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID = "SNAPSHOT_TEST_GROUP_ID";
 
     @Test
-    public void testRecoverFromSnapshot() throws InterruptedException {
+    public void testRecoverFromSnapshot() throws Exception {
         // We expect 1000 artifacts to be present in the snapshots group, created before the snapshot.
-        Assertions.assertEquals(1000, registryClient.groups().byGroupId(NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID)
-                .artifacts().get().getCount());
+        retry(() -> {
+            Assertions.assertEquals(1000, registryClient.groups().byGroupId(NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID)
+                    .artifacts().get().getCount());
+        }, "verify 1000 artifacts in snapshot group", 20);
 
         // And another 1000 in the default group, created after the snapshot.
-        Assertions.assertEquals(1000, registryClient.groups().byGroupId(NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID)
-                .artifacts().get().getCount());
+        retry(() -> {
+            Assertions.assertEquals(1000, registryClient.groups().byGroupId("default")
+                    .artifacts().get().getCount());
+        }, "verify 1000 artifacts in default group", 20);
     }
 }


### PR DESCRIPTION
## Summary

- Fix copy-paste bug in `KafkaSqlSnapshottingIT.testRecoverFromSnapshot()` where both assertions checked `NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID` — the second should check `"default"` group (post-snapshot journal replay was never verified)
- Wrap assertions in `retry()` with descriptive names to handle multi-replica race condition (3 replicas behind LoadBalancer with no session affinity)

## Related Issues

Fixes #8179

## Changes

**`integration-tests/.../KafkaSqlSnapshottingIT.java`**
- Fixed second assertion to check `"default"` group instead of `NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID` (copy-paste bug — the comment said "default group" but the code checked the wrong one)
- Wrapped both assertions in `retry(runnable, name, 20)` for multi-replica eventual consistency
- Added descriptive retry names for clearer CI failure messages
- Changed `throws InterruptedException` → `throws Exception` to match `retry()` signature

## Root Cause Analysis

Three issues contribute to flakiness:

1. **Copy-paste assertion bug** (fixed here) — second assertion was identical to the first, so post-snapshot recovery was never actually tested
2. **Multi-replica race** (mitigated with retry) — `waitForRegistryReady()` passes when any single replica responds, but assertions can hit a different replica still bootstrapping
3. **PVC mismatch** (not addressed, infrastructure scope) — `ReadWriteMany` on minikube's `hostPath` provisioner only supports `ReadWriteOnce`

Issues 2 and 3 are infrastructure-level concerns in the deployment manager / Kubernetes manifests. They would benefit from:
- Adding session affinity to the test LoadBalancer service
- Enhancing `waitForRegistryReady()` to verify data-plane consistency across all replicas
- Using a storage class that actually supports RWX

These are intentionally left as follow-ups to keep this PR focused on the test fix.

## Known Trade-offs

- `retry(20)` adds up to ~21s per assertion on genuine failure (vs immediate fail without retry). Acceptable given the multi-replica setup.
- `retry()` error accumulation via `addSuppressed()` can bury the initial failure cause in CI logs. The named retry overload mitigates this with descriptive labels.

## Testing

- [x] Checkstyle passes (`./mvnw checkstyle:check`)
- [x] Compiles clean (`./mvnw install -Pintegration-tests -DskipTests`)
- [ ] CI integration test run (kafkasql-snapshotting profile)