### PR TITLE
[CI Optimization] Skip git-commit-id plugin in unit test shards

### DIFF
--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -82,7 +82,7 @@ jobs:
             -Pprod ${{ matrix.shard.modules }} \
             ${{ matrix.shard.test-filter }} \
             -Dsurefire.failIfNoSpecifiedTests=false \
-            -DskipCommitIdPlugin=false \
+            -DskipCommitIdPlugin=true \
             -Dcheckstyle.skip=true \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
             -Dmaven.wagon.http.retryHandler.count=5


### PR DESCRIPTION
## Summary

Skip the `git-commit-id-maven-plugin` in unit test shards. The build step already generates `target/meta/git.properties` and uploads it as a build artifact. Unit test shards download these pre-built artifacts, so running the plugin again is redundant.

Closes #8342

## Baseline Timings (before)

From 3 green runs on `main` (June 22, 2026) — see backlog doc-4.

**After-merge timings will be recorded from 3 green runs and added here.**

## Changes

- `verify-unit-tests.yaml`: change `-DskipCommitIdPlugin=false` to `-DskipCommitIdPlugin=true`

## What's NOT affected

- Build step still generates `git.properties` (it uses `-DskipCommitIdPlugin=false`)
- Release builds — no changes to `pom.xml`

## Testing

- [ ] CI fully green (pending)

## Part of

Maven Build Optimization series (milestone m-4). Each optimization is a separate PR so the team can evaluate and keep/revert independently.