### PR TITLE
fix(build): fix -Dlocal build dependency resolution

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -274,11 +274,6 @@
     </dependency>
     <dependency>
       <groupId>io.apicurio</groupId>
-      <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-java-sdk</artifactId>
       <scope>test</scope>
     </dependency>
@@ -295,27 +290,6 @@
     <dependency>
       <groupId>io.kiota</groupId>
       <artifactId>kiota-http-vertx</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.apicurio</groupId>
-      <artifactId>apicurio-registry-protobuf-serde-kafka</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.apicurio</groupId>
-      <artifactId>apicurio-registry-jsonschema-serde-kafka</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.apicurio</groupId>
-      <artifactId>apicurio-registry-avro-serde-pulsar</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.apicurio</groupId>
-      <artifactId>apicurio-registry-maven-plugin</artifactId>
-      <type>maven-plugin</type>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -367,12 +341,6 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>raml-test-micro-service</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -716,5 +684,53 @@
       </plugin>
     </plugins>
   </build>
+
+  <!-- Test-scoped dependencies on modules excluded from the reactor by the -Dlocal profile
+       (serdes, maven-plugin, raml-test-micro-service). Keep them out of -Dlocal builds so
+       dependency resolution succeeds even with -DskipTests; include them for non-local test runs. -->
+  <profiles>
+    <profile>
+      <id>local-excluded-test-deps</id>
+      <activation>
+        <property>
+          <name>!local</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.apicurio</groupId>
+          <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.apicurio</groupId>
+          <artifactId>apicurio-registry-protobuf-serde-kafka</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.apicurio</groupId>
+          <artifactId>apicurio-registry-jsonschema-serde-kafka</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.apicurio</groupId>
+          <artifactId>apicurio-registry-avro-serde-pulsar</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.apicurio</groupId>
+          <artifactId>apicurio-registry-maven-plugin</artifactId>
+          <type>maven-plugin</type>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>raml-test-micro-service</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION

### Summary

Fixes the README quick-start build failure when using `-Dlocal -DskipTests` on a fresh clone.

The `-Dlocal` profile excludes non-essential modules (serdes, maven-plugin, raml-test-micro-service) from the Maven reactor, but `app/pom.xml` still declared those modules as **test-scoped dependencies**. Maven resolves test dependencies even with `-DskipTests`, causing `DependencyResolutionException` before the server can be built.

This PR gates those six test dependencies behind a new Maven profile (`local-excluded-test-deps`) that only activates when `-Dlocal` is **not** set.

### Changes

- **`app/pom.xml`**: Move serdes/maven-plugin/raml-test-micro-service test dependencies into a profile activated by `!local`

### Fixes
Fixes #8522
Fresh clone → `./mvnw clean install -Dlocal -DskipTests` fails at `apicurio-registry-app` with unresolved test artifacts (as documented in README Getting started).

### Test plan

- [x] `mvn dependency:resolve -Dlocal -DskipTests -pl app` - succeeds (was failing before)
- [x] `mvn dependency:resolve -DskipTests -pl app` - succeeds (non-local builds still resolve serdes test deps)
- [x] `mvn compile -Dlocal -DskipTests -pl app -o` - succeeds