### PR TITLE
[CI] Add inline documentation to workflow Maven commands

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -37,7 +37,7 @@ jobs:
           distribution: temurin
           cache: maven
 
-      # Build operand (app + docker) and operator OLM tests. Changes in the current PR must be reflected.
+      # Build operand (app + docker) and operator OLM tests, so downstream tests reflect changes in the current PR.
       # -Dfull: include all optional modules needed for the Docker image
       # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
       - name: Build
@@ -158,7 +158,7 @@ jobs:
           docker push "$IMAGE"
 
       # Makefile enforces -T1 (single-threaded) because operator @QuarkusTest tests require sequential execution.
-      # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks
+      # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
       - name: Build and run local tests on Minikube
         working-directory: operator
         run: |

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -37,7 +37,9 @@ jobs:
           distribution: temurin
           cache: maven
 
-      # We need to build the operand image as well as the operator, otherwise the tests would not reflect changes in the current PR.
+      # Build operand (app + docker) and operator OLM tests. Changes in the current PR must be reflected.
+      # -Dfull: include all optional modules needed for the Docker image
+      # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
       - name: Build
         run: ./mvnw -B clean package -Dfull -pl app,distro/docker,operator/olm-tests -am -Pprod -DskipTests -Dmaven.javadoc.skip -Daether.syncContext.named.factory=noop
 
@@ -155,6 +157,8 @@ jobs:
           docker push "$REGISTRY_GITOPS_SYNC_IMAGE"
           docker push "$IMAGE"
 
+      # Makefile enforces -T1 (single-threaded) because operator @QuarkusTest tests require sequential execution.
+      # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks
       - name: Build and run local tests on Minikube
         working-directory: operator
         run: |
@@ -290,6 +294,9 @@ jobs:
           distribution: temurin
           cache: maven
 
+      # Rebuild operator controller to generate the install file, then verify it matches the committed version.
+      # -Dfull: include all optional modules needed for a complete operator build
+      # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
       - name: Build for install file generation
         run: ./mvnw -B clean package -Dfull -pl operator/controller -am -Pprod -DskipTests -Dmaven.javadoc.skip -Daether.syncContext.named.factory=noop
 

--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -38,6 +38,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For downloading Kiota binary.
         run: |
+          # -T 0.5C: half a thread per CPU core (overrides .mvn/maven.config's -T 1C for memory-heavy packaging)
+          # -Pprod -Dfull: production profile with all optional modules (CLI, serdes, distro, etc.)
+          # -DskipCommitIdPlugin=false: generate git commit metadata (needed for the Docker image)
+          # -DcliSkipNative: skip GraalVM native-image for CLI (separate verify-cli job handles this)
+          # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
+          # -Dmaven.wagon.http*: limit concurrent HTTP connections and retry on transient download failures
           ./mvnw clean package -T 0.5C --no-transfer-progress \
             -Pprod -Dfull -DskipTests -DskipCommitIdPlugin=false -DcliSkipNative \
             -Dmaven.source.skip=true -Dmaven.javadoc.skip=true \

--- a/.github/workflows/verify-cli.yaml
+++ b/.github/workflows/verify-cli.yaml
@@ -75,6 +75,10 @@ jobs:
 
       - name: Build and Test CLI
         run: |
+          # -Dquarkus.native.container-build=false: use locally installed GraalVM (not Docker-based native build)
+          # matrix.test-args: per-OS test config (Linux uses Docker-based tests, macOS skips them)
+          # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
+          # -Dmaven.wagon.http*: limit concurrent HTTP connections and retry on transient download failures
           ./mvnw verify -pl cli \
             --no-transfer-progress \
             -Dquarkus.native.container-build=false \

--- a/.github/workflows/verify-extras.yaml
+++ b/.github/workflows/verify-extras.yaml
@@ -231,5 +231,5 @@ jobs:
           # -T 1: single-threaded (overrides .mvn/maven.config's -T 1C to prevent module ordering issues with examples)
           # -Pexamples: activates the examples profile (builds example applications)
           # -Dassembly.skipAssembly=true: skip archive generation (not needed for example compilation)
-          # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks
+          # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
           mvn install -T 1 -DskipTests -Pexamples -Dassembly.skipAssembly=true -Daether.syncContext.named.factory=noop --no-transfer-progress

--- a/.github/workflows/verify-extras.yaml
+++ b/.github/workflows/verify-extras.yaml
@@ -41,6 +41,9 @@ jobs:
 
       - name: Run Extra Tests
         run: |
+          # -Pextra-tests: activates the extra-tests profile (additional validation beyond unit/integration)
+          # -Dregistry3-image: Docker image to test against (built by the Build job)
+          # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
           ./mvnw verify --no-transfer-progress -Dfull -pl utils/extra-tests -am \
             -Pextra-tests \
             -Dregistry3-image=apicurio/apicurio-registry:${{ inputs.image-tag }} \
@@ -225,4 +228,8 @@ jobs:
 
       - name: Build Apicurio Registry with Examples
         run: |
+          # -T 1: single-threaded (overrides .mvn/maven.config's -T 1C to prevent module ordering issues with examples)
+          # -Pexamples: activates the examples profile (builds example applications)
+          # -Dassembly.skipAssembly=true: skip archive generation (not needed for example compilation)
+          # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks
           mvn install -T 1 -DskipTests -Pexamples -Dassembly.skipAssembly=true -Daether.syncContext.named.factory=noop --no-transfer-progress

--- a/.github/workflows/verify-integration-tests.yaml
+++ b/.github/workflows/verify-integration-tests.yaml
@@ -67,6 +67,11 @@ jobs:
 
       - name: Run Integration Tests
         run: |
+          # -Pintegration-tests + -P<remote-profile>: select storage backend (remote-mem, remote-sql, remote-kafka, etc.)
+          # -Dgroups: JUnit 5 test tags filtering (e.g., auth, migration, debezium)
+          # -Dregistry-image: Docker image built by the Build job, loaded into Minikube
+          # -Dfailsafe.rerunFailingTestsCount=2: automatically retry flaky integration tests up to 2 times
+          # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
           ./mvnw verify -am --no-transfer-progress \
             -Pintegration-tests \
             -P${{ matrix.remote-profile }} \

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -77,6 +77,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_OPTS: ${{ matrix.shard.maven-opts }}
         run: |
+          # Each shard compiles the same modules but runs a different subset of tests via -Dtest= filters.
+          # Pre-built artifacts from the Build job are downloaded but Maven still needs to resolve/compile.
+          # -Dsurefire.failIfNoSpecifiedTests=false: don't fail if a shard's test filter matches zero tests
+          # -Dsurefire.rerunFailingTestsCount=2: automatically retry flaky tests up to 2 times
+          # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
           ./mvnw verify \
             --no-transfer-progress \
             -Pprod ${{ matrix.shard.modules }} \


### PR DESCRIPTION
## Summary

Add YAML comments to all CI workflow Maven commands explaining non-obvious flags. Documentation-only — no behavioral changes.

## Motivation

The CI optimization work over the past two weeks introduced many flags across 6 workflow files. Without comments, the rationale for flags like `-Daether.syncContext.named.factory=noop` or `-T 0.5C` (vs the default `-T 1C`) is not obvious to developers maintaining these workflows.

## What's documented

| Flag | Explanation |
|------|-------------|
| `-T 0.5C` | Overrides `.mvn/maven.config`'s `-T 1C` for memory-heavy packaging |
| `-T 1` | Overrides `-T 1C` to prevent module ordering issues with examples |
| `-Daether.syncContext.named.factory=noop` | Prevents Maven 3.9+ resolver lock deadlocks under parallel builds |
| `-DcliSkipNative` | Skips GraalVM native-image (separate CLI verification job handles it) |
| `-DskipCommitIdPlugin=false` | Generates git commit metadata for Docker image |
| `-Dsurefire.rerunFailingTestsCount=2` | Auto-retries flaky tests up to 2 times |
| `-Dsurefire.failIfNoSpecifiedTests=false` | Allows empty test filter matches per shard |
| `-Dmaven.wagon.http*` | Limits HTTP connections and retries downloads |
| Operator Makefile `-T1` | Operator `@QuarkusTest` tests require sequential execution |

Closes #8449

## Test plan

- [ ] No behavioral changes — only YAML comments added
- [ ] CI passes (comments don't affect execution)