### PR TITLE
fix(cors): auto-detect CORS origins from URL override configuration

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/CorsConfigInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/services/CorsConfigInterceptor.java
@@ -1,0 +1,58 @@
+package io.apicurio.registry.services;
+
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+import jakarta.annotation.Priority;
+
+@Priority(101)
+public class CorsConfigInterceptor implements ConfigSourceInterceptor {
+
+    private static final String CORS_ORIGINS_PROPERTY = "quarkus.http.cors.origins";
+    private static final String URL_OVERRIDE_HOST_PROPERTY = "apicurio.url.override.host";
+    private static final String URL_OVERRIDE_PORT_PROPERTY = "apicurio.url.override.port";
+
+    @Override
+    public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
+        if (!CORS_ORIGINS_PROPERTY.equals(name)) {
+            return context.proceed(name);
+        }
+
+        ConfigValue baseValue = context.proceed(name);
+        ConfigValue hostValue = context.proceed(URL_OVERRIDE_HOST_PROPERTY);
+
+        if (hostValue == null || hostValue.getValue() == null || hostValue.getValue().isBlank()) {
+            return baseValue;
+        }
+
+        String host = hostValue.getValue().trim();
+        String portSuffix = buildPortSuffix(context);
+        String autoOrigins = "http://" + host + portSuffix + ",https://" + host + portSuffix;
+
+        String combined;
+        if (baseValue != null && baseValue.getValue() != null && !baseValue.getValue().isBlank()) {
+            combined = baseValue.getValue() + "," + autoOrigins;
+        } else {
+            combined = autoOrigins;
+        }
+
+        return ConfigValue.builder().withName(name).withValue(combined).build();
+    }
+
+    private String buildPortSuffix(ConfigSourceInterceptorContext context) {
+        ConfigValue portValue = context.proceed(URL_OVERRIDE_PORT_PROPERTY);
+        if (portValue == null || portValue.getValue() == null || portValue.getValue().isBlank()) {
+            return "";
+        }
+
+        try {
+            int port = Integer.parseInt(portValue.getValue().trim());
+            if (port == 80 || port == 443 || port <= 0) {
+                return "";
+            }
+            return ":" + port;
+        } catch (NumberFormatException e) {
+            return "";
+        }
+    }
+}

--- a/app/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/app/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,2 +1,3 @@
 io.apicurio.registry.services.DatabaseConfigInterceptor
+io.apicurio.registry.services.CorsConfigInterceptor
 io.apicurio.registry.config.FileBasedSecretsInterceptor

--- a/app/src/test/java/io/apicurio/registry/cors/CorsUrlOverrideTest.java
+++ b/app/src/test/java/io/apicurio/registry/cors/CorsUrlOverrideTest.java
@@ -1,0 +1,144 @@
+package io.apicurio.registry.cors;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Reproduces GitHub issue #4446: behind an HTTPS reverse proxy, non-GET requests fail with 403 because
+ * the browser's origin does not match the hardcoded CORS origins. The CorsConfigInterceptor auto-detects
+ * origins from apicurio.url.override.host/port, which users already configure for proxy setups.
+ */
+@QuarkusTest
+@TestProfile(CorsUrlOverrideTest.ReverseProxyTestProfile.class)
+public class CorsUrlOverrideTest {
+
+    private static final String PROXY_HOST = "apicurio.example.com";
+    private static final String PROXY_ORIGIN = "https://" + PROXY_HOST;
+
+    /**
+     * Mirrors the reporter's environment: HTTPS reverse proxy on port 443 with URL overrides configured.
+     */
+    public static class ReverseProxyTestProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "apicurio.url.override.host", PROXY_HOST,
+                    "apicurio.url.override.port", "443"
+            );
+        }
+    }
+
+    /**
+     * The core scenario from issue #4446: a DELETE preflight from the proxy origin must succeed.
+     * Without the fix, this returns 403 because the origin is not in the allowed list.
+     */
+    @Test
+    public void testDeletePreflightFromProxyOrigin() {
+        given()
+                .header("Origin", PROXY_ORIGIN)
+                .header("Access-Control-Request-Method", "DELETE")
+                .header("Access-Control-Request-Headers", "authorization,content-type")
+                .when()
+                .options("/apis/registry/v3/groups/default/artifacts")
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", PROXY_ORIGIN)
+                .header("Access-Control-Allow-Methods", notNullValue());
+    }
+
+    /**
+     * After preflight passes, the actual POST request (e.g. creating a group) must also include
+     * CORS response headers so the browser accepts the response.
+     */
+    @Test
+    public void testPostRequestFromProxyOriginIncludesCorsHeaders() {
+        String groupId = "cors-test-" + UUID.randomUUID();
+        given()
+                .header("Origin", PROXY_ORIGIN)
+                .header("Content-Type", "application/json")
+                .body("{\"groupId\": \"" + groupId + "\"}")
+                .when()
+                .post("/apis/registry/v3/groups")
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", PROXY_ORIGIN);
+    }
+
+    /**
+     * DELETE request from the proxy origin must include CORS headers (the exact method that
+     * failed in #4446). We create a group first, then delete it with the proxy origin.
+     */
+    @Test
+    public void testDeleteRequestFromProxyOriginIncludesCorsHeaders() {
+        String groupId = "cors-delete-test-" + UUID.randomUUID();
+
+        // Create a group first
+        given()
+                .header("Content-Type", "application/json")
+                .body("{\"groupId\": \"" + groupId + "\"}")
+                .when()
+                .post("/apis/registry/v3/groups")
+                .then()
+                .statusCode(200);
+
+        // DELETE preflight from the proxy origin — this is the exact request that failed in #4446.
+        // The browser sends OPTIONS before DELETE; if this returns 403, the DELETE never happens.
+        given()
+                .header("Origin", PROXY_ORIGIN)
+                .header("Access-Control-Request-Method", "DELETE")
+                .header("Access-Control-Request-Headers", "authorization")
+                .when()
+                .options("/apis/registry/v3/groups/" + groupId)
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", PROXY_ORIGIN)
+                .header("Access-Control-Allow-Methods", notNullValue());
+
+        // The actual DELETE after preflight succeeds
+        given()
+                .header("Origin", PROXY_ORIGIN)
+                .when()
+                .delete("/apis/registry/v3/groups/" + groupId)
+                .then()
+                .header("Access-Control-Allow-Origin", PROXY_ORIGIN);
+    }
+
+    /**
+     * An origin not derived from the URL overrides must still be rejected.
+     */
+    @Test
+    public void testUnknownOriginIsRejected() {
+        given()
+                .header("Origin", "https://unknown.example.com")
+                .header("Access-Control-Request-Method", "DELETE")
+                .when()
+                .options("/apis/registry/v3/groups")
+                .then()
+                .statusCode(403);
+    }
+
+    /**
+     * The default localhost origins from application.properties must still work alongside
+     * the auto-detected proxy origins.
+     */
+    @Test
+    public void testDefaultLocalhostOriginStillWorks() {
+        given()
+                .header("Origin", "http://localhost:8888")
+                .header("Access-Control-Request-Method", "POST")
+                .when()
+                .options("/apis/registry/v3/groups")
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", "http://localhost:8888");
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/services/CorsConfigInterceptorTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/CorsConfigInterceptorTest.java
@@ -1,0 +1,153 @@
+package io.apicurio.registry.services;
+
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CorsConfigInterceptorTest {
+
+    private CorsConfigInterceptor interceptor;
+    private ConfigSourceInterceptorContext context;
+
+    private static final String CORS_ORIGINS = "quarkus.http.cors.origins";
+    private static final String URL_OVERRIDE_HOST = "apicurio.url.override.host";
+    private static final String URL_OVERRIDE_PORT = "apicurio.url.override.port";
+    private static final String BASE_ORIGINS = "http://localhost:8888,http://127.0.0.1:8888";
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new CorsConfigInterceptor();
+        context = mock(ConfigSourceInterceptorContext.class);
+    }
+
+    @Test
+    void testPassthroughForOtherProperties() {
+        ConfigValue expected = configValue("some.other.property", "value");
+        when(context.proceed("some.other.property")).thenReturn(expected);
+
+        ConfigValue result = interceptor.getValue(context, "some.other.property");
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testNoUrlOverride() {
+        when(context.proceed(CORS_ORIGINS)).thenReturn(configValue(CORS_ORIGINS, BASE_ORIGINS));
+        when(context.proceed(URL_OVERRIDE_HOST)).thenReturn(null);
+
+        ConfigValue result = interceptor.getValue(context, CORS_ORIGINS);
+
+        assertNotNull(result);
+        assertEquals(BASE_ORIGINS, result.getValue());
+    }
+
+    @Test
+    void testBlankHostOverride() {
+        when(context.proceed(CORS_ORIGINS)).thenReturn(configValue(CORS_ORIGINS, BASE_ORIGINS));
+        when(context.proceed(URL_OVERRIDE_HOST)).thenReturn(configValue(URL_OVERRIDE_HOST, "  "));
+
+        ConfigValue result = interceptor.getValue(context, CORS_ORIGINS);
+
+        assertNotNull(result);
+        assertEquals(BASE_ORIGINS, result.getValue());
+    }
+
+    @Test
+    void testHostOnlyNoPort() {
+        when(context.proceed(CORS_ORIGINS)).thenReturn(configValue(CORS_ORIGINS, BASE_ORIGINS));
+        when(context.proceed(URL_OVERRIDE_HOST)).thenReturn(configValue(URL_OVERRIDE_HOST, "apicurio.example.com"));
+        when(context.proceed(URL_OVERRIDE_PORT)).thenReturn(null);
+
+        ConfigValue result = interceptor.getValue(context, CORS_ORIGINS);
+
+        assertNotNull(result);
+        assertEquals(BASE_ORIGINS + ",http://apicurio.example.com,https://apicurio.example.com",
+                result.getValue());
+    }
+
+    @Test
+    void testHostWithCustomPort() {
+        when(context.proceed(CORS_ORIGINS)).thenReturn(configValue(CORS_ORIGINS, BASE_ORIGINS));
+        when(context.proceed(URL_OVERRIDE_HOST)).thenReturn(configValue(URL_OVERRIDE_HOST, "apicurio.example.com"));
+        when(context.proceed(URL_OVERRIDE_PORT)).thenReturn(configValue(URL_OVERRIDE_PORT, "9443"));
+
+        ConfigValue result = interceptor.getValue(context, CORS_ORIGINS);
+
+        assertNotNull(result);
+        assertEquals(BASE_ORIGINS + ",http://apicurio.example.com:9443,https://apicurio.example.com:9443",
+                result.getValue());
+    }
+
+    @Test
+    void testHostWithPort443() {
+        when(context.proceed(CORS_ORIGINS)).thenReturn(configValue(CORS_ORIGINS, BASE_ORIGINS));
+        when(context.proceed(URL_OVERRIDE_HOST)).thenReturn(configValue(URL_OVERRIDE_HOST, "apicurio.example.com"));
+        when(context.proceed(URL_OVERRIDE_PORT)).thenReturn(configValue(URL_OVERRIDE_PORT, "443"));
+
+        ConfigValue result = interceptor.getValue(context, CORS_ORIGINS);
+
+        assertNotNull(result);
+        assertEquals(BASE_ORIGINS + ",http://apicurio.example.com,https://apicurio.example.com",
+                result.getValue());
+    }
+
+    @Test
+    void testHostWithPort80() {
+        when(context.proceed(CORS_ORIGINS)).thenReturn(configValue(CORS_ORIGINS, BASE_ORIGINS));
+        when(context.proceed(URL_OVERRIDE_HOST)).thenReturn(configValue(URL_OVERRIDE_HOST, "apicurio.example.com"));
+        when(context.proceed(URL_OVERRIDE_PORT)).thenReturn(configValue(URL_OVERRIDE_PORT, "80"));
+
+        ConfigValue result = interceptor.getValue(context, CORS_ORIGINS);
+
+        assertNotNull(result);
+        assertEquals(BASE_ORIGINS + ",http://apicurio.example.com,https://apicurio.example.com",
+                result.getValue());
+    }
+
+    @Test
+    void testNullBaseValue() {
+        when(context.proceed(CORS_ORIGINS)).thenReturn(null);
+        when(context.proceed(URL_OVERRIDE_HOST)).thenReturn(configValue(URL_OVERRIDE_HOST, "apicurio.example.com"));
+        when(context.proceed(URL_OVERRIDE_PORT)).thenReturn(null);
+
+        ConfigValue result = interceptor.getValue(context, CORS_ORIGINS);
+
+        assertNotNull(result);
+        assertEquals("http://apicurio.example.com,https://apicurio.example.com", result.getValue());
+    }
+
+    @Test
+    void testInvalidPort() {
+        when(context.proceed(CORS_ORIGINS)).thenReturn(configValue(CORS_ORIGINS, BASE_ORIGINS));
+        when(context.proceed(URL_OVERRIDE_HOST)).thenReturn(configValue(URL_OVERRIDE_HOST, "apicurio.example.com"));
+        when(context.proceed(URL_OVERRIDE_PORT)).thenReturn(configValue(URL_OVERRIDE_PORT, "notanumber"));
+
+        ConfigValue result = interceptor.getValue(context, CORS_ORIGINS);
+
+        assertNotNull(result);
+        assertEquals(BASE_ORIGINS + ",http://apicurio.example.com,https://apicurio.example.com",
+                result.getValue());
+    }
+
+    @Test
+    void testNullHostValue() {
+        when(context.proceed(CORS_ORIGINS)).thenReturn(configValue(CORS_ORIGINS, BASE_ORIGINS));
+        ConfigValue nullValueHost = ConfigValue.builder().withName(URL_OVERRIDE_HOST).withValue(null).build();
+        when(context.proceed(URL_OVERRIDE_HOST)).thenReturn(nullValueHost);
+
+        ConfigValue result = interceptor.getValue(context, CORS_ORIGINS);
+
+        assertNotNull(result);
+        assertEquals(BASE_ORIGINS, result.getValue());
+    }
+
+    private static ConfigValue configValue(String name, String value) {
+        return ConfigValue.builder().withName(name).withValue(value).build();
+    }
+}

--- a/app/src/test/resources/cors-proxy-test/docker-compose.yaml
+++ b/app/src/test/resources/cors-proxy-test/docker-compose.yaml
@@ -1,0 +1,42 @@
+## Manual end-to-end verification for GitHub issue #4446.
+## Starts an nginx reverse proxy in front of the registry on https://localhost:8443.
+##
+## Usage:
+##   1. Build the app:   ./mvnw clean install -DskipTests -pl app -am
+##   2. Start:           docker compose -f app/src/test/resources/cors-proxy-test/docker-compose.yaml up
+##   3. Test preflight:
+##        curl -v -X OPTIONS https://localhost:8443/apis/registry/v3/groups \
+##          -H "Origin: https://localhost:8443" \
+##          -H "Access-Control-Request-Method: DELETE" \
+##          -H "Access-Control-Request-Headers: authorization" \
+##          --insecure
+##      Expected: 200 with Access-Control-Allow-Origin: https://localhost:8443
+##
+##   4. Test actual POST:
+##        curl -v -X POST https://localhost:8443/apis/registry/v3/groups \
+##          -H "Origin: https://localhost:8443" \
+##          -H "Content-Type: application/json" \
+##          -d '{"groupId": "cors-test"}' \
+##          --insecure
+##      Expected: 200 with Access-Control-Allow-Origin: https://localhost:8443
+##
+##   5. Stop:            docker compose -f app/src/test/resources/cors-proxy-test/docker-compose.yaml down
+
+services:
+  registry:
+    image: quay.io/apicurio/apicurio-registry:latest-snapshot
+    environment:
+      APICURIO_URL_OVERRIDE_HOST: localhost
+      APICURIO_URL_OVERRIDE_PORT: "8443"
+    ports:
+      - "8080:8080"
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "8443:8443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./certs:/etc/nginx/certs:ro
+    depends_on:
+      - registry

--- a/app/src/test/resources/cors-proxy-test/generate-certs.sh
+++ b/app/src/test/resources/cors-proxy-test/generate-certs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Generate self-signed certs for the test proxy
+mkdir -p certs
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout certs/server.key -out certs/server.crt \
+  -subj "/CN=localhost" 2>/dev/null
+echo "Certificates generated in certs/"

--- a/app/src/test/resources/cors-proxy-test/nginx.conf
+++ b/app/src/test/resources/cors-proxy-test/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 8443 ssl;
+    server_name localhost;
+
+    ssl_certificate     /etc/nginx/certs/server.crt;
+    ssl_certificate_key /etc/nginx/certs/server.key;
+
+    location / {
+        proxy_pass http://host.docker.internal:8080/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Port 8443;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/app/src/test/resources/cors-proxy-test/proxy.py
+++ b/app/src/test/resources/cors-proxy-test/proxy.py
@@ -1,0 +1,60 @@
+"""Minimal HTTPS reverse proxy for CORS testing. Forwards all requests to http://localhost:8080."""
+import http.server
+import ssl
+import urllib.request
+import os
+
+BACKEND = "http://localhost:8080"
+LISTEN_PORT = int(os.environ.get("PROXY_PORT", "8443"))
+CERT_DIR = os.path.join(os.path.dirname(__file__), "certs")
+
+
+class ProxyHandler(http.server.BaseHTTPRequestHandler):
+    def do_request(self):
+        url = BACKEND + self.path
+        body = None
+        if "Content-Length" in self.headers:
+            body = self.rfile.read(int(self.headers["Content-Length"]))
+
+        headers = {k: v for k, v in self.headers.items()
+                   if k.lower() not in ("host", "transfer-encoding")}
+        headers["X-Forwarded-Proto"] = "https"
+        headers["X-Forwarded-Port"] = str(LISTEN_PORT)
+
+        req = urllib.request.Request(url, data=body, headers=headers, method=self.command)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                resp_body = resp.read()
+                self.send_response(resp.status)
+                for k, v in resp.getheaders():
+                    if k.lower() not in ("transfer-encoding",):
+                        self.send_header(k, v)
+                self.end_headers()
+                self.wfile.write(resp_body)
+        except urllib.error.HTTPError as e:
+            resp_body = e.read()
+            self.send_response(e.code)
+            for k, v in e.headers.items():
+                if k.lower() not in ("transfer-encoding",):
+                    self.send_header(k, v)
+            self.end_headers()
+            self.wfile.write(resp_body)
+
+    do_GET = do_POST = do_PUT = do_DELETE = do_PATCH = do_OPTIONS = do_HEAD = do_request
+
+    def log_message(self, fmt, *args):
+        print(f"  [proxy] {self.command} {self.path} -> {args[1] if len(args) > 1 else '?'}")
+
+
+def main():
+    server = http.server.HTTPServer(("0.0.0.0", LISTEN_PORT), ProxyHandler)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(os.path.join(CERT_DIR, "server.crt"),
+                        os.path.join(CERT_DIR, "server.key"))
+    server.socket = ctx.wrap_socket(server.socket, server_side=True)
+    print(f"HTTPS reverse proxy listening on https://localhost:{LISTEN_PORT} -> {BACKEND}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/src/test/resources/cors-proxy-test/test-cors.sh
+++ b/app/src/test/resources/cors-proxy-test/test-cors.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# End-to-end CORS verification through an actual nginx reverse proxy.
+# Reproduces the exact scenario from GitHub issue #4446.
+#
+# Prerequisites:
+#   ./generate-certs.sh
+#   docker compose up -d
+#   Wait ~10s for registry to start
+
+set -e
+PROXY_URL="https://localhost:8443"
+PASS=0
+FAIL=0
+
+check() {
+    local desc="$1"
+    local expected_code="$2"
+    local expected_header="$3"
+    shift 3
+
+    local response
+    response=$(curl -s -o /dev/null -w "%{http_code}\n%{header_json}" "$@" --insecure 2>/dev/null)
+    local code
+    code=$(echo "$response" | head -1)
+
+    if [ "$code" = "$expected_code" ]; then
+        echo "  PASS: $desc (HTTP $code)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc (expected HTTP $expected_code, got $code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo ""
+echo "=== CORS Reverse Proxy Test (issue #4446) ==="
+echo "Proxy: $PROXY_URL"
+echo ""
+
+# Wait for registry to be ready
+echo "Waiting for registry..."
+for i in $(seq 1 30); do
+    if curl -s -o /dev/null -w "%{http_code}" "$PROXY_URL/apis/registry/v3/system/info" --insecure 2>/dev/null | grep -q 200; then
+        echo "Registry is ready."
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        echo "Registry not ready after 30s, aborting."
+        exit 1
+    fi
+    sleep 1
+done
+
+echo ""
+echo "--- Test 1: DELETE preflight through proxy (the #4446 scenario) ---"
+check "DELETE preflight with proxy origin" "200" "" \
+    -X OPTIONS "$PROXY_URL/apis/registry/v3/groups/default/artifacts" \
+    -H "Origin: $PROXY_URL" \
+    -H "Access-Control-Request-Method: DELETE" \
+    -H "Access-Control-Request-Headers: authorization"
+
+echo ""
+echo "--- Test 2: POST preflight through proxy ---"
+check "POST preflight with proxy origin" "200" "" \
+    -X OPTIONS "$PROXY_URL/apis/registry/v3/groups" \
+    -H "Origin: $PROXY_URL" \
+    -H "Access-Control-Request-Method: POST" \
+    -H "Access-Control-Request-Headers: authorization,content-type"
+
+echo ""
+echo "--- Test 3: Actual POST through proxy ---"
+check "POST create group through proxy" "200" "" \
+    -X POST "$PROXY_URL/apis/registry/v3/groups" \
+    -H "Origin: $PROXY_URL" \
+    -H "Content-Type: application/json" \
+    -d '{"groupId": "cors-e2e-test"}'
+
+echo ""
+echo "--- Test 4: Unknown origin is rejected ---"
+check "Preflight with unknown origin" "403" "" \
+    -X OPTIONS "$PROXY_URL/apis/registry/v3/groups" \
+    -H "Origin: https://evil.example.com" \
+    -H "Access-Control-Request-Method: DELETE"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
Fixes #4446

When Apicurio Registry runs behind an HTTPS reverse proxy, non-GET HTTP methods (POST, PUT, DELETE) fail with 403 because CORS origins are hardcoded to `localhost`. This adds a `CorsConfigInterceptor` that automatically derives CORS origins from the existing `apicurio.url.override.host` and `apicurio.url.override.port` properties, so users who already configure URL overrides for proxy setups get CORS working automatically.

## Root Cause
`quarkus.http.cors.origins` in `application.properties` is hardcoded to `http://localhost:8888,http://127.0.0.1:8888`. When the registry is accessed via a reverse proxy (e.g. `https://apicurio.example.com`), the browser's origin doesn't match, causing Quarkus's CORS filter to reject preflight (OPTIONS) requests. Simple GET requests bypass preflight and work fine, but all mutating methods fail with 403. The operator already handles this via `Cors.java`, but non-operator deployments had no equivalent.

## Changes
- **New:** `app/src/main/java/io/apicurio/registry/services/CorsConfigInterceptor.java` — `ConfigSourceInterceptor` that intercepts `quarkus.http.cors.origins` and appends `http://` and `https://` origins derived from `apicurio.url.override.host` and `apicurio.url.override.port`. Omits default ports (80, 443). Falls through unchanged when no URL override is configured.
- **Modified:** `app/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor` — registered `CorsConfigInterceptor`
- **New:** `app/src/test/java/io/apicurio/registry/services/CorsConfigInterceptorTest.java` — 10 unit tests covering: no override, host-only, custom port, default ports 80/443, blank/null host, invalid port, null base value

## Test plan
- [x] Unit tests added (`CorsConfigInterceptorTest` — 10 tests, all passing)
- [ ] Manual test: deploy behind reverse proxy with `APICURIO_URL_OVERRIDE_HOST` set, verify non-GET requests succeed
- [ ] Integration tests pass (no CORS changes affect existing test infrastructure since tests don't go through a browser)