### PR TITLE
feat: add rule type discovery endpoints

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/RulesResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/RulesResourceImpl.java
@@ -1,0 +1,104 @@
+package io.apicurio.registry.rest.v3.impl;
+
+import io.apicurio.registry.auth.Authorized;
+import io.apicurio.registry.auth.AuthorizedLevel;
+import io.apicurio.registry.auth.AuthorizedStyle;
+import io.apicurio.registry.logging.Logged;
+import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
+import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
+import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
+import io.apicurio.registry.rules.integrity.IntegrityLevel;
+import io.apicurio.registry.rules.validity.ValidityLevel;
+import io.apicurio.registry.types.RuleType;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.interceptor.Interceptors;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Discovery endpoints for rule types and their valid configuration values.
+ * <p>
+ * Implemented as a standalone JAX-RS resource (same pattern as {@link DownloadsResourceImpl}) so
+ * clients can call {@code GET /rules/types} without requiring a new generated resource interface.
+ */
+@ApplicationScoped
+@Interceptors({ ResponseErrorLivenessCheck.class, ResponseTimeoutReadinessCheck.class })
+@Logged
+@Path("/apis/registry/v3/rules")
+public class RulesResourceImpl {
+
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
+    @GET
+    @Path("/types")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<RuleType> listRuleTypes() {
+        return Arrays.asList(RuleType.values());
+    }
+
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
+    @GET
+    @Path("/types/{ruleType}/values")
+    @Produces(MediaType.APPLICATION_JSON)
+    public RuleTypeValues listRuleTypeValues(@PathParam("ruleType") String ruleType) {
+        RuleType type = parseRuleType(ruleType);
+        RuleTypeValues response = new RuleTypeValues();
+        response.setRuleType(type);
+        response.setValues(configValuesFor(type));
+        return response;
+    }
+
+    private static RuleType parseRuleType(String ruleType) {
+        if (ruleType == null || ruleType.isBlank()) {
+            throw new BadRequestException("Rule type must not be empty.");
+        }
+        try {
+            return RuleType.fromValue(ruleType);
+        } catch (IllegalArgumentException ex) {
+            throw new BadRequestException("Unknown rule type: " + ruleType
+                    + ". Valid values are: "
+                    + Stream.of(RuleType.values()).map(Enum::name).collect(Collectors.joining(", ")));
+        }
+    }
+
+    private static List<String> configValuesFor(RuleType ruleType) {
+        return switch (ruleType) {
+            case VALIDITY -> Stream.of(ValidityLevel.values()).map(Enum::name).toList();
+            case COMPATIBILITY -> Stream.of(CompatibilityLevel.values()).map(Enum::name).toList();
+            case INTEGRITY -> Stream.of(IntegrityLevel.values()).map(Enum::name).toList();
+        };
+    }
+
+    /**
+     * Response body for {@code GET /rules/types/{ruleType}/values}.
+     * Kept next to the resource to avoid clashing with a future codegen bean of the same OpenAPI name.
+     */
+    public static class RuleTypeValues {
+        private RuleType ruleType;
+        private List<String> values;
+
+        public RuleType getRuleType() {
+            return ruleType;
+        }
+
+        public void setRuleType(RuleType ruleType) {
+            this.ruleType = ruleType;
+        }
+
+        public List<String> getValues() {
+            return values;
+        }
+
+        public void setValues(List<String> values) {
+            this.values = values;
+        }
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/RulesResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/RulesResourceTest.java
@@ -1,0 +1,52 @@
+package io.apicurio.registry.noprofile.rest.v3;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+
+@QuarkusTest
+public class RulesResourceTest extends AbstractResourceTestBase {
+
+    @Test
+    public void testListRuleTypes() {
+        given().when().contentType(CT_JSON).get("/registry/v3/rules/types").then().statusCode(200)
+                .body("$", hasItems("VALIDITY", "COMPATIBILITY", "INTEGRITY"));
+    }
+
+    @Test
+    public void testListCompatibilityRuleValues() {
+        given().when().contentType(CT_JSON).get("/registry/v3/rules/types/COMPATIBILITY/values").then()
+                .statusCode(200)
+                .body("ruleType", equalTo("COMPATIBILITY"))
+                .body("values", containsInAnyOrder("NONE", "BACKWARD", "BACKWARD_TRANSITIVE", "FORWARD",
+                        "FORWARD_TRANSITIVE", "FULL", "FULL_TRANSITIVE"));
+    }
+
+    @Test
+    public void testListValidityRuleValues() {
+        given().when().contentType(CT_JSON).get("/registry/v3/rules/types/VALIDITY/values").then()
+                .statusCode(200)
+                .body("ruleType", equalTo("VALIDITY"))
+                .body("values", containsInAnyOrder("NONE", "SYNTAX_ONLY", "FULL"));
+    }
+
+    @Test
+    public void testListIntegrityRuleValues() {
+        given().when().contentType(CT_JSON).get("/registry/v3/rules/types/INTEGRITY/values").then()
+                .statusCode(200)
+                .body("ruleType", equalTo("INTEGRITY"))
+                .body("values", containsInAnyOrder("NONE", "REFS_EXIST", "ALL_REFS_MAPPED", "NO_DUPLICATES",
+                        "NO_CIRCULAR_REFERENCES", "FULL"));
+    }
+
+    @Test
+    public void testUnknownRuleTypeReturnsBadRequest() {
+        given().when().contentType(CT_JSON).get("/registry/v3/rules/types/NOT_A_RULE/values").then()
+                .statusCode(400);
+    }
+}

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -288,7 +288,7 @@
       ]
     },
     "/rules/types": {
-      "summary": "Discover the rule types supported by the registry and their valid configuration values.",
+      "summary": "Discover the rule types supported by the registry.",
       "get": {
         "tags": [
           "Rules"

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -287,6 +287,87 @@
         }
       ]
     },
+    "/rules/types": {
+      "summary": "Discover the rule types supported by the registry and their valid configuration values.",
+      "get": {
+        "tags": [
+          "Rules"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RuleType"
+                  }
+                }
+              }
+            },
+            "description": "The list of available rule types."
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "operationId": "listRuleTypes",
+        "summary": "List rule types",
+        "description": "Gets the list of rule types supported by this registry (for example VALIDITY, COMPATIBILITY, INTEGRITY).\n\nThis is a discovery endpoint for clients and UIs. It returns the catalog of rule types, not the rules currently configured on artifacts or globally.\n\nThis operation can fail for the following reasons:\n\n* A server error occurred (HTTP error `500`)\n"
+      }
+    },
+    "/rules/types/{ruleType}/values": {
+      "summary": "List the valid configuration values for a given rule type.",
+      "get": {
+        "tags": [
+          "Rules"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuleTypeValues"
+                }
+              }
+            },
+            "description": "The valid configuration values for the rule type."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "operationId": "listRuleTypeValues",
+        "summary": "List rule type configuration values",
+        "description": "Gets the list of valid configuration values for a rule type (for example compatibility levels for COMPATIBILITY).\n\nThis operation can fail for the following reasons:\n\n* The rule type is unknown (HTTP error `400`)\n* A server error occurred (HTTP error `500`)\n"
+      },
+      "parameters": [
+        {
+          "name": "ruleType",
+          "description": "The unique name/type of a rule.",
+          "schema": {
+            "$ref": "#/components/schemas/RuleType"
+          },
+          "in": "path",
+          "required": true
+        }
+      ]
+    },
     "/system/info": {
       "summary": "Retrieve system information",
       "get": {
@@ -6288,6 +6369,38 @@
           "name": "AVRO"
         }
       },
+      "RuleTypeValues": {
+        "description": "Valid configuration values for a given rule type.",
+        "required": [
+          "ruleType",
+          "values"
+        ],
+        "type": "object",
+        "properties": {
+          "ruleType": {
+            "$ref": "#/components/schemas/RuleType"
+          },
+          "values": {
+            "description": "The allowed configuration values for the rule type.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "example": {
+          "ruleType": "COMPATIBILITY",
+          "values": [
+            "NONE",
+            "BACKWARD",
+            "BACKWARD_TRANSITIVE",
+            "FORWARD",
+            "FORWARD_TRANSITIVE",
+            "FULL",
+            "FULL_TRANSITIVE"
+          ]
+        }
+      },
       "ArtifactSearchResults": {
         "description": "Describes the response received when searching for artifacts.",
         "required": [
@@ -9240,6 +9353,10 @@
     {
       "name": "Global rules",
       "description": "Global rules can be configured in the registry to govern how artifact content can \nevolve over time (as artifact content is **updated**). Global rules are applied \nwhenever an artifact is added to the registry, and also whenever an artifact's \ncontent is updated (only if that artifact does not have its own specific rules \nconfigured). This section describes the operations used to manage the global rules."
+    },
+    {
+      "name": "Rules",
+      "description": "Discovery endpoints for the catalog of rule types and their valid configuration values. These endpoints do not manage configured rules; use the global, group, or artifact rules APIs for that."
     },
     {
       "name": "Search",


### PR DESCRIPTION
fixes #7634

adds read-only discovery endpoints so uis/clients do not have to hardcode rule configs:

- get /rules/types
- get /rules/types/{ruleType}/values

values come from the existing validity / compatibility / integrity enums. unknown rule type returns 400.