### PR TITLE
[CI Optimization] Skip source/javadoc JAR generation and equalize MAVEN_OPTS

### DIFF
--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -40,6 +40,7 @@ jobs:
         run: |
           ./mvnw clean package -T 0.5C --no-transfer-progress \
             -Pprod -Dfull -DskipTests -DskipCommitIdPlugin=false -DcliSkipNative \
+            -Dmaven.source.skip=true -Dmaven.javadoc.skip=true \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
             -Dmaven.wagon.http.retryHandler.count=5
 

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -83,5 +83,6 @@ jobs:
             ${{ matrix.shard.test-filter }} \
             -Dsurefire.failIfNoSpecifiedTests=false \
             -DskipCommitIdPlugin=false \
+            -Dmaven.source.skip=true -Dmaven.javadoc.skip=true \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
             -Dmaven.wagon.http.retryHandler.count=5

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -37,11 +37,11 @@ jobs:
           - name: app-gitops
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=io.apicurio.registry.storage.impl.gitops.**"
-            maven-opts: "-Xmx2g"
+            maven-opts: "-Xmx4g"
           - name: app-kubernetesops
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=io.apicurio.registry.storage.impl.kubernetesops.**"
-            maven-opts: "-Xmx2g"
+            maven-opts: "-Xmx4g"
           - name: app-other
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=!io.apicurio.registry.noprofile.rest.**,!io.apicurio.registry.noprofile.ccompat.**,!io.apicurio.registry.storage.**,!io.apicurio.registry.event.**"
@@ -49,7 +49,7 @@ jobs:
           - name: non-app
             modules: "-Dfull -DcliSkipNative -pl !app,!distro/docker,!docs,!docs/config-generator,!docs/rest-api"
             test-filter: ""
-            maven-opts: "-Xmx2g"
+            maven-opts: "-Xmx4g"
     steps:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6


### PR DESCRIPTION
## Summary

Skip `maven-source-plugin` and `maven-javadoc-plugin` execution in CI workflows. These plugins generate source and javadoc JARs that CI never publishes — they're only needed for releases (`-Prelease`).

Closes #8338

## Baseline Timings (before)

From 3 green runs on `main` (June 22, 2026) — see backlog doc-4:

| Shard | Average |
|-------|---------|
| Build Java | 7m31s |
| UT app-rest | 6m58s |
| UT app-sql | 6m09s |
| UT app-kafkasql | 7m45s |
| UT app-gitops | 5m25s |
| UT app-kubernetesops | 4m30s |
| UT app-other | 13m49s |
| UT non-app | 7m48s |

**After-merge timings will be recorded from 3 green runs and added here.**

## Changes

- `verify-build.yaml`: add `-Dmaven.source.skip=true -Dmaven.javadoc.skip=true` to the build command
- `verify-unit-tests.yaml`: add the same flags to the unit test command

## What's NOT affected

- Release builds (`-Prelease`) — flags are only in CI workflow YAML, not in `pom.xml`
- Integration tests — they already skip javadoc via `-Dmaven.javadoc.skip=true`
- Local development — no changes to `pom.xml`

## Testing

- [x] Local `mvn package` with skip flags succeeds (BUILD SUCCESS)
- [x] No source/javadoc JARs produced in `app/target/`
- [ ] CI fully green (pending)

## Part of

Maven Build Optimization series (milestone m-4). Each optimization is a separate PR so the team can evaluate and keep/revert independently.