### PR TITLE
docs(ui): fix config dir name in ui-app README

### DIFF
--- a/ui/ui-app/README.md
+++ b/ui/ui-app/README.md
@@ -17,7 +17,7 @@ Run a full build
 Initialize config.js
 `./init-dev.sh`
 
-Note: the init-dev.sh script just copies an appropriate file from config/config-*.js to the right place.  You can 
+Note: the init-dev.sh script just copies an appropriate file from configs/config-*.js to the right place.  You can 
 either specify `local` or `3scale` (for example) as the argument to the script.  The choice depends on how you are 
 running the back-end component.
 

--- a/ui/ui-app/README.md
+++ b/ui/ui-app/README.md
@@ -17,8 +17,8 @@ Run a full build
 Initialize config.js
 `./init-dev.sh`
 
-Note: the init-dev.sh script just copies an appropriate file from configs/config-*.js to the right place.  You can 
-either specify `local` or `3scale` (for example) as the argument to the script.  The choice depends on how you are 
+Note: the init-dev.sh script copies configs/version.js and an appropriate configs/config-*.js into place.
+You can either specify `local` or `3scale` (for example) as the argument to the script.  The choice depends on how you are
 running the back-end component.
 
 Start the development server


### PR DESCRIPTION
## description
fixes #8535

ui-app readme said init-dev.sh copies from `config/config-*.js`, but the real path is `configs/`. updated the note so it matches the script.

## test plan
- [ ] open `ui/ui-app/README.md` and confirm it says `configs/`
- [ ] compare against `init-dev.sh`