### PR TITLE
test(iceberg): add schema evolution tests for CommitTable last-column-id

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergApiTest.java
@@ -568,6 +568,93 @@ public class IcebergApiTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void testCommitTableSchemaEvolutionWithNestedFields() {
+        String namespaceName = "test_evolve_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String tableName = "evolve_table";
+
+        // Create namespace
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(Map.of("namespace", List.of(namespaceName), "properties", Map.of()))
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces")
+            .then()
+            .statusCode(200);
+
+        // Create table with 4 flat fields
+        Map<String, Object> createTableRequest = Map.of(
+            "name", tableName,
+            "schema", Map.of(
+                "type", "struct",
+                "schema-id", 0,
+                "fields", List.of(
+                    Map.of("id", 1, "name", "id", "required", true, "type", "long"),
+                    Map.of("id", 2, "name", "first_name", "required", false, "type", "string"),
+                    Map.of("id", 3, "name", "last_name", "required", false, "type", "string"),
+                    Map.of("id", 4, "name", "email", "required", false, "type", "string")
+                )
+            ),
+            "properties", Map.of()
+        );
+
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(createTableRequest)
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/tables")
+            .then()
+            .statusCode(200)
+            .body("metadata.last-column-id", equalTo(4));
+
+        // Evolve schema: add nested struct and list fields (IDs 5-9)
+        Map<String, Object> nestedStruct = Map.of(
+            "type", "struct",
+            "fields", List.of(
+                Map.of("id", 6, "name", "street", "type", "string", "required", false),
+                Map.of("id", 7, "name", "city", "type", "string", "required", false)));
+        Map<String, Object> listType = Map.of(
+            "type", "list",
+            "element-id", 9,
+            "element", "string",
+            "element-required", false);
+
+        Map<String, Object> evolvedSchema = new HashMap<>();
+        evolvedSchema.put("type", "struct");
+        evolvedSchema.put("schema-id", -1);
+        evolvedSchema.put("fields", List.of(
+            Map.of("id", 1, "name", "id", "required", true, "type", "long"),
+            Map.of("id", 2, "name", "first_name", "required", false, "type", "string"),
+            Map.of("id", 3, "name", "last_name", "required", false, "type", "string"),
+            Map.of("id", 4, "name", "email", "required", false, "type", "string"),
+            Map.of("id", 5, "name", "address", "required", false, "type", nestedStruct),
+            Map.of("id", 8, "name", "aliases", "required", false, "type", listType)));
+
+        // Commit with assert-last-assigned-field-id=4 (current stored value)
+        Map<String, Object> requirement = new HashMap<>();
+        requirement.put("type", "assert-last-assigned-field-id");
+        requirement.put("last-assigned-field-id", 4);
+
+        Map<String, Object> commitRequest = Map.of(
+            "requirements", List.of(requirement),
+            "updates", List.of(
+                Map.of("action", "add-schema", "schema", evolvedSchema),
+                Map.of("action", "set-current-schema", "schema-id", -1)
+            )
+        );
+
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(commitRequest)
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/tables/" + tableName)
+            .then()
+            .statusCode(200)
+            .body("metadata.last-column-id", equalTo(9));
+
+        cleanupTable(namespaceName, tableName);
+    }
+
+    @Test
     public void testCommitTableSetAndRemoveProperties() {
         String namespaceName = "test_props_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
         String tableName = "props_table";

--- a/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/commit/TableUpdateApplicatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/commit/TableUpdateApplicatorTest.java
@@ -339,6 +339,69 @@ public class TableUpdateApplicatorTest {
     }
 
     @Test
+    public void testAddSchemaEvolutionWithNestedFields() {
+        Map<String, Object> metadata = buildMetadata();
+        metadata.put("last-column-id", 4);
+
+        // Initial schema already stored (4 flat fields)
+        Map<String, Object> initialSchema = Map.of(
+                "type", "struct", "schema-id", 0,
+                "fields", List.of(
+                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                        Map.of("id", 2, "name", "first_name", "type", "string", "required", false),
+                        Map.of("id", 3, "name", "last_name", "type", "string", "required", false),
+                        Map.of("id", 4, "name", "email", "type", "string", "required", false)));
+        metadata.put("schemas", new ArrayList<>(List.of(initialSchema)));
+
+        // Evolved schema adds nested struct wrapping existing fields + new nested fields
+        Map<String, Object> nestedStruct = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 6, "name", "first_name", "type", "string", "required", false),
+                        Map.of("id", 7, "name", "last_name", "type", "string", "required", false)));
+        Map<String, Object> listType = Map.of(
+                "type", "list",
+                "element-id", 9,
+                "element", "string",
+                "element-required", false);
+        Map<String, Object> evolvedSchema = new HashMap<>();
+        evolvedSchema.put("type", "struct");
+        evolvedSchema.put("schema-id", 1);
+        evolvedSchema.put("fields", List.of(
+                Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                Map.of("id", 5, "name", "full_name", "type", nestedStruct, "required", false),
+                Map.of("id", 4, "name", "email", "type", "string", "required", false),
+                Map.of("id", 8, "name", "aliases", "type", listType, "required", false)));
+
+        List<Map<String, Object>> updates = List
+                .of(Map.of("action", "add-schema", "schema", evolvedSchema));
+        TableUpdateApplicator.apply(updates, metadata);
+
+        assertEquals(9, metadata.get("last-column-id"));
+    }
+
+    @Test
+    public void testAddSchemaWithExplicitLastColumnId() {
+        Map<String, Object> metadata = buildMetadata();
+        metadata.put("last-column-id", 3);
+
+        Map<String, Object> newSchema = new HashMap<>();
+        newSchema.put("type", "struct");
+        newSchema.put("schema-id", 1);
+        newSchema.put("fields", List.of(
+                Map.of("id", 1, "name", "id", "type", "long", "required", true)));
+
+        Map<String, Object> update = new HashMap<>();
+        update.put("action", "add-schema");
+        update.put("schema", newSchema);
+        update.put("last-column-id", 10);
+
+        TableUpdateApplicator.apply(List.of(update), metadata);
+
+        assertEquals(10, metadata.get("last-column-id"));
+    }
+
+    @Test
     public void testLastUpdatedMsAlwaysSet() {
         Map<String, Object> metadata = buildMetadata();
         long before = System.currentTimeMillis();


### PR DESCRIPTION
## Summary

Closes #8500

### Investigation

The `assert-last-assigned-field-id` failure reported in #8500 occurs because of a mismatch between how Apicurio computes `last-column-id` and how the Iceberg Kafka Connect sink (v0.6.19) tracks it:

1. **Apicurio (post-#8481)** correctly computes `last-column-id` recursively, including nested struct field IDs, list `element-id`, and map `key-id`/`value-id` — matching the [Iceberg spec](https://iceberg.apache.org/spec/) definition of `last-column-id` as "the highest assigned column ID" and `Schema.highestFieldId()` which [includes nested fields](https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/Schema.java).

2. **The Kafka Connect sink** (v0.6.19) has a [known bug](http://www.mail-archive.com/issues@iceberg.apache.org/msg212326.html) where schema evolution only tracks top-level fields. With `schema-force-optional=true`, fields are wrapped in optional structs adding nested IDs, but the sink's local tracking still reports `lastColumnId=4` (top-level only) while Apicurio stores `last-column-id=9` (recursive, per spec).

3. The fix in PR #8481 (already on `main`) made both `CreateTable` and `CommitTable` code paths use the same recursive `IcebergSchemaUtil.computeMaxFieldId()`, which is the correct behavior per the Iceberg specification.

### This PR

Adds test coverage for the specific CommitTable schema evolution scenario described in #8500:

- **Integration test** (`IcebergApiTest`): Creates a table with 4 flat fields, commits a schema evolution adding nested struct and list fields (IDs 5-9) with `assert-last-assigned-field-id=4` requirement — verifies the commit succeeds and `last-column-id` updates to 9.
- **Unit tests** (`TableUpdateApplicatorTest`): Schema evolution with nested struct/list types, and explicit `last-column-id` in the update payload.

## Test plan

- [x] `TableUpdateApplicatorTest` — 27 tests pass (2 new: evolution + explicit last-column-id)
- [x] `IcebergApiTest#testCommitTableSchemaEvolutionWithNestedFields` — end-to-end pass
- [x] Checkstyle — 0 violations