### PR TITLE
docs(ui): add Windows init scripts for UI dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ init-dev.cmd
 npm run dev
 ```
 
-The init scripts copy `configs/version.js` and `configs/config-local.js` into place (required for dev mode).
-You can pass a config type as an argument, e.g. `./init-dev.sh 3scale` or `.\init-dev.ps1 3scale`.
+The init scripts copy `configs/version.js` and `configs/config-<type>.js` into place (required for dev mode).
+By default `<type>` is `local`; you can pass a config type as an argument, e.g. `./init-dev.sh 3scale`, `.\init-dev.ps1 3scale`, or `init-dev.cmd 3scale`.
 
 This will start up the UI in development mode, hosted on port 8888 of your localhost:
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This should result in Quarkus and the in-memory registry starting up, with the R
 
 ### Getting started (UI)
 
+**Linux / macOS / Git Bash:**
 ```
 cd ui
 npm install
@@ -76,6 +77,27 @@ cd ui-app
 ./init-dev.sh
 npm run dev
 ```
+
+**Windows (PowerShell):**
+```
+cd ui
+npm install
+cd ui-app
+.\init-dev.ps1
+npm run dev
+```
+
+**Windows (Command Prompt):**
+```
+cd ui
+npm install
+cd ui-app
+init-dev.cmd
+npm run dev
+```
+
+The init scripts copy `configs/version.js` and `configs/config-local.js` into place (required for dev mode).
+You can pass a config type as an argument, e.g. `./init-dev.sh 3scale` or `.\init-dev.ps1 3scale`.
 
 This will start up the UI in development mode, hosted on port 8888 of your localhost:
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -92,8 +92,9 @@ If you would like to contribute code changes to the UI, you will want to run the
 in DEV mode.
 
 **Warning**: For the dev version of the UI to work, you will need two files that are not checked into
-version control:  `config.js` and `version.js`.  To ensure you have these files, run the `init-dev.sh`
-script from the `ui-app` directory.  For more details see [ui-app/README.md](ui-app/README.md).
+version control:  `config.js` and `version.js`.  To ensure you have these files, run an init script from
+the `ui-app` directory (`init-dev.sh`, `init-dev.ps1`, or `init-dev.cmd`).  For more details see
+[ui-app/README.md](ui-app/README.md).
 
 ```
 npm run dev

--- a/ui/ui-app/README.md
+++ b/ui/ui-app/README.md
@@ -15,10 +15,13 @@ Run a full build
 `npm run build`
 
 Initialize config.js
-`./init-dev.sh`
 
-Note: the init-dev.sh script just copies an appropriate file from config/config-*.js to the right place.  You can 
-either specify `local` or `3scale` (for example) as the argument to the script.  The choice depends on how you are 
+* Linux / macOS / Git Bash: `./init-dev.sh`
+* Windows PowerShell: `.\init-dev.ps1`
+* Windows Command Prompt: `init-dev.cmd`
+
+Note: the init scripts copy `configs/version.js` and an appropriate `configs/config-*.js` file into place.  You can
+specify `local` or `3scale` (for example) as an argument to the script.  The choice depends on how you are
 running the back-end component.
 
 Start the development server

--- a/ui/ui-app/init-dev.cmd
+++ b/ui/ui-app/init-dev.cmd
@@ -8,7 +8,7 @@ echo ----
 echo Initializing development environment for UI-only development.
 echo ----
 
-copy /Y configs\version.js version.js >nul
-copy /Y configs\config-%CONFIG_TYPE%.js config.js >nul
+copy /Y "configs\version.js" "version.js" >nul || (echo Failed to copy configs\version.js to version.js & exit /b 1)
+copy /Y "configs\config-%CONFIG_TYPE%.js" "config.js" >nul || (echo Failed to copy configs\config-%CONFIG_TYPE%.js to config.js & exit /b 1)
 
 echo Done.  Try:  'npm run dev'

--- a/ui/ui-app/init-dev.cmd
+++ b/ui/ui-app/init-dev.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal
+
+set CONFIG_TYPE=local
+if not "%~1"=="" set CONFIG_TYPE=%~1
+
+echo ----
+echo Initializing development environment for UI-only development.
+echo ----
+
+copy /Y configs\version.js version.js >nul
+copy /Y configs\config-%CONFIG_TYPE%.js config.js >nul
+
+echo Done.  Try:  'npm run dev'

--- a/ui/ui-app/init-dev.ps1
+++ b/ui/ui-app/init-dev.ps1
@@ -1,0 +1,12 @@
+param(
+    [string]$ConfigType = "local"
+)
+
+Write-Host "----"
+Write-Host "Initializing development environment for UI-only development."
+Write-Host "----"
+
+Copy-Item -Path "configs/version.js" -Destination "version.js" -Force
+Copy-Item -Path "configs/config-$ConfigType.js" -Destination "config.js" -Force
+
+Write-Host "Done.  Try:  'npm run dev'"

--- a/ui/ui-app/init-dev.ps1
+++ b/ui/ui-app/init-dev.ps1
@@ -6,7 +6,7 @@ Write-Host "----"
 Write-Host "Initializing development environment for UI-only development."
 Write-Host "----"
 
-Copy-Item -Path "configs/version.js" -Destination "version.js" -Force
-Copy-Item -Path "configs/config-$ConfigType.js" -Destination "config.js" -Force
+Copy-Item -LiteralPath "configs/version.js" -Destination "version.js" -Force -ErrorAction Stop
+Copy-Item -LiteralPath "configs/config-$ConfigType.js" -Destination "config.js" -Force -ErrorAction Stop
 
 Write-Host "Done.  Try:  'npm run dev'"


### PR DESCRIPTION


## PR description

## Summary

Fixes #8532

Windows contributors could not follow the root README UI getting-started steps because only `./init-dev.sh` was documented. That command does not work in native PowerShell or Command Prompt.

This PR adds Windows-native init scripts and documents the full cross-platform UI dev setup flow.

## Changes

- Added `ui/ui-app/init-dev.ps1` — PowerShell equivalent of `init-dev.sh`
- Added `ui/ui-app/init-dev.cmd` — Command Prompt equivalent of `init-dev.sh`
- Updated root `README.md` Getting started (UI) with Linux/macOS, PowerShell, and CMD instructions
- Updated `ui/README.md` to reference all three init scripts
- Updated `ui/ui-app/README.md` with per-platform init commands

All three scripts do the same thing:
- Copy `configs/version.js` → `version.js`
- Copy `configs/config-<type>.js` → `config.js` (default: `local`)
- Accept an optional config type argument (e.g. `3scale`)

## Before / After

**Before:** Windows users had to use Git Bash, WSL, or manually run:
```powershell
Copy-Item configs\version.js version.js
Copy-Item configs\config-local.js config.js
```

**After:** Windows users can follow documented steps:
```powershell
cd ui\ui-app
.\init-dev.ps1
npm run dev
```

