### PR TITLE
fix(ci): update apicurio-github-actions to v2.2.0

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -100,7 +100,7 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - uses: apicurio/apicurio-github-actions/setup-minikube@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/setup-minikube@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           driver: 'none'
           ingress-enable: 'true'
@@ -180,7 +180,7 @@ jobs:
           name: operator-build-artifacts
           path: operator/
 
-      - uses: apicurio/apicurio-github-actions/setup-minikube@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/setup-minikube@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           driver: 'none'
           ingress-enable: 'true'

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -226,7 +226,7 @@ jobs:
           name: operator-test-artifacts
           path: registry/operator/
 
-      - uses: apicurio/apicurio-github-actions/setup-minikube@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/setup-minikube@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           driver: 'none'
           ingress-enable: 'true'

--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -59,7 +59,7 @@ jobs:
             ./distro/docker/target/docker
 
       - name: Save Docker Image
-        uses: apicurio/apicurio-github-actions/save-docker-image@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+        uses: apicurio/apicurio-github-actions/save-docker-image@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           image-name: apicurio/apicurio-registry
           tag: '${{ github.sha }}'
@@ -128,7 +128,7 @@ jobs:
           docker build -t apicurio/apicurio-registry-ui:${{ github.sha }} .
 
       - name: Save UI Docker Image
-        uses: apicurio/apicurio-github-actions/save-docker-image@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+        uses: apicurio/apicurio-github-actions/save-docker-image@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           image-name: apicurio/apicurio-registry-ui
           tag: '${{ github.sha }}'

--- a/.github/workflows/verify-extras.yaml
+++ b/.github/workflows/verify-extras.yaml
@@ -32,7 +32,7 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - uses: apicurio/apicurio-github-actions/load-docker-image@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/load-docker-image@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           artifact-name: apicurio-registry-${{ inputs.image-tag }}.tar
           image-file: /tmp/apicurio-registry-${{ inputs.image-tag }}.tar
@@ -76,14 +76,14 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'ui/tests/package-lock.json'
 
-      - uses: apicurio/apicurio-github-actions/load-docker-image@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/load-docker-image@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           artifact-name: 'apicurio-registry-${{ inputs.image-tag }}.tar'
           image-file: '/tmp/apicurio-registry-${{ inputs.image-tag }}.tar'
           image-name: 'apicurio/apicurio-registry'
           tag: '${{ inputs.image-tag }}'
 
-      - uses: apicurio/apicurio-github-actions/load-docker-image@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/load-docker-image@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           artifact-name: 'apicurio-registry-ui-${{ inputs.image-tag }}.tar'
           image-file: '/tmp/apicurio-registry-ui-${{ inputs.image-tag }}.tar'
@@ -134,7 +134,7 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - uses: apicurio/apicurio-github-actions/load-docker-image@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/load-docker-image@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           artifact-name: 'apicurio-registry-${{ inputs.image-tag }}.tar'
           image-file: '/tmp/apicurio-registry-${{ inputs.image-tag }}.tar'
@@ -167,7 +167,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: apicurio/apicurio-github-actions/load-docker-image@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/load-docker-image@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           artifact-name: 'apicurio-registry-${{ inputs.image-tag }}.tar'
           image-file: '/tmp/apicurio-registry-${{ inputs.image-tag }}.tar'
@@ -211,7 +211,7 @@ jobs:
           find . -name "protoc-*" -type f -exec chmod +x {} \; 2>/dev/null || true
           find . -name "*.exe" -path "*/protoc-plugins/*" -type f -exec chmod +x {} \; 2>/dev/null || true
 
-      - uses: apicurio/apicurio-github-actions/load-docker-image@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/load-docker-image@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           artifact-name: 'apicurio-registry-${{ inputs.image-tag }}.tar'
           image-file: '/tmp/apicurio-registry-${{ inputs.image-tag }}.tar'

--- a/.github/workflows/verify-integration-tests.yaml
+++ b/.github/workflows/verify-integration-tests.yaml
@@ -55,9 +55,9 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - uses: apicurio/apicurio-github-actions/setup-minikube@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/setup-minikube@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
 
-      - uses: apicurio/apicurio-github-actions/load-docker-image@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/load-docker-image@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           artifact-name: 'apicurio-registry-${{ inputs.image-tag }}.tar'
           image-file: '/tmp/apicurio-registry-${{ inputs.image-tag }}.tar'

--- a/.github/workflows/verify-sdk.yaml
+++ b/.github/workflows/verify-sdk.yaml
@@ -44,7 +44,7 @@ jobs:
         working-directory: python-sdk
         run: make lint-check
 
-      - uses: apicurio/apicurio-github-actions/load-docker-image@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/load-docker-image@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           artifact-name: 'apicurio-registry-${{ inputs.image-tag }}.tar'
           image-file: '/tmp/apicurio-registry-${{ inputs.image-tag }}.tar'
@@ -77,7 +77,7 @@ jobs:
         with:
           go-version: '1.26.4'
 
-      - uses: apicurio/apicurio-github-actions/load-docker-image@1da7e1fef5962e611805b46e181e623efba5a5f9 # v2
+      - uses: apicurio/apicurio-github-actions/load-docker-image@8eb9b9495e35a3aac41ca8f361e6f4dc64d4f867 # v2
         with:
           artifact-name: 'apicurio-registry-${{ inputs.image-tag }}.tar'
           image-file: '/tmp/apicurio-registry-${{ inputs.image-tag }}.tar'


### PR DESCRIPTION
## Summary
- Update the pinned commit SHA for `apicurio-github-actions` across all workflows to pick up v2.2.0
- v2.2.0 switches `setup-minikube` from `manusa/actions-setup-minikube` to `medyagh/setup-minikube`
  (the official minikube GitHub Action), which downloads minikube via direct URL instead of the
  GitHub REST API, eliminating the recurring rate-limit 403 failures

## Test plan
- [ ] Integration tests (`verify-integration-tests.yaml`) pass with the new minikube setup
- [ ] Operator tests (`operator.yaml`) pass with the new minikube setup
- [ ] Docker image save/load (`verify-build.yaml`, `verify-extras.yaml`, `verify-sdk.yaml`) unaffected