### PR TITLE
docs(operator): add release process docs and fix README inaccuracies

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -74,7 +74,7 @@ The following steps have been tested for OpenShift:
 
 ### On-cluster Development Quickstart
 
-1. Create an image repository for your operator build, e.g. `quay.io/foo/apicurio-registry-operator`:
+1. Create an image repository for your operator build, e.g. `quay.io/foo/apicurio-registry-3-operator`:
     ```shell
    export IMAGE_REGISTRY=quay.io/foo
     ```
@@ -123,7 +123,7 @@ Available options:
 | Option               | Type   | Default value                  | Description                           |
 |----------------------|--------|--------------------------------|---------------------------------------|
 | IMAGE_REGISTRY       | string | `quay.io/apicurio`             | -                                     |
-| IMAGE_NAME           | string | `apicurio-registry-operator`   | -                                     |
+| IMAGE_NAME           | string | `apicurio-registry-3-operator`   | -                                     |
 | IMAGE_TAG            | string | *(current version, lowercase)* | -                                     |
 | ADDITIONAL_IMAGE_TAG | string | -                              | Tag the image with an additional tag. |
 
@@ -319,7 +319,7 @@ Available options:
 | INSTALL_FILE       | string | `install/apicurio-registry-operator-`*(current version)*`.yaml` | -           |
 | INSTALL_NAMESPACE  | string | `PLACEHOLDER_NAMESPACE`                                         | -           |
 | IMAGE_REGISTRY     | string | `quay.io/apicurio`                                              | -           |
-| IMAGE_NAME         | string | `apicurio-registry-operator`                                    | -           |
+| IMAGE_NAME         | string | `apicurio-registry-3-operator`                                    | -           |
 | IMAGE_TAG          | string | *(current version, lowercase)*                                  | -           |
 | REGISTRY_APP_IMAGE | string | `quay.io/apicurio/apicurio-registry:latest-snapshot`            | -           |
 | REGISTRY_UI_IMAGE  | string | `quay.io/apicurio/apicurio-registry-ui:latest-snapshot`         | -           |
@@ -340,7 +340,7 @@ Available options:
 | Option             | Type   | Default value                                           | Description |
 |--------------------|--------|---------------------------------------------------------|-------------|
 | IMAGE_REGISTRY     | string | `quay.io/apicurio`                                      | -           |
-| IMAGE_NAME         | string | `apicurio-registry-operator`                            | -           |
+| IMAGE_NAME         | string | `apicurio-registry-3-operator`                            | -           |
 | IMAGE_TAG          | string | *(current version, lowercase)*                          | -           |
 | REGISTRY_APP_IMAGE | string | `quay.io/apicurio/apicurio-registry:latest-snapshot`    | -           |
 | REGISTRY_UI_IMAGE  | string | `quay.io/apicurio/apicurio-registry-ui:latest-snapshot` | -           |
@@ -351,7 +351,7 @@ Available options:
 
 ### Operator Bundle
 
-You can create an OLM bundle files by running:
+You can create OLM bundle files by running:
 
 ```shell
 make bundle-build
@@ -359,13 +359,17 @@ make bundle-build
 
 Available options:
 
-| Option                   | Type             | Default value                  | Description |
-|--------------------------|------------------|--------------------------------|-------------|
-| BUNDLE_CHANNEL           | string           | `3.x`                          | -           |
-| BUNDLE_VERSION           | string           | *(current version, lowercase)* | -           |
-| PREVIOUS_PACKAGE_VERSION | string           | **TODO**                       | -           |
+| Option                   | Type   | Default value                           | Description                                                                                          |
+|--------------------------|--------|-----------------------------------------|------------------------------------------------------------------------------------------------------|
+| CHANNEL                  | string | *(auto-derived, e.g. `3.3.x`)*         | Minor-version channel, derived from the project version.                                             |
+| ROLLING_CHANNEL          | string | *(empty)*                               | Set to `3.x` to include the rolling channel. CI sets this for main-branch releases.                  |
+| CHANNELS                 | string | `ROLLING_CHANNEL,CHANNEL` or `CHANNEL`  | Computed from `ROLLING_CHANNEL` and `CHANNEL`. Do not override directly.                             |
+| DEFAULT_CHANNEL          | string | `ROLLING_CHANNEL` or `CHANNEL`          | Default channel for new installations.                                                               |
+| PREVIOUS_PACKAGE_VERSION | string | *(set in Makefile)*                     | Last released version; determines the `replaces` field.                                              |
 
 *NOTE: The CRD file must have been generated using `make build`.*
+
+See [RELEASING.md](RELEASING.md) for details on how channels work across main and maintenance branches.
 
 Then, to create a bundle image, run:
 
@@ -375,12 +379,12 @@ make bundle-image-build
 
 Available options:
 
-| Option                | Type   | Default value                       | Description                           |
-|-----------------------|--------|-------------------------------------|---------------------------------------|
-| IMAGE_REGISTRY        | string | `quay.io/apicurio`                  | -                                     |
-| BUNDLE_IMAGE_NAME     | string | `apicurio-registry-operator-bundle` | -                                     |
-| BUNDLE_IMAGE_TAG      | string | *(current version, lowercase)*      | -                                     |
-| ADDITIONAL_BUNDLE_TAG | string | -                                   | Tag the image with an additional tag. |
+| Option                | Type   | Default value                            | Description                           |
+|-----------------------|--------|------------------------------------------|---------------------------------------|
+| IMAGE_REGISTRY        | string | `quay.io/apicurio`                       | -                                     |
+| BUNDLE_IMAGE_NAME     | string | `apicurio-registry-3-operator-bundle`    | -                                     |
+| BUNDLE_IMAGE_TAG      | string | *(current version, lowercase)*           | -                                     |
+| ADDITIONAL_BUNDLE_TAG | string | -                                        | Tag the image with an additional tag. |
 
 After the bundle image is built, push it by running:
 
@@ -411,7 +415,7 @@ Available options:
 | Option                 | Type   | Default value                                                       | Description                           |
 |------------------------|--------|---------------------------------------------------------------------|---------------------------------------|
 | IMAGE_REGISTRY         | string | `quay.io/apicurio`                                                  | -                                     |
-| CATALOG_IMAGE_NAME     | string | `apicurio-registry-operator-catalog`                                | -                                     |
+| CATALOG_IMAGE_NAME     | string | `apicurio-registry-3-operator-catalog`                              | -                                     |
 | CATALOG_IMAGE_TAG      | string | *(current version, lowercase)*                                      | -                                     |
 | ADDITIONAL_CATALOG_TAG | string | `latest` *(with version suffix, lowercase, e.g. `latest-snapshot`)* | Tag the image with an additional tag. |
 


### PR DESCRIPTION
## Summary

- Add `operator/RELEASING.md` documenting the full operator release process so any maintainer can release independently. Covers:
  - How to release from main vs maintenance branches
  - OLM channel design and linearity constraints
  - Both community operator repos (what they are, what to do when PRs fail)
  - Key Makefile variables (`ROLLING_CHANNEL`, `OLD_PREVIOUS_CHANNEL`, etc.)
  - Internal catalog template vs upstream submissions
  - Troubleshooting common failures

- Fix `operator/README.md` inaccuracies:
  - Update bundle options table: replace non-existent `BUNDLE_CHANNEL` with actual variables (`CHANNEL`, `ROLLING_CHANNEL`, `CHANNELS`, `DEFAULT_CHANNEL`)
  - Fix `PREVIOUS_PACKAGE_VERSION` default from `**TODO**` to `*(set in Makefile)*`
  - Fix image names: `apicurio-registry-operator` → `apicurio-registry-3-operator` (bundle and catalog too)
  - Add link to RELEASING.md from the bundle section

## Test plan

- [ ] Review docs for accuracy