### PR TITLE
feat(cli): add search by content command

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchArtifactsCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchArtifactsCommand.java
@@ -1,33 +1,18 @@
 package io.apicurio.registry.cli.search;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.ArtifactOrderMixin;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.common.PaginationMixin;
 import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
-import io.apicurio.registry.cli.utils.TableBuilder;
 import io.apicurio.registry.rest.client.search.artifacts.ArtifactsRequestBuilder;
-import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
 import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
-import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPE;
-import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
-import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
-import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
-import static io.apicurio.registry.cli.utils.Columns.LABELS;
-import static io.apicurio.registry.cli.utils.Columns.MODIFIED_BY;
-import static io.apicurio.registry.cli.utils.Columns.MODIFIED_ON;
-import static io.apicurio.registry.cli.utils.Columns.NAME;
-import static io.apicurio.registry.cli.utils.Columns.OWNER;
 import static io.apicurio.registry.cli.utils.Conversions.convert;
-import static io.apicurio.registry.cli.utils.Conversions.convertToString;
-import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
 
 @Command(
         name = "artifact",
@@ -100,7 +85,7 @@ public class SearchArtifactsCommand extends AbstractCommand {
             //noinspection ConstantConditions
             applyFilters(r.queryParameters);
         }));
-        printResults(output, results);
+        SearchUtil.printArtifactResults(output, results, outputType, pagination);
     }
 
     private void applyFilters(final ArtifactsRequestBuilder.GetQueryParameters params) {
@@ -134,35 +119,4 @@ public class SearchArtifactsCommand extends AbstractCommand {
         }
     }
 
-    private void printResults(final OutputBuffer output, final ArtifactSearchResults results) throws JsonProcessingException {
-        output.writeStdOutChunkWithException(out -> {
-            switch (outputType.getOutputType()) {
-                case json -> {
-                    out.append(MAPPER.writeValueAsString(results));
-                    out.append('\n');
-                }
-                case table -> {
-                    final var table = new TableBuilder();
-                    table.addColumns(GROUP_ID, ARTIFACT_ID, NAME, ARTIFACT_TYPE, DESCRIPTION,
-                            CREATED_ON, OWNER, MODIFIED_ON, MODIFIED_BY, LABELS);
-                    results.getArtifacts().forEach(a -> {
-                        table.addRow(
-                                a.getGroupId(),
-                                a.getArtifactId(),
-                                a.getName(),
-                                a.getArtifactType(),
-                                a.getDescription(),
-                                convertToString(a.getCreatedOn()),
-                                a.getOwner(),
-                                convertToString(a.getModifiedOn()),
-                                a.getModifiedBy(),
-                                convertToString(a.getLabels())
-                        );
-                    });
-                    table.setPagination(pagination.getPage(), pagination.getSize(), results.getCount());
-                    table.print(out);
-                }
-            }
-        });
-    }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchByContentCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchByContentCommand.java
@@ -1,0 +1,98 @@
+package io.apicurio.registry.cli.search;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.ArtifactOrderMixin;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.common.PaginationMixin;
+import io.apicurio.registry.cli.utils.ContentTypeDetector;
+import io.apicurio.registry.cli.utils.FileUtils;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import java.io.ByteArrayInputStream;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+
+@Command(
+        name = "content",
+        aliases = {"contents"},
+        description = "Search for artifacts by content"
+)
+public class SearchByContentCommand extends AbstractCommand {
+
+    @Option(
+            names = {"-f", "--file"},
+            description = "Path to the content file. Use '-' to read from stdin.",
+            required = true
+    )
+    private String file;
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Filter by group ID."
+    )
+    private String groupId;
+
+    @Option(
+            names = {"--type"},
+            description = "Artifact type (e.g. AVRO, JSON, PROTOBUF, OPENAPI, ASYNCAPI)."
+                    + " Required when using --canonical. Use 'acr version' to see all supported types."
+    )
+    private String artifactType;
+
+    @Option(
+            names = {"--canonical"},
+            description = "Canonicalize content before searching. Requires --type.",
+            defaultValue = "false"
+    )
+    private boolean canonical;
+
+    @Option(
+            names = {"--content-type"},
+            description = "Content type of the file (e.g. application/json, application/x-protobuf)."
+                    + " Auto-detected from file extension if not specified."
+    )
+    private String contentType;
+
+    @Mixin
+    private ArtifactOrderMixin ordering;
+
+    @Mixin
+    private PaginationMixin pagination;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        if (canonical && artifactType == null) {
+            throw new CliException("--type is required when using --canonical.",
+                    CliException.VALIDATION_ERROR_RETURN_CODE);
+        }
+        final var resolvedContentType = contentType != null
+                ? contentType : ContentTypeDetector.detect(file);
+        final var inputStream = new ByteArrayInputStream(FileUtils.readContentAsBytes(file));
+
+        //noinspection ConstantConditions
+        final var results = convert(client.getRegistryClient().search().artifacts()
+                .post(inputStream, resolvedContentType, r -> {
+                    //noinspection ConstantConditions
+                    r.queryParameters.offset = (pagination.getPage() - 1) * pagination.getSize();
+                    r.queryParameters.limit = pagination.getSize();
+                    r.queryParameters.orderby = ordering.getOrderBy();
+                    r.queryParameters.order = ordering.getOrder();
+                    if (groupId != null) {
+                        r.queryParameters.groupId = groupId;
+                    }
+                    if (artifactType != null) {
+                        r.queryParameters.artifactType = artifactType;
+                    }
+                    if (canonical) {
+                        r.queryParameters.canonical = true;
+                    }
+                }));
+        SearchUtil.printArtifactResults(output, results, outputType, pagination);
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchCommand.java
@@ -6,9 +6,10 @@ import picocli.CommandLine.Command;
 
 @Command(
         name = "search",
-        description = "Search for groups, artifacts, and versions",
+        description = "Search for groups, artifacts, versions, and content",
         subcommands = {
                 SearchArtifactsCommand.class,
+                SearchByContentCommand.class,
                 SearchGroupsCommand.class,
                 SearchVersionsCommand.class
         }

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchGroupsCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchGroupsCommand.java
@@ -11,6 +11,7 @@ import io.apicurio.registry.cli.utils.TableBuilder;
 import io.apicurio.registry.rest.client.search.groups.GroupsRequestBuilder;
 import io.apicurio.registry.rest.v3.beans.GroupSearchResults;
 import java.util.List;
+import java.util.Optional;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -96,7 +97,7 @@ public class SearchGroupsCommand extends AbstractCommand {
                 case table -> {
                     final var table = new TableBuilder();
                     table.addColumns(GROUP_ID, DESCRIPTION, CREATED_ON, OWNER, MODIFIED_ON, MODIFIED_BY, LABELS);
-                    results.getGroups().forEach(g -> {
+                    Optional.ofNullable(results.getGroups()).orElse(List.of()).forEach(g -> {
                         table.addRow(
                                 g.getGroupId(),
                                 g.getDescription(),

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchUtil.java
@@ -1,0 +1,63 @@
+package io.apicurio.registry.cli.search;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.common.PaginationMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
+import java.util.List;
+import java.util.Optional;
+
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_TYPE;
+import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
+import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
+import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
+import static io.apicurio.registry.cli.utils.Columns.LABELS;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_BY;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_ON;
+import static io.apicurio.registry.cli.utils.Columns.NAME;
+import static io.apicurio.registry.cli.utils.Columns.OWNER;
+import static io.apicurio.registry.cli.utils.Conversions.convertToString;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+final class SearchUtil {
+
+    private SearchUtil() {
+    }
+
+    static void printArtifactResults(final OutputBuffer output, final ArtifactSearchResults results,
+                                     final OutputTypeMixin outputType, final PaginationMixin pagination)
+            throws JsonProcessingException {
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(results));
+                    out.append('\n');
+                }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(GROUP_ID, ARTIFACT_ID, NAME, ARTIFACT_TYPE, DESCRIPTION,
+                            CREATED_ON, OWNER, MODIFIED_ON, MODIFIED_BY, LABELS);
+                    Optional.ofNullable(results.getArtifacts()).orElse(List.of()).forEach(a -> {
+                        table.addRow(
+                                a.getGroupId(),
+                                a.getArtifactId(),
+                                a.getName(),
+                                a.getArtifactType(),
+                                a.getDescription(),
+                                convertToString(a.getCreatedOn()),
+                                a.getOwner(),
+                                convertToString(a.getModifiedOn()),
+                                a.getModifiedBy(),
+                                convertToString(a.getLabels())
+                        );
+                    });
+                    table.setPagination(pagination.getPage(), pagination.getSize(), results.getCount());
+                    table.print(out);
+                }
+            }
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchVersionsCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchVersionsCommand.java
@@ -12,6 +12,7 @@ import io.apicurio.registry.rest.client.models.VersionState;
 import io.apicurio.registry.rest.client.search.versions.VersionsRequestBuilder;
 import io.apicurio.registry.rest.v3.beans.VersionSearchResults;
 import java.util.List;
+import java.util.Optional;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -165,7 +166,7 @@ public class SearchVersionsCommand extends AbstractCommand {
                     final var table = new TableBuilder();
                     table.addColumns(GROUP_ID, ARTIFACT_ID, VERSION, NAME, ARTIFACT_TYPE,
                             STATE, GLOBAL_ID, CONTENT_ID, DESCRIPTION, CREATED_ON, OWNER);
-                    results.getVersions().forEach(v -> {
+                    Optional.ofNullable(results.getVersions()).orElse(List.of()).forEach(v -> {
                         table.addRow(
                                 v.getGroupId(),
                                 v.getArtifactId(),

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/ContentTypeDetector.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/ContentTypeDetector.java
@@ -1,0 +1,39 @@
+package io.apicurio.registry.cli.utils;
+
+import java.util.Locale;
+import java.util.Map;
+
+public final class ContentTypeDetector {
+
+    private static final String APPLICATION_JSON = "application/json";
+    private static final String APPLICATION_XML = "application/xml";
+    private static final String APPLICATION_YAML = "application/x-yaml";
+
+    private static final Map<String, String> EXTENSION_MAP = Map.of(
+            ".json", APPLICATION_JSON,
+            ".avsc", APPLICATION_JSON,
+            ".proto", "application/x-protobuf",
+            ".yaml", APPLICATION_YAML,
+            ".yml", APPLICATION_YAML,
+            ".xml", APPLICATION_XML,
+            ".xsd", APPLICATION_XML,
+            ".wsdl", APPLICATION_XML,
+            ".graphql", "application/graphql"
+    );
+
+    private ContentTypeDetector() {
+    }
+
+    public static String detect(final String file) {
+        if (file == null || "-".equals(file)) {
+            return APPLICATION_JSON;
+        }
+        final var lower = file.toLowerCase(Locale.ROOT);
+        for (final var entry : EXTENSION_MAP.entrySet()) {
+            if (lower.endsWith(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return APPLICATION_JSON;
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/FileUtils.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/FileUtils.java
@@ -102,6 +102,18 @@ public final class FileUtils {
         }
     }
 
+    public static byte[] readContentAsBytes(final String file) {
+        try {
+            if ("-".equals(file)) {
+                return System.in.readAllBytes();
+            } else {
+                return Files.readAllBytes(Path.of(file));
+            }
+        } catch (IOException ex) {
+            throw new CliException("Could not read content from: " + file, ex, APPLICATION_ERROR_RETURN_CODE);
+        }
+    }
+
     public static void deleteDirectory(Path dirPath) {
         if (!Files.exists(dirPath)) {
             log.debugf("Directory does not exist, nothing to delete: %s", dirPath);

--- a/cli/src/test/java/io/apicurio/registry/cli/SearchCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/SearchCommandTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -44,6 +47,7 @@ public class SearchCommandTest extends AbstractCLITest {
         testHelpCommand("search");
         testHelpCommand("search", "group");
         testHelpCommand("search", "artifact");
+        testHelpCommand("search", "content");
         testHelpCommand("search", "version");
     }
 
@@ -330,5 +334,102 @@ public class SearchCommandTest extends AbstractCLITest {
     @Order(26)
     public void testSearchVersionsInvalidState() {
         executeAndAssertFailure("search", "versions", "--state", "INVALID");
+    }
+
+    // -- Search by content --
+
+    @Test
+    @Order(27)
+    public void testSearchByContent() throws Exception {
+        final Path tempFile = Files.createTempFile("search-content", ".json");
+        Files.writeString(tempFile, "{\"type\": \"string\"}");
+        try {
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("search", "content", "--output-type", "json",
+                    "-f", tempFile.toString());
+            ArtifactSearchResults results = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+            assertThat(results.getArtifacts())
+                    .as(withCliOutput("Search by content should find the test artifact"))
+                    .isNotEmpty();
+            assertThat(results.getArtifacts())
+                    .anyMatch(a -> TEST_ARTIFACT.equals(a.getArtifactId()));
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    @Order(28)
+    public void testSearchByContentWithGroup() throws Exception {
+        final Path tempFile = Files.createTempFile("search-content", ".json");
+        Files.writeString(tempFile, "{\"type\": \"string\"}");
+        try {
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("search", "content", "--output-type", "json",
+                    "-f", tempFile.toString(), "-g", TEST_GROUP);
+            ArtifactSearchResults results = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+            assertThat(results.getArtifacts())
+                    .as(withCliOutput("Search by content with group filter should find the test artifact"))
+                    .isNotEmpty();
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    @Order(29)
+    public void testSearchByContentNoMatch() throws Exception {
+        final Path tempFile = Files.createTempFile("search-content", ".json");
+        Files.writeString(tempFile, "{\"type\": \"nonexistent-content-that-wont-match\"}");
+        try {
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("search", "content", "--output-type", "json",
+                    "-f", tempFile.toString());
+            ArtifactSearchResults results = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+
+            assertThat(results.getArtifacts())
+                    .as(withCliOutput("Search by content with no match should return empty"))
+                    .isEmpty();
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    @Order(30)
+    public void testSearchByContentMissingFile() {
+        executeAndAssertFailure("search", "content");
+    }
+
+    @Test
+    @Order(31)
+    public void testSearchByContentStdin() throws Exception {
+        final InputStream originalIn = System.in;
+        try {
+            System.setIn(new ByteArrayInputStream(
+                    "{\"type\": \"string\"}".getBytes(StandardCharsets.UTF_8)));
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("search", "content", "-o", "json", "-f", "-");
+            var results = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
+            assertThat(results.getArtifacts())
+                    .as(withCliOutput("Stdin search should find the test artifact"))
+                    .isNotEmpty();
+        } finally {
+            System.setIn(originalIn);
+        }
+    }
+
+    @Test
+    @Order(32)
+    public void testSearchByContentCanonicalWithoutType() throws Exception {
+        final Path tempFile = Files.createTempFile("search-content", ".json");
+        Files.writeString(tempFile, "{\"type\": \"string\"}");
+        try {
+            executeAndAssertFailure("search", "content", "-f", tempFile.toString(), "--canonical");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds `acr search content` command to search artifacts by their content. Posts file content to the search API and returns matching artifacts. Supports canonicalized matching for format-independent comparison.

Fixes #8265

## Usage

```bash
# Search by exact content match
acr search content --file schema.json

# JSON output
acr search content --file schema.json -o json

# Canonical search (normalizes content before comparing — requires --type)
acr search content --file schema.json --canonical --type JSON

# Filter by group
acr search content --file schema.json -g my-group

# Read content from stdin
cat schema.json | acr search content --file -

# With pagination
acr search content --file schema.json -p 1 -s 20
```

## Behavior

| Scenario | Result |
|----------|--------|
| `--file schema.json` | Exact byte match against registry content |
| `--file schema.json --canonical --type JSON` | Normalizes content (sorts keys, strips whitespace) before comparing |
| `--canonical` without `--type` | Validation error — type is required for canonicalization |
| `--file -` | Reads content from stdin |
| No `--file` | Picocli error — required option |
| No matching content | Empty results (exit 0) |

## Changes

| File | Purpose |
|------|---------|
| `SearchByContentCommand.java` | New — `acr search content` with `--file`, `--canonical`, `--type`, `--group`, `--content-type` options |
| `SearchUtil.java` | New — extracted shared `printArtifactResults()` for table/JSON rendering (follows `RoleMappingUtil` pattern) |
| `ContentTypeDetector.java` | New — auto-detects content type from file extension (`.json`, `.avsc`, `.proto`, `.yaml`, `.xml`, etc.) |
| `FileUtils.java` | Added `readContentAsBytes()` for binary-safe file/stdin reading |
| `SearchArtifactsCommand.java` | Refactored to use `SearchUtil.printArtifactResults()` instead of inline rendering |
| `SearchGroupsCommand.java` | Added `Optional.ofNullable` null-safety on `results.getGroups()` |
| `SearchVersionsCommand.java` | Added `Optional.ofNullable` null-safety on `results.getVersions()` |
| `SearchCommand.java` | Registered `SearchByContentCommand` as subcommand, updated description |
| `SearchCommandTest.java` | 6 new tests: help, content match, group filter, no match, stdin, canonical validation, missing file |

## Test plan
- [x] `acr search content --help` shows usage
- [x] `acr search content --file schema.json` returns matching artifacts
- [x] `acr search content --file schema.json -g <group>` filters by group
- [x] `acr search content --file schema.json` with non-matching content returns empty
- [x] `acr search content --file - ` reads from stdin
- [x] `--canonical` without `--type` fails with validation error
- [x] Missing `--file` fails with picocli error
- [x] JSON and table output formats work correctly
- [x] 33 tests pass in `SearchCommandTest` (27 existing + 6 new)
- [x] Manual E2E testing on podman verified all scenarios