### PR TITLE
fix(operator): force single-threaded Maven builds in operator Makefile

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -11,7 +11,8 @@ LC_VERSION_SUFFIX ?= $(shell echo "$(LC_VERSION)" | sed -n 's/[^-]*\(-.*\)/\1/p'
 
 BUILD_OPTS_EXT += $(BUILD_OPTS)
 
-BUILD_OPTS_EXT += -pl controller -am
+# -T1 overrides the inherited -T 1C from .mvn/maven.config — operator @QuarkusTest tests require single-threaded execution
+BUILD_OPTS_EXT += -T1 -pl controller -am
 
 SKIP_TESTS ?= false
 ifneq ($(SKIP_TESTS),true)


### PR DESCRIPTION
## Summary

One-line fix: add `-T1` to the operator Makefile to override the inherited `-T 1C` from `.mvn/maven.config`.

## Problem

`AppFeaturesITTest` has failed on **every main push since June 29** (5+ consecutive failures). Root cause: PR #8367 added `-T 1C` to `.mvn/maven.config` for parallel Maven builds. The operator's `make build` (which runs `mvn clean install`) inherits this, running with 8 parallel threads. The operator `@QuarkusTest` integration tests are not designed for parallel execution.

## Fix

```makefile
# -T1 overrides the inherited -T 1C from .mvn/maven.config — operator @QuarkusTest tests require single-threaded execution
BUILD_OPTS_EXT += -T1 -pl controller -am
```

This restores single-threaded operator builds while keeping parallel builds for all other modules. The compilation speed loss is negligible (operator has only 3 modules).

## Evidence

- Last green Operator Local Tests: run 28386258145 (June 29 16:13, before #8367 merged)
- First failure: run 28400600397 (June 29 20:29, after #8367 merged)
- 5 consecutive failures since then, all `ConditionTimeoutException` in `AppFeaturesITTest`

Closes #8447

## Test plan

- [ ] Operator Local Tests pass (AppFeaturesITTest no longer times out)
- [ ] Other modules still build with parallel threads