### PR TITLE
ci(operator): publish multi-arch operator images (arm64, s390x, ppc64le)

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -352,6 +352,12 @@ jobs:
           unset IMAGE REGISTRY_APP_IMAGE REGISTRY_GITOPS_SYNC_IMAGE BUNDLE_IMAGE CATALOG_IMAGE
           make BUILD_OPTS="--no-transfer-progress -Daether.syncContext.named.factory=noop" SKIP_TESTS=true build
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
       - name: Login to quay.io registry
         run: |
           docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
@@ -361,7 +367,7 @@ jobs:
         working-directory: operator
         run: |
           unset IMAGE REGISTRY_APP_IMAGE REGISTRY_GITOPS_SYNC_IMAGE BUNDLE_IMAGE CATALOG_IMAGE
-          make image-build image-push
+          make image-buildx-push
 
       - name: Build and publish operator bundle
         working-directory: operator

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -105,13 +105,19 @@ jobs:
         run: |
           make BUILD_OPTS=--no-transfer-progress SKIP_TESTS=true build
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
       - name: Login to Quay.io Registry
         run: docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
 
       - name: Build and push operator image
         working-directory: registry/operator
         run: |
-          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_IMAGE_TAG=latest image-build image-push
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_IMAGE_TAG=latest image-buildx-push
 
       - name: Wait on operand images
         working-directory: registry/operator

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -26,6 +26,8 @@ IMAGE_TAG ?= $(LC_VERSION)
 IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 ADDITIONAL_IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(ADDITIONAL_IMAGE_TAG)
 
+IMAGE_PLATFORMS ?= linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+
 OPERAND_IMAGE_TAG ?= latest-snapshot
 
 REGISTRY_APP_IMAGE ?= quay.io/apicurio/apicurio-registry:$(OPERAND_IMAGE_TAG)
@@ -310,6 +312,15 @@ ifneq ($(ADDITIONAL_IMAGE_TAG),)
 	docker push $(ADDITIONAL_IMAGE)
 endif
 endif
+
+
+.PHONY: image-buildx-push
+image-buildx-push: ## Build and push a multi-arch operator image
+	docker buildx build --push -f controller/src/main/docker/Dockerfile.jvm \
+		--platform $(IMAGE_PLATFORMS) \
+		-t $(IMAGE) \
+		$(if $(and $(ADDITIONAL_IMAGE),$(ADDITIONAL_IMAGE_TAG)),-t $(ADDITIONAL_IMAGE),) \
+		controller/target
 
 
 .PHONY: image


### PR DESCRIPTION
Add an `image-buildx-push` target to `operator/Makefile` that builds and pushes the operator image with `docker buildx build --push --platform ...` instead of the single-arch `docker build`

Addresses #7665

```
  docker buildx build --builder apicurio-multiarch \
    --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le \
    -f operator/controller/src/main/docker/Dockerfile.jvm \
    -o type=oci,dest=$S/operator-multiarch.tar $S/opctx
```
---

- [x] Verified `registry.access.redhat.com/ubi10/openjdk-21-runtime` publishes linux/amd64, arm64, s390x, and ppc64le variants
- [x] Ran `docker buildx build --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le` 