### PR TITLE
fix(kafkasql): retry topic config verification on UnknownTopicOrPartitionException

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
@@ -16,6 +16,7 @@ import org.apache.kafka.clients.admin.DescribeConfigsOptions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -133,27 +134,52 @@ public class KafkaAdminUtil {
         var key = new ConfigResource(ConfigResource.Type.TOPIC, topic);
         // includeSynonyms should ensure we get effective values (including default configs).
         var options = new DescribeConfigsOptions().includeSynonyms(true);
-        blockOn(toJavaFuture(adminClient.get().get().describeConfigs(singleton(key), options).all())
-                .thenAccept(d -> {
-                    var config = d.get(key);
-                    assertConfiguration(topic, config, TopicConfig.CLEANUP_POLICY_CONFIG, "delete"::equals, """
-                            Topic must not have '%s=%s'. While Apicurio Registry will work with topic compaction, it will not have any effect. \
-                            Use '%s=delete', '%s=-1', and '%s=-1' to disable automatic deletion of messages, and perform any cleanup manually after a backup has been made\
-                            """.formatted(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT,
-                            TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
 
-                    if (!topic.equals(configuration.get().getEventsTopic())) { // Events topic is allowed to use retention. If configured, old events should be eventually deleted.
-                        if (!configuration.get().isTopicConfigurationVerificationOverrideEnabled()) {
-                            assertConfiguration(topic, config, TopicConfig.RETENTION_MS_CONFIG, "-1"::equals,
-                                    "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
-                                            .formatted(TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
-                        }
-
-                        assertConfiguration(topic, config, TopicConfig.RETENTION_BYTES_CONFIG, "-1"::equals,
-                                "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
-                                        .formatted(TopicConfig.RETENTION_BYTES_CONFIG, TopicConfig.RETENTION_MS_CONFIG));
+        int maxRetries = 3;
+        long backoffMs = 100;
+        for (int attempt = 0; attempt <= maxRetries; attempt++) {
+            try {
+                blockOn(toJavaFuture(adminClient.get().get().describeConfigs(singleton(key), options).all())
+                        .thenAccept(configs -> assertTopicConfiguration(topic, key, configs)));
+                break;
+            } catch (UnknownTopicOrPartitionException e) {
+                if (attempt < maxRetries) {
+                    log.warn(
+                            "Topic '{}' configuration is not yet visible to Kafka metadata ({}). Retrying configuration verification in {} ms (attempt {}/{}).",
+                            topic, e.getMessage(), backoffMs, attempt + 1, maxRetries);
+                    try {
+                        Thread.sleep(backoffMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(ie);
                     }
-                }));
+                    backoffMs *= 2;
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    private void assertTopicConfiguration(String topic, ConfigResource key, Map<ConfigResource, Config> configs) {
+        var config = configs.get(key);
+        assertConfiguration(topic, config, TopicConfig.CLEANUP_POLICY_CONFIG, "delete"::equals, """
+                Topic must not have '%s=%s'. While Apicurio Registry will work with topic compaction, it will not have any effect. \
+                Use '%s=delete', '%s=-1', and '%s=-1' to disable automatic deletion of messages, and perform any cleanup manually after a backup has been made\
+                """.formatted(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT,
+                TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
+
+        if (!topic.equals(configuration.get().getEventsTopic())) {
+            if (!configuration.get().isTopicConfigurationVerificationOverrideEnabled()) {
+                assertConfiguration(topic, config, TopicConfig.RETENTION_MS_CONFIG, "-1"::equals,
+                        "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
+                                .formatted(TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
+            }
+
+            assertConfiguration(topic, config, TopicConfig.RETENTION_BYTES_CONFIG, "-1"::equals,
+                    "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
+                            .formatted(TopicConfig.RETENTION_BYTES_CONFIG, TopicConfig.RETENTION_MS_CONFIG));
+        }
     }
 
     private static void assertConfiguration(String topic, Config config, String property, Predicate<String> condition, String errorMessage) {

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
@@ -1,12 +1,21 @@
 package io.apicurio.registry.storage.impl.kafkasql;
 
+import io.apicurio.registry.storage.impl.kafkasql.KafkaSqlFactory.KafkaAdminClient;
 import io.apicurio.registry.storage.impl.kafkasql.KafkaSqlFactory.KafkaSqlVerificationJournalConsumer;
 import io.apicurio.registry.storage.impl.util.KafkaAdminUtil;
 import jakarta.enterprise.inject.Instance;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +44,9 @@ public class KafkaAdminUtilTest {
 
     private KafkaAdminUtil kafkaAdminUtil;
     private KafkaConsumer<Bytes, Bytes> consumer;
+    private KafkaSqlConfiguration config;
+    @SuppressWarnings("unchecked")
+    private Instance<KafkaSqlConfiguration> configInstance;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
@@ -47,11 +59,11 @@ public class KafkaAdminUtilTest {
         Instance<KafkaSqlVerificationJournalConsumer> verificationInstance = mock(Instance.class);
         when(verificationInstance.get()).thenReturn(verificationResource);
 
-        KafkaSqlConfiguration config = mock(KafkaSqlConfiguration.class);
+        config = mock(KafkaSqlConfiguration.class);
         when(config.getPollTimeout()).thenReturn(Duration.ofMillis(100));
         when(config.getTopic()).thenReturn(TEST_TOPIC);
 
-        Instance<KafkaSqlConfiguration> configInstance = mock(Instance.class);
+        configInstance = mock(Instance.class);
         when(configInstance.get()).thenReturn(config);
 
         kafkaAdminUtil = new KafkaAdminUtil();
@@ -150,6 +162,42 @@ public class KafkaAdminUtilTest {
 
         // 2 polls: assignment + one empty poll in the loop
         verify(consumer, times(2)).poll(any(Duration.class));
+    }
+
+    /**
+     * Verifies that topic configuration verification retries on UnknownTopicOrPartitionException,
+     * which can occur when Kafka topic metadata has not yet propagated to all brokers after topic creation.
+     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void testVerifyTopicConfigurationRetriesOnUnknownTopicOrPartition() throws Exception {
+        Admin admin = mock(Admin.class);
+        KafkaAdminClient adminClientResource = new KafkaAdminClient(() -> admin);
+        Instance<KafkaAdminClient> adminClientInstance = mock(Instance.class);
+        when(adminClientInstance.get()).thenReturn(adminClientResource);
+        setField("adminClient", adminClientInstance);
+
+        when(config.getEventsTopic()).thenReturn("events-topic");
+
+        ConfigResource key = new ConfigResource(ConfigResource.Type.TOPIC, TEST_TOPIC);
+        List<ConfigEntry> entries = List.of(
+                new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, "delete"),
+                new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, "-1"),
+                new ConfigEntry(TopicConfig.RETENTION_BYTES_CONFIG, "-1"));
+        Config topicConfig = new Config(entries);
+        Map<ConfigResource, Config> configs = Map.of(key, topicConfig);
+
+        DescribeConfigsResult failResult = mock(DescribeConfigsResult.class);
+        when(failResult.all()).thenThrow(new UnknownTopicOrPartitionException("test"));
+
+        DescribeConfigsResult successResult = mock(DescribeConfigsResult.class);
+        when(successResult.all()).thenReturn(KafkaFuture.completedFuture(configs));
+
+        when(admin.describeConfigs(any(), any())).thenReturn(failResult).thenReturn(successResult);
+
+        kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC);
+
+        verify(admin, times(2)).describeConfigs(any(), any());
     }
 
     private ConsumerRecords<Bytes, Bytes> createRecords(long startOffset, int count) {


### PR DESCRIPTION
## Description

- `describeConfigs()` in `verifyTopicConfiguration()` fails intermittently in CI with UnknownTopicOrPartitionException because Kafka's createTopics() is async, topic metadata may not be propagated to brokers yet when the verify call fires. On resource-constrained CI runners this race window widens.

- Added exponential backoff retry (3 retries, 100ms → 400ms) to KafkaAdminUtil.verifyTopicConfiguration() to tolerate transient metadata unavailability.

### Issue
fixes #8583 

### Proof Manifests

- All the affected now pass succesfully.
<img width="1065" height="353" alt="Screenshot 2026-07-14 at 02 20 10" src="https://github.com/user-attachments/assets/7022349a-0dc6-4230-ab81-8bae93c87619" />
<img width="1066" height="351" alt="Screenshot 2026-07-14 at 02 20 50" src="https://github.com/user-attachments/assets/fc4f349d-7f2d-4fd1-a545-f8ca6eaca75b" />
