### PR TITLE
docs: clarify how artifact refs work with data contracts

### DIFF
--- a/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsContract.java
+++ b/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsContract.java
@@ -24,6 +24,11 @@ public class OdcsContract {
     private String kind;
     private String id;
     private OdcsInfo info;
+    /**
+     * Schema artifacts governed by this contract. Entries are independent: each projects only onto
+     * its own {@code location}. Nested types that live in other registry artifacts need their own
+     * entry (or a separate contract); projection does not follow cross-artifact schema references.
+     */
     private List<OdcsSchema> schemas;
     private OdcsQuality quality;
     private OdcsServiceLevel serviceLevel;

--- a/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsSchema.java
+++ b/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsSchema.java
@@ -12,6 +12,14 @@ import lombok.Setter;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * One schema entry from an ODCS contract ({@code schemas[]}).
+ * <p>
+ * Each entry is independent: field metadata (PII, tags, classification) is projected only onto the
+ * artifact named in {@link #location}. Cross-artifact references inside the schema content are not
+ * resolved during projection. To govern a nested/shared type that lives in another artifact, add a
+ * separate {@code schemas[]} entry for that artifact or give it its own contract.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -21,6 +29,7 @@ import java.util.Map;
 public class OdcsSchema {
     private String name;
     private String type;
+    /** Registry location in the form {@code groupId/artifactId:version} (version optional). */
     private String location;
     private Map<String, OdcsFieldMetadata> fields;
 

--- a/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsSchema.java
+++ b/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsSchema.java
@@ -29,7 +29,11 @@ import java.util.Map;
 public class OdcsSchema {
     private String name;
     private String type;
-    /** Registry location in the form {@code groupId/artifactId:version} (version optional). */
+    /**
+     * Registry location in the form {@code [groupId/]artifactId[:versionOrBranch]}.
+     * Group may be omitted (defaults to the contract's group). Version/branch expression is optional
+     * (defaults to the latest version).
+     */
     private String location;
     private Map<String, OdcsFieldMetadata> fields;
 

--- a/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsSchemaLocations.java
+++ b/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsSchemaLocations.java
@@ -8,21 +8,23 @@ package io.apicurio.registry.contracts.odcs;
  */
 public final class OdcsSchemaLocations {
 
+    private static final String[] INVALID = new String[0];
+
     private OdcsSchemaLocations() {
     }
 
     /**
-     * @return {@code [groupId, artifactId]}, or {@code null} if {@code location} is invalid
+     * @return {@code [groupId, artifactId]}, or an empty array if {@code location} is invalid
      */
     public static String[] parse(String location, String defaultGroupId) {
         if (location == null || location.isBlank()) {
-            return null;
+            return INVALID;
         }
         String withoutVersion = location.contains(":")
                 ? location.substring(0, location.indexOf(':'))
                 : location;
         if (withoutVersion.isBlank()) {
-            return null;
+            return INVALID;
         }
 
         String schemaGroupId;
@@ -32,7 +34,7 @@ public final class OdcsSchemaLocations {
             schemaGroupId = withoutVersion.substring(0, slashIdx);
             schemaArtifactId = withoutVersion.substring(slashIdx + 1);
             if (schemaArtifactId.contains("/")) {
-                return null;
+                return INVALID;
             }
         } else {
             schemaGroupId = defaultGroupId;
@@ -41,8 +43,12 @@ public final class OdcsSchemaLocations {
 
         if (schemaGroupId == null || schemaGroupId.isBlank()
                 || schemaArtifactId.isBlank()) {
-            return null;
+            return INVALID;
         }
         return new String[] { schemaGroupId, schemaArtifactId };
+    }
+
+    public static boolean isValid(String[] parsed) {
+        return parsed != null && parsed.length == 2;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsSchemaLocations.java
+++ b/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsSchemaLocations.java
@@ -1,0 +1,48 @@
+package io.apicurio.registry.contracts.odcs;
+
+/**
+ * Parses ODCS {@code schemas[].location} values.
+ * <p>
+ * Supported forms: {@code [groupId/]artifactId[:versionOrBranch]}. Group may be omitted
+ * (defaults to {@code defaultGroupId}). Version/branch expression is optional.
+ */
+public final class OdcsSchemaLocations {
+
+    private OdcsSchemaLocations() {
+    }
+
+    /**
+     * @return {@code [groupId, artifactId]}, or {@code null} if {@code location} is invalid
+     */
+    public static String[] parse(String location, String defaultGroupId) {
+        if (location == null || location.isBlank()) {
+            return null;
+        }
+        String withoutVersion = location.contains(":")
+                ? location.substring(0, location.indexOf(':'))
+                : location;
+        if (withoutVersion.isBlank()) {
+            return null;
+        }
+
+        String schemaGroupId;
+        String schemaArtifactId;
+        int slashIdx = withoutVersion.indexOf('/');
+        if (slashIdx >= 0) {
+            schemaGroupId = withoutVersion.substring(0, slashIdx);
+            schemaArtifactId = withoutVersion.substring(slashIdx + 1);
+            if (schemaArtifactId.contains("/")) {
+                return null;
+            }
+        } else {
+            schemaGroupId = defaultGroupId;
+            schemaArtifactId = withoutVersion;
+        }
+
+        if (schemaGroupId == null || schemaGroupId.isBlank()
+                || schemaArtifactId.isBlank()) {
+            return null;
+        }
+        return new String[] { schemaGroupId, schemaArtifactId };
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsTagProjector.java
+++ b/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsTagProjector.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 @ApplicationScoped
 public class OdcsTagProjector {
@@ -34,7 +35,12 @@ public class OdcsTagProjector {
             return 0;
         }
         try {
-            String targetVersion = resolveTargetVersion(contract, groupId, artifactId);
+            OdcsSchema matchingSchema = findMatchingSchema(contract.getSchemas(), groupId, artifactId);
+            if (matchingSchema == null) {
+                return 0;
+            }
+
+            String targetVersion = resolveTargetVersion(matchingSchema, groupId, artifactId);
             if (targetVersion == null) {
                 warnings.add("No versions found for " + groupId + "/" + artifactId);
                 return 0;
@@ -44,11 +50,8 @@ public class OdcsTagProjector {
 
             var labels = new LinkedHashMap<String, String>();
             int count = 0;
-            for (OdcsSchema schema : contract.getSchemas()) {
-                if (schema.getFields() == null) {
-                    continue;
-                }
-                for (var entry : schema.getFields().entrySet()) {
+            if (matchingSchema.getFields() != null) {
+                for (var entry : matchingSchema.getFields().entrySet()) {
                     count += addTags(labels, tagPrefix, entry.getKey(),
                             entry.getValue(), warnings);
                 }
@@ -66,14 +69,76 @@ public class OdcsTagProjector {
         }
     }
 
-    private String resolveTargetVersion(OdcsContract contract, String groupId,
-            String artifactId) {
-        String versionExpression = null;
-        if (contract.getSchemas() != null && !contract.getSchemas().isEmpty()) {
-            String location = contract.getSchemas().get(0).getLocation();
-            if (location != null && location.contains(":")) {
-                versionExpression = location.substring(location.indexOf(':') + 1);
+    /**
+     * Returns the {@code schemas[]} entry whose {@code location} resolves to the target artifact.
+     * Group may be omitted in {@code location} (defaults to {@code groupId}).
+     */
+    static OdcsSchema findMatchingSchema(List<OdcsSchema> schemas, String groupId, String artifactId) {
+        if (schemas == null) {
+            return null;
+        }
+        for (OdcsSchema schema : schemas) {
+            if (matchesTarget(schema, groupId, artifactId)) {
+                return schema;
             }
+        }
+        return null;
+    }
+
+    static boolean matchesTarget(OdcsSchema schema, String groupId, String artifactId) {
+        if (schema == null) {
+            return false;
+        }
+        String[] parsed = parseSchemaLocation(schema.getLocation(), groupId);
+        return parsed != null
+                && Objects.equals(groupId, parsed[0])
+                && Objects.equals(artifactId, parsed[1]);
+    }
+
+    /**
+     * Parses {@code location} the same way as contract projection:
+     * {@code [groupId/]artifactId[:version]}, with optional group (defaults to {@code defaultGroupId})
+     * and optional version/expression.
+     *
+     * @return {@code [groupId, artifactId]} or {@code null} if invalid
+     */
+    static String[] parseSchemaLocation(String location, String defaultGroupId) {
+        if (location == null || location.isBlank()) {
+            return null;
+        }
+        String withoutVersion = location.contains(":")
+                ? location.substring(0, location.indexOf(':'))
+                : location;
+        if (withoutVersion.isBlank()) {
+            return null;
+        }
+
+        String schemaGroupId;
+        String schemaArtifactId;
+        int slashIdx = withoutVersion.indexOf('/');
+        if (slashIdx >= 0) {
+            schemaGroupId = withoutVersion.substring(0, slashIdx);
+            schemaArtifactId = withoutVersion.substring(slashIdx + 1);
+            if (schemaArtifactId.contains("/")) {
+                return null;
+            }
+        } else {
+            schemaGroupId = defaultGroupId;
+            schemaArtifactId = withoutVersion;
+        }
+
+        if (schemaGroupId == null || schemaGroupId.isBlank()
+                || schemaArtifactId.isBlank()) {
+            return null;
+        }
+        return new String[] { schemaGroupId, schemaArtifactId };
+    }
+
+    private String resolveTargetVersion(OdcsSchema schema, String groupId, String artifactId) {
+        String versionExpression = null;
+        String location = schema.getLocation();
+        if (location != null && location.contains(":")) {
+            versionExpression = location.substring(location.indexOf(':') + 1);
         }
 
         if (versionExpression != null && !versionExpression.isBlank()) {

--- a/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsTagProjector.java
+++ b/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsTagProjector.java
@@ -90,7 +90,7 @@ public class OdcsTagProjector {
             return false;
         }
         String[] parsed = OdcsSchemaLocations.parse(schema.getLocation(), groupId);
-        return parsed != null
+        return OdcsSchemaLocations.isValid(parsed)
                 && Objects.equals(groupId, parsed[0])
                 && Objects.equals(artifactId, parsed[1]);
     }

--- a/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsTagProjector.java
+++ b/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsTagProjector.java
@@ -89,49 +89,10 @@ public class OdcsTagProjector {
         if (schema == null) {
             return false;
         }
-        String[] parsed = parseSchemaLocation(schema.getLocation(), groupId);
+        String[] parsed = OdcsSchemaLocations.parse(schema.getLocation(), groupId);
         return parsed != null
                 && Objects.equals(groupId, parsed[0])
                 && Objects.equals(artifactId, parsed[1]);
-    }
-
-    /**
-     * Parses {@code location} the same way as contract projection:
-     * {@code [groupId/]artifactId[:version]}, with optional group (defaults to {@code defaultGroupId})
-     * and optional version/expression.
-     *
-     * @return {@code [groupId, artifactId]} or {@code null} if invalid
-     */
-    static String[] parseSchemaLocation(String location, String defaultGroupId) {
-        if (location == null || location.isBlank()) {
-            return null;
-        }
-        String withoutVersion = location.contains(":")
-                ? location.substring(0, location.indexOf(':'))
-                : location;
-        if (withoutVersion.isBlank()) {
-            return null;
-        }
-
-        String schemaGroupId;
-        String schemaArtifactId;
-        int slashIdx = withoutVersion.indexOf('/');
-        if (slashIdx >= 0) {
-            schemaGroupId = withoutVersion.substring(0, slashIdx);
-            schemaArtifactId = withoutVersion.substring(slashIdx + 1);
-            if (schemaArtifactId.contains("/")) {
-                return null;
-            }
-        } else {
-            schemaGroupId = defaultGroupId;
-            schemaArtifactId = withoutVersion;
-        }
-
-        if (schemaGroupId == null || schemaGroupId.isBlank()
-                || schemaArtifactId.isBlank()) {
-            return null;
-        }
-        return new String[] { schemaGroupId, schemaArtifactId };
     }
 
     private String resolveTargetVersion(OdcsSchema schema, String groupId, String artifactId) {

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -13,6 +13,7 @@ import io.apicurio.registry.contracts.odcs.OdcsParseException;
 import io.apicurio.registry.contracts.odcs.OdcsProjectionEngine;
 import io.apicurio.registry.contracts.odcs.OdcsProjectionResult;
 import io.apicurio.registry.contracts.odcs.OdcsSchema;
+import io.apicurio.registry.contracts.odcs.OdcsSchemaLocations;
 import io.apicurio.registry.rest.v3.beans.OdcsContractResult;
 import io.apicurio.registry.rest.v3.beans.OdcsContractSummary;
 import io.apicurio.registry.rest.v3.beans.OdcsProjectionSummary;
@@ -2424,7 +2425,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                 continue;
             }
 
-            String[] parsed = parseSchemaLocation(schema.getLocation(), groupId);
+            String[] parsed = OdcsSchemaLocations.parse(schema.getLocation(), groupId);
             if (parsed == null) {
                 combined.addWarning("Invalid schema location: " + schema.getLocation());
                 continue;
@@ -2447,38 +2448,6 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
             }
         }
         return combined;
-    }
-
-    private String[] parseSchemaLocation(String location, String defaultGroupId) {
-        if (location == null || location.isBlank()) {
-            return null;
-        }
-        String withoutVersion = location.contains(":")
-                ? location.substring(0, location.indexOf(':'))
-                : location;
-        if (withoutVersion.isBlank()) {
-            return null;
-        }
-
-        String schemaGroupId;
-        String schemaArtifactId;
-        int slashIdx = withoutVersion.indexOf('/');
-        if (slashIdx >= 0) {
-            schemaGroupId = withoutVersion.substring(0, slashIdx);
-            schemaArtifactId = withoutVersion.substring(slashIdx + 1);
-            if (schemaArtifactId.contains("/")) {
-                return null;
-            }
-        } else {
-            schemaGroupId = defaultGroupId;
-            schemaArtifactId = withoutVersion;
-        }
-
-        if (schemaGroupId == null || schemaGroupId.isBlank()
-                || schemaArtifactId.isBlank()) {
-            return null;
-        }
-        return new String[] { schemaGroupId, schemaArtifactId };
     }
 
     private OdcsContractResult toOdcsContractResult(String contractId, OdcsContract contract,

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -2426,7 +2426,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
             }
 
             String[] parsed = OdcsSchemaLocations.parse(schema.getLocation(), groupId);
-            if (parsed == null) {
+            if (!OdcsSchemaLocations.isValid(parsed)) {
                 combined.addWarning("Invalid schema location: " + schema.getLocation());
                 continue;
             }

--- a/app/src/test/java/io/apicurio/registry/contracts/odcs/OdcsTagProjectorTest.java
+++ b/app/src/test/java/io/apicurio/registry/contracts/odcs/OdcsTagProjectorTest.java
@@ -17,17 +17,17 @@ public class OdcsTagProjectorTest {
 
     @Test
     void parseSchemaLocationAllowsOptionalGroupAndVersion() {
-        assertEquals("orders", OdcsTagProjector.parseSchemaLocation("orders/OrderEvent:3", "default")[0]);
-        assertEquals("OrderEvent", OdcsTagProjector.parseSchemaLocation("orders/OrderEvent:3", "default")[1]);
+        assertEquals("orders", OdcsSchemaLocations.parse("orders/OrderEvent:3", "default")[0]);
+        assertEquals("OrderEvent", OdcsSchemaLocations.parse("orders/OrderEvent:3", "default")[1]);
 
-        assertEquals("default", OdcsTagProjector.parseSchemaLocation("OrderEvent:latest", "default")[0]);
-        assertEquals("OrderEvent", OdcsTagProjector.parseSchemaLocation("OrderEvent:latest", "default")[1]);
+        assertEquals("default", OdcsSchemaLocations.parse("OrderEvent:latest", "default")[0]);
+        assertEquals("OrderEvent", OdcsSchemaLocations.parse("OrderEvent:latest", "default")[1]);
 
-        assertEquals("default", OdcsTagProjector.parseSchemaLocation("OrderEvent", "default")[0]);
-        assertEquals("OrderEvent", OdcsTagProjector.parseSchemaLocation("OrderEvent", "default")[1]);
+        assertEquals("default", OdcsSchemaLocations.parse("OrderEvent", "default")[0]);
+        assertEquals("OrderEvent", OdcsSchemaLocations.parse("OrderEvent", "default")[1]);
 
-        assertNull(OdcsTagProjector.parseSchemaLocation(null, "default"));
-        assertNull(OdcsTagProjector.parseSchemaLocation("  ", "default"));
+        assertNull(OdcsSchemaLocations.parse(null, "default"));
+        assertNull(OdcsSchemaLocations.parse("  ", "default"));
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/contracts/odcs/OdcsTagProjectorTest.java
+++ b/app/src/test/java/io/apicurio/registry/contracts/odcs/OdcsTagProjectorTest.java
@@ -1,0 +1,69 @@
+package io.apicurio.registry.contracts.odcs;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Ensures field-tag projection only uses the {@code schemas[]} entry for the target artifact (#8104 / PR review).
+ */
+public class OdcsTagProjectorTest {
+
+    @Test
+    void parseSchemaLocationAllowsOptionalGroupAndVersion() {
+        assertEquals("orders", OdcsTagProjector.parseSchemaLocation("orders/OrderEvent:3", "default")[0]);
+        assertEquals("OrderEvent", OdcsTagProjector.parseSchemaLocation("orders/OrderEvent:3", "default")[1]);
+
+        assertEquals("default", OdcsTagProjector.parseSchemaLocation("OrderEvent:latest", "default")[0]);
+        assertEquals("OrderEvent", OdcsTagProjector.parseSchemaLocation("OrderEvent:latest", "default")[1]);
+
+        assertEquals("default", OdcsTagProjector.parseSchemaLocation("OrderEvent", "default")[0]);
+        assertEquals("OrderEvent", OdcsTagProjector.parseSchemaLocation("OrderEvent", "default")[1]);
+
+        assertNull(OdcsTagProjector.parseSchemaLocation(null, "default"));
+        assertNull(OdcsTagProjector.parseSchemaLocation("  ", "default"));
+    }
+
+    @Test
+    void matchesTargetOnlyForOwnLocation() {
+        OdcsSchema order = OdcsSchema.builder()
+                .name("OrderEvent")
+                .location("orders/OrderEvent:3")
+                .build();
+        OdcsSchema address = OdcsSchema.builder()
+                .name("Address")
+                .location("shared/Address:1")
+                .build();
+
+        assertTrue(OdcsTagProjector.matchesTarget(order, "orders", "OrderEvent"));
+        assertFalse(OdcsTagProjector.matchesTarget(order, "shared", "Address"));
+        assertTrue(OdcsTagProjector.matchesTarget(address, "shared", "Address"));
+        assertFalse(OdcsTagProjector.matchesTarget(address, "orders", "OrderEvent"));
+    }
+
+    @Test
+    void findMatchingSchemaIgnoresOtherEntries() {
+        OdcsSchema order = OdcsSchema.builder()
+                .name("OrderEvent")
+                .location("orders/OrderEvent")
+                .build();
+        OdcsSchema address = OdcsSchema.builder()
+                .name("Address")
+                .location("shared/Address")
+                .build();
+
+        OdcsSchema matched = OdcsTagProjector.findMatchingSchema(
+                List.of(order, address), "shared", "Address");
+        assertNotNull(matched);
+        assertEquals("Address", matched.getName());
+
+        assertNull(OdcsTagProjector.findMatchingSchema(
+                List.of(order, address), "other", "Thing"));
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/contracts/odcs/OdcsTagProjectorTest.java
+++ b/app/src/test/java/io/apicurio/registry/contracts/odcs/OdcsTagProjectorTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Ensures field-tag projection only uses the {@code schemas[]} entry for the target artifact (#8104 / PR review).
  */
-public class OdcsTagProjectorTest {
+class OdcsTagProjectorTest {
 
     @Test
     void parseSchemaLocationAllowsOptionalGroupAndVersion() {
@@ -26,8 +26,8 @@ public class OdcsTagProjectorTest {
         assertEquals("default", OdcsSchemaLocations.parse("OrderEvent", "default")[0]);
         assertEquals("OrderEvent", OdcsSchemaLocations.parse("OrderEvent", "default")[1]);
 
-        assertNull(OdcsSchemaLocations.parse(null, "default"));
-        assertNull(OdcsSchemaLocations.parse("  ", "default"));
+        assertFalse(OdcsSchemaLocations.isValid(OdcsSchemaLocations.parse(null, "default")));
+        assertFalse(OdcsSchemaLocations.isValid(OdcsSchemaLocations.parse("  ", "default")));
     }
 
     @Test

--- a/app/src/test/resources/io/apicurio/registry/contracts/odcs/valid-contract.yaml
+++ b/app/src/test/resources/io/apicurio/registry/contracts/odcs/valid-contract.yaml
@@ -12,9 +12,9 @@ team:
   domain: commerce
   contact: orders@company.com
 schemas:
-  # each schemas[] entry is independent — field pii/tags apply only to this artifact.
+  # each schemas[] entry is independent — field PII/tags apply only to this artifact.
   # nested types stored as separate registry artifacts need their own entry (or contract).
-  # cel rules on the parent can still reach nested values at evaluation time (records are materialized).
+  # CEL rules on the parent can still reach nested values at evaluation time (records are materialized).
   - name: OrderEvent
     type: avro
     location: orders/OrderEvent:3

--- a/app/src/test/resources/io/apicurio/registry/contracts/odcs/valid-contract.yaml
+++ b/app/src/test/resources/io/apicurio/registry/contracts/odcs/valid-contract.yaml
@@ -12,6 +12,9 @@ team:
   domain: commerce
   contact: orders@company.com
 schemas:
+  # each schemas[] entry is independent — field pii/tags apply only to this artifact.
+  # nested types stored as separate registry artifacts need their own entry (or contract).
+  # cel rules on the parent can still reach nested values at evaluation time (records are materialized).
   - name: OrderEvent
     type: avro
     location: orders/OrderEvent:3

--- a/docs/modules/ROOT/pages/getting-started/assembly-data-contracts.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-data-contracts.adoc
@@ -8,6 +8,7 @@ This chapter introduces the Data Contracts framework in {registry}, which uses t
 
 * xref:data-contracts-overview_{context}[]
 * xref:data-contracts-odcs_{context}[]
+* xref:data-contracts-artifact-references_{context}[]
 * xref:data-contracts-field-tags_{context}[]
 * xref:data-contracts-rules_{context}[]
 * xref:data-contracts-lifecycle_{context}[]
@@ -179,6 +180,46 @@ Examples:
 * `orders/OrderEvent:3` - group "orders", artifact "OrderEvent", version "3"
 * `OrderEvent:latest` - default group, artifact "OrderEvent", latest version
 * `OrderEvent` - default group, artifact "OrderEvent", latest version
+
+IMPORTANT: Each entry under `schemas[]` is independent. Projection and field metadata (PII, tags, classifications) apply only to the artifact named in that entry's `location`. Cross-artifact schema references inside the Avro/JSON Schema/Protobuf content are not followed during projection. If a nested type lives in another artifact, either add a separate `schemas[]` entry for that artifact or give it its own contract. See xref:data-contracts-artifact-references_{context}[].
+
+[id="data-contracts-artifact-references_{context}"]
+== Artifact references and data contracts
+
+[role="_abstract"]
+Schema artifacts can reference other artifacts (for example an Avro `OrderEvent` that references a shared `Address` record). Data contracts stay scoped to each artifact. {registry} does not walk those cross-artifact references when projecting ODCS field metadata.
+
+=== What works at evaluation time
+
+When a Kafka record is serialized, nested objects are fully materialized. An Avro `GenericRecord` contains the nested `Address` values inline, not a pointer to another registry artifact. After conversion to a map, CEL rules can reach nested paths:
+
+[source,json]
+----
+{
+  "orderId": "ORD-123",
+  "address": { "street": "123 Main St", "zipCode": "90210" }
+}
+----
+
+A CEL expression such as `address.zipCode != ""` works at rule evaluation time because the nested fields are present on the record.
+
+=== What projection does not do
+
+ODCS `schemas[].fields` metadata (PII flags, tags, classifications) is projected only for fields that belong to the artifact listed in that `schemas[]` entry. The projection engine does not resolve artifact references to discover fields that live on another schema.
+
+So you cannot tag `address.street` as PII from an `OrderEvent` contract if `street` is defined on a separate `Address` artifact. Declare PII on the `Address` contract (or add `Address` as its own `schemas[]` entry) instead.
+
+=== Why contracts stay per-artifact
+
+* Ownership stays clear: the team that owns `Address` declares which of its fields are PII.
+* Changing `Address` does not force every dependent contract to be re-projected.
+* Conflicting metadata is avoided when two contracts would otherwise both claim the same nested field.
+
+=== Practical guidance
+
+* Put field-level PII and tags on the contract (or `schemas[]` entry) for the artifact that actually defines those fields.
+* Use CEL quality rules on the parent artifact when you need to validate nested values on the wire; those rules see the materialized record.
+* List every governed schema under `schemas[]` when one ODCS document should cover several related artifacts.
 
 [id="data-contracts-field-tags_{context}"]
 == Field-level tags

--- a/examples/odcs-data-contracts/src/main/resources/order-contract.yaml
+++ b/examples/odcs-data-contracts/src/main/resources/order-contract.yaml
@@ -15,6 +15,8 @@ team:
   domain: commerce
   contact: orders-team@example.com
 schemas:
+  # each schemas[] entry is independent — field pii/tags apply only to this artifact.
+  # nested types stored as separate registry artifacts need their own entry (or contract).
   - name: OrderEvent
     type: avro
     location: ${GROUP_ID}/${ARTIFACT_ID}:latest

--- a/examples/odcs-data-contracts/src/main/resources/order-contract.yaml
+++ b/examples/odcs-data-contracts/src/main/resources/order-contract.yaml
@@ -15,7 +15,7 @@ team:
   domain: commerce
   contact: orders-team@example.com
 schemas:
-  # each schemas[] entry is independent — field pii/tags apply only to this artifact.
+  # each schemas[] entry is independent — field PII/tags apply only to this artifact.
   # nested types stored as separate registry artifacts need their own entry (or contract).
   - name: OrderEvent
     type: avro


### PR DESCRIPTION
fixes #8104

contracts are per-artifact and projection does not walk cross-artifact schema refs. cel can still read nested fields at eval time since records are materialized.

this adds:
- a section in the data contracts docs
- a note under schemas[].location
- javadoc on the odcs model
- short comments in the sample contract yaml

left the optional validation warning for a follow-up.