### PR TITLE
test(converter): add regression tests for Debezium logical type annotations (#8510)

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/converters/RegistryConverterIT.java
@@ -133,6 +133,63 @@ public class RegistryConverterIT extends ApicurioRegistryBaseIT {
     }
 
     @Test
+    public void testAvroConverterDebeziumLogicalTypes() throws Exception {
+        try (AvroConverter<Record> converter = new AvroConverter<>()) {
+
+            Map<String, Object> config = new HashMap<>();
+            config.put(SerdeConfig.REGISTRY_URL, getRegistryV3ApiUrl());
+            config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
+            converter.configure(config, false);
+
+            org.apache.kafka.connect.data.Schema dateSchema = org.apache.kafka.connect.data.SchemaBuilder
+                    .int32().name("io.debezium.time.Date").version(1).build();
+
+            org.apache.kafka.connect.data.Schema sc = struct()
+                    .name("dbserver1.inventory.orders.Value")
+                    .field("order_number", INT32_SCHEMA)
+                    .field("order_date", dateSchema)
+                    .field("customer_id", INT32_SCHEMA)
+                    .field("quantity", INT32_SCHEMA)
+                    .field("price", org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA)
+                    .build();
+
+            Struct struct = new Struct(sc);
+            struct.put("order_number", 10045);
+            struct.put("order_date", 19443);
+            struct.put("customer_id", 1001);
+            struct.put("quantity", 5);
+            struct.put("price", 29.99);
+
+            String subject = "subj_" + TestUtils.generateArtifactId().replace("-", "_");
+
+            byte[] bytes = converter.fromConnectData(subject, sc, struct);
+
+            TestUtils.waitForSchema(contentId -> {
+                try {
+                    return registryClient.ids().contentIds().byContentId(contentId.longValue()).get()
+                            .readAllBytes().length > 0;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }, bytes);
+
+            Struct result = (Struct) converter.toConnectData(subject, bytes).value();
+
+            Assertions.assertNotNull(result, "Deserialized struct must not be null");
+            Assertions.assertEquals(10045, result.get("order_number"));
+            Assertions.assertEquals(19443, result.get("order_date"),
+                    "order_date with connect.name=io.debezium.time.Date must not be null");
+            Assertions.assertEquals(1001, result.get("customer_id"));
+            Assertions.assertEquals(5, result.get("quantity"));
+            Assertions.assertEquals(29.99, result.get("price"));
+
+            Assertions.assertEquals("io.debezium.time.Date",
+                    result.schema().field("order_date").schema().name(),
+                    "Connect schema must preserve connect.name after registry round-trip");
+        }
+    }
+
+    @Test
     public void testAvroBytesDefaultValue() throws Exception {
         String expectedSchema = "{\n" + "  \"type\" : \"record\",\n" + "  \"name\" : \"ConnectDefault\",\n"
                 + "  \"namespace\" : \"io.confluent.connect.avro\",\n" + "  \"fields\" : [ {\n"

--- a/utils/converter/src/test/java/io/apicurio/registry/utils/converter/avro/AvroDataTest.java
+++ b/utils/converter/src/test/java/io/apicurio/registry/utils/converter/avro/AvroDataTest.java
@@ -8,6 +8,7 @@ import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +16,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -287,6 +289,178 @@ public class AvroDataTest {
             }
         }
         return schema;
+    }
+
+    @Test
+    void testDebeziumDateFieldRoundTrip() {
+        AvroData avroData = new AvroData(10);
+
+        Schema connectSchema = SchemaBuilder.struct()
+                .name("dbserver1.inventory.orders.Value")
+                .field("order_number", Schema.INT32_SCHEMA)
+                .field("order_date", SchemaBuilder.int32()
+                        .name("io.debezium.time.Date")
+                        .version(1)
+                        .build())
+                .field("customer_id", Schema.INT32_SCHEMA)
+                .build();
+
+        Struct input = new Struct(connectSchema)
+                .put("order_number", 10001)
+                .put("order_date", 19443)
+                .put("customer_id", 42);
+
+        Object avroValue = avroData.fromConnectData(connectSchema, input);
+        assertNotNull(avroValue, "fromConnectData must not return null");
+
+        org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(connectSchema);
+        SchemaAndValue result = avroData.toConnectData(avroSchema, avroValue);
+
+        assertNotNull(result, "toConnectData must not return null");
+        Struct output = (Struct) result.value();
+        assertEquals(10001, output.get("order_number"));
+        assertEquals(19443, output.get("order_date"),
+                "order_date with connect.name annotation must not be null");
+        assertEquals(42, output.get("customer_id"));
+    }
+
+    @Test
+    void testDebeziumDateInNullableUnion() {
+        String schemaJson = "{"
+                + "\"type\":\"record\","
+                + "\"name\":\"Value\","
+                + "\"namespace\":\"dbserver1.inventory.orders\","
+                + "\"fields\":["
+                + "  {\"name\":\"order_number\",\"type\":\"int\"},"
+                + "  {\"name\":\"order_date\",\"type\":[\"null\","
+                + "    {\"type\":\"int\",\"connect.version\":1,"
+                + "     \"connect.name\":\"io.debezium.time.Date\"}]},"
+                + "  {\"name\":\"customer_id\",\"type\":\"int\"}"
+                + "]}";
+
+        org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(schemaJson);
+        GenericRecord record = new GenericRecordBuilder(avroSchema)
+                .set("order_number", 10001)
+                .set("order_date", 19443)
+                .set("customer_id", 42)
+                .build();
+
+        AvroData avroData = new AvroData(10);
+        SchemaAndValue result = avroData.toConnectData(avroSchema, record);
+
+        assertNotNull(result);
+        Struct output = (Struct) result.value();
+        assertEquals(19443, output.get("order_date"),
+                "Nullable order_date with connect.name must not be null when value is set");
+        assertEquals(10001, output.get("order_number"));
+        assertEquals(42, output.get("customer_id"));
+    }
+
+    @Test
+    void testMixedPlainAndAnnotatedIntFieldsRoundTrip() {
+        AvroData avroData = new AvroData(10);
+
+        Schema connectSchema = SchemaBuilder.struct()
+                .name("dbserver1.inventory.orders.Value")
+                .field("order_number", Schema.INT32_SCHEMA)
+                .field("order_date", SchemaBuilder.int32()
+                        .name("io.debezium.time.Date")
+                        .version(1)
+                        .build())
+                .field("customer_id", Schema.INT32_SCHEMA)
+                .field("quantity", Schema.INT32_SCHEMA)
+                .field("price", Schema.FLOAT64_SCHEMA)
+                .build();
+
+        Struct input = new Struct(connectSchema)
+                .put("order_number", 10001)
+                .put("order_date", 19443)
+                .put("customer_id", 42)
+                .put("quantity", 5)
+                .put("price", 99.99);
+
+        Object avroValue = avroData.fromConnectData(connectSchema, input);
+        org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(connectSchema);
+        SchemaAndValue result = avroData.toConnectData(avroSchema, avroValue);
+
+        assertNotNull(result);
+        Struct output = (Struct) result.value();
+        assertEquals(10001, output.get("order_number"));
+        assertEquals(19443, output.get("order_date"),
+                "order_date with connect.name must preserve value");
+        assertEquals(42, output.get("customer_id"));
+        assertEquals(5, output.get("quantity"));
+        assertEquals(99.99, output.get("price"));
+    }
+
+    @Test
+    void testDebeziumSchemaParsePreservesConnectProps() {
+        String schemaJson = "{"
+                + "\"type\":\"record\","
+                + "\"name\":\"Value\","
+                + "\"namespace\":\"dbserver1.inventory.orders\","
+                + "\"fields\":["
+                + "  {\"name\":\"order_number\",\"type\":\"int\"},"
+                + "  {\"name\":\"order_date\",\"type\":{\"type\":\"int\","
+                + "    \"connect.version\":1,"
+                + "    \"connect.name\":\"io.debezium.time.Date\"}},"
+                + "  {\"name\":\"customer_id\",\"type\":\"int\"}"
+                + "]}";
+
+        org.apache.avro.Schema original = new org.apache.avro.Schema.Parser().parse(schemaJson);
+        String serialized = original.toString();
+        org.apache.avro.Schema reparsed = new org.apache.avro.Schema.Parser().parse(serialized);
+
+        org.apache.avro.Schema orderDateType = reparsed.getField("order_date").schema();
+        assertEquals("io.debezium.time.Date", orderDateType.getProp("connect.name"),
+                "connect.name must survive schema round-trip through toString/parse");
+        assertNotNull(orderDateType.getObjectProp("connect.version"),
+                "connect.version must survive schema round-trip through toString/parse");
+    }
+
+    @Test
+    void testToConnectDataFromReParsedDebeziumSchema() {
+        String schemaJson = "{"
+                + "\"type\":\"record\","
+                + "\"name\":\"Value\","
+                + "\"namespace\":\"dbserver1.inventory.orders\","
+                + "\"fields\":["
+                + "  {\"name\":\"order_number\",\"type\":\"int\"},"
+                + "  {\"name\":\"order_date\",\"type\":{\"type\":\"int\","
+                + "    \"connect.version\":1,"
+                + "    \"connect.name\":\"io.debezium.time.Date\"}},"
+                + "  {\"name\":\"customer_id\",\"type\":\"int\"},"
+                + "  {\"name\":\"quantity\",\"type\":\"int\"},"
+                + "  {\"name\":\"price\",\"type\":\"double\"}"
+                + "]}";
+
+        org.apache.avro.Schema original = new org.apache.avro.Schema.Parser().parse(schemaJson);
+        String serialized = original.toString();
+        org.apache.avro.Schema reparsed = new org.apache.avro.Schema.Parser().parse(serialized);
+
+        GenericRecord record = new GenericRecordBuilder(reparsed)
+                .set("order_number", 10001)
+                .set("order_date", 19443)
+                .set("customer_id", 42)
+                .set("quantity", 5)
+                .set("price", 99.99)
+                .build();
+
+        AvroData avroData = new AvroData(10);
+        SchemaAndValue result = avroData.toConnectData(reparsed, record);
+
+        assertNotNull(result);
+        Struct output = (Struct) result.value();
+        assertEquals(10001, output.get("order_number"));
+        assertEquals(19443, output.get("order_date"),
+                "order_date must not be null after schema re-parse (simulating registry round-trip)");
+        assertEquals(42, output.get("customer_id"));
+        assertEquals(5, output.get("quantity"));
+        assertEquals(99.99, output.get("price"));
+
+        assertEquals("io.debezium.time.Date",
+                result.schema().field("order_date").schema().name(),
+                "Connect schema must preserve connect.name from re-parsed Avro schema");
     }
 
     @Test


### PR DESCRIPTION
## Summary
Add comprehensive test coverage for Avro fields with Debezium/Connect logical type annotations (`connect.name`, `connect.version`). Relates to #8510.

## Root Cause
Issue #8510 reports that the `AvroConverter` returns `null` when deserializing Avro fields annotated with Debezium Connect logical types (e.g., `io.debezium.time.Date`), causing `NullPointerException` in downstream consumers like the Iceberg sink connector.

After extensive code analysis, the `AvroData` conversion logic correctly handles these annotations in isolation — including round-trips through `fromConnectData()` → `toConnectData()`, nullable unions, schema re-parsing (simulating registry storage/retrieval), and caching. The bug likely manifests under specific end-to-end pipeline conditions involving schema evolution or configuration. These tests serve as regression protection for all the code paths involved.

## Changes
- `utils/converter/src/test/java/.../avro/AvroDataTest.java` — 5 new unit tests:
  - `testDebeziumDateFieldRoundTrip`: full `fromConnectData` → `toConnectData` round-trip with `io.debezium.time.Date` INT32 field
  - `testDebeziumDateInNullableUnion`: nullable union `["null", {"type":"int","connect.name":"io.debezium.time.Date"}]` with non-null value
  - `testMixedPlainAndAnnotatedIntFieldsRoundTrip`: exact schema from the issue with mixed plain/annotated fields
  - `testDebeziumSchemaParsePreservesConnectProps`: verifies `connect.*` props survive `toString()` → `parse()` round-trip
  - `testToConnectDataFromReParsedDebeziumSchema`: deserialization from re-parsed schema (simulates registry round-trip)
- `integration-tests/src/test/java/.../converters/RegistryConverterIT.java` — 1 new integration test:
  - `testAvroConverterDebeziumLogicalTypes`: full `AvroConverter` serialize → registry store → deserialize round-trip with Debezium Date logical type

## Test plan
- [x] 5 unit tests added to `AvroDataTest` — all pass (16/16 total)
- [x] Checkstyle passes with 0 violations
- [x] 1 integration test added to `RegistryConverterIT` — requires running registry (`./mvnw verify -pl integration-tests -Plocal-tests`)
- [ ] Integration test validation against live registry instance