### PR TITLE
feat(resolver): add mTLS keystore configuration support to schema resolver and registry client

### DIFF
--- a/app/src/test/java/io/apicurio/registry/tls/MtlsSerdeTest.java
+++ b/app/src/test/java/io/apicurio/registry/tls/MtlsSerdeTest.java
@@ -1,0 +1,351 @@
+package io.apicurio.registry.tls;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.client.RegistryClientFactory;
+import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.resolver.config.SchemaResolverConfig;
+import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.serde.kafka.config.KafkaSerdeConfig;
+import io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaDeserializer;
+import io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaSerializer;
+import io.apicurio.registry.serde.strategy.SimpleTopicIdStrategy;
+import io.apicurio.registry.support.Person;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.IoUtil;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.Vertx;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests that SerDe classes (serializers/deserializers) work with mutual TLS (mTLS)
+ * configuration using JKS, PKCS12, and PEM keystores when connecting to a registry
+ * that requires client certificate authentication.
+ */
+@QuarkusTest
+@TestProfile(MtlsSerdeTest.MtlsSerdeTestProfile.class)
+public class MtlsSerdeTest extends AbstractResourceTestBase {
+
+    public static class MtlsSerdeTestProfile extends MtlsTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> props = new HashMap<>(super.getConfigOverrides());
+            // Keep basic auth enabled so that Quarkus registers the BasicAuthenticationMechanism bean.
+            // Note: Both basic auth (HTTP application layer) and mTLS client certification (TCP/TLS transport layer)
+            // coexist. The Quarkus HTTP server requires a valid client certificate to complete the TLS handshake;
+            // hence, the negative test (connecting without client keystore) fails at the transport layer before
+            // HTTP basic auth is evaluated.
+            props.put("quarkus.http.auth.basic", "true");
+            // Define an embedded user for our tests to authenticate with basic auth
+            props.put("quarkus.security.users.embedded.enabled", "true");
+            props.put("quarkus.security.users.embedded.plain-text", "true");
+            props.put("quarkus.security.users.embedded.users.alice", "alice");
+            props.put("quarkus.security.users.embedded.roles.alice", "sr-admin");
+            return props;
+        }
+    }
+
+    @TestHTTPResource(value = "/apis", tls = true)
+    URL httpsUrl;
+
+    @Override
+    protected void deleteGlobalRules(int expectedDefaultRulesCount) throws Exception {
+        // Don't bother with this test
+    }
+
+    @Override
+    @BeforeAll
+    protected void beforeAll() throws Exception {
+        vertx = Vertx.vertx();
+
+        // Override base URL to use HTTPS
+        registryApiBaseUrl = httpsUrl.toExternalForm();
+        registryV2ApiUrl = registryApiBaseUrl + "/registry/v2";
+        registryV3ApiUrl = registryApiBaseUrl + "/registry/v3";
+
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-truststore.jks");
+        URL keystoreUrl = getClass().getClassLoader().getResource("tls/client-keystore.jks");
+        Assertions.assertNotNull(truststoreUrl, "Truststore file not found");
+        Assertions.assertNotNull(keystoreUrl, "Client keystore file not found");
+
+        // Initialize API client with mTLS and Basic Auth
+        clientV3 = RegistryClientFactory.create(RegistryClientOptions.create()
+                .registryUrl(registryV3ApiUrl)
+                .trustStoreJks(truststoreUrl.getPath(), "registrytest")
+                .keystoreJks(keystoreUrl.getPath(), "registrytest")
+                .basicAuth("alice", "alice")
+                .vertx(vertx));
+    }
+
+    /**
+     * Helper to run basic serialization/deserialization flow with a specific SerDe configuration.
+     */
+    private void runSerdeTest(Map<String, Object> commonConfig, Person person) throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = generateArtifactId();
+
+        InputStream jsonSchema = getClass()
+                .getResourceAsStream("/io/apicurio/registry/util/json-schema.json");
+        Assertions.assertNotNull(jsonSchema);
+
+        createArtifact(groupId, artifactId, ArtifactType.JSON, IoUtil.toString(jsonSchema),
+                ContentTypes.APPLICATION_JSON);
+
+        try (JsonSchemaKafkaSerializer<Person> serializer = new JsonSchemaKafkaSerializer<>();
+            Deserializer<Person> deserializer = new JsonSchemaKafkaDeserializer<>()) {
+
+            // Configure the serializer
+            Map<String, Object> serializerConfig = new HashMap<>();
+            serializerConfig.putAll(commonConfig);
+            serializerConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+            serializerConfig.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, SimpleTopicIdStrategy.class.getName());
+            serializerConfig.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+            serializerConfig.put(SerdeConfig.VALIDATION_ENABLED, "true");
+            serializer.configure(serializerConfig, false);
+
+            // Configure the deserializer
+            Map<String, Object> deserializerConfig = new HashMap<>();
+            deserializerConfig.putAll(commonConfig);
+            deserializerConfig.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+            deserializer.configure(deserializerConfig, false);
+
+            // Serialize/deserialize the message
+            Headers headers = new RecordHeaders();
+            byte[] bytes = serializer.serialize(artifactId, headers, person);
+            Person deserialized = deserializer.deserialize(artifactId, headers, bytes);
+
+            Assertions.assertEquals(person.getFirstName(), deserialized.getFirstName());
+            Assertions.assertEquals(person.getLastName(), deserialized.getLastName());
+            Assertions.assertEquals(person.getAge(), deserialized.getAge());
+        }
+    }
+
+    /**
+     * Test JsonSchema SerDe with JKS truststore and JKS keystore (mTLS)
+     */
+    @Test
+    public void testJsonSchemaSerdeWithJksKeystore() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-truststore.jks");
+        URL keystoreUrl = getClass().getClassLoader().getResource("tls/client-keystore.jks");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(keystoreUrl);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "registrytest");
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "JKS");
+
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, keystoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_PASSWORD, "registrytest");
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "JKS");
+
+        runSerdeTest(config, new Person("Bob", "Johnson", 40));
+    }
+
+    /**
+     * Test JsonSchema SerDe with PKCS12 truststore and PKCS12 keystore (mTLS)
+     */
+    @Test
+    public void testJsonSchemaSerdeWithPkcs12Keystore() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-truststore.p12");
+        URL keystoreUrl = getClass().getClassLoader().getResource("tls/client-keystore.p12");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(keystoreUrl);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "registrytest");
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PKCS12");
+
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, keystoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_PASSWORD, "registrytest");
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "PKCS12");
+
+        runSerdeTest(config, new Person("Alice", "Smith", 25));
+    }
+
+    /**
+     * Test JsonSchema SerDe with PEM keystore via location, type, and key path
+     */
+    @Test
+    public void testJsonSchemaSerdeWithPemKeystoreLocation() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-cert.pem");
+        URL clientCertUrl = getClass().getClassLoader().getResource("tls/client-cert.pem");
+        URL clientKeyUrl = getClass().getClassLoader().getResource("tls/client-key.pem");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(clientCertUrl);
+        Assertions.assertNotNull(clientKeyUrl);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PEM");
+
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, clientCertUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "PEM");
+        config.put(SchemaResolverConfig.TLS_CLIENT_KEY, clientKeyUrl.getPath());
+
+        runSerdeTest(config, new Person("Emma", "Wilson", 32));
+    }
+
+    /**
+     * Test JsonSchema SerDe with PEM keystore via raw cert and key content
+     */
+    @Test
+    public void testJsonSchemaSerdeWithPemKeystoreContent() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-cert.pem");
+        URL clientCertUrl = getClass().getClassLoader().getResource("tls/client-cert.pem");
+        URL clientKeyUrl = getClass().getClassLoader().getResource("tls/client-key.pem");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(clientCertUrl);
+        Assertions.assertNotNull(clientKeyUrl);
+
+        String clientCertContent = Files.readString(Paths.get(clientCertUrl.getPath()));
+        String clientKeyContent = Files.readString(Paths.get(clientKeyUrl.getPath()));
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PEM");
+
+        config.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, clientCertContent);
+        config.put(SchemaResolverConfig.TLS_CLIENT_KEY, clientKeyContent);
+
+        runSerdeTest(config, new Person("John", "Doe", 45));
+    }
+
+    /**
+     * Test JsonSchema SerDe with mixed PEM: cert as file path and key as inline content
+     */
+    @Test
+    public void testJsonSchemaSerdeWithPemKeystoreMixedCertPathKeyContent() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-cert.pem");
+        URL clientCertUrl = getClass().getClassLoader().getResource("tls/client-cert.pem");
+        URL clientKeyUrl = getClass().getClassLoader().getResource("tls/client-key.pem");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(clientCertUrl);
+        Assertions.assertNotNull(clientKeyUrl);
+
+        String clientKeyContent = Files.readString(Paths.get(clientKeyUrl.getPath()));
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PEM");
+
+        // Cert is file path, Key is inline content
+        config.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, clientCertUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_CLIENT_KEY, clientKeyContent);
+
+        runSerdeTest(config, new Person("Jane", "Doe", 42));
+    }
+
+    /**
+     * Test JsonSchema SerDe with mixed PEM: cert as inline content and key as file path
+     */
+    @Test
+    public void testJsonSchemaSerdeWithPemKeystoreMixedCertContentKeyPath() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-cert.pem");
+        URL clientCertUrl = getClass().getClassLoader().getResource("tls/client-cert.pem");
+        URL clientKeyUrl = getClass().getClassLoader().getResource("tls/client-key.pem");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(clientCertUrl);
+        Assertions.assertNotNull(clientKeyUrl);
+
+        String clientCertContent = Files.readString(Paths.get(clientCertUrl.getPath()));
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PEM");
+
+        // Cert is inline content, Key is file path
+        config.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, clientCertContent);
+        config.put(SchemaResolverConfig.TLS_CLIENT_KEY, clientKeyUrl.getPath());
+
+        runSerdeTest(config, new Person("Grace", "Hopper", 85));
+    }
+
+    /**
+     * Negative test: verify that connecting without a client keystore fails when mTLS is required.
+     */
+    @Test
+    public void testJsonSchemaSerdeWithoutClientKeystoreFails() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-truststore.jks");
+        Assertions.assertNotNull(truststoreUrl);
+
+        InputStream jsonSchema = getClass()
+                .getResourceAsStream("/io/apicurio/registry/util/json-schema.json");
+        Assertions.assertNotNull(jsonSchema);
+
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = generateArtifactId();
+
+        // Registering artifact via clientV3 succeeds because clientV3 uses valid mTLS credentials
+        createArtifact(groupId, artifactId, ArtifactType.JSON, IoUtil.toString(jsonSchema),
+                ContentTypes.APPLICATION_JSON);
+
+        Person person = new Person("Charlie", "Brown", 12);
+
+        try (JsonSchemaKafkaSerializer<Person> serializer = new JsonSchemaKafkaSerializer<>()) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+            config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+            config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+            config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+            config.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "registrytest");
+            config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "JKS");
+
+            config.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+            config.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, SimpleTopicIdStrategy.class.getName());
+
+            // Should throw an exception during configuration or serialization because mTLS is missing
+            serializer.configure(config, false);
+            Headers headers = new RecordHeaders();
+            Exception exception = Assertions.assertThrows(Exception.class, () -> serializer.serialize(artifactId, headers, person));
+            
+            java.io.StringWriter sw = new java.io.StringWriter();
+            exception.printStackTrace(new java.io.PrintWriter(sw));
+            String stackTrace = sw.toString().toLowerCase();
+            Assertions.assertTrue(stackTrace.contains("ssl") || stackTrace.contains("tls") || 
+                    stackTrace.contains("certificate") || stackTrace.contains("pkix") || 
+                    stackTrace.contains("handshake"),
+                "Expected TLS-related exception, but got: " + exception.getMessage());
+        }
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/tls/MtlsSerdeTest.java
+++ b/app/src/test/java/io/apicurio/registry/tls/MtlsSerdeTest.java
@@ -1,0 +1,354 @@
+package io.apicurio.registry.tls;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.client.RegistryClientFactory;
+import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.resolver.config.SchemaResolverConfig;
+import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.serde.kafka.config.KafkaSerdeConfig;
+import io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaDeserializer;
+import io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaSerializer;
+import io.apicurio.registry.serde.strategy.SimpleTopicIdStrategy;
+import io.apicurio.registry.support.Person;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.IoUtil;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.Vertx;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Tests that SerDe classes (serializers/deserializers) work with mutual TLS (mTLS)
+ * configuration using JKS, PKCS12, and PEM keystores when connecting to a registry
+ * that requires client certificate authentication.
+ */
+@QuarkusTest
+@TestProfile(MtlsSerdeTest.MtlsSerdeTestProfile.class)
+public class MtlsSerdeTest extends AbstractResourceTestBase {
+
+    public static class MtlsSerdeTestProfile extends MtlsTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> props = new HashMap<>(super.getConfigOverrides());
+            // Keep basic auth enabled so that Quarkus registers the BasicAuthenticationMechanism bean.
+            // Note: Both basic auth (HTTP application layer) and mTLS client certification (TCP/TLS transport layer)
+            // coexist. The Quarkus HTTP server requires a valid client certificate to complete the TLS handshake;
+            // hence, the negative test (connecting without client keystore) fails at the transport layer before
+            // HTTP basic auth is evaluated.
+            props.put("quarkus.http.auth.basic", "true");
+            // Define an embedded user for our tests to authenticate with basic auth
+            props.put("quarkus.security.users.embedded.enabled", "true");
+            props.put("quarkus.security.users.embedded.plain-text", "true");
+            props.put("quarkus.security.users.embedded.users.alice", "alice");
+            props.put("quarkus.security.users.embedded.roles.alice", "sr-admin");
+            return props;
+        }
+    }
+
+    @TestHTTPResource(value = "/apis", tls = true)
+    URL httpsUrl;
+
+    @Override
+    protected void deleteGlobalRules(int expectedDefaultRulesCount) throws Exception {
+        // Don't bother with this test
+    }
+
+    @Override
+    @BeforeAll
+    protected void beforeAll() throws Exception {
+        vertx = Vertx.vertx();
+
+        // Override base URL to use HTTPS
+        registryApiBaseUrl = httpsUrl.toExternalForm();
+        registryV2ApiUrl = registryApiBaseUrl + "/registry/v2";
+        registryV3ApiUrl = registryApiBaseUrl + "/registry/v3";
+
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-truststore.jks");
+        URL keystoreUrl = getClass().getClassLoader().getResource("tls/client-keystore.jks");
+        Assertions.assertNotNull(truststoreUrl, "Truststore file not found");
+        Assertions.assertNotNull(keystoreUrl, "Client keystore file not found");
+
+        // Initialize API client with mTLS and Basic Auth
+        clientV3 = RegistryClientFactory.create(RegistryClientOptions.create()
+                .registryUrl(registryV3ApiUrl)
+                .trustStoreJks(truststoreUrl.getPath(), "registrytest")
+                .keystoreJks(keystoreUrl.getPath(), "registrytest")
+                .basicAuth("alice", "alice")
+                .vertx(vertx));
+    }
+
+    /**
+     * Helper to run basic serialization/deserialization flow with a specific SerDe configuration.
+     */
+    private void runSerdeTest(Map<String, Object> commonConfig, Person person) throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = generateArtifactId();
+
+        InputStream jsonSchema = getClass()
+                .getResourceAsStream("/io/apicurio/registry/util/json-schema.json");
+        Assertions.assertNotNull(jsonSchema);
+
+        createArtifact(groupId, artifactId, ArtifactType.JSON, IoUtil.toString(jsonSchema),
+                ContentTypes.APPLICATION_JSON);
+
+        try (JsonSchemaKafkaSerializer<Person> serializer = new JsonSchemaKafkaSerializer<>();
+            Deserializer<Person> deserializer = new JsonSchemaKafkaDeserializer<>()) {
+
+            // Configure the serializer
+            Map<String, Object> serializerConfig = new HashMap<>();
+            serializerConfig.putAll(commonConfig);
+            serializerConfig.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+            serializerConfig.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, SimpleTopicIdStrategy.class.getName());
+            serializerConfig.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+            serializerConfig.put(SerdeConfig.VALIDATION_ENABLED, "true");
+            serializer.configure(serializerConfig, false);
+
+            // Configure the deserializer
+            Map<String, Object> deserializerConfig = new HashMap<>();
+            deserializerConfig.putAll(commonConfig);
+            deserializerConfig.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+            deserializer.configure(deserializerConfig, false);
+
+            // Serialize/deserialize the message
+            Headers headers = new RecordHeaders();
+            byte[] bytes = serializer.serialize(artifactId, headers, person);
+            Person deserialized = deserializer.deserialize(artifactId, headers, bytes);
+
+            Assertions.assertEquals(person.getFirstName(), deserialized.getFirstName());
+            Assertions.assertEquals(person.getLastName(), deserialized.getLastName());
+            Assertions.assertEquals(person.getAge(), deserialized.getAge());
+        }
+    }
+
+    /**
+     * Test JsonSchema SerDe with JKS truststore and JKS keystore (mTLS)
+     */
+    @Test
+    public void testJsonSchemaSerdeWithJksKeystore() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-truststore.jks");
+        URL keystoreUrl = getClass().getClassLoader().getResource("tls/client-keystore.jks");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(keystoreUrl);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "registrytest");
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "JKS");
+
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, keystoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_PASSWORD, "registrytest");
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "JKS");
+
+        runSerdeTest(config, new Person("Bob", "Johnson", 40));
+    }
+
+    /**
+     * Test JsonSchema SerDe with PKCS12 truststore and PKCS12 keystore (mTLS)
+     */
+    @Test
+    public void testJsonSchemaSerdeWithPkcs12Keystore() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-truststore.p12");
+        URL keystoreUrl = getClass().getClassLoader().getResource("tls/client-keystore.p12");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(keystoreUrl);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "registrytest");
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PKCS12");
+
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, keystoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_PASSWORD, "registrytest");
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "PKCS12");
+
+        runSerdeTest(config, new Person("Alice", "Smith", 25));
+    }
+
+    /**
+     * Test JsonSchema SerDe with PEM keystore via location, type, and key path
+     */
+    @Test
+    public void testJsonSchemaSerdeWithPemKeystoreLocation() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-cert.pem");
+        URL clientCertUrl = getClass().getClassLoader().getResource("tls/client-cert.pem");
+        URL clientKeyUrl = getClass().getClassLoader().getResource("tls/client-key.pem");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(clientCertUrl);
+        Assertions.assertNotNull(clientKeyUrl);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PEM");
+
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, clientCertUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "PEM");
+        config.put(SchemaResolverConfig.TLS_CLIENT_KEY, clientKeyUrl.getPath());
+
+        runSerdeTest(config, new Person("Emma", "Wilson", 32));
+    }
+
+    /**
+     * Test JsonSchema SerDe with PEM keystore via raw cert and key content
+     */
+    @Test
+    public void testJsonSchemaSerdeWithPemKeystoreContent() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-cert.pem");
+        URL clientCertUrl = getClass().getClassLoader().getResource("tls/client-cert.pem");
+        URL clientKeyUrl = getClass().getClassLoader().getResource("tls/client-key.pem");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(clientCertUrl);
+        Assertions.assertNotNull(clientKeyUrl);
+
+        String clientCertContent = Files.readString(Paths.get(clientCertUrl.getPath()));
+        String clientKeyContent = Files.readString(Paths.get(clientKeyUrl.getPath()));
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PEM");
+
+        config.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, clientCertContent);
+        config.put(SchemaResolverConfig.TLS_CLIENT_KEY, clientKeyContent);
+
+        runSerdeTest(config, new Person("John", "Doe", 45));
+    }
+
+    /**
+     * Test JsonSchema SerDe with mixed PEM: cert as file path and key as inline content
+     */
+    @Test
+    public void testJsonSchemaSerdeWithPemKeystoreMixedCertPathKeyContent() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-cert.pem");
+        URL clientCertUrl = getClass().getClassLoader().getResource("tls/client-cert.pem");
+        URL clientKeyUrl = getClass().getClassLoader().getResource("tls/client-key.pem");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(clientCertUrl);
+        Assertions.assertNotNull(clientKeyUrl);
+
+        String clientKeyContent = Files.readString(Paths.get(clientKeyUrl.getPath()));
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PEM");
+
+        // Cert is file path, Key is inline content
+        config.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, clientCertUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_CLIENT_KEY, clientKeyContent);
+
+        runSerdeTest(config, new Person("Jane", "Doe", 42));
+    }
+
+    /**
+     * Test JsonSchema SerDe with mixed PEM: cert as inline content and key as file path
+     */
+    @Test
+    public void testJsonSchemaSerdeWithPemKeystoreMixedCertContentKeyPath() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-cert.pem");
+        URL clientCertUrl = getClass().getClassLoader().getResource("tls/client-cert.pem");
+        URL clientKeyUrl = getClass().getClassLoader().getResource("tls/client-key.pem");
+        Assertions.assertNotNull(truststoreUrl);
+        Assertions.assertNotNull(clientCertUrl);
+        Assertions.assertNotNull(clientKeyUrl);
+
+        String clientCertContent = Files.readString(Paths.get(clientCertUrl.getPath()));
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+        config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+        config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+        config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PEM");
+
+        // Cert is inline content, Key is file path
+        config.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, clientCertContent);
+        config.put(SchemaResolverConfig.TLS_CLIENT_KEY, clientKeyUrl.getPath());
+
+        runSerdeTest(config, new Person("Grace", "Hopper", 85));
+    }
+
+    /**
+     * Negative test: verify that connecting without a client keystore fails when mTLS is required.
+     */
+    @Test
+    public void testJsonSchemaSerdeWithoutClientKeystoreFails() throws Exception {
+        URL truststoreUrl = getClass().getClassLoader().getResource("tls/registry-truststore.jks");
+        Assertions.assertNotNull(truststoreUrl);
+
+        InputStream jsonSchema = getClass()
+                .getResourceAsStream("/io/apicurio/registry/util/json-schema.json");
+        Assertions.assertNotNull(jsonSchema);
+
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = generateArtifactId();
+
+        // Registering artifact via clientV3 succeeds because clientV3 uses valid mTLS credentials
+        createArtifact(groupId, artifactId, ArtifactType.JSON, IoUtil.toString(jsonSchema),
+                ContentTypes.APPLICATION_JSON);
+
+        Person person = new Person("Charlie", "Brown", 12);
+
+        try (JsonSchemaKafkaSerializer<Person> serializer = new JsonSchemaKafkaSerializer<>()) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(SerdeConfig.REGISTRY_URL, registryV3ApiUrl);
+            config.put(SchemaResolverConfig.AUTH_USERNAME, "alice");
+            config.put(SchemaResolverConfig.AUTH_PASSWORD, "alice");
+            config.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, truststoreUrl.getPath());
+            config.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "registrytest");
+            config.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "JKS");
+
+            config.put(SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID, groupId);
+            config.put(SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, SimpleTopicIdStrategy.class.getName());
+
+            // Should throw an exception during configuration or serialization because mTLS is missing
+            serializer.configure(config, false);
+            Headers headers = new RecordHeaders();
+            Exception exception = Assertions.assertThrows(Exception.class, () -> serializer.serialize(artifactId, headers, person));
+            
+            StringWriter sw = new StringWriter();
+            exception.printStackTrace(new PrintWriter(sw));
+            String stackTrace = sw.toString().toLowerCase(Locale.ROOT);
+            Assertions.assertTrue(stackTrace.contains("ssl") || stackTrace.contains("tls") || 
+                    stackTrace.contains("certificate") || stackTrace.contains("pkix") || 
+                    stackTrace.contains("handshake"),
+                "Expected TLS-related exception, but got: " + exception.getMessage());
+        }
+    }
+}

--- a/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
@@ -164,6 +164,36 @@ The `DefaultSchemaResolver` provides the following properties to configure acces
 |Used by serializers and deserializers. Password to access the registry. Required when accessing a secure registry by using HTTP basic authentication.
 |`String`
 |None
+
+|`TLS_KEYSTORE_LOCATION`
+|`apicurio.registry.tls.keystore.location`
+|Used by serializers and deserializers. The location of the key store file for mutual TLS (mTLS). Can be a file path or classpath resource.
+|`String`
+|None
+
+|`TLS_KEYSTORE_PASSWORD`
+|`apicurio.registry.tls.keystore.password`
+|Used by serializers and deserializers. The password for the key store file. Required when using JKS or PKCS12 key stores.
+|`String`
+|None
+
+|`TLS_KEYSTORE_TYPE`
+|`apicurio.registry.tls.keystore.type`
+|Used by serializers and deserializers. The type of key store. Valid values are JKS, PKCS12, or PEM.
+|`String`
+|`JKS`
+
+|`TLS_CLIENT_CERTIFICATE`
+|`apicurio.registry.tls.client-certificate`
+|Used by serializers and deserializers. The PEM client certificate content or file path for mutual TLS (mTLS).
+|`String`
+|None
+
+|`TLS_CLIENT_KEY`
+|`apicurio.registry.tls.client-key`
+|Used by serializers and deserializers. The PEM client private key content or file path for mutual TLS (mTLS).
+|`String`
+|None
 |===
 
 **OpenTelemetry distributed tracing**

--- a/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
@@ -164,6 +164,36 @@ The `DefaultSchemaResolver` provides the following properties to configure acces
 |Used by serializers and deserializers. Password to access the registry. Required when accessing a secure registry by using HTTP basic authentication.
 |`String`
 |None
+
+|`TLS_KEYSTORE_LOCATION`
+|`apicurio.registry.tls.keystore.location`
+|Used by serializers and deserializers. The location of the key store file for mutual TLS (mTLS). Can be a file path or classpath resource.
+|`String`
+|None
+
+|`TLS_KEYSTORE_PASSWORD`
+|`apicurio.registry.tls.keystore.password`
+|Used by serializers and deserializers. The password for the key store file. Required when using JKS or PKCS12 key stores.
+|`String`
+|None
+
+|`TLS_KEYSTORE_TYPE`
+|`apicurio.registry.tls.keystore.type`
+|Used by serializers and deserializers. The type of key store. Valid values are JKS, PKCS12, or PEM.
+|`String`
+|`JKS`
+
+|`TLS_CLIENT_CERTIFICATE`
+|`apicurio.registry.tls.client-certificate`
+|Used by serializers and deserializers. The PEM client certificate content or file path for mutual TLS (mTLS).
+|`String`
+|None
+
+|`TLS_CLIENT_KEY`
+|`apicurio.registry.tls.client-key`
+|Used by serializers and deserializers. The PEM client private key content or file path for mutual TLS (mTLS).
+|`String`
+|None
 |===
 
 **TLS security for the registry connection**

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -8,6 +8,14 @@ import io.apicurio.registry.resolver.config.SchemaResolverConfig;
 import io.vertx.core.Vertx;
 
 import java.util.logging.Logger;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Factory used to create instances of {@link RegistryClientFacade}.  Typically the
@@ -19,6 +27,7 @@ import java.util.logging.Logger;
 public class RegistryClientFacadeFactory {
 
     private static final Logger logger = Logger.getLogger(RegistryClientFacadeFactory.class.getSimpleName());
+    private static final String CLASSPATH_PREFIX = "classpath:";
 
     public static RegistryClientFacade create(SchemaResolverConfig config) {
         String baseUrl = config.getRegistryUrl();
@@ -48,28 +57,41 @@ public class RegistryClientFacadeFactory {
         }
     }
 
-    private static RegistryClientOptions buildClientOptions(SchemaResolverConfig config, Vertx vertx) {
+    static RegistryClientOptions buildClientOptions(SchemaResolverConfig config, Vertx vertx) {
         final String baseUrl = config.getRegistryUrl();
+        final String httpAdapterStr = config.getHttpAdapter();
+        HttpAdapterType httpAdapterType = parseHttpAdapterType(httpAdapterStr);
+
+        RegistryClientOptions clientOptions = createClientOptions(baseUrl, httpAdapterType, vertx);
+
+        configureAuthentication(clientOptions, config);
+
+        clientOptions.retry();
+
+        configureTrustStore(clientOptions, config);
+        configureKeyStore(clientOptions, config);
+        configureProxy(clientOptions, config);
+
+        if (config.isOtelEnabled()) {
+            clientOptions.enableOpenTelemetry();
+        }
+
+        return clientOptions;
+    }
+
+    private static RegistryClientOptions createClientOptions(String baseUrl, HttpAdapterType httpAdapterType, Vertx vertx) {
+        if (httpAdapterType == HttpAdapterType.JDK) {
+            return RegistryClientOptions.create(baseUrl).httpAdapter(HttpAdapterType.JDK);
+        } else if (httpAdapterType == HttpAdapterType.VERTX) {
+            return RegistryClientOptions.create(baseUrl, vertx).httpAdapter(HttpAdapterType.VERTX);
+        } else {
+            return RegistryClientOptions.create(baseUrl, vertx);
+        }
+    }
+
+    private static void configureAuthentication(RegistryClientOptions clientOptions, SchemaResolverConfig config) {
         final String tokenEndpoint = config.getTokenEndpoint();
         final String username = config.getAuthUsername();
-        final String httpAdapterStr = config.getHttpAdapter();
-
-        // Determine which HTTP adapter to use
-        HttpAdapterType httpAdapterType = parseHttpAdapterType(httpAdapterStr);
-        RegistryClientOptions clientOptions;
-
-        if (httpAdapterType == HttpAdapterType.JDK) {
-            // Use JDK adapter - don't pass Vertx instance
-            clientOptions = RegistryClientOptions.create(baseUrl)
-                    .httpAdapter(HttpAdapterType.JDK);
-        } else if (httpAdapterType == HttpAdapterType.VERTX) {
-            // Use Vert.x adapter explicitly
-            clientOptions = RegistryClientOptions.create(baseUrl, vertx)
-                    .httpAdapter(HttpAdapterType.VERTX);
-        } else {
-            // AUTO - use Vert.x if available (pass vertx instance for backward compatibility)
-            clientOptions = RegistryClientOptions.create(baseUrl, vertx);
-        }
         try {
             if (tokenEndpoint != null) {
                 final String clientId = config.getAuthClientId();
@@ -100,57 +122,192 @@ public class RegistryClientFacadeFactory {
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
+    }
 
-        // FIXME push retry options into the SchemaResolverConfig
-        if (Boolean.TRUE) {
-            clientOptions.retry();
-        }
-
-        // Configure TLS/SSL
-        String truststoreLocation = config.getTlsTruststoreLocation();
-        String truststorePassword = config.getTlsTruststorePassword();
-        String truststoreType = config.getTlsTruststoreType();
-        String certificates = config.getTlsCertificates();
-        boolean trustAll = config.getTlsTrustAll();
-        boolean verifyHost = config.getTlsVerifyHost();
-
-        if (trustAll) {
-            clientOptions.trustAll(true);
-        } else if (truststoreLocation != null) {
-            if ("JKS".equalsIgnoreCase(truststoreType)) {
-                clientOptions.trustStoreJks(truststoreLocation, truststorePassword);
-            } else if ("PKCS12".equalsIgnoreCase(truststoreType) || "P12".equalsIgnoreCase(truststoreType)) {
-                clientOptions.trustStorePkcs12(truststoreLocation, truststorePassword);
-            } else if ("PEM".equalsIgnoreCase(truststoreType)) {
-                clientOptions.trustStorePem(truststoreLocation);
-            }
-        } else if (certificates != null) {
-            // Detect if certificates contains PEM content or file paths
-            if (certificates.contains("-----BEGIN CERTIFICATE-----")) {
-                // It's PEM certificate content - pass as string
-                clientOptions.trustStorePemContent(certificates);
-            } else {
-                // It's a comma-separated list of PEM certificate file paths
-                String[] certPaths = certificates.split(",");
-                for (int i = 0; i < certPaths.length; i++) {
-                    certPaths[i] = certPaths[i].trim();
-                }
-                clientOptions.trustStorePem(certPaths);
-            }
-        }
-
-        if (!verifyHost) {
+    private static void configureTrustStore(RegistryClientOptions clientOptions, SchemaResolverConfig config) {
+        if (!config.getTlsVerifyHost()) {
             clientOptions.verifyHost(false);
         }
 
-        // Configure proxy
+        boolean trustAll = config.getTlsTrustAll();
+        if (trustAll) {
+            clientOptions.trustAll(true);
+            return;
+        }
+
+        String truststoreLocation = config.getTlsTruststoreLocation();
+        if (truststoreLocation != null) {
+            configureTrustStoreFile(clientOptions, truststoreLocation, config.getTlsTruststorePassword(), config.getTlsTruststoreType());
+        } else {
+            String certificates = config.getTlsCertificates();
+            if (certificates != null) {
+                configureTrustStoreCertificates(clientOptions, certificates);
+            }
+        }
+    }
+
+    private static void configureTrustStoreFile(RegistryClientOptions clientOptions, String location, String password, String type) {
+        String resolvedLocation = resolveClasspathResourceToTempFile(location);
+        if ("JKS".equalsIgnoreCase(type)) {
+            clientOptions.trustStoreJks(resolvedLocation, password);
+        } else if ("PKCS12".equalsIgnoreCase(type) || "P12".equalsIgnoreCase(type)) {
+            clientOptions.trustStorePkcs12(resolvedLocation, password);
+        } else if ("PEM".equalsIgnoreCase(type)) {
+            clientOptions.trustStorePem(resolvedLocation);
+        } else {
+            throw new IllegalArgumentException("Unsupported TLS truststore type: " + type + ". Supported types are: JKS, PKCS12, PEM");
+        }
+    }
+
+    private static void configureTrustStoreCertificates(RegistryClientOptions clientOptions, String certificates) {
+        if (certificates.contains("-----BEGIN CERTIFICATE-----")) {
+            clientOptions.trustStorePemContent(certificates);
+        } else {
+            String[] certPaths = certificates.split(",");
+            for (int i = 0; i < certPaths.length; i++) {
+                certPaths[i] = certPaths[i].trim();
+                if (!isFilePath(certPaths[i])) {
+                    throw new IllegalArgumentException("Invalid truststore certificate path: " + certPaths[i] + ". File does not exist.");
+                }
+                certPaths[i] = resolveClasspathResourceToTempFile(certPaths[i]);
+            }
+            clientOptions.trustStorePem(certPaths);
+        }
+    }
+
+    private static void configureKeyStore(RegistryClientOptions clientOptions, SchemaResolverConfig config) {
+        String keystoreLocation = config.getTlsKeystoreLocation();
+        String clientCert = config.getTlsClientCertificate();
+        String clientKey = config.getTlsClientKey();
+
+        if (keystoreLocation != null) {
+            configureKeyStoreFile(clientOptions, keystoreLocation, config.getTlsKeystorePassword(), config.getTlsKeystoreType(), clientKey);
+        } else if (clientCert != null && clientKey != null) {
+            configureKeyStorePem(clientOptions, clientCert, clientKey);
+        }
+    }
+
+    private static void configureKeyStoreFile(RegistryClientOptions clientOptions, String location, String password, String type, String clientKey) {
+        String resolvedLocation = resolveClasspathResourceToTempFile(location);
+        if ("JKS".equalsIgnoreCase(type)) {
+            clientOptions.keystoreJks(resolvedLocation, password);
+        } else if ("PKCS12".equalsIgnoreCase(type) || "P12".equalsIgnoreCase(type)) {
+            clientOptions.keystorePkcs12(resolvedLocation, password);
+        } else if ("PEM".equalsIgnoreCase(type)) {
+            String resolvedClientKey = resolveClasspathResourceToTempFile(clientKey);
+            if (resolvedClientKey == null) {
+                throw new IllegalArgumentException("TLS client key is required when TLS keystore type is PEM");
+            }
+            clientOptions.keystorePem(resolvedLocation, resolvedClientKey);
+        } else {
+            throw new IllegalArgumentException("Unsupported TLS keystore type: " + type + ". Supported types are: JKS, PKCS12, PEM");
+        }
+    }
+
+    private static void configureKeyStorePem(RegistryClientOptions clientOptions, String clientCert, String clientKey) {
+        boolean isCertPath = isFilePath(clientCert);
+        boolean isKeyPath = isFilePath(clientKey);
+
+        boolean isCertContent = !isCertPath && clientCert.contains("-----BEGIN CERTIFICATE-----");
+        boolean isKeyContent = !isKeyPath && isPemKeyContent(clientKey);
+
+        validatePemConfig(isCertPath, isCertContent, "certificate");
+        validatePemConfig(isKeyPath, isKeyContent, "key");
+
+        if (isCertContent && isKeyContent) {
+            clientOptions.keystorePemContent(clientCert, clientKey);
+        } else if (isCertPath && isKeyPath) {
+            String resolvedCert = resolveClasspathResourceToTempFile(clientCert);
+            String resolvedKey = resolveClasspathResourceToTempFile(clientKey);
+            clientOptions.keystorePem(resolvedCert, resolvedKey);
+        } else {
+            String certContent = isCertContent ? clientCert : readPemFile(clientCert);
+            String keyContent = isKeyContent ? clientKey : readPemFile(clientKey);
+            clientOptions.keystorePemContent(certContent, keyContent);
+        }
+    }
+
+    private static String resolveClasspathResourceToTempFile(String pathStr) {
+        if (pathStr == null || pathStr.isBlank()) {
+            return pathStr;
+        }
+        checkPathTraversal(pathStr);
+        if (pathStr.startsWith(CLASSPATH_PREFIX)) {
+            String resourcePath = pathStr.substring(CLASSPATH_PREFIX.length());
+            try (var is = RegistryClientFacadeFactory.class.getClassLoader().getResourceAsStream(resourcePath)) {
+                if (is == null) {
+                    throw new IllegalArgumentException("Classpath resource not found: " + resourcePath);
+                }
+                String prefix = "apicurio-tls-";
+                String suffix = ".tmp";
+                int lastDot = resourcePath.lastIndexOf('.');
+                if (lastDot != -1) {
+                    suffix = resourcePath.substring(lastDot);
+                }
+                Path parentDir = createSecureTempDirectory();
+                Path tempFile = Files.createTempFile(parentDir, prefix, suffix);
+                if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+                    Files.setPosixFilePermissions(tempFile, PosixFilePermissions.fromString("rw-------"));
+                }
+                // NOTE: deleteOnExit() registers the file with a JVM shutdown hook.
+                // In long-running applications (e.g., Kafka consumers), this may cause a memory leak
+                // and the file will only be deleted upon a clean JVM shutdown.
+                tempFile.toFile().deleteOnExit();
+                try (var os = Files.newOutputStream(tempFile)) {
+                    is.transferTo(os);
+                }
+                return tempFile.toAbsolutePath().toString();
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Failed to load classpath resource: " + pathStr, e);
+            }
+        }
+        return pathStr;
+    }
+
+    private static Path createSecureTempDirectory() throws IOException {
+        Path parentDir;
+        String userHome = System.getProperty("user.home");
+        if (userHome != null && !userHome.isBlank()) {
+            parentDir = Paths.get(userHome).resolve(".apicurio-tls");
+        } else {
+            parentDir = Paths.get(".").resolve(".apicurio-tls");
+        }
+        Files.createDirectories(parentDir);
+        setDirectoryPermissions(parentDir);
+        return parentDir;
+    }
+
+    private static void setDirectoryPermissions(Path parentDir) throws IOException {
+        if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            Files.setPosixFilePermissions(parentDir, PosixFilePermissions.fromString("rwx------"));
+        } else {
+            File dirFile = parentDir.toFile();
+            boolean readable = dirFile.setReadable(true, true);
+            boolean writable = dirFile.setWritable(true, true);
+            boolean executable = dirFile.setExecutable(true, true);
+            if (!readable || !writable || !executable) {
+                throw new IOException("Failed to set secure permissions on temp directory: " + parentDir);
+            }
+        }
+    }
+
+    private static boolean isPemKeyContent(String clientKey) {
+        return clientKey.contains("-----BEGIN ") && clientKey.contains(" PRIVATE KEY-----");
+    }
+
+    private static void validatePemConfig(boolean isPath, boolean isContent, String name) {
+        if (!isPath && !isContent) {
+            throw new IllegalArgumentException("Invalid client " + name + " configuration: value is not an existing file path and does not contain PEM " + name + " header");
+        }
+    }
+
+    private static void configureProxy(RegistryClientOptions clientOptions, SchemaResolverConfig config) {
         String proxyHost = config.getProxyHost();
         Integer proxyPort = config.getProxyPort();
 
         if (proxyHost != null && proxyPort != null) {
             clientOptions.proxy(proxyHost, proxyPort);
 
-            // Configure proxy authentication if credentials are provided
             String proxyUsername = config.getProxyUsername();
             String proxyPassword = config.getProxyPassword();
 
@@ -158,13 +315,6 @@ public class RegistryClientFacadeFactory {
                 clientOptions.proxyAuth(proxyUsername, proxyPassword);
             }
         }
-
-        // Configure OpenTelemetry trace context propagation
-        if (config.isOtelEnabled()) {
-            clientOptions.enableOpenTelemetry();
-        }
-
-        return clientOptions;
     }
 
     private static RegistryClientFacade create_v3(SchemaResolverConfig config, Vertx vertx) {
@@ -192,6 +342,67 @@ public class RegistryClientFacadeFactory {
             case "AUTO":
             default:
                 return HttpAdapterType.AUTO;
+        }
+    }
+
+    private static void checkPathTraversal(String pathStr) {
+        String cleanPath = pathStr.startsWith(CLASSPATH_PREFIX) ? pathStr.substring(CLASSPATH_PREFIX.length()) : pathStr;
+        Path path = Paths.get(cleanPath);
+        for (Path element : path) {
+            if ("..".equals(element.toString())) {
+                throw new IllegalArgumentException("Path traversal detected: " + pathStr);
+            }
+        }
+    }
+
+    private static boolean isFilePath(String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+        checkPathTraversal(value);
+        if (value.startsWith(CLASSPATH_PREFIX)) {
+            String resourcePath = value.substring(CLASSPATH_PREFIX.length());
+            try {
+                return RegistryClientFacadeFactory.class.getClassLoader().getResource(resourcePath) != null;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        try {
+            Path path = Paths.get(value).normalize();
+            return Files.exists(path) && Files.isRegularFile(path);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static String readPemFile(String pathStr) {
+        if (pathStr == null || pathStr.isBlank()) {
+            throw new IllegalArgumentException("PEM file path cannot be empty");
+        }
+        checkPathTraversal(pathStr);
+        try {
+            String content;
+            if (pathStr.startsWith(CLASSPATH_PREFIX)) {
+                String resourcePath = pathStr.substring(CLASSPATH_PREFIX.length());
+                try (var is = RegistryClientFacadeFactory.class.getClassLoader().getResourceAsStream(resourcePath)) {
+                    if (is == null) {
+                        throw new IllegalArgumentException("Classpath resource not found: " + resourcePath);
+                    }
+                    content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                }
+            } else {
+                content = Files.readString(Paths.get(pathStr).normalize(), StandardCharsets.UTF_8);
+            }
+
+            if (content.trim().isEmpty()) {
+                throw new IllegalArgumentException("PEM content is empty for path: " + pathStr);
+            }
+            return content;
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to read PEM file from path: " + pathStr, e);
         }
     }
 }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -7,6 +7,15 @@ import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.resolver.config.SchemaResolverConfig;
 import io.vertx.core.Vertx;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 /**
@@ -19,6 +28,7 @@ import java.util.logging.Logger;
 public class RegistryClientFacadeFactory {
 
     private static final Logger logger = Logger.getLogger(RegistryClientFacadeFactory.class.getSimpleName());
+    private static final String CLASSPATH_PREFIX = "classpath:";
 
     public static RegistryClientFacade create(SchemaResolverConfig config) {
         String baseUrl = config.getRegistryUrl();
@@ -35,9 +45,9 @@ public class RegistryClientFacadeFactory {
         }
         if (endpointVersion == null || endpointVersion.isEmpty()) {
             endpointVersion = baseUrl.contains("/apis/registry/v2") ? "2" : "3";
-        } else if (endpointVersion.startsWith("2") || endpointVersion.toLowerCase().startsWith("v2")) {
+        } else if (endpointVersion.startsWith("2") || endpointVersion.toLowerCase(Locale.ROOT).startsWith("v2")) {
             endpointVersion = "2";
-        } else if (endpointVersion.startsWith("3") || endpointVersion.toLowerCase().startsWith("v3")) {
+        } else if (endpointVersion.startsWith("3") || endpointVersion.toLowerCase(Locale.ROOT).startsWith("v3")) {
             endpointVersion = "3";
         }
 
@@ -50,28 +60,41 @@ public class RegistryClientFacadeFactory {
         }
     }
 
-    private static RegistryClientOptions buildClientOptions(SchemaResolverConfig config, Vertx vertx) {
+    static RegistryClientOptions buildClientOptions(SchemaResolverConfig config, Vertx vertx) {
         final String baseUrl = config.getRegistryUrl();
+        final String httpAdapterStr = config.getHttpAdapter();
+        HttpAdapterType httpAdapterType = parseHttpAdapterType(httpAdapterStr);
+
+        RegistryClientOptions clientOptions = createClientOptions(baseUrl, httpAdapterType, vertx);
+
+        configureAuthentication(clientOptions, config);
+
+        clientOptions.retry();
+
+        configureTrustStore(clientOptions, config);
+        configureKeyStore(clientOptions, config);
+        configureProxy(clientOptions, config);
+
+        if (config.isOtelEnabled()) {
+            clientOptions.enableOpenTelemetry();
+        }
+
+        return clientOptions;
+    }
+
+    private static RegistryClientOptions createClientOptions(String baseUrl, HttpAdapterType httpAdapterType, Vertx vertx) {
+        if (httpAdapterType == HttpAdapterType.JDK) {
+            return RegistryClientOptions.create(baseUrl).httpAdapter(HttpAdapterType.JDK);
+        } else if (httpAdapterType == HttpAdapterType.VERTX) {
+            return RegistryClientOptions.create(baseUrl, vertx).httpAdapter(HttpAdapterType.VERTX);
+        } else {
+            return RegistryClientOptions.create(baseUrl, vertx);
+        }
+    }
+
+    private static void configureAuthentication(RegistryClientOptions clientOptions, SchemaResolverConfig config) {
         final String tokenEndpoint = config.getTokenEndpoint();
         final String username = config.getAuthUsername();
-        final String httpAdapterStr = config.getHttpAdapter();
-
-        // Determine which HTTP adapter to use
-        HttpAdapterType httpAdapterType = parseHttpAdapterType(httpAdapterStr);
-        RegistryClientOptions clientOptions;
-
-        if (httpAdapterType == HttpAdapterType.JDK) {
-            // Use JDK adapter - don't pass Vertx instance
-            clientOptions = RegistryClientOptions.create(baseUrl)
-                    .httpAdapter(HttpAdapterType.JDK);
-        } else if (httpAdapterType == HttpAdapterType.VERTX) {
-            // Use Vert.x adapter explicitly
-            clientOptions = RegistryClientOptions.create(baseUrl, vertx)
-                    .httpAdapter(HttpAdapterType.VERTX);
-        } else {
-            // AUTO - use Vert.x if available (pass vertx instance for backward compatibility)
-            clientOptions = RegistryClientOptions.create(baseUrl, vertx);
-        }
         try {
             if (tokenEndpoint != null) {
                 final String clientId = config.getAuthClientId();
@@ -102,57 +125,200 @@ public class RegistryClientFacadeFactory {
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
+    }
 
-        // FIXME push retry options into the SchemaResolverConfig
-        if (Boolean.TRUE) {
-            clientOptions.retry();
-        }
-
-        // Configure TLS/SSL
-        String truststoreLocation = config.getTlsTruststoreLocation();
-        String truststorePassword = config.getTlsTruststorePassword();
-        String truststoreType = config.getTlsTruststoreType();
-        String certificates = config.getTlsCertificates();
-        boolean trustAll = config.getTlsTrustAll();
-        boolean verifyHost = config.getTlsVerifyHost();
-
-        if (trustAll) {
-            clientOptions.trustAll(true);
-        } else if (truststoreLocation != null) {
-            if ("JKS".equalsIgnoreCase(truststoreType)) {
-                clientOptions.trustStoreJks(truststoreLocation, truststorePassword);
-            } else if ("PKCS12".equalsIgnoreCase(truststoreType) || "P12".equalsIgnoreCase(truststoreType)) {
-                clientOptions.trustStorePkcs12(truststoreLocation, truststorePassword);
-            } else if ("PEM".equalsIgnoreCase(truststoreType)) {
-                clientOptions.trustStorePem(truststoreLocation);
-            }
-        } else if (certificates != null) {
-            // Detect if certificates contains PEM content or file paths
-            if (certificates.contains("-----BEGIN CERTIFICATE-----")) {
-                // It's PEM certificate content - pass as string
-                clientOptions.trustStorePemContent(certificates);
-            } else {
-                // It's a comma-separated list of PEM certificate file paths
-                String[] certPaths = certificates.split(",");
-                for (int i = 0; i < certPaths.length; i++) {
-                    certPaths[i] = certPaths[i].trim();
-                }
-                clientOptions.trustStorePem(certPaths);
-            }
-        }
-
-        if (!verifyHost) {
+    private static void configureTrustStore(RegistryClientOptions clientOptions, SchemaResolverConfig config) {
+        if (!config.getTlsVerifyHost()) {
             clientOptions.verifyHost(false);
         }
 
-        // Configure proxy
+        boolean trustAll = config.getTlsTrustAll();
+        if (trustAll) {
+            clientOptions.trustAll(true);
+            return;
+        }
+
+        String truststoreLocation = config.getTlsTruststoreLocation();
+        if (truststoreLocation != null) {
+            configureTrustStoreFile(clientOptions, truststoreLocation, config.getTlsTruststorePassword(), config.getTlsTruststoreType());
+        } else {
+            String certificates = config.getTlsCertificates();
+            if (certificates != null) {
+                configureTrustStoreCertificates(clientOptions, certificates);
+            }
+        }
+    }
+
+    private static void configureTrustStoreFile(RegistryClientOptions clientOptions, String location, String password, String type) {
+        String resolvedLocation = resolveClasspathResourceToTempFile(location);
+        if ("JKS".equalsIgnoreCase(type)) {
+            clientOptions.trustStoreJks(resolvedLocation, password);
+        } else if ("PKCS12".equalsIgnoreCase(type) || "P12".equalsIgnoreCase(type)) {
+            clientOptions.trustStorePkcs12(resolvedLocation, password);
+        } else if ("PEM".equalsIgnoreCase(type)) {
+            clientOptions.trustStorePem(resolvedLocation);
+        } else {
+            throw new IllegalArgumentException("Unsupported TLS truststore type: " + type + ". Supported types are: JKS, PKCS12, PEM");
+        }
+    }
+
+    private static void configureTrustStoreCertificates(RegistryClientOptions clientOptions, String certificates) {
+        if (certificates.contains("-----BEGIN CERTIFICATE-----")) {
+            clientOptions.trustStorePemContent(certificates);
+        } else {
+            String[] certPaths = certificates.split(",");
+            for (int i = 0; i < certPaths.length; i++) {
+                certPaths[i] = certPaths[i].trim();
+                if (!isFilePath(certPaths[i])) {
+                    throw new IllegalArgumentException("Invalid truststore certificate path: " + certPaths[i] + ". File does not exist.");
+                }
+                certPaths[i] = resolveClasspathResourceToTempFile(certPaths[i]);
+            }
+            clientOptions.trustStorePem(certPaths);
+        }
+    }
+
+    private static void configureKeyStore(RegistryClientOptions clientOptions, SchemaResolverConfig config) {
+        String keystoreLocation = config.getTlsKeystoreLocation();
+        String clientCert = config.getTlsClientCertificate();
+        String clientKey = config.getTlsClientKey();
+
+        if (keystoreLocation != null) {
+            configureKeyStoreFile(clientOptions, keystoreLocation, config.getTlsKeystorePassword(), config.getTlsKeystoreType(), clientKey);
+        } else if (clientCert != null && clientKey != null) {
+            configureKeyStorePem(clientOptions, clientCert, clientKey);
+        } else if (clientCert != null) {
+            throw new IllegalArgumentException(
+                    "TLS client key (" + SchemaResolverConfig.TLS_CLIENT_KEY + ") is required when TLS client certificate ("
+                            + SchemaResolverConfig.TLS_CLIENT_CERTIFICATE + ") is configured");
+        } else if (clientKey != null) {
+            throw new IllegalArgumentException(
+                    "TLS client certificate (" + SchemaResolverConfig.TLS_CLIENT_CERTIFICATE + ") is required when TLS client key ("
+                            + SchemaResolverConfig.TLS_CLIENT_KEY + ") is configured");
+        }
+    }
+
+    private static void configureKeyStoreFile(RegistryClientOptions clientOptions, String location, String password, String type, String clientKey) {
+        String resolvedLocation = resolveClasspathResourceToTempFile(location);
+        if ("JKS".equalsIgnoreCase(type)) {
+            clientOptions.keystoreJks(resolvedLocation, password);
+        } else if ("PKCS12".equalsIgnoreCase(type) || "P12".equalsIgnoreCase(type)) {
+            clientOptions.keystorePkcs12(resolvedLocation, password);
+        } else if ("PEM".equalsIgnoreCase(type)) {
+            String resolvedClientKey = resolveClasspathResourceToTempFile(clientKey);
+            if (resolvedClientKey == null) {
+                throw new IllegalArgumentException("TLS client key is required when TLS keystore type is PEM");
+            }
+            clientOptions.keystorePem(resolvedLocation, resolvedClientKey);
+        } else {
+            throw new IllegalArgumentException("Unsupported TLS keystore type: " + type + ". Supported types are: JKS, PKCS12, PEM");
+        }
+    }
+
+    private static void configureKeyStorePem(RegistryClientOptions clientOptions, String clientCert, String clientKey) {
+        boolean isCertPath = isFilePath(clientCert);
+        boolean isKeyPath = isFilePath(clientKey);
+
+        boolean isCertContent = !isCertPath && clientCert.contains("-----BEGIN CERTIFICATE-----");
+        boolean isKeyContent = !isKeyPath && isPemKeyContent(clientKey);
+
+        validatePemConfig(isCertPath, isCertContent, "certificate");
+        validatePemConfig(isKeyPath, isKeyContent, "key");
+
+        if (isCertContent && isKeyContent) {
+            clientOptions.keystorePemContent(clientCert, clientKey);
+        } else if (isCertPath && isKeyPath) {
+            String resolvedCert = resolveClasspathResourceToTempFile(clientCert);
+            String resolvedKey = resolveClasspathResourceToTempFile(clientKey);
+            clientOptions.keystorePem(resolvedCert, resolvedKey);
+        } else {
+            String certContent = isCertContent ? clientCert : readPemFile(clientCert);
+            String keyContent = isKeyContent ? clientKey : readPemFile(clientKey);
+            clientOptions.keystorePemContent(certContent, keyContent);
+        }
+    }
+
+    private static String resolveClasspathResourceToTempFile(String pathStr) {
+        if (pathStr == null || pathStr.isBlank()) {
+            return pathStr;
+        }
+        checkPathTraversal(pathStr);
+        if (pathStr.startsWith(CLASSPATH_PREFIX)) {
+            String resourcePath = pathStr.substring(CLASSPATH_PREFIX.length());
+            try (var is = RegistryClientFacadeFactory.class.getClassLoader().getResourceAsStream(resourcePath)) {
+                if (is == null) {
+                    throw new IllegalArgumentException("Classpath resource not found: " + resourcePath);
+                }
+                String prefix = "apicurio-tls-";
+                String suffix = ".tmp";
+                int lastDot = resourcePath.lastIndexOf('.');
+                if (lastDot != -1) {
+                    suffix = resourcePath.substring(lastDot);
+                }
+                Path parentDir = createSecureTempDirectory();
+                Path tempFile = Files.createTempFile(parentDir, prefix, suffix);
+                if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+                    Files.setPosixFilePermissions(tempFile, PosixFilePermissions.fromString("rw-------"));
+                }
+                // NOTE: deleteOnExit() registers the file with a JVM shutdown hook.
+                // In long-running applications (e.g., Kafka consumers), this may cause a memory leak
+                // and the file will only be deleted upon a clean JVM shutdown.
+                tempFile.toFile().deleteOnExit();
+                try (var os = Files.newOutputStream(tempFile)) {
+                    is.transferTo(os);
+                }
+                return tempFile.toAbsolutePath().toString();
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Failed to load classpath resource: " + pathStr, e);
+            }
+        }
+        return pathStr;
+    }
+
+    private static Path createSecureTempDirectory() throws IOException {
+        Path parentDir;
+        String userHome = System.getProperty("user.home");
+        if (userHome != null && !userHome.isBlank()) {
+            parentDir = Paths.get(userHome).resolve(".apicurio-tls");
+        } else {
+            parentDir = Paths.get(".").resolve(".apicurio-tls");
+        }
+        Files.createDirectories(parentDir);
+        setDirectoryPermissions(parentDir);
+        return parentDir;
+    }
+
+    private static void setDirectoryPermissions(Path parentDir) throws IOException {
+        if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            Files.setPosixFilePermissions(parentDir, PosixFilePermissions.fromString("rwx------"));
+        } else {
+            File dirFile = parentDir.toFile();
+            boolean readable = dirFile.setReadable(true, true);
+            boolean writable = dirFile.setWritable(true, true);
+            boolean executable = dirFile.setExecutable(true, true);
+            if (!readable || !writable || !executable) {
+                throw new IOException("Failed to set secure permissions on temp directory: " + parentDir);
+            }
+        }
+    }
+
+    private static boolean isPemKeyContent(String clientKey) {
+        return clientKey.contains("-----BEGIN ") && clientKey.contains(" PRIVATE KEY-----");
+    }
+
+    private static void validatePemConfig(boolean isPath, boolean isContent, String name) {
+        if (!isPath && !isContent) {
+            throw new IllegalArgumentException("Invalid client " + name + " configuration: value is not an existing file path and does not contain PEM " + name + " header");
+        }
+    }
+
+    private static void configureProxy(RegistryClientOptions clientOptions, SchemaResolverConfig config) {
         String proxyHost = config.getProxyHost();
         Integer proxyPort = config.getProxyPort();
 
         if (proxyHost != null && proxyPort != null) {
             clientOptions.proxy(proxyHost, proxyPort);
 
-            // Configure proxy authentication if credentials are provided
             String proxyUsername = config.getProxyUsername();
             String proxyPassword = config.getProxyPassword();
 
@@ -160,13 +326,6 @@ public class RegistryClientFacadeFactory {
                 clientOptions.proxyAuth(proxyUsername, proxyPassword);
             }
         }
-
-        // Configure OpenTelemetry trace context propagation
-        if (config.isOtelEnabled()) {
-            clientOptions.enableOpenTelemetry();
-        }
-
-        return clientOptions;
     }
 
     private static RegistryClientFacade create_v3(SchemaResolverConfig config, Vertx vertx) {
@@ -186,7 +345,7 @@ public class RegistryClientFacadeFactory {
         if (httpAdapterStr == null) {
             return HttpAdapterType.AUTO;
         }
-        switch (httpAdapterStr.toUpperCase()) {
+        switch (httpAdapterStr.toUpperCase(Locale.ROOT)) {
             case "JDK":
                 return HttpAdapterType.JDK;
             case "VERTX":
@@ -194,6 +353,67 @@ public class RegistryClientFacadeFactory {
             case "AUTO":
             default:
                 return HttpAdapterType.AUTO;
+        }
+    }
+
+    private static void checkPathTraversal(String pathStr) {
+        String cleanPath = pathStr.startsWith(CLASSPATH_PREFIX) ? pathStr.substring(CLASSPATH_PREFIX.length()) : pathStr;
+        Path path = Paths.get(cleanPath);
+        for (Path element : path) {
+            if ("..".equals(element.toString())) {
+                throw new IllegalArgumentException("Path traversal detected: " + pathStr);
+            }
+        }
+    }
+
+    private static boolean isFilePath(String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+        checkPathTraversal(value);
+        if (value.startsWith(CLASSPATH_PREFIX)) {
+            String resourcePath = value.substring(CLASSPATH_PREFIX.length());
+            try {
+                return RegistryClientFacadeFactory.class.getClassLoader().getResource(resourcePath) != null;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        try {
+            Path path = Paths.get(value).normalize();
+            return Files.exists(path) && Files.isRegularFile(path);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static String readPemFile(String pathStr) {
+        if (pathStr == null || pathStr.isBlank()) {
+            throw new IllegalArgumentException("PEM file path cannot be empty");
+        }
+        checkPathTraversal(pathStr);
+        try {
+            String content;
+            if (pathStr.startsWith(CLASSPATH_PREFIX)) {
+                String resourcePath = pathStr.substring(CLASSPATH_PREFIX.length());
+                try (var is = RegistryClientFacadeFactory.class.getClassLoader().getResourceAsStream(resourcePath)) {
+                    if (is == null) {
+                        throw new IllegalArgumentException("Classpath resource not found: " + resourcePath);
+                    }
+                    content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                }
+            } else {
+                content = Files.readString(Paths.get(pathStr).normalize(), StandardCharsets.UTF_8);
+            }
+
+            if (content.trim().isEmpty()) {
+                throw new IllegalArgumentException("PEM content is empty for path: " + pathStr);
+            }
+            return content;
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to read PEM file from path: " + pathStr, e);
         }
     }
 }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -257,6 +257,47 @@ public class SchemaResolverConfig extends AbstractConfig {
     public static final String TLS_CERTIFICATES = "apicurio.registry.tls.certificates";
 
     /**
+     * The location of the key store file for TLS/SSL connections (mTLS). Can be a file path or a resource
+     * on the classpath. Required when connecting to a registry over HTTPS with client certificate authentication.
+     */
+    public static final String TLS_KEYSTORE_LOCATION = "apicurio.registry.tls.keystore.location";
+
+    /**
+     * The password for the key store file specified by {@link #TLS_KEYSTORE_LOCATION}.
+     * Required when using JKS or PKCS12 key stores.
+     * <p>
+     * <b>WARNING:</b> Keystore passwords configured here are stored in memory as part of the
+     * configuration object and registry client options. Ensure proper security controls are in place
+     * to protect configuration data from unauthorized access/memory dumps.
+     */
+    public static final String TLS_KEYSTORE_PASSWORD = "apicurio.registry.tls.keystore.password";
+
+    /**
+     * The type of key store. Valid values are "JKS", "PKCS12" (or "P12"), and "PEM". Defaults to "JKS".
+     */
+    public static final String TLS_KEYSTORE_TYPE = "apicurio.registry.tls.keystore.type";
+    public static final String TLS_KEYSTORE_TYPE_DEFAULT = "JKS";
+
+    /**
+     * PEM client certificate configuration for mutual TLS (mTLS). This property accepts either:
+     * <ul>
+     *   <li>PEM certificate file path (e.g., "/path/to/client-cert.pem")</li>
+     *   <li>PEM certificate content as a string (assuming standard "-----BEGIN CERTIFICATE-----" header)</li>
+     * </ul>
+     * Note: This configuration is ignored if {@link #TLS_KEYSTORE_LOCATION} is also set.
+     */
+    public static final String TLS_CLIENT_CERTIFICATE = "apicurio.registry.tls.client-certificate";
+
+    /**
+     * PEM client private key configuration for mutual TLS (mTLS). This property accepts either:
+     * <ul>
+     *   <li>PEM private key file path (e.g., "/path/to/client-key.pem")</li>
+     *   <li>PEM private key content as a string (with "-----BEGIN PRIVATE KEY-----" markers)</li>
+     * </ul>
+     */
+    public static final String TLS_CLIENT_KEY = "apicurio.registry.tls.client-key";
+
+    /**
      * If true, disables all SSL/TLS certificate verification. This is insecure and should only be used
      * in development/testing environments. Defaults to false.
      */
@@ -474,6 +515,26 @@ public class SchemaResolverConfig extends AbstractConfig {
         return getString(TLS_CERTIFICATES);
     }
 
+    public String getTlsKeystoreLocation() {
+        return getString(TLS_KEYSTORE_LOCATION);
+    }
+
+    public String getTlsKeystorePassword() {
+        return getString(TLS_KEYSTORE_PASSWORD);
+    }
+
+    public String getTlsKeystoreType() {
+        return getString(TLS_KEYSTORE_TYPE);
+    }
+
+    public String getTlsClientCertificate() {
+        return getString(TLS_CLIENT_CERTIFICATE);
+    }
+
+    public String getTlsClientKey() {
+        return getString(TLS_CLIENT_KEY);
+    }
+
     public boolean getTlsTrustAll() {
         return getBooleanOrFalse(TLS_TRUST_ALL);
     }
@@ -571,6 +632,7 @@ public class SchemaResolverConfig extends AbstractConfig {
             entry(RETRY_BACKOFF_MS, RETRY_BACKOFF_MS_DEFAULT),
             entry(DEREFERENCE_SCHEMA, DEREFERENCE_DEFAULT),
             entry(TLS_TRUSTSTORE_TYPE, TLS_TRUSTSTORE_TYPE_DEFAULT),
+            entry(TLS_KEYSTORE_TYPE, TLS_KEYSTORE_TYPE_DEFAULT),
             entry(TLS_TRUST_ALL, TLS_TRUST_ALL_DEFAULT),
             entry(TLS_VERIFY_HOST, TLS_VERIFY_HOST_DEFAULT),
             entry(HTTP_ADAPTER, HTTP_ADAPTER_DEFAULT),

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactoryTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactoryTest.java
@@ -1,0 +1,276 @@
+package io.apicurio.registry.resolver.client;
+
+import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.client.common.RegistryClientOptions.KeyStoreType;
+import io.apicurio.registry.client.common.RegistryClientOptions.TrustStoreType;
+import io.apicurio.registry.resolver.config.SchemaResolverConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+class RegistryClientFacadeFactoryTest {
+
+    @Test
+    void testBuildClientOptionsJks() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, "/path/to/truststore.jks");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "trustpassword");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "JKS");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, "/path/to/keystore.jks");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_PASSWORD, "keypassword");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "JKS");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+        Assertions.assertEquals(TrustStoreType.JKS, options.getTrustStoreType());
+        Assertions.assertEquals("/path/to/truststore.jks", options.getTrustStorePath());
+        Assertions.assertEquals("trustpassword", options.getTrustStorePassword());
+
+        Assertions.assertEquals(KeyStoreType.JKS, options.getKeyStoreType());
+        Assertions.assertEquals("/path/to/keystore.jks", options.getKeyStorePath());
+        Assertions.assertEquals("keypassword", options.getKeyStorePassword());
+    }
+
+    @Test
+    void testBuildClientOptionsPkcs12() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, "/path/to/truststore.p12");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "trustpassword");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PKCS12");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, "/path/to/keystore.p12");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_PASSWORD, "keypassword");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "PKCS12");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+        Assertions.assertEquals(TrustStoreType.PKCS12, options.getTrustStoreType());
+        Assertions.assertEquals("/path/to/truststore.p12", options.getTrustStorePath());
+        Assertions.assertEquals("trustpassword", options.getTrustStorePassword());
+
+        Assertions.assertEquals(KeyStoreType.PKCS12, options.getKeyStoreType());
+        Assertions.assertEquals("/path/to/keystore.p12", options.getKeyStorePath());
+        Assertions.assertEquals("keypassword", options.getKeyStorePassword());
+    }
+
+    @Test
+    void testBuildClientOptionsPemFilePaths() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, "/path/to/truststore.pem");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PEM");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, "/path/to/keystore.pem");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "PEM");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, "/path/to/client.key");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+        Assertions.assertEquals(TrustStoreType.PEM, options.getTrustStoreType());
+        Assertions.assertArrayEquals(new String[]{"/path/to/truststore.pem"}, options.getPemCertPaths());
+
+        Assertions.assertEquals(KeyStoreType.PEM, options.getKeyStoreType());
+        Assertions.assertEquals("/path/to/keystore.pem", options.getPemClientCertPath());
+        Assertions.assertEquals("/path/to/client.key", options.getPemClientKeyPath());
+    }
+
+    @Test
+    void testBuildClientOptionsPemContent() {
+        String certContent = "-----BEGIN CERTIFICATE-----\ncert-body\n-----END CERTIFICATE-----";
+        String keyContent = "-----BEGIN PRIVATE KEY-----\nkey-body\n-----END PRIVATE KEY-----";
+
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, certContent);
+        originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, keyContent);
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+        Assertions.assertEquals(KeyStoreType.PEM, options.getKeyStoreType());
+        Assertions.assertEquals(certContent, options.getPemClientCertContent());
+        Assertions.assertEquals(keyContent, options.getPemClientKeyContent());
+    }
+
+    @Test
+    void testBuildClientOptionsPemMixedCertPathKeyContent() throws IOException {
+        Path tempCertFile = Files.createTempFile("client-cert", ".pem");
+        String certContent = "-----BEGIN CERTIFICATE-----\ninline-cert\n-----END CERTIFICATE-----";
+        Files.writeString(tempCertFile, certContent);
+
+        String keyContent = "-----BEGIN PRIVATE KEY-----\ninline-key\n-----END PRIVATE KEY-----";
+
+        try {
+            Map<String, Object> originals = new HashMap<>();
+            originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+            originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, tempCertFile.toString()); // path
+            originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, keyContent); // inline content
+
+            SchemaResolverConfig config = new SchemaResolverConfig(originals);
+            RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+            Assertions.assertEquals(KeyStoreType.PEM, options.getKeyStoreType());
+            Assertions.assertEquals(certContent, options.getPemClientCertContent());
+            Assertions.assertEquals(keyContent, options.getPemClientKeyContent());
+        } finally {
+            Files.deleteIfExists(tempCertFile);
+        }
+    }
+
+    @Test
+    void testBuildClientOptionsPemMixedCertContentKeyPath() throws IOException {
+        String certContent = "-----BEGIN CERTIFICATE-----\ninline-cert\n-----END CERTIFICATE-----";
+
+        Path tempKeyFile = Files.createTempFile("client-key", ".pem");
+        String keyContent = "-----BEGIN PRIVATE KEY-----\ninline-key\n-----END PRIVATE KEY-----";
+        Files.writeString(tempKeyFile, keyContent);
+
+        try {
+            Map<String, Object> originals = new HashMap<>();
+            originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+            originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, certContent); // inline content
+            originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, tempKeyFile.toString()); // path
+
+            SchemaResolverConfig config = new SchemaResolverConfig(originals);
+            RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+            Assertions.assertEquals(KeyStoreType.PEM, options.getKeyStoreType());
+            Assertions.assertEquals(certContent, options.getPemClientCertContent());
+            Assertions.assertEquals(keyContent, options.getPemClientKeyContent());
+        } finally {
+            Files.deleteIfExists(tempKeyFile);
+        }
+    }
+
+    @Test
+    void testBuildClientOptionsInvalidKeystoreType() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, "/path/to/keystore.jks");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "INVALID_TYPE");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RegistryClientFacadeFactory.buildClientOptions(config, null);
+        });
+    }
+
+    @Test
+    void testBuildClientOptionsInvalidTruststoreType() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, "/path/to/truststore.jks");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "INVALID_TYPE");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RegistryClientFacadeFactory.buildClientOptions(config, null);
+        });
+    }
+
+    @Test
+    void testBuildClientOptionsPemMissingKey() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, "/path/to/keystore.pem");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "PEM");
+        // Missing TLS_CLIENT_KEY
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RegistryClientFacadeFactory.buildClientOptions(config, null);
+        });
+    }
+
+    @Test
+    void testBuildClientOptionsPemMalformedContent() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, "invalid-pem-without-header");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, "-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RegistryClientFacadeFactory.buildClientOptions(config, null);
+        });
+    }
+
+    @Test
+    void testBuildClientOptionsPemFilePermissionError() throws IOException {
+        Path tempCertFile = Files.createTempFile("client-cert", ".pem");
+        String certContent = "-----BEGIN CERTIFICATE-----\ninline-cert\n-----END CERTIFICATE-----";
+        Files.writeString(tempCertFile, certContent);
+
+        // Make the file unreadable to simulate file permission errors
+        tempCertFile.toFile().setReadable(false);
+
+        String keyContent = "-----BEGIN PRIVATE KEY-----\ninline-key\n-----END PRIVATE KEY-----";
+
+        try {
+            Map<String, Object> originals = new HashMap<>();
+            originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+            originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, tempCertFile.toString()); // path (unreadable)
+            originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, keyContent); // inline content
+
+            SchemaResolverConfig config = new SchemaResolverConfig(originals);
+            Assertions.assertThrows(IllegalArgumentException.class, () -> {
+                RegistryClientFacadeFactory.buildClientOptions(config, null);
+            });
+        } finally {
+            tempCertFile.toFile().setReadable(true);
+            Files.deleteIfExists(tempCertFile);
+        }
+    }
+
+    @Test
+    void testBuildClientOptionsPemPathTraversalError() throws IOException {
+        Path tempDir = Files.createTempDirectory("traversal-test");
+        Path tempFile = Files.createTempFile(tempDir, "client-cert", ".pem");
+        Files.writeString(tempFile, "-----BEGIN CERTIFICATE-----\ninline-cert\n-----END CERTIFICATE-----");
+
+        // Construct a path that contains '..' but resolves to the existing file
+        String traversalPath = tempDir.resolve("nonexistent-subdir").resolve("..").resolve(tempFile.getFileName()).toString();
+
+        String keyContent = "-----BEGIN PRIVATE KEY-----\ninline-key\n-----END PRIVATE KEY-----";
+        try {
+            Map<String, Object> originals = new HashMap<>();
+            originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+            originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, traversalPath);
+            originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, keyContent);
+
+            SchemaResolverConfig config = new SchemaResolverConfig(originals);
+            IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+                RegistryClientFacadeFactory.buildClientOptions(config, null);
+            });
+            Assertions.assertTrue(ex.getMessage().contains("Path traversal detected"), "Expected path traversal exception, but got: " + ex.getMessage());
+        } finally {
+            Files.deleteIfExists(tempFile);
+            Files.deleteIfExists(tempDir);
+        }
+    }
+
+    @Test
+    void testBuildClientOptionsClasspathResolution() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, "classpath:io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.class");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "JKS");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "password");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+        String path = options.getTrustStorePath();
+        Assertions.assertNotNull(path);
+        Assertions.assertTrue(Files.exists(Path.of(path)));
+        Assertions.assertTrue(path.contains("apicurio-tls-"));
+    }
+}

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactoryTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactoryTest.java
@@ -16,11 +16,18 @@
 
 package io.apicurio.registry.resolver.client;
 
+import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.client.common.RegistryClientOptions.KeyStoreType;
+import io.apicurio.registry.client.common.RegistryClientOptions.TrustStoreType;
 import io.apicurio.registry.resolver.config.SchemaResolverConfig;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -97,5 +104,292 @@ class RegistryClientFacadeFactoryTest {
 
         RegistryClientFacade facade = RegistryClientFacadeFactory.create(new SchemaResolverConfig(props));
         assertInstanceOf(RegistryClientFacadeImpl.class, facade);
+    }
+
+    @Test
+    void testBuildClientOptionsJks() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, "/path/to/truststore.jks");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "trustpassword");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "JKS");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, "/path/to/keystore.jks");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_PASSWORD, "keypassword");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "JKS");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+        Assertions.assertEquals(TrustStoreType.JKS, options.getTrustStoreType());
+        Assertions.assertEquals("/path/to/truststore.jks", options.getTrustStorePath());
+        Assertions.assertEquals("trustpassword", options.getTrustStorePassword());
+
+        Assertions.assertEquals(KeyStoreType.JKS, options.getKeyStoreType());
+        Assertions.assertEquals("/path/to/keystore.jks", options.getKeyStorePath());
+        Assertions.assertEquals("keypassword", options.getKeyStorePassword());
+    }
+
+    @Test
+    void testBuildClientOptionsPkcs12() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, "/path/to/truststore.p12");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "trustpassword");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PKCS12");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, "/path/to/keystore.p12");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_PASSWORD, "keypassword");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "PKCS12");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+        Assertions.assertEquals(TrustStoreType.PKCS12, options.getTrustStoreType());
+        Assertions.assertEquals("/path/to/truststore.p12", options.getTrustStorePath());
+        Assertions.assertEquals("trustpassword", options.getTrustStorePassword());
+
+        Assertions.assertEquals(KeyStoreType.PKCS12, options.getKeyStoreType());
+        Assertions.assertEquals("/path/to/keystore.p12", options.getKeyStorePath());
+        Assertions.assertEquals("keypassword", options.getKeyStorePassword());
+    }
+
+    @Test
+    void testBuildClientOptionsPemFilePaths() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, "/path/to/truststore.pem");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "PEM");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, "/path/to/keystore.pem");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "PEM");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, "/path/to/client.key");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+        Assertions.assertEquals(TrustStoreType.PEM, options.getTrustStoreType());
+        Assertions.assertArrayEquals(new String[]{"/path/to/truststore.pem"}, options.getPemCertPaths());
+
+        Assertions.assertEquals(KeyStoreType.PEM, options.getKeyStoreType());
+        Assertions.assertEquals("/path/to/keystore.pem", options.getPemClientCertPath());
+        Assertions.assertEquals("/path/to/client.key", options.getPemClientKeyPath());
+    }
+
+    @Test
+    void testBuildClientOptionsPemContent() {
+        String certContent = "-----BEGIN CERTIFICATE-----\ncert-body\n-----END CERTIFICATE-----";
+        String keyContent = "-----BEGIN PRIVATE KEY-----\nkey-body\n-----END PRIVATE KEY-----";
+
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, certContent);
+        originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, keyContent);
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+        Assertions.assertEquals(KeyStoreType.PEM, options.getKeyStoreType());
+        Assertions.assertEquals(certContent, options.getPemClientCertContent());
+        Assertions.assertEquals(keyContent, options.getPemClientKeyContent());
+    }
+
+    @Test
+    void testBuildClientOptionsPemMixedCertPathKeyContent() throws IOException {
+        Path tempCertFile = Files.createTempFile("client-cert", ".pem");
+        String certContent = "-----BEGIN CERTIFICATE-----\ninline-cert\n-----END CERTIFICATE-----";
+        Files.writeString(tempCertFile, certContent);
+
+        String keyContent = "-----BEGIN PRIVATE KEY-----\ninline-key\n-----END PRIVATE KEY-----";
+
+        try {
+            Map<String, Object> originals = new HashMap<>();
+            originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+            originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, tempCertFile.toString()); // path
+            originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, keyContent); // inline content
+
+            SchemaResolverConfig config = new SchemaResolverConfig(originals);
+            RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+            Assertions.assertEquals(KeyStoreType.PEM, options.getKeyStoreType());
+            Assertions.assertEquals(certContent, options.getPemClientCertContent());
+            Assertions.assertEquals(keyContent, options.getPemClientKeyContent());
+        } finally {
+            Files.deleteIfExists(tempCertFile);
+        }
+    }
+
+    @Test
+    void testBuildClientOptionsPemMixedCertContentKeyPath() throws IOException {
+        String certContent = "-----BEGIN CERTIFICATE-----\ninline-cert\n-----END CERTIFICATE-----";
+
+        Path tempKeyFile = Files.createTempFile("client-key", ".pem");
+        String keyContent = "-----BEGIN PRIVATE KEY-----\ninline-key\n-----END PRIVATE KEY-----";
+        Files.writeString(tempKeyFile, keyContent);
+
+        try {
+            Map<String, Object> originals = new HashMap<>();
+            originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+            originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, certContent); // inline content
+            originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, tempKeyFile.toString()); // path
+
+            SchemaResolverConfig config = new SchemaResolverConfig(originals);
+            RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+            Assertions.assertEquals(KeyStoreType.PEM, options.getKeyStoreType());
+            Assertions.assertEquals(certContent, options.getPemClientCertContent());
+            Assertions.assertEquals(keyContent, options.getPemClientKeyContent());
+        } finally {
+            Files.deleteIfExists(tempKeyFile);
+        }
+    }
+
+    @Test
+    void testBuildClientOptionsInvalidKeystoreType() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, "/path/to/keystore.jks");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "INVALID_TYPE");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RegistryClientFacadeFactory.buildClientOptions(config, null);
+        });
+    }
+
+    @Test
+    void testBuildClientOptionsInvalidTruststoreType() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, "/path/to/truststore.jks");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "INVALID_TYPE");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RegistryClientFacadeFactory.buildClientOptions(config, null);
+        });
+    }
+
+    @Test
+    void testBuildClientOptionsPemMissingKey() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, "/path/to/keystore.pem");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "PEM");
+        // Missing TLS_CLIENT_KEY
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RegistryClientFacadeFactory.buildClientOptions(config, null);
+        });
+    }
+
+    @Test
+    void testBuildClientOptionsMissingClientKey() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, "-----BEGIN CERTIFICATE-----\ninline-cert\n-----END CERTIFICATE-----");
+        // Missing TLS_CLIENT_KEY
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RegistryClientFacadeFactory.buildClientOptions(config, null);
+        });
+        Assertions.assertTrue(ex.getMessage().contains(SchemaResolverConfig.TLS_CLIENT_KEY));
+    }
+
+    @Test
+    void testBuildClientOptionsMissingClientCertificate() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, "-----BEGIN PRIVATE KEY-----\ninline-key\n-----END PRIVATE KEY-----");
+        // Missing TLS_CLIENT_CERTIFICATE
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RegistryClientFacadeFactory.buildClientOptions(config, null);
+        });
+        Assertions.assertTrue(ex.getMessage().contains(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE));
+    }
+
+    @Test
+    void testBuildClientOptionsPemMalformedContent() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, "invalid-pem-without-header");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, "-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RegistryClientFacadeFactory.buildClientOptions(config, null);
+        });
+    }
+
+    @Test
+    void testBuildClientOptionsPemFilePermissionError() throws IOException {
+        Path tempCertFile = Files.createTempFile("client-cert", ".pem");
+        String certContent = "-----BEGIN CERTIFICATE-----\ninline-cert\n-----END CERTIFICATE-----";
+        Files.writeString(tempCertFile, certContent);
+
+        // Make the file unreadable to simulate file permission errors
+        tempCertFile.toFile().setReadable(false);
+
+        String keyContent = "-----BEGIN PRIVATE KEY-----\ninline-key\n-----END PRIVATE KEY-----";
+
+        try {
+            Map<String, Object> originals = new HashMap<>();
+            originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+            originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, tempCertFile.toString()); // path (unreadable)
+            originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, keyContent); // inline content
+
+            SchemaResolverConfig config = new SchemaResolverConfig(originals);
+            Assertions.assertThrows(IllegalArgumentException.class, () -> {
+                RegistryClientFacadeFactory.buildClientOptions(config, null);
+            });
+        } finally {
+            tempCertFile.toFile().setReadable(true);
+            Files.deleteIfExists(tempCertFile);
+        }
+    }
+
+    @Test
+    void testBuildClientOptionsPemPathTraversalError() throws IOException {
+        Path tempDir = Files.createTempDirectory("traversal-test");
+        Path tempFile = Files.createTempFile(tempDir, "client-cert", ".pem");
+        Files.writeString(tempFile, "-----BEGIN CERTIFICATE-----\ninline-cert\n-----END CERTIFICATE-----");
+
+        // Construct a path that contains '..' but resolves to the existing file
+        String traversalPath = tempDir.resolve("nonexistent-subdir").resolve("..").resolve(tempFile.getFileName()).toString();
+
+        String keyContent = "-----BEGIN PRIVATE KEY-----\ninline-key\n-----END PRIVATE KEY-----";
+        try {
+            Map<String, Object> originals = new HashMap<>();
+            originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+            originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, traversalPath);
+            originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, keyContent);
+
+            SchemaResolverConfig config = new SchemaResolverConfig(originals);
+            IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+                RegistryClientFacadeFactory.buildClientOptions(config, null);
+            });
+            Assertions.assertTrue(ex.getMessage().contains("Path traversal detected"), "Expected path traversal exception, but got: " + ex.getMessage());
+        } finally {
+            Files.deleteIfExists(tempFile);
+            Files.deleteIfExists(tempDir);
+        }
+    }
+
+    @Test
+    void testBuildClientOptionsClasspathResolution() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.REGISTRY_URL, "http://localhost:8080/apis/registry/v3");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_LOCATION, "classpath:io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.class");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_TYPE, "JKS");
+        originals.put(SchemaResolverConfig.TLS_TRUSTSTORE_PASSWORD, "password");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        RegistryClientOptions options = RegistryClientFacadeFactory.buildClientOptions(config, null);
+
+        String path = options.getTrustStorePath();
+        Assertions.assertNotNull(path);
+        Assertions.assertTrue(Files.exists(Path.of(path)));
+        Assertions.assertTrue(path.contains("apicurio-tls-"));
     }
 }

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/SchemaResolverConfigTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/SchemaResolverConfigTest.java
@@ -94,6 +94,37 @@ public class SchemaResolverConfigTest {
     }
 
     /**
+     * Test TLS/SSL keystore configuration properties.
+     */
+    @Test
+    void testKeystoreConfiguration() {
+        Map<String, Object> originals = new HashMap<>();
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+
+        // Test defaults
+        assertNull(config.getTlsKeystoreLocation());
+        assertNull(config.getTlsKeystorePassword());
+        assertEquals("JKS", config.getTlsKeystoreType());
+        assertNull(config.getTlsClientCertificate());
+        assertNull(config.getTlsClientKey());
+
+        // Test setting values
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_LOCATION, "/path/to/keystore.jks");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_PASSWORD, "keystore123");
+        originals.put(SchemaResolverConfig.TLS_KEYSTORE_TYPE, "PKCS12");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_CERTIFICATE, "/path/to/client-cert.pem");
+        originals.put(SchemaResolverConfig.TLS_CLIENT_KEY, "/path/to/client-key.pem");
+
+        config = new SchemaResolverConfig(originals);
+
+        assertEquals("/path/to/keystore.jks", config.getTlsKeystoreLocation());
+        assertEquals("keystore123", config.getTlsKeystorePassword());
+        assertEquals("PKCS12", config.getTlsKeystoreType());
+        assertEquals("/path/to/client-cert.pem", config.getTlsClientCertificate());
+        assertEquals("/path/to/client-key.pem", config.getTlsClientKey());
+    }
+
+    /**
      * Test proxy configuration properties.
      */
     @Test


### PR DESCRIPTION
This PR adds comprehensive mutual TLS (mTLS) support for registry clients and SerDes by supporting JKS, PKCS12, and PEM-based client certificates and keys.

### Changes

- Added new `SchemaResolverConfig` properties for configuring TLS keystore location, password, type, client certificate, and client key, supporting both file paths and inline PEM content.
- Updated `RegistryClientFacadeFactory` to build client options for JKS, PKCS12, and PEM keystores, including mixed file/content PEM configurations and loading PEM files from the filesystem or classpath.
- Added `MtlsSerdeTest` integration tests covering all supported keystore formats, configuration combinations, and missing credential scenarios.

These changes provide flexible mTLS configuration for secured registries across the supported certificate formats.

Closes #8222