### PR TITLE
[CI Reliability] Increase operator test timeouts and make them configurable

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -72,11 +72,12 @@ public abstract class ITBase implements OperatorTestContext {
     public static final String REMOTE_TESTS_INSTALL_FILE = "test.operator.install-file";
 
     public static final Duration POLL_INTERVAL_DURATION = ofSeconds(3);
-    public static final Duration SHORT_DURATION = ofSeconds(30);
-    // NOTE: When running remote tests, some extra time might be needed to pull an image before the pod can be run.
-    // TODO: Consider changing the duration based on test type or the situation.
-    public static final Duration MEDIUM_DURATION = ofSeconds(75);
-    public static final Duration LONG_DURATION = ofSeconds(300);
+    public static final Duration SHORT_DURATION = ofSeconds(
+            Integer.getInteger("test.operator.timeout.short", 30));
+    public static final Duration MEDIUM_DURATION = ofSeconds(
+            Integer.getInteger("test.operator.timeout.medium", 120));
+    public static final Duration LONG_DURATION = ofSeconds(
+            Integer.getInteger("test.operator.timeout.long", 420));
 
     public enum OperatorDeployment {
         local, remote


### PR DESCRIPTION
## Summary

- Increase operator test awaitility timeouts to reduce false failures on slow CI runners
- Make timeout constants configurable via system properties

## Related Issues

- Fixes #8389

## Changes

### `operator/controller/src/test/java/.../it/ITBase.java`

| Constant | Old | New | System Property |
|----------|-----|-----|-----------------|
| `SHORT_DURATION` | 30s | 30s (unchanged) | `test.operator.timeout.short` |
| `MEDIUM_DURATION` | 75s | **120s** | `test.operator.timeout.medium` |
| `LONG_DURATION` | 300s | **420s** | `test.operator.timeout.long` |

`waitOnOperatorPodReady` uses `MEDIUM_DURATION * 2`, so effective timeout goes from 150s → 240s.

## Testing

- `./mvnw test-compile -pl operator/controller -am -DskipTests -Dfull` — compiles
- `./mvnw checkstyle:check` (from operator/controller) — clean
- CI operator shards should pass with fewer timeout failures