### PR TITLE
fix(test): use optimistic fallback in Debezium V2 deserializer mixin

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroV2DeserializerMixin.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroV2DeserializerMixin.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 /**
  * Mixin interface providing Apicurio Registry wire format deserialization logic with
@@ -19,7 +20,8 @@ import java.nio.charset.StandardCharsets;
  * <p>Applies the same heuristic as {@code OptimisticFallbackIdHandler}: peek at the first
  * 4 bytes after the magic byte. If they are all zeros the data was written with the legacy
  * 8-byte format (globalId as a long); otherwise it was written with the default 4-byte
- * format (contentId as an int). The schema is then fetched via the matching endpoint.
+ * format (contentId as an int). The schema is then fetched via the matching endpoint and
+ * any Avro references are resolved before deserialization.
  */
 public interface DebeziumAvroV2DeserializerMixin {
 
@@ -37,7 +39,7 @@ public interface DebeziumAvroV2DeserializerMixin {
      * <p>If the first 4 bytes after the magic byte are all zeros the record is treated as
      * legacy 8-byte globalId format; otherwise it is treated as default 4-byte contentId
      * format. This mirrors the {@code OptimisticFallbackIdHandler} logic used in the serde
-     * library.
+     * library. Schema references are resolved before parsing.
      */
     default GenericRecord deserializeAvroValueV2(byte[] bytes) throws Exception {
         if (bytes == null || bytes.length < 5) {
@@ -65,24 +67,27 @@ public interface DebeziumAvroV2DeserializerMixin {
 
         boolean legacy8Byte = (firstFour == 0 && buffer.remaining() >= 4);
 
-        InputStream schemaStream;
+        String schemaJson;
+        Schema.Parser parser = new Schema.Parser();
+
         if (legacy8Byte) {
             // Rewind the 4 bytes we just read and consume a full 8-byte long
             buffer.position(buffer.position() - 4);
             long globalId = buffer.getLong();
             LOG.info("Detected legacy 8-byte format. Global ID: {} (0x{})",
                     globalId, Long.toHexString(globalId));
-            schemaStream = fetchSchemaByGlobalId(globalId);
+            schemaJson = fetchSchemaStringByGlobalId(globalId);
+            resolveReferencesByGlobalId(globalId, parser);
         } else {
             long contentId = Integer.toUnsignedLong(firstFour);
             LOG.info("Detected default 4-byte format. Content ID: {} (0x{})",
                     contentId, Long.toHexString(contentId));
-            schemaStream = fetchSchemaByContentId(contentId);
+            schemaJson = fetchSchemaStringByContentId(contentId);
+            resolveReferencesByContentId(contentId, parser);
         }
 
         try {
-            String schemaJson = new String(schemaStream.readAllBytes(), StandardCharsets.UTF_8);
-            Schema schema = new Schema.Parser().parse(schemaJson);
+            Schema schema = parser.parse(schemaJson);
 
             // Deserialize payload
             byte[] payload = new byte[buffer.remaining()];
@@ -100,11 +105,12 @@ public interface DebeziumAvroV2DeserializerMixin {
     }
 
     /**
-     * Fetches a schema by globalId (legacy 8-byte format).
+     * Fetches a schema as a JSON string by globalId (legacy 8-byte format).
      */
-    private InputStream fetchSchemaByGlobalId(long globalId) throws Exception {
+    private String fetchSchemaStringByGlobalId(long globalId) throws Exception {
         try {
-            return getRegistryClient().ids().globalIds().byGlobalId(globalId).get();
+            InputStream stream = getRegistryClient().ids().globalIds().byGlobalId(globalId).get();
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
         } catch (Exception e) {
             LOG.error("Failed to fetch schema for globalId: {}. Error: {}", globalId, e.getMessage());
             logRecentArtifacts();
@@ -113,15 +119,74 @@ public interface DebeziumAvroV2DeserializerMixin {
     }
 
     /**
-     * Fetches a schema by contentId (default 4-byte format).
+     * Fetches a schema as a JSON string by contentId (default 4-byte format).
      */
-    private InputStream fetchSchemaByContentId(long contentId) throws Exception {
+    private String fetchSchemaStringByContentId(long contentId) throws Exception {
         try {
-            return getRegistryClient().ids().contentIds().byContentId(contentId).get();
+            InputStream stream = getRegistryClient().ids().contentIds().byContentId(contentId).get();
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
         } catch (Exception e) {
             LOG.error("Failed to fetch schema for contentId: {}. Error: {}", contentId, e.getMessage());
             logRecentArtifacts();
             throw e;
+        }
+    }
+
+    /**
+     * Resolves and pre-parses schema references for a globalId.
+     */
+    private void resolveReferencesByGlobalId(long globalId, Schema.Parser parser) {
+        try {
+            var references = getRegistryClient().ids().globalIds().byGlobalId(globalId).references().get();
+            resolveReferences(references, parser);
+        } catch (Exception e) {
+            LOG.warn("Could not resolve references for globalId {}: {}", globalId, e.getMessage());
+        }
+    }
+
+    /**
+     * Resolves and pre-parses schema references for a contentId.
+     */
+    private void resolveReferencesByContentId(long contentId, Schema.Parser parser) {
+        try {
+            var references = getRegistryClient().ids().contentIds().byContentId(contentId).references().get();
+            resolveReferences(references, parser);
+        } catch (Exception e) {
+            LOG.warn("Could not resolve references for contentId {}: {}", contentId, e.getMessage());
+        }
+    }
+
+    /**
+     * Fetches and pre-parses each referenced schema so the main schema can resolve them.
+     */
+    private void resolveReferences(
+            List<io.apicurio.registry.rest.client.models.ArtifactReference> references,
+            Schema.Parser parser) {
+        if (references == null || references.isEmpty()) {
+            return;
+        }
+        LOG.info("Schema has {} references, resolving...", references.size());
+        for (var ref : references) {
+            try {
+                String refGroupId = ref.getGroupId() != null ? ref.getGroupId() : "default";
+                String refArtifactId = ref.getArtifactId();
+                String refVersion = ref.getVersion();
+
+                LOG.info("Resolving reference: name={}, groupId={}, artifactId={}, version={}",
+                        ref.getName(), refGroupId, refArtifactId, refVersion);
+
+                String versionExpr = (refVersion != null && !refVersion.isEmpty()) ? refVersion : "latest";
+                InputStream refStream = getRegistryClient().groups().byGroupId(refGroupId)
+                        .artifacts().byArtifactId(refArtifactId)
+                        .versions().byVersionExpression(versionExpr)
+                        .content().get();
+
+                String refSchemaJson = new String(refStream.readAllBytes(), StandardCharsets.UTF_8);
+                parser.parse(refSchemaJson);
+                LOG.info("Successfully resolved reference: {}", ref.getName());
+            } catch (Exception e) {
+                LOG.warn("Failed to resolve reference {}: {}", ref.getName(), e.getMessage());
+            }
         }
     }
 

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroV2DeserializerMixin.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroV2DeserializerMixin.java
@@ -13,9 +13,13 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Mixin interface providing common Apicurio Registry V2 wire format deserialization logic.
- * This can be used by any test class that needs to deserialize Avro messages encoded with
- * the V2 wire format: [magic byte (0x0)][long: global ID][avro payload]
+ * Mixin interface providing Apicurio Registry wire format deserialization logic with
+ * optimistic fallback between 4-byte and 8-byte ID formats.
+ *
+ * <p>Applies the same heuristic as {@code OptimisticFallbackIdHandler}: peek at the first
+ * 4 bytes after the magic byte. If they are all zeros the data was written with the legacy
+ * 8-byte format (globalId as a long); otherwise it was written with the default 4-byte
+ * format (contentId as an int). The schema is then fetched via the matching endpoint.
  */
 public interface DebeziumAvroV2DeserializerMixin {
 
@@ -28,8 +32,12 @@ public interface DebeziumAvroV2DeserializerMixin {
     io.apicurio.registry.rest.client.RegistryClient getRegistryClient();
 
     /**
-     * Deserializes Avro-encoded bytes to GenericRecord using V2 API format.
-     * Handles Apicurio Registry V2 wire format (magic byte + globalId + payload)
+     * Deserializes Avro-encoded bytes to GenericRecord, auto-detecting the wire format.
+     *
+     * <p>If the first 4 bytes after the magic byte are all zeros the record is treated as
+     * legacy 8-byte globalId format; otherwise it is treated as default 4-byte contentId
+     * format. This mirrors the {@code OptimisticFallbackIdHandler} logic used in the serde
+     * library.
      */
     default GenericRecord deserializeAvroValueV2(byte[] bytes) throws Exception {
         if (bytes == null || bytes.length < 5) {
@@ -43,21 +51,36 @@ public interface DebeziumAvroV2DeserializerMixin {
         }
         LOG.info(hexDump.toString());
 
-        // Parse Apicurio V2 wire format: [magic byte][long: global ID][payload]
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
 
         // Skip magic byte (should be 0x0)
         byte magicByte = buffer.get();
         LOG.info("Magic byte: {} (0x{})", magicByte, String.format("%02X", magicByte));
 
-        // Read global ID (8 bytes, big-endian long)
-        long globalId = buffer.getLong();
-        LOG.info("Global ID from wire format (decimal): {}", globalId);
-        LOG.info("Global ID from wire format (hex): 0x{}", Long.toHexString(globalId));
+        // Optimistic fallback: peek at the first 4 bytes to decide the format.
+        // If all four are zero and there is room for another 4 bytes, this was
+        // written with Legacy8ByteIdHandler (8-byte globalId). Otherwise, it was
+        // written with Default4ByteIdHandler (4-byte contentId).
+        int firstFour = buffer.getInt();
 
-        // Fetch schema from registry using global ID
+        boolean legacy8Byte = (firstFour == 0 && buffer.remaining() >= 4);
+
+        InputStream schemaStream;
+        if (legacy8Byte) {
+            // Rewind the 4 bytes we just read and consume a full 8-byte long
+            buffer.position(buffer.position() - 4);
+            long globalId = buffer.getLong();
+            LOG.info("Detected legacy 8-byte format. Global ID: {} (0x{})",
+                    globalId, Long.toHexString(globalId));
+            schemaStream = fetchSchemaByGlobalId(globalId);
+        } else {
+            long contentId = Integer.toUnsignedLong(firstFour);
+            LOG.info("Detected default 4-byte format. Content ID: {} (0x{})",
+                    contentId, Long.toHexString(contentId));
+            schemaStream = fetchSchemaByContentId(contentId);
+        }
+
         try {
-            InputStream schemaStream = getRegistryClient().ids().globalIds().byGlobalId(globalId).get();
             String schemaJson = new String(schemaStream.readAllBytes(), StandardCharsets.UTF_8);
             Schema schema = new Schema.Parser().parse(schemaJson);
 
@@ -70,23 +93,55 @@ public interface DebeziumAvroV2DeserializerMixin {
 
             return reader.read(null, decoder);
         } catch (Exception e) {
-            LOG.error("Failed to fetch schema for globalId: {}. Error: {}", globalId, e.getMessage());
-            LOG.error("Trying to list recent artifacts to debug...");
-            try {
-                var artifacts = getRegistryClient().search().artifacts().get(config -> {
-                    config.queryParameters.limit = 10;
-                    config.queryParameters.orderby = io.apicurio.registry.rest.client.models.ArtifactSortBy.CreatedOn;
-                    config.queryParameters.order = io.apicurio.registry.rest.client.models.SortOrder.Desc;
-                });
-                LOG.error("Recent artifacts in registry:");
-                artifacts.getArtifacts().forEach(artifact -> {
-                    LOG.error("  - Artifact: {}, Group: {}, Type: {}",
-                            artifact.getArtifactId(), artifact.getGroupId(), artifact.getArtifactType());
-                });
-            } catch (Exception listError) {
-                LOG.error("Could not list artifacts", listError);
-            }
+            LOG.error("Failed to deserialize Avro record. Error: {}", e.getMessage());
+            logRecentArtifacts();
             throw e;
+        }
+    }
+
+    /**
+     * Fetches a schema by globalId (legacy 8-byte format).
+     */
+    private InputStream fetchSchemaByGlobalId(long globalId) throws Exception {
+        try {
+            return getRegistryClient().ids().globalIds().byGlobalId(globalId).get();
+        } catch (Exception e) {
+            LOG.error("Failed to fetch schema for globalId: {}. Error: {}", globalId, e.getMessage());
+            logRecentArtifacts();
+            throw e;
+        }
+    }
+
+    /**
+     * Fetches a schema by contentId (default 4-byte format).
+     */
+    private InputStream fetchSchemaByContentId(long contentId) throws Exception {
+        try {
+            return getRegistryClient().ids().contentIds().byContentId(contentId).get();
+        } catch (Exception e) {
+            LOG.error("Failed to fetch schema for contentId: {}. Error: {}", contentId, e.getMessage());
+            logRecentArtifacts();
+            throw e;
+        }
+    }
+
+    /**
+     * Logs recently registered artifacts for debugging purposes.
+     */
+    private void logRecentArtifacts() {
+        try {
+            var artifacts = getRegistryClient().search().artifacts().get(config -> {
+                config.queryParameters.limit = 10;
+                config.queryParameters.orderby = io.apicurio.registry.rest.client.models.ArtifactSortBy.CreatedOn;
+                config.queryParameters.order = io.apicurio.registry.rest.client.models.SortOrder.Desc;
+            });
+            LOG.error("Recent artifacts in registry:");
+            artifacts.getArtifacts().forEach(artifact -> {
+                LOG.error("  - Artifact: {}, Group: {}, Type: {}",
+                        artifact.getArtifactId(), artifact.getGroupId(), artifact.getArtifactType());
+            });
+        } catch (Exception listError) {
+            LOG.error("Could not list artifacts", listError);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1477,5 +1477,4 @@
       </repositories>
     </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
## Summary

- Fix the `DebeziumAvroV2DeserializerMixin` to handle both 4-byte (default) and 8-byte
  (legacy) wire formats using the same heuristic as `OptimisticFallbackIdHandler`
- When the first 4 bytes after the magic byte are all zeros, treat the data as legacy
  8-byte globalId format and fetch via `/ids/globalIds/{id}`
- Otherwise, treat the 4 bytes as a contentId and fetch via `/ids/contentIds/{id}`

## Context

The `h2-debezium` integration tests (`DebeziumMySQLAvroIntegrationIT` and
`DebeziumPostgreSQLAvroIntegrationIT`) have been failing across all recent PRs. The root
cause is a wire format mismatch: the default `AvroConverter` uses `Default4ByteIdHandler`
which writes a 4-byte contentId, but the V2 deserializer mixin unconditionally read 8 bytes
as a globalId. This caused 4 bytes of Avro payload to be consumed as part of the ID,
producing invalid IDs (e.g. `42949804566`) that returned 404 from the registry.

## Test plan

- [ ] Verify the `h2-debezium` CI job passes (all 16 previously failing tests)
- [ ] Verify LocalConverters tests still pass (they use the V3 mixin, unaffected)
- [ ] Verify other integration test suites are unaffected