### PR TITLE
feat(metrics): add configurable distribution type for REST metrics

### DIFF
--- a/app/src/main/java/io/apicurio/registry/metrics/CustomMetricsConfiguration.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/CustomMetricsConfiguration.java
@@ -66,6 +66,24 @@ public class CustomMetricsConfiguration {
     @Singleton
     public MeterFilter configureDistribution() {
         String type = distributionType.toLowerCase(Locale.ROOT);
+        if (!"histogram".equals(type) && !"summary".equals(type)) {
+            throw new IllegalArgumentException(
+                    "Invalid value for 'apicurio.metrics.rest.distribution.type': '"
+                            + distributionType + "'. Valid values are: histogram, summary");
+        }
+        percentiles.stream().filter(p -> p < 0.0 || p > 1.0).findFirst().ifPresent(p -> {
+            throw new IllegalArgumentException(
+                    "Invalid percentile value " + p
+                            + " in 'apicurio.metrics.rest.distribution.percentiles'. "
+                            + "Each value must be between 0.0 and 1.0.");
+        });
+        slo.stream().filter(s -> s <= 0.0).findFirst().ifPresent(s -> {
+            throw new IllegalArgumentException(
+                    "Invalid SLO boundary value " + s
+                            + " in 'apicurio.metrics.rest.distribution.slo'. "
+                            + "Each value must be a positive number representing seconds.");
+        });
+
         double[] percentilesArray = toDoubleArray(percentiles);
         double[] sloNanosArray = toSloNanosArray(slo);
 

--- a/app/src/main/java/io/apicurio/registry/metrics/CustomMetricsConfiguration.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/CustomMetricsConfiguration.java
@@ -20,11 +20,7 @@ public class CustomMetricsConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(CustomMetricsConfiguration.class);
 
-    /**
-     * Conversion factor from seconds to nanoseconds for SLO boundaries.
-     * Micrometer Timer records values in nanoseconds, so SLO boundaries
-     * expressed in seconds must be multiplied by this factor.
-     */
+    // Micrometer Timer records values in nanoseconds.
     private static final double SECONDS_TO_NANOSECONDS = 1_000_000_000.0;
 
     @Info(description = """
@@ -62,10 +58,14 @@ public class CustomMetricsConfiguration {
             defaultValue = "0.1,0.25,0.5,1.0,2.0,5.0,10.0")
     List<Double> slo;
 
+    /**
+     * Produces a MeterFilter that configures the distribution statistics for REST request metrics.
+     * The returned filter captures immutable snapshots of the config values, making it thread-safe.
+     */
     @Produces
     @Singleton
-    public MeterFilter enableHistogram() {
-        String type = distributionType != null ? distributionType.toLowerCase(Locale.ROOT) : "histogram";
+    public MeterFilter configureDistribution() {
+        String type = distributionType.toLowerCase(Locale.ROOT);
         double[] percentilesArray = toDoubleArray(percentiles);
         double[] sloNanosArray = toSloNanosArray(slo);
 
@@ -89,14 +89,14 @@ public class CustomMetricsConfiguration {
     }
 
     private static double[] toDoubleArray(List<Double> values) {
-        if (values == null || values.isEmpty()) {
+        if (values.isEmpty()) {
             return new double[0];
         }
         return values.stream().mapToDouble(Double::doubleValue).toArray();
     }
 
     private static double[] toSloNanosArray(List<Double> sloSeconds) {
-        if (sloSeconds == null || sloSeconds.isEmpty()) {
+        if (sloSeconds.isEmpty()) {
             return new double[0];
         }
         return sloSeconds.stream()

--- a/app/src/main/java/io/apicurio/registry/metrics/CustomMetricsConfiguration.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/CustomMetricsConfiguration.java
@@ -1,30 +1,106 @@
 package io.apicurio.registry.metrics;
 
+import io.apicurio.common.apps.config.Info;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Locale;
+
+import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_OBSERVABILITY;
 
 @Singleton
 public class CustomMetricsConfiguration {
 
+    private static final Logger log = LoggerFactory.getLogger(CustomMetricsConfiguration.class);
+
+    /**
+     * Conversion factor from seconds to nanoseconds for SLO boundaries.
+     * Micrometer Timer records values in nanoseconds, so SLO boundaries
+     * expressed in seconds must be multiplied by this factor.
+     */
+    private static final double SECONDS_TO_NANOSECONDS = 1_000_000_000.0;
+
+    @Info(description = """
+                    The distribution type for REST API request metrics. \
+                    Use `histogram` (default) for explicit bucket histogram with SLO boundaries \
+                    and pre-computed percentiles. \
+                    Use `summary` for pre-computed percentiles only, without histogram buckets. \
+                    Datadog users should use `summary` for accurate latency percentiles, \
+                    since Datadog re-computes percentiles from histogram buckets \
+                    and the default bucket boundaries may not provide sufficient granularity.
+            """, category = CATEGORY_OBSERVABILITY, availableSince = "3.3.1")
+    @ConfigProperty(name = "apicurio.metrics.rest.distribution.type", defaultValue = "histogram")
+    String distributionType;
+
+    @Info(description = """
+                    Comma-separated list of percentile values to pre-compute \
+                    for REST API request metrics. \
+                    Each value must be between 0.0 and 1.0 (e.g. 0.5 for the median, \
+                    0.95 for the 95th percentile). \
+                    These percentiles are computed client-side and exported as individual gauge metrics.
+            """, category = CATEGORY_OBSERVABILITY, availableSince = "3.3.1")
+    @ConfigProperty(name = "apicurio.metrics.rest.distribution.percentiles",
+            defaultValue = "0.5,0.95,0.99,0.9995")
+    List<Double> percentiles;
+
+    @Info(description = """
+                    Comma-separated list of service level objective (SLO) boundary values \
+                    in seconds for REST API request histogram buckets. \
+                    Only used when the distribution type is `histogram`. \
+                    Each value defines a histogram bucket boundary. \
+                    Adjust these boundaries to match your monitoring system's expectations \
+                    for accurate percentile computation from histogram data.
+            """, category = CATEGORY_OBSERVABILITY, availableSince = "3.3.1")
+    @ConfigProperty(name = "apicurio.metrics.rest.distribution.slo",
+            defaultValue = "0.1,0.25,0.5,1.0,2.0,5.0,10.0")
+    List<Double> slo;
+
     @Produces
     @Singleton
     public MeterFilter enableHistogram() {
-        double factor = 1000000000; // to convert slos to seconds
+        String type = distributionType != null ? distributionType.toLowerCase(Locale.ROOT) : "histogram";
+        double[] percentilesArray = toDoubleArray(percentiles);
+        double[] sloNanosArray = toSloNanosArray(slo);
+
+        log.debug("REST metrics distribution type: {}, percentiles: {}, SLO boundaries (seconds): {}",
+                type, percentiles, slo);
+
         return new MeterFilter() {
             @Override
             public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
                 if (id.getName().startsWith(MetricsConstants.REST_REQUESTS)) {
-                    return DistributionStatisticConfig.builder().percentiles(0.5, 0.95, 0.99, 0.9995)
-                            .serviceLevelObjectives(0.1 * factor, 0.25 * factor, 0.5 * factor, 1.0 * factor,
-                                    2.0 * factor, 5.0 * factor, 10.0 * factor)
-                            .build().merge(config);
+                    DistributionStatisticConfig.Builder builder = DistributionStatisticConfig.builder()
+                            .percentiles(percentilesArray);
+                    if ("histogram".equals(type)) {
+                        builder.serviceLevelObjectives(sloNanosArray);
+                    }
+                    return builder.build().merge(config);
                 }
                 return config;
             }
         };
     }
 
+    private static double[] toDoubleArray(List<Double> values) {
+        if (values == null || values.isEmpty()) {
+            return new double[0];
+        }
+        return values.stream().mapToDouble(Double::doubleValue).toArray();
+    }
+
+    private static double[] toSloNanosArray(List<Double> sloSeconds) {
+        if (sloSeconds == null || sloSeconds.isEmpty()) {
+            return new double[0];
+        }
+        return sloSeconds.stream()
+                .mapToDouble(s -> s * SECONDS_TO_NANOSECONDS)
+                .toArray();
+    }
 }

--- a/app/src/test/java/io/apicurio/registry/metrics/CustomMetricsConfigurationTest.java
+++ b/app/src/test/java/io/apicurio/registry/metrics/CustomMetricsConfigurationTest.java
@@ -1,0 +1,166 @@
+package io.apicurio.registry.metrics;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link CustomMetricsConfiguration}.
+ * Tests verify that the MeterFilter is correctly configured based on properties.
+ */
+class CustomMetricsConfigurationTest {
+
+    private static final double SECONDS_TO_NANOSECONDS = 1_000_000_000.0;
+    private static final double DELTA = 0.001;
+
+    @Test
+    void testDefaultHistogramMode() throws Exception {
+        CustomMetricsConfiguration config = createConfig(
+                "histogram",
+                List.of(0.5, 0.95, 0.99, 0.9995),
+                List.of(0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0)
+        );
+
+        MeterFilter filter = config.enableHistogram();
+        DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
+
+        // Verify percentiles are set
+        assertNotNull(result.getPercentiles(), "Percentiles should be set in histogram mode");
+        assertArrayEquals(
+                new double[]{0.5, 0.95, 0.99, 0.9995},
+                result.getPercentiles(),
+                DELTA,
+                "Default percentiles should match"
+        );
+
+        // Verify SLO boundaries are set (converted to nanoseconds)
+        assertNotNull(result.getServiceLevelObjectiveBoundaries(),
+                "SLO boundaries should be set in histogram mode");
+        double[] expectedSlos = {
+                0.1 * SECONDS_TO_NANOSECONDS,
+                0.25 * SECONDS_TO_NANOSECONDS,
+                0.5 * SECONDS_TO_NANOSECONDS,
+                1.0 * SECONDS_TO_NANOSECONDS,
+                2.0 * SECONDS_TO_NANOSECONDS,
+                5.0 * SECONDS_TO_NANOSECONDS,
+                10.0 * SECONDS_TO_NANOSECONDS
+        };
+        assertArrayEquals(expectedSlos, result.getServiceLevelObjectiveBoundaries(), DELTA,
+                "Default SLO boundaries should match (in nanoseconds)");
+    }
+
+    @Test
+    void testSummaryMode() throws Exception {
+        CustomMetricsConfiguration config = createConfig(
+                "summary",
+                List.of(0.5, 0.95, 0.99),
+                List.of(0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0)
+        );
+
+        MeterFilter filter = config.enableHistogram();
+        DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
+
+        // Verify percentiles are set
+        assertNotNull(result.getPercentiles(), "Percentiles should be set in summary mode");
+        assertArrayEquals(
+                new double[]{0.5, 0.95, 0.99},
+                result.getPercentiles(),
+                DELTA,
+                "Percentiles should match configured values"
+        );
+
+        // Verify SLO boundaries are NOT set in summary mode
+        assertNull(result.getServiceLevelObjectiveBoundaries(),
+                "SLO boundaries should not be set in summary mode");
+    }
+
+    @Test
+    void testCustomBucketBoundaries() throws Exception {
+        List<Double> customSlo = List.of(0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0);
+        CustomMetricsConfiguration config = createConfig(
+                "histogram",
+                List.of(0.5, 0.99),
+                customSlo
+        );
+
+        MeterFilter filter = config.enableHistogram();
+        DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
+
+        // Verify custom percentiles
+        assertArrayEquals(
+                new double[]{0.5, 0.99},
+                result.getPercentiles(),
+                DELTA,
+                "Custom percentiles should be applied"
+        );
+
+        // Verify custom SLO boundaries
+        double[] expectedSlos = customSlo.stream()
+                .mapToDouble(s -> s * SECONDS_TO_NANOSECONDS)
+                .toArray();
+        assertArrayEquals(expectedSlos, result.getServiceLevelObjectiveBoundaries(), DELTA,
+                "Custom SLO boundaries should be applied (in nanoseconds)");
+    }
+
+    @Test
+    void testNonRestMetricsUnaffected() throws Exception {
+        CustomMetricsConfiguration config = createConfig(
+                "histogram",
+                List.of(0.5, 0.95, 0.99, 0.9995),
+                List.of(0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0)
+        );
+
+        MeterFilter filter = config.enableHistogram();
+        DistributionStatisticConfig result = applyFilter(filter, "some.other.metric");
+
+        // Non-REST metrics should get the default empty config back
+        assertNull(result.getPercentiles(), "Non-REST metrics should not have percentiles set");
+        assertNull(result.getServiceLevelObjectiveBoundaries(),
+                "Non-REST metrics should not have SLO boundaries set");
+    }
+
+    @Test
+    void testDistributionTypeCaseInsensitive() throws Exception {
+        CustomMetricsConfiguration config = createConfig(
+                "SUMMARY",
+                List.of(0.5, 0.95),
+                List.of(0.1)
+        );
+
+        MeterFilter filter = config.enableHistogram();
+        DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
+
+        // Should treat "SUMMARY" same as "summary"
+        assertNull(result.getServiceLevelObjectiveBoundaries(),
+                "Summary mode should work regardless of case");
+    }
+
+    private CustomMetricsConfiguration createConfig(String distributionType,
+            List<Double> percentiles, List<Double> slo) throws Exception {
+        CustomMetricsConfiguration config = new CustomMetricsConfiguration();
+        setField(config, "distributionType", distributionType);
+        setField(config, "percentiles", percentiles);
+        setField(config, "slo", slo);
+        return config;
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private DistributionStatisticConfig applyFilter(MeterFilter filter, String metricName) {
+        Meter.Id id = new Meter.Id(metricName, io.micrometer.core.instrument.Tags.empty(),
+                null, null, Meter.Type.TIMER);
+        return filter.configure(id, DistributionStatisticConfig.NONE);
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/metrics/CustomMetricsConfigurationTest.java
+++ b/app/src/test/java/io/apicurio/registry/metrics/CustomMetricsConfigurationTest.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link CustomMetricsConfiguration}.
@@ -123,19 +125,45 @@ class CustomMetricsConfigurationTest {
     }
 
     @Test
-    void testUnknownTypeTreatedAsSummary() {
+    void testUnknownTypeThrowsException() {
         CustomMetricsConfiguration config = createConfig(
                 "foobar",
                 List.of(0.5, 0.95),
                 List.of(0.1)
         );
 
-        MeterFilter filter = config.configureDistribution();
-        DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                config::configureDistribution);
+        assertTrue(ex.getMessage().contains("foobar"));
+        assertTrue(ex.getMessage().contains("histogram, summary"));
+    }
 
-        assertNotNull(result.getPercentiles(), "Percentiles should still be set for unknown type");
-        assertNull(result.getServiceLevelObjectiveBoundaries(),
-                "Unknown type should not produce SLO boundaries (only histogram does)");
+    @Test
+    void testInvalidPercentileThrowsException() {
+        CustomMetricsConfiguration config = createConfig(
+                "histogram",
+                List.of(0.5, 95.0),
+                List.of(0.1)
+        );
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                config::configureDistribution);
+        assertTrue(ex.getMessage().contains("95.0"));
+        assertTrue(ex.getMessage().contains("0.0 and 1.0"));
+    }
+
+    @Test
+    void testNegativeSloThrowsException() {
+        CustomMetricsConfiguration config = createConfig(
+                "histogram",
+                List.of(0.5),
+                List.of(-1.0, 0.5)
+        );
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                config::configureDistribution);
+        assertTrue(ex.getMessage().contains("-1.0"));
+        assertTrue(ex.getMessage().contains("positive"));
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/metrics/CustomMetricsConfigurationTest.java
+++ b/app/src/test/java/io/apicurio/registry/metrics/CustomMetricsConfigurationTest.java
@@ -1,20 +1,20 @@
 package io.apicurio.registry.metrics;
 
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Unit tests for {@link CustomMetricsConfiguration}.
- * Tests verify that the MeterFilter is correctly configured based on properties.
  */
 class CustomMetricsConfigurationTest {
 
@@ -22,26 +22,23 @@ class CustomMetricsConfigurationTest {
     private static final double DELTA = 0.001;
 
     @Test
-    void testDefaultHistogramMode() throws Exception {
+    void testDefaultHistogramMode() {
         CustomMetricsConfiguration config = createConfig(
                 "histogram",
                 List.of(0.5, 0.95, 0.99, 0.9995),
                 List.of(0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0)
         );
 
-        MeterFilter filter = config.enableHistogram();
+        MeterFilter filter = config.configureDistribution();
         DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
 
-        // Verify percentiles are set
         assertNotNull(result.getPercentiles(), "Percentiles should be set in histogram mode");
         assertArrayEquals(
                 new double[]{0.5, 0.95, 0.99, 0.9995},
                 result.getPercentiles(),
-                DELTA,
-                "Default percentiles should match"
+                DELTA
         );
 
-        // Verify SLO boundaries are set (converted to nanoseconds)
         assertNotNull(result.getServiceLevelObjectiveBoundaries(),
                 "SLO boundaries should be set in histogram mode");
         double[] expectedSlos = {
@@ -53,37 +50,29 @@ class CustomMetricsConfigurationTest {
                 5.0 * SECONDS_TO_NANOSECONDS,
                 10.0 * SECONDS_TO_NANOSECONDS
         };
-        assertArrayEquals(expectedSlos, result.getServiceLevelObjectiveBoundaries(), DELTA,
-                "Default SLO boundaries should match (in nanoseconds)");
+        assertArrayEquals(expectedSlos, result.getServiceLevelObjectiveBoundaries(), DELTA);
     }
 
     @Test
-    void testSummaryMode() throws Exception {
+    void testSummaryMode() {
         CustomMetricsConfiguration config = createConfig(
                 "summary",
                 List.of(0.5, 0.95, 0.99),
                 List.of(0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0)
         );
 
-        MeterFilter filter = config.enableHistogram();
+        MeterFilter filter = config.configureDistribution();
         DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
 
-        // Verify percentiles are set
         assertNotNull(result.getPercentiles(), "Percentiles should be set in summary mode");
-        assertArrayEquals(
-                new double[]{0.5, 0.95, 0.99},
-                result.getPercentiles(),
-                DELTA,
-                "Percentiles should match configured values"
-        );
+        assertArrayEquals(new double[]{0.5, 0.95, 0.99}, result.getPercentiles(), DELTA);
 
-        // Verify SLO boundaries are NOT set in summary mode
         assertNull(result.getServiceLevelObjectiveBoundaries(),
                 "SLO boundaries should not be set in summary mode");
     }
 
     @Test
-    void testCustomBucketBoundaries() throws Exception {
+    void testCustomBucketBoundaries() {
         List<Double> customSlo = List.of(0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0);
         CustomMetricsConfiguration config = createConfig(
                 "histogram",
@@ -91,76 +80,107 @@ class CustomMetricsConfigurationTest {
                 customSlo
         );
 
-        MeterFilter filter = config.enableHistogram();
+        MeterFilter filter = config.configureDistribution();
         DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
 
-        // Verify custom percentiles
-        assertArrayEquals(
-                new double[]{0.5, 0.99},
-                result.getPercentiles(),
-                DELTA,
-                "Custom percentiles should be applied"
-        );
+        assertArrayEquals(new double[]{0.5, 0.99}, result.getPercentiles(), DELTA);
 
-        // Verify custom SLO boundaries
         double[] expectedSlos = customSlo.stream()
                 .mapToDouble(s -> s * SECONDS_TO_NANOSECONDS)
                 .toArray();
-        assertArrayEquals(expectedSlos, result.getServiceLevelObjectiveBoundaries(), DELTA,
-                "Custom SLO boundaries should be applied (in nanoseconds)");
+        assertArrayEquals(expectedSlos, result.getServiceLevelObjectiveBoundaries(), DELTA);
     }
 
     @Test
-    void testNonRestMetricsUnaffected() throws Exception {
+    void testNonRestMetricsUnaffected() {
         CustomMetricsConfiguration config = createConfig(
                 "histogram",
                 List.of(0.5, 0.95, 0.99, 0.9995),
                 List.of(0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0)
         );
 
-        MeterFilter filter = config.enableHistogram();
+        MeterFilter filter = config.configureDistribution();
         DistributionStatisticConfig result = applyFilter(filter, "some.other.metric");
 
-        // Non-REST metrics should get the default empty config back
         assertNull(result.getPercentiles(), "Non-REST metrics should not have percentiles set");
         assertNull(result.getServiceLevelObjectiveBoundaries(),
                 "Non-REST metrics should not have SLO boundaries set");
     }
 
     @Test
-    void testDistributionTypeCaseInsensitive() throws Exception {
+    void testDistributionTypeCaseInsensitive() {
         CustomMetricsConfiguration config = createConfig(
                 "SUMMARY",
                 List.of(0.5, 0.95),
                 List.of(0.1)
         );
 
-        MeterFilter filter = config.enableHistogram();
+        MeterFilter filter = config.configureDistribution();
         DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
 
-        // Should treat "SUMMARY" same as "summary"
         assertNull(result.getServiceLevelObjectiveBoundaries(),
                 "Summary mode should work regardless of case");
     }
 
+    @Test
+    void testUnknownTypeTreatedAsSummary() {
+        CustomMetricsConfiguration config = createConfig(
+                "foobar",
+                List.of(0.5, 0.95),
+                List.of(0.1)
+        );
+
+        MeterFilter filter = config.configureDistribution();
+        DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
+
+        assertNotNull(result.getPercentiles(), "Percentiles should still be set for unknown type");
+        assertNull(result.getServiceLevelObjectiveBoundaries(),
+                "Unknown type should not produce SLO boundaries (only histogram does)");
+    }
+
+    @Test
+    void testEmptyPercentiles() {
+        CustomMetricsConfiguration config = createConfig(
+                "histogram",
+                List.of(),
+                List.of(0.1, 0.5, 1.0)
+        );
+
+        MeterFilter filter = config.configureDistribution();
+        DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
+
+        assertEquals(0, result.getPercentiles().length, "Empty percentiles should produce empty array");
+        assertNotNull(result.getServiceLevelObjectiveBoundaries(),
+                "SLO boundaries should still be set");
+    }
+
+    @Test
+    void testEmptySlo() {
+        CustomMetricsConfiguration config = createConfig(
+                "histogram",
+                List.of(0.5, 0.95),
+                List.of()
+        );
+
+        MeterFilter filter = config.configureDistribution();
+        DistributionStatisticConfig result = applyFilter(filter, MetricsConstants.REST_REQUESTS);
+
+        assertNotNull(result.getPercentiles(), "Percentiles should still be set");
+        assertEquals(0, result.getServiceLevelObjectiveBoundaries().length,
+                "Empty SLO should produce empty array");
+    }
+
     private CustomMetricsConfiguration createConfig(String distributionType,
-            List<Double> percentiles, List<Double> slo) throws Exception {
+            List<Double> percentiles, List<Double> slo) {
         CustomMetricsConfiguration config = new CustomMetricsConfiguration();
-        setField(config, "distributionType", distributionType);
-        setField(config, "percentiles", percentiles);
-        setField(config, "slo", slo);
+        config.distributionType = distributionType;
+        config.percentiles = percentiles;
+        config.slo = slo;
         return config;
     }
 
-    private void setField(Object target, String fieldName, Object value) throws Exception {
-        Field field = target.getClass().getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(target, value);
-    }
-
     private DistributionStatisticConfig applyFilter(MeterFilter filter, String metricName) {
-        Meter.Id id = new Meter.Id(metricName, io.micrometer.core.instrument.Tags.empty(),
-                null, null, Meter.Type.TIMER);
+        Meter.Id id = new Meter.Id(metricName, Tags.empty(), null, null, Meter.Type.TIMER);
         return filter.configure(id, DistributionStatisticConfig.NONE);
     }
 }

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -816,6 +816,24 @@ The following {registry} configuration options are available for each component 
 |Default
 |Available from
 |Description
+|`apicurio.metrics.rest.distribution.percentiles`
+|`list<double>`
+|`0.5,0.95,0.99,0.9995`
+|`3.3.1`
+|        Comma-separated list of percentile values to pre-compute         for REST API request metrics.         Each value must be between 0.0 and 1.0 (e.g. 0.5 for the median,         0.95 for the 95th percentile).         These percentiles are computed client-side and exported as individual gauge metrics.
+
+|`apicurio.metrics.rest.distribution.slo`
+|`list<double>`
+|`0.1,0.25,0.5,1.0,2.0,5.0,10.0`
+|`3.3.1`
+|        Comma-separated list of service level objective (SLO) boundary values         in seconds for REST API request histogram buckets.         Only used when the distribution type is `histogram`.         Each value defines a histogram bucket boundary.         Adjust these boundaries to match your monitoring system's expectations         for accurate percentile computation from histogram data.
+
+|`apicurio.metrics.rest.distribution.type`
+|`string`
+|`histogram`
+|`3.3.1`
+|        The distribution type for REST API request metrics.         Use `histogram` (default) for explicit bucket histogram with SLO boundaries         and pre-computed percentiles.         Use `summary` for pre-computed percentiles only, without histogram buckets.         Datadog users should use `summary` for accurate latency percentiles,         since Datadog re-computes percentiles from histogram buckets         and the default bucket boundaries may not provide sufficient granularity.
+
 |`apicurio.metrics.rest.enabled`
 |`boolean`
 |`true`


### PR DESCRIPTION
## Summary

- Makes REST metrics distribution type configurable for Datadog compatibility
- Adds 3 new config properties: `apicurio.metrics.rest.distribution.type`, `.percentiles`, `.slo`
- Default behavior unchanged (histogram with existing percentiles and SLO boundaries)
- Summary mode disables histogram buckets, exporting only pre-computed percentiles (recommended for Datadog)

## Related Issues

- Closes #8152 (Metrics distribution fix for Datadog)
- Part of EPIC #8211 (Production Observability)

## Changes

| File | Change |
|------|--------|
| `CustomMetricsConfiguration.java` | 3 `@ConfigProperty` + `@Info` fields, conditional SLO boundaries |
| `CustomMetricsConfigurationTest.java` | 8 unit tests: default histogram, summary mode, custom boundaries, edge cases |

## Configuration

```properties
# Default (unchanged behavior)
apicurio.metrics.rest.distribution.type=histogram

# For Datadog — export pre-computed percentiles only
apicurio.metrics.rest.distribution.type=summary
```

## Test plan

- [ ] All 8 CustomMetricsConfiguration tests pass
- [ ] Default histogram behavior preserved
- [ ] Summary mode works for Datadog use case
- [ ] Checkstyle passes