### PR TITLE
fix(operator): close LogWatch in stopAndWait() to unblock readLine() (backport #8509)

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/PodLogManager.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/PodLogManager.java
@@ -23,6 +23,7 @@ public class PodLogManager {
     private final KubernetesClient k8sClient;
 
     private final Map<ResourceID, AtomicBoolean> activePodLogMap = new ConcurrentHashMap<>();
+    private final Map<ResourceID, LogWatch> activeLogWatchMap = new ConcurrentHashMap<>();
 
     public PodLogManager(KubernetesClient k8sClient) {
         this.k8sClient = k8sClient;
@@ -41,6 +42,7 @@ public class PodLogManager {
                     LogWatch logWatch = k8sClient.pods().inNamespace(getNamespace(podID)).withName(podID.getName()).watchLog();
                     BufferedReader reader = new BufferedReader(new InputStreamReader(logWatch.getOutput()))
             ) {
+                activeLogWatchMap.put(podID, logWatch);
                 AtomicBoolean stop = new AtomicBoolean(false);
                 log.debug("START LOG of pod {}/{}", getNamespace(podID), podID.getName());
                 activePodLogMap.put(podID, stop);
@@ -66,6 +68,7 @@ public class PodLogManager {
                     log.debug("LOG of pod {}/{}:\n{}", getNamespace(podID), podID.getName(), chunk);
                 }
                 log.debug("END LOG of pod {}/{}", getNamespace(podID), podID.getName());
+                activeLogWatchMap.remove(podID);
                 activePodLogMap.remove(podID);
             }
         }).start();
@@ -77,6 +80,13 @@ public class PodLogManager {
 
     public void stopAndWait() {
         activePodLogMap.values().forEach(stop -> stop.set(true));
-        await().until(activePodLogMap::isEmpty);
+        activeLogWatchMap.values().forEach(logWatch -> {
+            try {
+                logWatch.close();
+            } catch (Exception e) {
+                // Ignore
+            }
+        });
+        await().atMost(Duration.ofSeconds(30)).until(activePodLogMap::isEmpty);
     }
 }


### PR DESCRIPTION
## Summary
Backport of #8509 to the 3.2.x branch.

- Store `LogWatch` references in a new `activeLogWatchMap` so they can be closed externally
- In `stopAndWait()`, close all `LogWatch` instances after setting stop flags — this unblocks
  `readLine()` which was blocking indefinitely when pods were still running but not producing output
- Reduce the Awaitility timeout from the global default (420s) to 30s, since closing the streams
  causes near-immediate thread exit

## Related Issue
Fixes #8508

## Test Plan
- [ ] Verify operator controller module compiles: `./mvnw compile -pl operator/controller`
- [ ] Run operator integration tests on an OCP cluster and confirm the 8 previously-failing tests
  no longer time out during `@AfterAll` cleanup
- [ ] Verify that pod log collection still works correctly during normal test execution