### PR TITLE
fix(operator): add explicit timeouts to flaky Kafka integration tests

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -8,6 +8,7 @@ import io.apicurio.registry.utils.Cell;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
@@ -78,6 +79,8 @@ public abstract class ITBase implements OperatorTestContext {
             Integer.getInteger("test.operator.timeout.medium", 120));
     public static final Duration LONG_DURATION = ofSeconds(
             Integer.getInteger("test.operator.timeout.long", 420));
+    public static final Duration KAFKA_BROKER_READY_TIMEOUT = Duration.ofMinutes(10);
+    public static final Duration KAFKA_REGISTRY_READY_TIMEOUT = Duration.ofMinutes(8);
 
     public enum OperatorDeployment {
         local, remote
@@ -385,6 +388,38 @@ public abstract class ITBase implements OperatorTestContext {
                 });
             });
         }
+    }
+
+    /**
+     * Waits for a Kafka broker pod (deployed by Strimzi in KRaft mode) to become ready.
+     * Pod naming follows the KafkaNodePool convention: {@code <cluster>-<nodepool>-<id>}.
+     */
+    static void waitForKafkaBrokerReady(String clusterName) {
+        await().atMost(KAFKA_BROKER_READY_TIMEOUT).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.pods().inNamespace(namespace).withName(clusterName + "-dual-role-0")
+                        .get().getStatus().getConditions())
+                        .filteredOn(c -> "Ready".equals(c.getType()))
+                        .map(PodCondition::getStatus)
+                        .containsOnly("True"));
+    }
+
+    /**
+     * Waits for a KafkaSQL-backed registry deployment to have one ready replica and to log
+     * the expected storage message.
+     */
+    static void waitForKafkaSqlRegistryReady(ApicurioRegistry3 registry) {
+        var deploymentName = registry.getMetadata().getName() + "-app-deployment";
+        await().atMost(KAFKA_REGISTRY_READY_TIMEOUT).ignoreExceptions().untilAsserted(() -> {
+            var readyReplicas = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName).get().getStatus().getReadyReplicas();
+            assertThat(readyReplicas).isNotNull().isEqualTo(1);
+            var podName = client.pods().inNamespace(namespace).list().getItems().stream()
+                    .map(pod -> pod.getMetadata().getName())
+                    .filter(name -> name.startsWith(deploymentName))
+                    .findFirst().get();
+            assertThat(client.pods().inNamespace(namespace).withName(podName).getLog())
+                    .contains("Using Kafka-SQL artifactStore");
+        });
     }
 
     static void createNamespace(KubernetesClient client, String namespace) {

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -79,8 +79,10 @@ public abstract class ITBase implements OperatorTestContext {
             Integer.getInteger("test.operator.timeout.medium", 120));
     public static final Duration LONG_DURATION = ofSeconds(
             Integer.getInteger("test.operator.timeout.long", 420));
-    public static final Duration KAFKA_BROKER_READY_TIMEOUT = Duration.ofMinutes(10);
-    public static final Duration KAFKA_REGISTRY_READY_TIMEOUT = Duration.ofMinutes(8);
+    public static final Duration KAFKA_BROKER_READY_TIMEOUT = ofSeconds(
+            Integer.getInteger("test.operator.timeout.kafka-broker", 600));
+    public static final Duration KAFKA_REGISTRY_READY_TIMEOUT = ofSeconds(
+            Integer.getInteger("test.operator.timeout.kafka-registry", 480));
 
     public enum OperatorDeployment {
         local, remote

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlAccessITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlAccessITTest.java
@@ -2,7 +2,6 @@ package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
@@ -24,7 +23,6 @@ import java.util.List;
 import static io.apicurio.registry.operator.Tags.KAFKA;
 import static io.apicurio.registry.operator.Tags.SLOW;
 import static io.apicurio.registry.operator.resource.ResourceFactory.deserialize;
-import static java.time.Duration.ofMinutes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -117,10 +115,7 @@ public class KafkaSqlAccessITTest extends ITBase {
         final var clusterName = "example-cluster";
 
         // Wait for the Kafka broker pod to be ready
-        await().atMost(ofMinutes(10)).ignoreExceptions().untilAsserted(() ->
-                assertThat(client.pods().inNamespace(namespace).withName(clusterName + "-dual-role-0").get()
-                        .getStatus().getConditions()).filteredOn(c -> "Ready".equals(c.getType()))
-                        .map(PodCondition::getStatus).containsOnly("True"));
+        waitForKafkaBrokerReady(clusterName);
 
         // Create the KafkaUser
         client.load(getClass().getResourceAsStream("/k8s/examples/kafkasql/access/apicurio-registry.kafkauser.yaml"))
@@ -171,20 +166,6 @@ public class KafkaSqlAccessITTest extends ITBase {
 
         client.resource(registry).create();
 
-        // Wait for the registry deployment to come up and log "Using Kafka-SQL artifactStore".
-        // Use a longer timeout because this test deploys a lot of infrastructure (Strimzi, Kafka Access
-        // Operator, Kafka cluster) which can be slow on resource-constrained CI runners.
-        await().atMost(ofMinutes(8)).ignoreExceptions().untilAsserted(() -> {
-            var readyReplicas = client.apps().deployments().inNamespace(namespace)
-                    .withName(registry.getMetadata().getName() + "-app-deployment").get().getStatus()
-                    .getReadyReplicas();
-            assertThat(readyReplicas).isNotNull().isEqualTo(1);
-            var podName = client.pods().inNamespace(namespace).list().getItems().stream()
-                    .map(pod -> pod.getMetadata().getName())
-                    .filter(podN -> podN.startsWith(registry.getMetadata().getName() + "-app-deployment"))
-                    .findFirst().get();
-            assertThat(client.pods().inNamespace(namespace).withName(podName).getLog())
-                    .contains("Using Kafka-SQL artifactStore");
-        });
+        waitForKafkaSqlRegistryReady(registry);
     }
 }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlAccessITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlAccessITTest.java
@@ -117,7 +117,7 @@ public class KafkaSqlAccessITTest extends ITBase {
         final var clusterName = "example-cluster";
 
         // Wait for the Kafka broker pod to be ready
-        await().ignoreExceptions().untilAsserted(() ->
+        await().atMost(ofMinutes(10)).ignoreExceptions().untilAsserted(() ->
                 assertThat(client.pods().inNamespace(namespace).withName(clusterName + "-dual-role-0").get()
                         .getStatus().getConditions()).filteredOn(c -> "Ready".equals(c.getType()))
                         .map(PodCondition::getStatus).containsOnly("True"));

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlITTest.java
@@ -1,7 +1,6 @@
 package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
-import io.fabric8.kubernetes.api.model.PodCondition;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -12,9 +11,6 @@ import org.slf4j.LoggerFactory;
 import static io.apicurio.registry.operator.Tags.KAFKA;
 import static io.apicurio.registry.operator.Tags.SLOW;
 import static io.apicurio.registry.operator.resource.ResourceFactory.deserialize;
-import static java.time.Duration.ofMinutes;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @Tag(KAFKA)
@@ -36,12 +32,7 @@ public class KafkaSqlITTest extends ITBase {
                 .getResourceAsStream("/k8s/examples/kafkasql/plain/example-cluster.kafka.yaml")).create();
         final var clusterName = "example-cluster";
 
-        await().atMost(ofMinutes(10)).ignoreExceptions().untilAsserted(() ->
-        // Strimzi uses StrimziPodSet instead of ReplicaSet, so we have to check pods
-        // KRaft mode uses KafkaNodePool, so pod naming is <cluster>-<nodepool>-<id>
-        assertThat(client.pods().inNamespace(namespace).withName(clusterName + "-dual-role-0").get().getStatus()
-                .getConditions()).filteredOn(c -> "Ready".equals(c.getType())).map(PodCondition::getStatus)
-                .containsOnly("True"));
+        waitForKafkaBrokerReady(clusterName);
 
         // We're guessing the value here to avoid using Strimzi Java model, and relying on retries below.
         var bootstrapServers = clusterName + "-kafka-bootstrap." + namespace + ".svc:9092";
@@ -54,17 +45,6 @@ public class KafkaSqlITTest extends ITBase {
 
         client.resource(registry).create();
 
-        await().atMost(ofMinutes(8)).ignoreExceptions().until(() -> {
-            assertThat(client.apps().deployments().inNamespace(namespace)
-                    .withName(registry.getMetadata().getName() + "-app-deployment").get().getStatus()
-                    .getReadyReplicas().intValue()).isEqualTo(1);
-            var podName = client.pods().inNamespace(namespace).list().getItems().stream()
-                    .map(pod -> pod.getMetadata().getName())
-                    .filter(podN -> podN.startsWith(registry.getMetadata().getName() + "-app-deployment"))
-                    .findFirst().get();
-            assertThat(client.pods().inNamespace(namespace).withName(podName).getLog())
-                    .contains("Using Kafka-SQL artifactStore");
-            return true;
-        });
+        waitForKafkaSqlRegistryReady(registry);
     }
 }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlITTest.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import static io.apicurio.registry.operator.Tags.KAFKA;
 import static io.apicurio.registry.operator.Tags.SLOW;
 import static io.apicurio.registry.operator.resource.ResourceFactory.deserialize;
+import static java.time.Duration.ofMinutes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -35,7 +36,7 @@ public class KafkaSqlITTest extends ITBase {
                 .getResourceAsStream("/k8s/examples/kafkasql/plain/example-cluster.kafka.yaml")).create();
         final var clusterName = "example-cluster";
 
-        await().ignoreExceptions().untilAsserted(() ->
+        await().atMost(ofMinutes(10)).ignoreExceptions().untilAsserted(() ->
         // Strimzi uses StrimziPodSet instead of ReplicaSet, so we have to check pods
         // KRaft mode uses KafkaNodePool, so pod naming is <cluster>-<nodepool>-<id>
         assertThat(client.pods().inNamespace(namespace).withName(clusterName + "-dual-role-0").get().getStatus()
@@ -53,7 +54,7 @@ public class KafkaSqlITTest extends ITBase {
 
         client.resource(registry).create();
 
-        await().ignoreExceptions().until(() -> {
+        await().atMost(ofMinutes(8)).ignoreExceptions().until(() -> {
             assertThat(client.apps().deployments().inNamespace(namespace)
                     .withName(registry.getMetadata().getName() + "-app-deployment").get().getStatus()
                     .getReadyReplicas().intValue()).isEqualTo(1);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlOAuthITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlOAuthITTest.java
@@ -13,6 +13,7 @@ import static io.apicurio.registry.operator.Tags.AUTH;
 import static io.apicurio.registry.operator.Tags.KAFKA;
 import static io.apicurio.registry.operator.Tags.SLOW;
 import static io.apicurio.registry.operator.resource.ResourceFactory.deserialize;
+import static java.time.Duration.ofMinutes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -39,7 +40,7 @@ public class KafkaSqlOAuthITTest extends BaseAuthITTest {
                 .create();
         final var clusterName = "oauth-example-cluster";
 
-        await().ignoreExceptions().untilAsserted(() ->
+        await().atMost(ofMinutes(10)).ignoreExceptions().untilAsserted(() ->
                 // Strimzi uses StrimziPodSet instead of ReplicaSet, so we have to check pods
                 assertThat(client.pods().inNamespace(namespace).withName(clusterName + "-dual-role-0").get().getStatus()
                         .getConditions()).filteredOn(c -> "Ready".equals(c.getType())).map(PodCondition::getStatus)
@@ -56,7 +57,7 @@ public class KafkaSqlOAuthITTest extends BaseAuthITTest {
 
         client.resource(registry).create();
 
-        await().ignoreExceptions().until(() -> {
+        await().atMost(ofMinutes(8)).ignoreExceptions().until(() -> {
             assertThat(client.apps().deployments().inNamespace(namespace)
                     .withName(registry.getMetadata().getName() + "-app-deployment").get().getStatus()
                     .getReadyReplicas().intValue()).isEqualTo(1);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlOAuthITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlOAuthITTest.java
@@ -1,7 +1,6 @@
 package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
-import io.fabric8.kubernetes.api.model.PodCondition;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -13,9 +12,6 @@ import static io.apicurio.registry.operator.Tags.AUTH;
 import static io.apicurio.registry.operator.Tags.KAFKA;
 import static io.apicurio.registry.operator.Tags.SLOW;
 import static io.apicurio.registry.operator.resource.ResourceFactory.deserialize;
-import static java.time.Duration.ofMinutes;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @Tag(KAFKA)
@@ -40,11 +36,7 @@ public class KafkaSqlOAuthITTest extends BaseAuthITTest {
                 .create();
         final var clusterName = "oauth-example-cluster";
 
-        await().atMost(ofMinutes(10)).ignoreExceptions().untilAsserted(() ->
-                // Strimzi uses StrimziPodSet instead of ReplicaSet, so we have to check pods
-                assertThat(client.pods().inNamespace(namespace).withName(clusterName + "-dual-role-0").get().getStatus()
-                        .getConditions()).filteredOn(c -> "Ready".equals(c.getType())).map(PodCondition::getStatus)
-                        .containsOnly("True"));
+        waitForKafkaBrokerReady(clusterName);
 
         // We're guessing the value here to avoid using Strimzi Java model, and relying on retries below.
         var bootstrapServers = clusterName + "-kafka-bootstrap." + namespace + ".svc:9093";
@@ -57,17 +49,6 @@ public class KafkaSqlOAuthITTest extends BaseAuthITTest {
 
         client.resource(registry).create();
 
-        await().atMost(ofMinutes(8)).ignoreExceptions().until(() -> {
-            assertThat(client.apps().deployments().inNamespace(namespace)
-                    .withName(registry.getMetadata().getName() + "-app-deployment").get().getStatus()
-                    .getReadyReplicas().intValue()).isEqualTo(1);
-            var podName = client.pods().inNamespace(namespace).list().getItems().stream()
-                    .map(pod -> pod.getMetadata().getName())
-                    .filter(podN -> podN.startsWith(registry.getMetadata().getName() + "-app-deployment"))
-                    .findFirst().get();
-            assertThat(client.pods().inNamespace(namespace).withName(podName).getLog())
-                    .contains("Using Kafka-SQL artifactStore");
-            return true;
-        });
+        waitForKafkaSqlRegistryReady(registry);
     }
 }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlTLSITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlTLSITTest.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import static io.apicurio.registry.operator.Tags.KAFKA;
 import static io.apicurio.registry.operator.Tags.SLOW;
 import static io.apicurio.registry.operator.resource.ResourceFactory.deserialize;
+import static java.time.Duration.ofMinutes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -35,7 +36,7 @@ public class KafkaSqlTLSITTest extends ITBase {
                 .create();
         final var clusterName = "example-cluster";
 
-        await().ignoreExceptions().untilAsserted(() ->
+        await().atMost(ofMinutes(10)).ignoreExceptions().untilAsserted(() ->
                 // Strimzi uses StrimziPodSet instead of ReplicaSet, so we have to check pods
                 // KRaft mode uses KafkaNodePool, so pod naming is <cluster>-<nodepool>-<id>
                 assertThat(client.pods().inNamespace(namespace).withName(clusterName + "-dual-role-0").get().getStatus()
@@ -61,7 +62,7 @@ public class KafkaSqlTLSITTest extends ITBase {
 
         client.resource(registry).create();
 
-        await().ignoreExceptions().until(() -> {
+        await().atMost(ofMinutes(8)).ignoreExceptions().until(() -> {
             assertThat(client.apps().deployments().inNamespace(namespace)
                     .withName(registry.getMetadata().getName() + "-app-deployment").get().getStatus()
                     .getReadyReplicas().intValue()).isEqualTo(1);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlTLSITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlTLSITTest.java
@@ -1,7 +1,6 @@
 package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
-import io.fabric8.kubernetes.api.model.PodCondition;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -12,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import static io.apicurio.registry.operator.Tags.KAFKA;
 import static io.apicurio.registry.operator.Tags.SLOW;
 import static io.apicurio.registry.operator.resource.ResourceFactory.deserialize;
-import static java.time.Duration.ofMinutes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -36,12 +34,7 @@ public class KafkaSqlTLSITTest extends ITBase {
                 .create();
         final var clusterName = "example-cluster";
 
-        await().atMost(ofMinutes(10)).ignoreExceptions().untilAsserted(() ->
-                // Strimzi uses StrimziPodSet instead of ReplicaSet, so we have to check pods
-                // KRaft mode uses KafkaNodePool, so pod naming is <cluster>-<nodepool>-<id>
-                assertThat(client.pods().inNamespace(namespace).withName(clusterName + "-dual-role-0").get().getStatus()
-                        .getConditions()).filteredOn(c -> "Ready".equals(c.getType())).map(PodCondition::getStatus)
-                        .containsOnly("True"));
+        waitForKafkaBrokerReady(clusterName);
 
         client.load(getClass().getResourceAsStream("/k8s/examples/kafkasql/tls/apicurio.kafkauser.yaml"))
                 .inNamespace(namespace).create();
@@ -62,17 +55,6 @@ public class KafkaSqlTLSITTest extends ITBase {
 
         client.resource(registry).create();
 
-        await().atMost(ofMinutes(8)).ignoreExceptions().until(() -> {
-            assertThat(client.apps().deployments().inNamespace(namespace)
-                    .withName(registry.getMetadata().getName() + "-app-deployment").get().getStatus()
-                    .getReadyReplicas().intValue()).isEqualTo(1);
-            var podName = client.pods().inNamespace(namespace).list().getItems().stream()
-                    .map(pod -> pod.getMetadata().getName())
-                    .filter(podN -> podN.startsWith(registry.getMetadata().getName() + "-app-deployment"))
-                    .findFirst().get();
-            assertThat(client.pods().inNamespace(namespace).withName(podName).getLog())
-                    .contains("Using Kafka-SQL artifactStore");
-            return true;
-        });
+        waitForKafkaSqlRegistryReady(registry);
     }
 }


### PR DESCRIPTION
## Summary

- Adds explicit `atMost(ofMinutes(10))` for Kafka broker readiness checks in all 4 KafkaSql test classes
- Adds explicit `atMost(ofMinutes(8))` for registry deployment readiness checks in 3 test classes (KafkaSqlAccessITTest already had this)
- Aligns all Kafka integration tests to the same timeout pattern

## Problem

The Kafka broker readiness checks relied on the awaitility default timeout (7 minutes, set in `ITBase.setDefaultAwaitilityTimings()`). On resource-constrained CI runners, Strimzi/Kafka broker pods can take longer than 7 minutes to start, causing `ConditionTimeoutException` failures.

**Evidence:** PR #8452 CI run [29016096872](https://github.com/Apicurio/apicurio-registry/actions/runs/29016096872) — 3 of 4 Kafka tests timed out at exactly 7 minutes. The 4th test (`KafkaSqlAccessITTest`) passed because its registry deployment check already had an explicit longer timeout.

## Test plan

- [ ] Operator Kafka tests pass in CI (all 4 KafkaSql* tests)
- [ ] No change to test behavior — only timeout windows widened