### PR TITLE
fix(operator): handle CRD 404 in OLM v1 test setup (3.2.x)

### DIFF
--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
@@ -100,11 +100,19 @@ public abstract class OLMITBase implements OperatorTestContext {
                 log.warn("When using OLM v1, ApicurioRegistry3 CRD must be created when installing the bundle. Deleting the existing CRD before we can continue.");
 
                 await().atMost(MEDIUM_DURATION).ignoreExceptions().untilAsserted(() -> {
-                    client.resources(ApicurioRegistry3.class).list().getItems().forEach(ar -> {
-                        log.warn("Deleting ApicurioRegistry3 CR: {}", ResourceID.fromResource(ar));
-                        client.resource(ar).delete();
-                    });
-                    assertThat(client.resources(ApicurioRegistry3.class).list().getItems()).isEmpty();
+                    try {
+                        client.resources(ApicurioRegistry3.class).list().getItems().forEach(ar -> {
+                            log.warn("Deleting ApicurioRegistry3 CR: {}", ResourceID.fromResource(ar));
+                            client.resource(ar).delete();
+                        });
+                        assertThat(client.resources(ApicurioRegistry3.class).list().getItems()).isEmpty();
+                    } catch (io.fabric8.kubernetes.client.KubernetesClientException e) {
+                        if (e.getCode() == 404) {
+                            log.debug("CRD already removed, no CRs to delete.");
+                        } else {
+                            throw e;
+                        }
+                    }
                 });
 
                 await().atMost(MEDIUM_DURATION).ignoreExceptions().until(() -> {


### PR DESCRIPTION
Cherry-pick from main (PR #8264).

The OLM v1 `SmokeOLMITTest` fails with `CrashLoopBackOff` because the CRD deletion
race condition in `OLMITBase.beforeAll()` causes a 404 when listing CRs after the CRD
has already been removed by a previous test's cleanup.

This fix catches the 404 `KubernetesClientException` and treats it as "no CRs to delete",
allowing the test to proceed normally.

Blocks the 3.2.6 downstream QE operator tests.