### PR TITLE
feat(cli): add server configuration management commands

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -9,6 +9,7 @@ import io.apicurio.registry.cli.globalrule.GlobalRuleCommand;
 import io.apicurio.registry.cli.group.GroupCommand;
 import io.apicurio.registry.cli.rolemapping.RoleMappingCommand;
 import io.apicurio.registry.cli.search.SearchCommand;
+import io.apicurio.registry.cli.serverconfig.ServerConfigCommand;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import lombok.Getter;
 import picocli.CommandLine.Command;
@@ -38,6 +39,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
                 LogoutCommand.class,
                 RoleMappingCommand.class,
                 SearchCommand.class,
+                ServerConfigCommand.class,
                 UpdateCommand.class,
                 VersionCommand.class
         },

--- a/cli/src/main/java/io/apicurio/registry/cli/serverconfig/ServerConfigCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/serverconfig/ServerConfigCommand.java
@@ -1,0 +1,61 @@
+package io.apicurio.registry.cli.serverconfig;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.ConfigurationProperty;
+import java.util.List;
+import java.util.Optional;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+import static io.apicurio.registry.cli.utils.Columns.LABEL;
+import static io.apicurio.registry.cli.utils.Columns.NAME;
+import static io.apicurio.registry.cli.utils.Columns.VALUE;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+@Command(
+        name = "server-config",
+        aliases = {"server-configs"},
+        description = "Manage server-side configuration properties",
+        subcommands = {
+                ServerConfigGetCommand.class,
+                ServerConfigSetCommand.class,
+                ServerConfigResetCommand.class
+        }
+)
+public class ServerConfigCommand extends AbstractCommand {
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var properties = Optional.ofNullable(
+                client.getRegistryClient().admin().config().properties().get()
+        ).orElse(List.of());
+
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(properties));
+                    out.append('\n');
+                }
+                case table -> {
+                    if (properties.isEmpty()) {
+                        out.append("No configuration properties found.\n");
+                    } else {
+                        final var table = new TableBuilder();
+                        table.addColumns(NAME, VALUE, LABEL);
+                        for (final ConfigurationProperty prop : properties) {
+                            table.addRow(prop.getName(), prop.getValue(), prop.getLabel());
+                        }
+                        table.print(out);
+                    }
+                }
+            }
+        });
+    }
+
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/serverconfig/ServerConfigGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/serverconfig/ServerConfigGetCommand.java
@@ -1,0 +1,31 @@
+package io.apicurio.registry.cli.serverconfig;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Parameters;
+
+@Command(
+        name = "get",
+        description = "Get a server configuration property"
+)
+public class ServerConfigGetCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The property name."
+    )
+    private String propertyName;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var prop = client.getRegistryClient().admin().config().properties()
+                .byPropertyName(propertyName).get();
+        ServerConfigUtil.printProperty(output, prop, outputType);
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/serverconfig/ServerConfigResetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/serverconfig/ServerConfigResetCommand.java
@@ -1,0 +1,43 @@
+package io.apicurio.registry.cli.serverconfig;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Parameters;
+
+@Command(
+        name = "reset",
+        description = "Reset a server configuration property to its default value"
+)
+public class ServerConfigResetCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The property name."
+    )
+    private String propertyName;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        client.getRegistryClient().admin().config().properties()
+                .byPropertyName(propertyName).delete();
+
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out));
+            case table -> output.writeStdOutChunk(out -> successMessage(out));
+        }
+
+        final var prop = client.getRegistryClient().admin().config().properties()
+                .byPropertyName(propertyName).get();
+        ServerConfigUtil.printProperty(output, prop, outputType);
+    }
+
+    private void successMessage(final StringBuilder out) {
+        out.append("Property '").append(propertyName).append("' reset to default.\n");
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/serverconfig/ServerConfigSetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/serverconfig/ServerConfigSetCommand.java
@@ -1,0 +1,54 @@
+package io.apicurio.registry.cli.serverconfig;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.UpdateConfigurationProperty;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Parameters;
+
+@Command(
+        name = "set",
+        description = "Set a server configuration property"
+)
+public class ServerConfigSetCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The property name."
+    )
+    private String propertyName;
+
+    @Parameters(
+            index = "1",
+            description = "The property value."
+    )
+    private String propertyValue;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var update = new UpdateConfigurationProperty();
+        update.setValue(propertyValue);
+
+        client.getRegistryClient().admin().config().properties()
+                .byPropertyName(propertyName).put(update);
+
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out));
+            case table -> output.writeStdOutChunk(out -> successMessage(out));
+        }
+
+        final var prop = client.getRegistryClient().admin().config().properties()
+                .byPropertyName(propertyName).get();
+        ServerConfigUtil.printProperty(output, prop, outputType);
+    }
+
+    private void successMessage(final StringBuilder out) {
+        out.append("Property '").append(propertyName).append("' set to '")
+                .append(propertyValue).append("'.\n");
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/serverconfig/ServerConfigUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/serverconfig/ServerConfigUtil.java
@@ -1,0 +1,41 @@
+package io.apicurio.registry.cli.serverconfig;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.ConfigurationProperty;
+
+import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
+import static io.apicurio.registry.cli.utils.Columns.FIELD;
+import static io.apicurio.registry.cli.utils.Columns.LABEL;
+import static io.apicurio.registry.cli.utils.Columns.NAME;
+import static io.apicurio.registry.cli.utils.Columns.VALUE;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+final class ServerConfigUtil {
+
+    private ServerConfigUtil() {
+    }
+
+    static void printProperty(final OutputBuffer output, final ConfigurationProperty prop,
+                              final OutputTypeMixin outputType) throws JsonProcessingException {
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(prop));
+                    out.append('\n');
+                }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(FIELD, VALUE);
+                    table.addRow(NAME, prop.getName());
+                    table.addRow(VALUE, prop.getValue());
+                    table.addRow(LABEL, prop.getLabel());
+                    table.addRow(DESCRIPTION, prop.getDescription());
+                    table.print(out);
+                }
+            }
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
@@ -12,6 +12,7 @@ public final class Columns {
     public static final String OWNER = "Owner";
     public static final String MODIFIED_ON = "Modified On";
     public static final String MODIFIED_BY = "Modified By";
+    public static final String LABEL = "Label";
     public static final String LABELS = "Labels";
 
     public static final String FIELD = "Field";

--- a/cli/src/test/java/io/apicurio/registry/cli/ServerConfigCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ServerConfigCommandTest.java
@@ -1,0 +1,148 @@
+package io.apicurio.registry.cli;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestMethodOrder(OrderAnnotation.class)
+public class ServerConfigCommandTest extends AbstractCLITest {
+
+    private static final String TEST_PROPERTY = "apicurio.ccompat.max-subjects";
+    private static final String TEST_VALUE = "500";
+
+    // -- Help --
+
+    @Test
+    @Order(0)
+    public void testServerConfigHelp() {
+        testHelpCommand("server-config");
+        testHelpCommand("server-config", "get");
+        testHelpCommand("server-config", "set");
+        testHelpCommand("server-config", "reset");
+    }
+
+    // -- CRUD flow --
+
+    @Test
+    @Order(1)
+    public void testList() throws Exception {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("server-config", "--output-type", "json");
+        JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.isArray())
+                .as(withCliOutput("Should return an array"))
+                .isTrue();
+        assertThat(json.size())
+                .as(withCliOutput("Should have properties"))
+                .isGreaterThan(0);
+    }
+
+    @Test
+    @Order(2)
+    public void testListTable() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("server-config");
+        assertThat(out.toString())
+                .as(withCliOutput("Table should have column headers"))
+                .contains("Name")
+                .contains("Value");
+    }
+
+    @Test
+    @Order(3)
+    public void testGet() throws Exception {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("server-config", "get", "--output-type", "json", TEST_PROPERTY);
+        JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.get("name").asText())
+                .as(withCliOutput("Should return the correct property"))
+                .isEqualTo(TEST_PROPERTY);
+        assertThat(json.has("value"))
+                .as(withCliOutput("Should have a value"))
+                .isTrue();
+    }
+
+    @Test
+    @Order(4)
+    public void testSet() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("server-config", "set", TEST_PROPERTY, TEST_VALUE);
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm property set"))
+                .contains("set to '500'");
+    }
+
+    @Test
+    @Order(5)
+    public void testSetJson() throws Exception {
+        out.getBuffer().setLength(0);
+        err.getBuffer().setLength(0);
+        executeAndAssertSuccess("server-config", "set", TEST_PROPERTY, TEST_VALUE,
+                "--output-type", "json");
+        assertThat(err.toString())
+                .as(withCliOutput("Success message should go to stderr for JSON"))
+                .contains("set to '500'");
+        JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.get("name").asText())
+                .as(withCliOutput("JSON should contain the property name"))
+                .isEqualTo(TEST_PROPERTY);
+    }
+
+    @Test
+    @Order(6)
+    public void testGetAfterSet() throws Exception {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("server-config", "get", "--output-type", "json", TEST_PROPERTY);
+        JsonNode json = MAPPER.readTree(out.toString());
+        assertThat(json.get("value").asText())
+                .as(withCliOutput("Should have the updated value"))
+                .isEqualTo(TEST_VALUE);
+    }
+
+    @Test
+    @Order(7)
+    public void testReset() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("server-config", "reset", TEST_PROPERTY);
+        String output = out.toString();
+        assertThat(output)
+                .as(withCliOutput("Should confirm reset"))
+                .contains("reset to default");
+        assertThat(output)
+                .as(withCliOutput("Should show the default value"))
+                .contains(TEST_PROPERTY);
+    }
+
+    // -- Error cases --
+
+    @Test
+    @Order(8)
+    public void testGetMissingArg() {
+        executeAndAssertFailure("server-config", "get");
+    }
+
+    @Test
+    @Order(9)
+    public void testSetMissingArgs() {
+        executeAndAssertFailure("server-config", "set");
+    }
+
+    @Test
+    @Order(10)
+    public void testResetMissingArg() {
+        executeAndAssertFailure("server-config", "reset");
+    }
+
+    @Test
+    @Order(11)
+    public void testGetNonExistent() {
+        executeAndAssertFailure("server-config", "get", "non.existent.property");
+    }
+}


### PR DESCRIPTION
## Summary

Adds `acr server-config` commands to manage server-side configuration properties. Supports listing all properties, getting/setting individual properties, and resetting to defaults.

Fixes #8267

## Usage

```bash
# List all server configuration properties
acr server-config
acr server-config -o json

# Get a specific property
acr server-config get apicurio.ccompat.max-subjects
acr server-config get apicurio.ccompat.max-subjects -o json

# Set a property value
acr server-config set apicurio.ccompat.max-subjects 500
acr server-config set apicurio.ccompat.max-subjects 500 -o json

# Reset a property to its default
acr server-config reset apicurio.ccompat.max-subjects
acr server-config reset apicurio.ccompat.max-subjects -o json
```

## Behavior

| Scenario | Result |
|----------|--------|
| `server-config` | Lists all properties in table (Name, Value, Label) |
| `server-config -o json` | Lists all properties as JSON array |
| `server-config get <name>` | Shows property details (Name, Value, Label, Description) |
| `server-config set <name> <value>` | Updates property, confirms with message and property details |
| `server-config set <name> <value> -o json` | Success message to stderr, JSON property to stdout |
| `server-config reset <name>` | Resets to default, confirms with message and shows default value |
| `server-config reset <name> -o json` | Success message to stderr, JSON property with default value to stdout |
| Non-existent property name | Server error (404) |
| Missing required arguments | Picocli validation error |

## Changes

| File | Purpose |
|------|---------|
| `ServerConfigCommand.java` | New — parent command, lists all properties by default |
| `ServerConfigGetCommand.java` | New — `server-config get <name>` |
| `ServerConfigSetCommand.java` | New — `server-config set <name> <value>`, success message to stderr for JSON output |
| `ServerConfigResetCommand.java` | New — `server-config reset <name>`, re-fetches and shows default value, supports `-o` |
| `ServerConfigUtil.java` | New — package-private shared `printProperty` helper (follows `RoleMappingUtil` pattern) |
| `Acr.java` | Registered `ServerConfigCommand` as subcommand |
| `Columns.java` | Added `LABEL` constant |
| `ServerConfigCommandTest.java` | 12 tests: help, list (JSON + table), get, set, set JSON (stderr/stdout split), get-after-set, reset (verifies default value), error cases |

## Test plan
- [x] `acr server-config --help` shows usage for all subcommands
- [x] `acr server-config` lists properties in table format
- [x] `acr server-config -o json` returns JSON array
- [x] `acr server-config get <name>` returns property details
- [x] `acr server-config set <name> <value>` updates property
- [x] `acr server-config set <name> <value> -o json` — success to stderr, JSON to stdout
- [x] `acr server-config reset <name>` resets to default and shows default value
- [x] `acr server-config reset <name> -o json` — success to stderr, JSON to stdout
- [x] Non-existent property fails gracefully
- [x] Missing arguments fail with picocli validation error
- [x] 12 tests pass in `ServerConfigCommandTest`
- [x] Manual E2E testing on podman verified all scenarios