### PR TITLE
[CI Reliability] Fix Maven lock contention in parallel builds

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -39,7 +39,7 @@ jobs:
 
       # We need to build the operand image as well as the operator, otherwise the tests would not reflect changes in the current PR.
       - name: Build
-        run: ./mvnw -B clean package -Dfull -pl app,distro/docker,operator/olm-tests -am -Pprod -DskipTests -Dmaven.javadoc.skip
+        run: ./mvnw -B clean package -Dfull -pl app,distro/docker,operator/olm-tests -am -Pprod -DskipTests -Dmaven.javadoc.skip -Daether.syncContext.named.factory=noop
 
       - name: Build operand image
         run: |
@@ -125,7 +125,7 @@ jobs:
       - name: Build and run local tests on Minikube
         working-directory: operator
         run: |
-          make BUILD_OPTS=--no-transfer-progress build
+          make BUILD_OPTS="--no-transfer-progress -Daether.syncContext.named.factory=noop" build
 
   operator-test:
     name: Remote Tests (${{ matrix.name }})
@@ -235,7 +235,7 @@ jobs:
       - name: Run ${{ matrix.name }} tests on Minikube
         working-directory: operator
         run: |
-          make BUILD_OPTS="--no-transfer-progress -Dtest.operator.deployment-target=minikube ${{ matrix.extra-build-opts }}" \
+          make BUILD_OPTS="--no-transfer-progress -Daether.syncContext.named.factory=noop -Dtest.operator.deployment-target=minikube ${{ matrix.extra-build-opts }}" \
             REMOTE_TESTS_ALL_INSTALL_FILE=controller/target/test-install.yaml \
             GROUPS="${{ matrix.groups }}" \
             EXCLUDED_GROUPS="${{ matrix.excluded-groups }}" \
@@ -258,7 +258,7 @@ jobs:
           cache: maven
 
       - name: Build for install file generation
-        run: ./mvnw -B clean package -Dfull -pl operator/controller -am -Pprod -DskipTests -Dmaven.javadoc.skip
+        run: ./mvnw -B clean package -Dfull -pl operator/controller -am -Pprod -DskipTests -Dmaven.javadoc.skip -Daether.syncContext.named.factory=noop
 
       - name: Update install file
         working-directory: operator
@@ -309,7 +309,7 @@ jobs:
       - name: Build
         working-directory: operator
         run: |
-          make BUILD_OPTS=--no-transfer-progress SKIP_TESTS=true build
+          make BUILD_OPTS="--no-transfer-progress -Daether.syncContext.named.factory=noop" SKIP_TESTS=true build
 
       - name: Login to quay.io registry
         run: |

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -116,6 +116,7 @@ jobs:
         working-directory: registry
         run: |
           ./mvnw clean package -am --no-transfer-progress -Pprod -Dfull -DskipTests -DskipCommitIdPlugin=false -DcliSkipNative \
+            -Daether.syncContext.named.factory=noop \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 
       - name: Build Registry UI

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -211,6 +211,7 @@ jobs:
             -Pprod -Dfull -pl '!cli' \
             -DskipTests \
             -DskipCommitIdPlugin=false \
+            -Daether.syncContext.named.factory=noop \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
             -Dmaven.wagon.http.retryHandler.count=5
 
@@ -289,6 +290,7 @@ jobs:
             -pl cli -am \
             -DskipTests \
             -Dquarkus.native.container-build=false \
+            -Daether.syncContext.named.factory=noop \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
             -Dmaven.wagon.http.retryHandler.count=5
 

--- a/.github/workflows/reusable-docker-build.yaml
+++ b/.github/workflows/reusable-docker-build.yaml
@@ -64,7 +64,7 @@ on:
         description: 'Maven arguments for build'
         required: false
         type: string
-        default: 'clean package -Pprod -DskipTests --no-transfer-progress'
+        default: 'clean package -Pprod -DskipTests --no-transfer-progress -Daether.syncContext.named.factory=noop'
       npm-build:
         description: 'Run npm build before Docker build'
         required: false

--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -41,6 +41,7 @@ jobs:
           ./mvnw clean package -T 0.5C --no-transfer-progress \
             -Pprod -Dfull -DskipTests -DskipCommitIdPlugin=false -DcliSkipNative \
             -Dmaven.source.skip=true -Dmaven.javadoc.skip=true \
+            -Daether.syncContext.named.factory=noop \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
             -Dmaven.wagon.http.retryHandler.count=5
 

--- a/.github/workflows/verify-cli.yaml
+++ b/.github/workflows/verify-cli.yaml
@@ -80,6 +80,7 @@ jobs:
             -Dquarkus.native.container-build=false \
             ${{ matrix.test-args }} \
             -Dmaven.javadoc.skip=true \
+            -Daether.syncContext.named.factory=noop \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
             -Dmaven.wagon.http.retryHandler.count=5
 

--- a/.github/workflows/verify-extras.yaml
+++ b/.github/workflows/verify-extras.yaml
@@ -44,7 +44,8 @@ jobs:
           ./mvnw verify --no-transfer-progress -Dfull -pl utils/extra-tests -am \
             -Pextra-tests \
             -Dregistry3-image=apicurio/apicurio-registry:${{ inputs.image-tag }} \
-            -Dmaven.javadoc.skip=true
+            -Dmaven.javadoc.skip=true \
+            -Daether.syncContext.named.factory=noop
 
       - name: Run examples/http-caching tests
         working-directory: examples/http-caching/test
@@ -224,4 +225,4 @@ jobs:
 
       - name: Build Apicurio Registry with Examples
         run: |
-          mvn install -T 1 -DskipTests -Pexamples -Dassembly.skipAssembly=true --no-transfer-progress
+          mvn install -T 1 -DskipTests -Pexamples -Dassembly.skipAssembly=true -Daether.syncContext.named.factory=noop --no-transfer-progress

--- a/.github/workflows/verify-integration-tests.yaml
+++ b/.github/workflows/verify-integration-tests.yaml
@@ -74,6 +74,7 @@ jobs:
             -Dregistry-image=apicurio/apicurio-registry:${{ inputs.image-tag }} \
             -pl integration-tests \
             -Dmaven.javadoc.skip=true \
+            -Daether.syncContext.named.factory=noop \
             -Dfailsafe.rerunFailingTestsCount=2
 
       - name: Collect logs

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -85,6 +85,7 @@ jobs:
             -DskipCommitIdPlugin=true \
             -Dcheckstyle.skip=true \
             -Dmaven.source.skip=true -Dmaven.javadoc.skip=true \
+            -Daether.syncContext.named.factory=noop \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
             -Dmaven.wagon.http.retryHandler.count=5 \
             -Dsurefire.rerunFailingTestsCount=2


### PR DESCRIPTION
## Summary

- Add `-Daether.syncContext.named.factory=noop` to all CI Maven commands using parallel threads
- Eliminates random `Could not acquire lock(s)` failures from Maven 3.9+ resolver locking
- Applied consistently to 9 workflow files (verify, operator, release, reusable-docker-build)

## Problem

CI builds randomly fail with `Could not acquire lock(s)` when Maven 3.9+ runs with parallel threads (`-T`). The `maven-resolver-named-locks` library deadlocks under concurrent resolver operations. Recent examples:
- PR #8435: 2 consecutive failures, 3 re-triggers needed
- Main branch run after #8412: operator build failed

## Why this is safe

Each GitHub Actions runner has its own `.m2/repository` — there's no cross-process contention. The file-based locking was designed for multi-process scenarios (e.g., two Maven instances sharing a local repo), not multi-thread within a single process. Disabling it in CI is a no-op from a safety perspective.

## Scope

CI workflows only. NOT added to `.mvn/maven.config` — local development is unaffected.

Closes #8438

## Test plan

- [ ] No `Could not acquire lock(s)` failures in CI run for this PR
- [ ] All existing tests pass (no behavioral change)
- [ ] Verify flag is only on commands with parallel threads