### PR TITLE
[CI Reliability] Add surefire/failsafe rerunFailingTestsCount for flaky test retry

### DIFF
--- a/.github/workflows/verify-integration-tests.yaml
+++ b/.github/workflows/verify-integration-tests.yaml
@@ -73,7 +73,8 @@ jobs:
             ${{ matrix.groups && format('-Dgroups={0}', matrix.groups) || '' }} \
             -Dregistry-image=apicurio/apicurio-registry:${{ inputs.image-tag }} \
             -pl integration-tests \
-            -Dmaven.javadoc.skip=true
+            -Dmaven.javadoc.skip=true \
+            -Dfailsafe.rerunFailingTestsCount=2
 
       - name: Collect logs
         if: failure()

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -86,4 +86,5 @@ jobs:
             -Dcheckstyle.skip=true \
             -Dmaven.source.skip=true -Dmaven.javadoc.skip=true \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
-            -Dmaven.wagon.http.retryHandler.count=5
+            -Dmaven.wagon.http.retryHandler.count=5 \
+            -Dsurefire.rerunFailingTestsCount=2

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,10 @@
     <!-- Skip commit id plugin -->
     <skipCommitIdPlugin>true</skipCommitIdPlugin>
 
+    <!-- Flaky test retry: 0 locally, CI sets higher values -->
+    <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
+    <failsafe.rerunFailingTestsCount>0</failsafe.rerunFailingTestsCount>
+
     <!-- Apitomy Data Models (OpenAPI and AsyncAPI support) -->
     <apitomy-data-models.version>3.1.1</apitomy-data-models.version>
 
@@ -1033,11 +1037,17 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${version.failsafe.plugin}</version>
+          <configuration>
+            <rerunFailingTestsCount>${failsafe.rerunFailingTestsCount}</rerunFailingTestsCount>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${version.surefire.plugin}</version>
+          <configuration>
+            <rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</rerunFailingTestsCount>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

- Add automatic retry for flaky tests via `rerunFailingTestsCount` in surefire and failsafe plugins
- Default 0 (disabled) for local dev; CI sets to 2
- Tests that pass on retry show as "flaky" in reports — visible for investigation without blocking the build

## Related Issues

- Fixes #8387

## Changes

### `pom.xml`
- Added `surefire.rerunFailingTestsCount` and `failsafe.rerunFailingTestsCount` properties (default: 0)
- Added `<rerunFailingTestsCount>` configuration to both plugins in `<pluginManagement>`

### `.github/workflows/verify-unit-tests.yaml`
- Added `-Dsurefire.rerunFailingTestsCount=2` to the Maven verify command

### `.github/workflows/verify-integration-tests.yaml`
- Added `-Dfailsafe.rerunFailingTestsCount=2` to the Maven verify command

## Research

Based on cross-project research (44 OSS projects):
- **Strimzi**: `rerunFailingTestsCount=5` (UT), `2` (IT)
- **Infinispan**: `rerunFailingTestsCount=2`
- We chose 2 (conservative) to avoid hiding real failures

## Testing

- `./mvnw validate` — pom.xml valid
- `./mvnw help:evaluate -Dexpression=surefire.rerunFailingTestsCount -q -DforceStdout` → `0`
- CI must be green