### PR TITLE
fix(storage): implement semantic version sorting for artifact versions

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -1014,13 +1014,23 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
         return versionRepository.getArtifactVersions(groupId, artifactId, filterBy);
     }
 
-    @Override
-    public VersionSearchResultsDto searchVersions(Set<SearchFilter> filters, OrderBy orderBy,
-            OrderDirection orderDirection, int offset, int limit, boolean skipCount)
-            throws RegistryStorageException {
+@Override
+public VersionSearchResultsDto searchVersions(Set<SearchFilter> filters, OrderBy orderBy,
+        OrderDirection orderDirection, int offset, int limit, boolean skipCount)
+        throws RegistryStorageException {
 
-        return searchRepository.searchVersions(filters, orderBy, orderDirection, offset, limit, skipCount);
+    VersionSearchResultsDto results = searchRepository.searchVersions(filters, orderBy, orderDirection, offset, limit, skipCount);
+
+    if (orderBy == OrderBy.version) {
+        results.getVersions().sort((v1, v2) -> compareVersions(v1.getVersion(), v2.getVersion()));
+
+        if (orderDirection == OrderDirection.desc) {
+            java.util.Collections.reverse(results.getVersions());
+        }
     }
+
+    return results;
+}
 
     @Override
     public StoredArtifactVersionDto getArtifactVersionContent(long globalId)
@@ -1780,4 +1790,16 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     private boolean isH2() {
         return sqlStatements.dbType().equals("h2");
     }
+
+    protected int compareVersions(String v1, String v2) {
+    String[] parts1 = v1.split("\\.");
+    String[] parts2 = v2.split("\\.");
+    int length = Math.max(parts1.length, parts2.length);
+    for (int i = 0; i < length; i++) {
+        int p1 = i < parts1.length ? Integer.parseInt(parts1[i]) : 0;
+        int p2 = i < parts2.length ? Integer.parseInt(parts2[i]) : 0;
+        if (p1 != p2) return Integer.compare(p1, p2);
+    }
+    return 0;
+}
 }


### PR DESCRIPTION
Fixes #7871

**What changed:**
- Added a `compareVersions` helper method in `AbstractSqlRegistryStorage.java` to parse and numerically sort semantic version strings.
- Applied the custom SemVer sort when `OrderBy.version` is requested.
- Verified local sorting behavior for ascending and descending requests.

**Signed-off-by:** Raghav Gupta raghav.gupta000001@gmail.com