### PR TITLE
fix(ui): Dashboard does not load current user on first render (OIDC/RBAC) (#8371)

### DIFF
--- a/ui/ui-app/src/app/pages/dashboard/DashboardPage.tsx
+++ b/ui/ui-app/src/app/pages/dashboard/DashboardPage.tsx
@@ -13,7 +13,7 @@ import {
     CodeBranchIcon,
     FolderOpenIcon
 } from "@patternfly/react-icons";
-import { DASHBOARD_PAGE_IDX, PageError, PageErrorHandler, PageProperties, toPageError } from "@app/pages";
+import { DASHBOARD_PAGE_IDX, PageDataLoader, PageError, PageErrorHandler, PageProperties, toPageError } from "@app/pages";
 import { CreateArtifactModal, RootPageHeader } from "@app/components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { SearchService, useSearchService } from "@services/useSearchService.ts";
@@ -41,6 +41,7 @@ interface RegistryStats {
  */
 export const DashboardPage: FunctionComponent<PageProperties> = () => {
     const [pageError, setPageError] = useState<PageError>();
+    const [loaders, setLoaders] = useState<Promise<any> | Promise<any>[] | undefined>();
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [stats, setStats] = useState<RegistryStats>({
         groupCount: 0,
@@ -100,10 +101,12 @@ export const DashboardPage: FunctionComponent<PageProperties> = () => {
         setUsageSummary(summary);
     };
 
+    const createLoaders = (): Promise<any>[] => {
+        return [loadStats(), loadRecentArtifacts(), loadUsageSummary()];
+    };
+
     useEffect(() => {
-        loadStats();
-        loadRecentArtifacts();
-        loadUsageSummary();
+        setLoaders(createLoaders());
     }, []);
 
     const handleCreateArtifact = (): void => {
@@ -141,79 +144,81 @@ export const DashboardPage: FunctionComponent<PageProperties> = () => {
 
     return (
         <PageErrorHandler error={pageError}>
-            <PageSection hasBodyWrapper={false} className="ps_dashboard-header"  padding={{ default: "noPadding" }}>
-                <RootPageHeader tabKey={DASHBOARD_PAGE_IDX} />
-            </PageSection>
-            <PageSection hasBodyWrapper={false} className="ps_dashboard-description" >
-                <Flex direction={{ default: "column" }}>
-                    <FlexItem>
-                        <Title headingLevel="h1">Registry Dashboard</Title>
-                    </FlexItem>
-                    <FlexItem>
-                        <p className="dashboard-description">
-                            Welcome to Apicurio Registry. Manage your schemas and API definitions in one central location.
-                        </p>
-                    </FlexItem>
-                </Flex>
-            </PageSection>
-            <PageSection hasBodyWrapper={false} isFilled={true} className="ps_dashboard-content">
-                <Grid hasGutter>
-                    <GridItem span={12}>
-                        <Flex spaceItems={{ default: "spaceItemsLg" }}>
-                            <FlexItem>
-                                <StatsCard
-                                    title="Groups"
-                                    value={stats.groupCount}
-                                    icon={<FolderOpenIcon />}
-                                    isLoading={isLoading}
-                                    onClick={() => handleStatsClick("/search?for=groups")}
-                                />
-                            </FlexItem>
-                            <FlexItem>
-                                <StatsCard
-                                    title="Artifacts"
-                                    value={stats.artifactCount}
-                                    icon={<CubesIcon />}
-                                    isLoading={isLoading}
-                                    onClick={() => handleStatsClick("/search?for=artifacts")}
-                                />
-                            </FlexItem>
-                            <FlexItem>
-                                <StatsCard
-                                    title="Versions"
-                                    value={stats.versionCount}
-                                    icon={<CodeBranchIcon />}
-                                    isLoading={isLoading}
-                                    onClick={() => handleStatsClick("/search?for=versions")}
-                                />
-                            </FlexItem>
-                            {usageSummary && (
+            <PageDataLoader loaders={loaders}>
+                <PageSection hasBodyWrapper={false} className="ps_dashboard-header"  padding={{ default: "noPadding" }}>
+                    <RootPageHeader tabKey={DASHBOARD_PAGE_IDX} />
+                </PageSection>
+                <PageSection hasBodyWrapper={false} className="ps_dashboard-description" >
+                    <Flex direction={{ default: "column" }}>
+                        <FlexItem>
+                            <Title headingLevel="h1">Registry Dashboard</Title>
+                        </FlexItem>
+                        <FlexItem>
+                            <p className="dashboard-description">
+                                Welcome to Apicurio Registry. Manage your schemas and API definitions in one central location.
+                            </p>
+                        </FlexItem>
+                    </Flex>
+                </PageSection>
+                <PageSection hasBodyWrapper={false} isFilled={true} className="ps_dashboard-content">
+                    <Grid hasGutter>
+                        <GridItem span={12}>
+                            <Flex spaceItems={{ default: "spaceItemsLg" }}>
                                 <FlexItem>
-                                    <UsageSummaryCard
-                                        data={usageSummary}
+                                    <StatsCard
+                                        title="Groups"
+                                        value={stats.groupCount}
+                                        icon={<FolderOpenIcon />}
                                         isLoading={isLoading}
+                                        onClick={() => handleStatsClick("/search?for=groups")}
                                     />
                                 </FlexItem>
-                            )}
-                        </Flex>
-                    </GridItem>
-                    <GridItem span={8}>
-                        <RecentArtifacts
-                            artifacts={recentArtifacts}
-                            isLoading={isLoading}
-                            error={recentArtifactsError}
-                        />
-                    </GridItem>
-                    <GridItem span={4}>
-                        <QuickActions
-                            onCreateArtifact={handleCreateArtifact}
-                            onSearch={handleSearch}
-                            onExplore={handleExplore}
-                            onSettings={handleSettings}
-                        />
-                    </GridItem>
-                </Grid>
-            </PageSection>
+                                <FlexItem>
+                                    <StatsCard
+                                        title="Artifacts"
+                                        value={stats.artifactCount}
+                                        icon={<CubesIcon />}
+                                        isLoading={isLoading}
+                                        onClick={() => handleStatsClick("/search?for=artifacts")}
+                                    />
+                                </FlexItem>
+                                <FlexItem>
+                                    <StatsCard
+                                        title="Versions"
+                                        value={stats.versionCount}
+                                        icon={<CodeBranchIcon />}
+                                        isLoading={isLoading}
+                                        onClick={() => handleStatsClick("/search?for=versions")}
+                                    />
+                                </FlexItem>
+                                {usageSummary && (
+                                    <FlexItem>
+                                        <UsageSummaryCard
+                                            data={usageSummary}
+                                            isLoading={isLoading}
+                                        />
+                                    </FlexItem>
+                                )}
+                            </Flex>
+                        </GridItem>
+                        <GridItem span={8}>
+                            <RecentArtifacts
+                                artifacts={recentArtifacts}
+                                isLoading={isLoading}
+                                error={recentArtifactsError}
+                            />
+                        </GridItem>
+                        <GridItem span={4}>
+                            <QuickActions
+                                onCreateArtifact={handleCreateArtifact}
+                                onSearch={handleSearch}
+                                onExplore={handleExplore}
+                                onSettings={handleSettings}
+                            />
+                        </GridItem>
+                    </Grid>
+                </PageSection>
+            </PageDataLoader>
             <CreateArtifactModal
                 isOpen={isCreateArtifactModalOpen}
                 onClose={() => setIsCreateArtifactModalOpen(false)}


### PR DESCRIPTION
## Summary
- Wrapped `DashboardPage` content in `<PageDataLoader>` so that `updateCurrentUser()` is called
  and awaited before rendering, matching the pattern used by every other page in the UI.
- This ensures the authenticated user's identity and roles are available on first render, so
  RBAC-gated actions (Create Artifact, Settings) display correctly and the header shows the
  real username instead of "User".

## Related Issue
Fixes #8371

## Test Plan
- [ ] Enable OIDC + `apicurio.auth.role-based-authorization=true`
- [ ] Log in as a user with the admin role (`sr-admin`)
- [ ] Navigate directly to `/dashboard` after login
- [ ] Verify Quick Actions shows **Create Artifact** and **Settings** buttons
- [ ] Verify the header dropdown shows the real username (not "User")
- [ ] Navigate to other pages (Explore, Search) and back to Dashboard — verify it still works
- [ ] TypeScript type check passes (`cd ui/ui-app && npx tsc --noEmit`)
- [ ] UI build succeeds (`cd ui && npm run build`)