### PR TITLE
fix(ui): unify detail page canvas background to remove nested border banding

### DIFF
--- a/ui/ui-app/src/app/App.css
+++ b/ui/ui-app/src/app/App.css
@@ -1,8 +1,37 @@
 :root {
   --myApp-global--spacer--md: 30px;
+  --registry-page-canvas-bg: var(--pf-v5-global--BackgroundColor--200, #f0f0f0);
 }
 
 .pf-c-page {
   width: 100%;
   height: 100vh;
+}
+
+/* Apicurio#8310: use a single canvas background in filled detail pages so nested
+   tab panels and content wrappers do not create gray/white/gray/white banding. */
+.artifact-details-main,
+.branch-details-main {
+  background-color: var(--registry-page-canvas-bg);
+}
+
+.artifact-details-main .pf-c-tab-content,
+.branch-details-main .pf-c-tab-content,
+.artifact-details-main .pf-v6-c-tab-content,
+.branch-details-main .pf-v6-c-tab-content,
+#pf-tab-section-content-artifact-page-tabs,
+#pf-tab-section-content-group-page-tabs,
+#pf-tab-section-content-branch-page-tabs {
+  background-color: var(--registry-page-canvas-bg);
+}
+
+/* Secondary cards inside detail tabs add a redundant gray frame on the canvas. */
+.artifact-details-main [class*="-tab-content"] .pf-v6-c-card.pf-m-secondary,
+.branch-details-main [class*="-tab-content"] .pf-v6-c-card.pf-m-secondary,
+.artifact-details-main [class*="-tab-content"] .pf-c-card.pf-m-secondary,
+.branch-details-main [class*="-tab-content"] .pf-c-card.pf-m-secondary {
+  --pf-v6-c-card--BackgroundColor: transparent;
+  --pf-c-card--BackgroundColor: transparent;
+  border: none;
+  box-shadow: none;
 }

--- a/ui/ui-app/src/app/pages/artifact/ArtifactPage.css
+++ b/ui/ui-app/src/app/pages/artifact/ArtifactPage.css
@@ -7,7 +7,8 @@ div.artifact-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs
     flex-direction: column;
 }
 
-.artifact-details-main .pf-c-tab-content {
+.artifact-details-main .pf-c-tab-content,
+.artifact-details-main .pf-v6-c-tab-content {
     flex-grow: 1;
     display: flex;
     flex-direction: column;

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactBranchesTabContent.css
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactBranchesTabContent.css
@@ -2,7 +2,7 @@
     padding: 22px;
     display: flex;
     flex-direction: column;
-    background-color: rgb(240,240,240);
+    flex-grow: 1;
 }
 
 .branches-tab-content > div {

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactOverviewTabContent.css
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactOverviewTabContent.css
@@ -1,7 +1,7 @@
 
 .artifact-overview-tab-content {
     padding: 22px;
-    background-color: rgb(240,240,240);
+    flex-grow: 1;
 }
 
 .artifact-overview-tab-content .__drawer-head {

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactRulesTabContent.css
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactRulesTabContent.css
@@ -2,7 +2,7 @@
     padding: 22px;
     display: flex;
     flex-direction: row;
-    background-color: rgb(240,240,240);
+    flex-grow: 1;
 }
 
 

--- a/ui/ui-app/src/app/pages/branch/BranchPage.css
+++ b/ui/ui-app/src/app/pages/branch/BranchPage.css
@@ -7,7 +7,8 @@ div.branch-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs__
     flex-direction: column;
 }
 
-.branch-details-main .pf-c-tab-content {
+.branch-details-main .pf-c-tab-content,
+.branch-details-main .pf-v6-c-tab-content {
     flex-grow: 1;
     display: flex;
     flex-direction: column;

--- a/ui/ui-app/src/app/pages/branch/components/tabs/BranchOverviewTabContent.css
+++ b/ui/ui-app/src/app/pages/branch/components/tabs/BranchOverviewTabContent.css
@@ -3,7 +3,7 @@
     padding: 22px;
     display: flex;
     flex-direction: row;
-    background-color: rgb(240,240,240);
+    flex-grow: 1;
 }
 
 .branch-overview-tab-content .branch-basics {

--- a/ui/ui-app/src/app/pages/dashboard/DashboardPage.css
+++ b/ui/ui-app/src/app/pages/dashboard/DashboardPage.css
@@ -14,5 +14,5 @@
 }
 
 .ps_dashboard-content {
-    background-color: #f0f0f0;
+    background-color: var(--registry-page-canvas-bg, #f0f0f0);
 }

--- a/ui/ui-app/src/app/pages/group/GroupPage.css
+++ b/ui/ui-app/src/app/pages/group/GroupPage.css
@@ -8,7 +8,8 @@ div.group-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs__b
     gap: 0;
 }
 
-.artifact-details-main .pf-c-tab-content {
+.artifact-details-main .pf-c-tab-content,
+.artifact-details-main .pf-v6-c-tab-content {
     flex-grow: 1;
     display: flex;
     flex-direction: column;

--- a/ui/ui-app/src/app/pages/group/components/tabs/GroupOverviewTabContent.css
+++ b/ui/ui-app/src/app/pages/group/components/tabs/GroupOverviewTabContent.css
@@ -1,7 +1,7 @@
 
 .group-overview-tab-content {
     padding: 22px;
-    background-color: rgb(240,240,240);
+    flex-grow: 1;
 }
 
 .group-overview-tab-content .__drawer-head {

--- a/ui/ui-app/src/app/pages/group/components/tabs/GroupRulesTabContent.css
+++ b/ui/ui-app/src/app/pages/group/components/tabs/GroupRulesTabContent.css
@@ -2,7 +2,7 @@
     padding: 22px;
     display: flex;
     flex-direction: row;
-    background-color: rgb(240,240,240);
+    flex-grow: 1;
 }
 
 .group-tab-content .group-rules {

--- a/ui/ui-app/src/app/pages/version/VersionPage.css
+++ b/ui/ui-app/src/app/pages/version/VersionPage.css
@@ -7,7 +7,8 @@ div.artifact-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs
     flex-direction: column;
 }
 
-.artifact-details-main .pf-c-tab-content {
+.artifact-details-main .pf-c-tab-content,
+.artifact-details-main .pf-v6-c-tab-content {
     flex-grow: 1;
     display: flex;
     flex-direction: column;

--- a/ui/ui-app/src/app/pages/version/components/tabs/ReferencesTabContent.css
+++ b/ui/ui-app/src/app/pages/version/components/tabs/ReferencesTabContent.css
@@ -2,7 +2,7 @@
     padding: 22px;
     display: flex;
     flex-direction: column;
-    background-color: rgb(240,240,240);
+    flex-grow: 1;
 }
 
 .references-tab-content > div {

--- a/ui/ui-app/src/app/pages/version/components/tabs/VersionOverviewTabContent.css
+++ b/ui/ui-app/src/app/pages/version/components/tabs/VersionOverviewTabContent.css
@@ -1,7 +1,7 @@
 
 .version-overview-tab-content {
     padding: 22px;
-    background-color: rgb(240,240,240);
+    flex-grow: 1;
 }
 
 .version-overview-tab-content .__drawer-head {


### PR DESCRIPTION
## Summary
Fixes #8310 by removing gray/white/gray/white banding on artifact, group, version, and branch detail pages when tab content does not fill the viewport.

## Root Cause
Detail pages stacked multiple background layers with different colors:
- White `PageSection` (PatternFly default)
- Gray tab wrapper backgrounds (`rgb(240,240,240)` + padding)
- Gray `Card variant="secondary"` framing around drawer layouts
- White drawer panels and cards inside

When content was shorter than the page height, these nested layers were visible as alternating gray and white borders.

## Changes
- **`ui/ui-app/src/app/App.css`**
  - Introduced shared `--registry-page-canvas-bg` token
  - Applied unified canvas background to filled detail sections and tab panels (`artifact-details-main`, `branch-details-main`, PatternFly v5/v6 tab content selectors)
  - Neutralized redundant `Card variant="secondary"` framing inside detail tab content
- **Tab content CSS** (artifact, group, version, branch)
  - Removed redundant per-tab gray backgrounds
  - Added `flex-grow: 1` so the canvas fills short pages
- **Page CSS** (`ArtifactPage.css`, `GroupPage.css`, `VersionPage.css`, `BranchPage.css`)
  - Added PatternFly v6 `pf-v6-c-tab-content` flex layout rules alongside existing v5 selectors
- **`DashboardPage.css`**
  - Reused the shared canvas background variable for consistency

## Test plan
- [x] Manual: verified group/artifact overview pages render with a single gray canvas and white panels (no nested bordered frame)
- [ ] UI lint/build (CI smoke tests)
- [ ] N/A — CSS-only UI change; no backend or storage variant impact


Made with [Cursor](https://cursor.com)