### PR TITLE
[CI Optimization] Skip checkstyle in unit test shards

### DIFF
--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -83,5 +83,6 @@ jobs:
             ${{ matrix.shard.test-filter }} \
             -Dsurefire.failIfNoSpecifiedTests=false \
             -DskipCommitIdPlugin=false \
+            -Dcheckstyle.skip=true \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
             -Dmaven.wagon.http.retryHandler.count=5


### PR DESCRIPTION
## Summary

Skip checkstyle in unit test shards — it already runs in the build step (`mvn package` includes the `validate` phase). Running it again in 7 parallel shards is redundant.

Closes #8340

## Baseline Timings (before)

From 3 green runs on `main` (June 22, 2026) — see backlog doc-4:

| Shard | Average |
|-------|---------|
| UT app-rest | 6m58s |
| UT app-sql | 6m09s |
| UT app-kafkasql | 7m45s |
| UT app-gitops | 5m25s |
| UT app-kubernetesops | 4m30s |
| UT app-other | 13m49s |
| UT non-app | 7m48s |

**After-merge timings will be recorded from 3 green runs and added here.**

## Changes

- `verify-unit-tests.yaml`: add `-Dcheckstyle.skip=true` to the `mvn verify` command

## What's NOT affected

- Build step still runs checkstyle (catches violations before unit tests start)
- Release builds — no changes to `pom.xml`
- Local development — no changes to `pom.xml`

## Testing

- [ ] CI fully green (pending)
- Checkstyle enforcement guaranteed by build step running before unit tests in the pipeline

## Part of

Maven Build Optimization series (milestone m-4). Each optimization is a separate PR so the team can evaluate and keep/revert independently.