### PR TITLE
Preserve original $ref provenance as $comment when dereferencing JSON schemas

### DIFF
--- a/schema-util/json/src/main/java/io/apicurio/registry/json/content/dereference/JsonSchemaDereferencer.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/json/content/dereference/JsonSchemaDereferencer.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
@@ -35,6 +36,7 @@ public class JsonSchemaDereferencer implements ContentDereferencer {
     private static final Logger log = LoggerFactory.getLogger(JsonSchemaDereferencer.class);
     private static final String idKey = "$id";
     private static final String schemaKey = "$schema";
+    private static final String commentKey = "$comment";
 
     static {
         objectMapper = new ObjectMapper();
@@ -100,9 +102,48 @@ public class JsonSchemaDereferencer implements ContentDereferencer {
             lookups.computeIfAbsent(externalRef.getResource(), (key) -> {
                 JsonObject resolvedSchema = JsonRef.resolve(new JsonObject(schema.getContent().content()),
                         lookups);
+                // When refs were rewritten to GAV coordinates, keep provenance on the inlined schema
+                // via $comment (JSON Schema draft-07+ non-functional metadata). Vert.x JsonRef strips
+                // $id/$schema during resolve but leaves $comment intact.
+                buildOriginalRefComment(referenceName).ifPresent(comment -> {
+                    if (!resolvedSchema.containsKey(commentKey)) {
+                        resolvedSchema.put(commentKey, comment);
+                    }
+                });
                 return JsonSchema.of(resolvedSchema);
             });
         });
+    }
+
+    /**
+     * Builds a provenance comment when the resolved reference key uses registry GAV coordinates:
+     * {@code groupId:artifactId:version:referenceName}.
+     * <p>
+     * Format: {@code referenceName:groupId/artifactId:version}
+     * <p>
+     * Plain logical names (e.g. {@code customer.json}) return empty so existing unit fixtures stay stable.
+     */
+    static Optional<String> buildOriginalRefComment(String referenceKey) {
+        if (referenceKey == null || referenceKey.isBlank()) {
+            return Optional.empty();
+        }
+        JsonPointerExternalReference externalRef = new JsonPointerExternalReference(referenceKey);
+        String resource = externalRef.getResource();
+        if (resource == null) {
+            return Optional.empty();
+        }
+        String[] parts = resource.split(":", 4);
+        if (parts.length < 4) {
+            return Optional.empty();
+        }
+        String groupId = parts[0];
+        String artifactId = parts[1];
+        String version = parts[2];
+        String name = parts[3];
+        if (groupId.isBlank() || artifactId.isBlank() || version.isBlank() || name.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(name + ":" + groupId + "/" + artifactId + ":" + version);
     }
 
     /**

--- a/schema-util/json/src/main/java/io/apicurio/registry/json/content/dereference/JsonSchemaDereferencer.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/json/content/dereference/JsonSchemaDereferencer.java
@@ -36,7 +36,7 @@ public class JsonSchemaDereferencer implements ContentDereferencer {
     private static final Logger log = LoggerFactory.getLogger(JsonSchemaDereferencer.class);
     private static final String idKey = "$id";
     private static final String schemaKey = "$schema";
-    private static final String commentKey = "$comment";
+    private static final String COMMENT_KEY = "$comment";
 
     static {
         objectMapper = new ObjectMapper();
@@ -106,8 +106,8 @@ public class JsonSchemaDereferencer implements ContentDereferencer {
                 // via $comment (JSON Schema draft-07+ non-functional metadata). Vert.x JsonRef strips
                 // $id/$schema during resolve but leaves $comment intact.
                 buildOriginalRefComment(referenceName).ifPresent(comment -> {
-                    if (!resolvedSchema.containsKey(commentKey)) {
-                        resolvedSchema.put(commentKey, comment);
+                    if (!resolvedSchema.containsKey(COMMENT_KEY)) {
+                        resolvedSchema.put(COMMENT_KEY, comment);
                     }
                 });
                 return JsonSchema.of(resolvedSchema);

--- a/schema-util/json/src/main/java/io/apicurio/registry/json/content/dereference/JsonSchemaDereferencer.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/json/content/dereference/JsonSchemaDereferencer.java
@@ -123,7 +123,7 @@ public class JsonSchemaDereferencer implements ContentDereferencer {
      * <p>
      * Plain logical names (e.g. {@code customer.json}) return empty so existing unit fixtures stay stable.
      */
-    static Optional<String> buildOriginalRefComment(String referenceKey) {
+    public static Optional<String> buildOriginalRefComment(String referenceKey) {
         if (referenceKey == null || referenceKey.isBlank()) {
             return Optional.empty();
         }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/content/dereference/JsonSchemaContentDereferencerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/content/dereference/JsonSchemaContentDereferencerTest.java
@@ -1,5 +1,7 @@
 package io.apicurio.registry.content.dereference;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.refs.ExternalReference;
 import io.apicurio.registry.content.refs.JsonPointerExternalReference;
@@ -186,14 +188,24 @@ public class JsonSchemaContentDereferencerTest extends ArtifactUtilProviderTestB
                 ContentTypes.APPLICATION_JSON));
 
         TypedContent modifiedContent = dereferencer.dereference(rewritten, resolvedReferences);
-        String dereferenced = modifiedContent.getContent().content();
+        JsonNode root = new ObjectMapper().readTree(modifiedContent.getContent().content());
 
-        Assertions.assertTrue(dereferenced.contains("\"$comment\""),
-                "expected $comment provenance on inlined schema");
-        Assertions.assertTrue(dereferenced.contains("customer.json:orders/Customer:1"),
-                "expected GAV provenance in $comment, got: " + dereferenced);
-        // original $ref should be gone
-        Assertions.assertFalse(dereferenced.contains("\"$ref\""));
+        String expectedComment = "customer.json:orders/Customer:1";
+        assertInlinedSchemaHasComment(root.path("allOf").path(0), expectedComment);
+        assertInlinedSchemaHasComment(root.path("anyOf").path(0), expectedComment);
+        assertInlinedSchemaHasComment(root.path("oneOf").path(0), expectedComment);
+
+        // original $ref should be gone from those inlined nodes
+        Assertions.assertFalse(root.path("allOf").path(0).has("$ref"));
+        Assertions.assertFalse(root.path("anyOf").path(0).has("$ref"));
+        Assertions.assertFalse(root.path("oneOf").path(0).has("$ref"));
+    }
+
+    private static void assertInlinedSchemaHasComment(JsonNode inlined, String expectedComment) {
+        Assertions.assertFalse(inlined.isMissingNode() || inlined.isNull(),
+                "expected inlined schema node to be present");
+        Assertions.assertEquals(expectedComment, inlined.path("$comment").asText(null),
+                "expected $comment provenance on inlined schema, got: " + inlined);
     }
 
     @Test

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/content/dereference/JsonSchemaContentDereferencerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/content/dereference/JsonSchemaContentDereferencerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static io.apicurio.registry.utils.tests.TestUtils.normalizeMultiLineString;
@@ -165,6 +166,45 @@ public class JsonSchemaContentDereferencerTest extends ArtifactUtilProviderTestB
         Set<ExternalReference> externalReferences = finder.findExternalReferences(modifiedContent);
         Assertions.assertTrue(externalReferences
                 .contains(new JsonPointerExternalReference("https://www.example.org/schemas/customer.json")));
+    }
+
+    /**
+     * When resolved refs use registry GAV coordinates (as after rewrite-with-context),
+     * dereferencing should keep provenance in $comment on the inlined schema.
+     */
+    @Test
+    public void testDereferencePreservesOriginalRefComment() throws Exception {
+        TypedContent content = TypedContent.create(resourceToContentHandle("order.json"),
+                ContentTypes.APPLICATION_JSON);
+        JsonSchemaDereferencer dereferencer = new JsonSchemaDereferencer();
+
+        String gavRef = "orders:Customer:1:customer.json";
+        TypedContent rewritten = dereferencer.rewriteReferences(content, Map.of("customer.json", gavRef));
+
+        Map<String, TypedContent> resolvedReferences = new LinkedHashMap<>();
+        resolvedReferences.put(gavRef, TypedContent.create(resourceToContentHandle("customer.json"),
+                ContentTypes.APPLICATION_JSON));
+
+        TypedContent modifiedContent = dereferencer.dereference(rewritten, resolvedReferences);
+        String dereferenced = modifiedContent.getContent().content();
+
+        Assertions.assertTrue(dereferenced.contains("\"$comment\""),
+                "expected $comment provenance on inlined schema");
+        Assertions.assertTrue(dereferenced.contains("customer.json:orders/Customer:1"),
+                "expected GAV provenance in $comment, got: " + dereferenced);
+        // original $ref should be gone
+        Assertions.assertFalse(dereferenced.contains("\"$ref\""));
+    }
+
+    @Test
+    public void testBuildOriginalRefComment() {
+        Assertions.assertEquals(Optional.of("customer.json:orders/Customer:1"),
+                JsonSchemaDereferencer.buildOriginalRefComment("orders:Customer:1:customer.json"));
+        Assertions.assertEquals(Optional.of("types/all-types.json:default/City:2"),
+                JsonSchemaDereferencer
+                        .buildOriginalRefComment("default:City:2:types/all-types.json#/definitions/City"));
+        Assertions.assertTrue(JsonSchemaDereferencer.buildOriginalRefComment("customer.json").isEmpty());
+        Assertions.assertTrue(JsonSchemaDereferencer.buildOriginalRefComment(null).isEmpty());
     }
 
     /**


### PR DESCRIPTION
## description
fixes #7633

when json schemas are dereferenced after refs are rewritten to registry gav coordinates, the original reference info was getting dropped. this adds a non-functional `$comment` on the inlined schema so you can still tell where the content came from.

format: `referenceName:groupId/artifactId:version`

only kicks in for gav-style keys; plain names like `customer.json` are unchanged so existing unit fixtures keep working.

## test plan
- [ ] `./mvnw -pl schema-util/util-provider -am test -Dtest=JsonSchemaContentDereferencerTest`
- [ ] check deref with gav refs includes `$comment`
- [ ] check existing deref golden tests still pass