### PR TITLE
fix(iceberg): use top-level field IDs only for last-column-id

### DIFF
--- a/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/IcebergSchemaUtil.java
+++ b/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/IcebergSchemaUtil.java
@@ -16,58 +16,10 @@ public final class IcebergSchemaUtil {
         }
         int maxId = 0;
         for (Map<String, Object> field : fields) {
-            maxId = Math.max(maxId, computeMaxFieldIdFromField(field));
-        }
-        return maxId;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static int computeMaxFieldIdFromField(Map<String, Object> field) {
-        int maxId = toInt(field.get("id"));
-        Object type = field.get("type");
-        if (type instanceof Map) {
-            maxId = Math.max(maxId, computeMaxFieldIdFromType((Map<String, Object>) type));
-        }
-        return maxId;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static int computeMaxFieldIdFromType(Map<String, Object> type) {
-        String typeName = (String) type.get("type");
-        if (typeName == null) {
-            return 0;
-        }
-        int maxId = 0;
-        switch (typeName) {
-            case "struct":
-                List<Map<String, Object>> fields = (List<Map<String, Object>>) type.get("fields");
-                if (fields != null) {
-                    for (Map<String, Object> field : fields) {
-                        maxId = Math.max(maxId, computeMaxFieldIdFromField(field));
-                    }
-                }
-                break;
-            case "list":
-                maxId = Math.max(maxId, toInt(type.get("element-id")));
-                Object element = type.get("element");
-                if (element instanceof Map) {
-                    maxId = Math.max(maxId, computeMaxFieldIdFromType((Map<String, Object>) element));
-                }
-                break;
-            case "map":
-                maxId = Math.max(maxId, toInt(type.get("key-id")));
-                maxId = Math.max(maxId, toInt(type.get("value-id")));
-                Object key = type.get("key");
-                if (key instanceof Map) {
-                    maxId = Math.max(maxId, computeMaxFieldIdFromType((Map<String, Object>) key));
-                }
-                Object value = type.get("value");
-                if (value instanceof Map) {
-                    maxId = Math.max(maxId, computeMaxFieldIdFromType((Map<String, Object>) value));
-                }
-                break;
-            default:
-                break;
+            int fieldId = toInt(field.get("id"));
+            if (fieldId > maxId) {
+                maxId = fieldId;
+            }
         }
         return maxId;
     }

--- a/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergApiTest.java
@@ -568,6 +568,104 @@ public class IcebergApiTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void testCommitTableSchemaEvolutionDebeziumCdcScenario() {
+        // Reproduces issue #8500: CreateTable with nested types (Debezium CDC),
+        // then CommitTable with schema evolution fails assert-last-assigned-field-id
+        String namespaceName = "test_cdc_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String tableName = "customers";
+
+        // Create namespace
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(Map.of("namespace", List.of(namespaceName), "properties", Map.of()))
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces")
+            .then()
+            .statusCode(200);
+
+        // Create table with 4 top-level fields where field 4 has a nested struct
+        // (simulating Debezium CDC with schema-force-optional wrapping).
+        // Top-level IDs: 1,2,3,4. Nested struct has element-id=5,6,7,8,9.
+        // The Iceberg client would compute highestFieldId()=4 for just the top-level,
+        // but the server's recursive computation gives 9.
+        Map<String, Object> sourceStruct = Map.of(
+            "type", "struct",
+            "fields", List.of(
+                Map.of("id", 5, "name", "version", "type", "string", "required", false),
+                Map.of("id", 6, "name", "connector", "type", "string", "required", false),
+                Map.of("id", 7, "name", "ts_ms", "type", "long", "required", false),
+                Map.of("id", 8, "name", "db", "type", "string", "required", false),
+                Map.of("id", 9, "name", "table", "type", "string", "required", false)));
+
+        Map<String, Object> createTableRequest = Map.of(
+            "name", tableName,
+            "schema", Map.of(
+                "type", "struct",
+                "schema-id", 0,
+                "fields", List.of(
+                    Map.of("id", 1, "name", "id", "required", true, "type", "long"),
+                    Map.of("id", 2, "name", "first_name", "required", false, "type", "string"),
+                    Map.of("id", 3, "name", "last_name", "required", false, "type", "string"),
+                    Map.of("id", 4, "name", "source", "required", false, "type", sourceStruct)
+                )
+            ),
+            "properties", Map.of()
+        );
+
+        // CreateTable stores last-column-id=9 (recursive) due to nested struct IDs
+        int storedLastColumnId = given()
+            .when()
+            .contentType(CT_JSON)
+            .body(createTableRequest)
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/tables")
+            .then()
+            .statusCode(200)
+            .extract()
+            .jsonPath()
+            .getInt("metadata.last-column-id");
+
+        // Server stores last-column-id=4 (top-level fields only, not nested)
+        assertTrue(storedLastColumnId == 4, "Expected last-column-id=4 but was " + storedLastColumnId);
+
+        // The Iceberg client should use the server-returned last-column-id
+        // for the assert-last-assigned-field-id requirement.
+        // Schema evolution: add a new top-level field
+        Map<String, Object> evolvedSchema = new HashMap<>();
+        evolvedSchema.put("type", "struct");
+        evolvedSchema.put("schema-id", -1);
+        evolvedSchema.put("fields", List.of(
+            Map.of("id", 1, "name", "id", "required", true, "type", "long"),
+            Map.of("id", 2, "name", "first_name", "required", false, "type", "string"),
+            Map.of("id", 3, "name", "last_name", "required", false, "type", "string"),
+            Map.of("id", 4, "name", "source", "required", false, "type", sourceStruct),
+            Map.of("id", 10, "name", "email", "required", false, "type", "string")));
+
+        // Use the server-returned last-column-id for the requirement
+        Map<String, Object> requirement = new HashMap<>();
+        requirement.put("type", "assert-last-assigned-field-id");
+        requirement.put("last-assigned-field-id", storedLastColumnId);
+
+        Map<String, Object> commitRequest = Map.of(
+            "requirements", List.of(requirement),
+            "updates", List.of(
+                Map.of("action", "add-schema", "schema", evolvedSchema),
+                Map.of("action", "set-current-schema", "schema-id", -1)
+            )
+        );
+
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(commitRequest)
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/tables/" + tableName)
+            .then()
+            .statusCode(200)
+            .body("metadata.last-column-id", equalTo(10));
+
+        cleanupTable(namespaceName, tableName);
+    }
+
+    @Test
     public void testCommitTableSchemaEvolutionWithNestedFields() {
         String namespaceName = "test_evolve_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
         String tableName = "evolve_table";
@@ -649,7 +747,7 @@ public class IcebergApiTest extends AbstractResourceTestBase {
             .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/tables/" + tableName)
             .then()
             .statusCode(200)
-            .body("metadata.last-column-id", equalTo(9));
+            .body("metadata.last-column-id", equalTo(8));
 
         cleanupTable(namespaceName, tableName);
     }

--- a/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergApiTest.java
@@ -568,6 +568,93 @@ public class IcebergApiTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void testCommitTableSchemaEvolutionWithNestedFields() {
+        String namespaceName = "test_evolve_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String tableName = "evolve_table";
+
+        // Create namespace
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(Map.of("namespace", List.of(namespaceName), "properties", Map.of()))
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces")
+            .then()
+            .statusCode(200);
+
+        // Create table with 4 flat fields
+        Map<String, Object> createTableRequest = Map.of(
+            "name", tableName,
+            "schema", Map.of(
+                "type", "struct",
+                "schema-id", 0,
+                "fields", List.of(
+                    Map.of("id", 1, "name", "id", "required", true, "type", "long"),
+                    Map.of("id", 2, "name", "first_name", "required", false, "type", "string"),
+                    Map.of("id", 3, "name", "last_name", "required", false, "type", "string"),
+                    Map.of("id", 4, "name", "email", "required", false, "type", "string")
+                )
+            ),
+            "properties", Map.of()
+        );
+
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(createTableRequest)
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/tables")
+            .then()
+            .statusCode(200)
+            .body("metadata.last-column-id", equalTo(4));
+
+        // Evolve schema: add nested struct and list fields (IDs 5-9)
+        Map<String, Object> nestedStruct = Map.of(
+            "type", "struct",
+            "fields", List.of(
+                Map.of("id", 6, "name", "street", "type", "string", "required", false),
+                Map.of("id", 7, "name", "city", "type", "string", "required", false)));
+        Map<String, Object> listType = Map.of(
+            "type", "list",
+            "element-id", 9,
+            "element", "string",
+            "element-required", false);
+
+        Map<String, Object> evolvedSchema = new HashMap<>();
+        evolvedSchema.put("type", "struct");
+        evolvedSchema.put("schema-id", -1);
+        evolvedSchema.put("fields", List.of(
+            Map.of("id", 1, "name", "id", "required", true, "type", "long"),
+            Map.of("id", 2, "name", "first_name", "required", false, "type", "string"),
+            Map.of("id", 3, "name", "last_name", "required", false, "type", "string"),
+            Map.of("id", 4, "name", "email", "required", false, "type", "string"),
+            Map.of("id", 5, "name", "address", "required", false, "type", nestedStruct),
+            Map.of("id", 8, "name", "aliases", "required", false, "type", listType)));
+
+        // Commit with assert-last-assigned-field-id=4 (current stored value)
+        Map<String, Object> requirement = new HashMap<>();
+        requirement.put("type", "assert-last-assigned-field-id");
+        requirement.put("last-assigned-field-id", 4);
+
+        Map<String, Object> commitRequest = Map.of(
+            "requirements", List.of(requirement),
+            "updates", List.of(
+                Map.of("action", "add-schema", "schema", evolvedSchema),
+                Map.of("action", "set-current-schema", "schema-id", -1)
+            )
+        );
+
+        given()
+            .when()
+            .contentType(CT_JSON)
+            .body(commitRequest)
+            .post(ICEBERG_API_BASE + "/iceberg/v1/default/namespaces/" + namespaceName + "/tables/" + tableName)
+            .then()
+            .statusCode(200)
+            .body("metadata.last-column-id", equalTo(9));
+
+        cleanupTable(namespaceName, tableName);
+    }
+
+    @Test
     public void testCommitTableSetAndRemoveProperties() {
         String namespaceName = "test_props_ns_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
         String tableName = "props_table";

--- a/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergSchemaUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/IcebergSchemaUtilTest.java
@@ -37,7 +37,7 @@ public class IcebergSchemaUtilTest {
     }
 
     @Test
-    public void testNestedStruct() {
+    public void testNestedStructOnlyCountsTopLevel() {
         Map<String, Object> schema = Map.of(
                 "type", "struct",
                 "fields", List.of(
@@ -52,11 +52,11 @@ public class IcebergSchemaUtilTest {
                                                         "required", false),
                                                 Map.of("id", 5, "name", "zip", "type", "string",
                                                         "required", false))))));
-        assertEquals(5, IcebergSchemaUtil.computeMaxFieldId(schema));
+        assertEquals(2, IcebergSchemaUtil.computeMaxFieldId(schema));
     }
 
     @Test
-    public void testListType() {
+    public void testListTypeOnlyCountsTopLevel() {
         Map<String, Object> schema = Map.of(
                 "type", "struct",
                 "fields", List.of(
@@ -67,11 +67,11 @@ public class IcebergSchemaUtilTest {
                                         "element-id", 3,
                                         "element", "string",
                                         "element-required", false))));
-        assertEquals(3, IcebergSchemaUtil.computeMaxFieldId(schema));
+        assertEquals(2, IcebergSchemaUtil.computeMaxFieldId(schema));
     }
 
     @Test
-    public void testMapType() {
+    public void testMapTypeOnlyCountsTopLevel() {
         Map<String, Object> schema = Map.of(
                 "type", "struct",
                 "fields", List.of(
@@ -84,81 +84,38 @@ public class IcebergSchemaUtilTest {
                                         "value-id", 4,
                                         "value", "string",
                                         "value-required", false))));
-        assertEquals(4, IcebergSchemaUtil.computeMaxFieldId(schema));
+        assertEquals(2, IcebergSchemaUtil.computeMaxFieldId(schema));
     }
 
     @Test
-    public void testDeeplyNestedSchema() {
-        // struct -> list -> struct (simulates Debezium CDC nested records)
-        Map<String, Object> innerStruct = Map.of(
-                "type", "struct",
-                "fields", List.of(
-                        Map.of("id", 5, "name", "key", "type", "string", "required", true),
-                        Map.of("id", 6, "name", "value", "type", "string", "required", false)));
-
-        Map<String, Object> listType = Map.of(
-                "type", "list",
-                "element-id", 4,
-                "element", innerStruct,
-                "element-required", false);
-
-        Map<String, Object> schema = Map.of(
-                "type", "struct",
-                "fields", List.of(
-                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
-                        Map.of("id", 2, "name", "name", "type", "string", "required", false),
-                        Map.of("id", 3, "name", "items", "required", false, "type", listType)));
-        assertEquals(6, IcebergSchemaUtil.computeMaxFieldId(schema));
-    }
-
-    @Test
-    public void testMapWithStructValue() {
-        Map<String, Object> valueStruct = Map.of(
-                "type", "struct",
-                "fields", List.of(
-                        Map.of("id", 5, "name", "amount", "type", "double", "required", true),
-                        Map.of("id", 6, "name", "currency", "type", "string", "required", true)));
-
-        Map<String, Object> mapType = Map.of(
-                "type", "map",
-                "key-id", 3,
-                "key", "string",
-                "value-id", 4,
-                "value", valueStruct,
-                "value-required", true);
-
-        Map<String, Object> schema = Map.of(
-                "type", "struct",
-                "fields", List.of(
-                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
-                        Map.of("id", 2, "name", "prices", "required", false, "type", mapType)));
-        assertEquals(6, IcebergSchemaUtil.computeMaxFieldId(schema));
-    }
-
-    @Test
-    public void testDebeziumCdcLikeSchema() {
-        // Simulates a typical Debezium CDC schema with nested source info
+    public void testDebeziumCdcLikeSchemaOnlyCountsTopLevel() {
         Map<String, Object> sourceStruct = Map.of(
                 "type", "struct",
                 "fields", List.of(
                         Map.of("id", 5, "name", "version", "type", "string", "required", false),
                         Map.of("id", 6, "name", "connector", "type", "string", "required", false),
-                        Map.of("id", 7, "name", "name", "type", "string", "required", false),
-                        Map.of("id", 8, "name", "ts_ms", "type", "long", "required", false),
-                        Map.of("id", 9, "name", "snapshot", "type", "string", "required", false),
-                        Map.of("id", 10, "name", "db", "type", "string", "required", false),
-                        Map.of("id", 11, "name", "schema", "type", "string", "required", false),
-                        Map.of("id", 12, "name", "table", "type", "string", "required", false)));
+                        Map.of("id", 7, "name", "ts_ms", "type", "long", "required", false),
+                        Map.of("id", 8, "name", "db", "type", "string", "required", false),
+                        Map.of("id", 9, "name", "table", "type", "string", "required", false)));
 
         Map<String, Object> schema = Map.of(
                 "type", "struct",
                 "fields", List.of(
-                        Map.of("id", 1, "name", "customer_id", "type", "int", "required", true),
+                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
                         Map.of("id", 2, "name", "first_name", "type", "string", "required", false),
                         Map.of("id", 3, "name", "last_name", "type", "string", "required", false),
                         Map.of("id", 4, "name", "source", "required", false, "type", sourceStruct)));
+        assertEquals(4, IcebergSchemaUtil.computeMaxFieldId(schema));
+    }
 
-        // Top-level max is 4, but nested goes to 12
-        assertEquals(12, IcebergSchemaUtil.computeMaxFieldId(schema));
+    @Test
+    public void testNonSequentialIds() {
+        Map<String, Object> schema = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                        Map.of("id", 5, "name", "name", "type", "string", "required", false),
+                        Map.of("id", 3, "name", "email", "type", "string", "required", false)));
+        assertEquals(5, IcebergSchemaUtil.computeMaxFieldId(schema));
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/commit/TableUpdateApplicatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/commit/TableUpdateApplicatorTest.java
@@ -306,7 +306,7 @@ public class TableUpdateApplicatorTest {
         List<Map<String, Object>> updates = List.of(Map.of("action", "add-schema", "schema", newSchema));
         TableUpdateApplicator.apply(updates, metadata);
 
-        assertEquals(5, metadata.get("last-column-id"));
+        assertEquals(2, metadata.get("last-column-id"));
     }
 
     @Test
@@ -335,7 +335,7 @@ public class TableUpdateApplicatorTest {
         List<Map<String, Object>> updates = List.of(Map.of("action", "add-schema", "schema", newSchema));
         TableUpdateApplicator.apply(updates, metadata);
 
-        assertEquals(6, metadata.get("last-column-id"));
+        assertEquals(4, metadata.get("last-column-id"));
     }
 
     @Test
@@ -377,7 +377,7 @@ public class TableUpdateApplicatorTest {
                 .of(Map.of("action", "add-schema", "schema", evolvedSchema));
         TableUpdateApplicator.apply(updates, metadata);
 
-        assertEquals(9, metadata.get("last-column-id"));
+        assertEquals(8, metadata.get("last-column-id"));
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/commit/TableUpdateApplicatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/commit/TableUpdateApplicatorTest.java
@@ -339,6 +339,69 @@ public class TableUpdateApplicatorTest {
     }
 
     @Test
+    public void testAddSchemaEvolutionWithNestedFields() {
+        Map<String, Object> metadata = buildMetadata();
+        metadata.put("last-column-id", 4);
+
+        // Initial schema already stored (4 flat fields)
+        Map<String, Object> initialSchema = Map.of(
+                "type", "struct", "schema-id", 0,
+                "fields", List.of(
+                        Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                        Map.of("id", 2, "name", "first_name", "type", "string", "required", false),
+                        Map.of("id", 3, "name", "last_name", "type", "string", "required", false),
+                        Map.of("id", 4, "name", "email", "type", "string", "required", false)));
+        metadata.put("schemas", new ArrayList<>(List.of(initialSchema)));
+
+        // Evolved schema adds nested struct wrapping existing fields + new nested fields
+        Map<String, Object> nestedStruct = Map.of(
+                "type", "struct",
+                "fields", List.of(
+                        Map.of("id", 6, "name", "first_name", "type", "string", "required", false),
+                        Map.of("id", 7, "name", "last_name", "type", "string", "required", false)));
+        Map<String, Object> listType = Map.of(
+                "type", "list",
+                "element-id", 9,
+                "element", "string",
+                "element-required", false);
+        Map<String, Object> evolvedSchema = new HashMap<>();
+        evolvedSchema.put("type", "struct");
+        evolvedSchema.put("schema-id", 1);
+        evolvedSchema.put("fields", List.of(
+                Map.of("id", 1, "name", "id", "type", "long", "required", true),
+                Map.of("id", 5, "name", "full_name", "type", nestedStruct, "required", false),
+                Map.of("id", 4, "name", "email", "type", "string", "required", false),
+                Map.of("id", 8, "name", "aliases", "type", listType, "required", false)));
+
+        List<Map<String, Object>> updates = List
+                .of(Map.of("action", "add-schema", "schema", evolvedSchema));
+        TableUpdateApplicator.apply(updates, metadata);
+
+        assertEquals(9, metadata.get("last-column-id"));
+    }
+
+    @Test
+    public void testAddSchemaWithExplicitLastColumnId() {
+        Map<String, Object> metadata = buildMetadata();
+        metadata.put("last-column-id", 3);
+
+        Map<String, Object> newSchema = new HashMap<>();
+        newSchema.put("type", "struct");
+        newSchema.put("schema-id", 1);
+        newSchema.put("fields", List.of(
+                Map.of("id", 1, "name", "id", "type", "long", "required", true)));
+
+        Map<String, Object> update = new HashMap<>();
+        update.put("action", "add-schema");
+        update.put("schema", newSchema);
+        update.put("last-column-id", 10);
+
+        TableUpdateApplicator.apply(List.of(update), metadata);
+
+        assertEquals(10, metadata.get("last-column-id"));
+    }
+
+    @Test
     public void testLastUpdatedMsAlwaysSet() {
         Map<String, Object> metadata = buildMetadata();
         long before = System.currentTimeMillis();


### PR DESCRIPTION
## Summary

Fixes #8500

The recursive `computeMaxFieldId` introduced in #8481 traversed nested struct, list, and map types, producing a `last-column-id` higher than what Iceberg clients (e.g. Kafka Connect sink v0.6.19 with Iceberg 1.5.2) track internally. This caused `assert-last-assigned-field-id` to fail during `CommitTable` when schemas contain nested types — specifically in the Debezium CDC + `schema-force-optional` scenario.

**Root cause**: `IcebergSchemaUtil.computeMaxFieldId()` recursed into nested struct fields, list `element-id`, and map `key-id`/`value-id`, setting `last-column-id=9` during `CreateTable` for a schema with 4 top-level fields but nested IDs up to 9. The Iceberg client then sent `assert-last-assigned-field-id=4` (its tracked value) during schema evolution, which failed against the server's stored value of 9.

**Fix**: Revert `IcebergSchemaUtil.computeMaxFieldId()` to scan only top-level field IDs, matching what Iceberg clients use for their requirement assertions.

## Test plan

- [x] `IcebergSchemaUtilTest` — 8 tests: flat, empty, null, nested struct (top-level only), list (top-level only), map (top-level only), Debezium CDC-like, non-sequential IDs
- [x] `TableUpdateApplicatorTest` — 27 tests including nested struct, list/map, schema evolution, explicit last-column-id
- [x] `IcebergApiTest` — 2 new integration tests: Debezium CDC scenario with nested types at CreateTable + CommitTable evolution; flat schema evolution with nested fields
- [x] Checkstyle — 0 violations