### PR TITLE
[CI Optimization] Tune surefire forkCount for parallel test execution

### DIFF
--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -49,7 +49,7 @@ jobs:
           - name: non-app
             modules: "-Dfull -DcliSkipNative -pl !app,!distro/docker,!docs,!docs/config-generator,!docs/rest-api"
             test-filter: ""
-            maven-opts: "-Xmx4g"
+            maven-opts: "-Xmx4g -Dsurefire.forkCount=2"
     steps:
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,7 @@
     <!-- Flaky test retry: 0 locally, CI sets higher values -->
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
     <failsafe.rerunFailingTestsCount>0</failsafe.rerunFailingTestsCount>
+    <surefire.forkCount>1</surefire.forkCount>
 
     <!-- Apitomy Data Models (OpenAPI and AsyncAPI support) -->
     <apitomy-data-models.version>3.1.1</apitomy-data-models.version>
@@ -1047,6 +1048,8 @@
           <version>${version.surefire.plugin}</version>
           <configuration>
             <rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</rerunFailingTestsCount>
+            <forkCount>${surefire.forkCount}</forkCount>
+            <reuseForks>true</reuseForks>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
## Summary

- Add configurable `surefire.forkCount` property (default: 1) with `reuseForks=true`
- Set `forkCount=2` in the non-app CI shard for parallel test execution
- Local builds and app-* shards unaffected

## Related Issues

- Fixes #8413

## Changes

### `pom.xml`
- Added `surefire.forkCount` property (default: `1`)
- Added `<forkCount>` and `<reuseForks>` to surefire plugin configuration in `<pluginManagement>`

### `.github/workflows/verify-unit-tests.yaml`
- Added `-Dsurefire.forkCount=2` to non-app shard MAVEN_OPTS

## Why only non-app?

The app-* shards use `@QuarkusTest` which starts a Quarkus instance on a fixed port (8081). With `forkCount > 1`, two JVM forks would collide on the same port. The non-app shard runs schema-util, serdes, java-sdk modules which don't use `@QuarkusTest` — they're fork-safe.

## Testing

- `./mvnw validate` — pom.xml valid
- `./mvnw help:evaluate -Dexpression=surefire.forkCount -q -DforceStdout` → `1`
- CI must pass — specifically the non-app shard with forkCount=2