### PR TITLE
docs: fix typos in README and operator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To see additional options, visit:
 `./mvnw clean install -Pprod -DskipTests` builds the application artifact.
 The newly built runner can be found in `/app/target`
 ```
-java Dapicurio.storage.kind=kafkasql -jar apicurio-registry-app-<version>-SNAPSHOT-runner.jar
+java -Dapicurio.storage.kind=kafkasql -jar apicurio-registry-app-<version>-SNAPSHOT-runner.jar
 ```
 For using Kafka as the persistent storage for the server information the only required configuration is to set the property *apicurio.storage.kind*.
 
@@ -241,9 +241,9 @@ services:
 
 You can enable authentication for both the application REST APIs and the user interface using a server based
 on OpenID Connect (OIDC). The same server and users are federated across the user interface and the
-REST APIs using Open ID Connect so that you only require one set of credentials.
+REST APIs using OpenID Connect so that you only require one set of credentials.
 
-In order no enable this integration, you will need to set the following environment variables.
+In order to enable this integration, you will need to set the following environment variables.
 
 ### REST API Environment Variables
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -448,7 +448,7 @@ Available options:
 
 ### Watched Namespaces
 
-Namespace that are watched by the operator are configured using `APICURIO_OPERATOR_WATCHED_NAMESPACES` environment variable. Its value is configured to reflect the OLM annotation `olm.targetNamespaces` by default. This means that if the operator is not installed by OLM (e.g. using the install file), the annotation is empty, which means the operator will watch **all namespaces**. Because of this, cluster-level RBAC resources are used by default. In the future, we may release additional install file with reduced permissions, intended to be used when the operator only manages its own namespace.
+Namespaces that are watched by the operator are configured using the `APICURIO_OPERATOR_WATCHED_NAMESPACES` environment variable. Its value is configured to reflect the OLM annotation `olm.targetNamespaces` by default. This means that if the operator is not installed by OLM (e.g. using the install file), the annotation is empty, which means the operator will watch **all namespaces**. Because of this, cluster-level RBAC resources are used by default. In the future, we may release additional install file with reduced permissions, intended to be used when the operator only manages its own namespace.
 
 ### Leader Election
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -448,7 +448,7 @@ Available options:
 
 ### Watched Namespaces
 
-Namespaces that are watched by the operator are configured using the `APICURIO_OPERATOR_WATCHED_NAMESPACES` environment variable. Its value is configured to reflect the OLM annotation `olm.targetNamespaces` by default. This means that if the operator is not installed by OLM (e.g. using the install file), the annotation is empty, which means the operator will watch **all namespaces**. Because of this, cluster-level RBAC resources are used by default. In the future, we may release additional install file with reduced permissions, intended to be used when the operator only manages its own namespace.
+Namespaces that are watched by the operator are configured using the `APICURIO_OPERATOR_WATCHED_NAMESPACES` environment variable. Its value is configured to reflect the OLM annotation `olm.targetNamespaces` by default. This means that if the operator is not installed by OLM (e.g. using the install file), the annotation is empty, which means the operator will watch **all namespaces**. Because of this, cluster-level RBAC resources are used by default. In the future, we may release an additional install file with reduced permissions, intended to be used when the operator only manages its own namespace.
 
 ### Leader Election
 


### PR DESCRIPTION

### PR description:

Fixes documentation typos:
- README: missing -D flag in KafkaSQL java command
- README: "In order no enable" → "In order to enable"
- README: "Open ID Connect" → "OpenID Connect"
- operator/README: "Namespace that are" → "Namespaces that are"