### PR TITLE
test: add MCP well-known discovery endpoint tests (#8613)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
@@ -156,8 +156,8 @@ public interface WellKnownResource {
     McpToolSearchResults searchMcpTools(
             @QueryParam("name") String name,
             @QueryParam("parameter") List<String> parameters,
-            @QueryParam("offset") @DefaultValue("0") Integer offset,
-            @QueryParam("limit") @DefaultValue("20") Integer limit);
+            @QueryParam("offset") @DefaultValue("0") String offset,
+            @QueryParam("limit") @DefaultValue("20") String limit);
 
     /**
      * Returns the JSON Schema for a specific LLM artifact type.

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -47,6 +47,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptors;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
@@ -518,10 +519,13 @@ public class WellKnownResourceImpl implements WellKnownResource {
     @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
     public McpToolSearchResults searchMcpTools(String name, List<String> parameters,
-            Integer offset, Integer limit) {
+            String offset, String limit) {
         if (!mcpToolsConfig.isEnabled()) {
             throw new NotFoundException("MCP tools support is disabled");
         }
+
+        int safeOffset = Math.max(0, parsePaginationParam(offset, "offset", 0));
+        int safeLimit = Math.max(1, Math.min(parsePaginationParam(limit, "limit", 20), 500));
 
         Set<SearchFilter> filters = new HashSet<>();
 
@@ -538,7 +542,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
         }
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(filters, OrderBy.createdOn,
-                OrderDirection.desc, offset, limit, false);
+                OrderDirection.desc, safeOffset, safeLimit, false);
 
         List<McpToolSearchResult> tools = new ArrayList<>();
         for (SearchedArtifactDto artifact : results.getArtifacts()) {
@@ -546,6 +550,17 @@ public class WellKnownResourceImpl implements WellKnownResource {
         }
 
         return McpToolSearchResults.builder().count(results.getCount()).tools(tools).build();
+    }
+
+    private int parsePaginationParam(String value, String name, int defaultValue) {
+        if (StringUtil.isEmpty(value)) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new BadRequestException("Invalid " + name + ": must be an integer");
+        }
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/ExperimentalFeatureGateTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/ExperimentalFeatureGateTest.java
@@ -9,7 +9,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests that A2A endpoints are blocked when the experimental features gate is disabled (default).
+ * Tests that A2A and MCP well-known endpoints are blocked when experimental features / feature
+ * flags are disabled (default).
  */
 @QuarkusTest
 public class ExperimentalFeatureGateTest extends AbstractResourceTestBase {
@@ -62,6 +63,38 @@ public class ExperimentalFeatureGateTest extends AbstractResourceTestBase {
                 .when()
                 .contentType(CT_JSON)
                 .get("/.well-known/schemas/model-schema/v1")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testMcpToolsSearchBlockedWhenDisabled() {
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testMcpToolGetBlockedWhenDisabled() {
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .pathParam("groupId", "some-group")
+                .pathParam("artifactId", "some-tool")
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testMcpToolSchemaBlockedWhenAllExperimentalDisabled() {
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .get("/.well-known/schemas/mcp-tool/v1")
                 .then()
                 .statusCode(404);
     }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/ExperimentalFeaturesEnabledProfile.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/ExperimentalFeaturesEnabledProfile.java
@@ -5,7 +5,8 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import java.util.Map;
 
 /**
- * Test profile that enables the experimental features gate and A2A so that A2A endpoints are accessible.
+ * Test profile that enables the experimental features gate, A2A, and MCP tools so that
+ * well-known discovery endpoints are accessible.
  */
 public class ExperimentalFeaturesEnabledProfile implements QuarkusTestProfile {
 
@@ -13,7 +14,8 @@ public class ExperimentalFeaturesEnabledProfile implements QuarkusTestProfile {
     public Map<String, String> getConfigOverrides() {
         return Map.of(
                 "apicurio.features.experimental.enabled", "true",
-                "apicurio.a2a.enabled", "true"
+                "apicurio.a2a.enabled", "true",
+                "apicurio.mcp-tools.enabled", "true"
         );
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/McpToolsDisabledProfile.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/McpToolsDisabledProfile.java
@@ -1,0 +1,20 @@
+package io.apicurio.registry.noprofile.rest.mcptools;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+/**
+ * Enables experimental features and A2A while keeping MCP tools disabled.
+ */
+public class McpToolsDisabledProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "apicurio.features.experimental.enabled", "true",
+                "apicurio.a2a.enabled", "true",
+                "apicurio.mcp-tools.enabled", "false"
+        );
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/McpToolsFeatureGateTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/McpToolsFeatureGateTest.java
@@ -1,0 +1,60 @@
+package io.apicurio.registry.noprofile.rest.mcptools;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests MCP well-known endpoints when experimental/A2A are on but MCP tools are off.
+ */
+@QuarkusTest
+@TestProfile(McpToolsDisabledProfile.class)
+public class McpToolsFeatureGateTest extends AbstractResourceTestBase {
+
+    private String serverRootUrl;
+
+    @BeforeEach
+    public void setUp() {
+        int port = ConfigProvider.getConfig().getValue("quarkus.http.test-port", Integer.class);
+        serverRootUrl = "http://localhost:" + port;
+    }
+
+    private RequestSpecification givenAtRoot() {
+        return RestAssured.given().baseUri(serverRootUrl);
+    }
+
+    @Test
+    public void testMcpToolsSearchBlockedWhenMcpDisabled() {
+        givenAtRoot()
+                .when()
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testMcpToolGetBlockedWhenMcpDisabled() {
+        givenAtRoot()
+                .when()
+                .pathParam("groupId", "some-group")
+                .pathParam("artifactId", "some-tool")
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testMcpToolSchemaAvailableWhenA2AEnabledAndMcpDisabled() {
+        // Schema gate is a2a || mcp, so A2A alone still serves the schema.
+        givenAtRoot()
+                .when()
+                .get("/.well-known/schemas/mcp-tool/v1")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
@@ -1,0 +1,345 @@
+package io.apicurio.registry.noprofile.rest.mcptools;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.noprofile.rest.a2a.ExperimentalFeaturesEnabledProfile;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Tests for the MCP tool well-known discovery endpoints.
+ */
+@QuarkusTest
+@TestProfile(ExperimentalFeaturesEnabledProfile.class)
+public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
+
+    private String serverRootUrl;
+
+    @BeforeEach
+    public void setUpWellKnown() {
+        int port = ConfigProvider.getConfig().getValue("quarkus.http.test-port", Integer.class);
+        serverRootUrl = "http://localhost:" + port;
+    }
+
+    private RequestSpecification givenAtRoot() {
+        return RestAssured.given().baseUri(serverRootUrl);
+    }
+
+    private static final String SEARCH_DATABASE_TOOL = """
+            {
+                "name": "search_database",
+                "title": "Database Search Tool",
+                "description": "Search the product database with filters",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": { "type": "string", "description": "Search query" },
+                        "limit": { "type": "integer", "default": 10 }
+                    },
+                    "required": ["query"]
+                },
+                "outputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "results": { "type": "array", "description": "Search results" },
+                        "total": { "type": "integer", "description": "Total count" }
+                    },
+                    "required": ["results", "total"]
+                },
+                "annotations": {
+                    "title": "DB Search",
+                    "audience": ["user", "assistant"],
+                    "priority": 0.8
+                }
+            }
+            """;
+
+    private static final String GET_WEATHER_TOOL = """
+            {
+                "name": "get_weather",
+                "title": "Weather Lookup",
+                "description": "Get the current weather for a location",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "location": { "type": "string", "description": "City name" },
+                        "units": { "type": "string", "enum": ["celsius", "fahrenheit"] }
+                    },
+                    "required": ["location"]
+                }
+            }
+            """;
+
+    @Test
+    public void testGetRegisteredMcpTool() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+
+        createMcpTool(groupId, artifactId, SEARCH_DATABASE_TOOL);
+
+        givenAtRoot()
+                .when()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("search_database"))
+                .body("title", equalTo("Database Search Tool"))
+                .body("description", equalTo("Search the product database with filters"))
+                .body("inputSchema.type", equalTo("object"))
+                .body("inputSchema.properties.query.type", equalTo("string"))
+                .body("inputSchema.required", hasItem("query"));
+    }
+
+    @Test
+    public void testGetRegisteredMcpToolNotFound() {
+        givenAtRoot()
+                .when()
+                .pathParam("groupId", "nonexistent-group")
+                .pathParam("artifactId", "nonexistent-tool")
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testGetNonMcpToolArtifact() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactId(artifactId);
+        createArtifact.setArtifactType(ArtifactType.AVRO);
+
+        CreateVersion createVersion = new CreateVersion();
+        VersionContent content = new VersionContent();
+        content.setContent("{\"type\": \"record\", \"name\": \"Test\", \"fields\": []}");
+        content.setContentType(ContentTypes.APPLICATION_JSON);
+        createVersion.setContent(content);
+        createArtifact.setFirstVersion(createVersion);
+
+        clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+
+        givenAtRoot()
+                .when()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testSearchMcpTools() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String tool1Id = "wcmcp-s1-" + unique;
+        String tool2Id = "wcmcp-s2-" + unique;
+
+        createMcpTool(groupId, tool1Id, SEARCH_DATABASE_TOOL);
+        createMcpTool(groupId, tool2Id, GET_WEATHER_TOOL);
+
+        givenAtRoot()
+                .when()
+                .queryParam("name", "*" + unique + "*")
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(2))
+                .body("tools", hasSize(2))
+                .body("tools.artifactId", hasItems(tool1Id, tool2Id));
+    }
+
+    @Test
+    public void testSearchMcpToolsWithPagination() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String prefix = "wcmcp-page-" + unique;
+
+        for (int i = 0; i < 3; i++) {
+            createMcpTool(groupId, prefix + "-" + i, SEARCH_DATABASE_TOOL);
+        }
+
+        String nameFilter = "*" + prefix + "*";
+
+        String firstPage0 = givenAtRoot()
+                .when()
+                .queryParam("name", nameFilter)
+                .queryParam("offset", 0)
+                .queryParam("limit", 2)
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(3))
+                .body("tools", hasSize(2))
+                .extract().path("tools[0].artifactId");
+
+        givenAtRoot()
+                .when()
+                .queryParam("name", nameFilter)
+                .queryParam("offset", 1)
+                .queryParam("limit", 2)
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(3))
+                .body("tools", hasSize(2))
+                .body("tools[0].artifactId", not(equalTo(firstPage0)));
+    }
+
+    @Test
+    public void testSearchMcpToolsOffsetBeyondResults() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String artifactId = "wcmcp-beyond-" + unique;
+
+        createMcpTool(groupId, artifactId, SEARCH_DATABASE_TOOL);
+
+        givenAtRoot()
+                .when()
+                .queryParam("name", "*wcmcp-beyond-" + unique + "*")
+                .queryParam("offset", 50)
+                .queryParam("limit", 10)
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("tools", hasSize(0));
+    }
+
+    @Test
+    public void testSearchMcpToolsMalformedOffset() {
+        givenAtRoot()
+                .when()
+                .queryParam("offset", "not-a-number")
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testSearchMcpToolsEndpointReturnsCorrectStructure() {
+        givenAtRoot()
+                .when()
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(200)
+                .body("count", notNullValue())
+                .body("tools", notNullValue());
+    }
+
+    @Test
+    public void testSearchMcpToolsByName() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+
+        createMcpTool(groupId, artifactId, SEARCH_DATABASE_TOOL);
+        createMcpTool(groupId, TestUtils.generateArtifactId(), GET_WEATHER_TOOL);
+
+        // name matches registry artifact name / artifactId, not the MCP tool JSON "name" field.
+        givenAtRoot()
+                .when()
+                .queryParam("name", artifactId)
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("tools", hasSize(1))
+                .body("tools[0].artifactId", equalTo(artifactId))
+                .body("tools[0].title", equalTo("Database Search Tool"));
+    }
+
+    @Test
+    public void testSearchMcpToolsByNameWildcard() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String artifactId = "wcmcp-" + unique;
+
+        createMcpTool(groupId, artifactId, SEARCH_DATABASE_TOOL);
+
+        givenAtRoot()
+                .when()
+                .queryParam("name", "*wcmcp-" + unique + "*")
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("tools", hasSize(1))
+                .body("tools[0].artifactId", equalTo(artifactId));
+    }
+
+    @Test
+    public void testSearchMcpToolsReturnsParameters() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+
+        createMcpTool(groupId, artifactId, SEARCH_DATABASE_TOOL);
+
+        givenAtRoot()
+                .when()
+                .queryParam("name", artifactId)
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("tools", hasSize(1))
+                .body("tools[0].artifactId", equalTo(artifactId))
+                .body("tools[0].title", equalTo("Database Search Tool"))
+                .body("tools[0].parameters", hasItems("query", "limit"));
+    }
+
+    @Test
+    public void testGetMcpToolSchemaV1() {
+        givenAtRoot()
+                .when()
+                .get("/.well-known/schemas/mcp-tool/v1")
+                .then()
+                .statusCode(200)
+                .body("title", equalTo("MCP Tool Definition"))
+                .body("required", hasItems("name", "inputSchema"))
+                .body("properties.name.type", equalTo("string"))
+                .body("properties.inputSchema.type", equalTo("object"));
+    }
+
+    @Test
+    public void testGetMcpToolSchemaUnknownVersion() {
+        givenAtRoot()
+                .when()
+                .get("/.well-known/schemas/mcp-tool/v99")
+                .then()
+                .statusCode(404);
+    }
+
+    private void createMcpTool(String groupId, String artifactId, String content) throws Exception {
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactId(artifactId);
+        createArtifact.setArtifactType(ArtifactType.MCP_TOOL);
+
+        CreateVersion createVersion = new CreateVersion();
+        VersionContent versionContent = new VersionContent();
+        versionContent.setContent(content);
+        versionContent.setContentType(ContentTypes.APPLICATION_JSON);
+        createVersion.setContent(versionContent);
+        createArtifact.setFirstVersion(createVersion);
+
+        clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
@@ -232,7 +232,7 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
                 .queryParam("offset", "not-a-number")
                 .get("/.well-known/mcp-tools")
                 .then()
-                .statusCode(404);
+                .statusCode(400);
     }
 
     @Test


### PR DESCRIPTION
## Summary
Adds coverage for the MCP well known discovery endpoints that already sit next to the A2A ones.

- enable `apicurio.mcp-tools.enabled` in the shared experimental test profile
- add `WellKnownMcpToolsTest` for get search and schema paths including basic failure cases
- assert those MCP endpoints return 404 when the feature flag is off

Fixes #8613

## Test plan
- [x] `./mvnw test -pl app -Dtest=WellKnownMcpToolsTest,ExperimentalFeatureGateTest,WellKnownResourceTest`
- [x] `./mvnw checkstyle:check -pl app`
- [ ] CI smoke and full suite on this PR