### PR TITLE
fix: proto2 ProtobufSerializer validation for schema registered as .proto text

### DIFF
--- a/schema-util/protobuf/src/main/java/io/apicurio/registry/protobuf/rules/compatibility/protobuf/ProtobufCompatibilityCheckerLibrary.java
+++ b/schema-util/protobuf/src/main/java/io/apicurio/registry/protobuf/rules/compatibility/protobuf/ProtobufCompatibilityCheckerLibrary.java
@@ -360,13 +360,9 @@ public class ProtobufCompatibilityCheckerLibrary {
             return buildFullyQualifiedName(file, type);
         }
 
-        // For types we can't locate in the schema, infer the fully qualified name
-        // This handles cross-file references or types that might be defined elsewhere
-        if (messageContext != null && !messageContext.isEmpty()) {
-            return buildFullyQualifiedName(file, messageContext + "." + type);
-        }
-
-        // Default: assume it's a top-level type
+        // For types not found in the current file (e.g., imported types), resolve against the
+        // current package. Protobuf scoping resolves unqualified simple names that are not found
+        // in nested scopes against the file's package, not against the current message context.
         return buildFullyQualifiedName(file, type);
     }
 

--- a/schema-util/protobuf/src/test/java/io/apicurio/registry/rules/compatibility/protobuf/ProtobufCompatibilityCheckerLibraryTest.java
+++ b/schema-util/protobuf/src/test/java/io/apicurio/registry/rules/compatibility/protobuf/ProtobufCompatibilityCheckerLibraryTest.java
@@ -1,10 +1,15 @@
 package io.apicurio.registry.rules.compatibility.protobuf;
 
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.squareup.wire.schema.internal.parser.ProtoFileElement;
+import com.squareup.wire.schema.internal.parser.ProtoParser;
 import io.apicurio.registry.protobuf.ProtobufDifference;
 import io.apicurio.registry.protobuf.rules.compatibility.protobuf.ProtobufCompatibilityCheckerLibrary;
+import io.apicurio.registry.utils.protobuf.schema.FileDescriptorUtils;
 import io.apicurio.registry.utils.protobuf.schema.ProtobufFile;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1142,4 +1147,60 @@ public class ProtobufCompatibilityCheckerLibraryTest {
                 "Type references should resolve to grandparent scope per Protobuf scoping rules. Found: "
                         + differences);
     }
+    /**
+     * Tests that a proto2 schema registered as .proto text is considered compatible with the same
+     * schema derived from a compiled protobuf descriptor. This specifically covers map fields and
+     * imported message references, which were previously reported as different because the
+     * descriptor-derived representation expanded map fields into synthetic *Entry repeated messages
+     * and used fully-qualified type names for imported messages.
+     */
+    @Test
+    public void testProto2MapFieldAndImportedReferenceCompatibility() throws Exception {
+        String detailSchema = """
+                syntax = "proto2";
+                package com.example.api;
+                option java_multiple_files = true;
+
+                message Detail {
+                  required int64 id = 1;
+                }
+                """;
+        String envelopeSchema = """
+                syntax = "proto2";
+                package com.example.api;
+                import "Detail.proto";
+                option java_multiple_files = true;
+
+                message Envelope {
+                  enum Type { UNKNOWN = 0; FULL = 1; }
+                  required Type type = 1;
+                  optional Detail detail = 2;
+                  optional Payload payload = 3;
+                }
+
+                message Payload {
+                  optional int64 id = 1;
+                  map<string, string> attributes = 2;
+                }
+                """;
+
+        FileDescriptor fileDescriptor = FileDescriptorUtils.toDescriptor("Envelope",
+                ProtoParser.Companion.parse(FileDescriptorUtils.DEFAULT_LOCATION, envelopeSchema),
+                Map.of("Detail.proto",
+                        ProtoParser.Companion.parse(FileDescriptorUtils.DEFAULT_LOCATION, detailSchema))).getFile();
+
+        ProtobufFile registeredFile = new ProtobufFile(envelopeSchema);
+
+        ProtoFileElement derivedElement = FileDescriptorUtils.fileDescriptorToProtoFile(fileDescriptor.toProto());
+        ProtobufFile derivedFile = new ProtobufFile(derivedElement);
+
+        ProtobufCompatibilityCheckerLibrary checker = new ProtobufCompatibilityCheckerLibrary(registeredFile,
+                derivedFile);
+        List<ProtobufDifference> differences = checker.findDifferences(false);
+
+        assertTrue(differences.isEmpty(),
+                "Proto2 schemas with map fields and imported message references should match their descriptor-derived counterpart. Found: "
+                        + differences);
+    }
+
 }

--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
@@ -1248,6 +1248,20 @@ public class FileDescriptorUtils {
     }
 
     private static MessageElement toMessage(FileDescriptorProto file, DescriptorProto descriptor) {
+        return toMessage(file, getMessageFullName(file, descriptor.getName()), descriptor);
+    }
+
+    private static String getMessageFullName(FileDescriptorProto file, String messageName) {
+        String packageName = file.getPackage();
+        if (packageName != null && !packageName.isEmpty()) {
+            return "." + packageName + "." + messageName;
+        } else {
+            return "." + messageName;
+        }
+    }
+
+    private static MessageElement toMessage(FileDescriptorProto file, String messageFullName,
+            DescriptorProto descriptor) {
         String name = descriptor.getName();
         ImmutableList.Builder<FieldElement> fields = ImmutableList.builder();
         ImmutableList.Builder<TypeElement> nested = ImmutableList.builder();
@@ -1260,25 +1274,45 @@ public class FileDescriptorUtils {
         List<Map.Entry<String, ImmutableList.Builder<FieldElement>>> oneofs = new ArrayList<>(
                 oneofsMap.entrySet());
         List<FieldElement> proto3OptionalFields = new ArrayList<>();
+
+        // Map fields are represented in descriptors as repeated message fields whose type is a
+        // synthetic nested message with the map_entry option enabled. Collapse them back to the
+        // map<KeyType, ValueType> syntax used in .proto text files, and omit the synthetic entry
+        // message from the nested type list.
+        //
+        // The map is keyed by the simple (unqualified) entry message name so that it works
+        // regardless of whether the descriptor uses fully-qualified type names (protoc-compiled
+        // descriptors, e.g. ".pkg.Payload.AttributesEntry") or short names (dynamically-built
+        // descriptors, e.g. "attributesEntry"). The field's type_name always resolves to the
+        // entry message's simple name as its last path component.
+        Map<String, String> mapEntryTypes = new HashMap<>();
+        for (DescriptorProto nestedDesc : descriptor.getNestedTypeList()) {
+            String nestedFullName = messageFullName + "." + nestedDesc.getName();
+            if (nestedDesc.getOptions().getMapEntry()) {
+                String keyType = getMapEntryFieldType(file, findFieldByName(nestedDesc, "key"));
+                String valueType = getMapEntryFieldType(file, findFieldByName(nestedDesc, "value"));
+                mapEntryTypes.put(nestedDesc.getName(), "map<" + keyType + ", " + valueType + ">");
+            } else {
+                nested.add(toMessage(file, nestedFullName, nestedDesc));
+            }
+        }
         for (FieldDescriptorProto fd : descriptor.getFieldList()) {
             if (fd.hasProto3Optional()) {
                 proto3OptionalFields.add(toField(file, fd, false));
                 continue;
             }
-            if (fd.hasOneofIndex()) {
+            String mapType = fd.hasTypeName() ? mapEntryTypes.get(getSimpleName(fd.getTypeName())) : null;
+            if (mapType != null) {
+                fields.add(toField(file, fd, false, mapType, null));
+            } else if (fd.hasOneofIndex()) {
                 FieldElement field = toField(file, fd, true);
                 oneofs.get(fd.getOneofIndex()).getValue().add(field);
-            }
-            else {
+            } else {
                 FieldElement field = toField(file, fd, false);
                 fields.add(field);
             }
         }
         fields.addAll(proto3OptionalFields);
-        for (DescriptorProto nestedDesc : descriptor.getNestedTypeList()) {
-            MessageElement nestedMessage = toMessage(file, nestedDesc);
-            nested.add(nestedMessage);
-        }
         for (EnumDescriptorProto nestedDesc : descriptor.getEnumTypeList()) {
             EnumElement nestedEnum = toEnum(nestedDesc);
             nested.add(nestedEnum);
@@ -1381,6 +1415,11 @@ public class FileDescriptorUtils {
     }
 
     private static FieldElement toField(FileDescriptorProto file, FieldDescriptorProto fd, boolean inOneof) {
+        return toField(file, fd, inOneof, dataType(fd), inOneof ? null : label(file, fd));
+    }
+
+    private static FieldElement toField(FileDescriptorProto file, FieldDescriptorProto fd, boolean inOneof,
+            String type, Field.Label label) {
         String name = fd.getName();
         DescriptorProtos.FieldOptions fieldDescriptorOptions = fd.getOptions();
         ImmutableList.Builder<OptionElement> options = ImmutableList.builder();
@@ -1427,8 +1466,54 @@ public class FileDescriptorUtils {
         String jsonName = null;
         String defaultValue = fd.hasDefaultValue() && fd.getDefaultValue() != null ? fd.getDefaultValue()
                 : null;
-        return new FieldElement(DEFAULT_LOCATION, inOneof ? null : label(file, fd), dataType(fd), name,
-                defaultValue, jsonName, fd.getNumber(), "", options.build());
+        return new FieldElement(DEFAULT_LOCATION, label, type, name, defaultValue, jsonName, fd.getNumber(), "", options.build());
+    }
+
+    private static FieldDescriptorProto findFieldByName(DescriptorProto descriptor, String name) {
+        for (FieldDescriptorProto field : descriptor.getFieldList()) {
+            if (field.getName().equals(name)) {
+                return field;
+            }
+        }
+        return null;
+    }
+
+    private static String getMapEntryFieldType(FileDescriptorProto file, FieldDescriptorProto field) {
+        if (field == null) {
+            return null;
+        }
+        if (field.hasTypeName()) {
+            return toRelativeTypeName(field.getTypeName(), file.getPackage());
+        }
+        return dataType(field);
+    }
+
+    private static String toRelativeTypeName(String typeName, String packageName) {
+        if (typeName == null) {
+            return null;
+        }
+        if (typeName.startsWith(".")) {
+            String fullyQualified = typeName.substring(1);
+            if (packageName != null && !packageName.isEmpty() && fullyQualified.startsWith(packageName + ".")) {
+                return fullyQualified.substring(packageName.length() + 1);
+            }
+            return fullyQualified;
+        }
+        return typeName;
+    }
+
+    /**
+     * Extracts the simple (unqualified) name from a potentially fully-qualified type name.
+     * Works for both fully-qualified names (e.g. ".com.example.Payload.AttributesEntry" -&gt;
+     * "AttributesEntry") and short names (e.g. "attributesEntry" -&gt; "attributesEntry").
+     */
+    private static String getSimpleName(String typeName) {
+        if (typeName == null) {
+            return null;
+        }
+        String name = typeName.startsWith(".") ? typeName.substring(1) : typeName;
+        int lastDot = name.lastIndexOf('.');
+        return lastDot >= 0 ? name.substring(lastDot + 1) : name;
     }
 
     private static ReservedElement toReserved(EnumDescriptorProto.EnumReservedRange range) {


### PR DESCRIPTION
## Description
- Collapse descriptor map fields back to map by detecting synthetic mapentry nested messages and replacing repeated EntryType fields with map fields having no label.

- Support explicit type/label passthrough in toField() by adding an overloaded variant so collapsed map fields can supply their own type and null label, bypassing proto2 label computation.

- Fix imported type resolution in normalizeType() by removing the fallback that incorrectly prefixed unknown type names with the current message scope instead resolving against the file's package per protobuf scoping rules.

- Add a test covering the exact reported scenario


## Issue
fixes #8279 