### PR TITLE
fix(ui): resolve OpenAPI documentation not rendering in Edge browser (#8455)

### DIFF
--- a/ui/ui-app/src/app/pages/version/components/tabs/visualizers/OpenApiVisualizer.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/visualizers/OpenApiVisualizer.tsx
@@ -42,9 +42,20 @@ export const OpenApiVisualizer: FunctionComponent<OpenApiVisualizerProps> = (pro
         sendSpecToIframe(props.spec);
     };
 
+    // Listen for "ready" signal from the iframe and send the spec in response.
+    // This handles the race where the iframe's onLoad fires before the iframe's
+    // message listener is set up, causing the initial postMessage to be lost.
+    useEffect(() => {
+        const handler = (evt: MessageEvent): void => {
+            if (evt.data?.type === "apicurio-docs-ready" && props.spec && Object.keys(props.spec).length > 0) {
+                sendSpecToIframe(props.spec);
+            }
+        };
+        window.addEventListener("message", handler);
+        return () => window.removeEventListener("message", handler);
+    }, [props.spec]);
+
     // Re-send the spec when it changes after the iframe has already loaded.
-    // This handles the race condition where the parent fetches content asynchronously
-    // and the iframe onLoad fires before the spec is available.
     useEffect(() => {
         if (iframeLoaded.current && props.spec && Object.keys(props.spec).length > 0) {
             sendSpecToIframe(props.spec);
@@ -54,7 +65,7 @@ export const OpenApiVisualizer: FunctionComponent<OpenApiVisualizerProps> = (pro
     return (
         <iframe id="openapi-editor-frame"
             ref={ ref }
-            style={{ width: "100%", height: "100%" }}
+            style={{ width: "100%", flex: 1, minHeight: 0, border: "none" }}
             className={ props.className ? props.className : "openapi-docs-container" }
             onLoad={ onIframeLoaded }
             src={ oaiDocsUrl() } />

--- a/ui/ui-docs/src/app/App.tsx
+++ b/ui/ui-docs/src/app/App.tsx
@@ -27,7 +27,7 @@ export const App: FunctionComponent<object> = () => {
             setContent(DEMO_OPENAPI);
             setContentType(ContentType.OPENAPI);
         } else {
-            w.onmessage = (evt: MessageEvent) => {
+            const handler = (evt: MessageEvent): void => {
                 console.info("[App] OnMessage received: ", evt);
                 if (evt.data && evt.data.type && evt.data.type === "apicurio-docs-render") {
                     const update: DocsUpdateType = evt.data.data as DocsUpdateType;
@@ -36,6 +36,10 @@ export const App: FunctionComponent<object> = () => {
                     setContentType(update.contentType);
                 }
             };
+            w.addEventListener("message", handler);
+            // Signal to the parent frame that the listener is ready to receive data.
+            w.parent.postMessage({ type: "apicurio-docs-ready" }, "*");
+            return () => w.removeEventListener("message", handler);
         }
     }, []);
 


### PR DESCRIPTION
## Summary
- Fixed a race condition where the parent frame's `postMessage` with the OpenAPI spec was sent
  before the iframe's message listener was registered, causing the Documentation tab to render
  blank. Added a handshake protocol: the iframe signals "ready" after setting up its listener,
  and the parent sends the spec in response.
- Replaced `window.onmessage` direct assignment with `addEventListener` in the docs iframe for
  robustness and proper cleanup on unmount.
- Fixed iframe CSS from `height: 100%` to `flex: 1` to prevent height collapse in Edge's
  flexbox containers.

## Related Issue
Fixes #8455

## Test Plan
- [ ] Open an OpenAPI artifact in the Registry UI and click the "Documentation" tab
- [ ] Verify the Redoc documentation renders correctly (not blank) in Chrome, Edge, and Safari
- [ ] Switch away from the Documentation tab and back — verify it re-renders correctly
- [ ] Test with both JSON and YAML formatted OpenAPI specs