### PR TITLE
feat(mcp): add HTTP with OAuth token forwarding

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-mcp-server-integration.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-mcp-server-integration.adoc
@@ -398,10 +398,12 @@ For the Docker method, pass environment variables by using separate `-e` element
 |`apicurio.mcp.http.forward-token`
 |`APICURIO_MCP_HTTP_FORWARD_TOKEN`
 |`true`
-|When HTTP mode is enabled, forwards the caller's bearer token to {registry} REST API calls (same RBAC as the UI). Stdio mode continues to use `apicurio.mcp.auth.*` client credentials.
+|When HTTP mode is enabled, forwards the caller's bearer token to {registry} REST API calls (same RBAC as the UI). If `false`, callers authenticate with OIDC but {registry} calls use shared `apicurio.mcp.auth.*` credentials. Stdio mode always uses `apicurio.mcp.auth.*`.
 |===
 
-.TLS properties
+.TLS properties (outbound to {registry} only)
+
+These properties apply to the MCP server's TLS connection to {registry}. They do not control the inbound HTTPS listener. Use Quarkus HTTP SSL settings (`quarkus.http.ssl.*`) for inbound TLS.
 
 [cols="3,2,1,4",options="header"]
 |===
@@ -578,6 +580,20 @@ WARNING: `QUARKUS_HTTP_CORS_ORIGINS=http://localhost:6274` is for local developm
 
 For a complete local example, see the `examples/mcp-keycloak` directory in the {registry} repository.
 
+=== HTTP mode without token forwarding
+
+HTTP mode forwards each caller's bearer token to {registry} by default, so per-user RBAC applies. Set `apicurio.mcp.http.forward-token=false` to turn that off.
+
+With forwarding disabled, callers still authenticate to the MCP server with OIDC (same Keycloak realm and HTTP auth settings as above). MCP tool calls use the shared `apicurio.mcp.auth.*` service account against {registry}, not the caller's token.
+
+This fits shared HTTP MCP setups where OIDC only needs to control access to the MCP endpoint, and every caller can act as the same service account in {registry}.
+
+You need:
+
+* `apicurio.mcp.http.enabled=true` and the Quarkus MCP HTTP / OIDC settings from the procedure above
+* `apicurio.mcp.http.forward-token=false`
+* `apicurio.mcp.auth.*` client credentials (token endpoint, client ID, and client secret), as in stdio mode when {registry} is secured
+
 // proc-configuring-mcp-server-tls
 [id="configuring-mcp-server-tls_{context}"]
 == Configuring MCP server TLS
@@ -585,7 +601,9 @@ For a complete local example, see the `examples/mcp-keycloak` directory in the {
 :_mod-docs-content-type: PROCEDURE
 
 [role="_abstract"]
-You can configure the {registry} MCP server to connect to {registry} over TLS. You configure trust store settings to verify the server certificate, and optionally configure key store settings for mutual TLS (mTLS) client certificate authentication.
+You can configure the {registry} MCP server to connect to {registry} over TLS. The `apicurio.mcp.tls.*` properties only affect that outbound connection. Inbound HTTPS for MCP clients is separate; configure it with Quarkus HTTP SSL (`quarkus.http.ssl.*`).
+
+You configure trust store settings to verify the {registry} server certificate, and optionally key store settings for mutual TLS (mTLS) client certificate authentication.
 
 .Prerequisites
 * {registry} is configured with TLS.

--- a/docs/modules/ROOT/pages/getting-started/assembly-mcp-server-integration.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-mcp-server-integration.adoc
@@ -381,6 +381,26 @@ For the Docker method, pass environment variables by using separate `-e` element
 |OAuth2 scope. Optional.
 |===
 
+.HTTP transport properties
+
+[cols="3,2,1,4",options="header"]
+|===
+|Property
+|Environment variable
+|Default
+|Description
+
+|`apicurio.mcp.http.enabled`
+|`APICURIO_MCP_HTTP_ENABLED`
+|`false`
+|When set to `true`, enables HTTP transport with inbound OIDC for MCP clients that connect over the network. Requires Quarkus MCP HTTP and OIDC settings at runtime (see xref:configuring-mcp-server-http-oauth_{context}[]).
+
+|`apicurio.mcp.http.forward-token`
+|`APICURIO_MCP_HTTP_FORWARD_TOKEN`
+|`true`
+|When HTTP mode is enabled, forwards the caller's bearer token to {registry} REST API calls (same RBAC as the UI). Stdio mode continues to use `apicurio.mcp.auth.*` client credentials.
+|===
+
 .TLS properties
 
 [cols="3,2,1,4",options="header"]
@@ -501,6 +521,62 @@ Replace `<your-client-secret>` with the client secret from your OIDC provider.
 * JAR: `"-Dapicurio.mcp.auth.scope=openid"`
 
 . Restart Claude Desktop to apply the changes.
+
+// proc-configuring-mcp-server-http-oauth
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-mcp-server-http-oauth_{context}"]
+== Configuring MCP server HTTP transport with OAuth
+
+[role="_abstract"]
+You can run the {registry} MCP server as an HTTP service for MCP clients that connect over the network, whether they run locally or remotely. Clients authenticate with the same Keycloak realm as {registry} and the UI. The MCP server validates the inbound bearer token and forwards it unchanged to {registry} REST API calls, so role-based access control applies per user.
+
+.Prerequisites
+* {registry} is configured with OIDC authentication.
+* Clients obtain OAuth2 access tokens from the same Keycloak realm as {registry}.
+* An MCP client that supports HTTP transport is available.
+
+.Procedure
+. Enable Apicurio HTTP mode. Example Docker environment variables:
++
+[source,bash]
+----
+APICURIO_MCP_HTTP_ENABLED=true
+APICURIO_MCP_HTTP_FORWARD_TOKEN=true
+REGISTRY_URL=http://apicurio-registry:8080
+----
++
+. Configure Quarkus MCP HTTP transport and inbound OIDC (companion settings required when HTTP mode is enabled):
++
+[source,bash]
+----
+QUARKUS_MCP_SERVER_HTTP_ENABLED=true
+QUARKUS_MCP_SERVER_STDIO_ENABLED=false
+QUARKUS_OIDC_TENANT_ENABLED=true
+QUARKUS_OIDC_APPLICATION_TYPE=service
+QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/realms/registry
+QUARKUS_HTTP_AUTH_PERMISSION_AUTHENTICATED_PATHS=/mcp
+QUARKUS_HTTP_AUTH_PERMISSION_AUTHENTICATED_POLICY=authenticated
+----
++
+NOTE: In HTTP mode with token forwarding, you do not need `APICURIO_MCP_AUTH_*` client credentials. Stdio mode continues to use `apicurio.mcp.auth.*` when {registry} is secured.
+
+. Optional: Enable CORS if a browser-based client must call the MCP endpoint:
++
+[source,bash]
+----
+QUARKUS_HTTP_CORS_ENABLED=true
+QUARKUS_HTTP_CORS_ORIGINS=http://localhost:6274
+----
++
+WARNING: `QUARKUS_HTTP_CORS_ORIGINS=http://localhost:6274` is for local development (for example, MCP Inspector). In production, set this to the exact origin(s) of your deployed MCP client. Do not use localhost origins or `*` in production.
+
+. Obtain an access token from Keycloak (authorization code, device flow, or client credentials for service accounts).
+
+. Connect your MCP client to `http://<mcp-host>:<port>/mcp` with `Authorization: Bearer <access-token>`.
+
+. Verify that operations respect {registry} roles: a token with `sr-readonly` cannot create artifacts or groups.
+
+For a complete local example, see the `examples/mcp-keycloak` directory in the {registry} repository.
 
 // proc-configuring-mcp-server-tls
 [id="configuring-mcp-server-tls_{context}"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,6 +82,12 @@ and model capability search. Includes integration examples for Quarkus + LangCha
 
 See the [llm-artifact-types](llm-artifact-types/) directory for details.
 
+## MCP Server + Keycloak Example
+Docker Compose stack for testing the Apicurio Registry MCP server against a Keycloak-secured Registry.
+Includes stdio mode (client credentials) and HTTP mode (OAuth token forwarding).
+
+See the [mcp-keycloak](mcp-keycloak/) directory for details.
+
 ## Kafka Order Processing Example
 This example provides a complete, realistic Kafka architecture demonstrating both message production and
 consumption with Apicurio Registry as the schema registry. The example simulates an order processing

--- a/examples/mcp-keycloak/README.md
+++ b/examples/mcp-keycloak/README.md
@@ -1,0 +1,73 @@
+# MCP Server + Keycloak + Apicurio Registry
+
+Local development stack for testing the [Apicurio Registry MCP server](https://github.com/Apicurio/apicurio-registry/tree/main/mcp) against a **Keycloak-secured** Registry instance.
+
+Two MCP modes are supported:
+
+- **stdio + client credentials** — The MCP client starts the server as a local process; MCP authenticates to Registry with a service account (`APICURIO_MCP_AUTH_*`).
+- **HTTP + OAuth token forwarding** — Local MCP clients or remote agents call a long-running MCP HTTP service; the caller's Keycloak bearer token is forwarded unchanged to Registry (same RBAC as the UI).
+
+## Stack
+
+| Service           | URL                       | Purpose                          |
+| ----------------- | ------------------------- | -------------------------------- |
+| Keycloak          | http://localhost:8080     | OIDC provider (`registry` realm) |
+| Registry API      | http://localhost:8081     | Secured REST API                 |
+| Registry UI       | http://localhost:8888     | Web console (OIDC login)         |
+| MCP server (HTTP) | http://localhost:8082/mcp | OAuth-secured MCP endpoint       |
+
+Keycloak imports the shared test realm from [`utils/tests/src/main/resources/realm.json`](../../utils/tests/src/main/resources/realm.json). A one-shot bootstrap container adds the **`apicurio-mcp`** public OAuth client (authorization code + PKCE) for HTTP-mode MCP clients. Service accounts from the shared realm include **`admin-client`** (secret: `test1`, `sr-admin`) for stdio mode.
+
+Configuration properties, HTTP/OAuth setup, and client examples are documented in the [MCP server integration guide](../../docs/modules/ROOT/pages/getting-started/assembly-mcp-server-integration.adoc).
+
+## Quick start
+
+```bash
+cd examples/mcp-keycloak
+docker compose up -d
+```
+
+The stack uses `quay.io/apicurio/apicurio-registry-mcp-server:latest-snapshot`. To exercise local MCP server changes, build and tag an image first:
+
+```bash
+# From repo root
+./mvnw install -Pfull -pl mcp -am -DskipTests
+cd mcp/target/docker
+docker build -f Dockerfile.jvm -t quay.io/apicurio/apicurio-registry-mcp-server:latest-snapshot .
+```
+
+Verify Registry access with client credentials:
+
+```bash
+ACCESS_TOKEN="$(
+  curl -sS -X POST "http://localhost:8080/realms/registry/protocol/openid-connect/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=client_credentials" \
+    -d "client_id=admin-client" \
+    -d "client_secret=test1" \
+  | jq -r '.access_token'
+)"
+
+curl -sS -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "http://localhost:8081/apis/registry/v3/system/info" | jq .
+```
+
+## Client configuration
+
+- **stdio:** copy [`stdio.example.json`](stdio.example.json) into your MCP client's configuration.
+- **HTTP:** copy [`http.example.json`](http.example.json) into your MCP client's configuration, or point the client at `http://localhost:8082/mcp` and complete OAuth against the `apicurio-mcp` client in Keycloak.
+
+See [`docker-compose.yml`](docker-compose.yml) for the full HTTP MCP + OIDC environment and the [integration guide](../../docs/modules/ROOT/pages/getting-started/assembly-mcp-server-integration.adoc) for property reference and HTTP/OAuth setup.
+
+## Stop
+
+```bash
+docker compose down
+```
+
+## Notes
+
+- This example is for **local development only** (Keycloak `start-dev`, known client secrets).
+- Port **8081** is used for Registry so Keycloak can keep **8080**.
+- HTTP transport is included in the MCP server image (`quarkus.mcp.server.http.enabled=true`). The `/mcp` endpoint is only reachable when `APICURIO_MCP_HTTP_ENABLED=true` with OIDC configured at runtime (see integration guide).
+- The MCP service sets `QUARKUS_HTTP_CORS_ORIGINS=http://localhost:6274` for local browser tools (e.g. MCP Inspector). **Do not use localhost CORS origins or `*` in production** — set the exact origin(s) of your deployed MCP client.

--- a/examples/mcp-keycloak/apicurio-mcp-client.json
+++ b/examples/mcp-keycloak/apicurio-mcp-client.json
@@ -1,0 +1,53 @@
+{
+  "clientId": "apicurio-mcp",
+  "name": "Apicurio Registry MCP",
+  "description": "Public OAuth client for HTTP-mode MCP clients using authorization code + PKCE",
+  "enabled": true,
+  "publicClient": true,
+  "standardFlowEnabled": true,
+  "implicitFlowEnabled": false,
+  "directAccessGrantsEnabled": false,
+  "serviceAccountsEnabled": false,
+  "redirectUris": [
+    "cursor://anysphere.cursor-mcp/oauth/callback",
+    "http://localhost:6274/oauth/callback",
+    "http://127.0.0.1:6274/oauth/callback"
+  ],
+  "webOrigins": [
+    "http://localhost:6274",
+    "http://127.0.0.1:6274",
+    "+"
+  ],
+  "attributes": {
+    "pkce.code.challenge.method": "S256",
+    "oauth2.device.authorization.grant.enabled": "false",
+    "post.logout.redirect.uris": "+",
+    "display.on.consent.screen": "false"
+  },
+  "protocol": "openid-connect",
+  "fullScopeAllowed": true,
+  "protocolMappers": [
+    {
+      "name": "audience-apicurio-mcp",
+      "protocol": "openid-connect",
+      "protocolMapper": "oidc-audience-mapper",
+      "consentRequired": false,
+      "config": {
+        "included.client.audience": "apicurio-mcp",
+        "id.token.claim": "false",
+        "access.token.claim": "true"
+      }
+    },
+    {
+      "name": "audience-registry-api",
+      "protocol": "openid-connect",
+      "protocolMapper": "oidc-audience-mapper",
+      "consentRequired": false,
+      "config": {
+        "included.client.audience": "registry-api",
+        "id.token.claim": "false",
+        "access.token.claim": "true"
+      }
+    }
+  ]
+}

--- a/examples/mcp-keycloak/bootstrap-apicurio-mcp-client.sh
+++ b/examples/mcp-keycloak/bootstrap-apicurio-mcp-client.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KC_URL="${KC_URL:-http://keycloak:8080}"
+REALM="${KC_REALM:-registry}"
+ADMIN_USER="${KEYCLOAK_ADMIN:-admin}"
+ADMIN_PASS="${KEYCLOAK_ADMIN_PASSWORD:-admin}"
+CLIENT_ID="apicurio-mcp"
+CLIENT_JSON="/bootstrap/apicurio-mcp-client.json"
+
+echo "Waiting for Keycloak at ${KC_URL}..."
+until /opt/keycloak/bin/kcadm.sh config credentials \
+  --server "${KC_URL}" \
+  --realm master \
+  --user "${ADMIN_USER}" \
+  --password "${ADMIN_PASS}" >/dev/null 2>&1; do
+  sleep 2
+done
+
+if /opt/keycloak/bin/kcadm.sh get clients -r "${REALM}" -q "clientId=${CLIENT_ID}" 2>/dev/null | grep -q '"id"'; then
+  echo "Keycloak client '${CLIENT_ID}' already exists in realm '${REALM}', skipping."
+  exit 0
+fi
+
+echo "Creating Keycloak client '${CLIENT_ID}' in realm '${REALM}'..."
+/opt/keycloak/bin/kcadm.sh create clients -r "${REALM}" -f "${CLIENT_JSON}"
+echo "Done."

--- a/examples/mcp-keycloak/docker-compose.yml
+++ b/examples/mcp-keycloak/docker-compose.yml
@@ -1,0 +1,138 @@
+# Registry + Keycloak for MCP server integration testing.
+#
+# Supports stdio (local process, client credentials) and HTTP (network clients,
+# OAuth token forwarding). See README.md for client configuration and verification steps.
+#
+# Usage:
+#   docker compose up -d
+
+services:
+  keycloak:
+    container_name: mcp-keycloak
+    image: quay.io/keycloak/keycloak:23.0.7
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HOSTNAME: localhost
+      KC_HOSTNAME_PORT: "8080"
+      KC_HOSTNAME_STRICT_BACKCHANNEL: "false"
+    command:
+      - start-dev
+      - --import-realm
+    ports:
+      - "8080:8080"
+    volumes:
+      # Shared test realm from apicurio-registry-utils-tests (no duplicate copy in this example)
+      - ../../utils/tests/src/main/resources/realm.json:/opt/keycloak/data/import/realm.json
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  # Adds the apicurio-mcp OAuth client (authorization code + PKCE) to the imported realm
+  keycloak-bootstrap:
+    image: quay.io/keycloak/keycloak:23.0.7
+    container_name: mcp-keycloak-bootstrap
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    restart: on-failure
+    entrypoint: ["/bin/bash", "/bootstrap/bootstrap-apicurio-mcp-client.sh"]
+    volumes:
+      - ./bootstrap-apicurio-mcp-client.sh:/bootstrap/bootstrap-apicurio-mcp-client.sh:ro
+      - ./apicurio-mcp-client.json:/bootstrap/apicurio-mcp-client.json:ro
+    environment:
+      KC_URL: http://keycloak:8080
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+
+  apicurio-registry:
+    image: quay.io/apicurio/apicurio-registry:latest-snapshot
+    container_name: mcp-keycloak-registry
+    environment:
+      APICURIO_REST_DELETION_GROUP_ENABLED: "true"
+      APICURIO_REST_DELETION_ARTIFACT_ENABLED: "true"
+      APICURIO_REST_DELETION_ARTIFACTVERSION_ENABLED: "true"
+      QUARKUS_OIDC_TENANT_ENABLED: "true"
+      QUARKUS_OIDC_AUTH_SERVER_URL: "http://keycloak:8080/realms/registry"
+      QUARKUS_OIDC_CLIENT_ID: "registry-api"
+      APICURIO_UI_AUTH_OIDC_CLIENT_ID: "apicurio-registry"
+      APICURIO_UI_AUTH_OIDC_REDIRECT_URI: "http://localhost:8888/"
+      APICURIO_AUTH_ROLE_BASED_AUTHORIZATION: "true"
+      QUARKUS_OIDC_TLS_VERIFICATION: "none"
+      QUARKUS_HTTP_CORS_ORIGINS: "*"
+      QUARKUS_PROFILE: "prod"
+    ports:
+      - "8081:8080"
+    depends_on:
+      keycloak:
+        condition: service_healthy
+      keycloak-bootstrap:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  apicurio-registry-ui:
+    image: quay.io/apicurio/apicurio-registry-ui:latest-snapshot
+    container_name: mcp-keycloak-registry-ui
+    environment:
+      REGISTRY_API_URL: "http://localhost:8081/apis/registry/v3"
+      REGISTRY_AUTH_TYPE: "oidc"
+      REGISTRY_AUTH_URL: "http://localhost:8080/realms/registry"
+    ports:
+      - "8888:8080"
+    depends_on:
+      apicurio-registry:
+        condition: service_healthy
+
+  # Optional: build a local MCP image when developing the MCP module:
+  #   ./mvnw install -Pfull -pl mcp -am -DskipTests
+  #   cd mcp/target/docker && docker build -f Dockerfile.jvm \
+  #     -t quay.io/apicurio/apicurio-registry-mcp-server:latest-snapshot .
+  apicurio-registry-mcp:
+    image: quay.io/apicurio/apicurio-registry-mcp-server:latest-snapshot
+    container_name: mcp-keycloak-mcp-server
+    environment:
+      # Required: dev profile disables HTTP auth by default (unauthenticated /mcp returns 200)
+      QUARKUS_PROFILE: "prod"
+      QUARKUS_HTTP_AUTH_PROACTIVE: "true"
+      REGISTRY_URL: "http://apicurio-registry:8080"
+      # Apicurio MCP HTTP settings
+      APICURIO_MCP_HTTP_ENABLED: "true"
+      APICURIO_MCP_HTTP_FORWARD_TOKEN: "true"
+      # Quarkus MCP + OIDC companion settings
+      QUARKUS_MCP_SERVER_HTTP_ENABLED: "true"
+      QUARKUS_MCP_SERVER_STDIO_ENABLED: "false"
+      QUARKUS_OIDC_TENANT_ENABLED: "true"
+      QUARKUS_OIDC_APPLICATION_TYPE: "service"
+      QUARKUS_OIDC_AUTH_SERVER_URL: "http://keycloak:8080/realms/registry"
+      QUARKUS_OIDC_TENANT_PATHS: "/mcp"
+      QUARKUS_HTTP_AUTH_PERMISSION_AUTHENTICATED_PATHS: "/mcp"
+      QUARKUS_HTTP_AUTH_PERMISSION_AUTHENTICATED_POLICY: "authenticated"
+      QUARKUS_OIDC_TLS_VERIFICATION: "none"
+      # Optional: OAuth discovery and CORS for HTTP-mode MCP clients
+      QUARKUS_OIDC_RESOURCE_METADATA_AUTHORIZATION_SERVER: "http://localhost:8080/realms/registry"
+      QUARKUS_OIDC_RESOURCE_METADATA_ENABLED: "true"
+      QUARKUS_OIDC_RESOURCE_METADATA_FORCE_HTTPS_SCHEME: "false"
+      QUARKUS_OIDC_TOKEN_AUDIENCE: "apicurio-mcp"
+      QUARKUS_HTTP_CORS_ENABLED: "true"
+      QUARKUS_HTTP_CORS_ORIGINS: "http://localhost:6274"
+    ports:
+      - "8082:8080"
+    depends_on:
+      keycloak:
+        condition: service_healthy
+      keycloak-bootstrap:
+        condition: service_completed_successfully
+      apicurio-registry:
+        condition: service_healthy
+
+networks:
+  default:
+    name: mcp-keycloak-network

--- a/examples/mcp-keycloak/http.example.json
+++ b/examples/mcp-keycloak/http.example.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "http": {
+      "url": "http://localhost:8082/mcp",
+      "auth": {
+        "CLIENT_ID": "apicurio-mcp",
+        "scopes": ["openid", "profile", "email"]
+      }
+    }
+  }
+}

--- a/examples/mcp-keycloak/stdio.example.json
+++ b/examples/mcp-keycloak/stdio.example.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "stdio": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e", "REGISTRY_URL=http://host.docker.internal:8081",
+        "-e", "APICURIO_MCP_AUTH_ENABLED=true",
+        "-e", "APICURIO_MCP_AUTH_TOKEN_ENDPOINT=http://host.docker.internal:8080/realms/registry/protocol/openid-connect/token",
+        "-e", "APICURIO_MCP_AUTH_CLIENT_ID=admin-client",
+        "-e", "APICURIO_MCP_AUTH_CLIENT_SECRET=test1",
+        "-e", "QUARKUS_OIDC_TENANT_ENABLED=false",
+        "-e", "APICURIO_MCP_HTTP_ENABLED=false",
+        "quay.io/apicurio/apicurio-registry-mcp-server:latest-snapshot"
+      ]
+    }
+  }
+}

--- a/java-sdk/adapter-jdk/src/main/java/io/apicurio/registry/client/common/JdkAdapterFactory.java
+++ b/java-sdk/adapter-jdk/src/main/java/io/apicurio/registry/client/common/JdkAdapterFactory.java
@@ -83,6 +83,10 @@ public final class JdkAdapterFactory {
                         options.getClientSecret(), options.getScope(), options.isOtelEnabled());
                 return new JdkOAuth2RequestAdapter(httpClient, tokenProvider);
 
+            case BEARER:
+                return new JdkAuthenticatedRequestAdapter(httpClient,
+                        "Bearer " + options.getBearerToken());
+
             default:
                 throw new IllegalArgumentException("Unsupported authentication type: " + options.getAuthType());
         }

--- a/java-sdk/adapter-jdk/src/test/java/io/apicurio/registry/client/common/JdkAdapterAuthenticationTest.java
+++ b/java-sdk/adapter-jdk/src/test/java/io/apicurio/registry/client/common/JdkAdapterAuthenticationTest.java
@@ -88,6 +88,21 @@ class JdkAdapterAuthenticationTest {
     }
 
     @Test
+    void testJdkAdapterWithBearerTokenCreatesAdapter() throws Exception {
+        RegistryClientOptions options = RegistryClientOptions.create()
+                .registryUrl("http://localhost:8080")
+                .httpAdapter(HttpAdapterType.JDK)
+                .bearerToken("test-access-token");
+
+        RequestAdapter adapter = assertDoesNotThrow(() ->
+                RegistryClientRequestAdapterFactory.createRequestAdapter(options, Version.V3));
+
+        assertNotNull(adapter, "Adapter should be created");
+        assertTrue(adapter.getClass().getName().contains("JdkAuthenticatedRequestAdapter"),
+                "Should create JdkAuthenticatedRequestAdapter for bearer auth");
+    }
+
+    @Test
     void testBasicAuthAdapterStoresAuthorizationHeader() throws Exception {
         RegistryClientOptions options = RegistryClientOptions.create()
                 .registryUrl("http://localhost:8080")

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientOptions.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientOptions.java
@@ -12,6 +12,7 @@ import io.vertx.ext.web.client.WebClient;
  *   <li>Anonymous (no authentication)</li>
  *   <li>Basic authentication (username/password)</li>
  *   <li>OAuth2/OIDC authentication (client credentials)</li>
+ *   <li>Bearer token authentication (pre-obtained access token)</li>
  *   <li>Custom WebClient (for advanced scenarios)</li>
  * </ul>
  */
@@ -56,6 +57,7 @@ public class RegistryClientOptions {
         ANONYMOUS,
         BASIC,
         OAUTH2,
+        BEARER,
         CUSTOM_WEBCLIENT
     }
 
@@ -91,6 +93,7 @@ public class RegistryClientOptions {
     private String clientId;
     private String clientSecret;
     private String scope;
+    private String bearerToken;
     private WebClient webClient;
     // Retry config
     private boolean retryEnabled = false;
@@ -161,6 +164,10 @@ public class RegistryClientOptions {
 
     public String getScope() {
         return scope;
+    }
+
+    public String getBearerToken() {
+        return bearerToken;
     }
 
     public Vertx getVertx() {
@@ -346,6 +353,21 @@ public class RegistryClientOptions {
     }
 
     /**
+     * Configures bearer token authentication using a pre-obtained access token.
+     * <p>
+     * Currently supported with the JDK HTTP adapter only.
+     *
+     * @param accessToken the OAuth2/OIDC access token (without the "Bearer " prefix)
+     * @return this builder
+     */
+    public RegistryClientOptions bearerToken(String accessToken) {
+        clearAuth();
+        this.authType = AuthType.BEARER;
+        this.bearerToken = accessToken;
+        return this;
+    }
+
+    /**
      * Configures a custom WebClient for advanced authentication scenarios.
      *
      * @param webClient the pre-configured WebClient to use
@@ -366,6 +388,7 @@ public class RegistryClientOptions {
         this.clientId = null;
         this.clientSecret = null;
         this.scope = null;
+        this.bearerToken = null;
         this.webClient = null;
     }
 

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -334,6 +334,11 @@ public class RegistryClientRequestAdapterFactory {
             case OAUTH2:
                 validateOAuth2Credentials(options.getTokenEndpoint(), options.getClientId(), options.getClientSecret());
                 break;
+            case BEARER:
+                if (options.getBearerToken() == null || options.getBearerToken().trim().isEmpty()) {
+                    throw new IllegalArgumentException("Bearer token cannot be null or empty");
+                }
+                break;
         }
     }
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -8,6 +8,7 @@ More information, see:
 - [Introduction to MCP](https://modelcontextprotocol.io/introduction)
 - [Quarkus MCP server extension](https://docs.quarkiverse.io/quarkus-mcp-server/dev/index.html)
 - [Quarkus MCP server examples](https://github.com/quarkiverse/quarkus-mcp-servers)
+- [MCP + Keycloak example](../examples/mcp-keycloak/README.md) (stdio and HTTP/OAuth modes)
 
 ## Quickstart
 
@@ -54,8 +55,12 @@ More information, see:
    directory):
 
    ```shell
-   mvn clean install -f ../pom.xml -pl mcp -am -DskipTests
+   ./mvnw install -Pfull -pl mcp -am -DskipTests
    ```
+
+   NOTE: HTTP transport is compiled in at build time (`quarkus.mcp.server.http.enabled=true` in
+   `application.properties`). Rebuild the image/JAR if you change that property. At runtime, `/mcp`
+   is only reachable when `APICURIO_MCP_HTTP_ENABLED=true` with OIDC configured.
 
 2. Update the configuration file as follows:
 
@@ -94,6 +99,9 @@ The following configuration properties can be provided in the `args` list:
 | apicurio.mcp.safe-mode          | `true`           | Prevent some operations from being performed, or filter which operations can be performed, for safety reasons.                                                                                                                   |
 | apicurio.mcp.paging.limit       | `200`            | Claude does not do well with paging, therefore we use a high limit parameter when paged results are returned. Increase the limit if your server contains large amount of objects, and you do not mind the higher operation cost. |
 | apicurio.mcp.paging.limit-error | `true`           | Fail the operation when there number of result exceeds the paging limit. This is guard against inaccurate results, e.g. counting.                                                                                                |
+| apicurio.mcp.auth.enabled       | `false`          | Enable OAuth2 client credentials for stdio mode connections to Registry (`apicurio.mcp.auth.token-endpoint`, `client-id`, `client-secret`).                                                                                      |
+| apicurio.mcp.http.enabled       | `false`          | Enable HTTP mode for MCP clients that connect over the network. Requires Quarkus MCP HTTP + OIDC at runtime (see integration guide).                                                                                           |
+| apicurio.mcp.http.forward-token | `true`           | When HTTP mode is enabled, forward the caller's bearer token to Registry REST calls (same RBAC as UI). Stdio mode continues to use `apicurio.mcp.auth.*`.                                                                      |
 
 ## Usage
 

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -36,8 +36,7 @@
     <dependencies>
 
         <!--
-        The stdio transport enables communication through standard input and output streams.
-        This is particularly useful for local integrations and command-line tools.
+        The HTTP transport enables remote agents with OAuth.
         -->
         <dependency>
             <groupId>io.quarkiverse.mcp</groupId>
@@ -51,6 +50,21 @@
         <dependency>
             <groupId>io.quarkiverse.mcp</groupId>
             <artifactId>quarkus-mcp-server-sse</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-http</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security</artifactId>
         </dependency>
 
         <dependency>
@@ -99,6 +113,12 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/mcp/src/main/java/io/apicurio/registry/mcp/McpConfig.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/McpConfig.java
@@ -34,6 +34,26 @@ public interface McpConfig {
      */
     Tls tls();
 
+    /**
+     * HTTP transport configuration.
+     */
+    Http http();
+
+    interface Http {
+        /**
+         * Enable HTTP transport with inbound OIDC authentication.
+         */
+        @WithDefault("false")
+        boolean enabled();
+
+        /**
+         * Forward the inbound caller's bearer token to Registry REST API calls.
+         */
+        @WithName("forward-token")
+        @WithDefault("true")
+        boolean forwardToken();
+    }
+
     interface Paging {
         /**
          * Maximum number of items to return in a single page.

--- a/mcp/src/main/java/io/apicurio/registry/mcp/McpHttpAuthValidator.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/McpHttpAuthValidator.java
@@ -1,0 +1,158 @@
+package io.apicurio.registry.mcp;
+
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URL;
+
+/**
+ * Validates HTTP transport and OIDC configuration at startup.
+ */
+@ApplicationScoped
+public class McpHttpAuthValidator {
+
+    private static final Logger log = LoggerFactory.getLogger(McpHttpAuthValidator.class);
+
+    private static final int REGISTRY_CONNECT_TIMEOUT_MS = 3_000;
+
+    @Inject
+    McpConfig config;
+
+    @ConfigProperty(name = "quarkus.oidc.tenant-enabled", defaultValue = "false")
+    boolean oidcTenantEnabled;
+
+    @ConfigProperty(name = "quarkus.mcp.server.http.enabled", defaultValue = "false")
+    boolean mcpHttpTransportEnabled;
+
+    @ConfigProperty(name = "registry.url", defaultValue = "localhost:8080")
+    String registryUrl;
+
+    /**
+     * Pluggable TCP probe so unit tests can avoid real network I/O.
+     */
+    ConnectivityProbe connectivityProbe = McpHttpAuthValidator::tcpConnect;
+
+    void onStart(@Observes StartupEvent event) {
+        if (!config.http().enabled()) {
+            return;
+        }
+
+        validateHttpAuthConfig();
+        validateRegistryUrl();
+
+        if (config.http().forwardToken() && config.auth().enabled()) {
+            log.warn("Both apicurio.mcp.http.forward-token and apicurio.mcp.auth.enabled are set. "
+                    + "HTTP requests will forward the caller's bearer token; client credentials are used "
+                    + "only for stdio transport.");
+        }
+
+        log.info("MCP HTTP transport enabled with inbound OIDC authentication"
+                + (config.http().forwardToken() ? " and bearer token forwarding to Registry" : ""));
+    }
+
+    /**
+     * Validates that HTTP mode has the required transport and OIDC settings.
+     *
+     * @throws IllegalStateException if required configuration is missing
+     */
+    void validateHttpAuthConfig() {
+        if (!mcpHttpTransportEnabled) {
+            throw new IllegalStateException(
+                    "apicurio.mcp.http.enabled is true but quarkus.mcp.server.http.enabled is false. "
+                            + "HTTP transport must be enabled at build time (quarkus.mcp.server.http.enabled=true "
+                            + "in application.properties) and the MCP server must be rebuilt.");
+        }
+
+        if (!oidcTenantEnabled) {
+            throw new IllegalStateException(
+                    "apicurio.mcp.http.enabled is true but quarkus.oidc.tenant-enabled is false. "
+                            + "Configure Quarkus OIDC (QUARKUS_OIDC_TENANT_ENABLED, QUARKUS_OIDC_AUTH_SERVER_URL) "
+                            + "to secure the MCP HTTP endpoint.");
+        }
+    }
+
+    /**
+     * Validates {@code registry.url} format and, when the resolver skips its authenticated
+     * {@code system.info()} probe (HTTP mode without client-credentials auth), checks that the
+     * host/port is reachable so misconfiguration fails at startup instead of the first tool call.
+     */
+    void validateRegistryUrl() {
+        HostPort hostPort = parseRegistryHostPort(registryUrl);
+        if (!config.auth().enabled()) {
+            try {
+                connectivityProbe.connect(hostPort.host(), hostPort.port());
+                log.info("Verified registry.url is reachable at {}:{}", hostPort.host(), hostPort.port());
+            } catch (IOException e) {
+                throw new IllegalStateException(
+                        "Cannot reach Apicurio Registry at registry.url=" + registryUrl
+                                + " (" + hostPort.host() + ":" + hostPort.port() + "). "
+                                + "Check REGISTRY_URL / registry.url and that Registry is running. "
+                                + "Details: " + e.getMessage(),
+                        e);
+            }
+        }
+    }
+
+    /**
+     * Parses {@code registry.url} values such as {@code localhost:8080} or
+     * {@code http://localhost:8080/apis/registry/v3} into a host/port pair using
+     * {@link URI} / {@link URL} (including {@link URL#getDefaultPort()}).
+     */
+    static HostPort parseRegistryHostPort(String rawRegistryUrl) {
+        if (rawRegistryUrl == null || rawRegistryUrl.isBlank()) {
+            throw new IllegalStateException(
+                    "registry.url must be configured when apicurio.mcp.http.enabled=true");
+        }
+
+        // registry.url often omits the scheme (e.g. "localhost:8080"); URI/URL require one.
+        String value = rawRegistryUrl.trim();
+        if (!value.contains("://")) {
+            log.info("registry.url has no scheme; assuming http:// for host/port parsing: {}", rawRegistryUrl);
+            value = "http://" + value;
+        }
+
+        try {
+            URL url = URI.create(value).toURL();
+            String host = url.getHost();
+            if (host == null || host.isBlank()) {
+                throw new IllegalStateException(
+                        "registry.url is invalid (could not determine host): " + rawRegistryUrl);
+            }
+            int port = url.getPort() >= 0 ? url.getPort() : url.getDefaultPort();
+            if (port < 0) {
+                throw new IllegalStateException(
+                        "registry.url is invalid (could not determine port): " + rawRegistryUrl);
+            }
+            log.debug("Parsed registry.url {} as {}:{}", rawRegistryUrl, host, port);
+            return new HostPort(host, port);
+        } catch (IllegalArgumentException | MalformedURLException e) {
+            throw new IllegalStateException(
+                    "registry.url is not a valid URL: " + rawRegistryUrl + ". Details: " + e.getMessage(),
+                    e);
+        }
+    }
+
+    private static void tcpConnect(String host, int port) throws IOException {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), REGISTRY_CONNECT_TIMEOUT_MS);
+        }
+    }
+
+    @FunctionalInterface
+    interface ConnectivityProbe {
+        void connect(String host, int port) throws IOException;
+    }
+
+    record HostPort(String host, int port) {
+    }
+}

--- a/mcp/src/main/java/io/apicurio/registry/mcp/McpHttpGateFilter.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/McpHttpGateFilter.java
@@ -1,0 +1,51 @@
+package io.apicurio.registry.mcp;
+
+import io.quarkus.runtime.StartupEvent;
+import io.vertx.ext.web.Router;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.regex.Pattern;
+
+/**
+ * Blocks MCP HTTP endpoints unless {@code apicurio.mcp.http.enabled} is true.
+ * <p>
+ * The Quarkus MCP HTTP transport is compiled in at build time, but HTTP mode is only
+ * intended to be reachable when explicitly enabled at runtime with OIDC configured.
+ */
+@ApplicationScoped
+public class McpHttpGateFilter {
+
+    @Inject
+    McpConfig config;
+
+    @Inject
+    Router router;
+
+    @ConfigProperty(name = "quarkus.mcp.server.http.root-path", defaultValue = "/mcp")
+    String mcpRootPath;
+
+    void register(@Observes StartupEvent event) {
+        String escapedRootPath = Pattern.quote(mcpRootPath);
+        router.routeWithRegex(escapedRootPath + "/?.*")
+                .order(Integer.MIN_VALUE)
+                .handler(ctx -> blockUnlessEnabled(ctx));
+        router.route("/.well-known/oauth-protected-resource")
+                .order(Integer.MIN_VALUE)
+                .handler(ctx -> blockUnlessEnabled(ctx));
+    }
+
+    void blockUnlessEnabled(io.vertx.ext.web.RoutingContext ctx) {
+        if (!config.http().enabled()) {
+            ctx.response()
+                    .setStatusCode(503)
+                    .putHeader("Content-Type", "text/plain; charset=UTF-8")
+                    .end("MCP HTTP transport is disabled. Set apicurio.mcp.http.enabled=true "
+                            + "with OIDC configured to enable it.");
+        } else {
+            ctx.next();
+        }
+    }
+}

--- a/mcp/src/main/java/io/apicurio/registry/mcp/RegistryClientResolver.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/RegistryClientResolver.java
@@ -1,0 +1,394 @@
+package io.apicurio.registry.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.client.RegistryClientFactory;
+import io.apicurio.registry.client.common.HttpAdapterType;
+import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Locale;
+
+/**
+ * Resolves the Registry REST client for the current request.
+ * <p>
+ * In HTTP mode with token forwarding, uses the inbound caller's bearer token.
+ * Otherwise uses a singleton client configured with OAuth2 client credentials or anonymous access.
+ */
+@ApplicationScoped
+public class RegistryClientResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(RegistryClientResolver.class);
+
+    private static final ObjectMapper JWT_PAYLOAD_MAPPER = new ObjectMapper();
+
+    /**
+     * Seconds after {@code exp} during which the token is still accepted.
+     * Covers small clock differences between this server and the OIDC provider.
+     */
+    static final long BEARER_TOKEN_EXPIRATION_SKEW_SECONDS = 30;
+
+    @ConfigProperty(name = "registry.url", defaultValue = "localhost:8080")
+    String rawBaseUrl;
+
+    @Inject
+    McpConfig config;
+
+    @Inject
+    Instance<SecurityIdentity> securityIdentity;
+
+    @Inject
+    Instance<JsonWebToken> jwt;
+
+    private RegistryClient fallbackClient;
+
+    /**
+     * Cached base options (URL, HTTP adapter, retry, TLS) built once at startup.
+     * Per-request callers must {@link #copyTransportOptions()} before applying a bearer
+     * token so concurrent requests do not mutate this shared instance.
+     */
+    private RegistryClientOptions transportOptions;
+
+    @PostConstruct
+    void init() {
+        transportOptions = buildTransportOptions();
+        if (needsFallbackClient()) {
+            fallbackClient = createClient(buildFallbackOptions());
+            if (!config.http().enabled() || config.auth().enabled()) {
+                var info = fallbackClient.system().info().get();
+                log.info("Successfully connected to Apicurio Registry version {} at {}", info.getVersion(),
+                        rawBaseUrl);
+            }
+        } else {
+            log.info("Registry client will authenticate using inbound bearer token forwarding");
+        }
+    }
+
+    /**
+     * Registry base URL from {@code registry.url} (same value used to build clients).
+     */
+    public String registryBaseUrl() {
+        return rawBaseUrl;
+    }
+
+    /**
+     * Returns a Registry client for the current context.
+     */
+    @ActivateRequestContext
+    public RegistryClient getClient() {
+        String bearerToken = resolveInboundBearerToken();
+        if (bearerToken != null) {
+            // Reuse cached transport settings (URL/TLS/adapter/retry); only the bearer token
+            // is applied per request on a fresh options instance.
+            var options = copyTransportOptions().bearerToken(bearerToken);
+            return RegistryClientFactory.create(options);
+        }
+        if (fallbackClient == null) {
+            boolean authenticated = securityIdentity.isResolvable()
+                    && securityIdentity.get() != null
+                    && !securityIdentity.get().isAnonymous();
+            if (authenticated) {
+                throw new IllegalStateException(
+                        "No Registry client available: HTTP token forwarding is enabled but no bearer access "
+                                + "token was found on the authenticated request. Ensure the MCP client sends "
+                                + "'Authorization: Bearer <access_token>' on every /mcp request (complete "
+                                + "OAuth login so the access token is sent).");
+            }
+            throw new IllegalStateException(
+                    "No Registry client available: HTTP token forwarding is enabled but no bearer token "
+                            + "was provided, and no fallback client credentials are configured");
+        }
+        return fallbackClient;
+    }
+
+    boolean hasFallbackClient() {
+        return fallbackClient != null;
+    }
+
+    boolean needsFallbackClient() {
+        if (!config.http().enabled()) {
+            return true;
+        }
+        return config.auth().enabled() || !config.http().forwardToken();
+    }
+
+    String resolveInboundBearerToken() {
+        if (!config.http().enabled() || !config.http().forwardToken()) {
+            return null;
+        }
+        String fromIdentity = resolveTokenFromSecurityIdentity();
+        if (fromIdentity != null) {
+            assertBearerTokenNotExpired(fromIdentity, resolveJsonWebToken());
+            return fromIdentity;
+        }
+        JsonWebToken token = resolveJsonWebToken();
+        if (token == null || token.getRawToken() == null || token.getRawToken().isBlank()) {
+            return null;
+        }
+        assertBearerTokenNotExpired(token.getRawToken(), token);
+        return token.getRawToken();
+    }
+
+    private JsonWebToken resolveJsonWebToken() {
+        if (!jwt.isResolvable()) {
+            return null;
+        }
+        return jwt.get();
+    }
+
+    /**
+     * Rejects expired bearer tokens before forwarding them to Registry, so callers get a clear
+     * re-auth message instead of an opaque Registry 401.
+     * <p>
+     * Best-effort only: opaque tokens cannot be checked. Tokens are still accepted for
+     * {@link #BEARER_TOKEN_EXPIRATION_SKEW_SECONDS} after {@code exp}, so a small clock
+     * difference between this server and the OIDC provider does not reject a still-valid token.
+     */
+    void assertBearerTokenNotExpired(String bearerToken, JsonWebToken jwtToken) {
+        Long expirationEpochSeconds = null;
+        if (jwtToken != null) {
+            long exp = jwtToken.getExpirationTime();
+            if (exp > 0) {
+                expirationEpochSeconds = exp;
+            }
+        }
+        if (expirationEpochSeconds == null) {
+            expirationEpochSeconds = parseJwtExpirationEpochSeconds(bearerToken);
+        }
+        if (expirationEpochSeconds != null
+                && Instant.now().getEpochSecond()
+                        >= (expirationEpochSeconds + BEARER_TOKEN_EXPIRATION_SKEW_SECONDS)) {
+            throw new IllegalStateException(
+                    "Bearer access token has expired. Re-authenticate and retry the request "
+                            + "with a fresh access token.");
+        }
+    }
+
+    /**
+     * Best-effort {@code exp} claim read for JWTs when {@link JsonWebToken} is unavailable.
+     * Opaque tokens return {@code null} (no proactive check).
+     */
+    static Long parseJwtExpirationEpochSeconds(String bearerToken) {
+        if (bearerToken == null) {
+            return null;
+        }
+        String[] parts = bearerToken.split("\\.");
+        if (parts.length < 2) {
+            return null;
+        }
+        try {
+            byte[] payloadBytes = Base64.getUrlDecoder().decode(parts[1]);
+            JsonNode payload = JWT_PAYLOAD_MAPPER.readTree(
+                    new String(payloadBytes, StandardCharsets.UTF_8));
+            JsonNode exp = payload.get("exp");
+            if (exp == null || !exp.canConvertToLong()) {
+                return null;
+            }
+            return exp.longValue();
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private String resolveTokenFromSecurityIdentity() {
+        if (!securityIdentity.isResolvable()) {
+            return null;
+        }
+        SecurityIdentity identity = securityIdentity.get();
+        if (identity == null || identity.isAnonymous()) {
+            return null;
+        }
+        AccessTokenCredential credential = identity.getCredential(AccessTokenCredential.class);
+        if (credential == null) {
+            return null;
+        }
+        String token = credential.getToken();
+        if (token == null || token.isBlank()) {
+            return null;
+        }
+        return token;
+    }
+
+    private RegistryClientOptions buildTransportOptions() {
+        var options = RegistryClientOptions.create(rawBaseUrl)
+                .httpAdapter(HttpAdapterType.JDK)
+                .retry();
+        configureTls(options);
+        return options;
+    }
+
+    private RegistryClientOptions buildFallbackOptions() {
+        var options = copyTransportOptions();
+        configureClientCredentials(options);
+        return options;
+    }
+
+    /**
+     * Builds a new options instance with only the cached transport settings (URL, adapter,
+     * retry, TLS). Auth is intentionally omitted so per-request bearer tokens (or fallback
+     * client credentials) can be applied without mutating {@link #transportOptions}.
+     */
+    private RegistryClientOptions copyTransportOptions() {
+        RegistryClientOptions options = transportOptions.getNormalizeRegistryUrl()
+                ? RegistryClientOptions.create(transportOptions.getRegistryUrl())
+                : RegistryClientOptions.create().rawRegistryUrl(transportOptions.getRegistryUrl());
+        options.httpAdapter(transportOptions.getHttpAdapterType());
+        if (transportOptions.isRetryEnabled()) {
+            options.retry(true, transportOptions.getMaxRetryAttempts(), transportOptions.getRetryDelayMs(),
+                    transportOptions.getBackoffMultiplier(), transportOptions.getMaxRetryDelayMs());
+        } else {
+            options.disableRetry();
+        }
+        copyTransportTls(transportOptions, options);
+        return options;
+    }
+
+    private static void copyTransportTls(RegistryClientOptions from, RegistryClientOptions to) {
+        if (from.isTrustAll()) {
+            to.trustAll(true);
+        }
+        if (!from.isVerifyHost()) {
+            to.verifyHost(false);
+        }
+
+        switch (from.getTrustStoreType()) {
+            case JKS:
+                to.trustStoreJks(from.getTrustStorePath(), from.getTrustStorePassword());
+                break;
+            case PKCS12:
+                to.trustStorePkcs12(from.getTrustStorePath(), from.getTrustStorePassword());
+                break;
+            case PEM:
+                if (from.getPemCertContent() != null) {
+                    to.trustStorePemContent(from.getPemCertContent());
+                } else if (from.getPemCertPaths() != null) {
+                    to.trustStorePem(from.getPemCertPaths());
+                }
+                break;
+            case NONE:
+            default:
+                break;
+        }
+
+        switch (from.getKeyStoreType()) {
+            case JKS:
+                to.keystoreJks(from.getKeyStorePath(), from.getKeyStorePassword());
+                break;
+            case PKCS12:
+                to.keystorePkcs12(from.getKeyStorePath(), from.getKeyStorePassword());
+                break;
+            case PEM:
+                if (from.getPemClientCertContent() != null) {
+                    to.keystorePemContent(from.getPemClientCertContent(), from.getPemClientKeyContent());
+                } else if (from.getPemClientCertPath() != null) {
+                    to.keystorePem(from.getPemClientCertPath(), from.getPemClientKeyPath());
+                }
+                break;
+            case NONE:
+            default:
+                break;
+        }
+    }
+
+    private void configureClientCredentials(RegistryClientOptions options) {
+        var auth = config.auth();
+        if (!auth.enabled()) {
+            log.info("Registry client authentication is disabled");
+            return;
+        }
+
+        if (auth.tokenEndpoint().isEmpty() || auth.clientId().isEmpty() || auth.clientSecret().isEmpty()) {
+            throw new IllegalStateException(
+                    "OAuth2 authentication requires 'apicurio.mcp.auth.token-endpoint', "
+                            + "'apicurio.mcp.auth.client-id', and 'apicurio.mcp.auth.client-secret' to be configured");
+        }
+
+        if (auth.scope().isPresent()) {
+            options.oauth2(auth.tokenEndpoint().get(), auth.clientId().get(), auth.clientSecret().get(),
+                    auth.scope().get());
+        } else {
+            options.oauth2(auth.tokenEndpoint().get(), auth.clientId().get(), auth.clientSecret().get());
+        }
+        log.info("Configured OAuth2 client credentials with token endpoint: {}", auth.tokenEndpoint().get());
+    }
+
+    private void configureTls(RegistryClientOptions options) {
+        var tls = config.tls();
+
+        if (tls.trustAll()) {
+            log.warn("TLS trust-all is enabled. This should only be used in development environments.");
+            options.trustAll(true);
+        }
+
+        if (!tls.verifyHost()) {
+            log.warn("TLS hostname verification is disabled. This reduces security.");
+            options.verifyHost(false);
+        }
+
+        var truststore = tls.truststore();
+        if (truststore.type().isPresent() && truststore.path().isPresent()) {
+            String type = truststore.type().get().toUpperCase(Locale.ROOT);
+            String path = truststore.path().get();
+            String password = truststore.password().orElse(null);
+
+            switch (type) {
+                case "JKS":
+                    options.trustStoreJks(path, password);
+                    log.info("Configured JKS trust store: {}", path);
+                    break;
+                case "PKCS12":
+                case "P12":
+                    options.trustStorePkcs12(path, password);
+                    log.info("Configured PKCS12 trust store: {}", path);
+                    break;
+                case "PEM":
+                    options.trustStorePem(path);
+                    log.info("Configured PEM trust store: {}", path);
+                    break;
+                default:
+                    throw new IllegalStateException("Unsupported trust store type: " + type
+                            + ". Supported types: JKS, PKCS12, PEM");
+            }
+        }
+
+        var keystore = tls.keystore();
+        if (keystore.type().isPresent() && keystore.path().isPresent()) {
+            String type = keystore.type().get().toUpperCase(Locale.ROOT);
+            String path = keystore.path().get();
+            String password = keystore.password().orElse(null);
+
+            switch (type) {
+                case "JKS":
+                    options.keystoreJks(path, password);
+                    log.info("Configured JKS key store for mTLS: {}", path);
+                    break;
+                case "PKCS12":
+                case "P12":
+                    options.keystorePkcs12(path, password);
+                    log.info("Configured PKCS12 key store for mTLS: {}", path);
+                    break;
+                default:
+                    throw new IllegalStateException("Unsupported key store type: " + type
+                            + ". Supported types: JKS, PKCS12");
+            }
+        }
+    }
+
+    private RegistryClient createClient(RegistryClientOptions options) {
+        return RegistryClientFactory.create(options);
+    }
+}

--- a/mcp/src/main/java/io/apicurio/registry/mcp/RegistryClientResolver.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/RegistryClientResolver.java
@@ -97,22 +97,30 @@ public class RegistryClientResolver {
             var options = copyTransportOptions().bearerToken(bearerToken);
             return RegistryClientFactory.create(options);
         }
+
+        // HTTP token-forwarding must never fall back to service-account (typically sr-admin)
+        // credentials. That would bypass per-user RBAC for authenticated callers that somehow
+        // lack an extractable bearer token. Stdio (anonymous / no identity) still uses fallback.
+        if (config.http().enabled() && config.http().forwardToken() && isAuthenticatedRequest()) {
+            throw new IllegalStateException(
+                    "No Registry client available: HTTP token forwarding is enabled but no bearer access "
+                            + "token was found on the authenticated request. Ensure the MCP client sends "
+                            + "'Authorization: Bearer <access_token>' on every /mcp request (complete "
+                            + "OAuth login so the access token is sent).");
+        }
+
         if (fallbackClient == null) {
-            boolean authenticated = securityIdentity.isResolvable()
-                    && securityIdentity.get() != null
-                    && !securityIdentity.get().isAnonymous();
-            if (authenticated) {
-                throw new IllegalStateException(
-                        "No Registry client available: HTTP token forwarding is enabled but no bearer access "
-                                + "token was found on the authenticated request. Ensure the MCP client sends "
-                                + "'Authorization: Bearer <access_token>' on every /mcp request (complete "
-                                + "OAuth login so the access token is sent).");
-            }
             throw new IllegalStateException(
                     "No Registry client available: HTTP token forwarding is enabled but no bearer token "
                             + "was provided, and no fallback client credentials are configured");
         }
         return fallbackClient;
+    }
+
+    private boolean isAuthenticatedRequest() {
+        return securityIdentity.isResolvable()
+                && securityIdentity.get() != null
+                && !securityIdentity.get().isAnonymous();
     }
 
     boolean hasFallbackClient() {

--- a/mcp/src/main/java/io/apicurio/registry/mcp/RegistryService.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/RegistryService.java
@@ -1,7 +1,5 @@
 package io.apicurio.registry.mcp;
 
-import io.apicurio.registry.client.RegistryClientFactory;
-import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.rest.client.RegistryClient;
 import io.apicurio.registry.rest.client.models.ArtifactMetaData;
 import io.apicurio.registry.rest.client.models.ArtifactSortBy;
@@ -27,12 +25,8 @@ import io.apicurio.registry.rest.client.models.VersionSortBy;
 import io.apicurio.registry.rest.client.models.VersionState;
 import io.apicurio.registry.rest.client.models.WrappedVersionState;
 import io.quarkiverse.mcp.server.ToolCallException;
-import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,127 +36,28 @@ import java.util.List;
 @ApplicationScoped
 public class RegistryService {
 
-    private static final Logger log = LoggerFactory.getLogger(RegistryService.class);
-
-    @ConfigProperty(name = "registry.url", defaultValue = "localhost:8080")
-    String rawBaseUrl;
-
     @Inject
     McpConfig config;
 
     @Inject
     Utils utils;
 
-    private RegistryClient client;
+    @Inject
+    RegistryClientResolver clientResolver;
 
-    @PostConstruct
-    void init() {
-        var options = RegistryClientOptions.create(rawBaseUrl).retry();
-        configureAuthentication(options);
-        configureTls(options);
-        client = RegistryClientFactory.create(options);
-        // Test the connection
-        var info = client.system().info().get();
-        log.info("Successfully connected to Apicurio Registry version {} at {}", info.getVersion(), rawBaseUrl);
-    }
-
-    private void configureAuthentication(RegistryClientOptions options) {
-        var auth = config.auth();
-        if (!auth.enabled()) {
-            log.info("Authentication is disabled");
-            return;
-        }
-
-        if (auth.tokenEndpoint().isEmpty() || auth.clientId().isEmpty() || auth.clientSecret().isEmpty()) {
-            throw new IllegalStateException(
-                    "OAuth2 authentication requires 'apicurio.mcp.auth.token-endpoint', "
-                            + "'apicurio.mcp.auth.client-id', and 'apicurio.mcp.auth.client-secret' to be configured");
-        }
-
-        if (auth.scope().isPresent()) {
-            options.oauth2(auth.tokenEndpoint().get(), auth.clientId().get(), auth.clientSecret().get(),
-                    auth.scope().get());
-        } else {
-            options.oauth2(auth.tokenEndpoint().get(), auth.clientId().get(), auth.clientSecret().get());
-        }
-        log.info("Configured OAuth2 authentication with token endpoint: {}", auth.tokenEndpoint().get());
-    }
-
-    private void configureTls(RegistryClientOptions options) {
-        var tls = config.tls();
-
-        // Trust all certificates (development only)
-        if (tls.trustAll()) {
-            log.warn("TLS trust-all is enabled. This should only be used in development environments.");
-            options.trustAll(true);
-        }
-
-        // Hostname verification
-        if (!tls.verifyHost()) {
-            log.warn("TLS hostname verification is disabled. This reduces security.");
-            options.verifyHost(false);
-        }
-
-        // Trust store configuration
-        var truststore = tls.truststore();
-        if (truststore.type().isPresent() && truststore.path().isPresent()) {
-            String type = truststore.type().get().toUpperCase();
-            String path = truststore.path().get();
-            String password = truststore.password().orElse(null);
-
-            switch (type) {
-                case "JKS":
-                    options.trustStoreJks(path, password);
-                    log.info("Configured JKS trust store: {}", path);
-                    break;
-                case "PKCS12":
-                case "P12":
-                    options.trustStorePkcs12(path, password);
-                    log.info("Configured PKCS12 trust store: {}", path);
-                    break;
-                case "PEM":
-                    options.trustStorePem(path);
-                    log.info("Configured PEM trust store: {}", path);
-                    break;
-                default:
-                    throw new IllegalStateException("Unsupported trust store type: " + type
-                            + ". Supported types: JKS, PKCS12, PEM");
-            }
-        }
-
-        // Key store configuration (mTLS)
-        var keystore = tls.keystore();
-        if (keystore.type().isPresent() && keystore.path().isPresent()) {
-            String type = keystore.type().get().toUpperCase();
-            String path = keystore.path().get();
-            String password = keystore.password().orElse(null);
-
-            switch (type) {
-                case "JKS":
-                    options.keystoreJks(path, password);
-                    log.info("Configured JKS key store for mTLS: {}", path);
-                    break;
-                case "PKCS12":
-                case "P12":
-                    options.keystorePkcs12(path, password);
-                    log.info("Configured PKCS12 key store for mTLS: {}", path);
-                    break;
-                default:
-                    throw new IllegalStateException("Unsupported key store type: " + type
-                            + ". Supported types: JKS, PKCS12");
-            }
-        }
+    private RegistryClient client() {
+        return clientResolver.getClient();
     }
 
     public SystemInfo getServerInfo() {
-        return client.system().info().get();
+        return client().system().info().get();
     }
 
     public List<SearchedGroup> listGroups(
             String order,
             String groupOrderBy
     ) {
-        var page = client.groups().get(r -> {
+        var page = client().groups().get(r -> {
             r.queryParameters.limit = config.paging().limit() + 1;
             r.queryParameters.order = SortOrder.forValue(order);
             r.queryParameters.orderby = GroupSortBy.forValue(groupOrderBy);
@@ -190,13 +85,13 @@ public class RegistryService {
         g.setDescription(description);
         g.setLabels(utils.toLabels(jsonLabels));
 
-        return client.groups().post(g);
+        return client().groups().post(g);
     }
 
     public GroupMetaData getGroupMetadata(
             String groupId
     ) {
-        return client.groups().byGroupId(groupId).get();
+        return client().groups().byGroupId(groupId).get();
     }
 
     public void updateGroupMetadata(
@@ -208,11 +103,11 @@ public class RegistryService {
         m.setDescription(description);
         m.setLabels(utils.toLabels(jsonLabels));
 
-        client.groups().byGroupId(groupId).put(m);
+        client().groups().byGroupId(groupId).put(m);
     }
 
     public List<ArtifactTypeInfo> getArtifactTypes() {
-        return client.admin().config().artifactTypes().get();
+        return client().admin().config().artifactTypes().get();
     }
 
     public List<SearchedArtifact> listArtifacts(
@@ -220,7 +115,7 @@ public class RegistryService {
             String order,
             String artifactOrderBy
     ) {
-        var page = client.groups().byGroupId(groupId).artifacts().get(r -> {
+        var page = client().groups().byGroupId(groupId).artifacts().get(r -> {
             r.queryParameters.limit = config.paging().limit() + 1;
             r.queryParameters.order = SortOrder.forValue(order);
             r.queryParameters.orderby = ArtifactSortBy.forValue(artifactOrderBy);
@@ -233,7 +128,7 @@ public class RegistryService {
             String groupId,
             String artifactId
     ) {
-        return client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).get();
+        return client().groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).get();
     }
 
     public void updateArtifactMetadata(
@@ -248,7 +143,7 @@ public class RegistryService {
         m.setDescription(description);
         m.setLabels(utils.toLabels(jsonLabels));
 
-        client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).put(m);
+        client().groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).put(m);
     }
 
     public void updateVersionMetadata(
@@ -264,7 +159,7 @@ public class RegistryService {
         m.setDescription(description);
         m.setLabels(utils.toLabels(jsonLabels));
 
-        client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId)
+        client().groups().byGroupId(groupId).artifacts().byArtifactId(artifactId)
                 .versions().byVersionExpression(versionExpression).put(m);
     }
 
@@ -273,7 +168,7 @@ public class RegistryService {
             String artifactId,
             String versionExpression
     ) throws IOException {
-        return new String(client
+        return new String(client()
                 .groups().byGroupId(groupId)
                 .artifacts().byArtifactId(artifactId)
                 .versions().byVersionExpression(versionExpression)
@@ -286,7 +181,7 @@ public class RegistryService {
             String artifactId,
             String versionExpression
     ) {
-        return client.groups().byGroupId(groupId)
+        return client().groups().byGroupId(groupId)
                 .artifacts().byArtifactId(artifactId)
                 .versions().byVersionExpression(versionExpression)
                 .get();
@@ -303,7 +198,7 @@ public class RegistryService {
         vc.setContentType(versionContentType);
         vc.setContent(versionContent);
 
-        client.groups().byGroupId(groupId)
+        client().groups().byGroupId(groupId)
                 .artifacts().byArtifactId(artifactId)
                 .versions().byVersionExpression(versionExpression)
                 .content().put(vc);
@@ -315,7 +210,7 @@ public class RegistryService {
             String order,
             String versionOrderBy
     ) {
-        var page = client.groups().byGroupId(groupId)
+        var page = client().groups().byGroupId(groupId)
                 .artifacts().byArtifactId(artifactId)
                 .versions()
                 .get(r -> {
@@ -342,7 +237,7 @@ public class RegistryService {
         a.setDescription(description);
         a.setLabels(utils.toLabels(jsonLabels));
 
-        return client.groups().byGroupId(groupId).artifacts().post(a).getArtifact();
+        return client().groups().byGroupId(groupId).artifacts().post(a).getArtifact();
     }
 
     public VersionMetaData createVersion(
@@ -368,7 +263,7 @@ public class RegistryService {
         c.setContent(versionContent);
         v.setContent(c);
 
-        return client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions().post(v);
+        return client().groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions().post(v);
     }
 
     public void updateVersionState(
@@ -380,7 +275,7 @@ public class RegistryService {
         var vs = new WrappedVersionState();
         vs.setState(VersionState.valueOf(versionState));
 
-        client.groups().byGroupId(groupId)
+        client().groups().byGroupId(groupId)
                 .artifacts().byArtifactId(artifactId)
                 .versions().byVersionExpression(versionExpression)
                 .state().put(vs);
@@ -393,7 +288,7 @@ public class RegistryService {
             String order,
             String groupOrderBy
     ) {
-        var page = client.search().groups().get(r -> {
+        var page = client().search().groups().get(r -> {
             r.queryParameters.groupId = groupId;
             r.queryParameters.description = description;
             r.queryParameters.labels = utils.toQueryLabels(labels);
@@ -416,7 +311,7 @@ public class RegistryService {
             String order,
             String versionOrderBy
     ) {
-        var page = client.search().versions().get(r -> {
+        var page = client().search().versions().get(r -> {
             r.queryParameters.groupId = groupId;
             r.queryParameters.artifactId = artifactId;
             r.queryParameters.artifactType = artifactType;
@@ -442,7 +337,7 @@ public class RegistryService {
             String order,
             String artifactOrderBy
     ) {
-        var page = client.search().artifacts().get(r -> {
+        var page = client().search().artifacts().get(r -> {
             r.queryParameters.groupId = groupId;
             r.queryParameters.artifactId = artifactId;
             r.queryParameters.artifactType = artifactType;
@@ -459,15 +354,15 @@ public class RegistryService {
     }
 
     public List<ConfigurationProperty> listConfigurationProperties() {
-        return client.admin().config().properties().get();
+        return client().admin().config().properties().get();
     }
 
     public ConfigurationProperty getConfigurationProperty(String propertyName) {
-        return client.admin().config().properties().byPropertyName(propertyName).get();
+        return client().admin().config().properties().byPropertyName(propertyName).get();
     }
 
     public String searchAgentCards(String name, String skill, String capability) throws Exception {
-        var results = client.wellKnown().agents().get(config -> {
+        var results = client().wellKnown().agents().get(config -> {
             config.queryParameters.limit = 50;
             if (name != null && !name.isBlank()) {
                 config.queryParameters.name = name;
@@ -483,7 +378,7 @@ public class RegistryService {
     }
 
     public String getAgentCard(String groupId, String artifactId) throws Exception {
-        try (InputStream is = client.wellKnown().agents().byGroupId(groupId).byArtifactId(artifactId).get()) {
+        try (InputStream is = client().wellKnown().agents().byGroupId(groupId).byArtifactId(artifactId).get()) {
             if (is == null) {
                 throw new ToolCallException("Unable to retrieve Agent Card.");
             }
@@ -492,7 +387,7 @@ public class RegistryService {
     }
 
     public String searchMcpTools(String name, String parameter) throws Exception {
-        var results = client.wellKnown().mcpTools().get(config -> {
+        var results = client().wellKnown().mcpTools().get(config -> {
             config.queryParameters.limit = 50;
             if (name != null && !name.isBlank()) {
                 config.queryParameters.name = name;
@@ -505,7 +400,7 @@ public class RegistryService {
     }
 
     public String getMcpTool(String groupId, String artifactId) throws Exception {
-        try (InputStream is = client.wellKnown().mcpTools().byGroupId(groupId).byArtifactId(artifactId).get()) {
+        try (InputStream is = client().wellKnown().mcpTools().byGroupId(groupId).byArtifactId(artifactId).get()) {
             if (is == null) {
                 throw new ToolCallException("Unable to retrieve MCP tool.");
             }
@@ -521,6 +416,6 @@ public class RegistryService {
         }
         var p = new UpdateConfigurationProperty();
         p.setValue(propertyValue);
-        client.admin().config().properties().byPropertyName(propertyName).put(p);
+        client().admin().config().properties().byPropertyName(propertyName).put(p);
     }
 }

--- a/mcp/src/main/java/io/apicurio/registry/mcp/Utils.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/Utils.java
@@ -6,14 +6,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.registry.rest.client.models.Labels;
 import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.client.models.RuleViolationProblemDetails;
 import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class Utils {
@@ -79,13 +84,109 @@ public class Utils {
         try {
             return action.apply();
         } catch (ProblemDetails ex) {
-            throw new ToolCallException("Request to Apicurio Registry returned an error: " + ex.getMessage(), ex);
+            throw new ToolCallException(formatRegistryApiError(ex), ex);
+        } catch (RuleViolationProblemDetails ex) {
+            throw new ToolCallException(formatRegistryApiError(ex), ex);
         } catch (Exception ex) {
+            Throwable registryError = findRegistryApiError(ex);
+            if (registryError instanceof RuleViolationProblemDetails ruleViolation) {
+                throw new ToolCallException(formatRegistryApiError(ruleViolation), ex);
+            }
+            if (registryError instanceof ProblemDetails problem) {
+                throw new ToolCallException(formatRegistryApiError(problem), ex);
+            }
             if (ex.getMessage() == null) {
-                throw new ToolCallException("Request to Apicurio Registry failed with an unknown error. Ask the user to check Apicurio Registry server logs.");
+                throw new ToolCallException(
+                        "Request to Apicurio Registry failed with an unknown error. Ask the user to check Apicurio Registry server logs.");
             }
             throw new ToolCallException("Execution failed: " + ex.getMessage(), ex);
         }
+    }
+
+    static String formatRegistryApiError(ProblemDetails ex) {
+        return formatRegistryApiError(ex, includeAuthorizationHints());
+    }
+
+    static String formatRegistryApiError(ProblemDetails ex, boolean includeAuthorizationHints) {
+        return formatRegistryApiError(ex.getStatus(), ex.getDetail(), ex.getTitle(), ex.getName(),
+                includeAuthorizationHints);
+    }
+
+    static String formatRegistryApiError(RuleViolationProblemDetails ex) {
+        return formatRegistryApiError(ex, includeAuthorizationHints());
+    }
+
+    static String formatRegistryApiError(RuleViolationProblemDetails ex, boolean includeAuthorizationHints) {
+        StringBuilder message = new StringBuilder(
+                formatRegistryApiError(ex.getStatus(), ex.getDetail(), ex.getTitle(), ex.getName(),
+                        includeAuthorizationHints));
+        if (ex.getCauses() != null && !ex.getCauses().isEmpty()) {
+            String causes = ex.getCauses().stream()
+                    .map(cause -> firstNonBlank(cause.getContext(), "rule") + ": "
+                            + firstNonBlank(cause.getDescription(), "violation"))
+                    .collect(Collectors.joining("; "));
+            message.append(" Causes: ").append(causes);
+        }
+        return message.toString();
+    }
+
+    private static String formatRegistryApiError(Integer status, String detail, String title, String name,
+            boolean includeAuthorizationHints) {
+        StringBuilder message = new StringBuilder("Request to Apicurio Registry returned an error");
+        if (status != null) {
+            message.append(" (HTTP ").append(status);
+            if (status == 403) {
+                message.append(" Forbidden");
+            } else if (status == 401) {
+                message.append(" Unauthorized");
+            }
+            message.append(')');
+        }
+        message.append(": ").append(firstNonBlank(detail, title, name, "Unknown error"));
+        // Only include Registry role names for authenticated callers — avoids leaking the
+        // authorization model to unauthenticated probes that receive 401/403.
+        if (includeAuthorizationHints && Integer.valueOf(403).equals(status)) {
+            message.append(". Your user may be missing the required Registry role "
+                    + "(sr-readonly, sr-developer, or sr-admin for this operation).");
+        }
+        return message.toString();
+    }
+
+    /**
+     * Role-name hints are only useful (and safe) when the caller is already authenticated.
+     */
+    static boolean includeAuthorizationHints() {
+        try {
+            Instance<SecurityIdentity> identity = CDI.current().select(SecurityIdentity.class);
+            if (!identity.isResolvable()) {
+                return false;
+            }
+            SecurityIdentity securityIdentity = identity.get();
+            return securityIdentity != null && !securityIdentity.isAnonymous();
+        } catch (IllegalStateException ignored) {
+            // Outside a CDI context (unit tests, stdio without security)
+            return false;
+        }
+    }
+
+    private static Throwable findRegistryApiError(Throwable ex) {
+        Throwable current = ex;
+        while (current != null) {
+            if (current instanceof ProblemDetails || current instanceof RuleViolationProblemDetails) {
+                return current;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
     }
 
     public static String handleError(Function0 action) {

--- a/mcp/src/main/resources/application.properties
+++ b/mcp/src/main/resources/application.properties
@@ -13,28 +13,56 @@ quarkus.package.jar.type=fast-jar
 
 %test.quarkus.log.category."io.apicurio".level=debug
 
+# Build-time MCP transports (rebuild the image/JAR after changing):
+quarkus.mcp.server.stdio.enabled=true
+quarkus.mcp.server.http.enabled=true
+quarkus.mcp.server.http.root-path=/mcp
+
+# Runtime gate for HTTP mode: /mcp returns 503 unless this is true AND OIDC is configured.
+# Build-time HTTP support only compiles the transport; it does not expose an unauthenticated endpoint.
+apicurio.mcp.http.enabled=false
+
 # =============================================================================
-# Authentication Configuration
+# Authentication Configuration (stdio client-credentials to Registry)
 # =============================================================================
-# The MCP server can be configured to authenticate with the Apicurio Registry
-# using different authentication methods.
-#
-# Authentication type: none, basic, oauth2 (or oidc)
-# apicurio.mcp.auth.type=none
-#
-# -----------------------------------------------------------------------------
-# Basic Authentication
-# -----------------------------------------------------------------------------
-# When apicurio.mcp.auth.type=basic, configure:
-# apicurio.mcp.auth.basic.username=<username>
-# apicurio.mcp.auth.basic.password=<password>
-#
-# -----------------------------------------------------------------------------
-# OAuth2/OIDC Authentication (Client Credentials Flow)
-# -----------------------------------------------------------------------------
-# When apicurio.mcp.auth.type=oauth2 (or oidc), configure:
-# apicurio.mcp.auth.oauth2.token-endpoint=<token-endpoint-url>
-# apicurio.mcp.auth.oauth2.client-id=<client-id>
-# apicurio.mcp.auth.oauth2.client-secret=<client-secret>
-# apicurio.mcp.auth.oauth2.scope=<optional-scope>
+# See MCP integration guide for details:
+# apicurio.mcp.auth.enabled=true
+# apicurio.mcp.auth.token-endpoint=<token-endpoint-url>
+# apicurio.mcp.auth.client-id=<client-id>
+# apicurio.mcp.auth.client-secret=<client-secret>
+# apicurio.mcp.auth.scope=<optional-scope>
 # =============================================================================
+
+# =============================================================================
+# HTTP transport (optional)
+# =============================================================================
+# apicurio.mcp.http.enabled=false
+# apicurio.mcp.http.forward-token=true
+#
+# When apicurio.mcp.http.enabled=true, also configure Quarkus MCP + OIDC at runtime:
+# QUARKUS_MCP_SERVER_HTTP_ENABLED=true
+# QUARKUS_MCP_SERVER_STDIO_ENABLED=false
+# QUARKUS_OIDC_TENANT_ENABLED=true
+# QUARKUS_OIDC_APPLICATION_TYPE=service
+# QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/realms/registry
+# QUARKUS_OIDC_TENANT_PATHS=/mcp
+# QUARKUS_HTTP_AUTH_PERMISSION_AUTHENTICATED_PATHS=/mcp
+# QUARKUS_HTTP_AUTH_PERMISSION_AUTHENTICATED_POLICY=authenticated
+#
+# Optional (HTTP-mode OAuth discovery):
+# QUARKUS_OIDC_RESOURCE_METADATA_AUTHORIZATION_SERVER=http://localhost:8080/realms/registry
+# QUARKUS_OIDC_RESOURCE_METADATA_ENABLED=true
+# QUARKUS_HTTP_CORS_ENABLED=true
+# QUARKUS_HTTP_CORS_ORIGINS=http://localhost:6274
+# WARNING: localhost CORS origins are for local development only (e.g. MCP Inspector).
+# In production, set QUARKUS_HTTP_CORS_ORIGINS to your deployed client origin(s), not localhost or *.
+# =============================================================================
+
+# HTTP mode OIDC is configured at runtime via environment variables (see docker-compose.yml
+# and assembly-mcp-server-integration.adoc). Do not enable OIDC in the prod profile here —
+# stdio mode uses prod by default and only needs APICURIO_MCP_AUTH_*.
+
+%test.quarkus.devservices.enabled=false
+%test.quarkus.oidc.devservices.enabled=false
+%test.quarkus.oidc.tenant-enabled=false
+%test.quarkus.mcp.server.http.streamable.auto-init=true

--- a/mcp/src/test/java/io/apicurio/registry/mcp/AuthTestContainersManager.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/AuthTestContainersManager.java
@@ -15,8 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Test container manager that starts both Keycloak and Apicurio Registry containers
- * for testing the MCP server authentication functionality.
+ * Test container manager that starts Keycloak and Apicurio Registry for MCP authentication tests.
  * <p>
  * Uses the shared realm.json from apicurio-registry-utils-tests.
  */
@@ -29,16 +28,23 @@ public class AuthTestContainersManager implements QuarkusTestResourceLifecycleMa
 
     public static final String ADMIN_CLIENT_ID = "admin-client";
     public static final String ADMIN_CLIENT_SECRET = "test1";
+    public static final String READONLY_CLIENT_ID = "readonly-client";
+    public static final String READONLY_CLIENT_SECRET = "test1";
 
     private KeycloakContainer keycloak;
     private GenericContainer<?> registry;
     private Network network;
 
+    private static volatile String sharedTokenEndpoint;
+
+    public static String sharedTokenEndpoint() {
+        return sharedTokenEndpoint;
+    }
+
     @Override
     public Map<String, String> start() {
         network = Network.newNetwork();
 
-        // Start Keycloak first - uses realm.json from apicurio-registry-utils-tests classpath
         keycloak = new KeycloakContainer(DockerImageName.parse(KEYCLOAK_IMAGE).toString())
                 .withNetwork(network)
                 .withNetworkAliases("keycloak")
@@ -49,16 +55,18 @@ public class AuthTestContainersManager implements QuarkusTestResourceLifecycleMa
         keycloak.start();
         log.info("Keycloak started at: {}", keycloak.getAuthServerUrl());
 
-        String keycloakInternalUrl = "http://keycloak:8080";
-        String tokenEndpoint = keycloakInternalUrl + "/realms/registry/protocol/openid-connect/token";
+        String keycloakExternalRealmUrl = keycloak.getAuthServerUrl() + "/realms/registry";
+        String keycloakInternalRealmUrl = "http://keycloak:8080/realms/registry";
+        String tokenEndpoint = keycloakExternalRealmUrl + "/protocol/openid-connect/token";
+        sharedTokenEndpoint = tokenEndpoint;
 
-        // Start Registry with authentication enabled
         registry = new GenericContainer<>(DockerImageName.parse(REGISTRY_IMAGE))
                 .withNetwork(network)
                 .withNetworkAliases("registry")
                 .withExposedPorts(8080)
-                .withEnv("QUARKUS_OIDC_AUTH_SERVER_URL", keycloakInternalUrl + "/realms/registry")
-                .withEnv("QUARKUS_OIDC_TOKEN_PATH", tokenEndpoint)
+                .withEnv("QUARKUS_OIDC_AUTH_SERVER_URL", keycloakInternalRealmUrl)
+                .withEnv("QUARKUS_OIDC_TOKEN_PATH", keycloakInternalRealmUrl + "/protocol/openid-connect/token")
+                .withEnv("QUARKUS_OIDC_TOKEN_ISSUER", keycloakExternalRealmUrl)
                 .withEnv("QUARKUS_OIDC_TENANT_ENABLED", "true")
                 .withEnv("APICURIO_AUTH_ROLE_BASED_AUTHORIZATION", "true")
                 .withEnv("APICURIO_AUTH_OWNER_ONLY_AUTHORIZATION", "true")
@@ -70,23 +78,24 @@ public class AuthTestContainersManager implements QuarkusTestResourceLifecycleMa
         log.info("Starting Registry container with authentication...");
         registry.start();
 
-        String registryHost = registry.getHost();
-        Integer registryPort = registry.getMappedPort(8080);
-        String registryUrl = "http://" + registryHost + ":" + registryPort;
-
+        String registryUrl = "http://" + registry.getHost() + ":" + registry.getMappedPort(8080);
         log.info("Registry started at: {}", registryUrl);
 
-        // Build the token endpoint URL using the external Keycloak URL
-        String externalTokenEndpoint = keycloak.getAuthServerUrl() + "/realms/registry/protocol/openid-connect/token";
+        Map<String, String> props = buildMcpProperties(registryUrl, tokenEndpoint, keycloakExternalRealmUrl);
+        Map<String, String> safeProps = new HashMap<>(props);
+        safeProps.replace("apicurio.mcp.auth.client-secret", "***");
+        log.info("MCP test configuration: {}", safeProps);
+        return props;
+    }
 
+    protected Map<String, String> buildMcpProperties(String registryUrl, String tokenEndpoint,
+            String keycloakExternalRealmUrl) {
         Map<String, String> props = new HashMap<>();
         props.put("registry.url", registryUrl);
         props.put("apicurio.mcp.auth.enabled", "true");
-        props.put("apicurio.mcp.auth.token-endpoint", externalTokenEndpoint);
+        props.put("apicurio.mcp.auth.token-endpoint", tokenEndpoint);
         props.put("apicurio.mcp.auth.client-id", ADMIN_CLIENT_ID);
         props.put("apicurio.mcp.auth.client-secret", ADMIN_CLIENT_SECRET);
-
-        log.info("MCP Test configuration: {}", props);
         return props;
     }
 

--- a/mcp/src/test/java/io/apicurio/registry/mcp/HttpAuthTestContainersManager.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/HttpAuthTestContainersManager.java
@@ -1,0 +1,31 @@
+package io.apicurio.registry.mcp;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test container manager for MCP HTTP transport with inbound OIDC and token forwarding.
+ */
+public class HttpAuthTestContainersManager extends AuthTestContainersManager {
+
+    @Override
+    protected Map<String, String> buildMcpProperties(String registryUrl, String tokenEndpoint,
+            String keycloakExternalRealmUrl) {
+        Map<String, String> props = new HashMap<>();
+        props.put("registry.url", registryUrl);
+        props.put("apicurio.mcp.http.enabled", "true");
+        props.put("apicurio.mcp.http.forward-token", "true");
+        props.put("apicurio.mcp.auth.enabled", "false");
+        props.put("quarkus.mcp.server.http.enabled", "true");
+        props.put("quarkus.mcp.server.stdio.enabled", "false");
+        props.put("quarkus.oidc.tenant-enabled", "true");
+        props.put("quarkus.oidc.application-type", "service");
+        props.put("quarkus.oidc.auth-server-url", keycloakExternalRealmUrl);
+        props.put("quarkus.oidc.tls.verification", "none");
+        props.put("quarkus.http.auth.permission.authenticated.paths", "/mcp");
+        props.put("quarkus.http.auth.permission.authenticated.policy", "authenticated");
+        props.put("quarkus.oidc.tenant-paths", "/mcp");
+        props.put("quarkus.http.auth.proactive", "true");
+        return props;
+    }
+}

--- a/mcp/src/test/java/io/apicurio/registry/mcp/KeycloakTokenHelper.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/KeycloakTokenHelper.java
@@ -1,0 +1,26 @@
+package io.apicurio.registry.mcp;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+/**
+ * Utility for obtaining OAuth2 access tokens from Keycloak in tests.
+ */
+final class KeycloakTokenHelper {
+
+    private KeycloakTokenHelper() {
+    }
+
+    static String getClientCredentialsToken(String tokenEndpoint, String clientId, String clientSecret) {
+        return RestAssured.given()
+                .contentType(ContentType.URLENC)
+                .formParam("grant_type", "client_credentials")
+                .formParam("client_id", clientId)
+                .formParam("client_secret", clientSecret)
+                .post(tokenEndpoint)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("access_token");
+    }
+}

--- a/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpAuthTestProfile.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpAuthTestProfile.java
@@ -1,0 +1,16 @@
+package io.apicurio.registry.mcp;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.List;
+
+/**
+ * Test profile for MCP HTTP transport with OIDC and token forwarding.
+ */
+public class McpHttpAuthTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return List.of(new TestResourceEntry(HttpAuthTestContainersManager.class));
+    }
+}

--- a/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpAuthValidatorTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpAuthValidatorTest.java
@@ -1,0 +1,273 @@
+package io.apicurio.registry.mcp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link McpHttpAuthValidator} startup configuration checks.
+ */
+class McpHttpAuthValidatorTest {
+
+    private McpHttpAuthValidator validator;
+    private TestHttp http;
+    private TestAuth auth;
+
+    @BeforeEach
+    void setUp() {
+        validator = new McpHttpAuthValidator();
+        http = new TestHttp(false, true);
+        auth = new TestAuth(false);
+        validator.config = new ValidatorMcpConfig(http, auth);
+        validator.oidcTenantEnabled = false;
+        validator.mcpHttpTransportEnabled = false;
+        validator.registryUrl = "localhost:8080";
+        validator.connectivityProbe = (host, port) -> {
+            // no-op: unit tests do not require a live Registry
+        };
+    }
+
+    @Test
+    void skipsValidationWhenHttpModeDisabled() {
+        http.enabled = false;
+        validator.mcpHttpTransportEnabled = false;
+        validator.oidcTenantEnabled = false;
+
+        assertDoesNotThrow(() -> validator.onStart(null));
+    }
+
+    @Test
+    void failsWhenHttpModeEnabledButTransportDisabled() {
+        http.enabled = true;
+        validator.mcpHttpTransportEnabled = false;
+        validator.oidcTenantEnabled = true;
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                validator::validateHttpAuthConfig);
+        assertTrue(error.getMessage().contains("quarkus.mcp.server.http.enabled"));
+    }
+
+    @Test
+    void failsWhenHttpModeEnabledButOidcDisabled() {
+        http.enabled = true;
+        validator.mcpHttpTransportEnabled = true;
+        validator.oidcTenantEnabled = false;
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                validator::validateHttpAuthConfig);
+        assertTrue(error.getMessage().contains("quarkus.oidc.tenant-enabled"));
+    }
+
+    @Test
+    void succeedsWhenHttpTransportAndOidcEnabled() {
+        http.enabled = true;
+        validator.mcpHttpTransportEnabled = true;
+        validator.oidcTenantEnabled = true;
+
+        assertDoesNotThrow(validator::validateHttpAuthConfig);
+    }
+
+    @Test
+    void succeedsWhenForwardTokenAndClientCredentialsBothConfigured() {
+        http.enabled = true;
+        http.forwardToken = true;
+        auth.enabled = true;
+        validator.mcpHttpTransportEnabled = true;
+        validator.oidcTenantEnabled = true;
+
+        assertDoesNotThrow(validator::validateHttpAuthConfig);
+    }
+
+    @Test
+    void succeedsWhenForwardTokenDisabledWithHttpAndOidc() {
+        http.enabled = true;
+        http.forwardToken = false;
+        validator.mcpHttpTransportEnabled = true;
+        validator.oidcTenantEnabled = true;
+
+        assertDoesNotThrow(validator::validateHttpAuthConfig);
+    }
+
+    @Test
+    void parseRegistryHostPortAcceptsHostPortAndFullUrl() {
+        assertEquals(new McpHttpAuthValidator.HostPort("localhost", 8080),
+                McpHttpAuthValidator.parseRegistryHostPort("localhost:8080"));
+        assertEquals(new McpHttpAuthValidator.HostPort("registry.example.com", 443),
+                McpHttpAuthValidator.parseRegistryHostPort("https://registry.example.com"));
+        assertEquals(new McpHttpAuthValidator.HostPort("localhost", 8080),
+                McpHttpAuthValidator.parseRegistryHostPort("http://localhost:8080/apis/registry/v3"));
+    }
+
+    @Test
+    void parseRegistryHostPortRejectsBlankAndInvalid() {
+        IllegalStateException blank = assertThrows(IllegalStateException.class,
+                () -> McpHttpAuthValidator.parseRegistryHostPort("  "));
+        assertTrue(blank.getMessage().contains("registry.url must be configured"));
+
+        IllegalStateException invalid = assertThrows(IllegalStateException.class,
+                () -> McpHttpAuthValidator.parseRegistryHostPort("not a url"));
+        assertTrue(invalid.getMessage().contains("registry.url"));
+    }
+
+    @Test
+    void validateRegistryUrlProbesReachabilityWhenAuthDisabled() {
+        http.enabled = true;
+        auth.enabled = false;
+        validator.registryUrl = "localhost:8080";
+
+        boolean[] probed = {false};
+        validator.connectivityProbe = (host, port) -> {
+            probed[0] = true;
+            assertEquals("localhost", host);
+            assertEquals(8080, port);
+        };
+
+        assertDoesNotThrow(validator::validateRegistryUrl);
+        assertTrue(probed[0]);
+    }
+
+    @Test
+    void validateRegistryUrlSkipsReachabilityWhenAuthEnabled() {
+        http.enabled = true;
+        auth.enabled = true;
+        validator.registryUrl = "localhost:8080";
+        validator.connectivityProbe = (host, port) -> {
+            throw new IOException("should not be called when client-credentials probe covers startup");
+        };
+
+        assertDoesNotThrow(validator::validateRegistryUrl);
+    }
+
+    @Test
+    void validateRegistryUrlFailsWhenHostUnreachable() {
+        http.enabled = true;
+        auth.enabled = false;
+        validator.registryUrl = "registry.invalid:9999";
+        validator.connectivityProbe = (host, port) -> {
+            throw new IOException("Connection refused");
+        };
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                validator::validateRegistryUrl);
+        assertTrue(error.getMessage().contains("Cannot reach Apicurio Registry"));
+        assertTrue(error.getMessage().contains("registry.invalid:9999"));
+    }
+
+    @Test
+    void onStartValidatesRegistryUrlWhenHttpEnabled() {
+        http.enabled = true;
+        validator.mcpHttpTransportEnabled = true;
+        validator.oidcTenantEnabled = true;
+        validator.registryUrl = "localhost:8080";
+        boolean[] probed = {false};
+        validator.connectivityProbe = (host, port) -> probed[0] = true;
+
+        assertDoesNotThrow(() -> validator.onStart(null));
+        assertTrue(probed[0]);
+    }
+
+    private static final class TestHttp implements McpConfig.Http {
+        private boolean enabled;
+        private boolean forwardToken;
+
+        private TestHttp(boolean enabled, boolean forwardToken) {
+            this.enabled = enabled;
+            this.forwardToken = forwardToken;
+        }
+
+        @Override
+        public boolean enabled() {
+            return enabled;
+        }
+
+        @Override
+        public boolean forwardToken() {
+            return forwardToken;
+        }
+    }
+
+    private static final class TestAuth implements McpConfig.Auth {
+        private boolean enabled;
+
+        private TestAuth(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        public boolean enabled() {
+            return enabled;
+        }
+
+        @Override
+        public Optional<String> tokenEndpoint() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> clientId() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> clientSecret() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> scope() {
+            return Optional.empty();
+        }
+    }
+
+    private static final class ValidatorMcpConfig implements McpConfig {
+        private final TestHttp http;
+        private final TestAuth auth;
+
+        private ValidatorMcpConfig(TestHttp http, TestAuth auth) {
+            this.http = http;
+            this.auth = auth;
+        }
+
+        @Override
+        public boolean safeMode() {
+            return true;
+        }
+
+        @Override
+        public Paging paging() {
+            return new Paging() {
+                @Override
+                public int limit() {
+                    return 200;
+                }
+
+                @Override
+                public boolean limitError() {
+                    return true;
+                }
+            };
+        }
+
+        @Override
+        public Auth auth() {
+            return auth;
+        }
+
+        @Override
+        public Tls tls() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Http http() {
+            return http;
+        }
+    }
+}

--- a/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpDisabledByDefaultTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpDisabledByDefaultTest.java
@@ -1,0 +1,37 @@
+package io.apicurio.registry.mcp;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that MCP HTTP endpoints are not reachable unless HTTP mode is explicitly enabled.
+ */
+@QuarkusTest
+public class McpHttpDisabledByDefaultTest {
+
+    @Test
+    void testMcpEndpointNotReachableWhenHttpModeDisabled() {
+        io.restassured.RestAssured.given()
+                .header("Accept", "application/json, text/event-stream")
+                .contentType("application/json")
+                .body("""
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "initialize",
+                          "params": {
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {},
+                            "clientInfo": {
+                              "name": "mcp-http-test",
+                              "version": "1.0"
+                            }
+                          }
+                        }
+                        """)
+                .post("/mcp")
+                .then()
+                .statusCode(503)
+                .body(org.hamcrest.Matchers.containsString("MCP HTTP transport is disabled"));
+    }
+}

--- a/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpGateFilterTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpGateFilterTest.java
@@ -1,0 +1,215 @@
+package io.apicurio.registry.mcp;
+
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link McpHttpGateFilter} request gating.
+ */
+class McpHttpGateFilterTest {
+
+    private McpHttpGateFilter filter;
+    private TestHttp http;
+    private AtomicInteger statusCode;
+    private AtomicBoolean ended;
+    private AtomicBoolean nextCalled;
+    private AtomicReference<String> responseBody;
+    private AtomicReference<String> contentType;
+    private RoutingContext context;
+
+    @BeforeEach
+    void setUp() {
+        filter = new McpHttpGateFilter();
+        http = new TestHttp(false);
+        filter.config = new GateMcpConfig(http);
+        statusCode = new AtomicInteger(-1);
+        ended = new AtomicBoolean(false);
+        nextCalled = new AtomicBoolean(false);
+        responseBody = new AtomicReference<>();
+        contentType = new AtomicReference<>();
+        context = stubRoutingContext();
+    }
+
+    @Test
+    void blocksWith503WhenHttpModeDisabled() {
+        http.enabled = false;
+
+        filter.blockUnlessEnabled(context);
+
+        assertEquals(503, statusCode.get());
+        assertTrue(ended.get());
+        assertFalse(nextCalled.get());
+        assertTrue(contentType.get().contains("text/plain"));
+        assertTrue(responseBody.get().contains("MCP HTTP transport is disabled"));
+        assertTrue(responseBody.get().contains("apicurio.mcp.http.enabled=true"));
+    }
+
+    @Test
+    void continuesWhenHttpModeEnabled() {
+        http.enabled = true;
+
+        filter.blockUnlessEnabled(context);
+
+        assertEquals(-1, statusCode.get());
+        assertFalse(ended.get());
+        assertTrue(nextCalled.get());
+    }
+
+    private RoutingContext stubRoutingContext() {
+        HttpServerResponse response = (HttpServerResponse) Proxy.newProxyInstance(
+                HttpServerResponse.class.getClassLoader(),
+                new Class<?>[] {HttpServerResponse.class},
+                (proxy, method, args) -> {
+                    String name = method.getName();
+                    if ("setStatusCode".equals(name)) {
+                        statusCode.set((Integer) args[0]);
+                        return proxy;
+                    }
+                    if ("putHeader".equals(name)) {
+                        if ("Content-Type".equals(String.valueOf(args[0]))) {
+                            contentType.set(String.valueOf(args[1]));
+                        }
+                        return proxy;
+                    }
+                    if ("end".equals(name)) {
+                        ended.set(true);
+                        if (args != null && args.length == 1 && args[0] instanceof String body) {
+                            responseBody.set(body);
+                        }
+                        return Future.succeededFuture();
+                    }
+                    if (method.getReturnType().equals(void.class)) {
+                        return null;
+                    }
+                    if (method.getReturnType().equals(boolean.class)) {
+                        return false;
+                    }
+                    if (method.getReturnType().equals(int.class)) {
+                        return 0;
+                    }
+                    return null;
+                });
+
+        return (RoutingContext) Proxy.newProxyInstance(
+                RoutingContext.class.getClassLoader(),
+                new Class<?>[] {RoutingContext.class},
+                (proxy, method, args) -> {
+                    if ("response".equals(method.getName())) {
+                        return response;
+                    }
+                    if ("next".equals(method.getName())) {
+                        nextCalled.set(true);
+                        return null;
+                    }
+                    if (method.getReturnType().equals(void.class)) {
+                        return null;
+                    }
+                    if (method.getReturnType().equals(boolean.class)) {
+                        return false;
+                    }
+                    if (method.getReturnType().equals(int.class)) {
+                        return 0;
+                    }
+                    return null;
+                });
+    }
+
+    private static final class TestHttp implements McpConfig.Http {
+        private boolean enabled;
+
+        private TestHttp(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        public boolean enabled() {
+            return enabled;
+        }
+
+        @Override
+        public boolean forwardToken() {
+            return true;
+        }
+    }
+
+    private static final class GateMcpConfig implements McpConfig {
+        private final TestHttp http;
+
+        private GateMcpConfig(TestHttp http) {
+            this.http = http;
+        }
+
+        @Override
+        public boolean safeMode() {
+            return true;
+        }
+
+        @Override
+        public Paging paging() {
+            return new Paging() {
+                @Override
+                public int limit() {
+                    return 200;
+                }
+
+                @Override
+                public boolean limitError() {
+                    return true;
+                }
+            };
+        }
+
+        @Override
+        public Auth auth() {
+            return new Auth() {
+                @Override
+                public boolean enabled() {
+                    return false;
+                }
+
+                @Override
+                public Optional<String> tokenEndpoint() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> clientId() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> clientSecret() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> scope() {
+                    return Optional.empty();
+                }
+            };
+        }
+
+        @Override
+        public Tls tls() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Http http() {
+            return http;
+        }
+    }
+}

--- a/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpTestHelper.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpTestHelper.java
@@ -1,0 +1,92 @@
+package io.apicurio.registry.mcp;
+
+import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Helper for exercising the MCP streamable HTTP transport in integration tests.
+ */
+final class McpHttpTestHelper {
+
+    static final String MCP_SESSION_HEADER = "Mcp-Session-Id";
+    static final String MCP_PROTOCOL_HEADER = "Mcp-Protocol-Version";
+    static final String MCP_PROTOCOL_VERSION = "2024-11-05";
+
+    private McpHttpTestHelper() {
+    }
+
+    static String initializeSession(String bearerToken) {
+        Response response = given()
+                .header("Authorization", "Bearer " + bearerToken)
+                .header("Accept", "application/json, text/event-stream")
+                .header(MCP_PROTOCOL_HEADER, MCP_PROTOCOL_VERSION)
+                .contentType("application/json")
+                .body("""
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 0,
+                          "method": "initialize",
+                          "params": {
+                            "protocolVersion": "%s",
+                            "capabilities": {},
+                            "clientInfo": {
+                              "name": "mcp-http-test",
+                              "version": "1.0"
+                            }
+                          }
+                        }
+                        """.formatted(MCP_PROTOCOL_VERSION))
+                .post("/mcp")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        String sessionId = response.getHeader(MCP_SESSION_HEADER);
+        assertNotNull(sessionId, "Mcp-Session-Id header should be present after initialize");
+
+        given()
+                .header("Authorization", "Bearer " + bearerToken)
+                .header("Accept", "application/json, text/event-stream")
+                .header(MCP_SESSION_HEADER, sessionId)
+                .header(MCP_PROTOCOL_HEADER, MCP_PROTOCOL_VERSION)
+                .contentType("application/json")
+                .body("""
+                        {
+                          "jsonrpc": "2.0",
+                          "method": "notifications/initialized"
+                        }
+                        """)
+                .post("/mcp")
+                .then()
+                .statusCode(202);
+
+        return sessionId;
+    }
+
+    static ValidatableResponse callTool(String bearerToken, String sessionId, int id,
+            String toolName, String argumentsJson) {
+        return given()
+                .header("Authorization", "Bearer " + bearerToken)
+                .header("Accept", "application/json, text/event-stream")
+                .header(MCP_SESSION_HEADER, sessionId)
+                .header(MCP_PROTOCOL_HEADER, MCP_PROTOCOL_VERSION)
+                .contentType("application/json")
+                .body("""
+                        {
+                          "jsonrpc": "2.0",
+                          "id": %d,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "%s",
+                            "arguments": %s
+                          }
+                        }
+                        """.formatted(id, toolName, argumentsJson))
+                .post("/mcp")
+                .then();
+    }
+}

--- a/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpTokenForwardingTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/McpHttpTokenForwardingTest.java
@@ -1,0 +1,95 @@
+package io.apicurio.registry.mcp;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Integration tests for MCP HTTP transport with inbound OIDC and bearer token forwarding to Registry.
+ */
+@QuarkusTest
+@TestProfile(McpHttpAuthTestProfile.class)
+@Tag("integration")
+public class McpHttpTokenForwardingTest {
+
+    private static final Logger log = LoggerFactory.getLogger(McpHttpTokenForwardingTest.class);
+
+    @Test
+    void testUnauthenticatedRequestIsRejected() {
+        io.restassured.RestAssured.given()
+                .header("Accept", "application/json, text/event-stream")
+                .contentType("application/json")
+                .body("""
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "initialize",
+                          "params": {
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {},
+                            "clientInfo": {
+                              "name": "mcp-http-test",
+                              "version": "1.0"
+                            }
+                          }
+                        }
+                        """)
+                .post("/mcp")
+                .then()
+                .statusCode(401);
+
+        log.info("Unauthenticated initialize correctly returned 401");
+    }
+
+    @Test
+    void testAdminTokenCanCallGetServerInfo() {
+        String token = KeycloakTokenHelper.getClientCredentialsToken(
+                AuthTestContainersManager.sharedTokenEndpoint(),
+                AuthTestContainersManager.ADMIN_CLIENT_ID,
+                AuthTestContainersManager.ADMIN_CLIENT_SECRET);
+
+        assertNotNull(token);
+
+        String sessionId = McpHttpTestHelper.initializeSession(token);
+
+        McpHttpTestHelper.callTool(token, sessionId, 1, "get_server_info", "{}")
+                .statusCode(200)
+                .body(containsString("version"));
+
+        log.info("Admin token successfully called get_server_info via HTTP MCP");
+    }
+
+    @Test
+    void testReadonlyTokenCannotCreateGroup() {
+        String token = KeycloakTokenHelper.getClientCredentialsToken(
+                AuthTestContainersManager.sharedTokenEndpoint(),
+                AuthTestContainersManager.READONLY_CLIENT_ID,
+                AuthTestContainersManager.READONLY_CLIENT_SECRET);
+
+        assertNotNull(token);
+
+        String sessionId = McpHttpTestHelper.initializeSession(token);
+        String groupId = "mcp-http-readonly-test-" + System.currentTimeMillis();
+
+        McpHttpTestHelper.callTool(token, sessionId, 2, "create_group",
+                """
+                        {
+                          "groupId": "%s",
+                          "description": "should fail"
+                        }
+                        """.formatted(groupId))
+                .statusCode(200)
+                .body(containsString("HTTP 403 Forbidden"))
+                .body(not(containsString("\"groupId\":\"" + groupId + "\"")))
+                .body(containsString("may be missing the required Registry role"));
+
+        log.info("Readonly token correctly denied create_group via HTTP MCP");
+    }
+}

--- a/mcp/src/test/java/io/apicurio/registry/mcp/RegistryClientResolverTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/RegistryClientResolverTest.java
@@ -1,0 +1,583 @@
+package io.apicurio.registry.mcp;
+
+import com.microsoft.kiota.RequestAdapter;
+import io.apicurio.registry.client.common.HttpAdapterType;
+import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.security.credential.Credential;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.security.Permission;
+import java.security.Principal;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link RegistryClientResolver} token extraction and fallback selection.
+ */
+class RegistryClientResolverTest {
+
+    private RegistryClientResolver resolver;
+    private TestHttp http;
+    private TestAuth auth;
+    private ResolvableInstance<SecurityIdentity> securityIdentity;
+    private ResolvableInstance<JsonWebToken> jwt;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new RegistryClientResolver();
+        resolver.rawBaseUrl = "http://localhost:8080";
+        http = new TestHttp(true, true);
+        auth = new TestAuth(false);
+        resolver.config = new TestMcpConfig(http, auth);
+        securityIdentity = new ResolvableInstance<>();
+        jwt = new ResolvableInstance<>();
+        resolver.securityIdentity = securityIdentity;
+        resolver.jwt = jwt;
+    }
+
+    @Test
+    void needsFallbackClientWhenHttpDisabled() {
+        http.enabled = false;
+        assertTrue(resolver.needsFallbackClient());
+    }
+
+    @Test
+    void needsFallbackClientWhenAuthEnabledAlongsideHttp() {
+        auth.enabled = true;
+        assertTrue(resolver.needsFallbackClient());
+    }
+
+    @Test
+    void needsFallbackClientWhenForwardTokenDisabled() {
+        http.forwardToken = false;
+        assertTrue(resolver.needsFallbackClient());
+    }
+
+    @Test
+    void doesNotNeedFallbackClientWhenHttpForwardTokenOnly() {
+        assertFalse(resolver.needsFallbackClient());
+    }
+
+    @Test
+    void resolveInboundBearerTokenReturnsNullWhenHttpDisabled() {
+        http.enabled = false;
+        securityIdentity.set(new TestSecurityIdentity(false, "identity-token"));
+        assertNull(resolver.resolveInboundBearerToken());
+    }
+
+    @Test
+    void resolveInboundBearerTokenReturnsNullWhenForwardTokenDisabled() {
+        http.forwardToken = false;
+        securityIdentity.set(new TestSecurityIdentity(false, "identity-token"));
+        assertNull(resolver.resolveInboundBearerToken());
+    }
+
+    @Test
+    void resolveInboundBearerTokenFromSecurityIdentity() {
+        securityIdentity.set(new TestSecurityIdentity(false, "identity-token"));
+        jwt.set(new TestJsonWebToken("jwt-token"));
+
+        assertEquals("identity-token", resolver.resolveInboundBearerToken());
+    }
+
+    @Test
+    void resolveInboundBearerTokenFallsBackToJsonWebToken() {
+        jwt.set(new TestJsonWebToken("jwt-token"));
+
+        assertEquals("jwt-token", resolver.resolveInboundBearerToken());
+    }
+
+    @Test
+    void resolveInboundBearerTokenIgnoresAnonymousSecurityIdentity() {
+        securityIdentity.set(new TestSecurityIdentity(true, null));
+        jwt.set(new TestJsonWebToken("jwt-token"));
+
+        assertEquals("jwt-token", resolver.resolveInboundBearerToken());
+    }
+
+    @Test
+    void resolveInboundBearerTokenIgnoresBlankTokens() {
+        securityIdentity.set(new TestSecurityIdentity(false, "   "));
+        jwt.set(new TestJsonWebToken("   "));
+
+        assertNull(resolver.resolveInboundBearerToken());
+    }
+
+    @Test
+    void resolveInboundBearerTokenReturnsNullWhenNoCredentialOrJwt() {
+        securityIdentity.set(new TestSecurityIdentity(false, null));
+
+        assertNull(resolver.resolveInboundBearerToken());
+    }
+
+    @Test
+    void resolveInboundBearerTokenRejectsExpiredJsonWebToken() {
+        long expired = Instant.now().getEpochSecond() - 60;
+        jwt.set(new TestJsonWebToken(jwtWithExp(expired), expired));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                resolver::resolveInboundBearerToken);
+        assertTrue(error.getMessage().contains("expired"));
+    }
+
+    @Test
+    void resolveInboundBearerTokenRejectsExpiredRawJwtFromIdentity() {
+        long expired = Instant.now().getEpochSecond() - 60;
+        String raw = jwtWithExp(expired);
+        securityIdentity.set(new TestSecurityIdentity(false, raw));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                resolver::resolveInboundBearerToken);
+        assertTrue(error.getMessage().contains("expired"));
+    }
+
+    @Test
+    void resolveInboundBearerTokenAllowsUnexpiredToken() {
+        long future = Instant.now().getEpochSecond() + 3600;
+        String raw = jwtWithExp(future);
+        jwt.set(new TestJsonWebToken(raw, future));
+
+        assertEquals(raw, resolver.resolveInboundBearerToken());
+    }
+
+    @Test
+    void resolveInboundBearerTokenAllowsRecentlyExpiredTokenWithinClockSkew() {
+        long withinSkew = Instant.now().getEpochSecond()
+                - (RegistryClientResolver.BEARER_TOKEN_EXPIRATION_SKEW_SECONDS / 2);
+        String raw = jwtWithExp(withinSkew);
+        jwt.set(new TestJsonWebToken(raw, withinSkew));
+
+        assertEquals(raw, resolver.resolveInboundBearerToken());
+    }
+
+    @Test
+    void parseJwtExpirationEpochSecondsReadsExpClaim() {
+        long exp = Instant.now().getEpochSecond() + 120;
+        assertEquals(exp, RegistryClientResolver.parseJwtExpirationEpochSeconds(jwtWithExp(exp)));
+    }
+
+    @Test
+    void parseJwtExpirationEpochSecondsReturnsNullForOpaqueToken() {
+        assertNull(RegistryClientResolver.parseJwtExpirationEpochSeconds("not-a-jwt"));
+    }
+
+    @Test
+    void getClientReturnsFallbackWhenNoInboundToken() throws Exception {
+        RegistryClient fallback = markerClient();
+        setFallbackClient(fallback);
+
+        assertSame(fallback, resolver.getClient());
+        assertTrue(resolver.hasFallbackClient());
+    }
+
+    @Test
+    void getClientFailsWhenForwardingEnabledAuthenticatedButNoToken() throws Exception {
+        setFallbackClient(null);
+        securityIdentity.set(new TestSecurityIdentity(false, null));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, resolver::getClient);
+        assertTrue(error.getMessage().contains("no bearer access token was found"));
+        assertTrue(error.getMessage().contains("Authorization: Bearer"));
+    }
+
+    @Test
+    void getClientFailsWhenForwardingEnabledAndNoTokenOrFallback() throws Exception {
+        setFallbackClient(null);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, resolver::getClient);
+        assertTrue(error.getMessage().contains("no bearer token was provided"));
+        assertTrue(error.getMessage().contains("no fallback client credentials are configured"));
+    }
+
+    @Test
+    void getClientAppliesBearerTokenWithoutMutatingCachedTransportOptions() throws Exception {
+        RegistryClientOptions cached = RegistryClientOptions.create("http://localhost:8080")
+                .httpAdapter(HttpAdapterType.JDK)
+                .retry()
+                .trustAll(true)
+                .verifyHost(false);
+        setTransportOptions(cached);
+        securityIdentity.set(new TestSecurityIdentity(false, "per-request-token"));
+
+        RegistryClient client = resolver.getClient();
+
+        assertNotNull(client);
+        assertEquals(RegistryClientOptions.AuthType.ANONYMOUS, cached.getAuthType());
+        assertNull(cached.getBearerToken());
+        assertTrue(cached.isTrustAll());
+        assertFalse(cached.isVerifyHost());
+    }
+
+    private static String jwtWithExp(long expEpochSeconds) {
+        String header = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"alg\":\"none\"}".getBytes(StandardCharsets.UTF_8));
+        String payload = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(("{\"exp\":" + expEpochSeconds + "}").getBytes(StandardCharsets.UTF_8));
+        return header + "." + payload + ".sig";
+    }
+
+    private static RegistryClient markerClient() {
+        RequestAdapter adapter = (RequestAdapter) Proxy.newProxyInstance(
+                RequestAdapter.class.getClassLoader(),
+                new Class<?>[] {RequestAdapter.class},
+                (proxy, method, args) -> {
+                    if ("getBaseUrl".equals(method.getName())) {
+                        return "http://localhost:8080";
+                    }
+                    if (method.getReturnType().equals(void.class)) {
+                        return null;
+                    }
+                    return null;
+                });
+        return new RegistryClient(adapter);
+    }
+
+    private void setFallbackClient(RegistryClient client) throws Exception {
+        Field field = RegistryClientResolver.class.getDeclaredField("fallbackClient");
+        field.setAccessible(true);
+        field.set(resolver, client);
+    }
+
+    private void setTransportOptions(RegistryClientOptions options) throws Exception {
+        Field field = RegistryClientResolver.class.getDeclaredField("transportOptions");
+        field.setAccessible(true);
+        field.set(resolver, options);
+    }
+
+    private static final class TestMcpConfig implements McpConfig {
+        private final TestHttp http;
+        private final TestAuth auth;
+        private final TestTls tls = new TestTls();
+
+        private TestMcpConfig(TestHttp http, TestAuth auth) {
+            this.http = http;
+            this.auth = auth;
+        }
+
+        @Override
+        public boolean safeMode() {
+            return true;
+        }
+
+        @Override
+        public Paging paging() {
+            return new Paging() {
+                @Override
+                public int limit() {
+                    return 200;
+                }
+
+                @Override
+                public boolean limitError() {
+                    return true;
+                }
+            };
+        }
+
+        @Override
+        public Auth auth() {
+            return auth;
+        }
+
+        @Override
+        public Tls tls() {
+            return tls;
+        }
+
+        @Override
+        public Http http() {
+            return http;
+        }
+    }
+
+    private static final class TestHttp implements McpConfig.Http {
+        private boolean enabled;
+        private boolean forwardToken;
+
+        private TestHttp(boolean enabled, boolean forwardToken) {
+            this.enabled = enabled;
+            this.forwardToken = forwardToken;
+        }
+
+        @Override
+        public boolean enabled() {
+            return enabled;
+        }
+
+        @Override
+        public boolean forwardToken() {
+            return forwardToken;
+        }
+    }
+
+    private static final class TestAuth implements McpConfig.Auth {
+        private boolean enabled;
+
+        private TestAuth(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        public boolean enabled() {
+            return enabled;
+        }
+
+        @Override
+        public Optional<String> tokenEndpoint() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> clientId() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> clientSecret() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> scope() {
+            return Optional.empty();
+        }
+    }
+
+    private static final class TestTls implements McpConfig.Tls {
+        @Override
+        public boolean trustAll() {
+            return false;
+        }
+
+        @Override
+        public boolean verifyHost() {
+            return true;
+        }
+
+        @Override
+        public McpConfig.Truststore truststore() {
+            return new McpConfig.Truststore() {
+                @Override
+                public Optional<String> type() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> path() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> password() {
+                    return Optional.empty();
+                }
+            };
+        }
+
+        @Override
+        public McpConfig.Keystore keystore() {
+            return new McpConfig.Keystore() {
+                @Override
+                public Optional<String> type() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> path() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> password() {
+                    return Optional.empty();
+                }
+            };
+        }
+    }
+
+    private static final class ResolvableInstance<T> implements Instance<T> {
+        private T value;
+
+        void set(T value) {
+            this.value = value;
+        }
+
+        @Override
+        public Instance<T> select(Annotation... qualifiers) {
+            return this;
+        }
+
+        @Override
+        public <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isUnsatisfied() {
+            return value == null;
+        }
+
+        @Override
+        public boolean isAmbiguous() {
+            return false;
+        }
+
+        @Override
+        public Handle<T> getHandle() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Iterable<? extends Handle<T>> handles() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public T get() {
+            return value;
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            return value == null ? Collections.emptyIterator() : Collections.singleton(value).iterator();
+        }
+
+        @Override
+        public void destroy(T instance) {
+            // no-op
+        }
+    }
+
+    private static final class TestSecurityIdentity implements SecurityIdentity {
+        private final boolean anonymous;
+        private final AccessTokenCredential credential;
+
+        private TestSecurityIdentity(boolean anonymous, String token) {
+            this.anonymous = anonymous;
+            this.credential = token == null ? null : new AccessTokenCredential(token);
+        }
+
+        @Override
+        public Principal getPrincipal() {
+            return () -> "test";
+        }
+
+        @Override
+        public boolean isAnonymous() {
+            return anonymous;
+        }
+
+        @Override
+        public Set<String> getRoles() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public boolean hasRole(String role) {
+            return false;
+        }
+
+        @Override
+        public Set<Permission> getPermissions() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public <T> T getAttribute(String name) {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getAttributes() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Uni<Boolean> checkPermission(Permission permission) {
+            return Uni.createFrom().item(false);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends Credential> T getCredential(Class<T> credentialType) {
+            if (credential != null && credentialType.isInstance(credential)) {
+                return (T) credential;
+            }
+            return null;
+        }
+
+        @Override
+        public Set<Credential> getCredentials() {
+            return credential == null ? Collections.emptySet() : Set.of(credential);
+        }
+    }
+
+    private static final class TestJsonWebToken implements JsonWebToken {
+        private final String rawToken;
+        private final long expirationTime;
+
+        private TestJsonWebToken(String rawToken) {
+            this(rawToken, 0);
+        }
+
+        private TestJsonWebToken(String rawToken, long expirationTime) {
+            this.rawToken = rawToken;
+            this.expirationTime = expirationTime;
+        }
+
+        @Override
+        public String getName() {
+            return "test";
+        }
+
+        @Override
+        public Set<String> getClaimNames() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public <T> T getClaim(String claimName) {
+            return null;
+        }
+
+        @Override
+        public String getRawToken() {
+            return rawToken;
+        }
+
+        @Override
+        public long getExpirationTime() {
+            return expirationTime;
+        }
+    }
+}

--- a/mcp/src/test/java/io/apicurio/registry/mcp/RegistryClientResolverTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/RegistryClientResolverTest.java
@@ -196,6 +196,17 @@ class RegistryClientResolverTest {
     }
 
     @Test
+    void getClientRejectsAuthenticatedRequestWithoutBearerEvenWhenFallbackExists() throws Exception {
+        RegistryClient fallback = markerClient();
+        setFallbackClient(fallback);
+        securityIdentity.set(new TestSecurityIdentity(false, null));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, resolver::getClient);
+        assertTrue(error.getMessage().contains("no bearer access token was found"));
+        assertTrue(error.getMessage().contains("Authorization: Bearer"));
+    }
+
+    @Test
     void getClientFailsWhenForwardingEnabledAuthenticatedButNoToken() throws Exception {
         setFallbackClient(null);
         securityIdentity.set(new TestSecurityIdentity(false, null));

--- a/mcp/src/test/java/io/apicurio/registry/mcp/RegistryServiceTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/RegistryServiceTest.java
@@ -2,14 +2,19 @@ package io.apicurio.registry.mcp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpServer;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,7 +57,7 @@ public class RegistryServiceTest {
                 return;
             }
 
-            // System info GET endpoint (called in init)
+            // System info GET endpoint (called in resolver init)
             if (path.endsWith("/system/info")) {
                 String response = "{\"version\":\"3.0.0\"}";
                 exchange.getResponseHeaders().set("Content-Type", "application/json");
@@ -131,12 +136,7 @@ public class RegistryServiceTest {
     }
 
     private RegistryService createService(String rawUrl, boolean authEnabled) {
-        RegistryService service = new RegistryService();
-        service.rawBaseUrl = rawUrl;
-        Utils utils = new Utils();
-        utils.mapper = new ObjectMapper();
-        service.utils = utils;
-        service.config = new McpConfig() {
+        McpConfig config = new McpConfig() {
             @Override
             public boolean safeMode() {
                 return false;
@@ -188,6 +188,21 @@ public class RegistryServiceTest {
             }
 
             @Override
+            public Http http() {
+                return new Http() {
+                    @Override
+                    public boolean enabled() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean forwardToken() {
+                        return true;
+                    }
+                };
+            }
+
+            @Override
             public Tls tls() {
                 return new Tls() {
                     @Override
@@ -227,8 +242,72 @@ public class RegistryServiceTest {
             }
         };
 
-        service.init();
+        RegistryClientResolver resolver = new RegistryClientResolver();
+        resolver.rawBaseUrl = rawUrl;
+        resolver.config = config;
+        resolver.securityIdentity = new UnresolvableInstance<>();
+        resolver.jwt = new UnresolvableInstance<>();
+        resolver.init();
+
+        RegistryService service = new RegistryService();
+        Utils utils = new Utils();
+        utils.mapper = new ObjectMapper();
+        service.utils = utils;
+        service.config = config;
+        service.clientResolver = resolver;
         return service;
+    }
+
+    private static final class UnresolvableInstance<T> implements Instance<T> {
+        @Override
+        public Instance<T> select(Annotation... qualifiers) {
+            return this;
+        }
+
+        @Override
+        public <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isUnsatisfied() {
+            return true;
+        }
+
+        @Override
+        public boolean isAmbiguous() {
+            return false;
+        }
+
+        @Override
+        public Handle<T> getHandle() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Iterable<? extends Handle<T>> handles() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public T get() {
+            return null;
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            return Collections.emptyIterator();
+        }
+
+        @Override
+        public void destroy(T instance) {
+            // no-op
+        }
     }
 
     @Test

--- a/mcp/src/test/java/io/apicurio/registry/mcp/UtilsErrorFormattingTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/UtilsErrorFormattingTest.java
@@ -1,0 +1,88 @@
+package io.apicurio.registry.mcp;
+
+import io.apicurio.registry.rest.client.models.ProblemDetails;
+import io.apicurio.registry.rest.client.models.RuleViolationCause;
+import io.apicurio.registry.rest.client.models.RuleViolationProblemDetails;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UtilsErrorFormattingTest {
+
+    @Test
+    void formatProblemDetailsOmitsRoleNamesByDefault() {
+        var error = new ProblemDetails();
+        error.setStatus(403);
+        error.setTitle("User alice is not authorized to perform the requested operation.");
+        error.setDetail("ForbiddenException: User alice is not authorized to perform the requested operation.");
+        error.setName("ForbiddenException");
+
+        String message = Utils.formatRegistryApiError(error);
+
+        assertTrue(message.contains("HTTP 403 Forbidden"));
+        assertTrue(message.contains("User alice is not authorized"));
+        assertFalse(message.contains("sr-readonly"));
+        assertFalse(message.contains("sr-developer"));
+        assertFalse(message.contains("sr-admin"));
+    }
+
+    @Test
+    void formatProblemDetailsIncludesRoleNamesWhenHintsEnabled() {
+        var error = new ProblemDetails();
+        error.setStatus(403);
+        error.setTitle("User alice is not authorized to perform the requested operation.");
+        error.setDetail("ForbiddenException: User alice is not authorized to perform the requested operation.");
+        error.setName("ForbiddenException");
+
+        String message = Utils.formatRegistryApiError(error, true);
+
+        assertTrue(message.contains("HTTP 403 Forbidden"));
+        assertTrue(message.contains("User alice is not authorized"));
+        assertTrue(message.contains("Your user may be missing the required Registry role"));
+        assertTrue(message.contains("sr-readonly"));
+    }
+
+    @Test
+    void formatProblemDetailsNeverIncludesRoleNamesFor401() {
+        var error = new ProblemDetails();
+        error.setStatus(401);
+        error.setTitle("Unauthorized");
+        error.setDetail("Missing or invalid credentials");
+
+        String message = Utils.formatRegistryApiError(error, true);
+
+        assertTrue(message.contains("HTTP 401 Unauthorized"));
+        assertFalse(message.contains("sr-readonly"));
+    }
+
+    @Test
+    void formatProblemDetailsFallsBackToTitleWhenDetailMissing() {
+        var error = new ProblemDetails();
+        error.setStatus(403);
+        error.setTitle("User alice is not authorized to perform the requested operation.");
+
+        String message = Utils.formatRegistryApiError(error);
+
+        assertTrue(message.contains("User alice is not authorized"));
+    }
+
+    @Test
+    void formatRuleViolationProblemDetailsIncludesCauses() {
+        var cause = new RuleViolationCause();
+        cause.setContext("SYNTAX");
+        cause.setDescription("Invalid JSON Schema");
+
+        var error = new RuleViolationProblemDetails();
+        error.setStatus(409);
+        error.setTitle("Rule violation");
+        error.setCauses(List.of(cause));
+
+        String message = Utils.formatRegistryApiError(error);
+
+        assertTrue(message.contains("HTTP 409"));
+        assertTrue(message.contains("SYNTAX: Invalid JSON Schema"));
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds an **HTTP transport** to the Apicurio Registry MCP server, secured with **inbound OIDC** and **per-caller bearer-token forwarding** to Registry.

Today, MCP only works as a local process (stdio) that authenticates to Registry with a **shared service account**. After this change, you can also run MCP as a long-lived HTTP service: clients log in with their own Keycloak user, and Registry applies **that user’s RBAC** (same as the UI).

Stdio mode is unchanged and remains the default for local desktop clients.

Fixes: #8394

---

## Mental model

### Before (stdio only)

```text
┌─────────────┐   spawn process    ┌──────────────┐   client credentials   ┌──────────┐
│ MCP client  │ ─────────────────► │ MCP server   │ ─────────────────────► │ Registry │
│ (desktop)   │   stdin / stdout   │ (one-shot)   │   admin-client token   │          │
└─────────────┘                    └──────────────┘                        └──────────┘

• One shared service account for all tool calls
• Every user effectively has the same Registry permissions
• Works well for local Claude Desktop / Cursor command configs
```

### After (stdio **or** HTTP)

```text
MODE A — stdio (unchanged)
┌─────────────┐   spawn process    ┌──────────────┐   client credentials   ┌──────────┐
│ MCP client  │ ─────────────────► │ MCP server   │ ─────────────────────► │ Registry │
└─────────────┘                    └──────────────┘                        └──────────┘

MODE B — HTTP + token forwarding (new)
┌─────────────┐   HTTPS + Bearer   ┌──────────────┐   same Bearer token    ┌──────────┐
│ MCP client  │ ─────────────────► │ MCP server   │ ─────────────────────► │ Registry │
│ (remote /   │   POST /mcp        │ (long-lived) │   per-user RBAC        │          │
│  desktop)   │                    └──────┬───────┘                        └──────────┘
└──────┬──────┘                           │
       │                                  │ validates token
       │         OAuth login              ▼
       └──────────────────────────► ┌──────────┐
                                    │ Keycloak │
                                    └──────────┘

• Caller’s own Keycloak token is forwarded to Registry
• sr-readonly cannot create groups; sr-admin can — same as the UI
• Suitable for MCP Inspector, remote agents, shared deployments
```

### Runtime safety gate

HTTP transport is **compiled into** the MCP image at build time, but `/mcp` is **not exposed** unless you opt in at runtime:

```text
quarkus.mcp.server.http.enabled=true     ← build time (always in published images)
apicurio.mcp.http.enabled=false          ← runtime default

                    ┌─ apicurio.mcp.http.enabled=false ──► /mcp returns 404
Request to /mcp ───┤
                    └─ apicurio.mcp.http.enabled=true
                       + Quarkus OIDC configured ─────────► /mcp requires Bearer token
```

Enforced by `McpHttpGateFilter` (see `McpHttpDisabledByDefaultTest`).

---

## User journeys

### Journey 1 — Local desktop client (stdio) — **no change required**

1. Point your MCP client at the MCP Docker image / JAR (as today).
2. If Registry is secured, set `APICURIO_MCP_AUTH_*` client credentials.
3. Keep HTTP mode **off** (`APICURIO_MCP_HTTP_ENABLED=false`, `QUARKUS_OIDC_TENANT_ENABLED=false`).

Example: [`examples/mcp-keycloak/stdio.example.json`](https://github.com/Joel-hanson/apicurio-registry/blob/efb855974bdf1ed98dff1a716b8951476c9e8170/examples/mcp-keycloak/stdio.example.json)

### Journey 2 — HTTP MCP with OAuth (new)

1. Run a secured Registry + Keycloak (or use the example stack below).
2. Start the MCP server as an HTTP service with HTTP mode + OIDC enabled.
3. Configure your MCP client with `url: http://<host>:8082/mcp` and OAuth client `apicurio-mcp`.
4. Client completes OAuth login; MCP validates the token and forwards it to Registry.
5. Tool calls succeed or fail based on **that user’s** Registry roles.

Example: [`examples/mcp-keycloak/http.example.json`](https://github.com/Joel-hanson/apicurio-registry/blob/efb855974bdf1ed98dff1a716b8951476c9e8170/examples/mcp-keycloak/http.example.json)

---

## What users need to set

### Stdio mode (MCP → Registry)

| Setting | Env var | Example |
| --- | --- | --- |
| Registry URL | `REGISTRY_URL` | `http://localhost:8081` |
| Enable OAuth2 | `APICURIO_MCP_AUTH_ENABLED` | `true` |
| Token endpoint | `APICURIO_MCP_AUTH_TOKEN_ENDPOINT` | `http://localhost:8080/realms/registry/protocol/openid-connect/token` |
| Client ID | `APICURIO_MCP_AUTH_CLIENT_ID` | `admin-client` |
| Client secret | `APICURIO_MCP_AUTH_CLIENT_SECRET` | `test1` |
| Disable inbound OIDC | `QUARKUS_OIDC_TENANT_ENABLED` | `false` |
| Disable HTTP mode | `APICURIO_MCP_HTTP_ENABLED` | `false` |

### HTTP mode (remote / OAuth clients)

**Apicurio settings:**

| Setting | Env var | Example |
| --- | --- | --- |
| Enable HTTP mode | `APICURIO_MCP_HTTP_ENABLED` | `true` |
| Forward caller token | `APICURIO_MCP_HTTP_FORWARD_TOKEN` | `true` |
| Registry URL | `REGISTRY_URL` | `http://apicurio-registry:8080` |

**Quarkus companion settings (required when HTTP mode is on):**

| Setting | Env var | Example |
| --- | --- | --- |
| Enable HTTP transport | `QUARKUS_MCP_SERVER_HTTP_ENABLED` | `true` |
| Disable stdio | `QUARKUS_MCP_SERVER_STDIO_ENABLED` | `false` |
| Enable OIDC | `QUARKUS_OIDC_TENANT_ENABLED` | `true` |
| Application type | `QUARKUS_OIDC_APPLICATION_TYPE` | `service` |
| Auth server | `QUARKUS_OIDC_AUTH_SERVER_URL` | `http://keycloak:8080/realms/registry` |
| Secure `/mcp` | `QUARKUS_HTTP_AUTH_PERMISSION_AUTHENTICATED_PATHS` | `/mcp` |
| Require auth | `QUARKUS_HTTP_AUTH_PERMISSION_AUTHENTICATED_POLICY` | `authenticated` |

Optional (OAuth discovery / CORS for Inspector-style clients): see `examples/mcp-keycloak/docker-compose.yml`.

Full reference: [MCP server integration guide](docs/modules/ROOT/pages/getting-started/assembly-mcp-server-integration.adoc)

---

## What’s in the code

| Area | Change |
| --- | --- |
| `RegistryClientResolver` | Per-request client: forward inbound Bearer token, or fall back to client credentials / anonymous |
| `McpHttpGateFilter` | `/mcp` returns **404** unless `apicurio.mcp.http.enabled=true` |
| `McpHttpAuthValidator` | Fail-fast at startup if HTTP mode is on without OIDC / transport |
| Java SDK | `RegistryClientOptions.bearerToken()`, `AuthType.BEARER`, JDK adapter support |
| `Utils.java` | Clearer `ProblemDetails` / 401–403 messages (roles matter now that tokens are per-user) |
| `examples/mcp-keycloak` | Local Keycloak + Registry + MCP HTTP stack |
| Docs | HTTP/OAuth section in the integration guide |

### Why `Utils.java` error formatting is in this PR

With token forwarding, tool calls fail based on the **caller’s** Keycloak role. Returning a clear 401/403 (with role hints) is part of making HTTP mode usable for agents and users.


[Quarkus OIDC](https://quarkus.io/guides/security-oidc-bearer-token-authentication)

