### PR TITLE
fix(ui): load current user on dashboard first render

### DIFF
--- a/ui/ui-app/src/app/MainPageWithAuth.tsx
+++ b/ui/ui-app/src/app/MainPageWithAuth.tsx
@@ -22,6 +22,7 @@ import { RolesPage, SettingsPage } from "./pages";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { ApplicationAuth, AuthConfig, AuthConfigContext } from "@apicurio/common-ui-components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
+import { UserProvider } from "@services/useUserService.ts";
 
 export type MainPageWithAuthProps = object;
 
@@ -55,88 +56,90 @@ export const MainPageWithAuth: FunctionComponent<MainPageWithAuthProps> = () => 
     return (
         <AuthConfigContext.Provider value={authConfig}>
             <ApplicationAuth>
-                <Page
-                    className="pf-m-redhat-font"
-                    isManagedSidebar={false}
-                    masthead={<AppHeader />}
-                    isContentFilled={true}
-                >
-                    <Routes>
-                        <Route path="/" element={ <RootRedirectPage /> } />
-                        <Route path="/dashboard" element={ <DashboardPage /> } />
-                        <Route path="/rules" element={ <RulesPage /> } />
-                        <Route path="/contract-rules" element={ <GlobalContractRulesPage /> } />
-                        <Route path="/roles" element={ <RolesPage /> } />
-                        <Route path="/settings" element={ <SettingsPage /> } />
-                        <Route path="/search" element={ <SearchPage /> } />
-                        <Route path="/drafts" element={ <DraftsPage /> } />
-                        <Route path="/explore" element={ <ExplorePage /> } />
-                        <Route path="/agents" element={ <AgentsPage /> } />
+                <UserProvider>
+                    <Page
+                        className="pf-m-redhat-font"
+                        isManagedSidebar={false}
+                        masthead={<AppHeader />}
+                        isContentFilled={true}
+                    >
+                        <Routes>
+                            <Route path="/" element={ <RootRedirectPage /> } />
+                            <Route path="/dashboard" element={ <DashboardPage /> } />
+                            <Route path="/rules" element={ <RulesPage /> } />
+                            <Route path="/contract-rules" element={ <GlobalContractRulesPage /> } />
+                            <Route path="/roles" element={ <RolesPage /> } />
+                            <Route path="/settings" element={ <SettingsPage /> } />
+                            <Route path="/search" element={ <SearchPage /> } />
+                            <Route path="/drafts" element={ <DraftsPage /> } />
+                            <Route path="/explore" element={ <ExplorePage /> } />
+                            <Route path="/agents" element={ <AgentsPage /> } />
 
-                        <Route
-                            path="/explore/:groupId"
-                            element={ <GroupPage /> }
-                        />
-                        <Route
-                            path="/explore/:groupId/rules"
-                            element={ <GroupPage /> }
-                        />
+                            <Route
+                                path="/explore/:groupId"
+                                element={ <GroupPage /> }
+                            />
+                            <Route
+                                path="/explore/:groupId/rules"
+                                element={ <GroupPage /> }
+                            />
 
-                        <Route
-                            path="/explore/:groupId/:artifactId"
-                            element={ <ArtifactPage /> }
-                        />
-                        <Route
-                            path="/explore/:groupId/:artifactId/rules"
-                            element={ <ArtifactPage /> }
-                        />
-                        <Route
-                            path="/explore/:groupId/:artifactId/branches"
-                            element={ <ArtifactPage /> }
-                        />
-                        <Route
-                            path="/explore/:groupId/:artifactId/contract"
-                            element={ <ArtifactPage /> }
-                        />
-                        <Route
-                            path="/explore/:groupId/:artifactId/usage"
-                            element={ <ArtifactPage /> }
-                        />
+                            <Route
+                                path="/explore/:groupId/:artifactId"
+                                element={ <ArtifactPage /> }
+                            />
+                            <Route
+                                path="/explore/:groupId/:artifactId/rules"
+                                element={ <ArtifactPage /> }
+                            />
+                            <Route
+                                path="/explore/:groupId/:artifactId/branches"
+                                element={ <ArtifactPage /> }
+                            />
+                            <Route
+                                path="/explore/:groupId/:artifactId/contract"
+                                element={ <ArtifactPage /> }
+                            />
+                            <Route
+                                path="/explore/:groupId/:artifactId/usage"
+                                element={ <ArtifactPage /> }
+                            />
 
-                        <Route
-                            path="/explore/:groupId/:artifactId/versions/:version"
-                            element={ <VersionPage /> }
-                        />
-                        <Route
-                            path="/explore/:groupId/:artifactId/versions/:version/:editor"
-                            element={ <EditorPage /> }
-                        />
-                        <Route
-                            path="/explore/:groupId/:artifactId/versions/:version/content"
-                            element={ <VersionPage /> }
-                        />
-                        <Route
-                            path="/explore/:groupId/:artifactId/versions/:version/documentation"
-                            element={ <VersionPage /> }
-                        />
-                        <Route
-                            path="/explore/:groupId/:artifactId/versions/:version/references"
-                            element={ <VersionPage /> }
-                        />
+                            <Route
+                                path="/explore/:groupId/:artifactId/versions/:version"
+                                element={ <VersionPage /> }
+                            />
+                            <Route
+                                path="/explore/:groupId/:artifactId/versions/:version/:editor"
+                                element={ <EditorPage /> }
+                            />
+                            <Route
+                                path="/explore/:groupId/:artifactId/versions/:version/content"
+                                element={ <VersionPage /> }
+                            />
+                            <Route
+                                path="/explore/:groupId/:artifactId/versions/:version/documentation"
+                                element={ <VersionPage /> }
+                            />
+                            <Route
+                                path="/explore/:groupId/:artifactId/versions/:version/references"
+                                element={ <VersionPage /> }
+                            />
 
-                        <Route
-                            path="/explore/:groupId/:artifactId/branches/:branchId"
-                            element={ <BranchPage /> }
-                        />
-                        <Route
-                            path="/explore/:groupId/:artifactId/branches/:branchId/versions"
-                            element={ <BranchPage /> }
-                        />
+                            <Route
+                                path="/explore/:groupId/:artifactId/branches/:branchId"
+                                element={ <BranchPage /> }
+                            />
+                            <Route
+                                path="/explore/:groupId/:artifactId/branches/:branchId/versions"
+                                element={ <BranchPage /> }
+                            />
 
 
-                        <Route element={ <NotFoundPage /> } />
-                    </Routes>
-                </Page>
+                            <Route element={ <NotFoundPage /> } />
+                        </Routes>
+                    </Page>
+                </UserProvider>
             </ApplicationAuth>
         </AuthConfigContext.Provider>
     );

--- a/ui/ui-app/src/app/pages/dashboard/DashboardPage.tsx
+++ b/ui/ui-app/src/app/pages/dashboard/DashboardPage.tsx
@@ -13,7 +13,7 @@ import {
     CodeBranchIcon,
     FolderOpenIcon
 } from "@patternfly/react-icons";
-import { DASHBOARD_PAGE_IDX, PageError, PageErrorHandler, PageProperties, toPageError } from "@app/pages";
+import { DASHBOARD_PAGE_IDX, PageDataLoader, PageError, PageErrorHandler, PageProperties, toPageError } from "@app/pages";
 import { CreateArtifactModal, RootPageHeader } from "@app/components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { SearchService, useSearchService } from "@services/useSearchService.ts";
@@ -41,7 +41,7 @@ interface RegistryStats {
  */
 export const DashboardPage: FunctionComponent<PageProperties> = () => {
     const [pageError, setPageError] = useState<PageError>();
-    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [loaders, setLoaders] = useState<Promise<any> | Promise<any>[] | undefined>();
     const [stats, setStats] = useState<RegistryStats>({
         groupCount: 0,
         artifactCount: 0,
@@ -58,7 +58,6 @@ export const DashboardPage: FunctionComponent<PageProperties> = () => {
     const usage: UsageService = useUsageService();
 
     const loadStats = async (): Promise<void> => {
-        setIsLoading(true);
         try {
             const [groupsResult, artifactsResult, versionsResult] = await Promise.all([
                 search.searchGroups([], GroupSortByObject.GroupId, SortOrderObject.Asc, { page: 1, pageSize: 1 }),
@@ -74,8 +73,6 @@ export const DashboardPage: FunctionComponent<PageProperties> = () => {
         } catch (error) {
             console.error("Error loading stats:", error);
             setPageError(toPageError(error, "Error loading registry statistics."));
-        } finally {
-            setIsLoading(false);
         }
     };
 
@@ -100,10 +97,16 @@ export const DashboardPage: FunctionComponent<PageProperties> = () => {
         setUsageSummary(summary);
     };
 
+    const createLoaders = (): Promise<any> => {
+        return Promise.all([
+            loadStats(),
+            loadRecentArtifacts(),
+            loadUsageSummary()
+        ]);
+    };
+
     useEffect(() => {
-        loadStats();
-        loadRecentArtifacts();
-        loadUsageSummary();
+        setLoaders(createLoaders());
     }, []);
 
     const handleCreateArtifact = (): void => {
@@ -141,84 +144,86 @@ export const DashboardPage: FunctionComponent<PageProperties> = () => {
 
     return (
         <PageErrorHandler error={pageError}>
-            <PageSection hasBodyWrapper={false} className="ps_dashboard-header"  padding={{ default: "noPadding" }}>
-                <RootPageHeader tabKey={DASHBOARD_PAGE_IDX} />
-            </PageSection>
-            <PageSection hasBodyWrapper={false} className="ps_dashboard-description" >
-                <Flex direction={{ default: "column" }}>
-                    <FlexItem>
-                        <Title headingLevel="h1">Registry Dashboard</Title>
-                    </FlexItem>
-                    <FlexItem>
-                        <p className="dashboard-description">
-                            Welcome to Apicurio Registry. Manage your schemas and API definitions in one central location.
-                        </p>
-                    </FlexItem>
-                </Flex>
-            </PageSection>
-            <PageSection hasBodyWrapper={false} isFilled={true} className="ps_dashboard-content">
-                <Grid hasGutter>
-                    <GridItem span={12}>
-                        <Flex spaceItems={{ default: "spaceItemsLg" }}>
-                            <FlexItem>
-                                <StatsCard
-                                    title="Groups"
-                                    value={stats.groupCount}
-                                    icon={<FolderOpenIcon />}
-                                    isLoading={isLoading}
-                                    onClick={() => handleStatsClick("/search?for=groups")}
-                                />
-                            </FlexItem>
-                            <FlexItem>
-                                <StatsCard
-                                    title="Artifacts"
-                                    value={stats.artifactCount}
-                                    icon={<CubesIcon />}
-                                    isLoading={isLoading}
-                                    onClick={() => handleStatsClick("/search?for=artifacts")}
-                                />
-                            </FlexItem>
-                            <FlexItem>
-                                <StatsCard
-                                    title="Versions"
-                                    value={stats.versionCount}
-                                    icon={<CodeBranchIcon />}
-                                    isLoading={isLoading}
-                                    onClick={() => handleStatsClick("/search?for=versions")}
-                                />
-                            </FlexItem>
-                            {usageSummary && (
+            <PageDataLoader loaders={loaders}>
+                <PageSection hasBodyWrapper={false} className="ps_dashboard-header"  padding={{ default: "noPadding" }}>
+                    <RootPageHeader tabKey={DASHBOARD_PAGE_IDX} />
+                </PageSection>
+                <PageSection hasBodyWrapper={false} className="ps_dashboard-description" >
+                    <Flex direction={{ default: "column" }}>
+                        <FlexItem>
+                            <Title headingLevel="h1">Registry Dashboard</Title>
+                        </FlexItem>
+                        <FlexItem>
+                            <p className="dashboard-description">
+                                Welcome to Apicurio Registry. Manage your schemas and API definitions in one central location.
+                            </p>
+                        </FlexItem>
+                    </Flex>
+                </PageSection>
+                <PageSection hasBodyWrapper={false} isFilled={true} className="ps_dashboard-content">
+                    <Grid hasGutter>
+                        <GridItem span={12}>
+                            <Flex spaceItems={{ default: "spaceItemsLg" }}>
                                 <FlexItem>
-                                    <UsageSummaryCard
-                                        data={usageSummary}
-                                        isLoading={isLoading}
+                                    <StatsCard
+                                        title="Groups"
+                                        value={stats.groupCount}
+                                        icon={<FolderOpenIcon />}
+                                        isLoading={false}
+                                        onClick={() => handleStatsClick("/search?for=groups")}
                                     />
                                 </FlexItem>
-                            )}
-                        </Flex>
-                    </GridItem>
-                    <GridItem span={8}>
-                        <RecentArtifacts
-                            artifacts={recentArtifacts}
-                            isLoading={isLoading}
-                            error={recentArtifactsError}
-                        />
-                    </GridItem>
-                    <GridItem span={4}>
-                        <QuickActions
-                            onCreateArtifact={handleCreateArtifact}
-                            onSearch={handleSearch}
-                            onExplore={handleExplore}
-                            onSettings={handleSettings}
-                        />
-                    </GridItem>
-                </Grid>
-            </PageSection>
-            <CreateArtifactModal
-                isOpen={isCreateArtifactModalOpen}
-                onClose={() => setIsCreateArtifactModalOpen(false)}
-                onCreate={doCreateArtifact}
-            />
+                                <FlexItem>
+                                    <StatsCard
+                                        title="Artifacts"
+                                        value={stats.artifactCount}
+                                        icon={<CubesIcon />}
+                                        isLoading={false}
+                                        onClick={() => handleStatsClick("/search?for=artifacts")}
+                                    />
+                                </FlexItem>
+                                <FlexItem>
+                                    <StatsCard
+                                        title="Versions"
+                                        value={stats.versionCount}
+                                        icon={<CodeBranchIcon />}
+                                        isLoading={false}
+                                        onClick={() => handleStatsClick("/search?for=versions")}
+                                    />
+                                </FlexItem>
+                                {usageSummary && (
+                                    <FlexItem>
+                                        <UsageSummaryCard
+                                            data={usageSummary}
+                                            isLoading={false}
+                                        />
+                                    </FlexItem>
+                                )}
+                            </Flex>
+                        </GridItem>
+                        <GridItem span={8}>
+                            <RecentArtifacts
+                                artifacts={recentArtifacts}
+                                isLoading={false}
+                                error={recentArtifactsError}
+                            />
+                        </GridItem>
+                        <GridItem span={4}>
+                            <QuickActions
+                                onCreateArtifact={handleCreateArtifact}
+                                onSearch={handleSearch}
+                                onExplore={handleExplore}
+                                onSettings={handleSettings}
+                            />
+                        </GridItem>
+                    </Grid>
+                </PageSection>
+                <CreateArtifactModal
+                    isOpen={isCreateArtifactModalOpen}
+                    onClose={() => setIsCreateArtifactModalOpen(false)}
+                    onCreate={doCreateArtifact}
+                />
+            </PageDataLoader>
         </PageErrorHandler>
     );
 };

--- a/ui/ui-app/src/services/useUserService.ts
+++ b/ui/ui-app/src/services/useUserService.ts
@@ -1,31 +1,15 @@
+import React, { createContext, FunctionComponent, ReactNode, useCallback, useContext, useMemo, useState } from "react";
 import { AuthService, useAuth } from "@apicurio/common-ui-components";
 import { getRegistryClient } from "@utils/rest.utils.ts";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { UserInfo } from "@sdk/lib/generated-client/models";
 
-let currentUserInfo: UserInfo = {
+const DEFAULT_USER_INFO: UserInfo = {
     username: "",
     displayName: "",
     admin: false,
     developer: false,
     viewer: false
-};
-
-
-const currentUser = (): UserInfo => {
-    return currentUserInfo;
-};
-
-const updateCurrentUser = async (config: ConfigService, auth: AuthService): Promise<UserInfo> => {
-    const isAuthenticated: boolean = await auth.isAuthenticated();
-    if (isAuthenticated) {
-        return getRegistryClient(config, auth).users.me.get().then(userInfo => {
-            currentUserInfo = userInfo!;
-            return userInfo!;
-        });
-    } else {
-        return Promise.resolve(currentUserInfo);
-    }
 };
 
 const isRbacEnabled = (config: ConfigService): boolean => {
@@ -36,37 +20,37 @@ const isObacEnabled = (config: ConfigService): boolean => {
     return config.authObacEnabled();
 };
 
-const isUserAdmin = (config: ConfigService, auth: AuthService): boolean => {
+const isUserAdmin = (config: ConfigService, auth: AuthService, currentUserInfo: UserInfo): boolean => {
     if (!auth.isOidcAuthEnabled() && !auth.isBasicAuthEnabled()) {
         return true;
     }
     if (!isRbacEnabled(config) && !isObacEnabled(config)) {
         return true;
     }
-    return currentUser().admin || false;
+    return currentUserInfo.admin || false;
 };
 
-const isUserDeveloper = (config: ConfigService, auth: AuthService, resourceOwner?: string): boolean => {
+const isUserDeveloper = (config: ConfigService, auth: AuthService, currentUserInfo: UserInfo, resourceOwner?: string): boolean => {
     if (!auth.isOidcAuthEnabled() && !auth.isBasicAuthEnabled()) {
         return true;
     }
     if (!isRbacEnabled(config) && !isObacEnabled(config)) {
         return true;
     }
-    if (isUserAdmin(config, auth)) {
+    if (isUserAdmin(config, auth, currentUserInfo)) {
         return true;
     }
-    if (isRbacEnabled(config) && !currentUser().developer) {
+    if (isRbacEnabled(config) && !currentUserInfo.developer) {
         return false;
     }
-    if (isObacEnabled(config) && resourceOwner && currentUser().username !== resourceOwner) {
+    if (isObacEnabled(config) && resourceOwner && currentUserInfo.username !== resourceOwner) {
         return false;
     }
     return true;
 };
 
-const isUserId = (userId: string): boolean => {
-    return currentUser().username === userId;
+const isUserId = (currentUserInfo: UserInfo, userId: string): boolean => {
+    return currentUserInfo.username === userId;
 };
 
 
@@ -78,24 +62,56 @@ export interface UserService {
     isUserId(userId: string): boolean;
 }
 
+const UserContext = createContext<UserService | null>(null);
 
-export const useUserService: () => UserService = (): UserService => {
+export type UserProviderProps = {
+    children?: ReactNode;
+};
+
+export const UserProvider: FunctionComponent<UserProviderProps> = (props: UserProviderProps) => {
     const auth: AuthService = useAuth();
     const config: ConfigService = useConfigService();
+    const [currentUserInfo, setCurrentUserInfo] = useState<UserInfo>(DEFAULT_USER_INFO);
 
-    return {
-        currentUser,
+    const updateCurrentUser = useCallback(async (): Promise<UserInfo> => {
+        const isAuthenticated: boolean = await auth.isAuthenticated();
+        if (isAuthenticated) {
+            const userInfo = await getRegistryClient(config, auth).users.me.get();
+            setCurrentUserInfo(userInfo!);
+            return userInfo!;
+        }
+        return DEFAULT_USER_INFO;
+    }, [auth, config]);
+
+    const userService: UserService = useMemo(() => ({
+        currentUser(): UserInfo {
+            return currentUserInfo;
+        },
         updateCurrentUser(): Promise<UserInfo> {
-            return updateCurrentUser(config, auth);
+            return updateCurrentUser();
         },
         isUserId(userId: string): boolean {
-            return isUserId(userId);
+            return isUserId(currentUserInfo, userId);
         },
         isUserAdmin(): boolean {
-            return isUserAdmin(config, auth);
+            return isUserAdmin(config, auth, currentUserInfo);
         },
         isUserDeveloper(resourceOwner?: string): boolean {
-            return isUserDeveloper(config, auth, resourceOwner);
+            return isUserDeveloper(config, auth, currentUserInfo, resourceOwner);
         }
-    };
+    }), [auth, config, currentUserInfo, updateCurrentUser]);
+
+    return React.createElement(
+        UserContext.Provider,
+        { value: userService },
+        props.children
+    );
+};
+
+export const useUserService: () => UserService = (): UserService => {
+    const userService = useContext(UserContext);
+    if (!userService) {
+        throw new Error("useUserService must be used within a UserProvider");
+    }
+    return userService;
 };


### PR DESCRIPTION
## Summary

- Wrap `DashboardPage` in `PageDataLoader` so `GET /users/me` runs before the dashboard renders, matching every other top-level page.
- Replace the module-level `currentUserInfo` variable in `useUserService` with a reactive `UserProvider` (React Context), so the header, `IfAuth`-gated controls, and RBAC checks re-render when user info resolves.

Fixes #8371

## Root cause

`DashboardPage` was the only top-level page that skipped `PageDataLoader`, which is the sole caller of `updateCurrentUser()`. Because user identity was stored in a non-reactive module-level variable, the dashboard and header rendered with default `{ admin: false, displayName: "" }` on first landing after login.

## Test plan

- [x] `npm run lint` passes in `ui/ui-app`
- [x] `npm run build` passes in `ui/ui-app`
- [ ] Log in with OIDC + RBAC enabled as an admin user and land on `/dashboard` — header shows real `displayName`, Quick Actions shows **Create Artifact** and **Settings**
- [ ] Navigate to Explore / Search and confirm header and RBAC-gated tabs still work
- [ ] Confirm no-auth mode still works (RBAC helpers return permissive defaults when auth is disabled)


Made with [Cursor](https://cursor.com)