### PR TITLE
fix(serdes): use fully-expanded schema for content-based registry lookups

### DIFF
--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/DefaultSchemaResolver.java
@@ -293,7 +293,7 @@ public class DefaultSchemaResolver<S, T> extends AbstractSchemaResolver<S, T> {
     private SchemaLookupResult<S> handleResolveSchemaByContent(ParsedSchema<S> parsedSchema,
                                                                final ArtifactReference artifactReference) {
 
-        String rawSchemaString = IoUtil.toString(parsedSchema.getRawSchema());
+        String rawSchemaString = IoUtil.toString(parsedSchema.getReferencelessRawSchema());
 
         return schemaCache.getByContent(ContentWithReferences.builder().content(rawSchemaString).build(), contentKey -> {
             logger.info(String.format("Retrieving schema content using string: %s", rawSchemaString));

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/ParsedSchema.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/ParsedSchema.java
@@ -33,4 +33,12 @@ public interface ParsedSchema<T> {
      * set the name to be used when referencing this schema
      */
     public ParsedSchemaImpl<T> setReferenceName(String referenceName);
+
+    /**
+     * @return the rawSchema with all references fully expanded inline (no name-only references).
+     * Defaults to {@link #getRawSchema()} when not explicitly set.
+     */
+    default byte[] getReferencelessRawSchema() {
+        return getRawSchema();
+    }
 }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/ParsedSchemaImpl.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/ParsedSchemaImpl.java
@@ -6,6 +6,7 @@ public class ParsedSchemaImpl<T> implements ParsedSchema<T> {
 
     private T parsedSchema;
     private byte[] rawSchema;
+    private byte[] referencelessRawSchema;
     private List<ParsedSchema<T>> schemaReferences;
     private String referenceName;
 
@@ -57,6 +58,16 @@ public class ParsedSchemaImpl<T> implements ParsedSchema<T> {
      */
     public ParsedSchemaImpl<T> setSchemaReferences(List<ParsedSchema<T>> schemaReferences) {
         this.schemaReferences = schemaReferences;
+        return this;
+    }
+
+    @Override
+    public byte[] getReferencelessRawSchema() {
+        return referencelessRawSchema != null ? referencelessRawSchema : rawSchema;
+    }
+
+    public ParsedSchemaImpl<T> setReferencelessRawSchema(byte[] referencelessRawSchema) {
+        this.referencelessRawSchema = referencelessRawSchema;
         return this;
     }
 

--- a/serdes/generic/serde-common-avro/src/main/java/io/apicurio/registry/serde/avro/AvroSchemaParser.java
+++ b/serdes/generic/serde-common-avro/src/main/java/io/apicurio/registry/serde/avro/AvroSchemaParser.java
@@ -74,7 +74,8 @@ public class AvroSchemaParser<U> implements SchemaParser<Schema, U> {
                 return new ParsedSchemaImpl<Schema>().setParsedSchema(s).setReferenceName(s.getFullName())
                         .setSchemaReferences(deduplicatedReferences)
                         .setRawSchema(IoUtil.toBytes(s.toString(deduplicatedReferences.stream()
-                                .map(ParsedSchema::getParsedSchema).collect(Collectors.toSet()), false)));
+                                .map(ParsedSchema::getParsedSchema).collect(Collectors.toSet()), false)))
+                        .setReferencelessRawSchema(IoUtil.toBytes(s.toString()));
             });
         }
     }

--- a/serdes/generic/serde-common-avro/src/test/java/io/apicurio/registry/serde/avro/AvroSchemaParserDuplicateReferencesTest.java
+++ b/serdes/generic/serde-common-avro/src/test/java/io/apicurio/registry/serde/avro/AvroSchemaParserDuplicateReferencesTest.java
@@ -478,6 +478,65 @@ public class AvroSchemaParserDuplicateReferencesTest {
                 "Expected cached instance for dereferenced call");
     }
 
+    /**
+     * Test that getReferencelessRawSchema() contains the full nested record definition
+     * instead of just the record name reference. This reproduces issue #3602 where
+     * content-based schema lookup fails because nested records are serialized as
+     * name-only references.
+     */
+    @Test
+    public void testReferencelessRawSchemaContainsFullNestedDefinition() {
+        Schema.Parser schemaParser = new Schema.Parser();
+
+        String schemaJson = """
+            {
+              "type": "record",
+              "name": "TestAvro",
+              "namespace": "test.avro",
+              "fields": [
+                {"name": "field1", "type": "string"},
+                {"name": "field2", "type": "string"},
+                {
+                  "name": "record1",
+                  "type": {
+                    "type": "record",
+                    "name": "record1Avro",
+                    "fields": [
+                      {"name": "subfield1", "type": "string"},
+                      {"name": "subfield2", "type": ["null", "string"], "default": null}
+                    ]
+                  }
+                }
+              ]
+            }
+            """;
+        Schema schema = schemaParser.parse(schemaJson);
+
+        GenericRecord nested = new GenericData.Record(
+                schema.getField("record1").schema());
+        nested.put("subfield1", "value1");
+        nested.put("subfield2", "value2");
+
+        GenericRecord main = new GenericData.Record(schema);
+        main.put("field1", "a");
+        main.put("field2", "b");
+        main.put("record1", nested);
+
+        ParsedSchema<Schema> parsedSchema = parser.getSchemaFromData(createRecord(main));
+
+        // The rawSchema (with references) should have replaced the nested record with its name
+        String rawSchema = new String(parsedSchema.getRawSchema());
+        Assertions.assertFalse(rawSchema.contains("subfield1"),
+                "rawSchema should NOT contain nested record fields (they should be replaced by name reference)");
+
+        // The referencelessRawSchema should contain the full nested record definition
+        String referencelessRawSchema = new String(parsedSchema.getReferencelessRawSchema());
+        Assertions.assertTrue(referencelessRawSchema.contains("subfield1"),
+                "referencelessRawSchema should contain the full nested record definition");
+        Assertions.assertTrue(referencelessRawSchema.contains("record1Avro"),
+                "referencelessRawSchema should contain the nested record name");
+    }
+
     private Record<GenericRecord> createRecord(GenericRecord genericRecord) {
         return new Record<GenericRecord>() {
             @Override

--- a/serdes/generic/serde-common-avro/src/test/java/io/apicurio/registry/serde/avro/AvroSchemaParserDuplicateReferencesTest.java
+++ b/serdes/generic/serde-common-avro/src/test/java/io/apicurio/registry/serde/avro/AvroSchemaParserDuplicateReferencesTest.java
@@ -537,6 +537,173 @@ public class AvroSchemaParserDuplicateReferencesTest {
                 "referencelessRawSchema should contain the nested record name");
     }
 
+    /**
+     * Test that getReferencelessRawSchema() falls back to getRawSchema() when the schema
+     * has no nested records (no references extracted).
+     */
+    @Test
+    public void testReferencelessRawSchemaFallsBackForFlatSchemas() {
+        Schema.Parser schemaParser = new Schema.Parser();
+
+        String schemaJson = """
+            {
+              "type": "record",
+              "name": "FlatRecord",
+              "namespace": "test.avro",
+              "fields": [
+                {"name": "id", "type": "int"},
+                {"name": "name", "type": "string"},
+                {"name": "active", "type": "boolean"}
+              ]
+            }
+            """;
+        Schema schema = schemaParser.parse(schemaJson);
+
+        GenericRecord record = new GenericData.Record(schema);
+        record.put("id", 1);
+        record.put("name", "test");
+        record.put("active", true);
+
+        ParsedSchema<Schema> parsedSchema = parser.getSchemaFromData(createRecord(record));
+
+        Assertions.assertArrayEquals(parsedSchema.getRawSchema(),
+                parsedSchema.getReferencelessRawSchema(),
+                "For schemas without references, getReferencelessRawSchema() should equal getRawSchema()");
+        Assertions.assertFalse(parsedSchema.hasReferences(),
+                "Flat schema should have no references");
+    }
+
+    /**
+     * Test that getReferencelessRawSchema() contains the full nested record definition
+     * when the nested record is wrapped in a union (e.g. ["null", {record}]).
+     * The issue reporter confirmed this case already worked, so this is a regression guard.
+     */
+    @Test
+    public void testReferencelessRawSchemaWithUnionWrappedNestedRecord() {
+        Schema.Parser schemaParser = new Schema.Parser();
+
+        String schemaJson = """
+            {
+              "type": "record",
+              "name": "WithOptionalNested",
+              "namespace": "test.avro",
+              "fields": [
+                {"name": "id", "type": "int"},
+                {
+                  "name": "optionalRecord",
+                  "type": [
+                    "null",
+                    {
+                      "type": "record",
+                      "name": "NestedInUnion",
+                      "fields": [
+                        {"name": "value", "type": "string"}
+                      ]
+                    }
+                  ],
+                  "default": null
+                }
+              ]
+            }
+            """;
+        Schema schema = schemaParser.parse(schemaJson);
+
+        Schema nestedSchema = schema.getField("optionalRecord").schema().getTypes().get(1);
+        GenericRecord nested = new GenericData.Record(nestedSchema);
+        nested.put("value", "hello");
+
+        GenericRecord main = new GenericData.Record(schema);
+        main.put("id", 1);
+        main.put("optionalRecord", nested);
+
+        ParsedSchema<Schema> parsedSchema = parser.getSchemaFromData(createRecord(main));
+
+        String referencelessRawSchema = new String(parsedSchema.getReferencelessRawSchema());
+        Assertions.assertTrue(referencelessRawSchema.contains("NestedInUnion"),
+                "referencelessRawSchema should contain the union-wrapped nested record name");
+        Assertions.assertTrue(referencelessRawSchema.contains("\"value\""),
+                "referencelessRawSchema should contain the union-wrapped nested record fields");
+    }
+
+    /**
+     * Test that getReferencelessRawSchema() contains full definitions for deeply nested
+     * records (record -> record -> record).
+     */
+    @Test
+    public void testReferencelessRawSchemaWithDeeplyNestedRecords() {
+        Schema.Parser schemaParser = new Schema.Parser();
+
+        String schemaJson = """
+            {
+              "type": "record",
+              "name": "Level0",
+              "namespace": "test.avro",
+              "fields": [
+                {"name": "name", "type": "string"},
+                {
+                  "name": "level1",
+                  "type": {
+                    "type": "record",
+                    "name": "Level1",
+                    "fields": [
+                      {"name": "mid", "type": "int"},
+                      {
+                        "name": "level2",
+                        "type": {
+                          "type": "record",
+                          "name": "Level2",
+                          "fields": [
+                            {"name": "deep", "type": "string"}
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+            """;
+        Schema schema = schemaParser.parse(schemaJson);
+
+        Schema level1Schema = schema.getField("level1").schema();
+        Schema level2Schema = level1Schema.getField("level2").schema();
+
+        GenericRecord level2 = new GenericData.Record(level2Schema);
+        level2.put("deep", "bottom");
+
+        GenericRecord level1 = new GenericData.Record(level1Schema);
+        level1.put("mid", 42);
+        level1.put("level2", level2);
+
+        GenericRecord level0 = new GenericData.Record(schema);
+        level0.put("name", "top");
+        level0.put("level1", level1);
+
+        ParsedSchema<Schema> parsedSchema = parser.getSchemaFromData(createRecord(level0));
+
+        // rawSchema should have replaced nested records with name references
+        String rawSchema = new String(parsedSchema.getRawSchema());
+        Assertions.assertFalse(rawSchema.contains("\"deep\""),
+                "rawSchema should NOT contain deeply nested record fields");
+
+        // referencelessRawSchema should contain ALL nested definitions
+        String referencelessRawSchema = new String(parsedSchema.getReferencelessRawSchema());
+        Assertions.assertTrue(referencelessRawSchema.contains("Level1"),
+                "referencelessRawSchema should contain Level1 definition");
+        Assertions.assertTrue(referencelessRawSchema.contains("Level2"),
+                "referencelessRawSchema should contain Level2 definition");
+        Assertions.assertTrue(referencelessRawSchema.contains("\"deep\""),
+                "referencelessRawSchema should contain the deepest nested field");
+        Assertions.assertTrue(referencelessRawSchema.contains("\"mid\""),
+                "referencelessRawSchema should contain mid-level nested field");
+
+        // Verify it's a valid parseable schema
+        Schema reparsed = new Schema.Parser().parse(referencelessRawSchema);
+        Assertions.assertEquals("test.avro.Level0", reparsed.getFullName());
+        Assertions.assertNotNull(reparsed.getField("level1").schema().getField("level2"),
+                "Reparsed schema should preserve the full nesting structure");
+    }
+
     private Record<GenericRecord> createRecord(GenericRecord genericRecord) {
         return new Record<GenericRecord>() {
             @Override


### PR DESCRIPTION
## Summary
Fixes #3602. When an Avro schema has a nested record as the sole type of a field (not in a union), the `AvroSchemaParser` replaces the full nested record definition with just its name in the serialized raw schema. This causes `DefaultSchemaResolver.handleResolveSchemaByContent()` to send a schema to the registry that doesn't match the fully-expanded schema stored there, resulting in a lookup failure and NPE.

## Root Cause
`AvroSchemaParser.getSchemaFromData()` calls `schema.toString(references, false)` which replaces nested record definitions in the reference set with just their name (e.g., `"type": "record1Avro"` instead of the full record definition). This canonicalized form is stored as `rawSchema` and is what `DefaultSchemaResolver` sends to the registry for content-based lookups. The registry has the fully-expanded schema, so the content search returns no results.

The auto-create path works correctly because it sends both the referenced schema and the reference links. But the content-search path sends only the referenced schema without any reference context.

## Changes
- **`ParsedSchema.java`**: Added `getReferencelessRawSchema()` default method that falls back to `getRawSchema()` when not explicitly set
- **`ParsedSchemaImpl.java`**: Added `referencelessRawSchema` field with getter (returns field if set, otherwise falls back to `rawSchema`) and builder-style setter
- **`AvroSchemaParser.java`**: In `getSchemaFromData()`, now stores the fully-expanded schema via `s.toString()` as `referencelessRawSchema` alongside the existing reference-canonicalized `rawSchema`
- **`DefaultSchemaResolver.java`**: `handleResolveSchemaByContent()` now uses `getReferencelessRawSchema()` instead of `getRawSchema()` for content-based lookups
- **`AvroSchemaParserDuplicateReferencesTest.java`**: Added `testReferencelessRawSchemaContainsFullNestedDefinition()` test that reproduces the exact schema from issue #3602

## Test plan
- [x] Unit test added: `testReferencelessRawSchemaContainsFullNestedDefinition()` verifies that the referenceless raw schema contains full nested record definitions while the raw schema has name-only references
- [x] Existing unit tests pass (`./mvnw test -pl serdes/generic/serde-common-avro`)
- [x] Checkstyle passes (`./mvnw checkstyle:check -pl schema-resolver,serdes/generic/serde-common-avro`)
- [ ] Integration tests with SQL storage variant
- [ ] Integration tests with KafkaSQL storage variant