### PR TITLE
chore(fossa): FOSSA license scan remediation

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,12 @@
+version: 3
+
+project:
+  id: github.com/Apicurio/apicurio-registry
+  name: apicurio-registry
+
+paths:
+  exclude:
+    # Test-only modules — dependencies here are not shipped
+    - integration-tests/
+    - utils/extra-tests/
+    - utils/concurrency-tests/

--- a/ui/ui-editors/src/index.html
+++ b/ui/ui-editors/src/index.html
@@ -5,7 +5,7 @@
   <title>Apicurio Studio Editors (Demo)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link rel="stylesheet" type="text/css" href="https://unpkg.com/@patternfly/patternfly/patternfly.css"/>
+
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary

Addresses license issues flagged by the CNCF FOSSA scan. After analysis, **none are actual compliance blockers** — they are dual-licensed packages, test-only dependencies, or FOSSA metadata detection failures.

### Code changes in this PR

- **`.fossa.yml`**: Exclude test-only modules (`integration-tests/`, `utils/extra-tests/`) from scanning. These contain test-scoped dependencies (e.g., MySQL Connector/J) that are not shipped.
- **`ui/ui-editors/src/index.html`**: Remove redundant unpinned `@patternfly/patternfly` CDN link. The CSS is already loaded from `node_modules` via `angular.json` — the CDN link was loading a second (unpinned, latest) copy, which is both redundant and a supply chain risk.

### FOSSA overrides required (in FOSSA dashboard, not code)

The following packages need manual license overrides in the FOSSA project settings:

#### GPL-flagged packages (dual-licensed, permissive license applies)

| Package | Version | Flagged | Override To | Reason |
|---|---|---|---|---|
| cache-directory | 2.0.0 | GPL-3.0, LGPL-3.0 | MIT | Dual-licensed, MIT applies |
| MySQL Connector/J | 9.7.0 | GPL-2.0 | Apache-2.0 FOSS Exception | Test-only dep (`<scope>test</scope>`), excluded via `.fossa.yml` |
| lmdb | 3.0.13 | GPL-2.0 | OpenLDAP | Build-time transitive dep, not shipped |
| node-forge | 1.4.0 | GPL-2.0 | BSD-3-Clause | Dual-licensed (BSD-3-Clause or GPL-2.0) |
| @patternfly/patternfly | 1.0.250 | LGPL-3.0 | MIT | LGPL is for bundled font files only; code is MIT |

#### "Unlicensed" packages (FOSSA metadata detection failure)

| Package | Version | Actual License |
|---|---|---|
| All Quarkus modules (18 packages) | 3.37.2 | Apache-2.0 ([source](https://github.com/quarkusio/quarkus/blob/main/LICENSE)) |
| Jandex | 3.1.7 | Apache-2.0 ([source](https://github.com/smallrye/jandex/blob/main/LICENSE)) |
| ICU4J | 78.3 | Unicode-3.0 ([source](https://github.com/unicode-org/icu/blob/main/LICENSE)) |
| base64-js | 0.0.2 | MIT ([source](https://www.npmjs.com/package/base64-js)) |

## Context

Part of CNCF Sandbox onboarding — [cncf/sandbox#495](https://github.com/cncf/sandbox/issues/495). This is the last remaining onboarding checklist item (import repos into FOSSA).

## Test plan

- [ ] Verify `ui/ui-editors` still builds: `cd ui/ui-editors && npm run build`
- [ ] Apply FOSSA overrides in dashboard and re-scan
- [ ] Verify zero flagged issues after overrides