### PR TITLE
feat(cli): add content retrieval by global ID, content ID, and hash

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -3,6 +3,7 @@ package io.apicurio.registry.cli;
 import io.apicurio.registry.cli.artifact.ArtifactCommand;
 import io.apicurio.registry.cli.auth.LoginCommand;
 import io.apicurio.registry.cli.auth.LogoutCommand;
+import io.apicurio.registry.cli.content.ContentCommand;
 import io.apicurio.registry.cli.config.ConfigPropertyCommand;
 import io.apicurio.registry.cli.context.ContextCommand;
 import io.apicurio.registry.cli.globalrule.GlobalRuleCommand;
@@ -30,6 +31,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
         subcommands = {
                 ArtifactCommand.class,
                 ConfigPropertyCommand.class,
+                ContentCommand.class,
                 ContextCommand.class,
                 GlobalRuleCommand.class,
                 GroupCommand.class,

--- a/cli/src/main/java/io/apicurio/registry/cli/content/ContentCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/content/ContentCommand.java
@@ -1,0 +1,123 @@
+package io.apicurio.registry.cli.content;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.RegistryClient;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+@Command(
+        name = "content",
+        description = "Retrieve artifact content by global ID, content ID, or SHA-256 hash"
+)
+public class ContentCommand extends AbstractCommand {
+
+    @ArgGroup(exclusive = true, multiplicity = "1")
+    private ContentIdentifier identifier;
+
+    static class ContentIdentifier {
+        @Option(
+                names = {"--global-id"},
+                description = "Retrieve content by global ID."
+        )
+        Long globalId;
+
+        @Option(
+                names = {"--content-id"},
+                description = "Retrieve content by content ID."
+        )
+        Long contentId;
+
+        @Option(
+                names = {"--hash"},
+                description = "Retrieve content by SHA-256 hash."
+        )
+        String contentHash;
+    }
+
+    @Option(
+            names = {"-o", "--output-type"},
+            description = "Output format. Valid values: ${COMPLETION-CANDIDATES}. Default: ${DEFAULT-VALUE}.",
+            defaultValue = "raw"
+    )
+    private ContentOutputType outputType;
+
+    enum ContentOutputType {
+        raw,
+        json
+    }
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        validateIdentifier();
+
+        try (final InputStream content = fetchContent(client.getRegistryClient())) {
+            final var text = new String(content.readAllBytes(), StandardCharsets.UTF_8);
+            output.writeStdOutChunkWithException(out -> {
+                switch (outputType) {
+                    case raw -> {
+                        out.append(text);
+                        if (!text.endsWith("\n")) {
+                            out.append('\n');
+                        }
+                    }
+                    case json -> {
+                        out.append(MAPPER.writeValueAsString(buildJsonResult(text)));
+                        out.append('\n');
+                    }
+                }
+            });
+        } catch (IOException ex) {
+            throw new CliException("Could not read content.", ex, APPLICATION_ERROR_RETURN_CODE);
+        }
+    }
+
+    private void validateIdentifier() {
+        if (identifier.globalId != null && identifier.globalId <= 0) {
+            throw new CliException("--global-id must be a positive number.",
+                    VALIDATION_ERROR_RETURN_CODE);
+        }
+        if (identifier.contentId != null && identifier.contentId <= 0) {
+            throw new CliException("--content-id must be a positive number.",
+                    VALIDATION_ERROR_RETURN_CODE);
+        }
+        if (identifier.contentHash != null && identifier.contentHash.isBlank()) {
+            throw new CliException("--hash must not be blank.",
+                    VALIDATION_ERROR_RETURN_CODE);
+        }
+    }
+
+    private Map<String, Object> buildJsonResult(final String text) {
+        final Map<String, Object> result = new LinkedHashMap<>();
+        if (identifier.globalId != null) {
+            result.put("globalId", identifier.globalId);
+        } else if (identifier.contentId != null) {
+            result.put("contentId", identifier.contentId);
+        } else {
+            result.put("hash", identifier.contentHash);
+        }
+        result.put("content", text);
+        return result;
+    }
+
+    private InputStream fetchContent(final RegistryClient registryClient) {
+        if (identifier.globalId != null) {
+            return registryClient.ids().globalIds().byGlobalId(identifier.globalId).get();
+        } else if (identifier.contentId != null) {
+            return registryClient.ids().contentIds().byContentId(identifier.contentId).get();
+        } else {
+            return registryClient.ids().contentHashes().byContentHash(identifier.contentHash).get();
+        }
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/ContentCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ContentCommandTest.java
@@ -1,0 +1,177 @@
+package io.apicurio.registry.cli;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.Locale;
+
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestMethodOrder(OrderAnnotation.class)
+public class ContentCommandTest extends AbstractCLITest {
+
+    private static final String TEST_GROUP = "content-test-group";
+    private static final String TEST_ARTIFACT = "content-test-artifact";
+    private static final String TEST_CONTENT = "{\"type\": \"string\"}";
+
+    // -- Help --
+
+    @Test
+    @Order(0)
+    public void testContentHelp() {
+        testHelpCommand("content");
+    }
+
+    // -- Setup --
+
+    @Test
+    @Order(1)
+    public void testSetup() throws Exception {
+        executeAndAssertSuccess("group", "create", TEST_GROUP);
+        final Path tempFile = Files.createTempFile("content-test", ".json");
+        Files.writeString(tempFile, TEST_CONTENT);
+        try {
+            executeAndAssertSuccess("artifact", "create", "-g", TEST_GROUP,
+                    "--type", "JSON", "--file", tempFile.toString(), TEST_ARTIFACT);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    // -- Retrieval --
+
+    @Test
+    @Order(2)
+    public void testGetByGlobalId() throws Exception {
+        final long globalId = getVersionField("globalId");
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("content", "--global-id", String.valueOf(globalId));
+        assertThat(out.toString().trim())
+                .as(withCliOutput("Should return artifact content"))
+                .isEqualTo(TEST_CONTENT);
+    }
+
+    @Test
+    @Order(3)
+    public void testGetByContentId() throws Exception {
+        final long contentId = getVersionField("contentId");
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("content", "--content-id", String.valueOf(contentId));
+        assertThat(out.toString().trim())
+                .as(withCliOutput("Should return artifact content"))
+                .isEqualTo(TEST_CONTENT);
+    }
+
+    @Test
+    @Order(4)
+    public void testGetByHash() throws Exception {
+        final String hash = getContentHash();
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("content", "--hash", hash);
+        assertThat(out.toString().trim())
+                .as(withCliOutput("Should return artifact content"))
+                .isEqualTo(TEST_CONTENT);
+    }
+
+    // -- JSON output --
+
+    @Test
+    @Order(5)
+    public void testGetByGlobalIdJson() throws Exception {
+        final long globalId = getVersionField("globalId");
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("content", "--global-id", String.valueOf(globalId), "-o", "json");
+        final JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.has("globalId"))
+                .as(withCliOutput("JSON output should echo back the globalId"))
+                .isTrue();
+        assertThat(json.get("globalId").asLong())
+                .as(withCliOutput("JSON globalId should match queried ID"))
+                .isEqualTo(globalId);
+        assertThat(json.get("content").asText())
+                .as(withCliOutput("JSON content field should match artifact content"))
+                .isEqualTo(TEST_CONTENT);
+    }
+
+    // -- Error cases --
+
+    @Test
+    @Order(6)
+    public void testContentNoArgs() {
+        executeAndAssertFailure("content");
+    }
+
+    @Test
+    @Order(7)
+    public void testContentMultipleArgs() {
+        executeAndAssertFailure("content", "--global-id", "1", "--content-id", "1");
+    }
+
+    @Test
+    @Order(8)
+    public void testNegativeGlobalId() {
+        executeAndAssertFailure("content", "--global-id", "-1");
+    }
+
+    @Test
+    @Order(9)
+    public void testZeroContentId() {
+        executeAndAssertFailure("content", "--content-id", "0");
+    }
+
+    @Test
+    @Order(10)
+    public void testGetByNonExistentGlobalId() {
+        executeAndAssertFailure("content", "--global-id", "999999999");
+    }
+
+    @Test
+    @Order(11)
+    public void testGetByNonExistentContentId() {
+        executeAndAssertFailure("content", "--content-id", "999999999");
+    }
+
+    @Test
+    @Order(12)
+    public void testGetByNonExistentHash() {
+        executeAndAssertFailure("content", "--hash", "0".repeat(64));
+    }
+
+    // -- Helpers --
+
+    private long getVersionField(final String fieldName) throws Exception {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "version", "get", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "--output-type", "json", "1");
+        final JsonNode json = MAPPER.readTree(out.toString());
+        return json.get(fieldName).asLong();
+    }
+
+    private String getContentHash() throws Exception {
+        final long globalId = getVersionField("globalId");
+        final byte[] bytes;
+        try (final var content = client.getRegistryClient().ids().globalIds().byGlobalId(globalId).get()) {
+            bytes = content.readAllBytes();
+        }
+        final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        final byte[] hash = digest.digest(bytes);
+        final StringBuilder sb = new StringBuilder();
+        for (final byte b : hash) {
+            sb.append(String.format(Locale.ROOT, "%02x", b));
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Summary

Adds `acr content` command to retrieve artifact content by global ID, content ID, or SHA-256 hash. Provides direct access to stored content without needing to know the group/artifact/version coordinates.

Fixes #8266

## Usage

```bash
# Retrieve content by global ID (raw output, default)
acr content --global-id 5

# Retrieve content by content ID
acr content --content-id 3

# Retrieve content by SHA-256 hash
acr content --hash abc123def456...

# Retrieve content as JSON (includes queried identifier)
acr content --global-id 5 -o json
# → {"globalId": 5, "content": "..."}

acr content --content-id 3 -o json
# → {"contentId": 3, "content": "..."}
```

## Behavior

| Scenario | Result |
|----------|--------|
| `--global-id <id>` | Retrieves content associated with the global ID |
| `--content-id <id>` | Retrieves content by its content ID |
| `--hash <sha256>` | Retrieves content by its SHA-256 hash |
| `-o raw` (default) | Outputs raw content |
| `-o json` | Outputs JSON with queried identifier and content |
| Multiple options provided | Picocli validation error — only one allowed (`@ArgGroup`) |
| No option provided | Picocli validation error — one is required (`multiplicity = "1"`) |
| Non-positive ID or blank hash | Client-side validation error before server call |
| Non-existent ID/hash | Server error (404) |

## Changes

| File | Purpose |
|------|---------|
| `ContentCommand.java` | New — `acr content` with `@ArgGroup` for mutually exclusive `--global-id`, `--content-id`, `--hash` options. Supports `-o raw\|json` output. JSON includes queried identifier. Client-side validation for non-positive IDs and blank hash. |
| `Acr.java` | Registered `ContentCommand` as subcommand |
| `ContentCommandTest.java` | 13 tests: help, retrieval by each ID type, JSON output (verifies identifier echoed), validation errors (no args, multiple args, negative ID, zero ID), non-existent IDs/hash. Hash test retrieves content from server for robust hashing. |

## Test plan
- [x] `acr content --help` shows usage with `Default: raw` via `${DEFAULT-VALUE}`
- [x] `acr content --global-id <id>` retrieves content (raw)
- [x] `acr content --content-id <id>` retrieves content (raw)
- [x] `acr content --hash <sha256>` retrieves content (raw)
- [x] `acr content --global-id <id> -o json` returns `{"globalId": N, "content": "..."}`
- [x] Multiple identifiers fails with picocli validation error
- [x] No identifier fails with picocli validation error
- [x] Negative global ID fails with client-side validation error
- [x] Zero content ID fails with client-side validation error
- [x] Non-existent global ID, content ID, and hash fail gracefully (404)
- [x] 13 tests pass in `ContentCommandTest`
- [x] Manual E2E testing on podman verified all scenarios