### PR TITLE
ci: upload all reactor module target/ dirs to eliminate shard recompilation

### DIFF
--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -80,18 +80,17 @@ jobs:
           name: build-artifacts-${{ github.sha }}
           path: |
             app/target/
+            cli/target/
             common/target/
             contracts-rules/target/
             schema-resolver/target/
             config-index/*/target/
+            distro/*/target/
+            java-sdk/*/target/
             schema-util/*/target/
             schema-validation/*/target/
-            java-sdk/*/target/
-            utils/*/target/
             serdes/*/*/target/
-            distro/docker/target/
-            distro/connect-converter/target/
-            cli/target/
+            utils/*/target/
             mcp/target/docker/
           retention-days: 1
 

--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -74,22 +74,25 @@ jobs:
           output-path: '/tmp/apicurio-registry-${{ github.sha }}.tar'
           artifact-name: 'apicurio-registry-${{ github.sha }}.tar'
 
-      - name: Upload Build Artifacts for Publish
+      - name: Upload Build Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-artifacts-${{ github.sha }}
           path: |
             app/target/
-            distro/docker/target/
-            mcp/target/docker/
-            java-sdk/common/target/
-            java-sdk/adapter-vertx/target/
-            java-sdk/adapter-jdk/target/
-            java-sdk/client/target/
-            java-sdk/client-v2/target/
-            config-index/definitions/target/
             common/target/
-            schema-util/common/target/
+            contracts-rules/target/
+            schema-resolver/target/
+            config-index/*/target/
+            schema-util/*/target/
+            schema-validation/*/target/
+            java-sdk/*/target/
+            utils/*/target/
+            serdes/*/*/target/
+            distro/docker/target/
+            distro/connect-converter/target/
+            cli/target/
+            mcp/target/docker/
           retention-days: 1
 
   build-ui:


### PR DESCRIPTION
## Summary

Expands the Build job artifact upload from 11 explicit `target/` directories to 14 glob-based patterns covering all reactor modules. This eliminates redundant upstream recompilation in unit-test shards.

## Problem

Each of the 7 unit-test shards runs `mvn verify -pl app -am -Dfull`, triggering Maven's "also make" reactor walk. The Build job uploaded only 11 `target/` directories, but `-am` needs ~35+. Missing modules were recompiled from scratch — 7 times, once per shard. Estimated waste: 2-3 minutes per shard, ~15-20 minutes total per CI run.

## Changes

| File | Change |
|------|--------|
| `verify-build.yaml` | Expand artifact upload paths from 11 explicit dirs to 14 glob patterns |

**New patterns**: `config-index/*/target/`, `schema-util/*/target/`, `schema-validation/*/target/`, `java-sdk/*/target/`, `utils/*/target/`, `serdes/*/*/target/`, plus explicit `contracts-rules/`, `schema-resolver/`, `cli/`, `distro/connect-converter/`.

**Excluded intentionally**: `docs/*/target/` (no JARs), `go-sdk/` (Make wrapper), `operator/*/target/` (separate workflow).

Glob patterns are self-maintaining — new modules matching the pattern are automatically included.

## Risk

- Artifact size increases ~25% (+50-100 MB), offset by 2-3 min saved per shard
- If a glob fails to match, `upload-artifact` silently skips — never fails
- No Maven command changes in any consumer workflow

## Test plan

- [ ] Build job uploads successfully with expanded paths
- [ ] Unit test shard logs show `Nothing to compile - all classes are up to date` for upstream modules
- [ ] Per-shard timing drops by 2-3 minutes vs current baseline
- [ ] All existing consumers (unit tests, CLI, extras, publish) work unchanged