### PR TITLE
feat(kafkasql): remove deprecated ssl configuration properties

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
@@ -311,61 +311,21 @@ public class KafkaSqlConfiguration {
     @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage ssl truststore password")
     Optional<String> trustStorePassword;
 
-    /**
-     * @deprecated Use apicurio.kafkasql.security.ssl.truststore.password instead. This property will be removed in a future version.
-     */
-    @Deprecated(since = "3.1.0", forRemoval = true)
-    @ConfigProperty(name = "apicurio.kafkasql.ssl.truststore.password")
-    @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage ssl truststore password (deprecated, use apicurio.kafkasql.security.ssl.truststore.password)")
-    Optional<String> trustStorePasswordDeprecated;
-
     @ConfigProperty(name = "apicurio.kafkasql.security.ssl.keystore.location")
     @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage ssl keystore location")
     Optional<String> keyStoreLocation;
-
-    /**
-     * @deprecated Use apicurio.kafkasql.security.ssl.keystore.location instead. This property will be removed in a future version.
-     */
-    @Deprecated(since = "3.1.0", forRemoval = true)
-    @ConfigProperty(name = "apicurio.kafkasql.ssl.keystore.location")
-    @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage ssl keystore location (deprecated, use apicurio.kafkasql.security.ssl.keystore.location)")
-    Optional<String> keyStoreLocationDeprecated;
 
     @ConfigProperty(name = "apicurio.kafkasql.security.ssl.keystore.type")
     @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage ssl keystore type")
     Optional<String> keyStoreType;
 
-    /**
-     * @deprecated Use apicurio.kafkasql.security.ssl.keystore.type instead. This property will be removed in a future version.
-     */
-    @Deprecated(since = "3.1.0", forRemoval = true)
-    @ConfigProperty(name = "apicurio.kafkasql.ssl.keystore.type")
-    @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage ssl keystore type (deprecated, use apicurio.kafkasql.security.ssl.keystore.type)")
-    Optional<String> keyStoreTypeDeprecated;
-
     @ConfigProperty(name = "apicurio.kafkasql.security.ssl.keystore.password")
     @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage ssl keystore password")
     Optional<String> keyStorePassword;
 
-    /**
-     * @deprecated Use apicurio.kafkasql.security.ssl.keystore.password instead. This property will be removed in a future version.
-     */
-    @Deprecated(since = "3.1.0", forRemoval = true)
-    @ConfigProperty(name = "apicurio.kafkasql.ssl.keystore.password")
-    @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage ssl keystore password (deprecated, use apicurio.kafkasql.security.ssl.keystore.password)")
-    Optional<String> keyStorePasswordDeprecated;
-
     @ConfigProperty(name = "apicurio.kafkasql.security.ssl.key.password")
     @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage ssl key password")
     Optional<String> keyPassword;
-
-    /**
-     * @deprecated Use apicurio.kafkasql.security.ssl.key.password instead. This property will be removed in a future version.
-     */
-    @Deprecated(since = "3.1.0", forRemoval = true)
-    @ConfigProperty(name = "apicurio.kafkasql.ssl.key.password")
-    @Info(category = CATEGORY_STORAGE, description = "Kafka sql storage ssl key password (deprecated, use apicurio.kafkasql.security.ssl.key.password)")
-    Optional<String> keyPasswordDeprecated;
 
     private void tryToConfigureClientSecurity(Map<String, String> props) {
         protocol.ifPresent(s -> props.putIfAbsent("security.protocol", s));
@@ -383,60 +343,18 @@ public class KafkaSqlConfiguration {
         }
 
         // Try to configure the trustStore, if specified
-        // Use new property names, falling back to deprecated ones if new ones are not set
-        Optional<String> effectiveTrustStorePassword = trustStorePassword.or(() -> {
-            if (trustStorePasswordDeprecated.isPresent()) {
-                log.warn("Configuration property 'apicurio.kafkasql.ssl.truststore.password' is deprecated and will be removed in a future version. "
-                        + "Please migrate to 'apicurio.kafkasql.security.ssl.truststore.password'");
-            }
-            return trustStorePasswordDeprecated;
-        });
-
-        if (trustStoreLocation.isPresent() && effectiveTrustStorePassword.isPresent() && trustStoreType.isPresent()) {
+        if (trustStoreLocation.isPresent() && trustStorePassword.isPresent() && trustStoreType.isPresent()) {
             props.putIfAbsent(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, trustStoreType.get());
             props.putIfAbsent(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStoreLocation.get());
-            props.putIfAbsent(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, effectiveTrustStorePassword.get());
+            props.putIfAbsent(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trustStorePassword.get());
         }
 
-        // Finally, try to configure the keystore, if specified
-        // Use new property names, falling back to deprecated ones if new ones are not set
-        Optional<String> effectiveKeyStoreLocation = keyStoreLocation.or(() -> {
-            if (keyStoreLocationDeprecated.isPresent()) {
-                log.warn("Configuration property 'apicurio.kafkasql.ssl.keystore.location' is deprecated and will be removed in a future version. "
-                        + "Please migrate to 'apicurio.kafkasql.security.ssl.keystore.location'");
-            }
-            return keyStoreLocationDeprecated;
-        });
-
-        Optional<String> effectiveKeyStoreType = keyStoreType.or(() -> {
-            if (keyStoreTypeDeprecated.isPresent()) {
-                log.warn("Configuration property 'apicurio.kafkasql.ssl.keystore.type' is deprecated and will be removed in a future version. "
-                        + "Please migrate to 'apicurio.kafkasql.security.ssl.keystore.type'");
-            }
-            return keyStoreTypeDeprecated;
-        });
-
-        Optional<String> effectiveKeyStorePassword = keyStorePassword.or(() -> {
-            if (keyStorePasswordDeprecated.isPresent()) {
-                log.warn("Configuration property 'apicurio.kafkasql.ssl.keystore.password' is deprecated and will be removed in a future version. "
-                        + "Please migrate to 'apicurio.kafkasql.security.ssl.keystore.password'");
-            }
-            return keyStorePasswordDeprecated;
-        });
-
-        Optional<String> effectiveKeyPassword = keyPassword.or(() -> {
-            if (keyPasswordDeprecated.isPresent()) {
-                log.warn("Configuration property 'apicurio.kafkasql.ssl.key.password' is deprecated and will be removed in a future version. "
-                        + "Please migrate to 'apicurio.kafkasql.security.ssl.key.password'");
-            }
-            return keyPasswordDeprecated;
-        });
-
-        if (effectiveKeyStoreLocation.isPresent() && effectiveKeyStorePassword.isPresent() && effectiveKeyStoreType.isPresent()) {
-            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, effectiveKeyStoreType.get());
-            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, effectiveKeyStoreLocation.get());
-            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, effectiveKeyStorePassword.get());
-            effectiveKeyPassword.ifPresent(s -> props.putIfAbsent(SslConfigs.SSL_KEY_PASSWORD_CONFIG, s));
+        // Try to configure the keystore, if specified
+        if (keyStoreLocation.isPresent() && keyStorePassword.isPresent() && keyStoreType.isPresent()) {
+            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, keyStoreType.get());
+            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keyStoreLocation.get());
+            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, keyStorePassword.get());
+            keyPassword.ifPresent(s -> props.putIfAbsent(SslConfigs.SSL_KEY_PASSWORD_CONFIG, s));
         }
     }
 }

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfigurationTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfigurationTest.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.storage.impl.kafkasql;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.SslConfigs;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,19 +21,15 @@ public class KafkaSqlConfigurationTest {
         setField("groupPrefix", "apicurio-");
         setField("bootstrapServers", "localhost:9092");
         setField("consumerProperties", new Properties());
+        setField("adminProperties", new Properties());
         setField("protocol", Optional.empty());
         setField("trustStoreLocation", Optional.empty());
         setField("trustStoreType", Optional.empty());
         setField("trustStorePassword", Optional.empty());
-        setField("trustStorePasswordDeprecated", Optional.empty());
         setField("keyStoreLocation", Optional.empty());
-        setField("keyStoreLocationDeprecated", Optional.empty());
         setField("keyStoreType", Optional.empty());
-        setField("keyStoreTypeDeprecated", Optional.empty());
         setField("keyStorePassword", Optional.empty());
-        setField("keyStorePasswordDeprecated", Optional.empty());
         setField("keyPassword", Optional.empty());
-        setField("keyPasswordDeprecated", Optional.empty());
     }
 
     @Test
@@ -76,6 +73,100 @@ public class KafkaSqlConfigurationTest {
         Assertions.assertNotNull(groupId);
         Assertions.assertTrue(groupId.startsWith("custom-prefix-"),
                 "Consumer group ID must use the configured prefix");
+    }
+
+    @Test
+    public void testSslConfigurationWithNewProperties() throws Exception {
+        setField("trustStoreLocation", Optional.of("/path/to/truststore.jks"));
+        setField("trustStoreType", Optional.of("JKS"));
+        setField("trustStorePassword", Optional.of("trustpass"));
+
+        setField("keyStoreLocation", Optional.of("/path/to/keystore.jks"));
+        setField("keyStoreType", Optional.of("JKS"));
+        setField("keyStorePassword", Optional.of("keypass"));
+        setField("keyPassword", Optional.of("keypwd"));
+
+        Map<String, String> consumerProps = configuration.getConsumerProperties();
+        Map<String, String> adminProps = configuration.getAdminProperties();
+
+        // Assert consumer properties
+        Assertions.assertEquals("JKS", consumerProps.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG));
+        Assertions.assertEquals("/path/to/truststore.jks", consumerProps.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
+        Assertions.assertEquals("trustpass", consumerProps.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
+
+        Assertions.assertEquals("JKS", consumerProps.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG));
+        Assertions.assertEquals("/path/to/keystore.jks", consumerProps.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
+        Assertions.assertEquals("keypass", consumerProps.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG));
+        Assertions.assertEquals("keypwd", consumerProps.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG));
+
+        // Assert admin properties
+        Assertions.assertEquals("JKS", adminProps.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG));
+        Assertions.assertEquals("/path/to/truststore.jks", adminProps.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
+        Assertions.assertEquals("trustpass", adminProps.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
+
+        Assertions.assertEquals("JKS", adminProps.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG));
+        Assertions.assertEquals("/path/to/keystore.jks", adminProps.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
+        Assertions.assertEquals("keypass", adminProps.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG));
+        Assertions.assertEquals("keypwd", adminProps.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG));
+    }
+
+    @Test
+    public void testDeprecatedSslPropertiesAreIgnored() throws Exception {
+        // 1. Structure check: Assert that the deprecated fields no longer exist on the class
+        Assertions.assertThrows(NoSuchFieldException.class, () -> {
+            KafkaSqlConfiguration.class.getDeclaredField("trustStorePasswordDeprecated");
+        });
+        Assertions.assertThrows(NoSuchFieldException.class, () -> {
+            KafkaSqlConfiguration.class.getDeclaredField("keyStoreLocationDeprecated");
+        });
+        Assertions.assertThrows(NoSuchFieldException.class, () -> {
+            KafkaSqlConfiguration.class.getDeclaredField("keyStoreTypeDeprecated");
+        });
+        Assertions.assertThrows(NoSuchFieldException.class, () -> {
+            KafkaSqlConfiguration.class.getDeclaredField("keyStorePasswordDeprecated");
+        });
+        Assertions.assertThrows(NoSuchFieldException.class, () -> {
+            KafkaSqlConfiguration.class.getDeclaredField("keyPasswordDeprecated");
+        });
+
+        // 2. Behavior check: Assert that if deprecated properties are supplied, they do not map to any Kafka SSL config
+        Properties deprecatedConsumerProps = new Properties();
+        deprecatedConsumerProps.setProperty("apicurio.kafkasql.ssl.truststore.location", "/path/to/truststore.jks");
+        deprecatedConsumerProps.setProperty("apicurio.kafkasql.ssl.truststore.password", "trustpass");
+        deprecatedConsumerProps.setProperty("apicurio.kafkasql.ssl.truststore.type", "JKS");
+        deprecatedConsumerProps.setProperty("apicurio.kafkasql.ssl.keystore.location", "/path/to/keystore.jks");
+        deprecatedConsumerProps.setProperty("apicurio.kafkasql.ssl.keystore.password", "keypass");
+        deprecatedConsumerProps.setProperty("apicurio.kafkasql.ssl.keystore.type", "JKS");
+        deprecatedConsumerProps.setProperty("apicurio.kafkasql.ssl.key.password", "keypwd");
+        setField("consumerProperties", deprecatedConsumerProps);
+
+        Properties deprecatedAdminProps = new Properties();
+        deprecatedAdminProps.setProperty("apicurio.kafkasql.ssl.truststore.location", "/path/to/truststore.jks");
+        deprecatedAdminProps.setProperty("apicurio.kafkasql.ssl.truststore.password", "trustpass");
+        deprecatedAdminProps.setProperty("apicurio.kafkasql.ssl.truststore.type", "JKS");
+        deprecatedAdminProps.setProperty("apicurio.kafkasql.ssl.keystore.location", "/path/to/keystore.jks");
+        deprecatedAdminProps.setProperty("apicurio.kafkasql.ssl.keystore.password", "keypass");
+        deprecatedAdminProps.setProperty("apicurio.kafkasql.ssl.keystore.type", "JKS");
+        deprecatedAdminProps.setProperty("apicurio.kafkasql.ssl.key.password", "keypwd");
+        setField("adminProperties", deprecatedAdminProps);
+
+        Map<String, String> consumerProps = configuration.getConsumerProperties();
+        Map<String, String> adminProps = configuration.getAdminProperties();
+
+        java.util.List<String> sslKeys = java.util.List.of(
+            SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
+            SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG,
+            SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+            SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+            SslConfigs.SSL_KEYSTORE_TYPE_CONFIG,
+            SslConfigs.SSL_KEY_PASSWORD_CONFIG
+        );
+
+        for (String key : sslKeys) {
+            Assertions.assertNull(consumerProps.get(key), "Deprecated SSL property " + key + " should not be configured");
+            Assertions.assertNull(adminProps.get(key), "Deprecated SSL property " + key + " should not be configured");
+        }
     }
 
     private void setField(String fieldName, Object value) throws Exception {

--- a/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
@@ -1188,31 +1188,6 @@ The following {registry} configuration options are available for each component 
 |
 |`3.1.3`
 |Kafka sql snapshots topic properties. There are two optional Registry-specific configuration properties: 'partitions' and 'replication.factor'. IMPORTANT: As a temporary compatibility measure, configuration properties for this topic are also inherited from 'apicurio.kafkasql.topic' unless explicitly overridden by this property. This will be removed in a next minor version.
-|`apicurio.kafkasql.ssl.key.password`
-|`optional<string>`
-|
-|
-|Kafka sql storage ssl key password (deprecated, use apicurio.kafkasql.security.ssl.key.password)
-|`apicurio.kafkasql.ssl.keystore.location`
-|`optional<string>`
-|
-|
-|Kafka sql storage ssl keystore location (deprecated, use apicurio.kafkasql.security.ssl.keystore.location)
-|`apicurio.kafkasql.ssl.keystore.password`
-|`optional<string>`
-|
-|
-|Kafka sql storage ssl keystore password (deprecated, use apicurio.kafkasql.security.ssl.keystore.password)
-|`apicurio.kafkasql.ssl.keystore.type`
-|`optional<string>`
-|
-|
-|Kafka sql storage ssl keystore type (deprecated, use apicurio.kafkasql.security.ssl.keystore.type)
-|`apicurio.kafkasql.ssl.truststore.password`
-|`optional<string>`
-|
-|
-|Kafka sql storage ssl truststore password (deprecated, use apicurio.kafkasql.security.ssl.truststore.password)
 |`apicurio.kafkasql.topic`
 |`string`
 |`kafkasql-journal`

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -1269,31 +1269,6 @@ The following {registry} configuration options are available for each component 
 |
 |`3.1.3`
 |Kafka sql snapshots topic properties. There are two optional Registry-specific configuration properties: 'partitions' and 'replication.factor'. IMPORTANT: As a temporary compatibility measure, configuration properties for this topic are also inherited from 'apicurio.kafkasql.topic' unless explicitly overridden by this property. This will be removed in a next minor version.
-|`apicurio.kafkasql.ssl.key.password`
-|`optional<string>`
-|
-|
-|Kafka sql storage ssl key password (deprecated, use apicurio.kafkasql.security.ssl.key.password)
-|`apicurio.kafkasql.ssl.keystore.location`
-|`optional<string>`
-|
-|
-|Kafka sql storage ssl keystore location (deprecated, use apicurio.kafkasql.security.ssl.keystore.location)
-|`apicurio.kafkasql.ssl.keystore.password`
-|`optional<string>`
-|
-|
-|Kafka sql storage ssl keystore password (deprecated, use apicurio.kafkasql.security.ssl.keystore.password)
-|`apicurio.kafkasql.ssl.keystore.type`
-|`optional<string>`
-|
-|
-|Kafka sql storage ssl keystore type (deprecated, use apicurio.kafkasql.security.ssl.keystore.type)
-|`apicurio.kafkasql.ssl.truststore.password`
-|`optional<string>`
-|
-|
-|Kafka sql storage ssl truststore password (deprecated, use apicurio.kafkasql.security.ssl.truststore.password)
 |`apicurio.kafkasql.topic`
 |`string`
 |`kafkasql-journal`


### PR DESCRIPTION
closes: #7325 

Removed deprecated KafkaSQL SSL configuration properties and their fallback logic. users must now use the apicurio.kafkasql.security.ssl.* property names exclusively.

*Breaking Changes*:
The following deprecated properties have been removed along with their fallback logic in the code these are breaking changes:

apicurio.kafkasql.ssl.truststore.password
apicurio.kafkasql.ssl.keystore.location
apicurio.kafkasql.ssl.keystore.type
apicurio.kafkasql.ssl.keystore.password
apicurio.kafkasql.ssl.key.password
Users must migrate to their apicurio.kafkasql.security.ssl.* equivalents.

Unit Test Coverage: 
added unit tests in KafkaSqlConfigurationTest.java to lock down this behavior:

testSslConfigurationWithNewProperties(): verifies that the new properties map correctly to Kafka client configurations.
testDeprecatedSslPropertiesAreIgnored(): uses reflection to verify the deprecated fields are completely removed from the runtime configuration class.

All new and old tests passed:

<img width="1391" height="511" alt="image" src="https://github.com/user-attachments/assets/67933546-4d25-43fc-9540-a28a2cde3213" />
