### PR TITLE
[CI Optimization] Split Maven cache restore/save to prevent PR pollution

### DIFF
--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -32,7 +32,14 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
-          cache: 'maven'
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
 
       - name: Build Application (skip tests for speed)
         env:
@@ -84,6 +91,13 @@ jobs:
             common/target/
             schema-util/common/target/
           retention-days: 1
+
+      - name: Save Maven cache
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
 
   build-ui:
     name: Build UI Application

--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -41,6 +41,9 @@ jobs:
           restore-keys: |
             maven-
 
+      - name: Clean stale lock files
+        run: find ~/.m2/repository -name '*.lock' -delete 2>/dev/null || true
+
       - name: Build Application (skip tests for speed)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For downloading Kiota binary.

--- a/.github/workflows/verify-extras.yaml
+++ b/.github/workflows/verify-extras.yaml
@@ -132,7 +132,14 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
-          cache: 'maven'
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
 
       - uses: apicurio/apicurio-github-actions/load-docker-image@97d452c41f1abd7142c0ce2ac37e87922e35e71d # v2
         with:
@@ -196,7 +203,14 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
-          cache: 'maven'
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/verify-integration-tests.yaml
+++ b/.github/workflows/verify-integration-tests.yaml
@@ -53,7 +53,14 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
-          cache: 'maven'
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
 
       - uses: apicurio/apicurio-github-actions/setup-minikube@97d452c41f1abd7142c0ce2ac37e87922e35e71d # v2
 

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -59,7 +59,14 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
-          cache: 'maven'
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
## Summary

- Replace `setup-java` `cache: maven` with explicit `actions/cache/restore` and `actions/cache/save`
- PRs restore from main's cache but never write back
- Cache is only saved on push to main (in verify-build.yaml)

## Related Issues

- Fixes #8416

## Changes

| Workflow | Restore | Save |
|----------|---------|------|
| `verify-build.yaml` | Yes | **Yes** (push only) |
| `verify-unit-tests.yaml` | Yes | No |
| `verify-integration-tests.yaml` | Yes | No |
| `verify-extras.yaml` (2 jobs) | Yes | No |

## Why?

The `setup-java` `cache: maven` lets every workflow run (including PRs) write to the shared cache. Branch-specific SNAPSHOT dependencies can pollute it, causing stale artifacts in subsequent main builds. This is the pattern Quarkus and Strimzi use for cache hygiene.

## Testing

- CI must pass — workflows should restore cache from main and run without saving on PRs
- On push to main, the build job saves the updated cache