### PR TITLE
fix: increase Kafka and registry startup timeouts 

### DIFF
--- a/.github/workflows/verify-extras.yaml
+++ b/.github/workflows/verify-extras.yaml
@@ -44,11 +44,15 @@ jobs:
           # -Pextra-tests: activates the extra-tests profile (additional validation beyond unit/integration)
           # -Dregistry3-image: Docker image to test against (built by the Build job)
           # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
+          # -Dfailsafe.rerunFailingTestsCount=2: automatically retry flaky extra-tests up to 2 times
+          #   (safe to use here: extra-tests are plain JUnit 5 + Testcontainers, no Quarkus @TestProfile
+          #    or test resources that would trigger quarkusio/quarkus#46048)
           ./mvnw verify --no-transfer-progress -Dfull -pl utils/extra-tests -am \
             -Pextra-tests \
             -Dregistry3-image=apicurio/apicurio-registry:${{ inputs.image-tag }} \
             -Dmaven.javadoc.skip=true \
-            -Daether.syncContext.named.factory=noop
+            -Daether.syncContext.named.factory=noop \
+            -Dfailsafe.rerunFailingTestsCount=2
 
       - name: Run examples/http-caching tests
         working-directory: examples/http-caching/test

--- a/utils/extra-tests/pom.xml
+++ b/utils/extra-tests/pom.xml
@@ -86,6 +86,11 @@
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
+                            <!--
+                                rerunFailingTestsCount is defined in the parent pom (../../pom.xml)
+                                as failsafe.rerunFailingTestsCount (default 0; CI overrides to a higher value).
+                            -->
+                            <rerunFailingTestsCount>${failsafe.rerunFailingTestsCount}</rerunFailingTestsCount>
                             <systemPropertyVariables>
                                 <java.util.logging.manager>java.util.logging.LogManager</java.util.logging.manager>
                             </systemPropertyVariables>

--- a/utils/extra-tests/src/test/java/io/apicurio/registry/utils/tests/infra/AbstractRegistryInfra.java
+++ b/utils/extra-tests/src/test/java/io/apicurio/registry/utils/tests/infra/AbstractRegistryInfra.java
@@ -17,9 +17,10 @@ public abstract class AbstractRegistryInfra {
     private static final Logger log = LoggerFactory.getLogger(AbstractRegistryInfra.class);
 
     // KafkaSQL bootstrap involves sequential Kafka consumer polls at 5s intervals
-    // plus SQL initialization. 75s provides margin over observed ~49s worst case
-    // under CI load without masking genuinely hung containers.
-    private static final Duration KAFKASQL_STARTUP_TIMEOUT = Duration.ofSeconds(75);
+    // plus SQL initialization. 120s provides headroom over the observed ~49s
+    // worst case, accounting for heavy CI load across 13 sequential test runs.
+    // Raised from 75s to match operator test timeout increases.
+    private static final Duration KAFKASQL_STARTUP_TIMEOUT = Duration.ofSeconds(120);
 
     private final String name;
 

--- a/utils/extra-tests/src/test/java/io/apicurio/registry/utils/tests/infra/KafkaInfra.java
+++ b/utils/extra-tests/src/test/java/io/apicurio/registry/utils/tests/infra/KafkaInfra.java
@@ -7,6 +7,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,11 +44,16 @@ public class KafkaInfra implements AutoCloseable {
     private KafkaInfra() {
     }
 
+    // 120 s gives ample headroom on resource-constrained CI runners where the
+    // default Testcontainers timeout can be exceeded under heavy parallel load.
+    private static final Duration KAFKA_STARTUP_TIMEOUT = Duration.ofSeconds(120);
+
     public void start() {
         if (!isRunning()) {
             kafkaCluster = new StrimziKafkaClusterBuilder()
                     .withNumberOfBrokers(1) // required
                     .withSharedNetwork()
+                    .withContainerCustomizer(c -> c.withStartupTimeout(KAFKA_STARTUP_TIMEOUT))
                     .build();
             kafkaCluster.start();
         }


### PR DESCRIPTION
## Description

- Increased Kafka cluster startup timeout to 120s

- Increased KAFKASQL_STARTUP_TIMEOUT from 75s to 120s

- Added rerunFailingTestsCount to extra-tests profile

## Issue 
fixes #8404 

## Proof Manifests
The test passes successfully now.
<img width="378" height="357" alt="Screenshot 2026-07-12 at 17 31 12" src="https://github.com/user-attachments/assets/bde9de92-3f64-48fe-9e59-e05bdb4658d8" />
