### PR TITLE
[CI Optimization] Split Maven cache with noop resolver locking

### DIFF
--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -32,13 +32,21 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
-          cache: 'maven'
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
 
       - name: Build Application (skip tests for speed)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For downloading Kiota binary.
         run: |
-          ./mvnw clean package -T 0.5C --no-transfer-progress \
+          ./mvnw clean package --no-transfer-progress \
+            -Daether.syncContext.named.factory=noop \
             -Pprod -Dfull -DskipTests -DskipCommitIdPlugin=false -DcliSkipNative \
             -Dmaven.source.skip=true -Dmaven.javadoc.skip=true \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
@@ -84,6 +92,13 @@ jobs:
             common/target/
             schema-util/common/target/
           retention-days: 1
+
+      - name: Save Maven cache
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
 
   build-ui:
     name: Build UI Application

--- a/.github/workflows/verify-extras.yaml
+++ b/.github/workflows/verify-extras.yaml
@@ -30,7 +30,14 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           distribution: temurin
-          cache: maven
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
 
       - uses: apicurio/apicurio-github-actions/load-docker-image@97d452c41f1abd7142c0ce2ac37e87922e35e71d # v2
         with:
@@ -41,7 +48,7 @@ jobs:
 
       - name: Run Extra Tests
         run: |
-          ./mvnw verify --no-transfer-progress -Dfull -pl utils/extra-tests -am \
+          ./mvnw verify --no-transfer-progress -Daether.syncContext.named.factory=noop -Dfull -pl utils/extra-tests -am \
             -Pextra-tests \
             -Dregistry3-image=apicurio/apicurio-registry:${{ inputs.image-tag }} \
             -Dmaven.javadoc.skip=true
@@ -132,7 +139,14 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
-          cache: 'maven'
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
 
       - uses: apicurio/apicurio-github-actions/load-docker-image@97d452c41f1abd7142c0ce2ac37e87922e35e71d # v2
         with:
@@ -145,9 +159,9 @@ jobs:
         run: |
           echo "Starting Registry App (In Memory)"
           docker run -it -p 8181:8080 -e apicurio.rest.deletion.artifact.enabled=true -d apicurio/apicurio-registry:${{ inputs.image-tag }}
-          ./mvnw -Pintegration-tests clean install -DskipTests -Dmaven.javadoc.skip=true -DcliSkipNative
+          ./mvnw -Daether.syncContext.named.factory=noop -Pintegration-tests clean install -DskipTests -Dmaven.javadoc.skip=true -DcliSkipNative
           cd integration-tests
-          ../mvnw verify -Dmaven.javadoc.skip=true -Dquarkus.http.test-host=localhost -Dquarkus.http.test-port=8181
+          ../mvnw -Daether.syncContext.named.factory=noop verify -Dmaven.javadoc.skip=true -Dquarkus.http.test-host=localhost -Dquarkus.http.test-port=8181
 
       - name: Collect logs
         if: failure()
@@ -196,7 +210,14 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
-          cache: 'maven'
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/verify-integration-tests.yaml
+++ b/.github/workflows/verify-integration-tests.yaml
@@ -53,7 +53,14 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
-          cache: 'maven'
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
 
       - uses: apicurio/apicurio-github-actions/setup-minikube@97d452c41f1abd7142c0ce2ac37e87922e35e71d # v2
 
@@ -68,6 +75,7 @@ jobs:
       - name: Run Integration Tests
         run: |
           ./mvnw verify -am --no-transfer-progress \
+            -Daether.syncContext.named.factory=noop \
             -Pintegration-tests \
             -P${{ matrix.remote-profile }} \
             ${{ matrix.groups && format('-Dgroups={0}', matrix.groups) || '' }} \

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -59,7 +59,14 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
-          cache: 'maven'
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -79,6 +86,7 @@ jobs:
         run: |
           ./mvnw verify \
             --no-transfer-progress \
+            -Daether.syncContext.named.factory=noop \
             -Pprod ${{ matrix.shard.modules }} \
             ${{ matrix.shard.test-filter }} \
             -Dsurefire.failIfNoSpecifiedTests=false \


### PR DESCRIPTION
## Summary

Split Maven cache into restore-only (PRs) and restore+save (push to main). Disables Maven 3.9+ file locking in CI to prevent lock contention.

## Related Issues

- Fixes #8416
- Third attempt — previous #8417 and #8428 failed with lock contention

## What's different this time

Added `-Daether.syncContext.named.factory=noop` to all Maven commands. This disables the Maven resolver's file locking, which was the root cause of all previous failures. In CI, each job has its own workspace — there's no concurrent Maven process to protect against.

## Changes

| Workflow | Cache | Locking |
|----------|-------|---------|
| verify-build | restore@v5 + save@v5 (push only) | noop |
| verify-unit-tests | restore@v5 | noop |
| verify-integration-tests | restore@v5 | noop |
| verify-extras | restore@v5 | noop |

## Testing

- CI must pass without lock contention
- Build step should restore cache and complete successfully