### PR TITLE
fix(rest): return 400 instead of 500 when rendering an invalid prompt template

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
+++ b/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.rest.v3.beans.RenderPromptResponse;
 import io.apicurio.registry.rest.v3.beans.RenderValidationError;
+import io.apicurio.registry.storage.error.InvalidContentException;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.ws.rs.BadRequestException;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -39,6 +39,9 @@ public class PromptRenderingService {
                                         String groupId, String artifactId, String version) {
         // Parse the template content (could be YAML or JSON)
         JsonNode templateNode = parseContent(content);
+        if (templateNode == null || !templateNode.isObject()) {
+            throw new InvalidContentException("Prompt template content must be a JSON or YAML object");
+        }
 
         // Extract template field and variables schema
         String templateText = extractTemplateText(templateNode);
@@ -73,7 +76,7 @@ public class PromptRenderingService {
             try {
                 return MAPPER.readTree(text);
             } catch (Exception ex) {
-                throw new BadRequestException("Prompt template content is not valid YAML or JSON");
+                throw new InvalidContentException("Prompt template content is not valid YAML or JSON");
             }
         }
     }
@@ -84,7 +87,7 @@ public class PromptRenderingService {
     private String extractTemplateText(JsonNode templateNode) {
         JsonNode templateField = templateNode.path("template");
         if (templateField.isMissingNode()) {
-            throw new BadRequestException("Prompt template is missing 'template' field");
+            throw new InvalidContentException("Prompt template is missing 'template' field");
         }
         return templateField.asText();
     }

--- a/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
+++ b/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
@@ -5,8 +5,7 @@ import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.rest.v3.beans.RenderPromptResponse;
 import io.apicurio.registry.rest.v3.beans.RenderValidationError;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-import org.slf4j.Logger;
+import jakarta.ws.rs.BadRequestException;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -26,9 +25,6 @@ public class PromptRenderingService {
 
     private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{\\{([^}]+)\\}\\}");
 
-    @Inject
-    Logger log;
-
     /**
      * Renders a prompt template by substituting variables.
      *
@@ -41,38 +37,32 @@ public class PromptRenderingService {
      */
     public RenderPromptResponse render(ContentHandle content, Map<String, Object> variables,
                                         String groupId, String artifactId, String version) {
-        try {
-            // Parse the template content (could be YAML or JSON)
-            JsonNode templateNode = parseContent(content);
+        // Parse the template content (could be YAML or JSON)
+        JsonNode templateNode = parseContent(content);
 
-            // Extract template field and variables schema
-            String templateText = extractTemplateText(templateNode);
-            JsonNode variablesSchema = templateNode.path("variables");
+        // Extract template field and variables schema
+        String templateText = extractTemplateText(templateNode);
+        JsonNode variablesSchema = templateNode.path("variables");
 
-            // Validate variables against schema
-            List<RenderValidationError> validationErrors = validateVariables(variables, variablesSchema);
+        // Validate variables against schema
+        List<RenderValidationError> validationErrors = validateVariables(variables, variablesSchema);
 
-            // Render the template by substituting variables
-            String rendered = substituteVariables(templateText, variables);
+        // Render the template by substituting variables
+        String rendered = substituteVariables(templateText, variables);
 
-            return RenderPromptResponse.builder()
-                    .rendered(rendered)
-                    .groupId(groupId)
-                    .artifactId(artifactId)
-                    .version(version)
-                    .validationErrors(validationErrors)
-                    .build();
-
-        } catch (Exception e) {
-            log.error("Failed to render prompt template", e);
-            throw new RuntimeException("Failed to render prompt template: " + e.getMessage(), e);
-        }
+        return RenderPromptResponse.builder()
+                .rendered(rendered)
+                .groupId(groupId)
+                .artifactId(artifactId)
+                .version(version)
+                .validationErrors(validationErrors)
+                .build();
     }
 
     /**
      * Parse content as YAML or JSON.
      */
-    private JsonNode parseContent(ContentHandle content) throws Exception {
+    private JsonNode parseContent(ContentHandle content) {
         String text = content.content();
 
         // Try YAML first (which also handles JSON)
@@ -80,7 +70,11 @@ public class PromptRenderingService {
             return YAML_MAPPER.readTree(text);
         } catch (Exception e) {
             // Fall back to JSON
-            return MAPPER.readTree(text);
+            try {
+                return MAPPER.readTree(text);
+            } catch (Exception ex) {
+                throw new BadRequestException("Prompt template content is not valid YAML or JSON");
+            }
         }
     }
 
@@ -90,7 +84,7 @@ public class PromptRenderingService {
     private String extractTemplateText(JsonNode templateNode) {
         JsonNode templateField = templateNode.path("template");
         if (templateField.isMissingNode()) {
-            throw new IllegalArgumentException("Prompt template is missing 'template' field");
+            throw new BadRequestException("Prompt template is missing 'template' field");
         }
         return templateField.asText();
     }

--- a/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
@@ -31,6 +31,7 @@ import io.apicurio.registry.storage.error.GroupNotFoundException;
 import io.apicurio.registry.storage.error.InvalidArtifactIdException;
 import io.apicurio.registry.storage.error.InvalidArtifactStateException;
 import io.apicurio.registry.storage.error.InvalidArtifactTypeException;
+import io.apicurio.registry.storage.error.InvalidContentException;
 import io.apicurio.registry.storage.error.InvalidContractMetadataException;
 import io.apicurio.registry.storage.error.InvalidGroupIdException;
 import io.apicurio.registry.storage.error.InvalidPropertyValueException;
@@ -98,6 +99,7 @@ public class HttpStatusCodeMap {
         map.put(InvalidArtifactStateException.class, HTTP_BAD_REQUEST);
         map.put(InvalidVersionStateException.class, HTTP_BAD_REQUEST);
         map.put(InvalidArtifactTypeException.class, HTTP_BAD_REQUEST);
+        map.put(InvalidContentException.class, HTTP_BAD_REQUEST);
         map.put(InvalidContractMetadataException.class, HTTP_CONFLICT);
         map.put(InvalidGroupIdException.class, HTTP_BAD_REQUEST);
         map.put(InvalidPropertyValueException.class, HTTP_BAD_REQUEST);

--- a/app/src/main/java/io/apicurio/registry/storage/error/InvalidContentException.java
+++ b/app/src/main/java/io/apicurio/registry/storage/error/InvalidContentException.java
@@ -1,0 +1,13 @@
+package io.apicurio.registry.storage.error;
+
+import io.apicurio.registry.types.RegistryException;
+
+public class InvalidContentException extends RegistryException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidContentException(String message) {
+        super(message);
+    }
+
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/PromptRenderTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/PromptRenderTest.java
@@ -301,4 +301,29 @@ public class PromptRenderTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(400);
     }
+
+    @Test
+    public void testRenderTemplateWithEmptyDocumentContent() throws Exception {
+        String group = "empty-document-" + UUID.randomUUID().toString();
+        String artifactId = "comment-only-content";
+
+        // A YAML comment parses to an empty document (null node), which must be a 400, not a 500.
+        String content = "# just a comment";
+
+        createArtifact(group, artifactId, PROMPT_TEMPLATE, content, ContentTypes.APPLICATION_JSON);
+
+        Map<String, Object> request = Map.of(
+                "variables", Map.of()
+        );
+
+        given().when()
+                .contentType(CT_JSON)
+                .pathParam("groupId", group)
+                .pathParam("artifactId", artifactId)
+                .pathParam("versionExpression", "branch=latest")
+                .body(request)
+                .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{versionExpression}/render")
+                .then()
+                .statusCode(400);
+    }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/PromptRenderTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/PromptRenderTest.java
@@ -245,4 +245,60 @@ public class PromptRenderTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(404);
     }
+
+    @Test
+    public void testRenderTemplateMissingTemplateField() throws Exception {
+        String group = "missing-template-field-" + UUID.randomUUID().toString();
+        String artifactId = "no-template-field";
+
+        // Valid JSON, but not a usable prompt template. Content is only validated on creation when a
+        // VALIDITY rule is enabled, so this is storable.
+        String content = """
+            {
+              "templateId": "no-template",
+              "name": "No Template"
+            }
+            """;
+
+        createArtifact(group, artifactId, PROMPT_TEMPLATE, content, ContentTypes.APPLICATION_JSON);
+
+        Map<String, Object> request = Map.of(
+                "variables", Map.of("name", "test")
+        );
+
+        // Bad stored content is a client error, not a 500 (a 500 would be reported to the liveness check).
+        given().when()
+                .contentType(CT_JSON)
+                .pathParam("groupId", group)
+                .pathParam("artifactId", artifactId)
+                .pathParam("versionExpression", "branch=latest")
+                .body(request)
+                .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{versionExpression}/render")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void testRenderTemplateWithUnparseableContent() throws Exception {
+        String group = "unparseable-template-" + UUID.randomUUID().toString();
+        String artifactId = "unparseable-content";
+
+        String content = "{{{{not valid yaml or json}}}}";
+
+        createArtifact(group, artifactId, PROMPT_TEMPLATE, content, ContentTypes.APPLICATION_JSON);
+
+        Map<String, Object> request = Map.of(
+                "variables", Map.of()
+        );
+
+        given().when()
+                .contentType(CT_JSON)
+                .pathParam("groupId", group)
+                .pathParam("artifactId", artifactId)
+                .pathParam("versionExpression", "branch=latest")
+                .body(request)
+                .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{versionExpression}/render")
+                .then()
+                .statusCode(400);
+    }
 }

--- a/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
@@ -21,6 +21,7 @@ import io.apicurio.registry.rest.v3.beans.RenderPromptResponse;
 import io.apicurio.registry.rest.v3.beans.RenderValidationError;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -538,7 +539,7 @@ public class PromptRenderingServiceTest {
         ContentHandle content = ContentHandle.create(yamlContent);
         Map<String, Object> variables = Map.of("name", "Test");
 
-        Assertions.assertThrows(RuntimeException.class, () -> {
+        Assertions.assertThrows(BadRequestException.class, () -> {
             renderingService.render(content, variables, "default", "no-template", "1.0");
         });
     }
@@ -550,8 +551,28 @@ public class PromptRenderingServiceTest {
         ContentHandle content = ContentHandle.create(invalidContent);
         Map<String, Object> variables = Map.of();
 
-        Assertions.assertThrows(RuntimeException.class, () -> {
+        Assertions.assertThrows(BadRequestException.class, () -> {
             renderingService.render(content, variables, "default", "invalid", "1.0");
+        });
+    }
+
+    @Test
+    public void testEmptyContent() {
+        ContentHandle content = ContentHandle.create("");
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            renderingService.render(content, variables, "default", "empty", "1.0");
+        });
+    }
+
+    @Test
+    public void testNonObjectContent() {
+        ContentHandle content = ContentHandle.create("just a plain string");
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            renderingService.render(content, variables, "default", "plain", "1.0");
         });
     }
 }

--- a/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
@@ -19,9 +19,9 @@ package io.apicurio.registry.services;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.rest.v3.beans.RenderPromptResponse;
 import io.apicurio.registry.rest.v3.beans.RenderValidationError;
+import io.apicurio.registry.storage.error.InvalidContentException;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.BadRequestException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -539,7 +539,7 @@ public class PromptRenderingServiceTest {
         ContentHandle content = ContentHandle.create(yamlContent);
         Map<String, Object> variables = Map.of("name", "Test");
 
-        Assertions.assertThrows(BadRequestException.class, () -> {
+        Assertions.assertThrows(InvalidContentException.class, () -> {
             renderingService.render(content, variables, "default", "no-template", "1.0");
         });
     }
@@ -551,7 +551,7 @@ public class PromptRenderingServiceTest {
         ContentHandle content = ContentHandle.create(invalidContent);
         Map<String, Object> variables = Map.of();
 
-        Assertions.assertThrows(BadRequestException.class, () -> {
+        Assertions.assertThrows(InvalidContentException.class, () -> {
             renderingService.render(content, variables, "default", "invalid", "1.0");
         });
     }
@@ -561,7 +561,7 @@ public class PromptRenderingServiceTest {
         ContentHandle content = ContentHandle.create("");
         Map<String, Object> variables = Map.of();
 
-        Assertions.assertThrows(BadRequestException.class, () -> {
+        Assertions.assertThrows(InvalidContentException.class, () -> {
             renderingService.render(content, variables, "default", "empty", "1.0");
         });
     }
@@ -571,8 +571,30 @@ public class PromptRenderingServiceTest {
         ContentHandle content = ContentHandle.create("just a plain string");
         Map<String, Object> variables = Map.of();
 
-        Assertions.assertThrows(BadRequestException.class, () -> {
+        Assertions.assertThrows(InvalidContentException.class, () -> {
             renderingService.render(content, variables, "default", "plain", "1.0");
+        });
+    }
+
+    @Test
+    public void testWhitespaceOnlyContent() {
+        // Whitespace parses as an empty YAML document, so readTree returns null.
+        ContentHandle content = ContentHandle.create("   ");
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            renderingService.render(content, variables, "default", "whitespace", "1.0");
+        });
+    }
+
+    @Test
+    public void testCommentOnlyContent() {
+        // A YAML comment is a valid but empty document, so readTree returns null.
+        ContentHandle content = ContentHandle.create("# just a comment");
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            renderingService.render(content, variables, "default", "comment", "1.0");
         });
     }
 }


### PR DESCRIPTION
## What

`POST /groups/{groupId}/artifacts/{artifactId}/versions/{versionExpression}/render` returns **500** when the stored PROMPT_TEMPLATE content is unparseable or has no `template` field. The request itself is well formed, the stored content simply isn't a usable prompt template, so this should be a 4xx.

Reported privately by email to @EricWittmann and @carlesarnal; opening this PR at Eric's suggestion.
## Why it matters

`PromptRenderingService.render()` wrapped every failure, including content-shaped ones, in a plain `RuntimeException`. That type isn't in `HttpStatusCodeMap`, so `getCode()` falls back to `HTTP_INTERNAL_ERROR`.

`CoreRegistryExceptionMapperService` reports **every** 500 to `ResponseErrorLivenessCheck`, whose `error-threshold` defaults to `1` per 60s window. So repeated render calls against one malformed template can drive `/health/live` down. The 500 response body also surfaced the underlying parser error.

Malformed content is storable because content is only validated on creation when a VALIDITY rule is enabled, which is off by default.

## Changes

`PromptRenderingService`:

- `extractTemplateText`: throw `BadRequestException` instead of `IllegalArgumentException` when the `template` field is missing.
- `parseContent`: throw `BadRequestException` when the content parses as neither YAML nor JSON. No cause is attached, so the response no longer exposes the raw parser message.
- Remove the blanket `catch (Exception) -> RuntimeException`. It produced the 500s, and it would otherwise re-wrap the mapped exception. Genuinely unexpected errors still surface as 500 and are still reported to the liveness check, which is the intent.

`BadRequestException` is already mapped to 400 in `HttpStatusCodeMap`, and is already what this endpoint throws for the wrong-artifact-type case, so no new exception type or mapping is introduced.

## Tests

- `PromptRenderTest`: two new cases asserting **400** (not 500), a template with no `template` field, and unparseable content.
- `PromptRenderingServiceTest`: the two existing error-case tests now assert `BadRequestException` instead of `RuntimeException`; added cases for empty content and non-object content.

Both new REST cases fail with `Expected status code <400> but was <500>` (emitting two `[500 ERROR DETECTED]` liveness reports) without the service change, and pass with it.

## Not changed

A non-textual `template` (e.g. `template: {a: 1}`) still renders as an empty string via `asText()`. It never throws, so it isn't part of this issue, happy to address it separately if you'd prefer.
