### PR TITLE
fix(ci): equalize MAVEN_OPTS to -Xmx4g for all unit test shards

### DIFF
--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -37,11 +37,11 @@ jobs:
           - name: app-gitops
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=io.apicurio.registry.storage.impl.gitops.**"
-            maven-opts: "-Xmx2g"
+            maven-opts: "-Xmx4g"
           - name: app-kubernetesops
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=io.apicurio.registry.storage.impl.kubernetesops.**"
-            maven-opts: "-Xmx2g"
+            maven-opts: "-Xmx4g"
           - name: app-other
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=!io.apicurio.registry.noprofile.rest.**,!io.apicurio.registry.noprofile.ccompat.**,!io.apicurio.registry.storage.**,!io.apicurio.registry.event.**"

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -49,7 +49,7 @@ jobs:
           - name: non-app
             modules: "-Dfull -DcliSkipNative -pl !app,!distro/docker,!docs,!docs/config-generator,!docs/rest-api"
             test-filter: ""
-            maven-opts: "-Xmx2g"
+            maven-opts: "-Xmx4g"
     steps:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6


### PR DESCRIPTION
## Summary

Equalize MAVEN_OPTS from `-Xmx2g` to `-Xmx4g` for `app-gitops` and `app-kubernetesops` unit test shards, matching all other shards. Defense-in-depth alongside the assembly skip flag from PR #8277.

Closes #8344

## Changes

- `verify-unit-tests.yaml`: change `app-gitops` and `app-kubernetesops` maven-opts from `-Xmx2g` to `-Xmx4g`

## What's NOT affected

- GitHub Actions runners have 7GB RAM — 4g is well within budget
- All other shards already use `-Xmx4g`
- No changes to `pom.xml` or local development

## Testing

- [ ] CI fully green (pending)

## Part of

Maven Build Optimization series (milestone m-4). Each optimization is a separate PR so the team can evaluate and keep/revert independently.