### PR TITLE
fix(storage): let DatabaseConfigInterceptor derive datasource activation from apicurio.storage.sql.kind (#8205)

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -239,12 +239,6 @@ apicurio.storage.sql.kind=h2
 apicurio.sql.init=true
 apicurio.sql.db-schema=*
 
-## Datasource activation (managed by DatabaseConfigInterceptor based on apicurio.storage.sql.kind)
-quarkus.datasource.h2.active=true
-quarkus.datasource.postgresql.active=false
-quarkus.datasource.mysql.active=false
-quarkus.datasource.mssql.active=false
-
 apicurio.datasource.url=jdbc:h2:mem:db_${quarkus.uuid}
 apicurio.datasource.username=sa
 apicurio.datasource.password=sa

--- a/app/src/test/java/io/apicurio/registry/event/kafkasql/KafkaSqlEventsTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/event/kafkasql/KafkaSqlEventsTestProfile.java
@@ -11,8 +11,6 @@ public class KafkaSqlEventsTestProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
         return Map.of("apicurio.storage.kind", "kafkasql",
-                "quarkus.datasource.h2.active", "true",
-                "quarkus.datasource.postgresql.active", "false",
                 "apicurio.rest.deletion.artifact.enabled", "true",
                 "apicurio.rest.deletion.artifact-version.enabled", "true",
                 "apicurio.rest.deletion.group.enabled", "true");

--- a/app/src/test/java/io/apicurio/registry/event/sql/EventsTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/EventsTestProfile.java
@@ -11,8 +11,6 @@ public class EventsTestProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
         return Map.of("apicurio.storage.sql.kind", "postgresql",
-                "quarkus.datasource.h2.active", "false",
-                "quarkus.datasource.postgresql.active", "true",
                 "apicurio.rest.deletion.artifact.enabled", "true",
                 "apicurio.rest.deletion.artifact-version.enabled", "true",
                 "apicurio.rest.deletion.group.enabled", "true");

--- a/app/src/test/java/io/apicurio/registry/storage/util/KubernetesOpsTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/storage/util/KubernetesOpsTestProfile.java
@@ -12,9 +12,7 @@ public class KubernetesOpsTestProfile implements QuarkusTestProfile {
     public Map<String, String> getConfigOverrides() {
         return Map.of(
                 "apicurio.storage.sql.kind", "h2",
-                "apicurio.storage.kind", "kubernetesops",
-                "quarkus.datasource.h2.active", "true",
-                "quarkus.datasource.postgresql.active", "false"
+                "apicurio.storage.kind", "kubernetesops"
         );
     }
 

--- a/app/src/test/java/io/apicurio/registry/storage/util/MssqlTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/storage/util/MssqlTestProfile.java
@@ -11,9 +11,7 @@ public class MssqlTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of("apicurio.storage.sql.kind", "mssql",
-                "quarkus.datasource.h2.active", "false",
-                "quarkus.datasource.mssql.active", "true");
+        return Map.of("apicurio.storage.sql.kind", "mssql");
     }
 
     @Override

--- a/app/src/test/java/io/apicurio/registry/storage/util/MysqlTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/storage/util/MysqlTestProfile.java
@@ -11,9 +11,7 @@ public class MysqlTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of("apicurio.storage.sql.kind", "mysql",
-                "quarkus.datasource.h2.active", "false",
-                "quarkus.datasource.mysql.active", "true");
+        return Map.of("apicurio.storage.sql.kind", "mysql");
     }
 
     @Override

--- a/app/src/test/java/io/apicurio/registry/storage/util/PostgresqlTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/storage/util/PostgresqlTestProfile.java
@@ -11,9 +11,7 @@ public class PostgresqlTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of("apicurio.storage.sql.kind", "postgresql",
-                "quarkus.datasource.h2.active", "false",
-                "quarkus.datasource.postgresql.active", "true");
+        return Map.of("apicurio.storage.sql.kind", "postgresql");
     }
 
     @Override

--- a/integration-tests/src/test/resources/infra/sql/registry-sql-secured.yml
+++ b/integration-tests/src/test/resources/infra/sql/registry-sql-secured.yml
@@ -23,10 +23,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: APICURIO_STORAGE_SQL_KIND
               value: "postgresql"
-            - name: QUARKUS_DATASOURCE_H2_ACTIVE
-              value: "false"
-            - name: QUARKUS_DATASOURCE_POSTGRESQL_ACTIVE
-              value: "true"
             - name: APICURIO_DATASOURCE_URL
               value: jdbc:postgresql://postgresql-service:5432/registry
             - name: APICURIO_DATASOURCE_USERNAME

--- a/integration-tests/src/test/resources/infra/sql/registry-sql.yml
+++ b/integration-tests/src/test/resources/infra/sql/registry-sql.yml
@@ -23,10 +23,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: APICURIO_STORAGE_SQL_KIND
               value: "postgresql"
-            - name: QUARKUS_DATASOURCE_H2_ACTIVE
-              value: "false"
-            - name: QUARKUS_DATASOURCE_POSTGRESQL_ACTIVE
-              value: "true"
             - name: APICURIO_DATASOURCE_URL
               value: jdbc:postgresql://postgresql-service:5432/registry
             - name: APICURIO_DATASOURCE_USERNAME

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/feat/SqlStorage.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/feat/SqlStorage.java
@@ -55,9 +55,6 @@ public class SqlStorage {
                         addEnvVar(env, new EnvVarBuilder().withName(ENV_APICURIO_STORAGE_SQL_KIND)
                                 .withValue(sqlKind).build());
 
-                        // Explicitly activate the appropriate Quarkus named datasource
-                        configureDatasourceActivation(storageType, env);
-
                         // Configure datasource connection details
                         addEnvVar(env, new EnvVarBuilder().withName(ENV_APICURIO_DATASOURCE_URL)
                                 .withValue(url).build());
@@ -117,47 +114,4 @@ public class SqlStorage {
         }
     }
 
-    /**
-     * Configures Quarkus datasource activation flags based on the storage type.
-     * Explicitly activates the correct named datasource and deactivates others.
-     *
-     * @param storageType the storage type from the CR
-     * @param env the environment variables map to populate
-     */
-    private static void configureDatasourceActivation(StorageType storageType, Map<String, EnvVar> env) {
-        // H2 is always inactive for operator-managed deployments
-        addEnvVar(env, new EnvVarBuilder()
-                .withName("QUARKUS_DATASOURCE_H2_ACTIVE")
-                .withValue("false")
-                .build());
-
-        // Activate the appropriate datasource based on storage type
-        if (storageType == StorageType.POSTGRESQL) {
-            addEnvVar(env, new EnvVarBuilder()
-                    .withName("QUARKUS_DATASOURCE_POSTGRESQL_ACTIVE")
-                    .withValue("true")
-                    .build());
-            addEnvVar(env, new EnvVarBuilder()
-                    .withName("QUARKUS_DATASOURCE_MYSQL_ACTIVE")
-                    .withValue("false")
-                    .build());
-            addEnvVar(env, new EnvVarBuilder()
-                    .withName("QUARKUS_DATASOURCE_MSSQL_ACTIVE")
-                    .withValue("false")
-                    .build());
-        } else if (storageType == StorageType.MYSQL) {
-            addEnvVar(env, new EnvVarBuilder()
-                    .withName("QUARKUS_DATASOURCE_POSTGRESQL_ACTIVE")
-                    .withValue("false")
-                    .build());
-            addEnvVar(env, new EnvVarBuilder()
-                    .withName("QUARKUS_DATASOURCE_MYSQL_ACTIVE")
-                    .withValue("true")
-                    .build());
-            addEnvVar(env, new EnvVarBuilder()
-                    .withName("QUARKUS_DATASOURCE_MSSQL_ACTIVE")
-                    .withValue("false")
-                    .build());
-        }
-    }
 }

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/KafkasqlAuthTestProfile.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/KafkasqlAuthTestProfile.java
@@ -11,8 +11,6 @@ public class KafkasqlAuthTestProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
         return Map.of("apicurio.storage.kind", "kafkasql",
-                "quarkus.datasource.h2.active", "true",
-                "quarkus.datasource.postgresql.active", "false",
                 "apicurio.rest.deletion.group.enabled", "true",
                 "apicurio.rest.deletion.artifact.enabled", "true",
                 "apicurio.rest.deletion.artifact-version.enabled", "true");

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/KafkasqlTestProfile.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/KafkasqlTestProfile.java
@@ -10,9 +10,7 @@ public class KafkasqlTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of("apicurio.storage.kind", "kafkasql",
-                "quarkus.datasource.h2.active", "true",
-                "quarkus.datasource.postgresql.active", "false");
+        return Map.of("apicurio.storage.kind", "kafkasql");
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Remove hardcoded `quarkus.datasource.*.active` defaults from `application.properties` that
  were defeating `DatabaseConfigInterceptor` — the interceptor's `context.proceed()` check
  could not distinguish these baked-in defaults from explicit user overrides, making the
  `apicurio.storage.sql.kind`-based derivation unreachable dead code
- Remove redundant `QUARKUS_DATASOURCE_*_ACTIVE` env var workarounds from integration test
  deployment YAMLs, all 8 test profiles, and the Kubernetes operator's `SqlStorage` class
- The `DatabaseConfigInterceptor` now correctly derives datasource activation everywhere,
  and tests exercise the interceptor in context rather than bypassing it

## Related Issue
Fixes #8205

## Test Plan
- [ ] Verify `DatabaseConfigInterceptorTest` passes: `./mvnw test -pl app -Dtest=DatabaseConfigInterceptorTest`
- [ ] Run full unit test suite for the `app` module: `./mvnw test -pl app`
- [ ] Run PostgreSQL storage tests to verify the interceptor activates the correct datasource
- [ ] Run KafkaSQL storage tests to verify h2 activation for kafkasql mode
- [ ] Verify operator builds cleanly: `./mvnw clean install -pl operator/controller -DskipTests`
- [ ] Manual Docker test: start with `APICURIO_STORAGE_SQL_KIND=postgresql` (no explicit
  `QUARKUS_DATASOURCE_*_ACTIVE` env vars) and confirm successful startup