### PR TITLE
fix(iceberg): compute last-column-id recursively for nested schema types

### DIFF
--- a/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/IcebergApiResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/IcebergApiResourceImpl.java
@@ -1097,21 +1097,7 @@ public class IcebergApiResourceImpl implements ApisResource {
         } else {
             schemaMap = objectMapper.convertValue(schema, Map.class);
         }
-        List<Map<String, Object>> fields = (List<Map<String, Object>>) schemaMap.get("fields");
-        if (fields == null || fields.isEmpty()) {
-            return 0;
-        }
-        int maxId = 0;
-        for (Map<String, Object> field : fields) {
-            Object idObj = field.get("id");
-            if (idObj instanceof Number) {
-                int id = ((Number) idObj).intValue();
-                if (id > maxId) {
-                    maxId = id;
-                }
-            }
-        }
-        return maxId;
+        return IcebergSchemaUtil.computeMaxFieldId(schemaMap);
     }
 
     private String getCurrentUser() {

--- a/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/IcebergSchemaUtil.java
+++ b/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/IcebergSchemaUtil.java
@@ -1,0 +1,88 @@
+package io.apicurio.registry.iceberg.rest.v1.impl;
+
+import java.util.List;
+import java.util.Map;
+
+public final class IcebergSchemaUtil {
+
+    private IcebergSchemaUtil() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static int computeMaxFieldId(Map<String, Object> schema) {
+        List<Map<String, Object>> fields = (List<Map<String, Object>>) schema.get("fields");
+        if (fields == null || fields.isEmpty()) {
+            return 0;
+        }
+        int maxId = 0;
+        for (Map<String, Object> field : fields) {
+            maxId = Math.max(maxId, computeMaxFieldIdFromField(field));
+        }
+        return maxId;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static int computeMaxFieldIdFromField(Map<String, Object> field) {
+        int maxId = toInt(field.get("id"));
+        Object type = field.get("type");
+        if (type instanceof Map) {
+            maxId = Math.max(maxId, computeMaxFieldIdFromType((Map<String, Object>) type));
+        }
+        return maxId;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static int computeMaxFieldIdFromType(Map<String, Object> type) {
+        String typeName = (String) type.get("type");
+        if (typeName == null) {
+            return 0;
+        }
+        int maxId = 0;
+        switch (typeName) {
+            case "struct":
+                List<Map<String, Object>> fields = (List<Map<String, Object>>) type.get("fields");
+                if (fields != null) {
+                    for (Map<String, Object> field : fields) {
+                        maxId = Math.max(maxId, computeMaxFieldIdFromField(field));
+                    }
+                }
+                break;
+            case "list":
+                maxId = Math.max(maxId, toInt(type.get("element-id")));
+                Object element = type.get("element");
+                if (element instanceof Map) {
+                    maxId = Math.max(maxId, computeMaxFieldIdFromType((Map<String, Object>) element));
+                }
+                break;
+            case "map":
+                maxId = Math.max(maxId, toInt(type.get("key-id")));
+                maxId = Math.max(maxId, toInt(type.get("value-id")));
+                Object key = type.get("key");
+                if (key instanceof Map) {
+                    maxId = Math.max(maxId, computeMaxFieldIdFromType((Map<String, Object>) key));
+                }
+                Object value = type.get("value");
+                if (value instanceof Map) {
+                    maxId = Math.max(maxId, computeMaxFieldIdFromType((Map<String, Object>) value));
+                }
+                break;
+            default:
+                break;
+        }
+        return maxId;
+    }
+
+    private static int toInt(Object value) {
+        if (value == null) {
+            return 0;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        try {
+            return Integer.parseInt(value.toString());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/commit/TableUpdateApplicator.java
+++ b/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/commit/TableUpdateApplicator.java
@@ -1,5 +1,7 @@
 package io.apicurio.registry.iceberg.rest.v1.impl.commit;
 
+import io.apicurio.registry.iceberg.rest.v1.impl.IcebergSchemaUtil;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -140,18 +142,11 @@ public final class TableUpdateApplicator {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static void updateLastColumnId(Map<String, Object> schema, Map<String, Object> metadata) {
-        List<Map<String, Object>> fields = (List<Map<String, Object>>) schema.get("fields");
-        if (fields != null) {
-            int maxFieldId = toInt(metadata.getOrDefault("last-column-id", 0));
-            for (Map<String, Object> field : fields) {
-                int fieldId = toInt(field.get("id"));
-                if (fieldId > maxFieldId) {
-                    maxFieldId = fieldId;
-                }
-            }
-            metadata.put("last-column-id", maxFieldId);
+        int schemaMaxId = IcebergSchemaUtil.computeMaxFieldId(schema);
+        int currentLastColumnId = toInt(metadata.getOrDefault("last-column-id", 0));
+        if (schemaMaxId > currentLastColumnId) {
+            metadata.put("last-column-id", schemaMaxId);
         }
     }
 

--- a/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergSchemaUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergSchemaUtilTest.java
@@ -1,0 +1,164 @@
+package io.apicurio.registry.noprofile.iceberg.rest.v1;
+
+import io.apicurio.registry.iceberg.rest.v1.impl.IcebergSchemaUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IcebergSchemaUtilTest {
+
+    @Test
+    public void testFlatSchema() {
+        Map<String, Object> schema = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                        Map.of("id", 2, "name", "name", "type", "string", "required", false),
+                        Map.of("id", 3, "name", "ts", "type", "timestamp", "required", false)));
+        assertEquals(3, IcebergSchemaUtil.computeMaxFieldId(schema));
+    }
+
+    @Test
+    public void testEmptyFields() {
+        Map<String, Object> schema = Map.of("type", "struct", "fields", List.of());
+        assertEquals(0, IcebergSchemaUtil.computeMaxFieldId(schema));
+    }
+
+    @Test
+    public void testNullFields() {
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "struct");
+        schema.put("fields", null);
+        assertEquals(0, IcebergSchemaUtil.computeMaxFieldId(schema));
+    }
+
+    @Test
+    public void testNestedStruct() {
+        Map<String, Object> schema = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                        Map.of("id", 2, "name", "address", "required", false,
+                                "type", Map.of(
+                                        "type", "struct",
+                                        "fields", List.of(
+                                                Map.of("id", 3, "name", "street", "type", "string",
+                                                        "required", false),
+                                                Map.of("id", 4, "name", "city", "type", "string",
+                                                        "required", false),
+                                                Map.of("id", 5, "name", "zip", "type", "string",
+                                                        "required", false))))));
+        assertEquals(5, IcebergSchemaUtil.computeMaxFieldId(schema));
+    }
+
+    @Test
+    public void testListType() {
+        Map<String, Object> schema = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                        Map.of("id", 2, "name", "tags", "required", false,
+                                "type", Map.of(
+                                        "type", "list",
+                                        "element-id", 3,
+                                        "element", "string",
+                                        "element-required", false))));
+        assertEquals(3, IcebergSchemaUtil.computeMaxFieldId(schema));
+    }
+
+    @Test
+    public void testMapType() {
+        Map<String, Object> schema = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                        Map.of("id", 2, "name", "metadata", "required", false,
+                                "type", Map.of(
+                                        "type", "map",
+                                        "key-id", 3,
+                                        "key", "string",
+                                        "value-id", 4,
+                                        "value", "string",
+                                        "value-required", false))));
+        assertEquals(4, IcebergSchemaUtil.computeMaxFieldId(schema));
+    }
+
+    @Test
+    public void testDeeplyNestedSchema() {
+        // struct -> list -> struct (simulates Debezium CDC nested records)
+        Map<String, Object> innerStruct = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 5, "name", "key", "type", "string", "required", true),
+                        Map.of("id", 6, "name", "value", "type", "string", "required", false)));
+
+        Map<String, Object> listType = Map.of(
+                "type", "list",
+                "element-id", 4,
+                "element", innerStruct,
+                "element-required", false);
+
+        Map<String, Object> schema = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                        Map.of("id", 2, "name", "name", "type", "string", "required", false),
+                        Map.of("id", 3, "name", "items", "required", false, "type", listType)));
+        assertEquals(6, IcebergSchemaUtil.computeMaxFieldId(schema));
+    }
+
+    @Test
+    public void testMapWithStructValue() {
+        Map<String, Object> valueStruct = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 5, "name", "amount", "type", "double", "required", true),
+                        Map.of("id", 6, "name", "currency", "type", "string", "required", true)));
+
+        Map<String, Object> mapType = Map.of(
+                "type", "map",
+                "key-id", 3,
+                "key", "string",
+                "value-id", 4,
+                "value", valueStruct,
+                "value-required", true);
+
+        Map<String, Object> schema = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                        Map.of("id", 2, "name", "prices", "required", false, "type", mapType)));
+        assertEquals(6, IcebergSchemaUtil.computeMaxFieldId(schema));
+    }
+
+    @Test
+    public void testDebeziumCdcLikeSchema() {
+        // Simulates a typical Debezium CDC schema with nested source info
+        Map<String, Object> sourceStruct = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 5, "name", "version", "type", "string", "required", false),
+                        Map.of("id", 6, "name", "connector", "type", "string", "required", false),
+                        Map.of("id", 7, "name", "name", "type", "string", "required", false),
+                        Map.of("id", 8, "name", "ts_ms", "type", "long", "required", false),
+                        Map.of("id", 9, "name", "snapshot", "type", "string", "required", false),
+                        Map.of("id", 10, "name", "db", "type", "string", "required", false),
+                        Map.of("id", 11, "name", "schema", "type", "string", "required", false),
+                        Map.of("id", 12, "name", "table", "type", "string", "required", false)));
+
+        Map<String, Object> schema = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 1, "name", "customer_id", "type", "int", "required", true),
+                        Map.of("id", 2, "name", "first_name", "type", "string", "required", false),
+                        Map.of("id", 3, "name", "last_name", "type", "string", "required", false),
+                        Map.of("id", 4, "name", "source", "required", false, "type", sourceStruct)));
+
+        // Top-level max is 4, but nested goes to 12
+        assertEquals(12, IcebergSchemaUtil.computeMaxFieldId(schema));
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/commit/TableUpdateApplicatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/commit/TableUpdateApplicatorTest.java
@@ -285,6 +285,60 @@ public class TableUpdateApplicatorTest {
     }
 
     @Test
+    public void testAddSchemaWithNestedStruct() {
+        Map<String, Object> metadata = buildMetadata();
+        Map<String, Object> newSchema = new HashMap<>();
+        newSchema.put("type", "struct");
+        newSchema.put("schema-id", 1);
+        newSchema.put("fields", List.of(
+                Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                Map.of("id", 2, "name", "address", "required", false,
+                        "type", Map.of(
+                                "type", "struct",
+                                "fields", List.of(
+                                        Map.of("id", 3, "name", "street", "type", "string",
+                                                "required", false),
+                                        Map.of("id", 4, "name", "city", "type", "string",
+                                                "required", false),
+                                        Map.of("id", 5, "name", "zip", "type", "string",
+                                                "required", false))))));
+
+        List<Map<String, Object>> updates = List.of(Map.of("action", "add-schema", "schema", newSchema));
+        TableUpdateApplicator.apply(updates, metadata);
+
+        assertEquals(5, metadata.get("last-column-id"));
+    }
+
+    @Test
+    public void testAddSchemaWithListAndMapTypes() {
+        Map<String, Object> metadata = buildMetadata();
+        Map<String, Object> newSchema = new HashMap<>();
+        newSchema.put("type", "struct");
+        newSchema.put("schema-id", 1);
+        newSchema.put("fields", List.of(
+                Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                Map.of("id", 2, "name", "tags", "required", false,
+                        "type", Map.of(
+                                "type", "list",
+                                "element-id", 3,
+                                "element", "string",
+                                "element-required", false)),
+                Map.of("id", 4, "name", "props", "required", false,
+                        "type", Map.of(
+                                "type", "map",
+                                "key-id", 5,
+                                "key", "string",
+                                "value-id", 6,
+                                "value", "string",
+                                "value-required", false))));
+
+        List<Map<String, Object>> updates = List.of(Map.of("action", "add-schema", "schema", newSchema));
+        TableUpdateApplicator.apply(updates, metadata);
+
+        assertEquals(6, metadata.get("last-column-id"));
+    }
+
+    @Test
     public void testLastUpdatedMsAlwaysSet() {
         Map<String, Object> metadata = buildMetadata();
         long before = System.currentTimeMillis();


### PR DESCRIPTION
## Summary

Fixes #8464

When using Apicurio Registry as an Iceberg REST Catalog with the Iceberg Kafka Connect sink connector, auto-created tables with nested schemas (e.g. from Debezium CDC) fail on the second commit with `CommitFailedException: assert-last-assigned-field-id`.

## Root Cause

Both `computeMaxFieldId()` in `IcebergApiResourceImpl` and `updateLastColumnId()` in `TableUpdateApplicator` only scanned **top-level** schema field IDs. In Iceberg, every nested struct field, list element, and map key/value gets a globally unique field ID. The `last-column-id` metadata must be the maximum across **all** field IDs including nested ones.

When the Iceberg client computed the correct `last-assigned-field-id` from all fields (including nested) and sent it as a commit requirement, it mismatched the stored `last-column-id` which only reflected top-level fields.

## Changes

- **New `IcebergSchemaUtil`** (`app/src/main/java/.../impl/IcebergSchemaUtil.java`): Shared utility that recursively computes the maximum field ID across all Iceberg type nesting:
  - `struct` types: recurses into nested `fields`
  - `list` types: includes `element-id`, recurses into `element` if complex
  - `map` types: includes `key-id` and `value-id`, recurses into `key`/`value` if complex
- **`IcebergApiResourceImpl.computeMaxFieldId()`**: Delegates to `IcebergSchemaUtil.computeMaxFieldId()`
- **`TableUpdateApplicator.updateLastColumnId()`**: Delegates to `IcebergSchemaUtil.computeMaxFieldId()`

## Test plan

- [x] New `IcebergSchemaUtilTest` with 9 tests covering: flat schemas, empty/null fields, nested structs, list types, map types, deeply nested schemas (struct→list→struct), maps with struct values, and Debezium CDC-like schemas
- [x] 2 new tests in `TableUpdateApplicatorTest` for `add-schema` with nested struct and list/map types
- [x] All 55 existing + new tests pass
- [x] Checkstyle passes with 0 violations
- [ ] No storage layer changes — this is pure metadata computation, works identically across all storage variants