### PR TITLE
[CI Optimization] Skip ZIP assembly in CI builds

### DIFF
--- a/app/src/main/assembly/assembly.xml
+++ b/app/src/main/assembly/assembly.xml
@@ -2,7 +2,6 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
   <id>all</id>
   <formats>
-    <format>zip</format>
     <format>tar.gz</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>

--- a/distro/docker/pom.xml
+++ b/distro/docker/pom.xml
@@ -47,7 +47,6 @@
                   <filtering>false</filtering>
                   <includes>
                     <include>apicurio-*.tar.gz</include>
-                    <include>apicurio-*.zip</include>
                     <include>apicurio-*runner</include>
                   </includes>
                 </resource>

--- a/docs/rest-api/src/main/assembly/static-assembly.xml
+++ b/docs/rest-api/src/main/assembly/static-assembly.xml
@@ -3,7 +3,6 @@
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
     <id>static</id>
     <formats>
-        <format>zip</format>
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>

--- a/examples/docker-compose/src/main/assembly/assembly.xml
+++ b/examples/docker-compose/src/main/assembly/assembly.xml
@@ -3,7 +3,6 @@
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
     <id>all</id>
     <formats>
-        <format>zip</format>
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>

--- a/operator/controller/src/main/assembly/assembly.xml
+++ b/operator/controller/src/main/assembly/assembly.xml
@@ -2,7 +2,6 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
   <id>quarkus-app</id>
   <formats>
-    <format>zip</format>
     <format>tar.gz</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>

--- a/utils/exportConfluent/src/main/assembly/exportConfluent.xml
+++ b/utils/exportConfluent/src/main/assembly/exportConfluent.xml
@@ -5,7 +5,6 @@
   <id>exportConfluent</id>
   <formats>
     <format>tar.gz</format>
-    <format>zip</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>


### PR DESCRIPTION
## Summary

Remove ZIP format from 5 assembly descriptors. Only tar.gz is produced for these modules — ZIP was never consumed downstream.

**Connect-converter retains ZIP** — needed by downstream builds (confirmed by @NikishaPatil).

## Changes

6 lines deleted, no new files:
- `app/src/main/assembly/assembly.xml` — remove `<format>zip</format>`
- `operator/controller/src/main/assembly/assembly.xml` — same
- `examples/docker-compose/src/main/assembly/assembly.xml` — same
- `docs/rest-api/src/main/assembly/static-assembly.xml` — same
- `utils/exportConfluent/src/main/assembly/exportConfluent.xml` — same
- `distro/docker/pom.xml` — remove dead `<include>apicurio-*.zip</include>`

## What's NOT changed

- `distro/connect-converter` — keeps both tar.gz + zip
- `cli` — keeps zip-only (platform releases)
- `mcp` — already tar.gz only

Closes #8434

## Test plan

- [ ] Build produces tar.gz (no zip) for app, operator, examples, docs, exportConfluent
- [ ] Connect-converter still produces both formats
- [ ] Docker image builds correctly from tar.gz