### PR TITLE
fix(operator): use non-blocking read in PodLogManager to prevent stopAndWait() timeout

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/PodLogManager.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/PodLogManager.java
@@ -48,17 +48,21 @@ public class PodLogManager {
                 activePodLogMap.put(podID, stop);
                 var lastWriteAt = Instant.now();
                 while (!stop.get()) {
-                    var line = reader.readLine();
-                    if (line != null) {
-                        chunk.append(getNamespace(podID)).append("/").append(podID.getName()).append(" >>> ")
-                                .append(line).append("\n");
+                    if (reader.ready()) {
+                        var line = reader.readLine();
+                        if (line == null) {
+                            break;
+                        }
+                        chunk.append(getNamespace(podID)).append("/").append(podID.getName())
+                                .append(" >>> ").append(line).append("\n");
                         if (lastWriteAt.plus(Duration.ofSeconds(5)).isBefore(Instant.now())) {
-                            log.debug("LOG of pod {}/{}:\n{}", getNamespace(podID), podID.getName(), chunk);
+                            log.debug("LOG of pod {}/{}:\n{}", getNamespace(podID), podID.getName(),
+                                    chunk);
                             chunk.setLength(0);
                             lastWriteAt = Instant.now();
                         }
                     } else {
-                        stop.set(true);
+                        Thread.sleep(100);
                     }
                 }
             } catch (Exception ex) {


### PR DESCRIPTION
## Summary

- Backport of #8595 to `3.2.x`
- Replace blocking `readLine()` with a `reader.ready()` check and 100ms sleep poll in `PodLogManager`,
  so the `stop` flag is checked periodically even when no log output is being produced.
- The previous fix (#8509/#8515) added `LogWatch.close()` but that doesn't unblock a `readLine()` that
  is mid-read on the input side of fabric8's internal `PipedInputStream`/`PipedOutputStream` pair.
- With non-blocking polling, `stopAndWait()` can signal termination within ~100ms regardless of pod
  log activity.

## Related Issue

Fixes #8508

## Test Plan

- [ ] Run operator integration tests (`SmokeITTest`, `MultiNamespaceSmokeITTest`) on an OCP cluster
  and verify that `@AfterAll` teardown completes without `ConditionTimeoutException`
- [ ] Verify that pod logs are still captured correctly during test execution (look for `START LOG`
  and `END LOG` entries with log content between them)
- [ ] Verify no `ConditionTimeoutException` in `PodLogManager` appears in test output