### PR TITLE
[CI Optimization] Add -Dquick profile for fast builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1300,6 +1300,23 @@
       </properties>
     </profile>
     <profile>
+      <id>quick</id>
+      <activation>
+        <property>
+          <name>quick</name>
+        </property>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+        <skipITs>true</skipITs>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.source.skip>true</maven.source.skip>
+        <checkstyle.skip>true</checkstyle.skip>
+        <skipCommitIdPlugin>true</skipCommitIdPlugin>
+        <assembly.skipAssembly>true</assembly.skipAssembly>
+      </properties>
+    </profile>
+    <profile>
       <id>non-essential</id>
       <activation>
         <property>


### PR DESCRIPTION
## Summary

Add a `quick` profile to the parent POM that bundles all common skip flags into a single `-Dquick` property.

Before:
```bash
./mvnw package -DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip=true \
  -Dcheckstyle.skip=true -DskipCommitIdPlugin=true -Dassembly.skipAssembly=true
```

After:
```bash
./mvnw package -Dquick
```

Closes #8355

## What's skipped by -Dquick

| Plugin | Property |
|--------|----------|
| Tests (surefire) | `skipTests=true` |
| Integration tests (failsafe) | `skipITs=true` |
| Javadoc | `maven.javadoc.skip=true` |
| Source JARs | `maven.source.skip=true` |
| Checkstyle | `checkstyle.skip=true` |
| Git commit ID | `skipCommitIdPlugin=true` |
| Assembly | `assembly.skipAssembly=true` |

## Industry precedent

| Project | Flag | Modules |
|---------|------|---------|
| Debezium | `-Dquick` | ~40 |
| Quarkus | `-Dquickly` | ~600 |
| Apache Flink | `-Dfast` | ~30 |
| SmallRye | `-Dquickly` | ~10-15 |

## What's NOT affected

- Release builds (`-Prelease`) — the `quick` property is not set
- Normal `./mvnw verify` — profile only activates when `-Dquick` is explicitly passed
- No behavioral changes to existing builds

## Testing

- [x] `./mvnw package -Dquick -pl app -am` produces main JAR (12:42 min)
- [x] No source JAR, javadoc JAR, or assembly archive produced
- [x] No checkstyle execution
- [ ] CI fully green (pending)

## Part of

Maven Build Optimization series (milestone m-4). Inspired by research across 17 open-source Java projects (see backlog doc-5).