### PR TITLE
feat(ci): limit non-maintainer contributors to 1 open PR

### DIFF
--- a/.github/pr-lifecycle.yml
+++ b/.github/pr-lifecycle.yml
@@ -11,6 +11,8 @@ maintainers:
 auto_accept:
   - renovate[bot]
 
+max_contributor_prs: 1
+
 merge:
   strategy: rebase
   delete_branch: true

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -492,11 +492,36 @@ async function reconcile(github, api, pr, core) {
 // Event Handlers
 // ---------------------------------------------------------------------------
 
+async function countOpenPrsByAuthor(github, owner, repo, author, excludePr) {
+  const prs = await github.paginate(github.rest.pulls.list, {
+    owner, repo, state: 'open', per_page: 100,
+  });
+  return prs.filter(p => p.user.login === author && p.number !== excludePr);
+}
+
 async function handlePrOpened({ github, context, core }) {
   const pr = context.payload.pull_request;
   const { owner, repo } = context.repo;
   const api = createApi(github, owner, repo);
   const config = loadConfig();
+
+  if (!isAutoAccepted(config, pr.user.login)) {
+    const existingPrs = await countOpenPrsByAuthor(github, owner, repo, pr.user.login, pr.number);
+    const maxPrs = config.max_contributor_prs ?? 1;
+    if (existingPrs.length >= maxPrs) {
+      const prLinks = existingPrs.map(p => `#${p.number}`).join(', ');
+      await api.postComment(pr.number,
+        `Thanks for your contribution! However, you already have ${existingPrs.length > 1 ? 'open PRs' : 'an open PR'} ` +
+        `(${prLinks}). To keep the review pipeline manageable, each ` +
+        `contributor can have at most ${maxPrs} open PR(s) at a time.\n\n` +
+        `Please complete or close your existing PR before opening a new one. ` +
+        `This PR has been closed automatically.`
+      );
+      await api.closePr(pr.number);
+      core.info(`PR #${pr.number} closed: ${pr.user.login} already has ${existingPrs.length} open PR(s)`);
+      return;
+    }
+  }
 
   if (isAutoAccepted(config, pr.user.login)) {
     const initialState = pr.draft ? LABELS.WIP : LABELS.READY_FOR_REVIEW;

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,36 @@
+# Artificial Intelligence (AI) Usage Policy
+
+At Apicurio Registry, we welcome tools that help developers become more productive — including AI tools such as Large Language Models (LLMs) and agents like Claude Code, Codex, ChatGPT, GitHub Copilot, and others.
+
+However, recent patterns of use have led to increased moderation burden, low-value contributions, and reduced community signal. To ensure a healthy and productive community, the following expectations apply to all contributions (issues, pull requests, comments, discussions, and other project interactions).
+
+## Acceptable Use of AI
+
+- You may use agents/LLMs to help you **write better**, but not to **post more**.
+- AI may be used to **assist your development** — for example drafting code, writing documentation, or proposing fixes — as long as **you understand, validate**, and **take responsibility for the results**.
+- You should only submit contributions (PRs, comments, discussions, issues) that reflect your **own understanding** and **intent**, not what an agent/LLM "spit out."
+  - This means that when the contribution is scrutinized by a maintainer, you need to be ready to argue about all aspects of it; simply responding that the contribution is what the LLM provided is completely unacceptable.
+
+## Unacceptable Use of AI
+
+- Submitting code, tests, comments, discussions or issues that appear to be **copied directly from an AI with little or no human oversight** is **not acceptable**.
+- Posting **large volumes of low-effort suggestions, vague issues, or links with no context** — even if technically accurate — is considered spam.
+- Submitting **AI-generated tests that do not validate actual behavior** or meaningfully cover functionality is not helpful and will be rejected.
+- Using bots, agents, or automated tools to open PRs, file issues, or post content **without human authorship and responsibility** is not allowed.
+
+## Signal-to-Noise Ratio
+
+As a general rule, the actual PR and its metadata should be similar to what the developer would have come up with had they not been using AI tools.
+For example, when writing PR descriptions, developers tend to make it clear what the PR does and don't pack the description with useless details or superfluous formatting and emojis.
+Furthermore, developers usually try to introduce focused tests that follow the project's existing test philosophy instead of dumping a bunch of new tests for everything that could conceivably be tested concerning the updated code.
+
+## Consequences
+
+- We may close issues, PRs, or discussions that violate this policy without detailed explanation.
+- Repeated violations may result in temporary or permanent restrictions from participating in the project.
+
+## If in Doubt
+
+If you're unsure whether your use of agents/LLMs is acceptable — ask! We're happy to help contributors learn how to use AI tools effectively **without creating noise**.
+
+> This isn't about banning AI — it's about keeping Apicurio Registry collaborative, human-driven, and focused on quality.


### PR DESCRIPTION
## Summary

- Adds a PR-count guard to the PR lifecycle orchestrator: non-maintainer contributors are limited to 1 open PR at a time
- When a contributor already has an open PR and opens another, the new PR is automatically closed with a comment linking the existing one
- Maintainers and auto-accepted accounts (e.g. `renovate[bot]`) are exempt
- The limit is configurable via `max_contributor_prs` in `.github/pr-lifecycle.yml`

Closes #8484

## Test plan

- [ ] Non-maintainer opens a 2nd PR → new PR is closed with a comment referencing the existing one
- [ ] Maintainer opens multiple PRs → no limit enforced
- [ ] Non-maintainer with 0 open PRs → PR proceeds normally through the lifecycle
- [ ] `renovate[bot]` → exempt, can open multiple PRs