### PR TITLE
fix(ci): add signal-aware diagnostics to readiness checks

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/deployment/DebeziumDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/DebeziumDeploymentManager.java
@@ -481,6 +481,9 @@ public class DebeziumDeploymentManager {
 
             int attempt = 0;
             boolean ready = false;
+            int connectionRefusedCount = 0;
+            int httpResponseCount = 0;
+            int lastStatusCode = -1;
 
             while (attempt < CONNECT_READY_MAX_ATTEMPTS && !ready) {
                 java.net.HttpURLConnection conn = null;
@@ -496,12 +499,15 @@ public class DebeziumDeploymentManager {
                         ready = true;
                         LOGGER.info("Debezium Connect is ready!");
                     } else {
-                        LOGGER.info("Attempt {}/{}: Debezium Connect returned status code: {}",
+                        httpResponseCount++;
+                        lastStatusCode = responseCode;
+                        LOGGER.info("Attempt {}/{}: Debezium Connect starting up (HTTP {})",
                                 attempt + 1, CONNECT_READY_MAX_ATTEMPTS, responseCode);
                     }
                 } catch (Exception e) {
-                    LOGGER.info("Attempt {}/{}: Debezium Connect not ready yet: {}",
+                    LOGGER.info("Attempt {}/{}: Debezium Connect not reachable ({})",
                             attempt + 1, CONNECT_READY_MAX_ATTEMPTS, e.getMessage());
+                    connectionRefusedCount++;
                 } finally {
                     if (conn != null) {
                         conn.disconnect();
@@ -514,8 +520,21 @@ public class DebeziumDeploymentManager {
             }
 
             if (!ready) {
-                throw new RuntimeException("Debezium Connect did not become ready after " + CONNECT_READY_MAX_ATTEMPTS + " attempts. " +
-                        "Make sure 'minikube tunnel' is running and LoadBalancer services are accessible.");
+                String diagnosis;
+                if (httpResponseCount == 0) {
+                    diagnosis = "All " + CONNECT_READY_MAX_ATTEMPTS + " attempts got Connection refused — " +
+                            "this is a routing issue, not a startup timeout. Check minikube tunnel status.";
+                } else if (connectionRefusedCount == 0) {
+                    diagnosis = "All attempts reached the server but never got HTTP 200 (last status: " +
+                            lastStatusCode + ") — startup is too slow or the service is unhealthy.";
+                } else {
+                    diagnosis = "Mixed signals: " + connectionRefusedCount + " Connection refused, " +
+                            httpResponseCount + " HTTP responses (last status: " + lastStatusCode +
+                            "). Service was intermittently reachable.";
+                }
+                LOGGER.error("Debezium Connect readiness check failed. Diagnosis: {}", diagnosis);
+                throw new RuntimeException("Debezium Connect did not become ready after " +
+                        CONNECT_READY_MAX_ATTEMPTS + " attempts. " + diagnosis);
             }
 
         } catch (InterruptedException e) {

--- a/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
@@ -256,12 +256,16 @@ public class RegistryDeploymentManager implements TestExecutionListener {
             int maxAttempts = 30;
             int attempt = 0;
             boolean ready = false;
+            int connectionRefusedCount = 0;
+            int httpResponseCount = 0;
+            int lastStatusCode = -1;
 
             while (attempt < maxAttempts && !ready) {
+                java.net.HttpURLConnection conn = null;
                 try {
                     // Simple HTTP GET to check if service is responding
                     java.net.URL url = new java.net.URL(registryUrl);
-                    java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
+                    conn = (java.net.HttpURLConnection) url.openConnection();
                     conn.setRequestMethod("GET");
                     conn.setConnectTimeout(2000);
                     conn.setReadTimeout(2000);
@@ -271,20 +275,41 @@ public class RegistryDeploymentManager implements TestExecutionListener {
                         ready = true;
                         LOGGER.info("Apicurio Registry is ready!");
                     } else {
-                        LOGGER.debug("Registry returned status code: {}", responseCode);
+                        httpResponseCount++;
+                        lastStatusCode = responseCode;
+                        LOGGER.info("Attempt {}/{}: Apicurio Registry starting up (HTTP {})",
+                                attempt + 1, maxAttempts, responseCode);
                     }
-                    conn.disconnect();
                 } catch (Exception e) {
-                    LOGGER.debug("Attempt {}/{}: Registry not ready yet: {}",
+                    LOGGER.info("Attempt {}/{}: Apicurio Registry not reachable ({})",
                             attempt + 1, maxAttempts, e.getMessage());
+                    connectionRefusedCount++;
+                } finally {
+                    if (conn != null) {
+                        conn.disconnect();
+                    }
+                }
+                if (!ready) {
                     Thread.sleep(2000);
                 }
                 attempt++;
             }
 
             if (!ready) {
-                throw new RuntimeException("Apicurio Registry did not become ready after " + maxAttempts + " attempts. " +
-                        "Make sure 'minikube tunnel' is running and LoadBalancer services are accessible.");
+                String diagnosis;
+                if (httpResponseCount == 0) {
+                    diagnosis = "All " + maxAttempts + " attempts got Connection refused — " +
+                            "this is a routing issue, not a startup timeout. Check minikube tunnel status.";
+                } else if (connectionRefusedCount == 0) {
+                    diagnosis = "All attempts reached the server but never got HTTP 200 (last status: " +
+                            lastStatusCode + ") — startup is too slow or the service is unhealthy.";
+                } else {
+                    diagnosis = "Mixed signals: " + connectionRefusedCount + " Connection refused, " +
+                            httpResponseCount + " HTTP responses (last status: " + lastStatusCode +
+                            "). Service was intermittently reachable.";
+                }
+                LOGGER.error("Apicurio Registry readiness check failed. Diagnosis: {}", diagnosis);
+                throw new RuntimeException("Apicurio Registry did not become ready after " + maxAttempts + " attempts. " + diagnosis);
             }
 
         } catch (InterruptedException e) {


### PR DESCRIPTION
## Summary

- Add signal-aware tracking to `waitForDebeziumConnectReady()` and `waitForRegistryReady()` to distinguish Connection refused (routing issue) from HTTP non-200 (startup timing)
- Fix `RegistryDeploymentManager` sleep bug: `Thread.sleep()` was inside the catch block, causing rapid-fire retries on non-200 responses
- Add diagnostic summary on failure with three categories: all-refused, all-HTTP, mixed

## Related Issues

Follow-up to #8244

## Changes

### `DebeziumDeploymentManager.java`
- Track `connectionRefusedCount`, `httpResponseCount`, `lastStatusCode` during readiness polling
- Log "not reachable" for connection failures vs "starting up (HTTP N)" for non-200 responses
- On final failure, emit diagnostic summary identifying whether it's a routing issue, startup timeout, or intermittent problem

### `RegistryDeploymentManager.java`
- Same signal-aware tracking and diagnostics
- **Bug fix**: moved `Thread.sleep(2000)` outside the catch block so it runs on all non-ready responses (was only sleeping on exceptions, burning through attempts in seconds on HTTP 503)
- Added `finally` block for `conn.disconnect()` (was leaking on exception path)

## Testing

- [x] Checkstyle passes (verified visually — module not in default reactor)
- [ ] CI integration test run