### PR TITLE
fix(ci): remove OLM channel linearity check from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,10 +9,6 @@ on:
         description: Branch to release from (main for minor releases, X.Y.x for patches)
         required: true
         default: main
-      no-more-minor-releases:
-        type: boolean
-        description: "I understand that releasing from main prevents further patch releases from older minor branches (e.g., 3.2.x)"
-        default: false
       notice:
         type: boolean
         description: I will notify jsenko if the operator release workflow fails!
@@ -78,34 +74,10 @@ jobs:
           git branch --set-upstream-to=origin/${{ github.event.inputs.branch }}
           git pull
 
-      - name: Verify OLM channel linearity
-        working-directory: registry
-        run: |
-          BRANCH="${{ github.event.inputs.branch }}"
-          OUR_PREV_VERSION=$(cd operator && make VAR=PREVIOUS_PACKAGE_VERSION variable-get)
-
-          if [ "$BRANCH" = "main" ]; then
-            # Releasing from main cuts off minor branch releases. Require acknowledgement.
-            if [ "${{ github.event.inputs.no-more-minor-releases }}" != "true" ]; then
-              echo "ERROR: Releasing from main prevents further patch releases from older minor branches."
-              echo "Check the 'no-more-minor-releases' parameter to acknowledge this and retry."
-              exit 1
-            fi
-          else
-            # Releasing from a minor branch — verify main hasn't released ahead.
-            # If main's PREVIOUS_PACKAGE_VERSION differs from ours, main already
-            # released a newer version and the OLM chain would fork.
-            MAIN_PREV_VERSION=$(git show origin/main:operator/Makefile | grep '^PREVIOUS_PACKAGE_VERSION' | sed 's/.*?=\s*//' | tr -d ' ')
-            echo "Branch PREVIOUS_PACKAGE_VERSION: $OUR_PREV_VERSION"
-            echo "Main PREVIOUS_PACKAGE_VERSION:   $MAIN_PREV_VERSION"
-            if [ "$OUR_PREV_VERSION" != "$MAIN_PREV_VERSION" ]; then
-              echo "ERROR: OLM channel linearity violation!"
-              echo "Main has PREVIOUS_PACKAGE_VERSION=$MAIN_PREV_VERSION but this branch has $OUR_PREV_VERSION."
-              echo "A release from main (or another branch) has already advanced the OLM channel."
-              echo "No more patch releases can be made from this branch."
-              exit 1
-            fi
-          fi
+      # Note: The OLM channel linearity check was removed. With multi-channel
+      # OLM support, each branch releases to its own channel (main → 3.x + minor,
+      # maintenance → minor only), so PREVIOUS_PACKAGE_VERSION divergence between
+      # branches is expected and correct. See operator/RELEASING.md for details.
 
       - name: Update Release Version ${{ github.event.inputs.release-version}}
         run: |


### PR DESCRIPTION
## Problem

The 3.2.6 release failed in two places:

1. **release.yaml**: OLM channel linearity check blocked the release
   > Main has PREVIOUS_PACKAGE_VERSION=3.3.0 but this branch has 3.2.5

2. **operator.yaml**: Catalog build failed with "multiple channel heads in 3.3.x"
   > The operator test workflow hardcodes `ROLLING_CHANNEL=3.x`. When triggered by a 3.2.x release push, it builds the catalog with main's channel structure, causing the 3.3.x channel to have two unlinked heads.

https://github.com/Apicurio/apicurio-registry/actions/runs/28604090915
https://github.com/Apicurio/apicurio-registry/actions/runs/28653430233

## Fix

1. **release.yaml**: Remove the linearity check — with multi-channel OLM, PREVIOUS_PACKAGE_VERSION divergence between branches is expected.

2. **operator.yaml**: Make `ROLLING_CHANNEL=3.x` conditional on branch — only pass it for `main`, not for maintenance branches. Uses `github.ref_name` and `github.base_ref` to detect the branch.

## Why this is safe

Each branch releases to its own OLM channel:
- `main` → `3.x` + minor channel (via `ROLLING_CHANNEL=3.x`)
- Maintenance branches → minor channel only (no `ROLLING_CHANNEL`)

There's no chain forking risk with separate channels. See `operator/RELEASING.md`.