### PR TITLE
fix(openapi): fix OpenAPI 3.1 server variables validation (#8505)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <failsafe.rerunFailingTestsCount>0</failsafe.rerunFailingTestsCount>
 
     <!-- Apitomy Data Models (OpenAPI and AsyncAPI support) -->
-    <apitomy-data-models.version>3.1.1</apitomy-data-models.version>
+    <apitomy-data-models.version>3.1.3</apitomy-data-models.version>
 
     <!-- GraphQL -->
     <graphql.version>26.0</graphql.version>

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/OpenApiContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/OpenApiContentValidatorTest.java
@@ -67,6 +67,18 @@ public class OpenApiContentValidatorTest extends ArtifactUtilProviderTestBase {
         validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
     }
 
+    /**
+     * Test for issue #8505 - OpenAPI 3.1 with server variables fails to validate.
+     * Before the fix in apitomy-data-models, this would throw a ClassCastException because
+     * OasServerVarNotFoundInTemplateRule casts to OpenApi30Server instead of OpenApiServer.
+     */
+    @Test
+    public void testValidateOpenApi31WithServerVariables() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("openapi-3.1-server-variables.json");
+        OpenApiContentValidator validator = new OpenApiContentValidator();
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+    }
+
     @Test
     public void testValidateRefs() throws Exception {
         TypedContent content = resourceToTypedContentHandle("openapi-valid-with-refs.json");

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/openapi-3.1-server-variables.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/openapi-3.1-server-variables.json
@@ -1,0 +1,35 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Apicurio 3.1 servers ClassCastException repro",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://{host}/v1",
+            "description": "Server with a templated variable.",
+            "variables": {
+                "host": {
+                    "default": "example.com",
+                    "enum": [
+                        "example.com",
+                        "staging.example.com"
+                    ],
+                    "description": "Target host."
+                }
+            }
+        }
+    ],
+    "paths": {
+        "/ping": {
+            "get": {
+                "operationId": "ping",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a regression test reproducing the `ClassCastException` when validating an OpenAPI 3.1
  document with `servers[].variables` (issue #8505)
- Upgrades `apitomy-data-models` to 3.1.3, which fixes the root cause
  (`OasServerVarNotFoundInTemplateRule` hard-casts to `OpenApi30Server` instead of `OpenApiServer`)

## Test plan
- [ ] CI passes — the new test validates the fix end-to-end

Closes #8505