### PR TITLE
fix(rest): include artifact references in v2 version list/search results

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/V2ApiUtil.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/V2ApiUtil.java
@@ -25,11 +25,13 @@ import io.apicurio.registry.types.ArtifactState;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public final class V2ApiUtil {
 
@@ -294,6 +296,12 @@ public final class V2ApiUtil {
             sv.setState(ArtifactState.fromValue(version.getState().name()));
             sv.setType(version.getArtifactType());
             sv.setVersion(version.getVersion());
+            if (version.getReferences() != null) {
+                sv.setReferences(version.getReferences().stream()
+                        .map(V2ApiUtil::referenceDtoToReference).collect(Collectors.toList()));
+            } else {
+                sv.setReferences(Collections.emptyList());
+            }
             results.getVersions().add(sv);
         });
         return results;

--- a/app/src/main/java/io/apicurio/registry/storage/dto/SearchedVersionDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/SearchedVersionDto.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 @NoArgsConstructor
@@ -36,5 +37,6 @@ public class SearchedVersionDto {
     private long contentId;
     private int versionOrder;
     private Map<String, String> labels;
+    private List<ArtifactReferenceDto> references;
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedVersionMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedVersionMapper.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.sql.mappers;
 
+import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
 import io.apicurio.registry.storage.dto.SearchedVersionDto;
 import io.apicurio.registry.storage.impl.sql.RegistryContentUtils;
 import io.apicurio.registry.storage.impl.sql.jdb.RowMapper;
@@ -7,6 +8,8 @@ import io.apicurio.registry.types.VersionState;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
 
 public class SearchedVersionMapper implements RowMapper<SearchedVersionDto> {
 
@@ -39,7 +42,17 @@ public class SearchedVersionMapper implements RowMapper<SearchedVersionDto> {
         dto.setDescription(rs.getString("description"));
         dto.setArtifactType(rs.getString("type"));
         dto.setLabels(RegistryContentUtils.deserializeLabels(rs.getString("labels")));
+        dto.setReferences(readReferences(rs));
         return dto;
+    }
+
+    private static List<ArtifactReferenceDto> readReferences(ResultSet rs) throws SQLException {
+        try {
+            return RegistryContentUtils.deserializeReferences(rs.getString("refs"));
+        } catch (SQLException e) {
+            // Query did not select content.refs (e.g. count-only paths should not hit this mapper).
+            return Collections.emptyList();
+        }
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlBranchRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlBranchRepository.java
@@ -330,7 +330,8 @@ public class SqlBranchRepository {
 
             selectTemplate.append("SELECT {{selectColumns}} FROM branch_versions bv "
                     + "JOIN versions v ON bv.groupId = v.groupId AND bv.artifactId = v.artifactId AND bv.version = v.version "
-                    + "JOIN artifacts a ON a.groupId = v.groupId AND a.artifactId = v.artifactId ");
+                    + "JOIN artifacts a ON a.groupId = v.groupId AND a.artifactId = v.artifactId "
+                    + "JOIN content c ON v.contentId = c.contentId ");
 
             where.append(" WHERE bv.groupId = ? AND bv.artifactId = ? AND bv.branchId = ?");
             binders.add((query, idx) -> query.bind(idx, ga.getRawGroupId()));
@@ -346,7 +347,7 @@ public class SqlBranchRepository {
             }
 
             String versionsQuerySql = new StringBuilder(selectTemplate).append(where).append(orderByQuery)
-                    .append(limitOffset).toString().replace("{{selectColumns}}", "v.*, a.type");
+                    .append(limitOffset).toString().replace("{{selectColumns}}", "v.*, a.type, c.refs");
             Query versionsQuery = handle.createQuery(versionsQuerySql);
 
             String countQuerySql = new StringBuilder(selectTemplate).append(where).toString()

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
@@ -299,7 +299,9 @@ public class SqlSearchRepository {
 
             // Formulate the SELECT clause for the query
             selectTemplate.append(
-                    "SELECT {{selectColumns}} FROM versions v JOIN artifacts a ON v.groupId = a.groupId AND v.artifactId = a.artifactId");
+                    "SELECT {{selectColumns}} FROM versions v "
+                            + "JOIN artifacts a ON v.groupId = a.groupId AND v.artifactId = a.artifactId "
+                            + "JOIN content c ON v.contentId = c.contentId");
 
             // Formulate the WHERE clause for both queries
             where.append(" WHERE (1 = 1)");
@@ -414,7 +416,7 @@ public class SqlSearchRepository {
 
             // Query for the versions
             String versionsQuerySql = new StringBuilder(selectTemplate).append(where).append(orderByQuery)
-                    .append(limitOffset).toString().replace("{{selectColumns}}", "v.*, a.type");
+                    .append(limitOffset).toString().replace("{{selectColumns}}", "v.*, a.type, c.refs");
             Query versionsQuery = handle.createQuery(versionsQuerySql);
             // Query for the total row count
             Query countQuery = null;

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/LegacyV2ApiTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/LegacyV2ApiTest.java
@@ -230,4 +230,36 @@ public class LegacyV2ApiTest extends AbstractResourceTestBase {
                         equalTo("Second version"));
     }
 
+    @Test
+    public void testVersionListIncludesReferences() throws Exception {
+        // Regression for #5224 — v2 version list must return references (OpenAPI requires the field).
+        String referencedContent = getRandomValidJsonSchemaContent();
+        var referenced = createArtifactExtendedRaw(GROUP, "testVersionListIncludesReferences-ref",
+                ArtifactType.JSON, referencedContent, ContentTypes.APPLICATION_JSON, List.of()).getVersion();
+
+        String referencingContent = getRandomValidJsonSchemaContent();
+        List<io.apicurio.registry.rest.v3.beans.ArtifactReference> references = List.of(
+                io.apicurio.registry.rest.v3.beans.ArtifactReference.builder()
+                        .groupId(referenced.getGroupId())
+                        .artifactId(referenced.getArtifactId())
+                        .version(referenced.getVersion())
+                        .name("foo")
+                        .build());
+
+        var referencing = createArtifactExtendedRaw(GROUP, "testVersionListIncludesReferences",
+                ArtifactType.JSON, referencingContent, ContentTypes.APPLICATION_JSON, references)
+                .getVersion();
+
+        given().when()
+                .pathParam("groupId", GROUP)
+                .pathParam("artifactId", referencing.getArtifactId())
+                .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("versions[0].references.size()", equalTo(1))
+                .body("versions[0].references[0].name", equalTo("foo"))
+                .body("versions[0].references[0].artifactId", equalTo(referenced.getArtifactId()));
+    }
+
 }

--- a/app/src/test/java/io/apicurio/registry/rest/v2/impl/V2ApiUtilVersionReferencesTest.java
+++ b/app/src/test/java/io/apicurio/registry/rest/v2/impl/V2ApiUtilVersionReferencesTest.java
@@ -1,0 +1,76 @@
+package io.apicurio.registry.rest.v2.impl;
+
+import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
+import io.apicurio.registry.storage.dto.SearchedVersionDto;
+import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
+import io.apicurio.registry.types.VersionState;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Regression for #5224 — version list/search responses must include artifact references.
+ */
+class V2ApiUtilVersionReferencesTest {
+
+    @Test
+    void dtoToSearchResultsIncludesReferences() {
+        ArtifactReferenceDto ref = ArtifactReferenceDto.builder()
+                .groupId("default")
+                .artifactId("Address")
+                .version("1")
+                .name("com.example.Address")
+                .build();
+
+        SearchedVersionDto version = SearchedVersionDto.builder()
+                .groupId("default")
+                .artifactId("Order")
+                .version("3")
+                .name("Order")
+                .owner("tester")
+                .createdOn(new Date())
+                .globalId(48L)
+                .contentId(37L)
+                .artifactType("AVRO")
+                .state(VersionState.ENABLED)
+                .references(List.of(ref))
+                .build();
+
+        VersionSearchResultsDto dto = new VersionSearchResultsDto();
+        dto.setCount(1);
+        dto.setVersions(List.of(version));
+
+        var results = V2ApiUtil.dtoToSearchResults(dto);
+        assertEquals(1, results.getVersions().size());
+        assertNotNull(results.getVersions().get(0).getReferences());
+        assertEquals(1, results.getVersions().get(0).getReferences().size());
+        assertEquals("Address", results.getVersions().get(0).getReferences().get(0).getArtifactId());
+        assertEquals("com.example.Address", results.getVersions().get(0).getReferences().get(0).getName());
+    }
+
+    @Test
+    void dtoToSearchResultsUsesEmptyListWhenReferencesNull() {
+        SearchedVersionDto version = SearchedVersionDto.builder()
+                .artifactId("Order")
+                .version("1")
+                .owner("tester")
+                .createdOn(new Date())
+                .globalId(1L)
+                .contentId(1L)
+                .artifactType("AVRO")
+                .state(VersionState.ENABLED)
+                .build();
+
+        VersionSearchResultsDto dto = new VersionSearchResultsDto();
+        dto.setCount(1);
+        dto.setVersions(List.of(version));
+
+        var results = V2ApiUtil.dtoToSearchResults(dto);
+        assertNotNull(results.getVersions().get(0).getReferences());
+        assertEquals(0, results.getVersions().get(0).getReferences().size());
+    }
+}


### PR DESCRIPTION
## Summary
- fixes #5224
- v2 version list/search always returned `references: []` even when content had refs (UI used the dedicated `/references` endpoint, so it looked fine there)
- SQL version search now joins `content` and maps `refs` into `SearchedVersionDto`
- `V2ApiUtil` maps those refs into the REST response

## Test plan
- [x] `V2ApiUtilVersionReferencesTest`
- [x] `LegacyV2ApiTest#testVersionListIncludesReferences` (rest-assured)