### PR TITLE
fix(auth): use GroupOnly for getGroupById authorization

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
@@ -363,7 +363,7 @@ public class GroupsResourceImpl implements GroupsResource {
     }
 
     @Override
-    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Read)
     public GroupMetaData getGroupById(String groupId) {
         GroupMetaDataDto group = storage.getGroupMetaData(groupId);
         return V2ApiUtil.groupDtoToGroup(group);

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -598,7 +598,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     }
 
     @Override
-    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
+    @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Read)
     public GroupMetaData getGroupById(String groupId) {
         GroupMetaDataDto group = storage.getGroupMetaData(groupId);
         return V3ApiUtil.groupDtoToGroup(group);

--- a/app/src/test/java/io/apicurio/registry/auth/AbstractAccessControllerOwnerCheckTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/AbstractAccessControllerOwnerCheckTest.java
@@ -1,0 +1,63 @@
+package io.apicurio.registry.auth;
+
+import jakarta.interceptor.InvocationContext;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies owner-check parameter indexing for {@link AuthorizedStyle} on single-parameter group operations.
+ * Regression test for issue #7866 (getGroupById).
+ */
+class AbstractAccessControllerOwnerCheckTest {
+
+    private static class TestableAccessController extends AbstractAccessController {
+
+        @Override
+        public boolean isAuthorized(InvocationContext context) {
+            throw new UnsupportedOperationException();
+        }
+
+        boolean ownerCheck(InvocationContext context) {
+            return isOwner(context);
+        }
+    }
+
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.AdminOrOwner)
+    public void groupAndArtifactMethod(String groupId) {
+    }
+
+    @Test
+    void getGroupByIdUsesGroupOnlyInV3() throws Exception {
+        Method method = io.apicurio.registry.rest.v3.impl.GroupsResourceImpl.class.getMethod("getGroupById",
+                String.class);
+        Authorized annotation = method.getAnnotation(Authorized.class);
+        assertEquals(AuthorizedStyle.GroupOnly, annotation.style());
+        assertEquals(AuthorizedLevel.Read, annotation.level());
+    }
+
+    @Test
+    void getGroupByIdUsesGroupOnlyInV2() throws Exception {
+        Method method = io.apicurio.registry.rest.v2.impl.GroupsResourceImpl.class.getMethod("getGroupById",
+                String.class);
+        Authorized annotation = method.getAnnotation(Authorized.class);
+        assertEquals(AuthorizedStyle.GroupOnly, annotation.style());
+        assertEquals(AuthorizedLevel.Read, annotation.level());
+    }
+
+    @Test
+    void groupAndArtifactStyleRequiresArtifactParameter() throws Exception {
+        TestableAccessController controller = new TestableAccessController();
+        InvocationContext context = mock(InvocationContext.class);
+        when(context.getMethod()).thenReturn(
+                AbstractAccessControllerOwnerCheckTest.class.getMethod("groupAndArtifactMethod", String.class));
+        when(context.getParameters()).thenReturn(new Object[] { "test-group" });
+
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> controller.ownerCheck(context));
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/auth/SimpleAuthTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/SimpleAuthTest.java
@@ -7,9 +7,11 @@ import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.rest.client.RegistryClient;
 import io.apicurio.registry.rest.client.models.ArtifactMetaData;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateGroup;
 import io.apicurio.registry.rest.client.models.CreateRule;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.EditableArtifactMetaData;
+import io.apicurio.registry.rest.client.models.GroupMetaData;
 import io.apicurio.registry.rest.client.models.IfArtifactExists;
 import io.apicurio.registry.rest.client.models.RuleType;
 import io.apicurio.registry.rest.client.models.UserInfo;
@@ -379,6 +381,38 @@ public class SimpleAuthTest extends AbstractResourceTestBase {
             client.groups().byGroupId(groupId).artifacts().post(createArtifact);
         });
         assertNotAuthorized(exception2);
+    }
+
+    @Test
+    public void testGetGroupByIdGroupReadSufficientWithoutArtifactPermissions() throws Exception {
+        var clientAdmin = RegistryClientFactory.create(
+                RegistryClientOptions.create(registryV3ApiUrl, vertx)
+                .oauth2(authServerUrlConfigured, KeycloakTestContainerManager.ADMIN_CLIENT_ID, "test1"));
+        var clientReadonly = RegistryClientFactory.create(
+                RegistryClientOptions.create(registryV3ApiUrl, vertx)
+                .oauth2(authServerUrlConfigured, KeycloakTestContainerManager.READONLY_CLIENT_ID, "test1"));
+
+        final String testGroupId = "testGetGroupByIdAuth";
+
+        CreateGroup createGroup = new CreateGroup();
+        createGroup.setGroupId(testGroupId);
+        createGroup.setDescription("getGroupById authorization test");
+        clientAdmin.groups().post(createGroup);
+
+        String artifactId = TestUtils.generateArtifactId();
+        createArtifact.setArtifactId(artifactId);
+        clientAdmin.groups().byGroupId(testGroupId).artifacts().post(createArtifact);
+
+        GroupMetaData group = clientReadonly.groups().byGroupId(testGroupId).get();
+        assertEquals(testGroupId, group.getGroupId());
+
+        EditableArtifactMetaData updatedMetaData = new EditableArtifactMetaData();
+        updatedMetaData.setName("should-fail");
+        var exception = assertThrows(Exception.class, () -> {
+            clientReadonly.groups().byGroupId(testGroupId).artifacts().byArtifactId(artifactId)
+                    .put(updatedMetaData);
+        });
+        assertForbidden(exception);
     }
 
     @Test


### PR DESCRIPTION
Fixes #7866

getGroupById only takes groupId, so AuthorizedStyle.GroupAndArtifact can throw ArrayIndexOutOfBoundsException when the access controller reads a second parameter. Switched to GroupOnly (same as deleteGroupById) in v2 and v3.

Tests added (per review):
AbstractAccessControllerOwnerCheckTest : verifies getGroupById uses GroupOnly in v2/v3 and documents the single-parameter GroupAndArtifact failure
SimpleAuthTest#testGetGroupByIdGroupReadSufficientWithoutArtifactPermissions : readonly user can fetch group metadata without artifact owner permissions; artifact write remains forbidden