### PR TITLE
fix(operator): update GitOpsTest to match writable volume mount

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/unit/GitOpsTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/unit/GitOpsTest.java
@@ -92,15 +92,14 @@ public class GitOpsTest {
         assertThat(sidecar.get().getVolumeMounts())
                 .anyMatch(vm -> "gitops-repos".equals(vm.getName()) && "/repos".equals(vm.getMountPath()));
 
-        // Verify app container has read-only volume mount
+        // Verify app container has the volume mount (writable for dry-run validation)
         var appContainer = podSpec.getContainers().stream()
                 .filter(c -> "apicurio-registry-app".equals(c.getName()))
                 .findFirst();
         assertThat(appContainer).isPresent();
         assertThat(appContainer.get().getVolumeMounts())
                 .anyMatch(vm -> "gitops-repos".equals(vm.getName())
-                        && "/repos".equals(vm.getMountPath())
-                        && Boolean.TRUE.equals(vm.getReadOnly()));
+                        && "/repos".equals(vm.getMountPath()));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixes `GitOpsTest.testSidecarInjection` unit test failure on main
- Commit `0676b0d9d` ("feat(gitops): add dry-run validation REST API and sidecar support") intentionally removed `readOnly(true)` from the app container's gitops-repos volume mount so dry-run validation can write to `/repos`, but the test assertion was not updated

## Test plan
- [ ] Operator unit tests pass (`make build` in `operator/`)
- [ ] CI `Operator Tests / Local Tests` job passes