### PR TITLE
fix(export): URL encode path elements in import/export ZIP entries

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/ImportExportTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/ImportExportTest.java
@@ -67,6 +67,8 @@ public class ImportExportTest extends AbstractResourceTestBase {
          */
 
         String groupId = "PrimaryTestGroup";
+        String complexGroupId = "Group/With\"And Spaces";
+        String complexArtifactId = "Artifact/With\"And Spaces";
 
         // Create the group
         CreateGroup createGroup = new CreateGroup();
@@ -103,6 +105,13 @@ public class ImportExportTest extends AbstractResourceTestBase {
             String artifactId = "TestArtifact-" + idx;
             createArtifact(groupId, artifactId, ArtifactType.JSON, "{}", ContentTypes.APPLICATION_JSON);
         }
+
+        // Add an artifact with complex ID to test URL encoding of zip paths
+        CreateGroup createComplexGroup = new CreateGroup();
+        createComplexGroup.setGroupId(complexGroupId);
+        createComplexGroup.setDescription("A group with a complex ID.");
+        clientV3.groups().post(createComplexGroup);
+        createArtifact(complexGroupId, complexArtifactId, ArtifactType.JSON, "{}", ContentTypes.APPLICATION_JSON);
 
         // Set artifact metadata
         for (int idx = 1; idx <= 10; idx++) {
@@ -258,6 +267,11 @@ public class ImportExportTest extends AbstractResourceTestBase {
             Assertions.assertEquals(Map.of("artifact-number", "" + idx), amd.getLabels().getAdditionalData());
             Assertions.assertEquals(ArtifactType.JSON, amd.getArtifactType());
         }
+
+        // Assert complex artifact
+        amd = clientV3.groups().byGroupId(complexGroupId).artifacts().byArtifactId(complexArtifactId).get();
+        Assertions.assertEquals(complexGroupId, amd.getGroupId());
+        Assertions.assertEquals(complexArtifactId, amd.getArtifactId());
 
         // Assert versions
         for (int idx = 1; idx <= 10; idx++) {

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v2/EntityWriter.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v2/EntityWriter.java
@@ -180,7 +180,10 @@ public class EntityWriter {
         if (value == null) {
             return null;
         }
-        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+        // URLEncoder is x-www-form-urlencoded; normalize to percent-encoding suitable for path segments.
+        return URLEncoder.encode(value, StandardCharsets.UTF_8)
+                .replace("+", "%20")
+                .replace("*", "%2A");
     }
 
     private void write(ZipEntry entry, Entity entity, Class<?> entityClass) throws IOException {

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v2/EntityWriter.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v2/EntityWriter.java
@@ -24,6 +24,8 @@ import io.apicurio.registry.utils.impexp.EntityType;
 import io.apicurio.registry.utils.impexp.ManifestEntity;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -136,15 +138,17 @@ public class EntityWriter {
 
     private ZipEntry createZipEntry(EntityType type, String groupId, String artifactId, String fileName,
             String fileExt) {
-        // TODO encode groupId, artifactId, and filename as path elements
+        groupId = encode(groupOrDefault(groupId));
+        artifactId = encode(artifactId);
+        fileName = encode(fileName);
         String path = null;
         switch (type) {
             case ArtifactRule:
-                path = String.format("groups/%s/artifacts/%s/rules/%s.%s.%s", groupOrDefault(groupId),
+                path = String.format("groups/%s/artifacts/%s/rules/%s.%s.%s", groupId,
                         artifactId, fileName, type.name(), fileExt);
                 break;
             case ArtifactVersion:
-                path = String.format("groups/%s/artifacts/%s/versions/%s.%s.%s", groupOrDefault(groupId),
+                path = String.format("groups/%s/artifacts/%s/versions/%s.%s.%s", groupId,
                         artifactId, fileName, type.name(), fileExt);
                 break;
             case Content:
@@ -170,6 +174,13 @@ public class EntityWriter {
 
     private String groupOrDefault(String groupId) {
         return groupId == null ? "default" : groupId;
+    }
+
+    private String encode(String value) {
+        if (value == null) {
+            return null;
+        }
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 
     private void write(ZipEntry entry, Entity entity, Class<?> entityClass) throws IOException {

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/EntityWriter.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/EntityWriter.java
@@ -204,7 +204,10 @@ public class EntityWriter {
         if (value == null) {
             return null;
         }
-        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+        // URLEncoder is x-www-form-urlencoded; normalize to percent-encoding suitable for path segments.
+        return URLEncoder.encode(value, StandardCharsets.UTF_8)
+                .replace("+", "%20")
+                .replace("*", "%2A");
     }
 
     private void write(ZipEntry entry, Entity entity, Class<?> entityClass) throws IOException {

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/EntityWriter.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/EntityWriter.java
@@ -8,6 +8,8 @@ import io.apicurio.registry.utils.impexp.EntityType;
 import io.apicurio.registry.utils.impexp.ManifestEntity;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -148,23 +150,25 @@ public class EntityWriter {
 
     private ZipEntry createZipEntry(EntityType type, String groupId, String artifactId, String fileName,
             String fileExt) {
-        // TODO encode groupId, artifactId, and filename as path elements
+        groupId = encode(groupOrDefault(groupId));
+        artifactId = encode(artifactId);
+        fileName = encode(fileName);
         String path = null;
         switch (type) {
             case ArtifactRule:
-                path = String.format("groups/%s/artifacts/%s/rules/%s.%s.%s", groupOrDefault(groupId),
+                path = String.format("groups/%s/artifacts/%s/rules/%s.%s.%s", groupId,
                         artifactId, fileName, type.name(), fileExt);
                 break;
             case Artifact:
-                path = String.format("groups/%s/artifacts/%s/%s.%s.%s", groupOrDefault(groupId), artifactId,
+                path = String.format("groups/%s/artifacts/%s/%s.%s.%s", groupId, artifactId,
                         fileName, type.name(), fileExt);
                 break;
             case Branch:
-                path = String.format("groups/%s/artifacts/%s/branches/%s.%s.%s", groupOrDefault(groupId),
+                path = String.format("groups/%s/artifacts/%s/branches/%s.%s.%s", groupId,
                         artifactId, fileName, type.name(), fileExt);
                 break;
             case ArtifactVersion:
-                path = String.format("groups/%s/artifacts/%s/versions/%s.%s.%s", groupOrDefault(groupId),
+                path = String.format("groups/%s/artifacts/%s/versions/%s.%s.%s", groupId,
                         artifactId, fileName, type.name(), fileExt);
                 break;
             case Content:
@@ -177,7 +181,7 @@ public class EntityWriter {
                 path = String.format("groups/%s.%s.%s", fileName, type.name(), fileExt);
                 break;
             case GroupRule:
-                path = String.format("groups/%s/rules/%s.%s.%s", groupOrDefault(groupId), fileName,
+                path = String.format("groups/%s/rules/%s.%s.%s", groupId, fileName,
                         type.name(), fileExt);
                 break;
             case Comment:
@@ -194,6 +198,13 @@ public class EntityWriter {
 
     private String groupOrDefault(String groupId) {
         return groupId == null ? "default" : groupId;
+    }
+
+    private String encode(String value) {
+        if (value == null) {
+            return null;
+        }
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 
     private void write(ZipEntry entry, Entity entity, Class<?> entityClass) throws IOException {


### PR DESCRIPTION
### Description
This PR resolves a known `TODO` in both `v2/EntityWriter` and `v3/EntityWriter` regarding the URL-encoding of path elements during ZIP export. 

**The Bug:**
Previously, if a user had a `groupId` or `artifactId` containing a slash (`/`) or other invalid filesystem characters, the `String.format` path construction would blindly append them. This created unintended nested directories, corrupting the internal directory structure of the export ZIP file and causing import/export failures. 

**The Fix:**
I have implemented `URLEncoder.encode(..., StandardCharsets.UTF_8)` for the `groupId`, `artifactId`, and `fileName` variables just before they are used to construct the `ZipEntry` paths. 

Because `EntityReader` relies entirely on parsing the embedded JSON contents (which retain the unencoded IDs) rather than extracting metadata from the file paths, this change is fully backward-compatible and safe.

### Motivation
Fixing structural data corruption in ZIP serialization and cleaning up acknowledged technical debt. 

### Checklist
- [x] Fixed `v2/EntityWriter.java`
- [x] Fixed `v3/EntityWriter.java`
- [x] Verified `utils/importexport` module compiles and tests pass successfully
- [x] Added `Developer's Certificate of Origin` sign-off to commits
