### PR TITLE
fix(iceberg): treat null and -1 as equivalent for snapshot-id assertions

### DIFF
--- a/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/commit/TableRequirementValidator.java
+++ b/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/commit/TableRequirementValidator.java
@@ -105,7 +105,7 @@ public final class TableRequirementValidator {
 
         if ("main".equals(refName)) {
             Long actualSnapshotId = toLong(currentMetadata.get("current-snapshot-id"));
-            if (!equalsLong(expectedSnapshotId, actualSnapshotId)) {
+            if (!equalsSnapshotId(expectedSnapshotId, actualSnapshotId)) {
                 throw new CommitFailedException(groupId, artifactId,
                         "Requirement failed: assert-ref-snapshot-id for ref 'main' - expected "
                                 + expectedSnapshotId + " but was " + actualSnapshotId);
@@ -175,6 +175,14 @@ public final class TableRequirementValidator {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Expected a numeric value but got: " + value, e);
         }
+    }
+
+    private static boolean equalsSnapshotId(Long a, Long b) {
+        return equalsLong(normalizeSnapshotId(a), normalizeSnapshotId(b));
+    }
+
+    private static Long normalizeSnapshotId(Long id) {
+        return (id != null && id == -1L) ? null : id;
     }
 
     private static boolean equalsLong(Long a, Long b) {

--- a/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/iceberg/v1/openapi.json
+++ b/app/src/main/resources-unfiltered/META-INF/resources/api-specifications/iceberg/v1/openapi.json
@@ -1269,19 +1269,22 @@
           "snapshots": {
             "type": "array",
             "items": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": true
             }
           },
           "snapshot-log": {
             "type": "array",
             "items": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": true
             }
           },
           "metadata-log": {
             "type": "array",
             "items": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": true
             }
           },
           "refs": {

--- a/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/commit/TableRequirementValidatorTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/iceberg/rest/v1/commit/TableRequirementValidatorTest.java
@@ -68,6 +68,29 @@ public class TableRequirementValidatorTest {
     }
 
     @Test
+    public void testAssertRefSnapshotIdMainNullExpectedWithMinusOneActual() {
+        Map<String, Object> metadata = buildMetadata();
+        metadata.put("current-snapshot-id", -1L);
+        Map<String, Object> req = new HashMap<>();
+        req.put("type", "assert-ref-snapshot-id");
+        req.put("ref", "main");
+        req.put("snapshot-id", null);
+        List<Map<String, Object>> reqs = List.of(req);
+        assertDoesNotThrow(
+                () -> TableRequirementValidator.validate(reqs, metadata, GROUP_ID, ARTIFACT_ID));
+    }
+
+    @Test
+    public void testAssertRefSnapshotIdMainMinusOneExpectedWithNullActual() {
+        Map<String, Object> metadata = buildMetadata();
+        metadata.remove("current-snapshot-id");
+        List<Map<String, Object>> reqs = List
+                .of(Map.of("type", "assert-ref-snapshot-id", "ref", "main", "snapshot-id", -1L));
+        assertDoesNotThrow(
+                () -> TableRequirementValidator.validate(reqs, metadata, GROUP_ID, ARTIFACT_ID));
+    }
+
+    @Test
     public void testAssertRefSnapshotIdMainMismatch() {
         Map<String, Object> metadata = buildMetadata();
         metadata.put("current-snapshot-id", -1L);


### PR DESCRIPTION
## Summary

Two fixes for the Iceberg REST Catalog that together enable end-to-end CDC pipelines with the Iceberg Kafka Connect sink connector.

### Fix 1: Snapshot ID assertion — null vs -1 equivalence

The Iceberg spec uses `-1` as the sentinel for `current-snapshot-id` when no snapshots exist, but clients send `null` in `assert-ref-snapshot-id` requirements. Both mean "no snapshot exists yet". Without this fix, the first `CommitTable` after table creation fails with `expected null but was -1`.

**Changes:**
- Add `equalsSnapshotId()` and `normalizeSnapshotId()` helpers in `TableRequirementValidator`
- 2 new tests covering null-vs-minus-one in both directions

### Fix 2: OpenAPI spec — snapshot serialization

The `snapshots`, `snapshot-log`, and `metadata-log` array items in the OpenAPI spec were defined as bare `type: object` without `additionalProperties: true`. The generated Java beans silently dropped all fields during deserialization, causing `LoadTable` responses to return empty snapshot objects `[{}]`. Trino then failed with `Cannot parse missing long: snapshot-id`.

**Changes:**
- Add `additionalProperties: true` to 3 array item schemas in `openapi.json`

## Context

Discovered while building a CDC-to-Iceberg demo pipeline: Debezium → Kafka (Avro via Apicurio converter) → Iceberg sink connector → Apicurio Registry (as both schema registry AND Iceberg REST catalog) → Trino.

Related issues: #8464, #8500

## Test plan

- [x] `TableRequirementValidatorTest` — all 23 tests pass (including 2 new ones)
- [x] End-to-end: Debezium CDC → Kafka → Iceberg sink → Apicurio Iceberg catalog → Trino query returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)