### PR TITLE
[CI Reliability] Fix Debezium MySQL integration test flake

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/deployment/DebeziumDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/DebeziumDeploymentManager.java
@@ -293,8 +293,8 @@ public class DebeziumDeploymentManager {
                 System.setProperty("debezium.mysql.host", mysqlClusterIP);
                 System.setProperty("debezium.mysql.port", "3306");
                 System.setProperty("debezium.mysql.database", "registry");
-                System.setProperty("debezium.mysql.username", "mysqluser");
-                System.setProperty("debezium.mysql.password", "mysqlpw");
+                System.setProperty("debezium.mysql.username", "root");
+                System.setProperty("debezium.mysql.password", "debezium");
                 LOGGER.info("MySQL JDBC URL: {}", mysqlJdbcUrl);
             } else {
                 LOGGER.error("Failed to get MySQL service");
@@ -446,37 +446,31 @@ public class DebeziumDeploymentManager {
         }
     }
 
-    /**
-     * Waits for Debezium Connect to be ready by checking the REST API health endpoint.
-     * Uses the external LoadBalancer service to check readiness via localhost.
-     */
     private static void waitForDebeziumConnectReady(boolean useLocalConverters) {
         String serviceName = useLocalConverters ? DEBEZIUM_CONNECT_LOCAL_SERVICE : DEBEZIUM_CONNECT_SERVICE;
-        String externalServiceName = useLocalConverters ?
-                "debezium-connect-local-service-external" : "debezium-connect-service-external";
 
         LOGGER.info("Waiting for Debezium Connect service {} to be ready ##################################################", serviceName);
 
-        // Get the LoadBalancer service
         Service service = kubernetesClient.services()
                 .inNamespace(TEST_NAMESPACE)
-                .withName(externalServiceName)
+                .withName(serviceName)
                 .get();
 
         if (service == null) {
-            LOGGER.error("Debezium Connect LoadBalancer service {} not found", externalServiceName);
-            throw new RuntimeException("Debezium Connect service " + externalServiceName + " not found");
+            LOGGER.error("Debezium Connect service {} not found", serviceName);
+            throw new RuntimeException("Debezium Connect service " + serviceName + " not found");
         }
 
-        // Wait for LoadBalancer to get an external IP (minikube tunnel assigns it)
-        LOGGER.info("Waiting for LoadBalancer external IP to be assigned (requires minikube tunnel)...");
         try {
-            // In minikube with tunnel, the service should be accessible via localhost
-            // Let's wait a bit and then try to connect
             Thread.sleep(CONNECT_READY_INITIAL_DELAY_MS);
 
-            String port = useLocalConverters ? "8084" : "8083";
-            String connectUrl = "http://localhost:" + port;
+            // On Linux/CI (driver:none), ClusterIPs are directly routable — no tunnel needed.
+            // On macOS, use localhost via minikube tunnel (routes to LoadBalancer external service).
+            boolean macOS = System.getProperty("os.name").contains("Mac OS");
+            String host = macOS ? "localhost" : service.getSpec().getClusterIP();
+            // ClusterIP services always expose 8083; LoadBalancer external uses 8084 for local converters
+            String port = macOS ? (useLocalConverters ? "8084" : "8083") : "8083";
+            String connectUrl = "http://" + host + ":" + port;
             LOGGER.info("Checking Debezium Connect readiness at: {}", connectUrl);
 
             int attempt = 0;
@@ -523,7 +517,7 @@ public class DebeziumDeploymentManager {
                 String diagnosis;
                 if (httpResponseCount == 0) {
                     diagnosis = "All " + CONNECT_READY_MAX_ATTEMPTS + " attempts got Connection refused — " +
-                            "this is a routing issue, not a startup timeout. Check minikube tunnel status.";
+                            "this is a routing issue, not a startup timeout. Check service " + serviceName + " at " + connectUrl;
                 } else if (connectionRefusedCount == 0) {
                     diagnosis = "All attempts reached the server but never got HTTP 200 (last status: " +
                             lastStatusCode + ") — startup is too slow or the service is unhealthy.";

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
@@ -150,12 +150,12 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         insertCustomer(tableName, "Alice Smith", "alice@example.com");
         insertCustomer(tableName, "Bob Jones", "bob@example.com");
 
-        List<GenericRecord> events = consumeAvroEvents(topicName, 2, Duration.ofSeconds(10));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 2, Duration.ofSeconds(20));
         assertEquals(2, events.size(), "Expected 2 CDC events");
 
         GenericRecord firstEvent = events.get(0);
@@ -188,7 +188,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         // INSERT
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
@@ -282,14 +282,14 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
         String topic3 = getTopicNameForTable(table3);
 
         consumer.subscribe(List.of(topic1, topic2, topic3));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + table1 + " (order_number, total) VALUES ('ORD-001', 99.99)");
         executeUpdate("INSERT INTO " + table2 + " (order_id, product_name, quantity) VALUES (1, 'Laptop', 1)");
         executeUpdate("INSERT INTO " + table3 + " (sku, stock_count) VALUES ('SKU-123', 50)");
 
         List<ConsumerRecord<byte[], byte[]>> allRecords = new ArrayList<>();
-        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+        Unreliables.retryUntilTrue(15, TimeUnit.SECONDS, () -> {
             consumer.poll(Duration.ofMillis(500)).forEach(allRecords::add);
             return allRecords.size() >= 3;
         });
@@ -323,13 +323,13 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
         // Using shared connector from @BeforeAll
         // Note: Shared connector already has schema.name.adjustment.mode and field.name.adjustment.mode set to "avro"
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName +
                 " (`first-name`, `last name`, `email@address`) VALUES " +
                 "('John', 'Doe', 'john@example.com')");
 
-        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
         assertEquals(1, events.size());
 
         GenericRecord event = events.get(0);
@@ -358,11 +358,11 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (name) VALUES ('Original')");
 
-        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
         assertEquals(1, events1.size());
 
         waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
@@ -373,7 +373,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         executeUpdate("INSERT INTO " + tableName + " (name, email) VALUES ('New Record', 'test@example.com')");
 
-        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
         assertEquals(1, events2.size());
 
         GenericRecord newEvent = events2.get(0);
@@ -407,7 +407,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('test')");
         waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
@@ -447,19 +447,19 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (field1) VALUES ('v1')");
-        consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
         waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
 
         executeUpdate("ALTER TABLE " + tableName + " ADD COLUMN field2 VARCHAR(100)");
         executeUpdate("INSERT INTO " + tableName + " (field1, field2) VALUES ('v2', 'data2')");
-        consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
 
         executeUpdate("ALTER TABLE " + tableName + " ADD COLUMN field3 INT");
         executeUpdate("INSERT INTO " + tableName + " (field1, field2, field3) VALUES ('v3', 'data3', 123)");
-        consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
 
         var versions = registryClient.groups().byGroupId("default")
                 .artifacts().byArtifactId(topicName + "-value")
@@ -496,7 +496,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
                 "INSERT INTO " + tableName +
@@ -512,7 +512,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
             stmt.executeUpdate();
         }
 
-        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
         assertEquals(1, events.size());
 
         GenericRecord event = events.get(0);
@@ -545,7 +545,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
                 "INSERT INTO " + tableName + " (price, tax_rate, weight, quantity) VALUES (?, ?, ?, ?)")) {
@@ -556,7 +556,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
             stmt.executeUpdate();
         }
 
-        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
         assertEquals(1, events.size());
 
         GenericRecord event = events.get(0);
@@ -587,7 +587,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         int totalRows = 1000;
         int batchSize = 100;
@@ -631,14 +631,14 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('before')");
-        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
         assertEquals(1, events1.size());
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('after')");
-        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
         assertEquals(1, events2.size());
 
         GenericRecord afterEvent = events2.get(0);


### PR DESCRIPTION
## Summary

- Fix `DebeziumMySQLAvroIntegrationIT` CI flake caused by unreliable LoadBalancer routing with minikube `driver:none`
- Align MySQL test timeouts with PostgreSQL values (MySQL tests run second, sharing a loaded Debezium Connect)
- Fix MySQL credential mismatch (`mysqluser` → `root` to match K8s manifest)

## Related Issues

- Fixes #8374

## Changes

### `DebeziumDeploymentManager.java`
- `waitForDebeziumConnectReady()`: use ClusterIP service instead of LoadBalancer external service on Linux/CI. ClusterIPs are directly routable with `driver:none` — the LoadBalancer/tunnel path was the flake source. macOS still uses localhost for local dev compatibility.
- `configureTestProperties()`: fix MySQL credentials from `mysqluser/mysqlpw` to `root/debezium` to match `mysql-debezium.yml` manifest (only creates root user).

### `DebeziumMySQLAvroBaseIT.java`
- `waitForConsumerReady`: 5s → 10s (matches PostgreSQL)
- `consumeAvroEvents` first test: 10s → 20s (matches PostgreSQL)
- `consumeAvroEvents` other tests: 10s → 15s (matches PostgreSQL)
- `Unreliables.retryUntilTrue` multi-table: 10s → 15s

## Testing

- Compilation verified: `./mvnw test-compile -DskipTests`
- Checkstyle clean: `./mvnw checkstyle:check`
- CI must pass `h2-debezium` shard — this is the exact shard that flaked