### PR TITLE
fix(ci): backport Debezium CI reliability fixes from main

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/deployment/DebeziumDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/DebeziumDeploymentManager.java
@@ -29,6 +29,10 @@ public class DebeziumDeploymentManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DebeziumDeploymentManager.class);
 
+    private static final int CONNECT_READY_MAX_ATTEMPTS = 60;
+    private static final int CONNECT_READY_SLEEP_MS = 5000;
+    private static final int CONNECT_READY_INITIAL_DELAY_MS = 10000;
+
     // Flags to track what infrastructure has been deployed (for idempotency)
     private static volatile boolean kafkaDeployed = false;
     private static volatile boolean postgresqlDeployed = false;
@@ -289,8 +293,8 @@ public class DebeziumDeploymentManager {
                 System.setProperty("debezium.mysql.host", mysqlClusterIP);
                 System.setProperty("debezium.mysql.port", "3306");
                 System.setProperty("debezium.mysql.database", "registry");
-                System.setProperty("debezium.mysql.username", "mysqluser");
-                System.setProperty("debezium.mysql.password", "mysqlpw");
+                System.setProperty("debezium.mysql.username", "root");
+                System.setProperty("debezium.mysql.password", "debezium");
                 LOGGER.info("MySQL JDBC URL: {}", mysqlJdbcUrl);
             } else {
                 LOGGER.error("Failed to get MySQL service");
@@ -442,49 +446,44 @@ public class DebeziumDeploymentManager {
         }
     }
 
-    /**
-     * Waits for Debezium Connect to be ready by checking the REST API health endpoint.
-     * Uses the external LoadBalancer service to check readiness via localhost.
-     */
     private static void waitForDebeziumConnectReady(boolean useLocalConverters) {
         String serviceName = useLocalConverters ? DEBEZIUM_CONNECT_LOCAL_SERVICE : DEBEZIUM_CONNECT_SERVICE;
-        String externalServiceName = useLocalConverters ?
-                "debezium-connect-local-service-external" : "debezium-connect-service-external";
 
         LOGGER.info("Waiting for Debezium Connect service {} to be ready ##################################################", serviceName);
 
-        // Get the LoadBalancer service
         Service service = kubernetesClient.services()
                 .inNamespace(TEST_NAMESPACE)
-                .withName(externalServiceName)
+                .withName(serviceName)
                 .get();
 
         if (service == null) {
-            LOGGER.error("Debezium Connect LoadBalancer service {} not found", externalServiceName);
-            throw new RuntimeException("Debezium Connect service " + externalServiceName + " not found");
+            LOGGER.error("Debezium Connect service {} not found", serviceName);
+            throw new RuntimeException("Debezium Connect service " + serviceName + " not found");
         }
 
-        // Wait for LoadBalancer to get an external IP (minikube tunnel assigns it)
-        LOGGER.info("Waiting for LoadBalancer external IP to be assigned (requires minikube tunnel)...");
         try {
-            // In minikube with tunnel, the service should be accessible via localhost
-            // Let's wait a bit and then try to connect
-            Thread.sleep(10000); // Give minikube tunnel time to set up the route
+            Thread.sleep(CONNECT_READY_INITIAL_DELAY_MS);
 
-            String port = useLocalConverters ? "8084" : "8083";
-            // Try to connect to the Debezium Connect REST API
-            String connectUrl = "http://localhost:" + port;
+            // On Linux/CI (driver:none), ClusterIPs are directly routable — no tunnel needed.
+            // On macOS, use localhost via minikube tunnel (routes to LoadBalancer external service).
+            boolean macOS = System.getProperty("os.name").contains("Mac OS");
+            String host = macOS ? "localhost" : service.getSpec().getClusterIP();
+            // ClusterIP services always expose 8083; LoadBalancer external uses 8084 for local converters
+            String port = macOS ? (useLocalConverters ? "8084" : "8083") : "8083";
+            String connectUrl = "http://" + host + ":" + port;
             LOGGER.info("Checking Debezium Connect readiness at: {}", connectUrl);
 
-            int maxAttempts = 30;
             int attempt = 0;
             boolean ready = false;
+            int connectionRefusedCount = 0;
+            int httpResponseCount = 0;
+            int lastStatusCode = -1;
 
-            while (attempt < maxAttempts && !ready) {
+            while (attempt < CONNECT_READY_MAX_ATTEMPTS && !ready) {
+                java.net.HttpURLConnection conn = null;
                 try {
-                    // Simple HTTP GET to check if service is responding
                     java.net.URL url = new java.net.URL(connectUrl);
-                    java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
+                    conn = (java.net.HttpURLConnection) url.openConnection();
                     conn.setRequestMethod("GET");
                     conn.setConnectTimeout(2000);
                     conn.setReadTimeout(2000);
@@ -494,20 +493,42 @@ public class DebeziumDeploymentManager {
                         ready = true;
                         LOGGER.info("Debezium Connect is ready!");
                     } else {
-                        LOGGER.debug("Debezium Connect returned status code: {}", responseCode);
+                        httpResponseCount++;
+                        lastStatusCode = responseCode;
+                        LOGGER.info("Attempt {}/{}: Debezium Connect starting up (HTTP {})",
+                                attempt + 1, CONNECT_READY_MAX_ATTEMPTS, responseCode);
                     }
-                    conn.disconnect();
                 } catch (Exception e) {
-                    LOGGER.debug("Attempt {}/{}: Debezium Connect not ready yet: {}",
-                            attempt + 1, maxAttempts, e.getMessage());
-                    Thread.sleep(5000);
+                    LOGGER.info("Attempt {}/{}: Debezium Connect not reachable ({})",
+                            attempt + 1, CONNECT_READY_MAX_ATTEMPTS, e.getMessage());
+                    connectionRefusedCount++;
+                } finally {
+                    if (conn != null) {
+                        conn.disconnect();
+                    }
+                }
+                if (!ready) {
+                    Thread.sleep(CONNECT_READY_SLEEP_MS);
                 }
                 attempt++;
             }
 
             if (!ready) {
-                throw new RuntimeException("Debezium Connect did not become ready after " + maxAttempts + " attempts. " +
-                        "Make sure 'minikube tunnel' is running and LoadBalancer services are accessible.");
+                String diagnosis;
+                if (httpResponseCount == 0) {
+                    diagnosis = "All " + CONNECT_READY_MAX_ATTEMPTS + " attempts got Connection refused — " +
+                            "this is a routing issue, not a startup timeout. Check service " + serviceName + " at " + connectUrl;
+                } else if (connectionRefusedCount == 0) {
+                    diagnosis = "All attempts reached the server but never got HTTP 200 (last status: " +
+                            lastStatusCode + ") — startup is too slow or the service is unhealthy.";
+                } else {
+                    diagnosis = "Mixed signals: " + connectionRefusedCount + " Connection refused, " +
+                            httpResponseCount + " HTTP responses (last status: " + lastStatusCode +
+                            "). Service was intermittently reachable.";
+                }
+                LOGGER.error("Debezium Connect readiness check failed. Diagnosis: {}", diagnosis);
+                throw new RuntimeException("Debezium Connect did not become ready after " +
+                        CONNECT_READY_MAX_ATTEMPTS + " attempts. " + diagnosis);
             }
 
         } catch (InterruptedException e) {

--- a/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
@@ -237,31 +237,27 @@ public class RegistryDeploymentManager implements TestExecutionListener {
         kubernetesClient.pods().inNamespace(TEST_NAMESPACE).waitUntilReady(360, TimeUnit.SECONDS);
     }
 
-    /**
-     * Waits for the Apicurio Registry to be ready by checking the REST API health endpoint.
-     * Uses the external LoadBalancer service to check readiness via localhost.
-     */
     static void waitForRegistryReady() {
         LOGGER.info("Waiting for Apicurio Registry to be accessible via LoadBalancer ##################################################");
 
         try {
-            // In minikube with tunnel, the service should be accessible via localhost
-            // Let's wait a bit and then try to connect
-            Thread.sleep(10000); // Give minikube tunnel time to set up the route
+            Thread.sleep(10000);
 
-            // Try to connect to the Registry REST API
             String registryUrl = "http://" + System.getProperty("quarkus.http.test-host") + ":9000/health/ready";
             LOGGER.info("Checking Registry readiness at: {}", registryUrl);
 
             int maxAttempts = 30;
             int attempt = 0;
             boolean ready = false;
+            int connectionRefusedCount = 0;
+            int httpResponseCount = 0;
+            int lastStatusCode = -1;
 
             while (attempt < maxAttempts && !ready) {
+                java.net.HttpURLConnection conn = null;
                 try {
-                    // Simple HTTP GET to check if service is responding
                     java.net.URL url = new java.net.URL(registryUrl);
-                    java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
+                    conn = (java.net.HttpURLConnection) url.openConnection();
                     conn.setRequestMethod("GET");
                     conn.setConnectTimeout(2000);
                     conn.setReadTimeout(2000);
@@ -271,20 +267,41 @@ public class RegistryDeploymentManager implements TestExecutionListener {
                         ready = true;
                         LOGGER.info("Apicurio Registry is ready!");
                     } else {
-                        LOGGER.debug("Registry returned status code: {}", responseCode);
+                        httpResponseCount++;
+                        lastStatusCode = responseCode;
+                        LOGGER.info("Attempt {}/{}: Apicurio Registry starting up (HTTP {})",
+                                attempt + 1, maxAttempts, responseCode);
                     }
-                    conn.disconnect();
                 } catch (Exception e) {
-                    LOGGER.debug("Attempt {}/{}: Registry not ready yet: {}",
+                    LOGGER.info("Attempt {}/{}: Apicurio Registry not reachable ({})",
                             attempt + 1, maxAttempts, e.getMessage());
+                    connectionRefusedCount++;
+                } finally {
+                    if (conn != null) {
+                        conn.disconnect();
+                    }
+                }
+                if (!ready) {
                     Thread.sleep(2000);
                 }
                 attempt++;
             }
 
             if (!ready) {
-                throw new RuntimeException("Apicurio Registry did not become ready after " + maxAttempts + " attempts. " +
-                        "Make sure 'minikube tunnel' is running and LoadBalancer services are accessible.");
+                String diagnosis;
+                if (httpResponseCount == 0) {
+                    diagnosis = "All " + maxAttempts + " attempts got Connection refused — " +
+                            "this is a routing issue, not a startup timeout. Check minikube tunnel status.";
+                } else if (connectionRefusedCount == 0) {
+                    diagnosis = "All attempts reached the server but never got HTTP 200 (last status: " +
+                            lastStatusCode + ") — startup is too slow or the service is unhealthy.";
+                } else {
+                    diagnosis = "Mixed signals: " + connectionRefusedCount + " Connection refused, " +
+                            httpResponseCount + " HTTP responses (last status: " + lastStatusCode +
+                            "). Service was intermittently reachable.";
+                }
+                LOGGER.error("Apicurio Registry readiness check failed. Diagnosis: {}", diagnosis);
+                throw new RuntimeException("Apicurio Registry did not become ready after " + maxAttempts + " attempts. " + diagnosis);
             }
 
         } catch (InterruptedException e) {

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroV2DeserializerMixin.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroV2DeserializerMixin.java
@@ -11,11 +11,17 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 /**
- * Mixin interface providing common Apicurio Registry V2 wire format deserialization logic.
- * This can be used by any test class that needs to deserialize Avro messages encoded with
- * the V2 wire format: [magic byte (0x0)][long: global ID][avro payload]
+ * Mixin interface providing Apicurio Registry wire format deserialization logic with
+ * optimistic fallback between 4-byte and 8-byte ID formats.
+ *
+ * <p>Applies the same heuristic as {@code OptimisticFallbackIdHandler}: peek at the first
+ * 4 bytes after the magic byte. If they are all zeros the data was written with the legacy
+ * 8-byte format (globalId as a long); otherwise it was written with the default 4-byte
+ * format (contentId as an int). The schema is then fetched via the matching endpoint and
+ * any Avro references are resolved before deserialization.
  */
 public interface DebeziumAvroV2DeserializerMixin {
 
@@ -28,8 +34,12 @@ public interface DebeziumAvroV2DeserializerMixin {
     io.apicurio.registry.rest.client.RegistryClient getRegistryClient();
 
     /**
-     * Deserializes Avro-encoded bytes to GenericRecord using V2 API format.
-     * Handles Apicurio Registry V2 wire format (magic byte + globalId + payload)
+     * Deserializes Avro-encoded bytes to GenericRecord, auto-detecting the wire format.
+     *
+     * <p>If the first 4 bytes after the magic byte are all zeros the record is treated as
+     * legacy 8-byte globalId format; otherwise it is treated as default 4-byte contentId
+     * format. This mirrors the {@code OptimisticFallbackIdHandler} logic used in the serde
+     * library. Schema references are resolved before parsing.
      */
     default GenericRecord deserializeAvroValueV2(byte[] bytes) throws Exception {
         if (bytes == null || bytes.length < 5) {
@@ -43,23 +53,41 @@ public interface DebeziumAvroV2DeserializerMixin {
         }
         LOG.info(hexDump.toString());
 
-        // Parse Apicurio V2 wire format: [magic byte][long: global ID][payload]
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
 
         // Skip magic byte (should be 0x0)
         byte magicByte = buffer.get();
         LOG.info("Magic byte: {} (0x{})", magicByte, String.format("%02X", magicByte));
 
-        // Read global ID (8 bytes, big-endian long)
-        long globalId = buffer.getLong();
-        LOG.info("Global ID from wire format (decimal): {}", globalId);
-        LOG.info("Global ID from wire format (hex): 0x{}", Long.toHexString(globalId));
+        // Optimistic fallback: peek at the first 4 bytes to decide the format.
+        // If all four are zero and there is room for another 4 bytes, this was
+        // written with Legacy8ByteIdHandler (8-byte globalId). Otherwise, it was
+        // written with Default4ByteIdHandler (4-byte contentId).
+        int firstFour = buffer.getInt();
 
-        // Fetch schema from registry using global ID
+        boolean legacy8Byte = (firstFour == 0 && buffer.remaining() >= 4);
+
+        String schemaJson;
+        Schema.Parser parser = new Schema.Parser();
+
+        if (legacy8Byte) {
+            // Rewind the 4 bytes we just read and consume a full 8-byte long
+            buffer.position(buffer.position() - 4);
+            long globalId = buffer.getLong();
+            LOG.info("Detected legacy 8-byte format. Global ID: {} (0x{})",
+                    globalId, Long.toHexString(globalId));
+            schemaJson = fetchSchemaStringByGlobalId(globalId);
+            resolveReferencesByGlobalId(globalId, parser);
+        } else {
+            long contentId = Integer.toUnsignedLong(firstFour);
+            LOG.info("Detected default 4-byte format. Content ID: {} (0x{})",
+                    contentId, Long.toHexString(contentId));
+            schemaJson = fetchSchemaStringByContentId(contentId);
+            resolveReferencesByContentId(contentId, parser);
+        }
+
         try {
-            InputStream schemaStream = getRegistryClient().ids().globalIds().byGlobalId(globalId).get();
-            String schemaJson = new String(schemaStream.readAllBytes(), StandardCharsets.UTF_8);
-            Schema schema = new Schema.Parser().parse(schemaJson);
+            Schema schema = parser.parse(schemaJson);
 
             // Deserialize payload
             byte[] payload = new byte[buffer.remaining()];
@@ -70,23 +98,115 @@ public interface DebeziumAvroV2DeserializerMixin {
 
             return reader.read(null, decoder);
         } catch (Exception e) {
-            LOG.error("Failed to fetch schema for globalId: {}. Error: {}", globalId, e.getMessage());
-            LOG.error("Trying to list recent artifacts to debug...");
-            try {
-                var artifacts = getRegistryClient().search().artifacts().get(config -> {
-                    config.queryParameters.limit = 10;
-                    config.queryParameters.orderby = io.apicurio.registry.rest.client.models.ArtifactSortBy.CreatedOn;
-                    config.queryParameters.order = io.apicurio.registry.rest.client.models.SortOrder.Desc;
-                });
-                LOG.error("Recent artifacts in registry:");
-                artifacts.getArtifacts().forEach(artifact -> {
-                    LOG.error("  - Artifact: {}, Group: {}, Type: {}",
-                            artifact.getArtifactId(), artifact.getGroupId(), artifact.getArtifactType());
-                });
-            } catch (Exception listError) {
-                LOG.error("Could not list artifacts", listError);
-            }
+            LOG.error("Failed to deserialize Avro record. Error: {}", e.getMessage());
+            logRecentArtifacts();
             throw e;
+        }
+    }
+
+    /**
+     * Fetches a schema as a JSON string by globalId (legacy 8-byte format).
+     */
+    private String fetchSchemaStringByGlobalId(long globalId) throws Exception {
+        try {
+            InputStream stream = getRegistryClient().ids().globalIds().byGlobalId(globalId).get();
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            LOG.error("Failed to fetch schema for globalId: {}. Error: {}", globalId, e.getMessage());
+            logRecentArtifacts();
+            throw e;
+        }
+    }
+
+    /**
+     * Fetches a schema as a JSON string by contentId (default 4-byte format).
+     */
+    private String fetchSchemaStringByContentId(long contentId) throws Exception {
+        try {
+            InputStream stream = getRegistryClient().ids().contentIds().byContentId(contentId).get();
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            LOG.error("Failed to fetch schema for contentId: {}. Error: {}", contentId, e.getMessage());
+            logRecentArtifacts();
+            throw e;
+        }
+    }
+
+    /**
+     * Resolves and pre-parses schema references for a globalId.
+     */
+    private void resolveReferencesByGlobalId(long globalId, Schema.Parser parser) {
+        try {
+            var references = getRegistryClient().ids().globalIds().byGlobalId(globalId).references().get();
+            resolveReferences(references, parser);
+        } catch (Exception e) {
+            LOG.warn("Could not resolve references for globalId {}: {}", globalId, e.getMessage());
+        }
+    }
+
+    /**
+     * Resolves and pre-parses schema references for a contentId.
+     */
+    private void resolveReferencesByContentId(long contentId, Schema.Parser parser) {
+        try {
+            var references = getRegistryClient().ids().contentIds().byContentId(contentId).references().get();
+            resolveReferences(references, parser);
+        } catch (Exception e) {
+            LOG.warn("Could not resolve references for contentId {}: {}", contentId, e.getMessage());
+        }
+    }
+
+    /**
+     * Fetches and pre-parses each referenced schema so the main schema can resolve them.
+     */
+    private void resolveReferences(
+            List<io.apicurio.registry.rest.client.models.ArtifactReference> references,
+            Schema.Parser parser) {
+        if (references == null || references.isEmpty()) {
+            return;
+        }
+        LOG.info("Schema has {} references, resolving...", references.size());
+        for (var ref : references) {
+            try {
+                String refGroupId = ref.getGroupId() != null ? ref.getGroupId() : "default";
+                String refArtifactId = ref.getArtifactId();
+                String refVersion = ref.getVersion();
+
+                LOG.info("Resolving reference: name={}, groupId={}, artifactId={}, version={}",
+                        ref.getName(), refGroupId, refArtifactId, refVersion);
+
+                String versionExpr = (refVersion != null && !refVersion.isEmpty()) ? refVersion : "latest";
+                InputStream refStream = getRegistryClient().groups().byGroupId(refGroupId)
+                        .artifacts().byArtifactId(refArtifactId)
+                        .versions().byVersionExpression(versionExpr)
+                        .content().get();
+
+                String refSchemaJson = new String(refStream.readAllBytes(), StandardCharsets.UTF_8);
+                parser.parse(refSchemaJson);
+                LOG.info("Successfully resolved reference: {}", ref.getName());
+            } catch (Exception e) {
+                LOG.warn("Failed to resolve reference {}: {}", ref.getName(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Logs recently registered artifacts for debugging purposes.
+     */
+    private void logRecentArtifacts() {
+        try {
+            var artifacts = getRegistryClient().search().artifacts().get(config -> {
+                config.queryParameters.limit = 10;
+                config.queryParameters.orderby = io.apicurio.registry.rest.client.models.ArtifactSortBy.CreatedOn;
+                config.queryParameters.order = io.apicurio.registry.rest.client.models.SortOrder.Desc;
+            });
+            LOG.error("Recent artifacts in registry:");
+            artifacts.getArtifacts().forEach(artifact -> {
+                LOG.error("  - Artifact: {}, Group: {}, Type: {}",
+                        artifact.getArtifactId(), artifact.getGroupId(), artifact.getArtifactType());
+            });
+        } catch (Exception listError) {
+            LOG.error("Could not list artifacts", listError);
         }
     }
 }

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
@@ -150,12 +150,12 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         insertCustomer(tableName, "Alice Smith", "alice@example.com");
         insertCustomer(tableName, "Bob Jones", "bob@example.com");
 
-        List<GenericRecord> events = consumeAvroEvents(topicName, 2, Duration.ofSeconds(10));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 2, Duration.ofSeconds(45));
         assertEquals(2, events.size(), "Expected 2 CDC events");
 
         GenericRecord firstEvent = events.get(0);
@@ -188,7 +188,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         // INSERT
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
@@ -216,7 +216,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
             }
         }
 
-        List<GenericRecord> events = consumeAvroEvents(topicName, 3, Duration.ofSeconds(15));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 3, Duration.ofSeconds(30));
         assertEquals(3, events.size());
 
         // Verify INSERT
@@ -282,14 +282,14 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
         String topic3 = getTopicNameForTable(table3);
 
         consumer.subscribe(List.of(topic1, topic2, topic3));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + table1 + " (order_number, total) VALUES ('ORD-001', 99.99)");
         executeUpdate("INSERT INTO " + table2 + " (order_id, product_name, quantity) VALUES (1, 'Laptop', 1)");
         executeUpdate("INSERT INTO " + table3 + " (sku, stock_count) VALUES ('SKU-123', 50)");
 
         List<ConsumerRecord<byte[], byte[]>> allRecords = new ArrayList<>();
-        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+        Unreliables.retryUntilTrue(20, TimeUnit.SECONDS, () -> {
             consumer.poll(Duration.ofMillis(500)).forEach(allRecords::add);
             return allRecords.size() >= 3;
         });
@@ -323,13 +323,13 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
         // Using shared connector from @BeforeAll
         // Note: Shared connector already has schema.name.adjustment.mode and field.name.adjustment.mode set to "avro"
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName +
                 " (`first-name`, `last name`, `email@address`) VALUES " +
                 "('John', 'Doe', 'john@example.com')");
 
-        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events.size());
 
         GenericRecord event = events.get(0);
@@ -358,11 +358,11 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (name) VALUES ('Original')");
 
-        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events1.size());
 
         waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
@@ -373,7 +373,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         executeUpdate("INSERT INTO " + tableName + " (name, email) VALUES ('New Record', 'test@example.com')");
 
-        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events2.size());
 
         GenericRecord newEvent = events2.get(0);
@@ -407,7 +407,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('test')");
         waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
@@ -447,19 +447,19 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (field1) VALUES ('v1')");
-        consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
 
         executeUpdate("ALTER TABLE " + tableName + " ADD COLUMN field2 VARCHAR(100)");
         executeUpdate("INSERT INTO " + tableName + " (field1, field2) VALUES ('v2', 'data2')");
-        consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
 
         executeUpdate("ALTER TABLE " + tableName + " ADD COLUMN field3 INT");
         executeUpdate("INSERT INTO " + tableName + " (field1, field2, field3) VALUES ('v3', 'data3', 123)");
-        consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
 
         var versions = registryClient.groups().byGroupId("default")
                 .artifacts().byArtifactId(topicName + "-value")
@@ -496,7 +496,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
                 "INSERT INTO " + tableName +
@@ -512,7 +512,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
             stmt.executeUpdate();
         }
 
-        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events.size());
 
         GenericRecord event = events.get(0);
@@ -545,7 +545,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
                 "INSERT INTO " + tableName + " (price, tax_rate, weight, quantity) VALUES (?, ?, ?, ?)")) {
@@ -556,7 +556,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
             stmt.executeUpdate();
         }
 
-        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events.size());
 
         GenericRecord event = events.get(0);
@@ -587,7 +587,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         int totalRows = 1000;
         int batchSize = 100;
@@ -631,14 +631,14 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('before')");
-        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events1.size());
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('after')");
-        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(10));
+        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events2.size());
 
         GenericRecord afterEvent = events2.get(0);

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroBaseIT.java
@@ -192,7 +192,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         insertCustomer(tableName, "Bob Jones", "bob@example.com");
 
         // Longer timeout for first table - Debezium needs time to detect new table and start capturing
-        List<GenericRecord> events = consumeAvroEvents(topicName, 2, Duration.ofSeconds(20));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 2, Duration.ofSeconds(45));
         assertEquals(2, events.size(), "Expected 2 CDC events");
 
         GenericRecord firstEvent = events.get(0);
@@ -230,7 +230,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         // INSERT
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
@@ -257,7 +257,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
             }
         }
 
-        List<GenericRecord> events = consumeAvroEvents(topicName, 3, Duration.ofSeconds(15));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 3, Duration.ofSeconds(30));
         assertEquals(3, events.size());
 
         // Verify INSERT
@@ -327,14 +327,14 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         String topic3 = getTopicNameForTable(table3);
 
         consumer.subscribe(List.of(topic1, topic2, topic3));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + table1 + " (order_number, total) VALUES ('ORD-001', 99.99)");
         executeUpdate("INSERT INTO " + table2 + " (order_id, product_name, quantity) VALUES (1, 'Laptop', 1)");
         executeUpdate("INSERT INTO " + table3 + " (sku, stock_count) VALUES ('SKU-123', 50)");
 
         List<ConsumerRecord<byte[], byte[]>> allRecords = new ArrayList<>();
-        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+        Unreliables.retryUntilTrue(20, TimeUnit.SECONDS, () -> {
             consumer.poll(Duration.ofMillis(500)).forEach(allRecords::add);
             return allRecords.size() >= 3;
         });
@@ -368,14 +368,14 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName +
                 " (\"first-name\", \"last name\", \"email@address\") VALUES " +
                 "('John', 'Doe', 'john@example.com')");
 
         // Increased timeout for table detection in CI environments
-        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events.size());
 
         GenericRecord event = events.get(0);
@@ -404,12 +404,12 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (name) VALUES ('Original')");
 
         // Increased timeout for table detection in CI environments
-        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
+        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events1.size());
 
         waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
@@ -421,7 +421,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         executeUpdate("INSERT INTO " + tableName + " (name, email) VALUES ('New Record', 'test@example.com')");
 
         // Increased timeout for schema evolution detection
-        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
+        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events2.size());
 
         GenericRecord newEvent = events2.get(0);
@@ -455,7 +455,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('test')");
         waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
@@ -495,22 +495,22 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (field1) VALUES ('v1')");
         // Increased timeout for table detection in CI environments
-        consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
+        consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
 
         executeUpdate("ALTER TABLE " + tableName + " ADD COLUMN field2 VARCHAR(100)");
         executeUpdate("INSERT INTO " + tableName + " (field1, field2) VALUES ('v2', 'data2')");
         // Increased timeout for schema evolution detection
-        consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
+        consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
 
         executeUpdate("ALTER TABLE " + tableName + " ADD COLUMN field3 INT");
         executeUpdate("INSERT INTO " + tableName + " (field1, field2, field3) VALUES ('v3', 'data3', 123)");
         // Increased timeout for schema evolution detection
-        consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
+        consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
 
         var versions = registryClient.groups().byGroupId("default")
                 .artifacts().byArtifactId(topicName + "-value")
@@ -549,7 +549,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
                 "INSERT INTO " + tableName +
@@ -563,7 +563,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         }
 
         // Increased timeout for table detection in CI environments
-        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events.size());
 
         GenericRecord event = events.get(0);
@@ -598,7 +598,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
                 "INSERT INTO " + tableName + " (price, tax_rate, weight, quantity) VALUES (?, ?, ?, ?)")) {
@@ -610,7 +610,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         }
 
         // Increased timeout for table detection in CI environments
-        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
+        List<GenericRecord> events = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events.size());
 
         GenericRecord event = events.get(0);
@@ -641,7 +641,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         int totalRows = 1000;
         int batchSize = 100;
@@ -685,15 +685,15 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(5));
+        waitForConsumerReady(Duration.ofSeconds(10));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('before')");
         // Increased timeout for table detection in CI environments
-        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
+        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events1.size());
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('after')");
-        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(15));
+        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events2.size());
 
         GenericRecord afterEvent = events2.get(0);


### PR DESCRIPTION
## Summary

Backports 5 Debezium CI reliability fixes from `main` to `3.2.x`. The `h2-debezium` integration
test job has been failing consistently on every `3.2.x` CI run for over a week because Debezium
Connect never becomes ready within the timeout.

Changes ported from these PRs on `main`:
- #8245 — Harden Debezium Connect readiness checks (increase timeout from 30→60 attempts, fix
  sleep logic, upgrade logging from DEBUG→INFO)
- #8246 — Use optimistic fallback in Debezium V2 deserializer mixin (auto-detect 4-byte vs
  8-byte wire format, resolve schema references)
- #8261 — Add signal-aware diagnostics to readiness check failures (connection-refused vs
  HTTP-non-200 vs mixed)
- #8375 — Use ClusterIP for Debezium readiness check on Linux/CI instead of LoadBalancer,
  fix MySQL test credentials
- #8476 — Increase Debezium integration test timeouts for CI stability (consumer ready,
  event consumption, retry loops)

## Test plan

- [ ] `h2-debezium` integration test job passes in CI (was failing on every 3.2.x run)
- [ ] All other integration test jobs remain green