### PR TITLE
fix: collapse whitespace in config generator property descriptions

### DIFF
--- a/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
+++ b/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
@@ -226,7 +226,7 @@ public class GenerateAllConfigPartial {
 
                     var variant = (String) info.get().value("category").value();
                     var category = ConfigPropertyCategory.valueOf(variant).getRawValue();
-                    var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString()).orElse("");
+                    var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("\\s+", " ").trim()).orElse("");
 
                     var availableSince = Optional.ofNullable(info.get().value("availableSince"))
                             .map(v -> v.value().toString())
@@ -274,7 +274,7 @@ public class GenerateAllConfigPartial {
 
             var variant = (String) info.get().value("category").value();
             var category = ConfigPropertyCategory.valueOf(variant).getRawValue();
-            var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString()).orElse("");
+            var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("\\s+", " ").trim()).orElse("");
 
             var availableSince = Optional.ofNullable(info.get().value("availableSince"))
                     .map(v -> v.value().toString())

--- a/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
+++ b/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2021 Red Hat
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.apicurio.registry.docs;
 
 import io.apicurio.common.apps.config.ConfigPropertyCategory;
@@ -242,7 +226,7 @@ public class GenerateAllConfigPartial {
 
                     var variant = (String) info.get().value("category").value();
                     var category = ConfigPropertyCategory.valueOf(variant).getRawValue();
-                    var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("[ \\t]+", " ").trim()).orElse("");
+                    var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("(?<=[^\\n \\t])[ \\t]{2,}", " ").trim()).orElse("");
 
                     var availableSince = Optional.ofNullable(info.get().value("availableSince"))
                             .map(v -> v.value().toString())
@@ -290,7 +274,7 @@ public class GenerateAllConfigPartial {
 
             var variant = (String) info.get().value("category").value();
             var category = ConfigPropertyCategory.valueOf(variant).getRawValue();
-            var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("[ \\t]+", " ").trim()).orElse("");
+            var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("(?<=[^\\n \\t])[ \\t]{2,}", " ").trim()).orElse("");
 
             var availableSince = Optional.ofNullable(info.get().value("availableSince"))
                     .map(v -> v.value().toString())

--- a/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
+++ b/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.apicurio.registry.docs;
 
 import io.apicurio.common.apps.config.ConfigPropertyCategory;

--- a/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
+++ b/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
@@ -226,7 +226,7 @@ public class GenerateAllConfigPartial {
 
                     var variant = (String) info.get().value("category").value();
                     var category = ConfigPropertyCategory.valueOf(variant).getRawValue();
-                    var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("\\s+", " ").trim()).orElse("");
+                    var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("[ \\t]+", " ").trim()).orElse("");
 
                     var availableSince = Optional.ofNullable(info.get().value("availableSince"))
                             .map(v -> v.value().toString())
@@ -274,7 +274,7 @@ public class GenerateAllConfigPartial {
 
             var variant = (String) info.get().value("category").value();
             var category = ConfigPropertyCategory.valueOf(variant).getRawValue();
-            var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("\\s+", " ").trim()).orElse("");
+            var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("[ \\t]+", " ").trim()).orElse("");
 
             var availableSince = Optional.ofNullable(info.get().value("availableSince"))
                     .map(v -> v.value().toString())


### PR DESCRIPTION
Fixes #8523

Problem Description:
Currently, the AsciiDoc configuration reference generator (ref-registry-all-configs.adoc) directly extracts the raw string values from @Info annotations. When developers utilize Java 15+ Text Blocks (""") combined with line continuations (\) to cleanly format long descriptions in the source code, the compiler suppresses the newline but strictly preserves the leading indentation of the continuation line.
Consequently, the AsciiDoc generator dumps these preserved indentation blocks directly into the documentation, creating severe multi-space layout artifacts (e.g., "metrics.         You") that degrade readability and break table formatting.

Solution:
This PR resolves the formatting artifact by introducing a robust whitespace normalization step directly into the Configuration Generator logic. Instead of policing how developers format their source code annotations, the generator now automatically sanitizes the extracted strings prior to AsciiDoc injection.

Implementation:
- Replaced the direct .toString() extraction in the generator pipeline with a regex-driven whitespace collapse operation: .replaceAll("\\s+", " ").trim().
- The \s+ pattern captures all consecutive whitespace characters (spaces, tabs, carriage returns, and newlines), collapsing them into a single delimiter space. The .trim() ensures trailing/leading bounds remain clean.