### PR TITLE
feat(cli): print raw HTTP request and response details when --verbose is enabled

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -451,7 +451,7 @@ All filters are optional and can be combined. Additional filters include `--desc
 
 These options work with most commands:
 
-- `--verbose, -v` - Enable verbose output for debugging
+- `--verbose, -v` - Enable verbose output for debugging (includes raw HTTP request/response details for registry calls; sensitive headers are redacted)
 - `--help, -h` - Show help information
 - `--output-type, -o` - Set output format (table or json)
 

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -107,6 +107,8 @@ public abstract class AbstractCommand implements Callable<Integer> {
             for (var handler : rootLogger.getHandlers()) {
                 handler.setLevel(java.util.logging.Level.FINE);
             }
+            // Enable raw HTTP request/response logging on the Registry client.
+            client.setVerbose(true);
             log.debug("Verbose logging enabled.");
         }
     }

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
@@ -33,6 +33,12 @@ public class Client {
 
     private HttpClient httpClient;
 
+    private boolean verbose;
+
+    public void setVerbose(boolean verbose) {
+        this.verbose = verbose;
+    }
+
     public RegistryClient getRegistryClient() {
         var currentContext = config.read();
         if (isBlank(currentContext.getCurrentContext())) {
@@ -47,6 +53,9 @@ public class Client {
                         uri = uri.resolve("/apis/registry/v3");
                     }
                     final var options = RegistryClientOptions.create(uri.toString(), vertx);
+                    if (verbose) {
+                        options.enableHttpLogging();
+                    }
                     final var context = currentContext.getContext().get(currentContext.getCurrentContext());
                     configureAuth(options, context, currentContext.getCurrentContext());
                     registryClient = RegistryClientFactory.create(options);
@@ -104,5 +113,6 @@ public class Client {
     public void reset() {
         registryClient = null;
         httpClient = null;
+        verbose = false;
     }
 }

--- a/cli/src/test/java/io/apicurio/registry/cli/VerboseLoggingCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/VerboseLoggingCommandTest.java
@@ -1,0 +1,93 @@
+package io.apicurio.registry.cli;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code --verbose} logs raw HTTP request and response details.
+ */
+@QuarkusTest
+public class VerboseLoggingCommandTest extends AbstractCLITest {
+
+    private static final String HTTP_LOGGER = "io.apicurio.registry.client.http";
+
+    @Test
+    public void testVerboseLogsRequestAndResponse() {
+        var httpLogger = Logger.getLogger(HTTP_LOGGER);
+        var previousLevel = httpLogger.getLevel();
+        var records = new CopyOnWriteArrayList<String>();
+        var handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record.getMessage());
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        handler.setLevel(Level.ALL);
+        httpLogger.setLevel(Level.FINE);
+        httpLogger.addHandler(handler);
+        try {
+            executeAndAssertSuccess("group", "--verbose", "--output-type", "json");
+        } finally {
+            httpLogger.removeHandler(handler);
+            httpLogger.setLevel(previousLevel);
+        }
+
+        assertThat(records)
+                .as("Verbose mode should log the outgoing request line")
+                .anySatisfy(msg -> assertThat(msg).contains("--> GET").contains("/apis/registry/v3"));
+        assertThat(records)
+                .as("Verbose mode should log the response status line")
+                .anySatisfy(msg -> assertThat(msg).contains("<-- 200"));
+    }
+
+    @Test
+    public void testWithoutVerboseNoHttpLogs() {
+        var httpLogger = Logger.getLogger(HTTP_LOGGER);
+        var previousLevel = httpLogger.getLevel();
+        List<String> records = new CopyOnWriteArrayList<>();
+        var handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record.getMessage());
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        handler.setLevel(Level.ALL);
+        httpLogger.setLevel(Level.FINE);
+        httpLogger.addHandler(handler);
+        try {
+            executeAndAssertSuccess("group", "--output-type", "json");
+        } finally {
+            httpLogger.removeHandler(handler);
+            httpLogger.setLevel(previousLevel);
+        }
+
+        assertThat(records)
+                .as("Without --verbose no HTTP wire logging should be produced")
+                .isEmpty();
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/VerboseLoggingCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/VerboseLoggingCommandTest.java
@@ -22,32 +22,7 @@ public class VerboseLoggingCommandTest extends AbstractCLITest {
 
     @Test
     public void testVerboseLogsRequestAndResponse() {
-        var httpLogger = Logger.getLogger(HTTP_LOGGER);
-        var previousLevel = httpLogger.getLevel();
-        var records = new CopyOnWriteArrayList<String>();
-        var handler = new Handler() {
-            @Override
-            public void publish(LogRecord record) {
-                records.add(record.getMessage());
-            }
-
-            @Override
-            public void flush() {
-            }
-
-            @Override
-            public void close() {
-            }
-        };
-        handler.setLevel(Level.ALL);
-        httpLogger.setLevel(Level.FINE);
-        httpLogger.addHandler(handler);
-        try {
-            executeAndAssertSuccess("group", "--verbose", "--output-type", "json");
-        } finally {
-            httpLogger.removeHandler(handler);
-            httpLogger.setLevel(previousLevel);
-        }
+        var records = captureHttpLogs("group", "--verbose", "--output-type", "json");
 
         assertThat(records)
                 .as("Verbose mode should log the outgoing request line")
@@ -59,35 +34,52 @@ public class VerboseLoggingCommandTest extends AbstractCLITest {
 
     @Test
     public void testWithoutVerboseNoHttpLogs() {
-        var httpLogger = Logger.getLogger(HTTP_LOGGER);
-        var previousLevel = httpLogger.getLevel();
-        List<String> records = new CopyOnWriteArrayList<>();
-        var handler = new Handler() {
-            @Override
-            public void publish(LogRecord record) {
-                records.add(record.getMessage());
-            }
-
-            @Override
-            public void flush() {
-            }
-
-            @Override
-            public void close() {
-            }
-        };
-        handler.setLevel(Level.ALL);
-        httpLogger.setLevel(Level.FINE);
-        httpLogger.addHandler(handler);
-        try {
-            executeAndAssertSuccess("group", "--output-type", "json");
-        } finally {
-            httpLogger.removeHandler(handler);
-            httpLogger.setLevel(previousLevel);
-        }
+        var records = captureHttpLogs("group", "--output-type", "json");
 
         assertThat(records)
                 .as("Without --verbose no HTTP wire logging should be produced")
                 .isEmpty();
+    }
+
+    /**
+     * Runs the given command while capturing everything logged to the HTTP wire logger at FINE.
+     */
+    private List<String> captureHttpLogs(String... command) {
+        var httpLogger = Logger.getLogger(HTTP_LOGGER);
+        var previousLevel = httpLogger.getLevel();
+        var handler = new CapturingHandler();
+        handler.setLevel(Level.ALL);
+        httpLogger.setLevel(Level.FINE);
+        httpLogger.addHandler(handler);
+        try {
+            executeAndAssertSuccess(command);
+        } finally {
+            httpLogger.removeHandler(handler);
+            httpLogger.setLevel(previousLevel);
+        }
+        return handler.messages;
+    }
+
+    /**
+     * A log handler that collects logged messages in memory for later assertions.
+     */
+    private static final class CapturingHandler extends Handler {
+
+        private final List<String> messages = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void publish(LogRecord logRecord) {
+            messages.add(logRecord.getMessage());
+        }
+
+        @Override
+        public void flush() {
+            // No-op: messages are kept in memory, there is nothing to flush.
+        }
+
+        @Override
+        public void close() {
+            // No-op: messages are kept in memory, there is nothing to close.
+        }
     }
 }

--- a/docs/modules/ROOT/pages/getting-started/assembly-managing-registry-artifacts-cli.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-managing-registry-artifacts-cli.adoc
@@ -305,7 +305,7 @@ The following options are available for most CLI commands:
 | Description
 
 | `--verbose`, `-v`
-| Enable verbose output for debugging.
+| Enable verbose output for debugging. This includes the raw HTTP request and response details (method, URL, headers, and body) for each call to the registry. Sensitive headers such as `Authorization` are redacted.
 
 | `--help`, `-h`
 | Display help information for the command.

--- a/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/HttpLoggingInterceptor.java
+++ b/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/HttpLoggingInterceptor.java
@@ -9,16 +9,15 @@ import io.vertx.ext.web.client.impl.HttpContext;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
  * A Vert.x {@link io.vertx.ext.web.client.WebClient} interceptor that logs raw HTTP request and
  * response details (method, URL, headers, and body) for outgoing Registry calls.
  *
- * <p>Details are logged to the {@code io.apicurio.registry.client.http} logger at {@link Level#FINE},
- * so nothing is emitted unless that logger is configured to log {@code FINE} messages. Sensitive
- * headers such as {@code Authorization} are redacted.</p>
+ * <p>Details are logged to the {@code io.apicurio.registry.client.http} logger at {@code FINE}
+ * level, so nothing is emitted unless that logger is configured to log {@code FINE} messages.
+ * Sensitive headers such as {@code Authorization} are redacted.</p>
  */
 class HttpLoggingInterceptor implements Handler<HttpContext<?>> {
 
@@ -33,12 +32,11 @@ class HttpLoggingInterceptor implements Handler<HttpContext<?>> {
 
     @Override
     public void handle(HttpContext<?> context) {
-        if (log.isLoggable(Level.FINE)) {
-            switch (context.phase()) {
-                case SEND_REQUEST -> logRequest(context);
-                case DISPATCH_RESPONSE -> logResponse(context);
-                default -> {
-                }
+        switch (context.phase()) {
+            case SEND_REQUEST -> logRequest(context);
+            case DISPATCH_RESPONSE -> logResponse(context);
+            default -> {
+                // Only the request-send and response-dispatch phases are logged.
             }
         }
         context.next();
@@ -49,11 +47,15 @@ class HttpLoggingInterceptor implements Handler<HttpContext<?>> {
         if (request == null) {
             return;
         }
-        var sb = new StringBuilder("--> ")
-                .append(request.getMethod()).append(' ').append(request.absoluteURI()).append('\n');
-        appendHeaders(sb, request.headers());
-        appendBody(sb, context.body());
-        log.fine(sb.toString());
+        // Supplier form defers the (potentially expensive) message building until it is known
+        // that the logger will actually emit at FINE.
+        log.fine(() -> {
+            var sb = new StringBuilder("--> ")
+                    .append(request.getMethod()).append(' ').append(request.absoluteURI()).append('\n');
+            appendHeaders(sb, request.headers());
+            appendBody(sb, context.body());
+            return sb.toString();
+        });
     }
 
     private static void logResponse(HttpContext<?> context) {
@@ -61,11 +63,13 @@ class HttpLoggingInterceptor implements Handler<HttpContext<?>> {
         if (response == null) {
             return;
         }
-        var sb = new StringBuilder("<-- ")
-                .append(response.statusCode()).append(' ').append(response.statusMessage()).append('\n');
-        appendHeaders(sb, response.headers());
-        appendBody(sb, safeBody(response));
-        log.fine(sb.toString());
+        log.fine(() -> {
+            var sb = new StringBuilder("<-- ")
+                    .append(response.statusCode()).append(' ').append(response.statusMessage()).append('\n');
+            appendHeaders(sb, response.headers());
+            appendBody(sb, safeBody(response));
+            return sb.toString();
+        });
     }
 
     private static void appendHeaders(StringBuilder sb, MultiMap headers) {

--- a/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/HttpLoggingInterceptor.java
+++ b/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/HttpLoggingInterceptor.java
@@ -1,0 +1,109 @@
+package io.apicurio.registry.client.common;
+
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.impl.HttpContext;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A Vert.x {@link io.vertx.ext.web.client.WebClient} interceptor that logs raw HTTP request and
+ * response details (method, URL, headers, and body) for outgoing Registry calls.
+ *
+ * <p>Details are logged to the {@code io.apicurio.registry.client.http} logger at {@link Level#FINE},
+ * so nothing is emitted unless that logger is configured to log {@code FINE} messages. Sensitive
+ * headers such as {@code Authorization} are redacted.</p>
+ */
+class HttpLoggingInterceptor implements Handler<HttpContext<?>> {
+
+    static final String LOGGER_NAME = "io.apicurio.registry.client.http";
+
+    private static final Logger log = Logger.getLogger(LOGGER_NAME);
+
+    private static final Set<String> REDACTED_HEADERS = Set.of(
+            "authorization", "proxy-authorization", "cookie", "set-cookie");
+
+    private static final String REDACTED = "<redacted>";
+
+    @Override
+    public void handle(HttpContext<?> context) {
+        if (log.isLoggable(Level.FINE)) {
+            switch (context.phase()) {
+                case SEND_REQUEST -> logRequest(context);
+                case DISPATCH_RESPONSE -> logResponse(context);
+                default -> {
+                }
+            }
+        }
+        context.next();
+    }
+
+    private static void logRequest(HttpContext<?> context) {
+        HttpClientRequest request = context.clientRequest();
+        if (request == null) {
+            return;
+        }
+        var sb = new StringBuilder("--> ")
+                .append(request.getMethod()).append(' ').append(request.absoluteURI()).append('\n');
+        appendHeaders(sb, request.headers());
+        appendBody(sb, context.body());
+        log.fine(sb.toString());
+    }
+
+    private static void logResponse(HttpContext<?> context) {
+        HttpResponse<?> response = context.response();
+        if (response == null) {
+            return;
+        }
+        var sb = new StringBuilder("<-- ")
+                .append(response.statusCode()).append(' ').append(response.statusMessage()).append('\n');
+        appendHeaders(sb, response.headers());
+        appendBody(sb, safeBody(response));
+        log.fine(sb.toString());
+    }
+
+    private static void appendHeaders(StringBuilder sb, MultiMap headers) {
+        if (headers == null) {
+            return;
+        }
+        for (Map.Entry<String, String> header : headers) {
+            var value = REDACTED_HEADERS.contains(header.getKey().toLowerCase(java.util.Locale.ROOT))
+                    ? REDACTED : header.getValue();
+            sb.append(header.getKey()).append(": ").append(value).append('\n');
+        }
+    }
+
+    private static void appendBody(StringBuilder sb, Object body) {
+        var text = bodyToString(body);
+        if (text != null && !text.isEmpty()) {
+            sb.append('\n').append(text).append('\n');
+        }
+    }
+
+    private static String bodyToString(Object body) {
+        if (body == null) {
+            return null;
+        }
+        if (body instanceof Buffer buffer) {
+            return buffer.toString();
+        }
+        if (body instanceof byte[] bytes) {
+            return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+        }
+        return body.toString();
+    }
+
+    private static Buffer safeBody(HttpResponse<?> response) {
+        try {
+            return response.bodyAsBuffer();
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+}

--- a/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/VertxAdapterFactory.java
+++ b/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/VertxAdapterFactory.java
@@ -44,18 +44,39 @@ public final class VertxAdapterFactory {
         Vertx vertxToUse = getVertx(options);
         WebClientOptions webClientOptions = buildWebClientOptions(options);
 
+        WebClient webClient;
         switch (options.getAuthType()) {
             case ANONYMOUS:
-                return createVertxAnonymous(vertxToUse, webClientOptions);
+                webClient = createVertxAnonymous(vertxToUse, webClientOptions);
+                break;
             case BASIC:
-                return createVertxBasicAuth(options.getUsername(), options.getPassword(), vertxToUse, webClientOptions);
+                webClient = createVertxBasicAuth(options.getUsername(), options.getPassword(), vertxToUse, webClientOptions);
+                break;
             case OAUTH2:
-                return createVertxOAuth2(options.getTokenEndpoint(), options.getClientId(),
+                webClient = createVertxOAuth2(options.getTokenEndpoint(), options.getClientId(),
                         options.getClientSecret(), options.getScope(), vertxToUse, webClientOptions);
+                break;
             case CUSTOM_WEBCLIENT:
-                return createVertxCustomWebClient(options);
+                webClient = createVertxCustomWebClient(options);
+                break;
             default:
                 throw new IllegalArgumentException("Unsupported authentication type: " + options.getAuthType());
+        }
+
+        applyHttpLogging(webClient, options);
+        return new VertXRequestAdapter(webClient);
+    }
+
+    /**
+     * Registers the HTTP wire-logging interceptor on the given WebClient when logging is enabled.
+     * All Vert.x WebClient variants (including the session- and OAuth2-aware wrappers) extend
+     * {@code WebClientBase}, which implements {@code WebClientInternal}, so a single cast covers
+     * every authentication type.
+     */
+    private static void applyHttpLogging(WebClient webClient, RegistryClientOptions options) {
+        if (options.isHttpLoggingEnabled()
+                && webClient instanceof io.vertx.ext.web.client.impl.WebClientInternal internal) {
+            internal.addInterceptor(new HttpLoggingInterceptor());
         }
     }
 
@@ -91,28 +112,25 @@ public final class VertxAdapterFactory {
         return DefaultVertxInstance.get();
     }
 
-    private static RequestAdapter createVertxAnonymous(Vertx vertx, WebClientOptions webClientOptions) {
-        WebClient webClient = webClientOptions == null ? WebClient.create(vertx) : WebClient.create(vertx, webClientOptions);
-        return new VertXRequestAdapter(webClient);
+    private static WebClient createVertxAnonymous(Vertx vertx, WebClientOptions webClientOptions) {
+        return webClientOptions == null ? WebClient.create(vertx) : WebClient.create(vertx, webClientOptions);
     }
 
-    private static RequestAdapter createVertxBasicAuth(String username, String password, Vertx vertx, WebClientOptions webClientOptions) {
-        WebClient webClient = VertXAuthFactory.buildSimpleAuthWebClient(vertx, webClientOptions, username, password);
-        return new VertXRequestAdapter(webClient);
+    private static WebClient createVertxBasicAuth(String username, String password, Vertx vertx, WebClientOptions webClientOptions) {
+        return VertXAuthFactory.buildSimpleAuthWebClient(vertx, webClientOptions, username, password);
     }
 
-    private static RequestAdapter createVertxOAuth2(String tokenEndpoint,
+    private static WebClient createVertxOAuth2(String tokenEndpoint,
                                                      String clientId, String clientSecret, String scope, Vertx vertx, WebClientOptions webClientOptions) {
-        WebClient webClient = VertXAuthFactory.buildOIDCWebClient(vertx, webClientOptions, tokenEndpoint, clientId, clientSecret, scope);
-        return new VertXRequestAdapter(webClient);
+        return VertXAuthFactory.buildOIDCWebClient(vertx, webClientOptions, tokenEndpoint, clientId, clientSecret, scope);
     }
 
-    private static RequestAdapter createVertxCustomWebClient(RegistryClientOptions options) {
+    private static WebClient createVertxCustomWebClient(RegistryClientOptions options) {
         WebClient webClient = options.getWebClient();
         if (webClient == null) {
             throw new IllegalArgumentException("WebClient cannot be null");
         }
-        return new VertXRequestAdapter(webClient);
+        return webClient;
     }
 
     private static WebClientOptions buildWebClientOptions(RegistryClientOptions options) {

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientOptions.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientOptions.java
@@ -123,6 +123,8 @@ public class RegistryClientOptions {
     private HttpAdapterType httpAdapterType = HttpAdapterType.AUTO;
     // OpenTelemetry config
     private boolean otelEnabled = false;
+    // HTTP wire logging config
+    private boolean httpLoggingEnabled = false;
 
     private RegistryClientOptions() {
     }
@@ -269,6 +271,10 @@ public class RegistryClientOptions {
 
     public boolean isOtelEnabled() {
         return otelEnabled;
+    }
+
+    public boolean isHttpLoggingEnabled() {
+        return httpLoggingEnabled;
     }
 
     /**
@@ -827,6 +833,22 @@ public class RegistryClientOptions {
      */
     public RegistryClientOptions enableOpenTelemetry() {
         this.otelEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables logging of raw HTTP request and response details (method, URL, headers, and body)
+     * for outgoing Registry calls. This is intended for debugging and is only supported by the
+     * Vert.x HTTP adapter. Sensitive headers (e.g. {@code Authorization}) are redacted.
+     *
+     * <p>Details are written to the {@code io.apicurio.registry.client.http} logger at
+     * {@code FINE} level, so the logger must be configured to emit {@code FINE} messages for
+     * the output to appear.</p>
+     *
+     * @return this builder
+     */
+    public RegistryClientOptions enableHttpLogging() {
+        this.httpLoggingEnabled = true;
         return this;
     }
 }


### PR DESCRIPTION
When `--verbose` is enabled, the CLI now logs the raw HTTP request and response (method, URL, headers, body) for each registry call, with sensitive headers redacted.

```
export ACR_HOME=/tmp/acrhome ACR_CURRENT_HOME=/tmp/acrhome
mkdir -p $ACR_HOME && cp cli/src/test/resources/acr-home/config.json $ACR_HOME/
java -jar cli/target/quarkus-app/quarkus-run.jar context create test http://localhost:18080
java -jar cli/target/quarkus-app/quarkus-run.jar group --verbose
```
works after you start the docker registry otherwise running tests works too `./mvnw test -pl cli -Dtest=VerboseLoggingCommandTest -Dcheckstyle.skip=true`

Closes https://github.com/Apicurio/apicurio-registry/issues/8027

---
- [x]  Verified via ./mvnw test -pl cli -Dtest=VerboseLoggingCommandTest -Dcheckstyle.skip=true
