### PR TITLE
[CI Reliability] Add integration-tests to java path filter

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -55,7 +55,8 @@ jobs:
               - 'java-sdk/**'
               - 'mcp/**'
               - 'distro/**'
-              - 'integration-tests/**'
+              - 'integration-tests/src/**'
+              - 'integration-tests/pom.xml'
               - 'pom.xml'
             ui:
               - 'ui/**'

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -55,6 +55,7 @@ jobs:
               - 'java-sdk/**'
               - 'mcp/**'
               - 'distro/**'
+              - 'integration-tests/**'
               - 'pom.xml'
             ui:
               - 'ui/**'


### PR DESCRIPTION
## Summary

- Add `integration-tests/src/**` and `integration-tests/pom.xml` to the `java` path filter in `verify.yaml`
- Ensures integration-test-only PRs trigger Build + Integration Tests

## Related Issues

- Fixes #8376
- Unblocks #8375 (Debezium MySQL flake fix — currently can't validate through CI)

## Changes

`integration-tests/**` was in the `integration` filter but not the `java` filter. Since Integration Tests depends on Build (gated by `java`), PRs modifying only integration test code never triggered a build, making them impossible to validate before merge.

Narrowed to `src/**` and `pom.xml` to avoid triggering builds on README or script changes.

## Testing

This PR itself changes `.github/workflows/**` which matches the `ci` filter, so full CI runs. The fix is self-validating: once merged, integration-test-only PRs like #8375 will trigger properly.