### PR TITLE
fix(storage): make H2 sequence counters instance-scoped to avoid ID collisions

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSequenceRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSequenceRepository.java
@@ -15,7 +15,8 @@ import java.util.concurrent.atomic.AtomicLong;
  * Extracted from AbstractSqlRegistryStorage to improve maintainability.
  *
  * Note: H2 uses in-memory atomic counters for sequences instead of database
- * sequences, which is why this repository maintains static counters.
+ * sequences. Counters are instance-scoped so multiple storage instances in the
+ * same JVM (e.g. blue/green) do not share or overwrite each other's IDs.
  */
 public class SqlSequenceRepository {
 
@@ -24,12 +25,7 @@ public class SqlSequenceRepository {
     public static final String COMMENT_ID_SEQUENCE = "commentId";
 
     // Sequence counters - only used for H2 in-memory (and as a result KafkaSQL)
-    private static final Map<String, AtomicLong> sequenceCounters = new HashMap<>();
-    static {
-        sequenceCounters.put(GLOBAL_ID_SEQUENCE, new AtomicLong(0));
-        sequenceCounters.put(CONTENT_ID_SEQUENCE, new AtomicLong(0));
-        sequenceCounters.put(COMMENT_ID_SEQUENCE, new AtomicLong(0));
-    }
+    private final Map<String, AtomicLong> sequenceCounters = new HashMap<>();
 
     private final Logger log;
 
@@ -41,6 +37,9 @@ public class SqlSequenceRepository {
         this.handles = handles;
         this.sqlStatements = sqlStatements;
         this.log = log;
+        sequenceCounters.put(GLOBAL_ID_SEQUENCE, new AtomicLong(0));
+        sequenceCounters.put(CONTENT_ID_SEQUENCE, new AtomicLong(0));
+        sequenceCounters.put(COMMENT_ID_SEQUENCE, new AtomicLong(0));
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSequenceRepositoryTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSequenceRepositoryTest.java
@@ -1,0 +1,36 @@
+package io.apicurio.registry.storage.impl.sql.repositories;
+
+import io.apicurio.registry.storage.impl.sql.H2SqlStatements;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Regression for #7585: H2 sequence counters must be per repository instance so
+ * multiple storages in one JVM do not overwrite each other's IDs.
+ */
+public class SqlSequenceRepositoryTest {
+
+    @Test
+    public void sequenceCountersAreIsolatedBetweenInstances() {
+        SqlSequenceRepository blue = new SqlSequenceRepository(null, new H2SqlStatements(),
+                LoggerFactory.getLogger("blue"));
+        SqlSequenceRepository green = new SqlSequenceRepository(null, new H2SqlStatements(),
+                LoggerFactory.getLogger("green"));
+
+        // Advance blue's counters
+        assertEquals(1L, blue.nextGlobalIdRaw(null));
+        assertEquals(2L, blue.nextGlobalIdRaw(null));
+        assertEquals(1L, blue.nextContentIdRaw(null));
+
+        // Green must start from its own counters, not continue from blue
+        assertEquals(1L, green.nextGlobalIdRaw(null));
+        assertEquals(1L, green.nextContentIdRaw(null));
+
+        // Blue continues independently
+        assertEquals(3L, blue.nextGlobalIdRaw(null));
+        assertNotEquals(blue.nextGlobalIdRaw(null), green.nextGlobalIdRaw(null));
+    }
+}


### PR DESCRIPTION
## description
fixes #7585

`SqlSequenceRepository` kept H2 sequence counters in a `static` map. when multiple storage instances share a JVM (e.g. blue/green), one instance's `initializeSequenceCounters()` could overwrite the shared counters and cause primary key collisions.

changed the map to instance-scoped, matching the proposed fix in the issue.

## test plan
- [x] `./mvnw -pl app test -Dtest=SqlSequenceRepositoryTest`
- [x] two H2 repository instances increment independently