### PR TITLE
fix(ci): complete localhost:5000 registry setup for Local Tests and Publish

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -123,12 +123,37 @@ jobs:
           distribution: temurin
           cache: maven
 
+      - name: Download Docker images
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: operator-test-images
+          path: /tmp/
+
       - uses: apicurio/apicurio-github-actions/setup-minikube@97d452c41f1abd7142c0ce2ac37e87922e35e71d # v2
         with:
           driver: 'none'
           ingress-enable: 'true'
           olm-enable: 'false'
           olm-v1-enable: 'false'
+
+      - name: Start local registry
+        run: |
+          docker run -d -p 5000:5000 --restart=always ghcr.io/distribution/distribution:3.0
+          for i in $(seq 1 20); do
+            curl -sf http://localhost:5000/v2/ >/dev/null 2>&1 && break
+            echo "Waiting for registry... ($i/20)"
+            sleep 0.5
+          done
+          curl -sf http://localhost:5000/v2/ || (echo "Registry not ready after 10s"; exit 1)
+
+      - name: Load and push images to local registry
+        run: |
+          docker load -i /tmp/operator-test-operator.tar
+          docker load -i /tmp/operator-test-registry-app.tar
+          docker load -i /tmp/operator-test-gitops-sync.tar
+          docker push "$REGISTRY_APP_IMAGE"
+          docker push "$REGISTRY_GITOPS_SYNC_IMAGE"
+          docker push "$IMAGE"
 
       - name: Build and run local tests on Minikube
         working-directory: operator
@@ -327,16 +352,19 @@ jobs:
       - name: Build and publish operator image
         working-directory: operator
         run: |
+          unset IMAGE REGISTRY_APP_IMAGE REGISTRY_GITOPS_SYNC_IMAGE BUNDLE_IMAGE CATALOG_IMAGE
           make image-build image-push
 
       - name: Build and publish operator bundle
         working-directory: operator
         run: |
+          unset IMAGE REGISTRY_APP_IMAGE REGISTRY_GITOPS_SYNC_IMAGE BUNDLE_IMAGE CATALOG_IMAGE
           make bundle
 
       - name: Build and publish operator catalog
         working-directory: operator
         run: |
+          unset IMAGE REGISTRY_APP_IMAGE REGISTRY_GITOPS_SYNC_IMAGE BUNDLE_IMAGE CATALOG_IMAGE
           make catalog
 
   # Slack notification using reusable workflow


### PR DESCRIPTION
## Summary

Completes the `localhost:5000` local registry migration that was partially applied:

- **Local Tests**: add image download, local registry start, and image load steps (mirroring what Remote Tests already has)
- **Publish**: `unset` the `localhost:5000` env vars so Makefile defaults (`quay.io`) apply

## Test plan

- [ ] Verify `Operator Tests / Local Tests` passes (no more `ErrImagePull`)
- [ ] Verify `Operator Tests / Publish Operator` pushes to quay.io
- [ ] Verify `Verification Gate` passes