### PR TITLE
fix(gitops): preserve trailing newline in rendered SSH config

### DIFF
--- a/distro/gitops/entrypoint.sh
+++ b/distro/gitops/entrypoint.sh
@@ -167,7 +167,7 @@ render_template() {
         content="${content//${placeholder}/${value}}"
     done
 
-    printf '%s' "${content}" > "${output}"
+    printf '%s\n' "${content}" > "${output}"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix `render_template` in the GitOps sidecar entrypoint to use `printf '%s\n'` instead of `printf '%s'`, preserving the trailing newline in rendered config files
- Without the newline, `IdentityFile` entries appended to `ssh_config` merged onto the `IdentitiesOnly yes` line, causing OpenSSH to reject the config with "extra arguments"
- This broke all SSH-key-based pull modes (pull-ssh, multi-repo with SSH)

## Test plan

- [x] Verified `pull-https` example works (not affected, no SSH keys)
- [x] Verified `multi-repo-pull-https` example works (not affected, no SSH keys)
- [x] Verified `push` example works (not affected, uses server-side SSH only)
- [x] Verified `pull-ssh` example **fails** with the original image (`dev-001`) — OpenSSH rejects the config
- [x] Built local image with the fix, verified `pull-ssh` example **passes** — clone succeeds, artifacts loaded