### PR TITLE
feat(rules): add Avro compatibility fix suggestions on rule violations

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/http/CCompatExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/CCompatExceptionMapperService.java
@@ -12,6 +12,7 @@ import io.apicurio.registry.ccompat.rest.error.SubjectSoftDeletedException;
 import io.apicurio.registry.ccompat.rest.error.UnprocessableEntityException;
 import io.apicurio.registry.metrics.health.liveness.LivenessUtil;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
+import io.apicurio.registry.rest.v2.beans.CompatibilityFixSuggestion;
 import io.apicurio.registry.rest.v2.beans.Error;
 import io.apicurio.registry.rest.v2.beans.RuleViolationCause;
 import io.apicurio.registry.rest.v2.beans.RuleViolationError;
@@ -170,6 +171,16 @@ public class CCompatExceptionMapperService {
             RuleViolationCause cause = new RuleViolationCause();
             cause.setContext(violation.getContext());
             cause.setDescription(violation.getDescription());
+            cause.setType(violation.getType());
+            if (violation.hasSuggestions()) {
+                cause.setSuggestions(violation.getSuggestions().stream().map(suggestion -> {
+                    CompatibilityFixSuggestion bean = new CompatibilityFixSuggestion();
+                    bean.setTier(suggestion.getTier().name());
+                    bean.setDescription(suggestion.getDescription());
+                    bean.setExample(suggestion.getExample());
+                    return bean;
+                }).collect(Collectors.toList()));
+            }
             return cause;
         }).collect(Collectors.toList());
     }

--- a/app/src/main/java/io/apicurio/registry/services/http/CoreRegistryExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/CoreRegistryExceptionMapperService.java
@@ -3,6 +3,7 @@ package io.apicurio.registry.services.http;
 import io.apicurio.common.apps.config.Info;
 import io.apicurio.registry.metrics.health.liveness.LivenessUtil;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
+import io.apicurio.registry.rest.v3.beans.CompatibilityFixSuggestion;
 import io.apicurio.registry.rest.v3.beans.ProblemDetails;
 import io.apicurio.registry.rest.v3.beans.RuleViolationCause;
 import io.apicurio.registry.rest.v3.beans.RuleViolationProblemDetails;
@@ -113,6 +114,16 @@ public class CoreRegistryExceptionMapperService {
             RuleViolationCause cause = new RuleViolationCause();
             cause.setContext(violation.getContext());
             cause.setDescription(violation.getDescription());
+            cause.setType(violation.getType());
+            if (violation.hasSuggestions()) {
+                cause.setSuggestions(violation.getSuggestions().stream().map(suggestion -> {
+                    CompatibilityFixSuggestion bean = new CompatibilityFixSuggestion();
+                    bean.setTier(suggestion.getTier().name());
+                    bean.setDescription(suggestion.getDescription());
+                    bean.setExample(suggestion.getExample());
+                    return bean;
+                }).collect(Collectors.toList()));
+            }
             return cause;
         }).collect(Collectors.toList());
     }

--- a/app/src/main/java/io/apicurio/registry/services/http/CoreV2RegistryExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/CoreV2RegistryExceptionMapperService.java
@@ -4,6 +4,7 @@ import io.apicurio.common.apps.config.Info;
 import io.apicurio.registry.metrics.health.liveness.LivenessUtil;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.rest.v2.beans.AuthError;
+import io.apicurio.registry.rest.v2.beans.CompatibilityFixSuggestion;
 import io.apicurio.registry.rest.v2.beans.Error;
 import io.apicurio.registry.rest.v2.beans.RuleViolationCause;
 import io.apicurio.registry.rest.v2.beans.RuleViolationError;
@@ -123,6 +124,16 @@ public class CoreV2RegistryExceptionMapperService {
             RuleViolationCause cause = new RuleViolationCause();
             cause.setContext(violation.getContext());
             cause.setDescription(violation.getDescription());
+            cause.setType(violation.getType());
+            if (violation.hasSuggestions()) {
+                cause.setSuggestions(violation.getSuggestions().stream().map(suggestion -> {
+                    CompatibilityFixSuggestion bean = new CompatibilityFixSuggestion();
+                    bean.setTier(suggestion.getTier().name());
+                    bean.setDescription(suggestion.getDescription());
+                    bean.setExample(suggestion.getExample());
+                    return bean;
+                }).collect(Collectors.toList()));
+            }
             return cause;
         }).collect(Collectors.toList());
     }

--- a/common/src/main/resources/META-INF/openapi-v2.json
+++ b/common/src/main/resources/META-INF/openapi-v2.json
@@ -3762,8 +3762,9 @@
         "properties": {
           "tier": {
             "description": "Quality tier of the suggestion: RECOMMENDED, ACCEPTABLE, WORKAROUND, or INFORMATIONAL.",
-            "type": "string"
-          },
+            "type": "string",
+            "enum": ["RECOMMENDED", "ACCEPTABLE", "WORKAROUND", "INFORMATIONAL"]
+          }
           "description": {
             "description": "Human-readable explanation of the suggested fix.",
             "type": "string"

--- a/common/src/main/resources/META-INF/openapi-v2.json
+++ b/common/src/main/resources/META-INF/openapi-v2.json
@@ -3729,11 +3729,54 @@
           },
           "context": {
             "type": "string"
+          },
+          "type": {
+            "description": "Machine-readable incompatibility type when available (for example Avro READER_FIELD_MISSING_DEFAULT_VALUE).",
+            "type": "string"
+          },
+          "suggestions": {
+            "description": "Optional structured suggestions for how to resolve this rule violation.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompatibilityFixSuggestion"
+            }
           }
         },
         "example": {
-          "description": "External documentation URL is not valid (it must be formatted as a URL).",
-          "context": "/info/externalDocs[url]"
+          "description": "New field 'email' has no default value. Old messages don't contain this field.",
+          "context": "/fields/1",
+          "type": "READER_FIELD_MISSING_DEFAULT_VALUE",
+          "suggestions": [
+            {
+              "tier": "RECOMMENDED",
+              "description": "Add a default value for 'email'",
+              "example": "{\"name\": \"email\", \"type\": \"string\", \"default\": \"\"}"
+            }
+          ]
+        }
+      },
+      "CompatibilityFixSuggestion": {
+        "title": "Root Type for CompatibilityFixSuggestion",
+        "description": "A concrete suggestion for resolving a compatibility (or other rule) violation.",
+        "type": "object",
+        "properties": {
+          "tier": {
+            "description": "Quality tier of the suggestion: RECOMMENDED, ACCEPTABLE, WORKAROUND, or INFORMATIONAL.",
+            "type": "string"
+          },
+          "description": {
+            "description": "Human-readable explanation of the suggested fix.",
+            "type": "string"
+          },
+          "example": {
+            "description": "Optional example snippet illustrating the fix.",
+            "type": "string"
+          }
+        },
+        "example": {
+          "tier": "RECOMMENDED",
+          "description": "Add a default value",
+          "example": "{\"name\": \"email\", \"type\": \"string\", \"default\": \"\"}"
         }
       },
       "GroupId": {

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -6348,11 +6348,54 @@
           },
           "context": {
             "type": "string"
+          },
+          "type": {
+            "description": "Machine-readable incompatibility type when available (for example Avro READER_FIELD_MISSING_DEFAULT_VALUE).",
+            "type": "string"
+          },
+          "suggestions": {
+            "description": "Optional structured suggestions for how to resolve this rule violation.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompatibilityFixSuggestion"
+            }
           }
         },
         "example": {
-          "description": "External documentation URL is not valid (it must be formatted as a URL).",
-          "context": "/info/externalDocs[url]"
+          "description": "New field 'email' has no default value. Old messages don't contain this field.",
+          "context": "/fields/1",
+          "type": "READER_FIELD_MISSING_DEFAULT_VALUE",
+          "suggestions": [
+            {
+              "tier": "RECOMMENDED",
+              "description": "Add a default value for 'email'",
+              "example": "{\"name\": \"email\", \"type\": \"string\", \"default\": \"\"}"
+            }
+          ]
+        }
+      },
+      "CompatibilityFixSuggestion": {
+        "title": "Root Type for CompatibilityFixSuggestion",
+        "description": "A concrete suggestion for resolving a compatibility (or other rule) violation.",
+        "type": "object",
+        "properties": {
+          "tier": {
+            "description": "Quality tier of the suggestion: RECOMMENDED, ACCEPTABLE, WORKAROUND, or INFORMATIONAL.",
+            "type": "string"
+          },
+          "description": {
+            "description": "Human-readable explanation of the suggested fix.",
+            "type": "string"
+          },
+          "example": {
+            "description": "Optional example snippet illustrating the fix.",
+            "type": "string"
+          }
+        },
+        "example": {
+          "tier": "RECOMMENDED",
+          "description": "Add a default value",
+          "example": "{\"name\": \"email\", \"type\": \"string\", \"default\": \"\"}"
         }
       },
       "IfArtifactExists": {

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/rules/compatibility/AvroCompatibilityChecker.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/rules/compatibility/AvroCompatibilityChecker.java
@@ -3,7 +3,6 @@ package io.apicurio.registry.avro.rules.compatibility;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.rules.compatibility.AbstractCompatibilityChecker;
 import io.apicurio.registry.rules.compatibility.CompatibilityDifference;
-import io.apicurio.registry.rules.compatibility.SimpleCompatibilityDifference;
 import io.apicurio.registry.rules.violation.UnprocessableSchemaException;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaCompatibility;
@@ -54,6 +53,6 @@ public class AvroCompatibilityChecker extends AbstractCompatibilityChecker<Incom
 
     @Override
     protected CompatibilityDifference transform(Incompatibility original) {
-        return new SimpleCompatibilityDifference(original.getMessage(), original.getLocation());
+        return new AvroCompatibilityDifference(original);
     }
 }

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/rules/compatibility/AvroCompatibilityDifference.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/rules/compatibility/AvroCompatibilityDifference.java
@@ -1,0 +1,199 @@
+package io.apicurio.registry.avro.rules.compatibility;
+
+import io.apicurio.registry.rules.compatibility.CompatibilityDifference;
+import io.apicurio.registry.rules.compatibility.CompatibilityFixSuggestion;
+import io.apicurio.registry.rules.violation.RuleViolation;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaCompatibility.Incompatibility;
+import org.apache.avro.SchemaCompatibility.SchemaIncompatibilityType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Avro-specific compatibility difference that preserves the Avro incompatibility type and attaches
+ * structured fix suggestions.
+ */
+public class AvroCompatibilityDifference implements CompatibilityDifference {
+
+    private final RuleViolation ruleViolation;
+
+    public AvroCompatibilityDifference(Incompatibility incompatibility) {
+        Objects.requireNonNull(incompatibility, "incompatibility");
+        SchemaIncompatibilityType type = incompatibility.getType();
+        String context = incompatibility.getLocation();
+        if (context == null || context.isBlank()) {
+            context = "/";
+        }
+        String description = buildDescription(incompatibility);
+        List<CompatibilityFixSuggestion> suggestions = AvroCompatibilityFixSuggestions
+                .suggestionsFor(incompatibility);
+        this.ruleViolation = new RuleViolation(description, context, type.name(), suggestions);
+    }
+
+    private static String buildDescription(Incompatibility incompatibility) {
+        String message = incompatibility.getMessage();
+        SchemaIncompatibilityType type = incompatibility.getType();
+        if (type == SchemaIncompatibilityType.READER_FIELD_MISSING_DEFAULT_VALUE) {
+            String field = message == null ? "field" : message;
+            return "New field '" + field
+                    + "' has no default value. Old messages don't contain this field.";
+        }
+        if (message == null || message.isBlank()) {
+            return type.name();
+        }
+        return type.name() + ": " + message;
+    }
+
+    @Override
+    public RuleViolation asRuleViolation() {
+        return ruleViolation;
+    }
+
+    /**
+     * Builds concrete fix suggestions for known Avro {@link SchemaIncompatibilityType}s.
+     */
+    static final class AvroCompatibilityFixSuggestions {
+
+        private AvroCompatibilityFixSuggestions() {
+        }
+
+        static List<CompatibilityFixSuggestion> suggestionsFor(Incompatibility incompatibility) {
+            List<CompatibilityFixSuggestion> suggestions = new ArrayList<>();
+            SchemaIncompatibilityType type = incompatibility.getType();
+            Schema reader = incompatibility.getReaderFragment();
+            Schema writer = incompatibility.getWriterFragment();
+            String fieldOrDetail = incompatibility.getMessage();
+
+            switch (type) {
+                case READER_FIELD_MISSING_DEFAULT_VALUE:
+                    suggestions.addAll(missingDefaultSuggestions(fieldOrDetail, reader));
+                    break;
+                case TYPE_MISMATCH:
+                    suggestions.addAll(typeMismatchSuggestions(reader, writer));
+                    break;
+                case MISSING_ENUM_SYMBOLS:
+                    suggestions.addAll(missingEnumSuggestions(fieldOrDetail));
+                    break;
+                case NAME_MISMATCH:
+                    suggestions.addAll(nameMismatchSuggestions(reader, writer));
+                    break;
+                case FIXED_SIZE_MISMATCH:
+                    suggestions.addAll(fixedSizeSuggestions(reader, writer));
+                    break;
+                case MISSING_UNION_BRANCH:
+                    suggestions.addAll(missingUnionBranchSuggestions(writer));
+                    break;
+                default:
+                    suggestions.add(CompatibilityFixSuggestion.of(
+                            CompatibilityFixSuggestion.Tier.INFORMATIONAL,
+                            "No automatic fix is available for incompatibility type " + type.name()
+                                    + ". Review the schema change manually."));
+                    break;
+            }
+            return suggestions;
+        }
+
+        private static List<CompatibilityFixSuggestion> missingDefaultSuggestions(String fieldName,
+                Schema readerFragment) {
+            String name = fieldName == null || fieldName.isBlank() ? "field" : fieldName;
+            String avroType = inferTypeName(readerFragment);
+            List<CompatibilityFixSuggestion> suggestions = new ArrayList<>();
+            suggestions.add(CompatibilityFixSuggestion.of(CompatibilityFixSuggestion.Tier.RECOMMENDED,
+                    "Add a default value for '" + name + "'",
+                    "{\"name\": \"" + name + "\", \"type\": \"" + avroType + "\", \"default\": "
+                            + defaultLiteralFor(avroType) + "}"));
+            suggestions.add(CompatibilityFixSuggestion.of(CompatibilityFixSuggestion.Tier.ACCEPTABLE,
+                    "Make '" + name + "' nullable with a null default",
+                    "{\"name\": \"" + name + "\", \"type\": [\"null\", \"" + avroType
+                            + "\"], \"default\": null}"));
+            return suggestions;
+        }
+
+        private static List<CompatibilityFixSuggestion> typeMismatchSuggestions(Schema reader, Schema writer) {
+            List<CompatibilityFixSuggestion> suggestions = new ArrayList<>();
+            String readerType = reader != null ? reader.getType().getName() : "reader";
+            String writerType = writer != null ? writer.getType().getName() : "writer";
+            suggestions.add(CompatibilityFixSuggestion.of(CompatibilityFixSuggestion.Tier.RECOMMENDED,
+                    "Widen the reader type back to be compatible with the writer type (" + writerType + ")",
+                    "\"type\": \"" + writerType + "\""));
+            suggestions.add(CompatibilityFixSuggestion.of(CompatibilityFixSuggestion.Tier.ACCEPTABLE,
+                    "Use a union that includes both types",
+                    "\"type\": [\"null\", \"" + writerType + "\", \"" + readerType + "\"]"));
+            return suggestions;
+        }
+
+        private static List<CompatibilityFixSuggestion> missingEnumSuggestions(String missingSymbols) {
+            List<CompatibilityFixSuggestion> suggestions = new ArrayList<>();
+            String symbols = missingSymbols == null ? "<removed-symbols>" : missingSymbols;
+            suggestions.add(CompatibilityFixSuggestion.of(CompatibilityFixSuggestion.Tier.RECOMMENDED,
+                    "Add the removed enum symbol(s) back to the reader schema",
+                    "\"symbols\": [ /* include */ " + symbols + " ]"));
+            suggestions.add(CompatibilityFixSuggestion.of(CompatibilityFixSuggestion.Tier.WORKAROUND,
+                    "Switch the compatibility level to FORWARD if old readers are no longer needed",
+                    "\"rule\": \"FORWARD\""));
+            return suggestions;
+        }
+
+        private static List<CompatibilityFixSuggestion> nameMismatchSuggestions(Schema reader, Schema writer) {
+            List<CompatibilityFixSuggestion> suggestions = new ArrayList<>();
+            String oldName = writer != null ? writer.getName() : "old_name";
+            String newName = reader != null ? reader.getName() : "new_name";
+            suggestions.add(CompatibilityFixSuggestion.of(CompatibilityFixSuggestion.Tier.RECOMMENDED,
+                    "Keep the original name, or add an Avro alias for the renamed type/field",
+                    "\"name\": \"" + newName + "\", \"aliases\": [\"" + oldName + "\"]"));
+            return suggestions;
+        }
+
+        private static List<CompatibilityFixSuggestion> fixedSizeSuggestions(Schema reader, Schema writer) {
+            List<CompatibilityFixSuggestion> suggestions = new ArrayList<>();
+            int expected = writer != null && writer.getType() == Schema.Type.FIXED ? writer.getFixedSize() : -1;
+            int found = reader != null && reader.getType() == Schema.Type.FIXED ? reader.getFixedSize() : -1;
+            suggestions.add(CompatibilityFixSuggestion.of(CompatibilityFixSuggestion.Tier.RECOMMENDED,
+                    "Restore the fixed size to match the writer schema",
+                    expected >= 0
+                            ? "\"type\": \"fixed\", \"size\": " + expected + " /* was " + found + " */"
+                            : "\"type\": \"fixed\", \"size\": <writer-size>"));
+            return suggestions;
+        }
+
+        private static List<CompatibilityFixSuggestion> missingUnionBranchSuggestions(Schema writer) {
+            List<CompatibilityFixSuggestion> suggestions = new ArrayList<>();
+            String branch = writer != null ? writer.getType().getName() : "branch";
+            suggestions.add(CompatibilityFixSuggestion.of(CompatibilityFixSuggestion.Tier.RECOMMENDED,
+                    "Add the missing writer union branch to the reader union",
+                    "\"type\": [\"null\", \"" + branch + "\" /* plus existing branches */ ]"));
+            return suggestions;
+        }
+
+        private static String inferTypeName(Schema schema) {
+            if (schema == null) {
+                return "string";
+            }
+            if (schema.getType() == Schema.Type.RECORD && !schema.getFields().isEmpty()) {
+                // For READER_FIELD_MISSING_DEFAULT_VALUE, the reader fragment is often the parent record.
+                // Prefer string as a safe default example type.
+                return "string";
+            }
+            if (schema.getType() == Schema.Type.UNION) {
+                for (Schema branch : schema.getTypes()) {
+                    if (branch.getType() != Schema.Type.NULL) {
+                        return branch.getType().getName();
+                    }
+                }
+            }
+            return schema.getType().getName();
+        }
+
+        private static String defaultLiteralFor(String avroType) {
+            return switch (avroType) {
+                case "int", "long", "float", "double" -> "0";
+                case "boolean" -> "false";
+                case "null" -> "null";
+                case "bytes" -> "\"\"";
+                default -> "\"\"";
+            };
+        }
+    }
+}

--- a/schema-util/avro/src/test/java/io/apicurio/registry/avro/rules/compatibility/AvroCompatibilityFixSuggestionsTest.java
+++ b/schema-util/avro/src/test/java/io/apicurio/registry/avro/rules/compatibility/AvroCompatibilityFixSuggestionsTest.java
@@ -1,0 +1,134 @@
+package io.apicurio.registry.avro.rules.compatibility;
+
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.rules.compatibility.CompatibilityDifference;
+import io.apicurio.registry.rules.compatibility.CompatibilityExecutionResult;
+import io.apicurio.registry.rules.compatibility.CompatibilityFixSuggestion;
+import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
+import io.apicurio.registry.rules.violation.RuleViolation;
+import io.apicurio.registry.types.ContentTypes;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AvroCompatibilityFixSuggestionsTest {
+
+    private final AvroCompatibilityChecker checker = new AvroCompatibilityChecker();
+
+    @Test
+    public void missingDefaultFieldProducesRecommendedAndAcceptableSuggestions() {
+        String existing = """
+                {"type":"record","name":"Order","fields":[
+                  {"name":"id","type":"string"}
+                ]}
+                """;
+        String proposed = """
+                {"type":"record","name":"Order","fields":[
+                  {"name":"id","type":"string"},
+                  {"name":"email","type":"string"}
+                ]}
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(CompatibilityLevel.BACKWARD,
+                List.of(typed(existing)), typed(proposed), Map.of());
+
+        assertFalse(result.isCompatible());
+        RuleViolation violation = singleViolation(result);
+        assertEquals("READER_FIELD_MISSING_DEFAULT_VALUE", violation.getType());
+        assertTrue(violation.getDescription().contains("email"));
+        assertTrue(violation.hasSuggestions());
+        assertEquals(2, violation.getSuggestions().size());
+        assertEquals(CompatibilityFixSuggestion.Tier.RECOMMENDED, violation.getSuggestions().get(0).getTier());
+        assertEquals(CompatibilityFixSuggestion.Tier.ACCEPTABLE, violation.getSuggestions().get(1).getTier());
+        assertTrue(violation.getSuggestions().get(0).getExample().contains("\"default\""));
+        assertTrue(violation.getSuggestions().get(1).getExample().contains("[\"null\""));
+    }
+
+    @Test
+    public void typeMismatchProducesWidenAndUnionSuggestions() {
+        String existing = """
+                {"type":"record","name":"Metrics","fields":[
+                  {"name":"count","type":"long"}
+                ]}
+                """;
+        String proposed = """
+                {"type":"record","name":"Metrics","fields":[
+                  {"name":"count","type":"int"}
+                ]}
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(CompatibilityLevel.BACKWARD,
+                List.of(typed(existing)), typed(proposed), Map.of());
+
+        assertFalse(result.isCompatible());
+        RuleViolation violation = singleViolation(result);
+        assertEquals("TYPE_MISMATCH", violation.getType());
+        assertTrue(violation.hasSuggestions());
+        assertTrue(violation.getSuggestions().stream()
+                .anyMatch(s -> s.getTier() == CompatibilityFixSuggestion.Tier.RECOMMENDED));
+        assertTrue(violation.getSuggestions().stream()
+                .anyMatch(s -> s.getExample() != null && s.getExample().contains("long")));
+    }
+
+    @Test
+    public void missingEnumSymbolProducesSuggestions() {
+        String existing = """
+                {"type":"record","name":"Event","fields":[
+                  {"name":"status","type":{"type":"enum","name":"Status","symbols":["NEW","DONE"]}}
+                ]}
+                """;
+        String proposed = """
+                {"type":"record","name":"Event","fields":[
+                  {"name":"status","type":{"type":"enum","name":"Status","symbols":["NEW"]}}
+                ]}
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(CompatibilityLevel.BACKWARD,
+                List.of(typed(existing)), typed(proposed), Map.of());
+
+        assertFalse(result.isCompatible());
+        RuleViolation violation = singleViolation(result);
+        assertEquals("MISSING_ENUM_SYMBOLS", violation.getType());
+        assertTrue(violation.hasSuggestions());
+        assertTrue(violation.getSuggestions().stream()
+                .anyMatch(s -> s.getTier() == CompatibilityFixSuggestion.Tier.RECOMMENDED));
+        assertTrue(violation.getSuggestions().stream()
+                .anyMatch(s -> s.getTier() == CompatibilityFixSuggestion.Tier.WORKAROUND));
+    }
+
+    @Test
+    public void compatibleChangeHasNoViolationsOrSuggestions() {
+        String existing = """
+                {"type":"record","name":"Order","fields":[
+                  {"name":"id","type":"string"}
+                ]}
+                """;
+        String proposed = """
+                {"type":"record","name":"Order","fields":[
+                  {"name":"id","type":"string"},
+                  {"name":"note","type":"string","default":""}
+                ]}
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(CompatibilityLevel.BACKWARD,
+                List.of(typed(existing)), typed(proposed), Map.of());
+
+        assertTrue(result.isCompatible());
+        assertTrue(result.getIncompatibleDifferences().isEmpty());
+    }
+
+    private static TypedContent typed(String schema) {
+        return TypedContent.create(ContentHandle.create(schema), ContentTypes.APPLICATION_JSON);
+    }
+
+    private static RuleViolation singleViolation(CompatibilityExecutionResult result) {
+        CompatibilityDifference difference = result.getIncompatibleDifferences().iterator().next();
+        return difference.asRuleViolation();
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityFixSuggestion.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityFixSuggestion.java
@@ -1,0 +1,59 @@
+package io.apicurio.registry.rules.compatibility;
+
+import java.util.Objects;
+
+/**
+ * A concrete suggestion for how to resolve a compatibility violation.
+ */
+public class CompatibilityFixSuggestion {
+
+    public enum Tier {
+        RECOMMENDED, ACCEPTABLE, WORKAROUND, INFORMATIONAL
+    }
+
+    private final Tier tier;
+    private final String description;
+    private final String example;
+
+    public CompatibilityFixSuggestion(Tier tier, String description, String example) {
+        this.tier = Objects.requireNonNull(tier, "tier");
+        this.description = Objects.requireNonNull(description, "description");
+        this.example = example;
+    }
+
+    public static CompatibilityFixSuggestion of(Tier tier, String description) {
+        return new CompatibilityFixSuggestion(tier, description, null);
+    }
+
+    public static CompatibilityFixSuggestion of(Tier tier, String description, String example) {
+        return new CompatibilityFixSuggestion(tier, description, example);
+    }
+
+    public Tier getTier() {
+        return tier;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getExample() {
+        return example;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        CompatibilityFixSuggestion that = (CompatibilityFixSuggestion) o;
+        return tier == that.tier && Objects.equals(description, that.description)
+                && Objects.equals(example, that.example);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tier, description, example);
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/violation/RuleViolation.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/violation/RuleViolation.java
@@ -1,11 +1,17 @@
 package io.apicurio.registry.rules.violation;
 
+import io.apicurio.registry.rules.compatibility.CompatibilityFixSuggestion;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 public class RuleViolation {
 
     private String description;
     private String context;
+    private String type;
+    private List<CompatibilityFixSuggestion> suggestions = Collections.emptyList();
 
     /**
      * Constructor.
@@ -22,6 +28,14 @@ public class RuleViolation {
     public RuleViolation(String description, String context) {
         this.setDescription(description);
         this.setContext(context);
+    }
+
+    public RuleViolation(String description, String context, String type,
+            List<CompatibilityFixSuggestion> suggestions) {
+        this.setDescription(description);
+        this.setContext(context);
+        this.setType(type);
+        this.setSuggestions(suggestions);
     }
 
     /**
@@ -53,11 +67,39 @@ public class RuleViolation {
     }
 
     /**
+     * @return machine-readable incompatibility type when available (e.g. Avro
+     *         {@code READER_FIELD_MISSING_DEFAULT_VALUE})
+     */
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * @return optional fix suggestions for this violation
+     */
+    public List<CompatibilityFixSuggestion> getSuggestions() {
+        return suggestions;
+    }
+
+    public void setSuggestions(List<CompatibilityFixSuggestion> suggestions) {
+        this.suggestions = suggestions == null ? Collections.emptyList()
+                : Collections.unmodifiableList(suggestions);
+    }
+
+    public boolean hasSuggestions() {
+        return suggestions != null && !suggestions.isEmpty();
+    }
+
+    /**
      * @see java.lang.Object#hashCode()
      */
     @Override
     public int hashCode() {
-        return Objects.hash(context, description);
+        return Objects.hash(context, description, type, suggestions);
     }
 
     /**
@@ -72,7 +114,8 @@ public class RuleViolation {
         if (getClass() != obj.getClass())
             return false;
         RuleViolation other = (RuleViolation) obj;
-        return Objects.equals(context, other.context) && Objects.equals(description, other.description);
+        return Objects.equals(context, other.context) && Objects.equals(description, other.description)
+                && Objects.equals(type, other.type) && Objects.equals(suggestions, other.suggestions);
     }
 
 }


### PR DESCRIPTION
## description
fixes #7874 (phase 1 — suggestion engine + api)

when an avro schema fails compatibility, the registry used to return only a raw difference message. this adds structured fix suggestions so users get concrete next steps instead of just a violation type.

### what changed
- avro incompatibilities now map to `RuleViolation` with `type` + `suggestions`
- covers all avro `SchemaIncompatibilityType`s (missing default, type mismatch, enum symbols, name mismatch, fixed size, missing union branch)
- openapi v2/v3: `RuleViolationCause` gains `type` and `suggestions`; new `CompatibilityFixSuggestion` schema
- exception mappers (v3, v2, ccompat) populate the new fields

phase 2 (ui apply-fix) and phase 3 (`?autoFix=true`) are left for follow-ups. other schema types can reuse the same suggestion model later.

## test plan
- [x] `./mvnw -pl schema-util/avro -am test -Dtest=AvroCompatibilityFixSuggestionsTest -Dsurefire.failIfNoSpecifiedTests=false`
- [ ] register an incompatible avro version and confirm 409/`RuleViolationProblemDetails` includes `suggestions`
- [ ] confirm compatible changes are unchanged