### PR TITLE
fix(version): improve file extension detection based on content type

### DIFF
--- a/ui/ui-app/src/app/pages/version/VersionPage.tsx
+++ b/ui/ui-app/src/app/pages/version/VersionPage.tsx
@@ -25,7 +25,7 @@ import {
     MetaData,
     RootPageHeader
 } from "@app/components";
-import { ContentTypes } from "@models/ContentTypes.ts";
+import { detectContentType, fileExtensionForContentType } from "@utils/content.utils.ts";
 import { PleaseWaitModal } from "@apicurio/common-ui-components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { LoggerService, useLoggerService } from "@services/useLoggerService.ts";
@@ -176,31 +176,15 @@ export const VersionPage: FunctionComponent<PageProperties> = () => {
     const doDownloadVersion = (): void => {
         const content: string = versionContent;
 
-        let contentType: string = ContentTypes.APPLICATION_JSON;
-        let fext: string = "json";
-        if (artifact?.artifactType === ArtifactTypes.PROTOBUF) {
-            contentType = ContentTypes.APPLICATION_PROTOBUF;
-            fext = "proto";
-        }
+        const contentType: string = detectContentType(artifact?.artifactType, content);
+
+        let fext: string;
         if (artifact?.artifactType === ArtifactTypes.WSDL) {
-            contentType = ContentTypes.APPLICATION_XML;
             fext = "wsdl";
-        }
-        if (artifact?.artifactType === ArtifactTypes.XSD) {
-            contentType = ContentTypes.APPLICATION_XML;
+        } else if (artifact?.artifactType === ArtifactTypes.XSD) {
             fext = "xsd";
-        }
-        if (artifact?.artifactType === ArtifactTypes.XML) {
-            contentType = ContentTypes.APPLICATION_XML;
-            fext = "xml";
-        }
-        if (artifact?.artifactType === ArtifactTypes.GRAPHQL) {
-            contentType = ContentTypes.APPLICATION_JSON;
-            fext = "graphql";
-        }
-        if (artifact?.artifactType === ArtifactTypes.THRIFT) {
-            contentType = ContentTypes.APPLICATION_THRIFT;
-            fext = "thrift";
+        } else {
+            fext = fileExtensionForContentType(contentType);
         }
 
         const fname: string = nameOrId() + "." + fext;

--- a/ui/ui-app/src/utils/content.utils.ts
+++ b/ui/ui-app/src/utils/content.utils.ts
@@ -163,25 +163,46 @@ export const draftContentToLanguage = (content: DraftContent): string => {
     return "json";
 };
 
+/**
+ * Maps a content type string to the appropriate file extension.
+ * @param contentType the content type (e.g. "application/json", "application/x-yaml")
+ * @returns the file extension without the leading dot (e.g. "json", "yaml")
+ */
+export function fileExtensionForContentType(contentType: string): string {
+    if (contentType === ContentTypes.APPLICATION_JSON) {
+        return "json";
+    }
+    if (contentType === ContentTypes.APPLICATION_YAML) {
+        return "yaml";
+    }
+    if (contentType === ContentTypes.APPLICATION_XML || contentType === ContentTypes.TEXT_XML) {
+        return "xml";
+    }
+    if (contentType === ContentTypes.APPLICATION_WSDL) {
+        return "wsdl";
+    }
+    if (contentType === ContentTypes.APPLICATION_PROTOBUF) {
+        return "proto";
+    }
+    if (contentType === ContentTypes.APPLICATION_GRAPHQL) {
+        return "graphql";
+    }
+    if (contentType === ContentTypes.APPLICATION_THRIFT) {
+        return "thrift";
+    }
+    return "txt";
+}
+
 export function fileExtensionForDraft(draft: Draft, content: DraftContent): string {
     if (draft.type === ArtifactTypes.PROTOBUF) {
         return "proto";
     }
 
-    if (content.contentType && content.contentType === ContentTypes.APPLICATION_JSON) {
-        return "json";
-    }
-    if (content.contentType && content.contentType === ContentTypes.APPLICATION_YAML) {
-        return "yaml";
-    }
-    if (content.contentType && content.contentType === ContentTypes.APPLICATION_XML) {
-        return "xml";
-    }
-    if (content.contentType && content.contentType === ContentTypes.APPLICATION_WSDL) {
-        return "wsdl";
-    }
-    if (content.contentType && content.contentType === ContentTypes.APPLICATION_GRAPHQL) {
-        return "graphql";
+    if (content.contentType) {
+        const ext: string = fileExtensionForContentType(content.contentType);
+        if (ext !== "txt") {
+            return ext;
+        }
     }
 
     return "txt";


### PR DESCRIPTION
## Description

The artifact content download on the version page always used .json as the file extension, even when the content was YAML or a different format. This happened because the extension was derived solely from the artifact type, which defaults to json for types like OpenAPI, AsyncAPI, JSON Schema, and Avro, all of which can be stored in either JSON or YAML format.

This fix uses the existing detectContentType utility to inspect the actual content string and determine the correct file extension at download time.
## Changes:
- Added fileExtensionForContentType() helper in content.utils.ts so maps content type strings to file extensions (e.g., application/x-yaml → yaml, application/json → json, application/xml → xml, etc.)
- Refactored fileExtensionForDraft() to reuse the new helper
- Updated doDownloadVersion() in VersionPage.tsx to detect content type from the content string and apply the correct extension, while preserving special-case extensions for WSDL (.wsdl) and XSD (.xsd)

### Issue
fixes #8172 