### PR TITLE
[CI Optimization] Rename -Dfast to -Dlocal with plugin skip properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Additionally, there are 2 main configuration profiles:
 ### Getting started (APIs)
 
  ```
- ./mvnw clean install -Dfast -DskipTests
+ ./mvnw clean install -Dlocal -DskipTests
  cd app/
  ../mvnw quarkus:dev
  ```
@@ -87,15 +87,15 @@ For more information on the UI, see the UI module's [README.md](ui/README.md).
 
 The project uses a three-tier build system to allow developers to build only what they need:
 
-| Tier        | Flag     | What's included                                         | Use case                           |
-|-------------|----------|---------------------------------------------------------|------------------------------------|
-| **Fast**    | `-Dfast` | Core server, Java SDK, schema utilities                 | Quick server development iteration |
-| **Default** | *(none)* | Fast + serializers, CLI, docs, distribution             | Normal development                 |
-| **Full**    | `-Dfull` | Default + MCP server, Go SDK, operator, extra utilities | CI builds, releases                |
+| Tier        | Flag      | What's included                                         | Use case                           |
+|-------------|-----------|--------------------------------------------------------|------------------------------------|
+| **Local**   | `-Dlocal` | Core server, Java SDK, schema utilities — skips javadoc, source JARs, checkstyle, assembly | Quick local development iteration |
+| **Default** | *(none)*  | Local + serializers, CLI, docs, distribution            | Normal development                 |
+| **Full**    | `-Dfull`  | Default + MCP server, Go SDK, operator, extra utilities | CI builds, releases                |
 
 ```bash
-# Fast: core server only (~3 min)
-./mvnw clean install -Dfast -DskipTests
+# Local: core server only, skip non-essential plugins (~3 min)
+./mvnw clean install -Dlocal -DskipTests
 
 # Default: normal development
 ./mvnw clean install -DskipTests

--- a/examples/gitops/docker-compose-dev.yaml
+++ b/examples/gitops/docker-compose-dev.yaml
@@ -19,7 +19,7 @@
 #      docker compose -f docker-compose-dev.yaml up
 #
 #   3. Start Registry in dev mode:
-#      mvn clean install -Dfast -pl app -am -DskipTests && cd app
+#      mvn clean install -Dlocal -pl app -am -DskipTests && cd app
 #      mvn quarkus:dev \
 #        -Dapicurio.storage.kind=gitops \
 #        -Dapicurio.features.experimental.enabled=true \

--- a/examples/gitops/multi-repo-pull-https/docker-compose-dev.yaml
+++ b/examples/gitops/multi-repo-pull-https/docker-compose-dev.yaml
@@ -10,7 +10,7 @@
 #
 #   2. Start Registry in dev mode:
 #      pushd ../../..
-#      mvn clean install -Dfast -pl app -am -DskipTests
+#      mvn clean install -Dlocal -pl app -am -DskipTests
 #      cd app
 #      mvn quarkus:dev \
 #        -Dapicurio.storage.kind=gitops \

--- a/examples/gitops/pull-https/docker-compose-dev.yaml
+++ b/examples/gitops/pull-https/docker-compose-dev.yaml
@@ -14,7 +14,7 @@
 #
 #   4. Start Registry in dev mode:
 #      pushd ../../..
-#      mvn clean install -Dfast -pl app -am -DskipTests
+#      mvn clean install -Dlocal -pl app -am -DskipTests
 #      cd app
 #      mvn quarkus:dev \
 #        -Dapicurio.storage.kind=gitops \

--- a/examples/gitops/pull-ssh/docker-compose-dev.yaml
+++ b/examples/gitops/pull-ssh/docker-compose-dev.yaml
@@ -20,7 +20,7 @@
 #
 #   6. Start Registry in dev mode:
 #      pushd ../../..
-#      mvn clean install -Dfast -pl app -am -DskipTests
+#      mvn clean install -Dlocal -pl app -am -DskipTests
 #      cd app
 #      mvn quarkus:dev \
 #        -Dapicurio.storage.kind=gitops \

--- a/examples/gitops/push/docker-compose-dev.yaml
+++ b/examples/gitops/push/docker-compose-dev.yaml
@@ -13,7 +13,7 @@
 #
 #   3. Start Registry in dev mode:
 #      pushd ../../..
-#      mvn clean install -Dfast -pl app -am -DskipTests
+#      mvn clean install -Dlocal -pl app -am -DskipTests
 #      cd app
 #      mvn quarkus:dev \
 #        -Dapicurio.storage.kind=gitops \

--- a/pom.xml
+++ b/pom.xml
@@ -1336,7 +1336,6 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.source.skip>true</maven.source.skip>
         <checkstyle.skip>true</checkstyle.skip>
-        <skipCommitIdPlugin>true</skipCommitIdPlugin>
         <assembly.skipAssembly>true</assembly.skipAssembly>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1303,7 +1303,7 @@
       <id>non-essential</id>
       <activation>
         <property>
-          <name>!fast</name>
+          <name>!local</name>
         </property>
       </activation>
       <modules>
@@ -1324,6 +1324,21 @@
         <module>serdes/nats/avro-serde</module>
         <module>serdes/pulsar/avro-serde</module>
       </modules>
+    </profile>
+    <profile>
+      <id>local</id>
+      <activation>
+        <property>
+          <name>local</name>
+        </property>
+      </activation>
+      <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.source.skip>true</maven.source.skip>
+        <checkstyle.skip>true</checkstyle.skip>
+        <skipCommitIdPlugin>true</skipCommitIdPlugin>
+        <assembly.skipAssembly>true</assembly.skipAssembly>
+      </properties>
     </profile>
     <profile>
       <id>full</id>


### PR DESCRIPTION
## Summary

- Rename `-Dfast` build profile to `-Dlocal` based on team consensus
- Add plugin skip properties (javadoc, source JARs, checkstyle, git-commit-id, assembly) so `-Dlocal` is a single shortcut for fast local builds
- Does NOT include `-DskipTests` — developers opt into that separately

## Related Issues

- Replaces PR #8356 (closed — naming discussion resolved)

## Context

Team discussion on Slack reached consensus:
- **Eric**: suggested `-Dlocal`, "more the intent (the profile of stuff you should be building when doing local development)"
- **Nikisha**: +1 for `-Dlocal`
- **Vandana**: +1 for `-Dlocal` — "describes the intent rather than the behavior"
- **Jakub**: open to rename, flagged `-DskipTests` should NOT be in the profile
- **Carles**: no strong opinion

## Changes

### `pom.xml`
- Renamed `non-essential` profile activation from `<name>!fast</name>` to `<name>!local</name>`
- Added new `local` profile with properties: `maven.javadoc.skip`, `maven.source.skip`, `checkstyle.skip`, `skipCommitIdPlugin`, `assembly.skipAssembly`

### `README.md`
- Updated build tier table: "Fast / `-Dfast`" → "Local / `-Dlocal`"
- Updated examples and descriptions

### `examples/gitops/*.yaml` (5 files)
- Replaced `-Dfast` with `-Dlocal` in commented-out build commands

## Breaking Change

`-Dfast` no longer works. Use `-Dlocal` instead. The profile was added fairly recently (by Jakub) so migration surface is small.

## Testing

- `./mvnw validate -Dlocal` — succeeds, `local` profile active, `non-essential` excluded
- `./mvnw help:active-profiles -Dlocal` — confirms correct activation
- No CI workflow files reference `-Dfast`