### PR TITLE
feat(serde): instrument AbstractSerializer and AbstractDeserializer with OTel spans

### DIFF
--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractDeserializer.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractDeserializer.java
@@ -19,6 +19,8 @@ import io.apicurio.registry.serde.config.SerdeConfig;
 import io.apicurio.registry.serde.config.SerdeDeserializerConfig;
 import io.apicurio.registry.serde.fallback.DefaultFallbackArtifactProvider;
 import io.apicurio.registry.serde.fallback.FallbackArtifactProvider;
+import io.apicurio.registry.serde.tracing.SerDesAttributes;
+import io.apicurio.registry.serde.tracing.SerDesTracer;
 
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -31,6 +33,7 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
 
     private static final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(
             AbstractDeserializer.class.getName());
+    private final SerDesTracer tracer = new SerDesTracer();
 
     /**
      * Cache key that distinguishes between contentId and globalId to avoid collisions.
@@ -129,23 +132,26 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
         if (data == null) {
             return null;
         }
+        return tracer.traceDeserialize(topic, span -> {
+            span.setAttribute(SerDesAttributes.DATA_SIZE, (long) data.length);
 
-        ByteBuffer buffer = getByteBuffer(data);
-        ArtifactReference artifactReference = baseSerde.getIdHandler().readId(buffer);
+            ByteBuffer buffer = getByteBuffer(data);
+            ArtifactReference artifactReference = baseSerde.getIdHandler().readId(buffer);
 
-        SchemaLookupResult<T> schema = resolve(topic, data, artifactReference);
+            SchemaLookupResult<T> schema = resolve(topic, data, artifactReference);
+            SerDesTracer.setSchemaAttributes(span, schema, false);
 
-        // Could this be replaced by buffer.limit() - buffer.position(); ?
-        int length = buffer.limit() - 1 - baseSerde.getIdHandler().idSize(artifactReference, buffer);
-        int start = buffer.position() + buffer.arrayOffset();
+            int length = buffer.limit() - 1 - baseSerde.getIdHandler().idSize(artifactReference, buffer);
+            int start = buffer.position() + buffer.arrayOffset();
 
-        U result = readData(schema.getParsedSchema(), buffer, start, length);
+            U result = readData(schema.getParsedSchema(), buffer, start, length);
 
-        if (contractRulesEnabled) {
-            executeContractRulesForRead(schema, result);
-        }
+            if (contractRulesEnabled) {
+                executeContractRulesForRead(schema, result);
+            }
 
-        return result;
+            return result;
+        });
     }
 
     protected abstract U readData(ParsedSchema<T> schema, ByteBuffer buffer, int start, int length);

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractDeserializer.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractDeserializer.java
@@ -33,7 +33,7 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
 
     private static final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(
             AbstractDeserializer.class.getName());
-    private final SerDesTracer tracer = new SerDesTracer();
+    private static final SerDesTracer tracer = new SerDesTracer();
 
     /**
      * Cache key that distinguishes between contentId and globalId to avoid collisions.
@@ -138,8 +138,11 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
             ByteBuffer buffer = getByteBuffer(data);
             ArtifactReference artifactReference = baseSerde.getIdHandler().readId(buffer);
 
+            SchemaCacheKey cacheKey = getCacheKey(artifactReference);
+            boolean cacheHit = cacheKey != null && fastPathCache.containsKey(cacheKey);
+
             SchemaLookupResult<T> schema = resolve(topic, data, artifactReference);
-            SerDesTracer.setSchemaAttributes(span, schema, false);
+            SerDesTracer.setSchemaAttributes(span, schema, cacheHit);
 
             int length = buffer.limit() - 1 - baseSerde.getIdHandler().idSize(artifactReference, buffer);
             int start = buffer.position() + buffer.arrayOffset();

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractSerializer.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractSerializer.java
@@ -16,6 +16,8 @@ import io.apicurio.registry.serde.config.SerdeConfig;
 import io.apicurio.registry.resolver.DefaultSchemaResolver;
 import io.apicurio.registry.serde.data.SerdeMetadata;
 import io.apicurio.registry.serde.data.SerdeRecord;
+import io.apicurio.registry.serde.tracing.SerDesAttributes;
+import io.apicurio.registry.serde.tracing.SerDesTracer;
 import io.apicurio.registry.serde.utils.BoundedCacheFactory;
 
 import java.io.ByteArrayOutputStream;
@@ -38,6 +40,7 @@ public abstract class AbstractSerializer<T, U> implements AutoCloseable {
      * Pre-sized to avoid array resizing for typical message sizes.
      */
     private static final int DEFAULT_BUFFER_SIZE = 1024;
+    private final SerDesTracer tracer = new SerDesTracer();
 
     /**
      * Maximum number of entries in the fast-path cache.
@@ -133,52 +136,55 @@ public abstract class AbstractSerializer<T, U> implements AutoCloseable {
     }
 
     public byte[] serializeData(String topic, U data) {
-        // just return null
         if (data == null) {
             return null;
         }
-        try {
-            SchemaLookupResult<T> schema = null;
-            SchemaCacheKey cacheKey = null;
+        return tracer.traceSerialize(topic, span -> {
+            try {
+                SchemaLookupResult<T> schema = null;
+                SchemaCacheKey cacheKey = null;
 
-            // Fast path: use cache if we have a valid schema cache key
-            Object schemaKey = getSchemaCacheKey(data);
-            if (schemaKey != null) {
-                cacheKey = new SchemaCacheKey(topic, schemaKey);
-                schema = fastPathCache.get(cacheKey);
-            }
-
-            if (schema == null) {
-                // Slow path: full resolution
-                DefaultSchemaResolver.currentOperation.set("SERIALIZE");
-                try {
-                    SerdeMetadata resolverMetadata = new SerdeMetadata(topic, baseSerde.isKey());
-                    schema = baseSerde.getSchemaResolver()
-                            .resolveSchema(new SerdeRecord<>(resolverMetadata, data));
-                } finally {
-                    DefaultSchemaResolver.currentOperation.remove();
+                Object schemaKey = getSchemaCacheKey(data);
+                if (schemaKey != null) {
+                    cacheKey = new SchemaCacheKey(topic, schemaKey);
+                    schema = fastPathCache.get(cacheKey);
                 }
 
-                // Cache result if we have a valid cache key
-                if (cacheKey != null) {
-                    fastPathCache.put(cacheKey, schema);
+                boolean cacheHit = schema != null;
+
+                if (schema == null) {
+                    DefaultSchemaResolver.currentOperation.set("SERIALIZE");
+                    try {
+                        SerdeMetadata resolverMetadata = new SerdeMetadata(topic, baseSerde.isKey());
+                        schema = baseSerde.getSchemaResolver()
+                                .resolveSchema(new SerdeRecord<>(resolverMetadata, data));
+                    } finally {
+                        DefaultSchemaResolver.currentOperation.remove();
+                    }
+
+                    if (cacheKey != null) {
+                        fastPathCache.put(cacheKey, schema);
+                    }
                 }
+
+                SerDesTracer.setSchemaAttributes(span, schema, cacheHit);
+
+                if (contractRulesEnabled) {
+                    executeContractRulesForWrite(schema, data);
+                }
+
+                ByteArrayOutputStream out = new ByteArrayOutputStream(DEFAULT_BUFFER_SIZE);
+                out.write(MAGIC_BYTE);
+                baseSerde.getIdHandler().writeId(schema.toArtifactReference(), out);
+                this.serializeData(schema.getParsedSchema(), data, out);
+
+                byte[] result = out.toByteArray();
+                span.setAttribute(SerDesAttributes.DATA_SIZE, (long) result.length);
+                return result;
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
             }
-
-            if (contractRulesEnabled) {
-                executeContractRulesForWrite(schema, data);
-            }
-
-            // Pre-size buffer to avoid array resizing for typical messages
-            ByteArrayOutputStream out = new ByteArrayOutputStream(DEFAULT_BUFFER_SIZE);
-            out.write(MAGIC_BYTE);
-            baseSerde.getIdHandler().writeId(schema.toArtifactReference(), out);
-            this.serializeData(schema.getParsedSchema(), data, out);
-
-            return out.toByteArray();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        });
     }
 
     public BaseSerde<T, U> getSerdeConfigurer() {

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractSerializer.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractSerializer.java
@@ -40,7 +40,7 @@ public abstract class AbstractSerializer<T, U> implements AutoCloseable {
      * Pre-sized to avoid array resizing for typical message sizes.
      */
     private static final int DEFAULT_BUFFER_SIZE = 1024;
-    private final SerDesTracer tracer = new SerDesTracer();
+    private static final SerDesTracer tracer = new SerDesTracer();
 
     /**
      * Maximum number of entries in the fast-path cache.

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/tracing/SerDesTracer.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/tracing/SerDesTracer.java
@@ -16,6 +16,7 @@
 
 package io.apicurio.registry.serde.tracing;
 
+import io.apicurio.registry.resolver.SchemaLookupResult;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
@@ -77,6 +78,22 @@ public class SerDesTracer {
             throw new RuntimeException(e);
         } finally {
             span.end();
+        }
+    }
+
+    public static void setSchemaAttributes(Span span, SchemaLookupResult<?> schema, boolean cacheHit) {
+        if (schema == null || !span.isRecording()) {
+            return;
+        }
+        span.setAttribute(SerDesAttributes.CACHE_HIT, cacheHit);
+        if (schema.getGroupId() != null) {
+            span.setAttribute(SerDesAttributes.GROUP_ID, schema.getGroupId());
+        }
+        if (schema.getArtifactId() != null) {
+            span.setAttribute(SerDesAttributes.ARTIFACT_ID, schema.getArtifactId());
+        }
+        if (schema.getVersion() != null) {
+            span.setAttribute(SerDesAttributes.VERSION, schema.getVersion());
         }
     }
 


### PR DESCRIPTION
## Summary

- Wraps `serializeData()` and `deserializeData()` with `SerDesTracer` (merged in #8408) to create `serde.serialize` and `serde.deserialize` spans
- Adds `setSchemaAttributes()` helper to `SerDesTracer` for consistent schema attribute decoration
- Each span includes: `messaging.destination.name`, `apicurio.registry.serde.operation`, `apicurio.registry.serde.data_size`, `apicurio.registry.serde.cache_hit`, `apicurio.registry.group_id`, `artifact_id`, `version`
- Zero overhead when OTel is not configured (`TracerProvider.noop()` fast-path)

## Related Issues

- Depends on #8408 (SerDesTracer utility) — merged
- Continues the SerDes observability work from #8156

## Changes

| File | Change |
|------|--------|
| `AbstractSerializer.java` | Wrap `serializeData()` in `tracer.traceSerialize()`, track `cache_hit` and `data_size` |
| `AbstractDeserializer.java` | Wrap `deserializeData()` in `tracer.traceDeserialize()`, track `cache_hit` via `fastPathCache.containsKey()` |
| `SerDesTracer.java` | Add `setSchemaAttributes()` static helper, import `SchemaLookupResult` |

## Test plan

- [ ] `./mvnw test-compile -pl serdes/generic/serde-common -am -DskipTests` passes
- [ ] `./mvnw checkstyle:check -pl serdes/generic/serde-common` passes
- [ ] SerDesTracerTest and SerDesTracerBenchmark pass
- [ ] No behavioral change to serialize/deserialize logic (only span wrapping added)
- [ ] When OTel is not configured, noop fast-path skips span creation