### PR TITLE
[CI Reliability] Don't trigger operator tests for non-operator workflow changes

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -85,6 +85,8 @@ jobs:
               - 'operator/**'
             ci:
               - '.github/workflows/**'
+            ci-operator:
+              - '.github/workflows/operator.yaml'
 
       - name: Evaluate scope and decide
         id: decide
@@ -154,6 +156,7 @@ jobs:
           OPERATOR='${{ steps.filter.outputs.operator }}'
           GO_SDK_GEN='${{ steps.filter.outputs.go-sdk-gen }}'
           CI='${{ steps.filter.outputs.ci }}'
+          CI_OPERATOR='${{ steps.filter.outputs.ci-operator }}'
 
           # ── Phase 3: Combine scope + changes into per-phase decisions ─
           # decide <output-name> <scope-flag> <change-flags...>
@@ -180,7 +183,7 @@ jobs:
           decide run-extras      "$run_full"  "$IS_PUSH" "$JAVA" "$UI" "$CI"
           decide run-sdk         "$run_full"  "$IS_PUSH" "$SDK" "$JAVA" "$CI"
           decide run-cli         "$run_full"  "$CLI"
-          decide run-operator   "$run_full"  "$IS_PUSH" "$OPERATOR" "$CI"
+          decide run-operator   "$run_full"  "$IS_PUSH" "$OPERATOR" "$CI_OPERATOR"
           decide run-go-sdk-freshness "$run_smoke" "$GO_SDK_GEN" "$CI"
 
       - name: Save decision summary


### PR DESCRIPTION
## Summary

Add a `ci-operator` path filter and use it instead of the broad `ci` filter for the operator test decision. This prevents the flaky 8-shard operator test matrix from running on PRs that only modify non-operator workflow files.

Closes #8368

## Problem

The `ci: '.github/workflows/**'` path filter triggers ALL test phases when any workflow file changes — including operator tests. Our recent CI optimization PRs (#8339, #8341, #8343, #8347, #8353) only touched `verify-*.yaml` files but ran the full operator matrix every time, hitting ~25% failure rate from ttl.sh/Minikube flakes.

## Changes

- `verify.yaml`: add `ci-operator: '.github/workflows/operator.yaml'` path filter
- `verify.yaml`: change operator decision from `$CI` to `$CI_OPERATOR`

## When operator tests run (after this change)

| Trigger | Runs? |
|---------|-------|
| Push to main | Yes (via `$IS_PUSH`) |
| PR changes `operator/**` | Yes (via `$OPERATOR`) |
| PR changes `.github/workflows/operator.yaml` | Yes (via `$CI_OPERATOR`) |
| PR changes only `verify-unit-tests.yaml` etc. | **No** (previously: yes) |

## Testing

- [ ] CI fully green (pending)
- This PR itself only touches `verify.yaml`, so operator tests should NOT run (self-validating!)

## Part of

CI Reliability series (milestone m-5).