### PR TITLE
fix: replace maven-dependency-plugin with resources plugin to fix MDEP-98

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -509,34 +509,7 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>unpack-openapi</id>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>apicurio-registry-common</artifactId>
-                  <version>${project.version}</version>
-                  <type>jar</type>
-                  <overWrite>true</overWrite>
-                  <includes>**/openapi.json</includes>
-                </artifactItem>
-              </artifactItems>
-              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>true</overWriteSnapshots>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
@@ -681,6 +654,27 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
+          <!-- Copy the v3 OpenAPI spec from common module to output directory.
+               This replaces the maven-dependency-plugin unpack execution which fails on mvn compile
+               due to MDEP-98 (artifact has not been packaged yet). -->
+          <execution>
+            <id>copy-openapi-from-common</id>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/../common/src/main/resources/META-INF</directory>
+                  <includes>
+                    <include>openapi.json</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
           <!-- Copy the v3 OpenAPI spec to the api-specifications path served by the Swagger UI.
                This keeps it in sync with the canonical spec in the common module. -->
           <execution>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -654,9 +654,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
-          <!-- Copy the v3 OpenAPI spec from common module to output directory.
-               This replaces the maven-dependency-plugin unpack execution which fails on mvn compile
-               due to MDEP-98 (artifact has not been packaged yet). -->
+            <!-- Copy the v3 OpenAPI spec from common module to output directory.
+                 This replaces the maven-dependency-plugin unpack execution which fails during the build
+                 (e.g., generate-resources phase) due to MDEP-98, because the sibling artifact has not been packaged into a JAR yet. -->
           <execution>
             <id>copy-openapi-from-common</id>
             <goals>
@@ -667,7 +667,7 @@
               <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.basedir}/../common/src/main/resources/META-INF</directory>
+                  <directory>${project.parent.basedir}/common/src/main/resources/META-INF</directory>
                   <includes>
                     <include>openapi.json</include>
                   </includes>
@@ -683,10 +683,9 @@
               <goal>copy-resources</goal>
             </goals>
             <phase>process-resources</phase>
-            <configuration>
-              <outputDirectory>${project.build.outputDirectory}/META-INF/resources/api-specifications/registry/v3</outputDirectory>
-              <overwrite>true</overwrite>
-              <resources>
+              <configuration>
+                <outputDirectory>${project.build.outputDirectory}/META-INF/resources/api-specifications/registry/v3</outputDirectory>
+                <resources>
                 <resource>
                   <directory>${project.build.outputDirectory}/META-INF</directory>
                   <includes>
@@ -702,10 +701,9 @@
               <goal>copy-resources</goal>
             </goals>
             <phase>prepare-package</phase>
-            <configuration>
-              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-              <overwrite>true</overwrite>
-              <resources>
+              <configuration>
+                <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                <resources>
                 <resource>
                   <directory>${project.basedir}/target/generated-test-sources/protobuf/</directory>
                   <filtering>false</filtering>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -685,6 +685,7 @@
             <phase>process-resources</phase>
             <configuration>
               <outputDirectory>${project.build.outputDirectory}/META-INF/resources/api-specifications/registry/v3</outputDirectory>
+              <overwrite>true</overwrite>
               <resources>
                 <resource>
                   <directory>${project.build.outputDirectory}/META-INF</directory>
@@ -703,6 +704,7 @@
             <phase>prepare-package</phase>
             <configuration>
               <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <overwrite>true</overwrite>
               <resources>
                 <resource>
                   <directory>${project.basedir}/target/generated-test-sources/protobuf/</directory>

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -364,7 +364,7 @@ The following {registry} configuration options are available for each component 
 |`boolean`
 |`true`
 |`3.2.0`
-|Provide higher quality ETags if possible, but they might be more expensive to compute. This feature trades more computation for potentially higher cacheability of some operations. 
+|Provide higher quality ETags if possible, but they might be more expensive to compute. This feature trades more computation for potentially higher cacheability of some operations.
 |`apicurio.http-caching.low-cacheability.max-age-seconds`
 |`long`
 |`10`
@@ -630,17 +630,17 @@ The following {registry} configuration options are available for each component 
 |`boolean`
 |`true`
 |`3.0.0`
-|When set to true, content IDs from the import file will be used (otherwise new IDs will be generated).  Defaults to 'true'.
+|When set to true, content IDs from the import file will be used (otherwise new IDs will be generated). Defaults to 'true'.
 |`apicurio.import.preserveGlobalId`
 |`boolean`
 |`true`
 |`3.0.0`
-|When set to true, global IDs from the import file will be used (otherwise new IDs will be generated).  Defaults to 'true'.
+|When set to true, global IDs from the import file will be used (otherwise new IDs will be generated). Defaults to 'true'.
 |`apicurio.import.requireEmptyRegistry`
 |`boolean`
 |`true`
 |`3.0.0`
-|When set to true, importing data will only work when the registry is empty.  Defaults to 'true'.
+|When set to true, importing data will only work when the registry is empty. Defaults to 'true'.
 |`apicurio.import.url`
 |`optional<url>`
 |
@@ -820,55 +820,48 @@ The following {registry} configuration options are available for each component 
 |`list<double>`
 |`0.5,0.95,0.99,0.9995`
 |`3.3.1`
-|        Comma-separated list of percentile values to pre-compute         for REST API request metrics.         Each value must be between 0.0 and 1.0 (e.g. 0.5 for the median,         0.95 for the 95th percentile).         These percentiles are computed client-side and exported as individual gauge metrics.
-
+|Comma-separated list of percentile values to pre-compute for REST API request metrics. Each value must be between 0.0 and 1.0 (e.g. 0.5 for the median, 0.95 for the 95th percentile). These percentiles are computed client-side and exported as individual gauge metrics.
 |`apicurio.metrics.rest.distribution.slo`
 |`list<double>`
 |`0.1,0.25,0.5,1.0,2.0,5.0,10.0`
 |`3.3.1`
-|        Comma-separated list of service level objective (SLO) boundary values         in seconds for REST API request histogram buckets.         Only used when the distribution type is `histogram`.         Each value defines a histogram bucket boundary.         Adjust these boundaries to match your monitoring system's expectations         for accurate percentile computation from histogram data.
-
+|Comma-separated list of service level objective (SLO) boundary values in seconds for REST API request histogram buckets. Only used when the distribution type is `histogram`. Each value defines a histogram bucket boundary. Adjust these boundaries to match your monitoring system's expectations for accurate percentile computation from histogram data.
 |`apicurio.metrics.rest.distribution.type`
 |`string`
 |`histogram`
 |`3.3.1`
-|        The distribution type for REST API request metrics.         Use `histogram` (default) for explicit bucket histogram with SLO boundaries         and pre-computed percentiles.         Use `summary` for pre-computed percentiles only, without histogram buckets.         Datadog users should use `summary` for accurate latency percentiles,         since Datadog re-computes percentiles from histogram buckets         and the default bucket boundaries may not provide sufficient granularity.
-
+|The distribution type for REST API request metrics. Use `histogram` (default) for explicit bucket histogram with SLO boundaries and pre-computed percentiles. Use `summary` for pre-computed percentiles only, without histogram buckets. Datadog users should use `summary` for accurate latency percentiles, since Datadog re-computes percentiles from histogram buckets and the default bucket boundaries may not provide sufficient granularity.
 |`apicurio.metrics.rest.enabled`
 |`boolean`
 |`true`
 |`3.1.1`
-|        Enable collecting metrics about REST API requests.
-
+|Enable collecting metrics about REST API requests.
 |`apicurio.metrics.rest.explicit-status-codes-list`
 |`list<string>`
 |`401`
 |`3.1.1`
-|        Only the general category of the HTTP status code is added as a tag/label on REST API request metrics,
-        e.g. `1xx`, `2xx`, ...         If you are interested in metrics for a specific status code, e.g. 401 for authentication errors,
-        this property allows you to specify a list of such codes.         Each request will be counted only once, i.e. either as the specific status code or in the general category. 
+|Only the general category of the HTTP status code is added as a tag/label on REST API request metrics,
+        e.g. `1xx`, `2xx`, ... If you are interested in metrics for a specific status code, e.g. 401 for authentication errors,
+        this property allows you to specify a list of such codes. Each request will be counted only once, i.e. either as the specific status code or in the general category.
 |`apicurio.metrics.rest.method-tag-enabled`
 |`boolean`
 |`true`
 |`3.1.1`
-|        Add the HTTP method tag/label on REST API request metrics.         You might disable this tag to reduce metrics cardinality.
-
+|Add the HTTP method tag/label on REST API request metrics. You might disable this tag to reduce metrics cardinality.
 |`apicurio.metrics.rest.path-filter-pattern`
 |`string`
 |`/apis/.*`
 |`3.1.1`
-|        Only requests with a path matching this pattern (Java syntax) will be considered for metrics collection.         The pattern is applied to the request path only,
+|Only requests with a path matching this pattern (Java syntax) will be considered for metrics collection. The pattern is applied to the request path only,
         e.g. `curl 'http://localhost:8080/apis/registry/v3/groups/default/artifacts?offset=42&limit=10'`
         will be matched against `/apis/registry/v3/groups/default/artifacts`.
-
 |`apicurio.metrics.rest.path-tag-enabled`
 |`boolean`
 |`true`
 |`3.1.1`
-|        Add the unsubstituted path tag/label on REST API request metrics,
-        e.g. `/apis/registry/v3/groups/{groupId}/artifacts/{artifactId}`.         You might disable this tag to reduce metrics cardinality.         When an unsubstituted REST API resource path could not be determined,
+|Add the unsubstituted path tag/label on REST API request metrics,
+        e.g. `/apis/registry/v3/groups/{groupId}/artifacts/{artifactId}`. You might disable this tag to reduce metrics cardinality. When an unsubstituted REST API resource path could not be determined,
         the tag value will be `(unspecified)`.
-
 |`quarkus.otel.enabled`
 |`boolean`
 |`true`


### PR DESCRIPTION
Fixes: #8431 

This PR resolves a build failure triggered by MDEP-98, a long-standing issue in the maven-dependency-plugin.

When developers run early-phase lifecycle commands for fast feedback loops (such as mvn generate-resources or mvn compile) on this multi-module project, the build fails. The maven-dependency-plugin attempts to unpack an artifact from the common sibling module, but because the build hasn't reached the package phase yet, the actual .jar file does not exist in the reactor. This strict reactor resolution failure is prevalent across Maven 3.x and continues to be an issue in Maven 4.x.

Fix: By switching from the maven-dependency-plugin (which requires a packaged artifact) to the maven-resources-plugin (which copies directly from the source directory), we completely bypass MDEP-98. This restores the ability for developers to run fast mvn compile loops without requiring a full mvn package execution, while maintaining identical output paths.