### PR TITLE
fix(serdes): surface original Registry errors from ERCache retries

### DIFF
--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -438,14 +438,12 @@ public class ERCache<V> {
                             "Could not retrieve schema for the cache. " + "Loading function returned null."));
                 }
             } catch (RuntimeException e) {
-                // TODO: verify if this is really needed, retries are already baked into the adapter ...
-                // if (i == retries || !(e.getCause() != null && e.getCause() instanceof ExecutionException
-                // && e.getCause().getCause() != null && e.getCause().getCause() instanceof ApiException
-                // && (((ApiException) e.getCause().getCause()).getResponseStatusCode() == 429)))
-                if (i == retries || !(e.getCause() != null && e.getCause() instanceof ApiException
-                        && (((ApiException) e.getCause()).getResponseStatusCode() == 429))) {
-                    log.error("Cache load failed after {} retries", i, e);
-                    return Result.error(new RuntimeException(e));
+                // Only retry on HTTP 429 (rate limit). All other Registry/client errors fail fast
+                // and are rethrown as-is so callers see the original Registry error response.
+                if (i == retries || !isRetryableRateLimit(e)) {
+                    log.error("Failed to load schema from Registry after {} retries: {}", i,
+                            describeRegistryError(e), e);
+                    return Result.error(e);
                 }
             }
             try {
@@ -456,6 +454,48 @@ public class ERCache<V> {
             }
         }
         return Result.error(new IllegalStateException("Unreachable."));
+    }
+
+    /**
+     * Returns true when the failure (or its cause chain) is an HTTP 429 from the Registry client.
+     */
+    private static boolean isRetryableRateLimit(RuntimeException e) {
+        ApiException apiException = findApiException(e);
+        return apiException != null && apiException.getResponseStatusCode() == 429;
+    }
+
+    private static ApiException findApiException(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof ApiException) {
+                return (ApiException) current;
+            }
+            Throwable cause = current.getCause();
+            if (cause == current) {
+                break;
+            }
+            current = cause;
+        }
+        return null;
+    }
+
+    /**
+     * Builds a concise description of the Registry/client failure for logs, preferring HTTP status
+     * and message from {@link ApiException} when present.
+     */
+    public static String describeRegistryError(Throwable throwable) {
+        ApiException apiException = findApiException(throwable);
+        if (apiException != null) {
+            String message = apiException.getMessage();
+            if (message == null || message.isBlank()) {
+                message = apiException.getClass().getSimpleName();
+            }
+            return "HTTP " + apiException.getResponseStatusCode() + " — " + message;
+        }
+        if (throwable.getMessage() != null && !throwable.getMessage().isBlank()) {
+            return throwable.getMessage();
+        }
+        return throwable.getClass().getName();
     }
 
     private static class WrappedValue<V> {

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/ERCacheTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/ERCacheTest.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.resolver;
 
+import com.microsoft.kiota.ApiException;
 import io.apicurio.registry.resolver.cache.ContentWithReferences;
 import io.apicurio.registry.resolver.cache.ERCache;
 import io.apicurio.registry.resolver.strategy.ArtifactCoordinates;
@@ -117,6 +118,46 @@ public class ERCacheTest {
         assertThrows(RuntimeException.class, () -> {
             cache.getByContentHash(contentHashKey, staticValueLoader);
         });
+    }
+
+    /**
+     * Regression for #5236: Registry/client failures must surface as the original exception
+     * (not wrapped in a generic cache RuntimeException that hides the Registry response).
+     */
+    @Test
+    void testPreservesOriginalLoadException() {
+        String contentHashKey = "preserve-original-error";
+        ERCache<String> cache = newCache(contentHashKey);
+        cache.configureRetryCount(0);
+
+        IllegalStateException original = new IllegalStateException(
+                "Registry rejected schema: validity rule failed");
+        Function<String, String> failingLoader = (key) -> {
+            throw original;
+        };
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> cache.getByContentHash(contentHashKey, failingLoader));
+
+        assertEquals(original, thrown);
+        assertEquals("Registry rejected schema: validity rule failed", thrown.getMessage());
+    }
+
+    @Test
+    void testDescribeRegistryErrorIncludesHttpStatusFromApiException() {
+        ApiException apiException = new TestApiException(409,
+                "RuleViolationProblemDetails: BACKWARD incompatible");
+
+        String description = ERCache.describeRegistryError(apiException);
+        assertTrue(description.contains("409"));
+        assertTrue(description.contains("BACKWARD incompatible"));
+    }
+
+    private static class TestApiException extends ApiException {
+        TestApiException(int statusCode, String message) {
+            super(message);
+            setResponseStatusCode(statusCode);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- fixes #5236
- ERCache no longer wraps load failures in a generic `RuntimeException`, so Registry/client errors (status + body) surface to serdes callers
- logs include HTTP status/message when an `ApiException` is in the cause chain
- only HTTP 429 still retries; other failures fail fast with the original exception

## Test plan
- [x] `ERCacheTest#testPreservesOriginalLoadException`
- [x] `ERCacheTest#testDescribeRegistryErrorIncludesHttpStatusFromApiException`
- [x] existing throw-by-default / fault-tolerant refresh tests still green