### PR TITLE
feat(cli): add artifact references and import/export commands

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.cli;
 
+import io.apicurio.registry.cli.admin.AdminCommand;
 import io.apicurio.registry.cli.artifact.ArtifactCommand;
 import io.apicurio.registry.cli.auth.LoginCommand;
 import io.apicurio.registry.cli.auth.LogoutCommand;
@@ -8,6 +9,7 @@ import io.apicurio.registry.cli.config.ConfigPropertyCommand;
 import io.apicurio.registry.cli.context.ContextCommand;
 import io.apicurio.registry.cli.globalrule.GlobalRuleCommand;
 import io.apicurio.registry.cli.group.GroupCommand;
+import io.apicurio.registry.cli.reference.ReferenceCommand;
 import io.apicurio.registry.cli.rolemapping.RoleMappingCommand;
 import io.apicurio.registry.cli.search.SearchCommand;
 import io.apicurio.registry.cli.serverconfig.ServerConfigCommand;
@@ -30,6 +32,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
                 "     /_/"
         },
         subcommands = {
+                AdminCommand.class,
                 ArtifactCommand.class,
                 ConfigPropertyCommand.class,
                 ContentCommand.class,
@@ -39,6 +42,7 @@ import static picocli.CommandLine.ScopeType.INHERIT;
                 InstallCommand.class,
                 LoginCommand.class,
                 LogoutCommand.class,
+                ReferenceCommand.class,
                 RoleMappingCommand.class,
                 SearchCommand.class,
                 ServerConfigCommand.class,

--- a/cli/src/main/java/io/apicurio/registry/cli/admin/AdminCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/admin/AdminCommand.java
@@ -1,0 +1,21 @@
+package io.apicurio.registry.cli.admin;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+
+@Command(
+        name = "admin",
+        description = "Admin operations: export and import",
+        subcommands = {
+                ExportCommand.class,
+                ImportCommand.class
+        }
+)
+public class AdminCommand extends AbstractCommand {
+
+    @Override
+    public void run(final OutputBuffer output) {
+        spec.commandLine().usage(spec.commandLine().getOut());
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/admin/ExportCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/admin/ExportCommand.java
@@ -1,0 +1,156 @@
+package io.apicurio.registry.cli.admin;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.jboss.logging.Logger;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+
+@Command(
+        name = "export",
+        description = "Export registry data to a ZIP file"
+)
+public class ExportCommand extends AbstractCommand {
+
+    private static final Logger log = Logger.getLogger(ExportCommand.class);
+    private static final int DOWNLOAD_TIMEOUT_SECONDS = 300;
+    private static final int HTTP_OK = 200;
+    private static final int DEFAULT_HTTP_PORT = 80;
+    private static final int DEFAULT_HTTPS_PORT = 443;
+    private static final String HTTPS_SCHEME = "https";
+
+    @Option(
+            names = {"-f", "--file"},
+            required = true,
+            description = "Output file path for the exported ZIP archive."
+    )
+    private String file;
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Export only data belonging to this group."
+    )
+    private String groupId;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var outputPath = Path.of(file);
+        final var parentDir = outputPath.getParent();
+        if (parentDir != null && !Files.isDirectory(parentDir)) {
+            throw new CliException("Parent directory does not exist: " + parentDir,
+                    VALIDATION_ERROR_RETURN_CODE);
+        }
+
+        final var registryClient = client.getRegistryClient();
+
+        final var downloadRef = registryClient.admin().export().get(r -> {
+            r.queryParameters.forBrowser = true;
+            r.queryParameters.groupId = groupId;
+        });
+
+        if (downloadRef == null || downloadRef.getHref() == null) {
+            throw new CliException("Server did not return a download reference.",
+                    APPLICATION_ERROR_RETURN_CODE);
+        }
+
+        final var baseUri = resolveBaseUri();
+        final var downloadUrl = baseUri.resolve(downloadRef.getHref());
+
+        downloadFile(downloadUrl, outputPath);
+
+        output.writeStdOutChunk(out ->
+                out.append("Registry data exported to '").append(file).append("'.\n"));
+    }
+
+    private URI resolveBaseUri() {
+        final var configModel = config.read();
+        final var contextName = configModel.getCurrentContext();
+        final var context = configModel.getContext().get(contextName);
+        final var registryUrl = context.getRegistryUrl();
+        final var suffix = "/apis/registry/v3";
+        final var idx = registryUrl.indexOf(suffix);
+        if (idx >= 0) {
+            return URI.create(registryUrl.substring(0, idx));
+        }
+        return URI.create(registryUrl);
+    }
+
+    private void downloadFile(final URI url, final Path outputPath) {
+        log.debugf("Downloading export from: %s", url);
+
+        try {
+            final var httpClient = client.getHttpClient();
+            final var future = new CompletableFuture<byte[]>();
+
+            final boolean ssl = HTTPS_SCHEME.equals(url.getScheme());
+            final int defaultPort = ssl ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
+            final int port = url.getPort() != -1 ? url.getPort() : defaultPort;
+            final var requestOptions = new RequestOptions()
+                    .setMethod(HttpMethod.GET)
+                    .setPort(port)
+                    .setHost(url.getHost())
+                    .setURI(url.getPath() + (url.getQuery() != null ? "?" + url.getQuery() : ""))
+                    .setSsl(ssl);
+
+            httpClient.request(requestOptions)
+                    .onSuccess(req -> req.send()
+                            .onSuccess(response -> {
+                                if (response.statusCode() != HTTP_OK) {
+                                    future.completeExceptionally(new CliException(
+                                            "Failed to download export: HTTP " + response.statusCode(),
+                                            APPLICATION_ERROR_RETURN_CODE));
+                                    return;
+                                }
+                                response.body()
+                                        .onSuccess(buffer -> future.complete(buffer.getBytes()))
+                                        .onFailure(future::completeExceptionally);
+                            })
+                            .onFailure(future::completeExceptionally))
+                    .onFailure(future::completeExceptionally);
+
+            final var bytes = future.get(DOWNLOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            Files.write(outputPath, bytes);
+        } catch (IOException ex) {
+            deleteQuietly(outputPath);
+            throw new CliException("Failed to write export file: " + ex.getMessage(), ex,
+                    APPLICATION_ERROR_RETURN_CODE);
+        } catch (InterruptedException ex) {
+            deleteQuietly(outputPath);
+            Thread.currentThread().interrupt();
+            throw new CliException("Download interrupted.", ex, APPLICATION_ERROR_RETURN_CODE);
+        } catch (TimeoutException ex) {
+            deleteQuietly(outputPath);
+            throw new CliException("Export download timed out after " + DOWNLOAD_TIMEOUT_SECONDS
+                    + " seconds.", ex, APPLICATION_ERROR_RETURN_CODE);
+        } catch (Exception ex) {
+            deleteQuietly(outputPath);
+            final var cause = ex.getCause() instanceof CliException ce ? ce : null;
+            if (cause != null) {
+                throw cause;
+            }
+            throw new CliException("Failed to download export: " + ex.getMessage(), ex,
+                    APPLICATION_ERROR_RETURN_CODE);
+        }
+    }
+
+    private void deleteQuietly(final Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException cleanupEx) {
+            log.debugf(cleanupEx, "Failed to delete partial export file: %s", path);
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/admin/ImportCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/admin/ImportCommand.java
@@ -1,0 +1,72 @@
+package io.apicurio.registry.cli.admin;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+
+@Command(
+        name = "import",
+        description = "Import registry data from a ZIP file"
+)
+public class ImportCommand extends AbstractCommand {
+
+    private static final String HEADER_PRESERVE_GLOBAL_ID = "X-Registry-Preserve-GlobalId";
+    private static final String HEADER_PRESERVE_CONTENT_ID = "X-Registry-Preserve-ContentId";
+
+    @Option(
+            names = {"-f", "--file"},
+            required = true,
+            description = "Input file path of the ZIP archive to import."
+    )
+    private String file;
+
+    @Option(
+            names = {"--no-require-empty"},
+            description = "Allow importing into a non-empty registry."
+    )
+    private boolean noRequireEmpty;
+
+    @Option(
+            names = {"--no-preserve-ids"},
+            description = "Do not preserve global and content IDs during import."
+    )
+    private boolean noPreserveIds;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var filePath = Path.of(file);
+        if (!Files.exists(filePath)) {
+            throw new CliException("File not found: " + file, VALIDATION_ERROR_RETURN_CODE);
+        }
+        if (!Files.isRegularFile(filePath) || !Files.isReadable(filePath)) {
+            throw new CliException("Cannot read file: " + file, VALIDATION_ERROR_RETURN_CODE);
+        }
+
+        final var registryClient = client.getRegistryClient();
+
+        try (InputStream inputStream = Files.newInputStream(filePath)) {
+            registryClient.admin().importEscaped().post(inputStream, r -> {
+                r.queryParameters.requireEmptyRegistry = !noRequireEmpty;
+                if (noPreserveIds) {
+                    r.headers.add(HEADER_PRESERVE_GLOBAL_ID, "false");
+                    r.headers.add(HEADER_PRESERVE_CONTENT_ID, "false");
+                }
+            });
+        } catch (IOException ex) {
+            throw new CliException("Failed to read import file: " + ex.getMessage(), ex,
+                    APPLICATION_ERROR_RETURN_CODE);
+        }
+
+        output.writeStdOutChunk(out ->
+                out.append("Registry data imported from '").append(file).append("'.\n"));
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/reference/ReferenceCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/reference/ReferenceCommand.java
@@ -1,0 +1,21 @@
+package io.apicurio.registry.cli.reference;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+
+@Command(
+        name = "reference",
+        aliases = {"references", "ref"},
+        description = "Manage artifact references",
+        subcommands = {
+                ReferenceListCommand.class
+        }
+)
+public class ReferenceCommand extends AbstractCommand {
+
+    @Override
+    public void run(final OutputBuffer output) {
+        spec.commandLine().usage(spec.commandLine().getOut());
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/reference/ReferenceListCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/reference/ReferenceListCommand.java
@@ -1,0 +1,96 @@
+package io.apicurio.registry.cli.reference;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.client.models.ArtifactReference;
+import io.apicurio.registry.rest.client.models.ReferenceType;
+import java.util.List;
+import java.util.Optional;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
+import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
+import static io.apicurio.registry.cli.utils.Columns.REFERENCE_NAME;
+import static io.apicurio.registry.cli.utils.Columns.VERSION;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+@Command(
+        name = "list",
+        aliases = {"ls"},
+        description = "List references for an artifact version"
+)
+public class ReferenceListCommand extends AbstractCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The version expression (e.g. '1.0.0', 'branch=latest')."
+    )
+    private String versionExpression;
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Group ID. If not provided, uses the groupId from the current context, or 'default'."
+    )
+    private String groupId;
+
+    @Option(
+            names = {"-a", "--artifact"},
+            description = "Artifact ID. If not provided, uses the artifactId from the current context."
+    )
+    private String artifactId;
+
+    @Option(
+            names = {"--inbound"},
+            description = "List inbound references instead of outbound."
+    )
+    private boolean inbound;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = IdUtil.resolveGroupId(groupId, config);
+        final var resolvedArtifactId = IdUtil.resolveArtifactId(artifactId, config);
+        final var registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+
+        final var refType = inbound ? ReferenceType.INBOUND : ReferenceType.OUTBOUND;
+
+        final var references = Optional.ofNullable(
+                registryClient.groups().byGroupId(resolvedGroupId)
+                        .artifacts().byArtifactId(resolvedArtifactId)
+                        .versions().byVersionExpression(versionExpression)
+                        .references().get(r -> r.queryParameters.refType = refType)
+        ).orElse(List.of());
+
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(references));
+                    out.append('\n');
+                }
+                case table -> {
+                    if (references.isEmpty()) {
+                        out.append("No references found.\n");
+                    } else {
+                        final var table = new TableBuilder();
+                        table.addColumns(GROUP_ID, ARTIFACT_ID, VERSION, REFERENCE_NAME);
+                        for (final ArtifactReference ref : references) {
+                            table.addRow(ref.getGroupId(), ref.getArtifactId(),
+                                    ref.getVersion(), ref.getName());
+                        }
+                        table.print(out);
+                    }
+                }
+            }
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
@@ -41,4 +41,6 @@ public final class Columns {
     public static final String PRINCIPAL_ID = "Principal ID";
     public static final String PRINCIPAL_NAME = "Principal Name";
     public static final String ROLE = "Role";
+
+    public static final String REFERENCE_NAME = "Ref Name";
 }

--- a/cli/src/test/java/io/apicurio/registry/cli/ImportExportCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ImportExportCommandTest.java
@@ -1,0 +1,171 @@
+package io.apicurio.registry.cli;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestMethodOrder(OrderAnnotation.class)
+public class ImportExportCommandTest extends AbstractCLITest {
+
+    private static Path exportFile;
+
+    @AfterAll
+    static void cleanup() throws Exception {
+        if (exportFile != null) {
+            Files.deleteIfExists(exportFile);
+        }
+    }
+
+    // -- Help --
+
+    @Test
+    @Order(0)
+    public void testAdminHelp() {
+        testHelpCommand("admin");
+        testHelpCommand("admin", "export");
+        testHelpCommand("admin", "import");
+    }
+
+    // -- Export --
+
+    @Test
+    @Order(1)
+    public void testSetupArtifact() throws Exception {
+        Path tempFile = Files.createTempFile("export-test-schema", ".json");
+        Files.writeString(tempFile, """
+                {"type": "string"}
+                """);
+        try {
+            executeAndAssertSuccess("artifact", "create",
+                    "--group", "default", "--type", "JSON",
+                    "--file", tempFile.toString(), "export-test-artifact");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    @Order(2)
+    public void testExport() throws Exception {
+        exportFile = Files.createTempFile("registry-export-", ".zip");
+        Files.deleteIfExists(exportFile);
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("admin", "export", "--file", exportFile.toString());
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm export"))
+                .contains("exported to");
+        assertThat(Files.exists(exportFile))
+                .as("Export file should exist")
+                .isTrue();
+        assertThat(Files.size(exportFile))
+                .as("Export file should not be empty")
+                .isGreaterThan(0);
+    }
+
+    @Test
+    @Order(3)
+    public void testExportWithGroup() throws Exception {
+        executeAndAssertSuccess("group", "create", "export-test-group");
+
+        Path tempFile = Files.createTempFile("export-group-schema", ".json");
+        Files.writeString(tempFile, """
+                {"type": "integer"}
+                """);
+        try {
+            executeAndAssertSuccess("artifact", "create",
+                    "--group", "export-test-group", "--type", "JSON",
+                    "--file", tempFile.toString(), "group-artifact");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+
+        Path groupExport = Files.createTempFile("registry-group-export-", ".zip");
+        Files.deleteIfExists(groupExport);
+
+        try {
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("admin", "export", "--file", groupExport.toString(),
+                    "--group", "export-test-group");
+            assertThat(out.toString())
+                    .as(withCliOutput("Should confirm export"))
+                    .contains("exported to");
+            assertThat(Files.exists(groupExport))
+                    .as("Group export file should exist")
+                    .isTrue();
+        } finally {
+            Files.deleteIfExists(groupExport);
+        }
+    }
+
+    // -- Import --
+
+    @Test
+    @Order(4)
+    public void testImportRequiresEmptyByDefault() {
+        Assumptions.assumeTrue(exportFile != null, "Export file not available");
+        out.getBuffer().setLength(0);
+        executeAndAssertFailure("admin", "import", "--file", exportFile.toString());
+    }
+
+    @Test
+    @Order(5)
+    public void testImportNoRequireEmpty() {
+        Assumptions.assumeTrue(exportFile != null, "Export file not available");
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("admin", "import", "--file", exportFile.toString(),
+                "--no-require-empty");
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm import"))
+                .contains("imported from");
+    }
+
+    @Test
+    @Order(6)
+    public void testImportWithNoPreserveIds() {
+        Assumptions.assumeTrue(exportFile != null, "Export file not available");
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("admin", "import", "--file", exportFile.toString(),
+                "--no-require-empty", "--no-preserve-ids");
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm import without preserved IDs"))
+                .contains("imported from");
+    }
+
+    // -- Error cases --
+
+    @Test
+    @Order(7)
+    public void testImportNonExistentFile() {
+        executeAndAssertFailure("admin", "import", "--file", "/tmp/nonexistent-file.zip");
+    }
+
+    @Test
+    @Order(8)
+    public void testExportInvalidDirectory() {
+        executeAndAssertFailure("admin", "export", "--file",
+                "/nonexistent/directory/export.zip");
+    }
+
+    @Test
+    @Order(9)
+    public void testExportMissingFile() {
+        executeAndAssertFailure("admin", "export");
+    }
+
+    @Test
+    @Order(10)
+    public void testImportMissingFile() {
+        executeAndAssertFailure("admin", "import");
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/ReferenceCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ReferenceCommandTest.java
@@ -1,0 +1,142 @@
+package io.apicurio.registry.cli;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apicurio.registry.rest.client.models.ArtifactReference;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.List;
+
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestMethodOrder(OrderAnnotation.class)
+public class ReferenceCommandTest extends AbstractCLITest {
+
+    private static final String TEST_GROUP = "ref-test-group";
+    private static final String TARGET_ARTIFACT = "ref-target-artifact";
+    private static final String SOURCE_ARTIFACT = "ref-source-artifact";
+    private static final String REF_NAME = "target-ref";
+
+    // -- Help --
+
+    @Test
+    @Order(0)
+    public void testReferenceHelp() {
+        testHelpCommand("reference");
+        testHelpCommand("reference", "list");
+    }
+
+    // -- Setup: create artifacts with an explicit reference --
+
+    @Test
+    @Order(1)
+    public void testSetup() {
+        executeAndAssertSuccess("group", "create", TEST_GROUP);
+
+        final var registryClient = client.getRegistryClient();
+
+        final var targetArtifact = new CreateArtifact();
+        targetArtifact.setArtifactId(TARGET_ARTIFACT);
+        targetArtifact.setArtifactType("JSON");
+        final var targetVersion = new CreateVersion();
+        final var targetContent = new VersionContent();
+        targetContent.setContent("{\"type\": \"string\"}");
+        targetContent.setContentType("application/json");
+        targetVersion.setContent(targetContent);
+        targetArtifact.setFirstVersion(targetVersion);
+        final var targetResponse = registryClient.groups().byGroupId(TEST_GROUP)
+                .artifacts().post(targetArtifact);
+
+        final var ref = new ArtifactReference();
+        ref.setGroupId(TEST_GROUP);
+        ref.setArtifactId(TARGET_ARTIFACT);
+        ref.setVersion(targetResponse.getVersion().getVersion());
+        ref.setName(REF_NAME);
+
+        final var sourceArtifact = new CreateArtifact();
+        sourceArtifact.setArtifactId(SOURCE_ARTIFACT);
+        sourceArtifact.setArtifactType("JSON");
+        final var sourceVersion = new CreateVersion();
+        final var sourceContent = new VersionContent();
+        sourceContent.setContent("{\"type\": \"object\", \"properties\": {\"name\": {\"$ref\": \"" + REF_NAME + "\"}}}");
+        sourceContent.setContentType("application/json");
+        sourceContent.setReferences(List.of(ref));
+        sourceVersion.setContent(sourceContent);
+        sourceArtifact.setFirstVersion(sourceVersion);
+        registryClient.groups().byGroupId(TEST_GROUP).artifacts().post(sourceArtifact);
+    }
+
+    // -- List references --
+
+    @Test
+    @Order(2)
+    public void testListOutboundTable() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("reference", "list",
+                "-g", TEST_GROUP, "-a", SOURCE_ARTIFACT, "branch=latest");
+        assertThat(out.toString())
+                .as(withCliOutput("Should show the target artifact reference"))
+                .contains(TARGET_ARTIFACT);
+    }
+
+    @Test
+    @Order(3)
+    public void testListOutboundJson() throws Exception {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("reference", "list", "-o", "json",
+                "-g", TEST_GROUP, "-a", SOURCE_ARTIFACT, "branch=latest");
+        JsonNode refs = MAPPER.readTree(out.toString());
+        assertThat(refs.isArray())
+                .as(withCliOutput("JSON output should be an array"))
+                .isTrue();
+        assertThat(refs.size())
+                .as(withCliOutput("Should contain at least one reference"))
+                .isGreaterThan(0);
+        boolean found = false;
+        for (JsonNode ref : refs) {
+            if (TARGET_ARTIFACT.equals(ref.get("artifactId").asText())
+                    && REF_NAME.equals(ref.get("name").asText())) {
+                found = true;
+                break;
+            }
+        }
+        assertThat(found)
+                .as(withCliOutput("Should contain reference to " + TARGET_ARTIFACT))
+                .isTrue();
+    }
+
+    @Test
+    @Order(4)
+    public void testListInbound() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("reference", "list", "--inbound",
+                "-g", TEST_GROUP, "-a", TARGET_ARTIFACT, "branch=latest");
+        assertThat(out.toString())
+                .as(withCliOutput("Should show the source artifact as inbound reference"))
+                .contains(SOURCE_ARTIFACT);
+    }
+
+    // -- Error cases --
+
+    @Test
+    @Order(5)
+    public void testListNonExistentArtifact() {
+        executeAndAssertFailure("reference", "list",
+                "-g", TEST_GROUP, "-a", "non-existent", "branch=latest");
+    }
+
+    @Test
+    @Order(6)
+    public void testListMissingArtifactNoContext() {
+        executeAndAssertFailure("reference", "list",
+                "-g", TEST_GROUP, "branch=latest");
+    }
+}


### PR DESCRIPTION
## Summary

Adds artifact references and import/export commands to the CLI. Admin operations are grouped under `acr admin`.

Fixes #8268

## Usage

```bash
# List outbound references for a version
acr reference list -g my-group -a my-artifact 1.0.0

# List inbound references
acr reference list --inbound -g my-group -a my-artifact 1.0.0

# Export registry data
acr admin export --file backup.zip
acr admin export --file backup.zip --group my-group

# Import registry data
acr admin import --file backup.zip --no-require-empty
acr admin import --file backup.zip --no-require-empty --no-preserve-ids
```

## Behavior

| Scenario | Result |
|----------|--------|
| `reference list -a artifact 1.0.0` | Lists outbound references in table |
| `reference list --inbound -a artifact 1.0.0` | Lists inbound references |
| `reference list -o json` | JSON array of references |
| `admin export --file backup.zip` | Exports all data to ZIP |
| `admin export --file backup.zip --group G` | Exports group-scoped data |
| `admin import --file backup.zip` | Imports into empty registry |
| `admin import --no-require-empty` | Allows import into non-empty registry |
| `admin import --no-preserve-ids` | Regenerates IDs instead of preserving originals |
| Invalid parent directory for export | Client-side validation error before server call |
| Non-existent artifact for references | Clear error via `validateArtifact()` |

## Changes

| File | Purpose |
|------|---------|
| `AdminCommand.java` | New — parent command grouping export/import under `acr admin` |
| `ExportCommand.java` | New — `acr admin export` with Vert.x HTTP client, `URI.resolve()`, output path validation, file cleanup on error, download timeout |
| `ImportCommand.java` | New — `acr admin import` with `--no-require-empty` and `--no-preserve-ids` flags |
| `ReferenceCommand.java` | New — `acr reference` parent command |
| `ReferenceListCommand.java` | New — `acr reference list` with inbound/outbound, table/JSON output, artifact validation |
| `Acr.java` | Registered `AdminCommand` and `ReferenceCommand` as subcommands |
| `Columns.java` | Added `REFERENCE_NAME` constant |
| `ReferenceCommandTest.java` | 7 tests: help, explicit reference setup via REST client, outbound table/JSON, inbound, error cases |
| `ImportExportCommandTest.java` | 11 tests: admin help, export, group export, import (empty/non-empty/no-preserve-ids), invalid directory, error cases. `@AfterAll` cleanup, `Assumptions` guards. |

## Design decisions

- **`acr admin` subcommand group**: Export/import are admin-only operations. Nesting under `acr admin` keeps the top-level namespace clean and makes the admin intent discoverable.
- **`--no-preserve-ids`** (not `--preserve-ids`): Follows the `--no-require-empty` pattern on the same command. When absent, server defaults apply (preserve=true). When present, sends explicit `false` headers.
- **Vert.x HTTP client for export download**: Uses `client.getHttpClient()` instead of `java.net.http.HttpClient`, consistent with `Update.java` and the CLI's native build configuration (JDK HTTP adapter is excluded for GraalVM compatibility).
- **Snapshot command removed**: Per Eric and Carles feedback — KafkaSQL-specific, requires admin access, not worth a CLI command.
- **Explicit references via REST client in tests**: CLI's `artifact create` doesn't support `--references`, so test setup creates artifacts with explicit references via the registry SDK for deterministic test behavior.

## Test plan
- [x] `acr admin --help` shows export/import subcommands
- [x] `acr admin export --file backup.zip` exports data (valid ZIP verified)
- [x] `acr admin export --file backup.zip --group G` exports group-scoped data
- [x] `acr admin export --file /nonexistent/dir/file.zip` fails with validation error
- [x] `acr admin import --file backup.zip --no-require-empty` imports data
- [x] `acr admin import --no-preserve-ids` regenerates IDs
- [x] `acr admin import` into non-empty registry fails with clear error
- [x] `acr reference list` shows outbound references in table and JSON
- [x] `acr reference list --inbound` shows inbound references
- [x] Non-existent artifact fails with clear validation error
- [x] 18 tests pass across ReferenceCommandTest (7), ImportExportCommandTest (11)
- [x] Manual E2E testing on podman verified all scenarios