### PR TITLE
fix(core): Resolve FIXME for GraphQL content-type auto-detection

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
@@ -200,6 +200,9 @@ public final class ContentTypeUtil {
     }
 
     public static String determineContentType(ContentHandle content) {
+        // Ensure content is fully materialized once, so multiple parse attempts
+        // don't depend on stream re-use.
+        content.bytes();
         if (isParsableJson(content)) {
             return CT_APPLICATION_JSON;
         }

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
@@ -175,7 +175,7 @@ public final class ContentTypeUtil {
         return node;
     }
 
-    private static final Pattern GRAPHQL_DEF_PATTERN = Pattern.compile("(?m)^\\s*(type|interface|scalar|union|input|enum)\\s+[a-zA-Z_][a-zA-Z0-9_]*\\s*(?:\\{|implements|\\=|$)");
+    private static final Pattern GRAPHQL_DEF_PATTERN = Pattern.compile("(?m)^\\s*(?:extend\\s+)?(type|interface|scalar|union|input|enum)\\s+[a-zA-Z_][a-zA-Z0-9_]*\\s*(?:\\{|implements|\\=|$)");
     private static final Pattern GRAPHQL_SCHEMA_PATTERN = Pattern.compile("(?m)^\\s*schema\\s*\\{");
     private static final Pattern GRAPHQL_DIRECTIVE_PATTERN = Pattern.compile("(?m)^\\s*directive\\s+@[a-zA-Z_][a-zA-Z0-9_]*");
 

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
@@ -14,6 +14,7 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.regex.Pattern;
 
 public final class ContentTypeUtil {
 
@@ -174,6 +175,10 @@ public final class ContentTypeUtil {
         return node;
     }
 
+    private static final Pattern GRAPHQL_DEF_PATTERN = Pattern.compile("(?m)^\\s*(type|interface|scalar|union|input|enum)\\s+[a-zA-Z_][a-zA-Z0-9_]*\\s*(?:\\{|implements|\\=|$)");
+    private static final Pattern GRAPHQL_SCHEMA_PATTERN = Pattern.compile("(?m)^\\s*schema\\s*\\{");
+    private static final Pattern GRAPHQL_DIRECTIVE_PATTERN = Pattern.compile("(?m)^\\s*directive\\s+@[a-zA-Z_][a-zA-Z0-9_]*");
+
     /**
      * Returns true if the content is likely a GraphQL schema.
      */
@@ -183,25 +188,20 @@ public final class ContentTypeUtil {
             if (text.startsWith("{") || text.startsWith("<")) {
                 return false;
             }
-            // Normalize whitespace so keyword checks work across tabs/newlines and formatting differences.
-            String normalized = text.replaceAll("\\s+", " ");
-            // Basic heuristics to differentiate GraphQL from Protobuf
-            return normalized.contains("type ")
-                    || normalized.contains("interface ")
-                    || normalized.contains("scalar ")
-                    || normalized.contains("union ")
-                    || normalized.contains("input ")
-                    || normalized.contains("schema{")
-                    || normalized.contains("schema {")
-                    || normalized.contains("directive @");
+            
+            return GRAPHQL_DEF_PATTERN.matcher(text).find()
+                    || GRAPHQL_SCHEMA_PATTERN.matcher(text).find()
+                    || GRAPHQL_DIRECTIVE_PATTERN.matcher(text).find();
         } catch (Exception e) {
             return false;
         }
     }
 
     public static String determineContentType(ContentHandle content) {
-        // Ensure content is fully materialized once, so multiple parse attempts
-        // don't depend on stream re-use.
+        // Ensure content is fully materialized once in memory.
+        // If we do not call bytes() here, the isParsableJson check may consume
+        // the underlying InputStream (e.g. via ObjectMapper.readTree), leaving
+        // the stream empty and causing subsequent format checks to incorrectly fail.
         content.bytes();
         if (isParsableJson(content)) {
             return CT_APPLICATION_JSON;

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
@@ -174,10 +174,34 @@ public final class ContentTypeUtil {
         return node;
     }
 
-    // FIXME this doesn't work for GraphQL
+    /**
+     * Returns true if the content is likely a GraphQL schema.
+     */
+    public static boolean isParsableGraphQL(ContentHandle content) {
+        try {
+            String text = content.content().trim();
+            if (text.startsWith("{") || text.startsWith("<")) {
+                return false;
+            }
+            // Basic heuristics to differentiate GraphQL from Protobuf
+            return text.contains("type ") || 
+                   text.contains("interface ") || 
+                   text.contains("scalar ") || 
+                   text.contains("union ") ||
+                   text.contains("input ") ||
+                   text.contains("schema {") ||
+                   text.contains("directive @");
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     public static String determineContentType(ContentHandle content) {
         if (isParsableJson(content)) {
             return CT_APPLICATION_JSON;
+        }
+        if (isParsableGraphQL(content)) {
+            return ContentTypes.APPLICATION_GRAPHQL;
         }
         if (isParsableYaml(content)) {
             return CT_APPLICATION_YAML;

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
@@ -175,7 +175,7 @@ public final class ContentTypeUtil {
         return node;
     }
 
-    private static final Pattern GRAPHQL_DEF_PATTERN = Pattern.compile("(?m)^\\s*(?:extend\\s+)?(type|interface|scalar|union|input|enum)\\s+[a-zA-Z_][a-zA-Z0-9_]*\\s*(?:\\{|implements|\\=|$)");
+    private static final Pattern GRAPHQL_DEF_PATTERN = Pattern.compile("(?m)^\\s*(?:extend\\s+)?(type|interface|scalar|union|input)\\s+[a-zA-Z_][a-zA-Z0-9_]*\\s*(?:\\{|implements|\\=|$)");
     private static final Pattern GRAPHQL_SCHEMA_PATTERN = Pattern.compile("(?m)^\\s*schema\\s*\\{");
     private static final Pattern GRAPHQL_DIRECTIVE_PATTERN = Pattern.compile("(?m)^\\s*directive\\s+@[a-zA-Z_][a-zA-Z0-9_]*");
 

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/util/ContentTypeUtil.java
@@ -183,14 +183,17 @@ public final class ContentTypeUtil {
             if (text.startsWith("{") || text.startsWith("<")) {
                 return false;
             }
+            // Normalize whitespace so keyword checks work across tabs/newlines and formatting differences.
+            String normalized = text.replaceAll("\\s+", " ");
             // Basic heuristics to differentiate GraphQL from Protobuf
-            return text.contains("type ") || 
-                   text.contains("interface ") || 
-                   text.contains("scalar ") || 
-                   text.contains("union ") ||
-                   text.contains("input ") ||
-                   text.contains("schema {") ||
-                   text.contains("directive @");
+            return normalized.contains("type ")
+                    || normalized.contains("interface ")
+                    || normalized.contains("scalar ")
+                    || normalized.contains("union ")
+                    || normalized.contains("input ")
+                    || normalized.contains("schema{")
+                    || normalized.contains("schema {")
+                    || normalized.contains("directive @");
         } catch (Exception e) {
             return false;
         }

--- a/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
@@ -110,4 +110,16 @@ public class ContentTypeUtilTest {
         ContentHandle protobuf = ContentHandle.create("message Foo { string bar = 1; }");
         Assertions.assertEquals(ContentTypes.APPLICATION_PROTOBUF, ContentTypeUtil.determineContentType(protobuf));
     }
+
+    @Test
+    public void testIsParsableGraphQL_rejectsYamlWithKeywords() {
+        String yamlContent = "type: Query\nfields:\n  - name: hello\n";
+        ContentHandle yaml = ContentHandle.create(yamlContent);
+        
+        // Should not be detected as GraphQL despite having "type: Query"
+        Assertions.assertFalse(ContentTypeUtil.isParsableGraphQL(yaml));
+        
+        // Should correctly fall back to YAML
+        Assertions.assertEquals(ContentTypes.APPLICATION_YAML, ContentTypeUtil.determineContentType(yaml));
+    }
 }

--- a/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
@@ -73,6 +73,14 @@ public class ContentTypeUtilTest {
         ContentHandle notGraphql = ContentHandle.create("message Hello { string msg = 1; }");
         Assertions.assertFalse(ContentTypeUtil.isParsableGraphQL(notGraphql));
 
+        // Protobuf enum should not be detected as GraphQL
+        ContentHandle protobufEnum = ContentHandle.create("enum Status { ACTIVE = 0; }");
+        Assertions.assertFalse(ContentTypeUtil.isParsableGraphQL(protobufEnum));
+
+        // GraphQL schema with newline should be detected
+        ContentHandle schemaNewline = ContentHandle.create("schema\n{\n  query: Query\n}");
+        Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(schemaNewline));
+
         // JSON-like content should not be detected as GraphQL
         ContentHandle jsonLike = ContentHandle.create("{ \"key\": \"value\" }");
         Assertions.assertFalse(ContentTypeUtil.isParsableGraphQL(jsonLike));

--- a/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
@@ -51,8 +51,11 @@ public class ContentTypeUtilTest {
         ContentHandle content = ContentHandle.create("type Query { hello: String }");
         Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(content));
         
-        ContentHandle content2 = ContentHandle.create("schema { query: Query }");
+        ContentHandle content2 = ContentHandle.create("schema{ query: Query }");
         Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(content2));
+
+        ContentHandle content3 = ContentHandle.create("type\tQuery { hello: String }");
+        Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(content3));
 
         ContentHandle notGraphql = ContentHandle.create("message Hello { string msg = 1; }");
         Assertions.assertFalse(ContentTypeUtil.isParsableGraphQL(notGraphql));

--- a/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
@@ -45,4 +45,22 @@ public class ContentTypeUtilTest {
         ContentHandle content = ContentHandle.create(billionLaughs);
         Assertions.assertFalse(ContentTypeUtil.isParsableXml(content));
     }
+
+    @Test
+    public void testIsParsableGraphQL() {
+        ContentHandle content = ContentHandle.create("type Query { hello: String }");
+        Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(content));
+        
+        ContentHandle content2 = ContentHandle.create("schema { query: Query }");
+        Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(content2));
+
+        ContentHandle notGraphql = ContentHandle.create("message Hello { string msg = 1; }");
+        Assertions.assertFalse(ContentTypeUtil.isParsableGraphQL(notGraphql));
+    }
+
+    @Test
+    public void testDetermineContentType_GraphQL() {
+        ContentHandle content = ContentHandle.create("type Query { hello: String }");
+        Assertions.assertEquals(io.apicurio.registry.types.ContentTypes.APPLICATION_GRAPHQL, ContentTypeUtil.determineContentType(content));
+    }
 }

--- a/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.content.util;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.types.ContentTypes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -48,22 +49,65 @@ public class ContentTypeUtilTest {
 
     @Test
     public void testIsParsableGraphQL() {
+        // Valid GraphQL schema
         ContentHandle content = ContentHandle.create("type Query { hello: String }");
         Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(content));
-        
+
+        // GraphQL schema keyword
         ContentHandle content2 = ContentHandle.create("schema{ query: Query }");
         Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(content2));
 
+        // GraphQL with tab whitespace
         ContentHandle content3 = ContentHandle.create("type\tQuery { hello: String }");
         Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(content3));
 
+        // Protobuf should not be detected as GraphQL
         ContentHandle notGraphql = ContentHandle.create("message Hello { string msg = 1; }");
         Assertions.assertFalse(ContentTypeUtil.isParsableGraphQL(notGraphql));
+
+        // JSON-like content should not be detected as GraphQL
+        ContentHandle jsonLike = ContentHandle.create("{ \"key\": \"value\" }");
+        Assertions.assertFalse(ContentTypeUtil.isParsableGraphQL(jsonLike));
+
+        // XML-like content should not be detected as GraphQL
+        ContentHandle xmlLike = ContentHandle.create("<root><child/></root>");
+        Assertions.assertFalse(ContentTypeUtil.isParsableGraphQL(xmlLike));
+
+        // Empty content should not be detected as GraphQL
+        ContentHandle empty = ContentHandle.create("");
+        Assertions.assertFalse(ContentTypeUtil.isParsableGraphQL(empty));
     }
 
     @Test
     public void testDetermineContentType_GraphQL() {
+        // GraphQL schema that was previously misclassified as YAML
         ContentHandle content = ContentHandle.create("type Query { hello: String }");
-        Assertions.assertEquals(io.apicurio.registry.types.ContentTypes.APPLICATION_GRAPHQL, ContentTypeUtil.determineContentType(content));
+        Assertions.assertEquals(ContentTypes.APPLICATION_GRAPHQL, ContentTypeUtil.determineContentType(content));
+    }
+
+    @Test
+    public void testDetermineContentType_YamlStillWorks() {
+        // Normal YAML document should still resolve to application/x-yaml
+        ContentHandle yaml = ContentHandle.create("foo: bar\nbaz: qux\n");
+        Assertions.assertEquals("application/x-yaml", ContentTypeUtil.determineContentType(yaml));
+
+        // Nested YAML
+        ContentHandle nestedYaml = ContentHandle.create("apiVersion: v1\nkind: Service\nmetadata:\n  name: test\n");
+        Assertions.assertEquals("application/x-yaml", ContentTypeUtil.determineContentType(nestedYaml));
+    }
+
+    @Test
+    public void testDetermineContentType_EdgeCases() {
+        // JSON should still be detected as JSON, not GraphQL
+        ContentHandle json = ContentHandle.create("{\"type\": \"Query\"}");
+        Assertions.assertEquals("application/json", ContentTypeUtil.determineContentType(json));
+
+        // XML should still be detected as XML
+        ContentHandle xml = ContentHandle.create("<type>Query</type>");
+        Assertions.assertEquals("application/xml", ContentTypeUtil.determineContentType(xml));
+
+        // Protobuf should still be the fallback
+        ContentHandle protobuf = ContentHandle.create("message Foo { string bar = 1; }");
+        Assertions.assertEquals(ContentTypes.APPLICATION_PROTOBUF, ContentTypeUtil.determineContentType(protobuf));
     }
 }

--- a/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/content/util/ContentTypeUtilTest.java
@@ -57,6 +57,14 @@ public class ContentTypeUtilTest {
         ContentHandle content2 = ContentHandle.create("schema{ query: Query }");
         Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(content2));
 
+        // GraphQL directive
+        ContentHandle contentDirective = ContentHandle.create("directive @deprecated(reason: String = \"No longer supported\") on FIELD_DEFINITION | ENUM_VALUE");
+        Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(contentDirective));
+
+        // GraphQL extend keyword
+        ContentHandle contentExtend = ContentHandle.create("extend type Foo { bar: String }");
+        Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(contentExtend));
+
         // GraphQL with tab whitespace
         ContentHandle content3 = ContentHandle.create("type\tQuery { hello: String }");
         Assertions.assertTrue(ContentTypeUtil.isParsableGraphQL(content3));


### PR DESCRIPTION
### Motivation

Currently, there is an undocumented `FIXME` in `ContentTypeUtil.java` regarding GraphQL schemas. Because valid GraphQL schemas can sometimes be parsed as valid YAML (e.g., `type Query { hello: String }` is technically a valid YAML string mapping), the existing logic was incorrectly identifying GraphQL files as YAML. This PR fixes the bug by prioritizing GraphQL keyword detection before falling back to the YAML parser.

Resolves #8557 

### Modifications

* **`ContentTypeUtil.java`**: 
  * Created a new heuristic detection method `isParsableGraphQL(ContentHandle content)` that safely reads text and checks for common GraphQL schema keywords (`type`, `interface`, `schema {`, `union`, `scalar`, `input`, etc.) to accurately identify GraphQL without bringing in heavy external parser dependencies.
  * Updated `determineContentType(ContentHandle content)` to check for GraphQL *before* checking for YAML.

* **`ContentTypeUtilTest.java`**: 
  * Added `testIsParsableGraphQL()` to verify the new heuristic successfully detects valid GraphQL and correctly rejects other formats like Protobuf.
  * Added `testDetermineContentType_GraphQL()` to assert that passing a GraphQL schema returns the expected `application/graphql` constant.

### Result / Validation

All tests in the `schema-util/common` module pass successfully. The registry will now correctly auto-detect `application/graphql` content types without incorrectly capturing them as `application/x-yaml`.

```text
[INFO] Running io.apicurio.registry.content.util.ContentTypeUtilTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
