### PR TITLE
fix(avro): improve AvroCanonicalHashUpgrader logging and reference tests

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/upgrader/AvroCanonicalHashUpgrader.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/upgrader/AvroCanonicalHashUpgrader.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.apicurio.registry.storage.impl.sql.RegistryContentUtils.normalizeGroupId;
 
@@ -46,18 +47,31 @@ public class AvroCanonicalHashUpgrader implements IDbUpgrader {
                     + "JOIN artifacts a ON a.groupId = v.groupId AND a.artifactId = v.artifactId "
                 + "WHERE a.type = ?";
 
-        int successCount = handle.createQuery(sql).bind(0, ArtifactType.AVRO).setFetchSize(50)
-                .map(new ContentWithTypeRowMapper()).stream().mapToInt(entity -> {
+        AtomicInteger processedCount = new AtomicInteger();
+        AtomicInteger updatedCount = new AtomicInteger();
+        AtomicInteger skippedCount = new AtomicInteger();
+        AtomicInteger failedCount = new AtomicInteger();
+
+        handle.createQuery(sql).bind(0, ArtifactType.AVRO).setFetchSize(50)
+                .map(new ContentWithTypeRowMapper()).stream().forEach(entity -> {
+                    processedCount.incrementAndGet();
                     try {
-                        return updateEntity(handle, entity);
+                        int result = updateEntity(handle, entity);
+                        if (result > 0) {
+                            updatedCount.incrementAndGet();
+                        } else {
+                            skippedCount.incrementAndGet();
+                        }
                     } catch (Exception ex) {
+                        failedCount.incrementAndGet();
                         log.warn("Failed to update canonical hash for contentId {}.",
                                 entity.contentEntity.contentId, ex);
-                        return 0;
                     }
-                }).sum();
+                });
 
-        log.info("Successfully updated {} Avro canonical content hashes.", successCount);
+        log.info(
+                "Avro canonical hash upgrade complete: processed={}, updated={}, skipped={}, failed={}.",
+                processedCount.get(), updatedCount.get(), skippedCount.get(), failedCount.get());
     }
 
     private int updateEntity(Handle handle, ContentWithType entity) {
@@ -78,7 +92,8 @@ public class AvroCanonicalHashUpgrader implements IDbUpgrader {
                     .bind(0, newCanonicalHash).bind(1, entity.contentEntity.contentId).execute();
             if (rowCount == 0) {
                 log.warn("Database row not found for contentId {}.", entity.contentEntity.contentId);
-                return 0;
+                throw new IllegalStateException(
+                        "Database row not found for contentId " + entity.contentEntity.contentId);
             }
             return 1;
         }

--- a/app/src/test/java/io/apicurio/registry/noprofile/storage/AvroCanonicalHashUpgraderTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/storage/AvroCanonicalHashUpgraderTest.java
@@ -2,7 +2,10 @@ package io.apicurio.registry.noprofile.storage;
 
 import io.apicurio.registry.AbstractResourceTestBase;
 import io.apicurio.registry.avro.content.canon.EnhancedAvroContentCanonicalizer;
+import io.apicurio.registry.rest.client.models.ArtifactReference;
+import io.apicurio.registry.rest.client.models.CreateArtifactResponse;
 import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
 import io.apicurio.registry.storage.dto.StoredArtifactVersionDto;
 import io.apicurio.registry.storage.impl.sql.HandleFactory;
 import io.apicurio.registry.storage.impl.sql.jdb.Handle;
@@ -17,6 +20,8 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -142,6 +147,99 @@ public class AvroCanonicalHashUpgraderTest extends AbstractResourceTestBase {
         assertEquals(ContentTypes.APPLICATION_JSON, getContentType(contentId));
     }
 
+    @Test
+    void testUpgraderRecomputesHashForSchemaWithArtifactReferences() throws Exception {
+        String addressArtifactId = "testUpgraderAddressRef";
+        String orderArtifactId = "testUpgraderOrderWithRef";
+
+        String addressSchema = "{\"type\":\"record\",\"name\":\"Address\","
+                + "\"namespace\":\"com.example.upgrader\","
+                + "\"fields\":[{\"name\":\"street\",\"type\":\"string\"},"
+                + "{\"name\":\"zip\",\"type\":\"string\"}]}";
+
+        CreateArtifactResponse addressResponse = createArtifact(GROUP_ID, addressArtifactId,
+                ArtifactType.AVRO, addressSchema, ContentTypes.APPLICATION_JSON);
+        String addressVersion = addressResponse.getVersion().getVersion();
+
+        ArtifactReference addressRef = new ArtifactReference();
+        addressRef.setGroupId(GROUP_ID);
+        addressRef.setArtifactId(addressArtifactId);
+        addressRef.setVersion(addressVersion);
+        addressRef.setName("com.example.upgrader.Address");
+
+        String orderSchema = "{\"type\":\"record\",\"name\":\"Order\","
+                + "\"namespace\":\"com.example.upgrader\","
+                + "\"fields\":[{\"name\":\"id\",\"type\":\"string\"},"
+                + "{\"name\":\"shippingAddress\",\"type\":\"com.example.upgrader.Address\"}]}";
+
+        createArtifactWithReferences(GROUP_ID, orderArtifactId, ArtifactType.AVRO, orderSchema,
+                ContentTypes.APPLICATION_JSON, Collections.singletonList(addressRef));
+
+        StoredArtifactVersionDto storedVersion = storage.getArtifactVersionContent(GROUP_ID, orderArtifactId,
+                "1");
+        long contentId = storedVersion.getContentId();
+
+        List<ArtifactReferenceDto> refs = storedVersion.getReferences();
+        assertNotNull(refs);
+        assertEquals(1, refs.size());
+
+        String correctCanonicalHash = getCanonicalHash(contentId);
+        assertNotNull(correctCanonicalHash);
+
+        String fakeHash = "1111111111111111111111111111111111111111111111111111111111111111";
+        setCanonicalHash(contentId, fakeHash);
+        assertEquals(fakeHash, getCanonicalHash(contentId));
+
+        // Exercises resolveReference() when recomputing the hash
+        runUpgrader();
+
+        assertEquals(correctCanonicalHash, getCanonicalHash(contentId));
+    }
+
+    @Test
+    void testUpgraderLeavesHashUnchangedWhenReferenceResolutionFails() throws Exception {
+        String addressArtifactId = "testUpgraderMissingRefAddress";
+        String orderArtifactId = "testUpgraderMissingRefOrder";
+
+        String addressSchema = "{\"type\":\"record\",\"name\":\"MissingRefAddress\","
+                + "\"namespace\":\"com.example.upgrader\","
+                + "\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}";
+
+        CreateArtifactResponse addressResponse = createArtifact(GROUP_ID, addressArtifactId,
+                ArtifactType.AVRO, addressSchema, ContentTypes.APPLICATION_JSON);
+
+        ArtifactReference addressRef = new ArtifactReference();
+        addressRef.setGroupId(GROUP_ID);
+        addressRef.setArtifactId(addressArtifactId);
+        addressRef.setVersion(addressResponse.getVersion().getVersion());
+        addressRef.setName("com.example.upgrader.MissingRefAddress");
+
+        String orderSchema = "{\"type\":\"record\",\"name\":\"MissingRefOrder\","
+                + "\"namespace\":\"com.example.upgrader\","
+                + "\"fields\":[{\"name\":\"id\",\"type\":\"string\"},"
+                + "{\"name\":\"addr\",\"type\":\"com.example.upgrader.MissingRefAddress\"}]}";
+
+        createArtifactWithReferences(GROUP_ID, orderArtifactId, ArtifactType.AVRO, orderSchema,
+                ContentTypes.APPLICATION_JSON, Collections.singletonList(addressRef));
+
+        StoredArtifactVersionDto storedVersion = storage.getArtifactVersionContent(GROUP_ID, orderArtifactId,
+                "1");
+        long contentId = storedVersion.getContentId();
+
+        // Point refs at a version that does not exist so resolveReference() fails
+        String brokenRefs = "[{\"groupId\":\"" + GROUP_ID + "\",\"artifactId\":\"" + addressArtifactId
+                + "\",\"version\":\"999\",\"name\":\"com.example.upgrader.MissingRefAddress\"}]";
+        setRefs(contentId, brokenRefs);
+
+        String fakeHash = "2222222222222222222222222222222222222222222222222222222222222222";
+        setCanonicalHash(contentId, fakeHash);
+
+        // Upgrade should not throw; failed rows keep their (stale) hash
+        runUpgrader();
+
+        assertEquals(fakeHash, getCanonicalHash(contentId));
+    }
+
     private String getCanonicalHash(long contentId) {
         return handles.withHandleNoException(
                 (Handle handle) -> handle
@@ -152,6 +250,14 @@ public class AvroCanonicalHashUpgraderTest extends AbstractResourceTestBase {
     private void setCanonicalHash(long contentId, String hash) {
         handles.<Void, RuntimeException>withHandleNoException((Handle handle) -> {
             handle.createUpdate("UPDATE content SET canonicalHash = ? WHERE contentId = ?").bind(0, hash)
+                    .bind(1, contentId).execute();
+            return null;
+        });
+    }
+
+    private void setRefs(long contentId, String refs) {
+        handles.<Void, RuntimeException>withHandleNoException((Handle handle) -> {
+            handle.createUpdate("UPDATE content SET refs = ? WHERE contentId = ?").bind(0, refs)
                     .bind(1, contentId).execute();
             return null;
         });


### PR DESCRIPTION
Fixes #8003

- Report processed/updated/skipped/failed counts at end of upgrade
- Add test coverage for schemas with artifact references (resolveReference path)
- Add failure-case test when a referenced version is missing