### PR TITLE
fix(ci): auto-update branch when merge fails due to PR being behind main

### DIFF
--- a/.github/PR_LIFECYCLE.md
+++ b/.github/PR_LIFECYCLE.md
@@ -112,6 +112,21 @@ instead of adding or removing labels directly.
 Use `/auto-merge` to enable automatic merging. When the PR reaches `ready-to-merge`
 (approved + tested), it will be merged automatically. Use `/auto-merge` again to disable.
 
+### Branch auto-update (merge-rebase)
+
+When merging fails because the PR branch is behind `main` (other PRs were merged in the
+meantime), the orchestrator handles it automatically:
+
+1. If the branch can be cleanly rebased (`rebaseable: true`), the branch is updated
+2. Tests are **skipped** — they already passed on the previous HEAD, and a clean rebase
+   means the code is functionally identical
+3. Only the Verification Gate runs (~1-2 minutes)
+4. Once the gate passes, the merge proceeds automatically
+
+If the branch has conflicts, the orchestrator posts an error and asks the author to
+resolve them manually. If the branch falls behind again during the gate run, the
+merge falls back to standard error handling (full test suite re-run).
+
 ## Configuration
 
 The orchestrator is configured in `.github/pr-lifecycle.yml`:

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -219,10 +219,10 @@ function createApi(github, owner, repo) {
       }
     },
 
-    updateBranch: async (prNumber) => {
-      await github.rest.pulls.updateBranch({
-        owner, repo, pull_number: prNumber,
-      });
+    updateBranch: async (prNumber, expectedHeadSha) => {
+      const params = { owner, repo, pull_number: prNumber };
+      if (expectedHeadSha) params.expected_head_sha = expectedHeadSha;
+      await github.rest.pulls.updateBranch(params);
     },
 
     findLatestVerifyRun: async (headSha) => {
@@ -341,13 +341,16 @@ async function performMerge(api, config, pr, core, { allowBranchUpdate = true } 
     core.info(`PR #${pr.number} merged using ${strategy}`);
     return true;
   } catch (e) {
-    // Branch is behind but can be cleanly updated — rebase and retry
-    if (allowBranchUpdate) {
+    // Branch is behind but can be cleanly updated — rebase and retry.
+    // Skip for permission errors (403 / "Resource not accessible") which
+    // indicate a different problem (e.g. workflow file modifications).
+    const isPermissionError = e.status === 403 || e.message?.includes('Resource not accessible');
+    if (allowBranchUpdate && !isPermissionError) {
       const currentPr = await api.getPr(pr.number);
       if (currentPr.rebaseable) {
         try {
           await api.addLabel(pr.number, LABELS.MERGE_REBASE);
-          await api.updateBranch(pr.number);
+          await api.updateBranch(pr.number, currentPr.head.sha);
           await api.postComment(pr.number,
             `Merge could not proceed because the branch is behind \`${currentPr.base.ref}\`. ` +
             `The branch has been updated automatically. Tests are skipped (they already ` +
@@ -542,13 +545,19 @@ async function handlePrSynchronize({ github, context, core }) {
   const { owner, repo } = context.repo;
   const api = createApi(github, owner, repo);
 
-  // Orchestrator-initiated branch update for merge — preserve state
+  // Orchestrator-initiated branch update for merge — preserve state.
+  // Only honour for bot-triggered syncs; if a human pushes while the
+  // label is set, abort the fast-merge flow and proceed normally.
   if (hasLabel(pr, LABELS.MERGE_REBASE)) {
-    core.info(`PR #${pr.number} orchestrator-initiated branch update for merge, preserving state`);
-    if (hasLabel(pr, LABELS.STALE)) {
-      await api.removeLabel(pr.number, LABELS.STALE);
+    if (context.payload.sender?.login === BOT_LOGIN) {
+      core.info(`PR #${pr.number} orchestrator-initiated branch update for merge, preserving state`);
+      if (hasLabel(pr, LABELS.STALE)) {
+        await api.removeLabel(pr.number, LABELS.STALE);
+      }
+      return;
     }
-    return;
+    await api.removeLabel(pr.number, LABELS.MERGE_REBASE);
+    core.info(`PR #${pr.number} human push during merge-rebase, aborting fast-merge`);
   }
 
   const rerunHints = [];

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -1282,8 +1282,8 @@ async function postDecisionSummary(github, owner, repo, workflowRun, prNumber, c
       const matching = jobs.filter(j => j.name.startsWith(namePrefix));
       if (!matching.length) return 'skipped';
       if (matching.some(j => j.conclusion === 'failure')) return 'failure';
-      if (matching.every(j => j.conclusion === 'success')) return 'success';
       if (matching.every(j => j.conclusion === 'skipped')) return 'skipped';
+      if (matching.every(j => j.conclusion === 'success' || j.conclusion === 'skipped')) return 'success';
       return 'mixed';
     };
 
@@ -1334,17 +1334,25 @@ async function postDecisionSummary(github, owner, repo, workflowRun, prNumber, c
 
     const body = bodyParts.join('\n');
 
-    // ── Post or update comment (paginated lookup) ────────────────────
+    // ── Minimize previous summaries and post a new comment ────────────
     const comments = await github.paginate(github.rest.issues.listComments, {
       owner, repo, issue_number: prNumber, per_page: 100,
     });
-    const existing = comments.find(c => c.body?.includes('<!-- verify-decide-summary -->'));
-
-    if (existing) {
-      await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-    } else {
-      await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+    const previous = comments.filter(c => c.body?.includes('<!-- verify-decide-summary -->'));
+    for (const old of previous) {
+      try {
+        await github.graphql(`
+          mutation($id: ID!) {
+            minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+              minimizedComment { isMinimized }
+            }
+          }
+        `, { id: old.node_id });
+      } catch (e) {
+        core.warning(`Failed to minimize old summary comment ${old.id}: ${e.message}`);
+      }
     }
+    await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
     core.info(`PR #${prNumber} decision summary posted`);
   } catch (err) {
     core.warning(`Failed to post decision summary: ${err.message}`);

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -25,6 +25,7 @@ const LABELS = {
   AUTO_MERGE: 'orchestrator/auto-merge',
   TESTS_DISABLED: 'orchestrator/tests-disabled',
   REVIEW_SKIPPED: 'orchestrator/review-skipped',
+  MERGE_REBASE: 'orchestrator/merge-rebase',
 };
 
 const PRIMARY_STATES = [
@@ -62,6 +63,7 @@ const LABEL_DEFS = {
   [LABELS.AUTO_MERGE]:           { color: COLORS.INFO, description: 'Auto-merge enabled' },
   [LABELS.TESTS_DISABLED]:       { color: COLORS.INFO, description: 'Smoke tests disabled for this PR' },
   [LABELS.REVIEW_SKIPPED]:       { color: COLORS.INFO, description: 'Review requirement skipped by maintainer' },
+  [LABELS.MERGE_REBASE]:         { color: COLORS.INFO, description: 'Branch auto-updated for merge, tests skipped' },
 };
 
 const BOT_LOGIN = 'github-actions[bot]';
@@ -217,6 +219,12 @@ function createApi(github, owner, repo) {
       }
     },
 
+    updateBranch: async (prNumber) => {
+      await github.rest.pulls.updateBranch({
+        owner, repo, pull_number: prNumber,
+      });
+    },
+
     findLatestVerifyRun: async (headSha) => {
       const { data } = await github.rest.actions.listWorkflowRuns({
         owner, repo, workflow_id: 'verify.yaml',
@@ -317,7 +325,7 @@ function hasLatestChangesRequested(reviews) {
   return latestReviewsByReviewer(reviews).some(r => r.state === 'CHANGES_REQUESTED');
 }
 
-async function performMerge(api, config, pr, core) {
+async function performMerge(api, config, pr, core, { allowBranchUpdate = true } = {}) {
   const freshPr = await api.getPr(pr.number);
   if (!hasLabel(freshPr, LABELS.TESTED) || !hasLabel(freshPr, LABELS.READY_TO_MERGE)) {
     core.warning(`PR #${pr.number} merge aborted: state changed since merge was initiated`);
@@ -333,16 +341,40 @@ async function performMerge(api, config, pr, core) {
     core.info(`PR #${pr.number} merged using ${strategy}`);
     return true;
   } catch (e) {
+    // Branch is behind but can be cleanly updated — rebase and retry
+    if (allowBranchUpdate) {
+      const currentPr = await api.getPr(pr.number);
+      if (currentPr.rebaseable) {
+        try {
+          await api.addLabel(pr.number, LABELS.MERGE_REBASE);
+          await api.updateBranch(pr.number);
+          await api.postComment(pr.number,
+            `Merge could not proceed because the branch is behind \`${currentPr.base.ref}\`. ` +
+            `The branch has been updated automatically. Tests are skipped (they already ` +
+            `passed for the previous HEAD) and the merge will proceed shortly.`
+          );
+          core.info(`PR #${pr.number} branch updated for merge-rebase`);
+          return false;
+        } catch (updateErr) {
+          await api.removeLabel(pr.number, LABELS.MERGE_REBASE);
+          core.warning(`PR #${pr.number} branch update failed: ${updateErr.message}`);
+        }
+      }
+    }
+
     const workflowHint = e.message?.includes('Resource not accessible')
       ? ' This may be because the PR modifies workflow files, which requires manual merge via the GitHub UI (the `workflow` token scope is not available to GitHub Actions).'
+      : '';
+    const conflictHint = freshPr.rebaseable === false
+      ? ' The branch has conflicts with the base branch that need manual resolution.'
       : '';
     await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
     await api.removeLabel(pr.number, LABELS.TESTED);
     await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
     await api.postComment(pr.number,
       `Merge failed: ${e.message}\n\n` +
-      `Reverted to \`lifecycle/ready-for-review\`.${workflowHint}` +
-      (workflowHint ? '' : ` The branch may need to be rebased. Use \`/auto-merge\` to merge automatically once approved and tested.`)
+      `Reverted to \`lifecycle/ready-for-review\`.${workflowHint}${conflictHint}` +
+      (workflowHint || conflictHint ? '' : ` The branch may need to be rebased. Use \`/auto-merge\` to merge automatically once approved and tested.`)
     );
     core.error(`PR #${pr.number} merge failed: ${e.message}`);
     return false;
@@ -509,6 +541,15 @@ async function handlePrSynchronize({ github, context, core }) {
   const pr = context.payload.pull_request;
   const { owner, repo } = context.repo;
   const api = createApi(github, owner, repo);
+
+  // Orchestrator-initiated branch update for merge — preserve state
+  if (hasLabel(pr, LABELS.MERGE_REBASE)) {
+    core.info(`PR #${pr.number} orchestrator-initiated branch update for merge, preserving state`);
+    if (hasLabel(pr, LABELS.STALE)) {
+      await api.removeLabel(pr.number, LABELS.STALE);
+    }
+    return;
+  }
 
   const rerunHints = [];
 
@@ -1063,6 +1104,35 @@ async function handleTestResult({ github, context, core }) {
     if (hasLabel(pr, LABELS.DISABLED)) continue;
 
     const state = getLifecycleState(pr);
+
+    // Merge-rebase flow: branch was auto-updated, tests were skipped,
+    // proceed to merge once the Verification Gate passes.
+    if (state === LABELS.READY_TO_MERGE && hasLabel(pr, LABELS.MERGE_REBASE)) {
+      if (pr.head.sha !== workflowRun.head_sha) {
+        core.info(`PR #${pr.number} merge-rebase SHA mismatch, skipping`);
+        continue;
+      }
+      if (workflowRun.conclusion === 'success') {
+        await api.removeLabel(pr.number, LABELS.MERGE_REBASE);
+        const config = loadConfig();
+        const merged = await performMerge(api, config, pr, core, { allowBranchUpdate: false });
+        if (!merged) {
+          core.warning(`PR #${pr.number} merge-rebase: merge failed after branch update`);
+        }
+      } else {
+        await api.removeLabel(pr.number, LABELS.MERGE_REBASE);
+        await api.removeLabel(pr.number, LABELS.TESTED);
+        await api.setLifecycleState(pr, LABELS.READY_FOR_REVIEW);
+        await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+        await api.postComment(pr.number,
+          `The verification workflow failed after the branch update. ` +
+          `Reverting to \`lifecycle/ready-for-review\` for a full test run.`
+        );
+      }
+      await postDecisionSummary(github, owner, repo, workflowRun, pr.number, core);
+      continue;
+    }
+
     if (state !== LABELS.READY_FOR_REVIEW && state !== LABELS.WIP) {
       core.info(`PR #${pr.number} not in ready-for-review or wip state, skipping test result`);
       continue;

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -123,8 +123,11 @@ jobs:
             LABELS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '[.labels[].name]')
             has_label() { echo "$LABELS" | jq -e "index(\"$1\")" > /dev/null 2>&1; }
 
-            # Orchestrator-initiated branch update for merge — skip all tests
-            if has_label "orchestrator/merge-rebase"; then
+            # Orchestrator-initiated branch update for merge — skip all tests.
+            # Only honour for bot-triggered syncs to prevent skipping tests
+            # if a human pushes while the label is still set.
+            SENDER='${{ github.event.sender.login }}'
+            if has_label "orchestrator/merge-rebase" && [ "$SENDER" = "github-actions[bot]" ]; then
               echo "lifecycle-ready=true" >> "$GITHUB_OUTPUT"
               for out in run-build run-unit-tests run-integration run-extras run-sdk run-cli run-operator run-go-sdk-freshness; do
                 echo "$out=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -123,6 +123,15 @@ jobs:
             LABELS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '[.labels[].name]')
             has_label() { echo "$LABELS" | jq -e "index(\"$1\")" > /dev/null 2>&1; }
 
+            # Orchestrator-initiated branch update for merge — skip all tests
+            if has_label "orchestrator/merge-rebase"; then
+              echo "lifecycle-ready=true" >> "$GITHUB_OUTPUT"
+              for out in run-build run-unit-tests run-integration run-extras run-sdk run-cli run-operator run-go-sdk-freshness; do
+                echo "$out=false" >> "$GITHUB_OUTPUT"
+              done
+              exit 0
+            fi
+
             if has_label "orchestrator/disabled"; then
               if has_label "DO NOT MERGE"; then
                 run_smoke=false; run_full=false


### PR DESCRIPTION
## Summary

Two fixes for the PR lifecycle orchestrator:

### 1. Auto-update branch when merge fails due to PR being behind main

When a PR is ready to merge but the branch is behind `main`, the `pulls.merge()` API fails. Previously, the orchestrator reverted to `ready-for-review`, removed `lifecycle/tested`, and posted a vague error — requiring manual rebase, re-running the full test suite (~50 min), and re-enabling auto-merge.

Now, when merge fails and the branch is conflict-free (`rebaseable: true`), the orchestrator automatically updates the branch and retries the merge **without re-running the full test suite**. Only the Verification Gate runs (~1-2 min) since tests already passed on the previous HEAD and a clean rebase means the code is functionally identical.

Fixes the issue observed on #8357.

**How it works:**

New label `orchestrator/merge-rebase` coordinates three components:

| Component | Behavior |
|-----------|----------|
| `performMerge()` | On merge failure: checks `rebaseable`, adds label, calls `updateBranch()`, posts comment |
| `handlePrSynchronize()` | Sees merge-rebase label → preserves state (tested, auto-merge, ready-to-merge) instead of reverting |
| Verify workflow Decide job | Sees merge-rebase label → outputs `lifecycle-ready=true` + all `run-*=false` → Gate passes with everything skipped |
| `handleTestResult()` | Sees ready-to-merge + merge-rebase → removes label → calls `performMerge()` with `allowBranchUpdate: false` |

**Flow:**

```
performMerge fails (behind) → add label → updateBranch()
  → synchronize event → state preserved
  → Verify runs → all tests skipped → Gate passes (~1-2 min)
  → test result → remove label → performMerge (retry) → merged!
```

**Safety:**

- **1 retry limit**: The retry calls `performMerge` with `allowBranchUpdate: false`. If main moves again during the ~1-2 min gate window, standard error handling takes over (revert to ready-for-review, full test suite).
- **Conflict detection**: If `rebaseable` is `false`, the orchestrator posts a clear error about conflicts needing manual resolution (improved from the previous vague message).
- **Both `/merge` and `/auto-merge` supported**: The merge-rebase flow triggers from `performMerge()`, which both commands use.

### 2. Fix mixed status icon for success+skipped jobs

The `jobResult` function treated a mix of `success` and `skipped` job conclusions as `"mixed"` (🟡) because the success check required ALL jobs to be `success`. This affected Operator Tests, which has conditional jobs (Local Tests, Publish, Slack Notification) that are always skipped on PRs. Fixed by reordering: check all-skipped first, then accept success-or-skipped as success (🟢).

### 3. Keep decision summary history across re-runs

Instead of updating the single summary comment in-place (losing previous results), the orchestrator now minimizes previous summaries as "outdated" and posts a new comment. This preserves the history of test results across re-runs.

## Changes

| File | Purpose |
|------|---------|
| `.github/scripts/pr-lifecycle.js` | Add `orchestrator/merge-rebase` label + `updateBranch` API method, branch-update logic in `performMerge`, state preservation in `handlePrSynchronize`, merge-rebase handler in `handleTestResult`, fix `jobResult` success+skipped logic, minimize old summary comments |
| `.github/workflows/verify.yaml` | Skip all tests when `orchestrator/merge-rebase` is present |
| `.github/PR_LIFECYCLE.md` | Document the branch auto-update behavior |

## Test plan

- [ ] PR with auto-merge enabled, branch behind main, no conflicts → branch auto-updated, tests skipped, merged in ~1-2 min
- [ ] PR with auto-merge enabled, branch behind main, has conflicts → clear error message about conflicts
- [ ] PR with `/merge` command, branch behind main → same auto-update flow
- [ ] Branch falls behind again during gate window → falls back to standard error handling
- [ ] `updateBranch` API call fails → merge-rebase label removed, standard error handling
- [ ] Normal PR pushes (not merge-rebase) → existing behavior unchanged
- [ ] Operator Tests shows 🟢 (not 🟡) when some jobs are skipped and the rest succeed
- [ ] Re-running the Verify workflow creates a new summary comment and minimizes the old one