### PR TITLE
[CI Reliability] Replace ttl.sh with workflow artifacts for operator test images

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -11,9 +11,11 @@ permissions:
   contents: read
 
 env:
-  REGISTRY_APP_IMAGE: ttl.sh/apicurio-registry-${{ github.sha }}:8h
-  REGISTRY_GITOPS_SYNC_IMAGE: ttl.sh/apicurio-registry-gitops-sync-${{ github.sha }}:8h
-  IMAGE: ttl.sh/apicurio-registry-3-operator-${{ github.sha }}:8h
+  # Non-OLM test shards use workflow artifacts + minikube image load (no registry needed).
+  # OLM shards still need ttl.sh because OLM itself pulls bundle/catalog images.
+  REGISTRY_APP_IMAGE: localhost/apicurio-registry:${{ github.sha }}
+  REGISTRY_GITOPS_SYNC_IMAGE: localhost/apicurio-registry-gitops-sync:${{ github.sha }}
+  IMAGE: localhost/apicurio-registry-3-operator:${{ github.sha }}
   BUNDLE_IMAGE: ttl.sh/apicurio-registry-3-operator-bundle-${{ github.sha }}:8h
   CATALOG_IMAGE: ttl.sh/apicurio-registry-3-operator-catalog-${{ github.sha }}:8h
 
@@ -39,30 +41,27 @@ jobs:
       - name: Build
         run: ./mvnw -B clean package -Dfull -pl app,distro/docker,operator/olm-tests -am -Pprod -DskipTests -Dmaven.javadoc.skip
 
-      # We need to push the operand image to ttl.sh so test matrix jobs on separate runners can pull it.
-      - name: Build and push temporary operand image
+      - name: Build operand image
         run: |
           docker build -f ./distro/docker/target/docker/Dockerfile.jvm -t "$REGISTRY_APP_IMAGE" ./distro/docker/target/docker
-          docker push "$REGISTRY_APP_IMAGE"
 
-      - name: Build and push temporary GitOps sync sidecar image
+      - name: Build GitOps sync sidecar image
         run: |
           docker build -t "$REGISTRY_GITOPS_SYNC_IMAGE" ./distro/gitops
-          docker push "$REGISTRY_GITOPS_SYNC_IMAGE"
 
-      # We need to push the bundle image because opm always pulls; the catalog image because OLM
-      # deploys it with `imagePullPolicy: Always`; and also the operator image itself for the same reason.
-      - name: Build and push temporary operator image
+      - name: Build operator image
         working-directory: operator
         run: |
-          make image-build image-push
+          make image-build
 
-      - name: Build and push temporary operator bundle
+      # OLM bundle and catalog must be pushed to a registry because OLM pulls them directly.
+      # ttl.sh is kept only for these two images.
+      - name: Build and push OLM bundle (ttl.sh)
         working-directory: operator
         run: |
           make ROLLING_CHANNEL=3.x bundle
 
-      - name: Build and push temporary operator catalog
+      - name: Build and push OLM catalog (ttl.sh)
         working-directory: operator
         run: |
           make ROLLING_CHANNEL=3.x catalog
@@ -71,6 +70,21 @@ jobs:
         working-directory: operator
         run: |
           make INSTALL_FILE=controller/target/test-install.yaml dist-install-file
+
+      # Save Docker images as artifacts so test shards can load them without a registry.
+      # This replaces ttl.sh for the operand, operator, and gitops-sync images.
+      - name: Save Docker images
+        run: |
+          docker save "$REGISTRY_APP_IMAGE" -o /tmp/operator-test-registry-app.tar
+          docker save "$REGISTRY_GITOPS_SYNC_IMAGE" -o /tmp/operator-test-gitops-sync.tar
+          docker save "$IMAGE" -o /tmp/operator-test-operator.tar
+
+      - name: Upload Docker images
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: operator-test-images
+          path: /tmp/operator-test-*.tar
+          retention-days: 1
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -180,6 +194,12 @@ jobs:
           name: operator-build-artifacts
           path: operator/
 
+      - name: Download Docker images
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: operator-test-images
+          path: /tmp/
+
       - uses: apicurio/apicurio-github-actions/setup-minikube@97d452c41f1abd7142c0ce2ac37e87922e35e71d # v2
         with:
           driver: 'none'
@@ -187,6 +207,14 @@ jobs:
           olm-enable: ${{ matrix.olm-enable }}
           olm-v1-enable: ${{ matrix.olm-v1-enable }}
           start-args: '--alsologtostderr --v=2'
+
+      # Load pre-built images into the Docker daemon (shared with Minikube via driver: none).
+      # This eliminates ttl.sh dependency for operand, operator, and gitops-sync images.
+      - name: Load Docker images
+        run: |
+          docker load -i /tmp/operator-test-registry-app.tar
+          docker load -i /tmp/operator-test-gitops-sync.tar
+          docker load -i /tmp/operator-test-operator.tar
 
       - name: Run ${{ matrix.name }} tests on Minikube
         working-directory: operator

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -214,8 +214,12 @@ jobs:
       - name: Start local registry
         run: |
           docker run -d -p 5000:5000 --restart=always ghcr.io/distribution/distribution:3.0
-          sleep 2
-          curl -sf http://localhost:5000/v2/ || (echo "Registry not ready"; exit 1)
+          for i in $(seq 1 20); do
+            curl -sf http://localhost:5000/v2/ >/dev/null 2>&1 && break
+            echo "Waiting for registry... ($i/20)"
+            sleep 0.5
+          done
+          curl -sf http://localhost:5000/v2/ || (echo "Registry not ready after 10s"; exit 1)
 
       # Load pre-built images into Docker, then push to the local registry.
       # Operator/operand/gitops-sync use localhost:5000; bundle/catalog use ttl.sh.

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -131,14 +131,6 @@ jobs:
     name: Remote Tests (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: operator-build
-    # OLM shards need a local registry so Kubernetes/OLM can pull bundle/catalog images.
-    # Non-OLM shards use docker load + imagePullPolicy: IfNotPresent (no registry needed,
-    # but we start one anyway for simplicity — all shards use the same image refs).
-    services:
-      registry:
-        image: ghcr.io/distribution/distribution:3.0
-        ports:
-          - 5000:5000
     strategy:
       fail-fast: false
       matrix:
@@ -217,10 +209,16 @@ jobs:
           olm-v1-enable: ${{ matrix.olm-v1-enable }}
           start-args: '--alsologtostderr --v=2'
 
+      # Start a local registry AFTER Minikube setup. The services: block doesn't
+      # survive Minikube's Docker reconfiguration with driver: none.
+      - name: Start local registry
+        run: |
+          docker run -d -p 5000:5000 --restart=always ghcr.io/distribution/distribution:3.0
+          sleep 2
+          curl -sf http://localhost:5000/v2/ || (echo "Registry not ready"; exit 1)
+
       # Load pre-built images into Docker, then push to the local registry.
-      # With driver: none, localhost:5000 is accessible to both Docker and Kubernetes.
-      # Operator/operand/gitops-sync use localhost:5000; bundle/catalog use ttl.sh
-      # (pushed by the build job — OLM pulls them directly from ttl.sh).
+      # Operator/operand/gitops-sync use localhost:5000; bundle/catalog use ttl.sh.
       - name: Load and push images to local registry
         run: |
           docker load -i /tmp/operator-test-operator.tar

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -11,13 +11,13 @@ permissions:
   contents: read
 
 env:
-  # All test images use localhost:5000 (a local registry started in each test shard).
-  # This eliminates the ttl.sh dependency entirely.
+  # Operator/operand/gitops-sync: saved as artifacts, pushed to localhost:5000 in test shards.
+  # Bundle/catalog: pushed to ttl.sh by build job (opm requires HTTPS for catalog-build).
   REGISTRY_APP_IMAGE: localhost:5000/apicurio-registry:${{ github.sha }}
   REGISTRY_GITOPS_SYNC_IMAGE: localhost:5000/apicurio-registry-gitops-sync:${{ github.sha }}
   IMAGE: localhost:5000/apicurio-registry-3-operator:${{ github.sha }}
-  BUNDLE_IMAGE: localhost:5000/apicurio-registry-3-operator-bundle:${{ github.sha }}
-  CATALOG_IMAGE: localhost:5000/apicurio-registry-3-operator-catalog:${{ github.sha }}
+  BUNDLE_IMAGE: ttl.sh/apicurio-registry-3-operator-bundle-${{ github.sha }}:8h
+  CATALOG_IMAGE: ttl.sh/apicurio-registry-3-operator-catalog-${{ github.sha }}:8h
 
 jobs:
 
@@ -54,43 +54,31 @@ jobs:
         run: |
           make image-build
 
-      # Build OLM bundle and catalog. The catalog-build uses opm which needs to pull
-      # the bundle image. We push bundle to the local registry first, then opm pulls it.
-      # Docker needs insecure-registries for localhost:5000 (plain HTTP).
-      # opm uses containers/image library — needs registries.conf to allow HTTP.
-      - name: Start local registry and configure insecure access
-        run: |
-          echo '{"insecure-registries": ["localhost:5000"]}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-          docker run -d -p 5000:5000 ghcr.io/distribution/distribution:3.0
-          mkdir -p $HOME/.config/containers
-          printf 'unqualified-search-registries = ["docker.io"]\n\n[[registry]]\nlocation = "localhost:5000"\ninsecure = true\n' > $HOME/.config/containers/registries.conf
-          sleep 2
-
-      - name: Build and push OLM bundle to local registry
+      # OLM bundle and catalog: opm requires an HTTPS registry to pull the bundle
+      # image during catalog-build. We use ttl.sh for the build step only (opm needs
+      # it), then save the final images as artifacts for test shards.
+      - name: Build and push OLM bundle
         working-directory: operator
         run: |
-          make ROLLING_CHANNEL=3.x bundle-build bundle-image-build bundle-image-push
+          make ROLLING_CHANNEL=3.x bundle
 
-      - name: Build OLM catalog
+      - name: Build and push OLM catalog
         working-directory: operator
         run: |
-          make ROLLING_CHANNEL=3.x catalog-build catalog-image-build
+          make ROLLING_CHANNEL=3.x catalog
 
       - name: Generate install file for tests
         working-directory: operator
         run: |
           make INSTALL_FILE=controller/target/test-install.yaml dist-install-file
 
-      # Save ALL Docker images as artifacts so test shards can load them without any registry.
-      # This completely eliminates the ttl.sh dependency.
+      # Save operator/operand/gitops-sync images as artifacts for test shards.
+      # Bundle/catalog are already on ttl.sh (pushed by make bundle/catalog above).
       - name: Save Docker images
         run: |
           docker save "$REGISTRY_APP_IMAGE" -o /tmp/operator-test-registry-app.tar
           docker save "$REGISTRY_GITOPS_SYNC_IMAGE" -o /tmp/operator-test-gitops-sync.tar
           docker save "$IMAGE" -o /tmp/operator-test-operator.tar
-          docker save "$BUNDLE_IMAGE" -o /tmp/operator-test-bundle.tar
-          docker save "$CATALOG_IMAGE" -o /tmp/operator-test-catalog.tar
 
       - name: Upload Docker images
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -238,18 +226,16 @@ jobs:
 
       # Load pre-built images into Docker, then push to the local registry.
       # With driver: none, localhost:5000 is accessible to both Docker and Kubernetes.
+      # Operator/operand/gitops-sync use localhost:5000; bundle/catalog use ttl.sh
+      # (pushed by the build job — OLM pulls them directly from ttl.sh).
       - name: Load and push images to local registry
         run: |
           docker load -i /tmp/operator-test-operator.tar
           docker load -i /tmp/operator-test-registry-app.tar
           docker load -i /tmp/operator-test-gitops-sync.tar
-          docker load -i /tmp/operator-test-bundle.tar
-          docker load -i /tmp/operator-test-catalog.tar
           docker push "$REGISTRY_APP_IMAGE"
           docker push "$REGISTRY_GITOPS_SYNC_IMAGE"
           docker push "$IMAGE"
-          docker push "$BUNDLE_IMAGE"
-          docker push "$CATALOG_IMAGE"
 
       - name: Run ${{ matrix.name }} tests on Minikube
         working-directory: operator

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -55,10 +55,16 @@ jobs:
           make image-build
 
       # Start a local registry so opm can pull the bundle image during catalog-build.
-      # The catalog-build step uses opm render-template which needs to pull the bundle.
+      # opm uses containers/image library which reads registries.conf for HTTP vs HTTPS.
+      # Docker also needs insecure-registries config for docker push to work.
       - name: Start local registry for OLM build
         run: |
+          sudo mkdir -p /etc/containers/registries.conf.d
+          printf '[[registry]]\nlocation = "localhost:5000"\ninsecure = true\n' | sudo tee /etc/containers/registries.conf.d/localhost.conf
+          echo '{"insecure-registries": ["localhost:5000"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
           docker run -d -p 5000:5000 ghcr.io/distribution/distribution:3.0
+          sleep 2
 
       # Build OLM bundle, push to local registry, then build catalog (which pulls from it).
       - name: Build and push OLM bundle to local registry
@@ -222,6 +228,13 @@ jobs:
           olm-enable: ${{ matrix.olm-enable }}
           olm-v1-enable: ${{ matrix.olm-v1-enable }}
           start-args: '--alsologtostderr --v=2'
+
+      # Configure Docker to allow HTTP push to the local registry (services: block
+      # runs plain HTTP, but Docker defaults to HTTPS for non-localhost pushes).
+      - name: Configure insecure registry
+        run: |
+          echo '{"insecure-registries": ["localhost:5000"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
       # Load pre-built images into Docker, then push to the local registry.
       # With driver: none, localhost:5000 is accessible to both Docker and Kubernetes.

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -54,11 +54,17 @@ jobs:
         run: |
           make image-build
 
-      # Build OLM bundle and catalog images (no push — saved as artifacts like all other images).
-      - name: Build OLM bundle
+      # Start a local registry so opm can pull the bundle image during catalog-build.
+      # The catalog-build step uses opm render-template which needs to pull the bundle.
+      - name: Start local registry for OLM build
+        run: |
+          docker run -d -p 5000:5000 ghcr.io/distribution/distribution:3.0
+
+      # Build OLM bundle, push to local registry, then build catalog (which pulls from it).
+      - name: Build and push OLM bundle to local registry
         working-directory: operator
         run: |
-          make ROLLING_CHANNEL=3.x bundle-build bundle-image-build
+          make ROLLING_CHANNEL=3.x bundle-build bundle-image-build bundle-image-push
 
       - name: Build OLM catalog
         working-directory: operator

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -217,13 +217,6 @@ jobs:
           olm-v1-enable: ${{ matrix.olm-v1-enable }}
           start-args: '--alsologtostderr --v=2'
 
-      # Configure Docker to allow HTTP push to the local registry (services: block
-      # runs plain HTTP, but Docker defaults to HTTPS for non-localhost pushes).
-      - name: Configure insecure registry
-        run: |
-          echo '{"insecure-registries": ["localhost:5000"]}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-
       # Load pre-built images into Docker, then push to the local registry.
       # With driver: none, localhost:5000 is accessible to both Docker and Kubernetes.
       # Operator/operand/gitops-sync use localhost:5000; bundle/catalog use ttl.sh

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -11,13 +11,13 @@ permissions:
   contents: read
 
 env:
-  # Non-OLM test shards use workflow artifacts + minikube image load (no registry needed).
-  # OLM shards still need ttl.sh because OLM itself pulls bundle/catalog images.
-  REGISTRY_APP_IMAGE: localhost/apicurio-registry:${{ github.sha }}
-  REGISTRY_GITOPS_SYNC_IMAGE: localhost/apicurio-registry-gitops-sync:${{ github.sha }}
-  IMAGE: localhost/apicurio-registry-3-operator:${{ github.sha }}
-  BUNDLE_IMAGE: ttl.sh/apicurio-registry-3-operator-bundle-${{ github.sha }}:8h
-  CATALOG_IMAGE: ttl.sh/apicurio-registry-3-operator-catalog-${{ github.sha }}:8h
+  # All test images use localhost:5000 (a local registry started in each test shard).
+  # This eliminates the ttl.sh dependency entirely.
+  REGISTRY_APP_IMAGE: localhost:5000/apicurio-registry:${{ github.sha }}
+  REGISTRY_GITOPS_SYNC_IMAGE: localhost:5000/apicurio-registry-gitops-sync:${{ github.sha }}
+  IMAGE: localhost:5000/apicurio-registry-3-operator:${{ github.sha }}
+  BUNDLE_IMAGE: localhost:5000/apicurio-registry-3-operator-bundle:${{ github.sha }}
+  CATALOG_IMAGE: localhost:5000/apicurio-registry-3-operator-catalog:${{ github.sha }}
 
 jobs:
 
@@ -54,30 +54,31 @@ jobs:
         run: |
           make image-build
 
-      # OLM bundle and catalog must be pushed to a registry because OLM pulls them directly.
-      # ttl.sh is kept only for these two images.
-      - name: Build and push OLM bundle (ttl.sh)
+      # Build OLM bundle and catalog images (no push — saved as artifacts like all other images).
+      - name: Build OLM bundle
         working-directory: operator
         run: |
-          make ROLLING_CHANNEL=3.x bundle
+          make ROLLING_CHANNEL=3.x bundle-build bundle-image-build
 
-      - name: Build and push OLM catalog (ttl.sh)
+      - name: Build OLM catalog
         working-directory: operator
         run: |
-          make ROLLING_CHANNEL=3.x catalog
+          make ROLLING_CHANNEL=3.x catalog-build catalog-image-build
 
       - name: Generate install file for tests
         working-directory: operator
         run: |
           make INSTALL_FILE=controller/target/test-install.yaml dist-install-file
 
-      # Save Docker images as artifacts so test shards can load them without a registry.
-      # This replaces ttl.sh for the operand, operator, and gitops-sync images.
+      # Save ALL Docker images as artifacts so test shards can load them without any registry.
+      # This completely eliminates the ttl.sh dependency.
       - name: Save Docker images
         run: |
           docker save "$REGISTRY_APP_IMAGE" -o /tmp/operator-test-registry-app.tar
           docker save "$REGISTRY_GITOPS_SYNC_IMAGE" -o /tmp/operator-test-gitops-sync.tar
           docker save "$IMAGE" -o /tmp/operator-test-operator.tar
+          docker save "$BUNDLE_IMAGE" -o /tmp/operator-test-bundle.tar
+          docker save "$CATALOG_IMAGE" -o /tmp/operator-test-catalog.tar
 
       - name: Upload Docker images
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -130,6 +131,14 @@ jobs:
     name: Remote Tests (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: operator-build
+    # OLM shards need a local registry so Kubernetes/OLM can pull bundle/catalog images.
+    # Non-OLM shards use docker load + imagePullPolicy: IfNotPresent (no registry needed,
+    # but we start one anyway for simplicity — all shards use the same image refs).
+    services:
+      registry:
+        image: ghcr.io/distribution/distribution:3.0
+        ports:
+          - 5000:5000
     strategy:
       fail-fast: false
       matrix:
@@ -208,21 +217,25 @@ jobs:
           olm-v1-enable: ${{ matrix.olm-v1-enable }}
           start-args: '--alsologtostderr --v=2'
 
-      # Load pre-built images into the Docker daemon (shared with Minikube via driver: none).
-      # This eliminates ttl.sh dependency for operand, operator, and gitops-sync images.
-      - name: Load Docker images
+      # Load pre-built images into Docker, then push to the local registry.
+      # With driver: none, localhost:5000 is accessible to both Docker and Kubernetes.
+      - name: Load and push images to local registry
         run: |
           docker load -i /tmp/operator-test-operator.tar
-      - name: Load operand images
-        if: matrix.olm-enable == 'false'
-        run: |
           docker load -i /tmp/operator-test-registry-app.tar
           docker load -i /tmp/operator-test-gitops-sync.tar
+          docker load -i /tmp/operator-test-bundle.tar
+          docker load -i /tmp/operator-test-catalog.tar
+          docker push "$REGISTRY_APP_IMAGE"
+          docker push "$REGISTRY_GITOPS_SYNC_IMAGE"
+          docker push "$IMAGE"
+          docker push "$BUNDLE_IMAGE"
+          docker push "$CATALOG_IMAGE"
 
       - name: Run ${{ matrix.name }} tests on Minikube
         working-directory: operator
         run: |
-          make BUILD_OPTS="--no-transfer-progress ${{ matrix.extra-build-opts }}" \
+          make BUILD_OPTS="--no-transfer-progress -Dtest.operator.deployment-target=minikube ${{ matrix.extra-build-opts }}" \
             REMOTE_TESTS_ALL_INSTALL_FILE=controller/target/test-install.yaml \
             GROUPS="${{ matrix.groups }}" \
             EXCLUDED_GROUPS="${{ matrix.excluded-groups }}" \

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -212,9 +212,12 @@ jobs:
       # This eliminates ttl.sh dependency for operand, operator, and gitops-sync images.
       - name: Load Docker images
         run: |
+          docker load -i /tmp/operator-test-operator.tar
+      - name: Load operand images
+        if: matrix.olm-enable == 'false'
+        run: |
           docker load -i /tmp/operator-test-registry-app.tar
           docker load -i /tmp/operator-test-gitops-sync.tar
-          docker load -i /tmp/operator-test-operator.tar
 
       - name: Run ${{ matrix.name }} tests on Minikube
         working-directory: operator

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -54,19 +54,19 @@ jobs:
         run: |
           make image-build
 
-      # Start a local registry so opm can pull the bundle image during catalog-build.
-      # opm uses containers/image library which reads registries.conf for HTTP vs HTTPS.
-      # Docker also needs insecure-registries config for docker push to work.
-      - name: Start local registry for OLM build
+      # Build OLM bundle and catalog. The catalog-build uses opm which needs to pull
+      # the bundle image. We push bundle to the local registry first, then opm pulls it.
+      # Docker needs insecure-registries for localhost:5000 (plain HTTP).
+      # opm uses containers/image library — needs registries.conf to allow HTTP.
+      - name: Start local registry and configure insecure access
         run: |
-          sudo mkdir -p /etc/containers/registries.conf.d
-          printf '[[registry]]\nlocation = "localhost:5000"\ninsecure = true\n' | sudo tee /etc/containers/registries.conf.d/localhost.conf
           echo '{"insecure-registries": ["localhost:5000"]}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker run -d -p 5000:5000 ghcr.io/distribution/distribution:3.0
+          mkdir -p $HOME/.config/containers
+          printf 'unqualified-search-registries = ["docker.io"]\n\n[[registry]]\nlocation = "localhost:5000"\ninsecure = true\n' > $HOME/.config/containers/registries.conf
           sleep 2
 
-      # Build OLM bundle, push to local registry, then build catalog (which pulls from it).
       - name: Build and push OLM bundle to local registry
         working-directory: operator
         run: |


### PR DESCRIPTION
## Summary

Replace `ttl.sh` with workflow artifacts (`docker save`/`docker load`) for 3 of 5 operator test images, eliminating the primary cause of CI flakes (~25% failure rate on `main`).

Closes #8348

## Problem

Operator tests push images to `ttl.sh` (a free, zero-SLA ephemeral registry). Test shards on separate runners pull them via Kubernetes. When `ttl.sh` is slow, pods fail readiness checks within the awaitility timeout, causing `ConditionTimeoutException`.

This has been a recurring problem — the project has tried `ghcr.io` (#6387, #6420), `quay.io` (#6426), and workflow artifacts (#6432) for non-operator workflows. The operator was never migrated because its test shards deploy pods that pull from a registry.

## Solution

**Key insight**: Minikube uses `driver: none`, which means the Docker daemon on the runner IS the Minikube Docker daemon. `docker load` makes images immediately available to Kubernetes without a registry pull. The test code already patches `imagePullPolicy` to `IfNotPresent` on Minikube (`ITBase.createTestResources` line 283).

### What changed

| Image | Before | After |
|-------|--------|-------|
| Operand (registry app) | `ttl.sh` push/pull | `docker save` → artifact → `docker load` |
| GitOps sync sidecar | `ttl.sh` push/pull | `docker save` → artifact → `docker load` |
| Operator | `ttl.sh` push/pull | `docker save` → artifact → `docker load` |
| OLM Bundle | `ttl.sh` push/pull | **Unchanged** — OLM pulls directly |
| OLM Catalog | `ttl.sh` push/pull | **Unchanged** — OLM pulls directly |

### What's still on ttl.sh

OLM bundle and catalog images stay on `ttl.sh` because OLM itself needs to pull them from a registry — this only affects 2 of 8 test shards (olm-v0, olm-v1).

## Testing

- [ ] All 6 non-OLM operator test shards pass (smoke, kafka, auth, database, feature, feature-setup)
- [ ] OLM test shards pass (olm-v0, olm-v1) — still use ttl.sh for bundle/catalog
- [ ] `operator-check-install` passes — install file unaffected
- [ ] Non-operator CI jobs unaffected

## Related

- #6282 — first ttl.sh reliability issues
- #6387 — ghcr migration (non-operator only)
- #6420 — ghcr for operator (closed — fork PR limitation)
- #6432 — workflow artifacts for non-operator (current approach)
- #7487 — operator test parallelization (kept ttl.sh)