### PR TITLE
fix(ci): remove OLM channel linearity check from release workflow (3.2.x)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,10 +9,6 @@ on:
         description: Branch to release from
         required: true
         default: main
-      no-more-minor-releases:
-        type: boolean
-        description: "I understand that releasing from main prevents further patch releases from older minor branches (e.g., 3.2.x)"
-        default: false
       notice:
         type: boolean
         description: I will notify jsenko if the operator release workflow fails!
@@ -75,34 +71,10 @@ jobs:
           git branch --set-upstream-to=origin/${{ github.event.inputs.branch }}
           git pull
 
-      - name: Verify OLM channel linearity
-        working-directory: registry
-        run: |
-          BRANCH="${{ github.event.inputs.branch }}"
-          OUR_PREV_VERSION=$(cd operator && make VAR=PREVIOUS_PACKAGE_VERSION variable-get)
-
-          if [ "$BRANCH" = "main" ]; then
-            # Releasing from main cuts off minor branch releases. Require acknowledgement.
-            if [ "${{ github.event.inputs.no-more-minor-releases }}" != "true" ]; then
-              echo "ERROR: Releasing from main prevents further patch releases from older minor branches."
-              echo "Check the 'no-more-minor-releases' parameter to acknowledge this and retry."
-              exit 1
-            fi
-          else
-            # Releasing from a minor branch — verify main hasn't released ahead.
-            # If main's PREVIOUS_PACKAGE_VERSION differs from ours, main already
-            # released a newer version and the OLM chain would fork.
-            MAIN_PREV_VERSION=$(git show origin/main:operator/Makefile | grep '^PREVIOUS_PACKAGE_VERSION' | sed 's/.*?=\s*//' | tr -d ' ')
-            echo "Branch PREVIOUS_PACKAGE_VERSION: $OUR_PREV_VERSION"
-            echo "Main PREVIOUS_PACKAGE_VERSION:   $MAIN_PREV_VERSION"
-            if [ "$OUR_PREV_VERSION" != "$MAIN_PREV_VERSION" ]; then
-              echo "ERROR: OLM channel linearity violation!"
-              echo "Main has PREVIOUS_PACKAGE_VERSION=$MAIN_PREV_VERSION but this branch has $OUR_PREV_VERSION."
-              echo "A release from main (or another branch) has already advanced the OLM channel."
-              echo "No more patch releases can be made from this branch."
-              exit 1
-            fi
-          fi
+      # Note: The OLM channel linearity check was removed. With multi-channel
+      # OLM support, each branch releases to its own channel (main → 3.x + minor,
+      # maintenance → minor only), so PREVIOUS_PACKAGE_VERSION divergence between
+      # branches is expected and correct. See operator/RELEASING.md for details.
 
       - name: Update Release Version ${{ github.event.inputs.release-version}}
         run: |


### PR DESCRIPTION
Cherry-pick of #8453 to the 3.2.x branch.

The OLM channel linearity check blocks the 3.2.6 release because main's
PREVIOUS_PACKAGE_VERSION has advanced to 3.3.0. With multi-channel OLM,
this divergence is expected — each branch releases to its own channel.

See #8453 for details.