### PR TITLE
fix(storage): include artifact references in gitops/kubernetesops content hashes

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataSourceManager.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataSourceManager.java
@@ -431,8 +431,12 @@ public abstract class AbstractPollingDataSourceManager<MARKER extends SourceMark
             // Determine artifact type from content if not specified
             String resolvedArtifactType = utils.determineArtifactType(typedContent, artifactType);
 
-            // Calculate content hash for deduplication
-            String contentHash = utils.getContentHash(typedContent, null);
+            // Build references before hashing so gitops/kubernetesops match SQL storage
+            // (both contentHash and canonicalHash include serialized references when present).
+            List<ArtifactReferenceDto> references = extractReferences(contentMetadata);
+
+            // Calculate content hash for deduplication (must include references when present)
+            String contentHash = utils.getContentHash(typedContent, references);
 
             // Check if this content was already imported (deduplication)
             Long existingContentId = state.getContentHashToId().get(contentHash);
@@ -456,21 +460,12 @@ public abstract class AbstractPollingDataSourceManager<MARKER extends SourceMark
             e.contentId = contentId;
             e.contentHash = contentHash;
             e.contentBytes = data.bytes();
-            e.canonicalHash = utils.getCanonicalContentHash(typedContent, resolvedArtifactType, null, null);
+            e.canonicalHash = computeCanonicalHash(typedContent, resolvedArtifactType, references, state);
             e.artifactType = resolvedArtifactType;
             e.contentType = contentType;
 
-            if (contentMetadata != null && contentMetadata.getReferences() != null
-                    && !contentMetadata.getReferences().isEmpty()) {
-                List<ArtifactReferenceDto> refs = contentMetadata.getReferences().stream()
-                        .map(ref -> ArtifactReferenceDto.builder()
-                                .groupId(ref.getGroupId())
-                                .artifactId(ref.getArtifactId())
-                                .version(ref.getVersion())
-                                .name(ref.getName())
-                                .build())
-                        .collect(Collectors.toList());
-                e.serializedReferences = RegistryContentUtils.serializeReferences(refs);
+            if (references != null && !references.isEmpty()) {
+                e.serializedReferences = RegistryContentUtils.serializeReferences(references);
             }
 
             log.trace("Importing content from {}",dataFile.getPath());
@@ -482,6 +477,35 @@ public abstract class AbstractPollingDataSourceManager<MARKER extends SourceMark
             state.recordError(dataFile, "Could not import content: %s", ex.getMessage());
             return null;
         }
+    }
+
+    /**
+     * Maps content-metadata references into DTOs used for hashing and storage.
+     * Returns {@code null} when there are no references so hash helpers match the SQL path.
+     */
+    static List<ArtifactReferenceDto> extractReferences(Content contentMetadata) {
+        if (contentMetadata == null || contentMetadata.getReferences() == null
+                || contentMetadata.getReferences().isEmpty()) {
+            return null;
+        }
+        return contentMetadata.getReferences().stream()
+                .map(ref -> ArtifactReferenceDto.builder()
+                        .groupId(ref.getGroupId())
+                        .artifactId(ref.getArtifactId())
+                        .version(ref.getVersion())
+                        .name(ref.getName())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private String computeCanonicalHash(TypedContent typedContent, String artifactType,
+            List<ArtifactReferenceDto> references, ProcessingState state) {
+        if (references == null || references.isEmpty()) {
+            return utils.getCanonicalContentHash(typedContent, artifactType, null, null);
+        }
+        return utils.getCanonicalContentHash(typedContent, artifactType, references,
+                refs -> RegistryContentUtils.recursivelyResolveReferences(refs,
+                        state.getStorage()::getContentByReference));
     }
 
     private PollingDataFile findFileByPathRef(ProcessingState state, PollingDataFile base, String ref) {

--- a/app/src/test/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataSourceManagerReferencesTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataSourceManagerReferencesTest.java
@@ -1,0 +1,75 @@
+package io.apicurio.registry.storage.impl.polling;
+
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
+import io.apicurio.registry.storage.impl.polling.model.v0.Content;
+import io.apicurio.registry.storage.impl.polling.model.v0.ContentReference;
+import io.apicurio.registry.storage.impl.sql.RegistryStorageContentUtils;
+import io.apicurio.registry.types.ContentTypes;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Ensures polling storage derives hashes from content-metadata references the same way SQL does (#8540).
+ */
+public class AbstractPollingDataSourceManagerReferencesTest {
+
+    private static final String AVRO = "{\"type\":\"record\",\"name\":\"TestRecord\","
+            + "\"namespace\":\"com.example\","
+            + "\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}]}";
+
+    @Test
+    void extractReferencesReturnsNullWhenMetadataMissing() {
+        assertNull(AbstractPollingDataSourceManager.extractReferences(null));
+        assertNull(AbstractPollingDataSourceManager.extractReferences(Content.builder().build()));
+    }
+
+    @Test
+    void extractReferencesMapsContentMetadata() {
+        Content metadata = Content.builder()
+                .references(List.of(ContentReference.builder()
+                        .groupId("com.example")
+                        .artifactId("Address")
+                        .version("1")
+                        .name("com.example.Address")
+                        .build()))
+                .build();
+
+        List<ArtifactReferenceDto> refs = AbstractPollingDataSourceManager.extractReferences(metadata);
+        assertEquals(1, refs.size());
+        assertEquals("com.example", refs.get(0).getGroupId());
+        assertEquals("Address", refs.get(0).getArtifactId());
+        assertEquals("1", refs.get(0).getVersion());
+        assertEquals("com.example.Address", refs.get(0).getName());
+    }
+
+    @Test
+    void pollingContentHashMatchesSqlWhenReferencesAreIncluded() {
+        RegistryStorageContentUtils utils = new RegistryStorageContentUtils();
+        TypedContent content = TypedContent.create(AVRO, ContentTypes.APPLICATION_JSON);
+
+        Content metadata = Content.builder()
+                .references(List.of(ContentReference.builder()
+                        .groupId("com.example")
+                        .artifactId("Address")
+                        .version("1")
+                        .name("com.example.Address")
+                        .build()))
+                .build();
+
+        List<ArtifactReferenceDto> refs = AbstractPollingDataSourceManager.extractReferences(metadata);
+
+        String sqlStyle = utils.getContentHash(content, refs);
+        String oldPollingStyle = utils.getContentHash(content, null);
+
+        assertNotEquals(sqlStyle, oldPollingStyle,
+                "pre-fix polling hashed without references and diverged from SQL");
+        assertEquals(sqlStyle, utils.getContentHash(content, refs),
+                "polling must hash with extracted references to match SQL");
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/storage/impl/sql/RegistryStorageContentUtilsTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/sql/RegistryStorageContentUtilsTest.java
@@ -1,0 +1,56 @@
+package io.apicurio.registry.storage.impl.sql;
+
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
+import io.apicurio.registry.types.ContentTypes;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Regression coverage for hash behavior that SQL and polling storages must share.
+ * See #8540 — polling previously hashed as if references were always absent.
+ */
+public class RegistryStorageContentUtilsTest {
+
+    private static final String AVRO = "{\"type\":\"record\",\"name\":\"TestRecord\","
+            + "\"namespace\":\"com.example\","
+            + "\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}]}";
+
+    private final RegistryStorageContentUtils utils = new RegistryStorageContentUtils();
+
+    private static List<ArtifactReferenceDto> oneReference() {
+        return List.of(ArtifactReferenceDto.builder()
+                .groupId("com.example")
+                .artifactId("Address")
+                .version("1")
+                .name("com.example.Address")
+                .build());
+    }
+
+    private static TypedContent avroContent() {
+        return TypedContent.create(AVRO, ContentTypes.APPLICATION_JSON);
+    }
+
+    @Test
+    void contentHashIncludesReferences() {
+        TypedContent content = avroContent();
+
+        String withRefs = utils.getContentHash(content, oneReference());
+        String withoutRefs = utils.getContentHash(content, null);
+
+        assertNotEquals(withRefs, withoutRefs,
+                "contentHash must include serialized references when present");
+    }
+
+    @Test
+    void contentHashIsStableForSameContentAndReferences() {
+        TypedContent content = avroContent();
+        List<ArtifactReferenceDto> refs = oneReference();
+
+        assertEquals(utils.getContentHash(content, refs), utils.getContentHash(content, refs));
+    }
+}


### PR DESCRIPTION
## Summary
- fixes #8540
- polling storages (`gitops` / `kubernetesops`) were computing `contentHash` and `canonicalHash` with `null` references, then attaching refs only when building the `ContentEntity`
- SQL includes serialized references in both hashes, so identical content+refs produced different hashes across backends
- now extract refs from content-metadata first, hash with them (same as SQL), and resolve refs via `storage::getContentByReference` for canonical hashing

## Test plan
- [x] `RegistryStorageContentUtilsTest` — contentHash changes when refs are present
- [x] `AbstractPollingDataSourceManagerReferencesTest` — extractReferences mapping + sql-style hash match