### PR TITLE
feat(cli): make token endpoint optional with OIDC discovery. Fixes #8379

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -258,11 +258,20 @@ acr login --username <username> --password <password>
 
 **OAuth2 client credentials:**
 ```bash
-acr login --token-endpoint <token-endpoint-url> --client-id <client-id> --client-secret <client-secret>
+# Using OIDC discovery (recommended) — discovers the token endpoint automatically
+acr login --client-id <client-id> --auth-server-url <auth-server-url>
+
+# With explicit token endpoint
+acr login --client-id <client-id> --token-endpoint <token-endpoint-url>
 
 # With scope
-acr login --token-endpoint <token-endpoint-url> --client-id <client-id> --client-secret <client-secret> --scope <scope>
+acr login --client-id <client-id> --auth-server-url <auth-server-url> --scope <scope>
+
+# Non-interactive (CI/CD)
+acr login --client-id <client-id> --client-secret <client-secret> --auth-server-url <auth-server-url>
 ```
+
+> **Note:** `--auth-server-url` is the base URL of your OIDC provider (e.g. `https://keycloak.example.com/realms/my-realm`). The CLI appends `/.well-known/openid-configuration` to discover the token endpoint automatically.
 
 **Log out (clears credentials from keychain and config):**
 ```bash

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -118,6 +118,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
@@ -41,9 +41,15 @@ public class LoginCommand extends AbstractCommand {
 
     @Option(
             names = {"--token-endpoint"},
-            description = "OAuth2 token endpoint URL."
+            description = "OAuth2 token endpoint URL. If not provided, use --auth-server-url for OIDC discovery."
     )
     private String tokenEndpoint;
+
+    @Option(
+            names = {"--auth-server-url"},
+            description = "OIDC auth server URL for automatic token endpoint discovery."
+    )
+    private String authServerUrl;
 
     @Option(
             names = {"--client-id"},
@@ -75,6 +81,9 @@ public class LoginCommand extends AbstractCommand {
     @Inject
     CredentialStore credentialStore;
 
+    @Inject
+    OidcDiscovery oidcDiscovery;
+
     @Override
     public void run(final OutputBuffer output) throws Exception {
         final var configModel = config.read();
@@ -89,11 +98,23 @@ public class LoginCommand extends AbstractCommand {
                         VALIDATION_ERROR_RETURN_CODE));
 
         if (!isBlank(username)) {
+            if (!isBlank(authServerUrl) || !isBlank(tokenEndpoint)
+                    || !isBlank(clientId) || !isBlank(clientSecret) || !isBlank(scope)) {
+                throw new CliException(
+                        "Cannot combine --username (basic auth) with OAuth2 options "
+                                + "(--token-endpoint, --auth-server-url, --client-id, --client-secret, --scope). "
+                                + "Choose one authentication method.",
+                        VALIDATION_ERROR_RETURN_CODE);
+            }
             loginBasic(output, configModel, context, contextName);
-        } else if (!isBlank(tokenEndpoint)) {
+        } else if (!isBlank(clientId)) {
             loginOAuth2(output, configModel, context, contextName);
+        } else if (!isBlank(tokenEndpoint) || !isBlank(authServerUrl)
+                || !isBlank(clientSecret) || !isBlank(scope)) {
+            throw new CliException("--client-id is required for OAuth2 authentication.",
+                    VALIDATION_ERROR_RETURN_CODE);
         } else {
-            throw new CliException("Specify --username for basic auth or --token-endpoint for OAuth2.",
+            throw new CliException("Specify --username for basic auth, or --client-id for OAuth2.",
                     VALIDATION_ERROR_RETURN_CODE);
         }
     }
@@ -137,10 +158,8 @@ public class LoginCommand extends AbstractCommand {
                              final ConfigModel configModel,
                              final ConfigModel.Context context,
                              final String contextName) {
-        if (isBlank(clientId)) {
-            throw new CliException("--client-id is required for OAuth2 authentication.",
-                    VALIDATION_ERROR_RETURN_CODE);
-        }
+        final var resolvedTokenEndpoint = resolveTokenEndpoint();
+
         var resolvedSecret = clientSecret;
         if (isBlank(resolvedSecret)) {
             resolvedSecret = readSecret("Client Secret: ",
@@ -155,7 +174,10 @@ public class LoginCommand extends AbstractCommand {
 
         context.clearAuth();
         context.setAuthType(ConfigModel.AUTH_TYPE_OAUTH2);
-        context.setTokenEndpoint(tokenEndpoint);
+        context.setTokenEndpoint(resolvedTokenEndpoint);
+        if (isBlank(tokenEndpoint) && !isBlank(authServerUrl)) {
+            context.setAuthServerUrl(authServerUrl);
+        }
         context.setClientId(clientId);
         context.setScope(scope);
         context.setUnsafeCredentialStorage(usedFileFallback);
@@ -171,6 +193,18 @@ public class LoginCommand extends AbstractCommand {
         output.writeStdOutChunk(out -> {
             out.append("Logged in to context '").append(contextName).append("' via OAuth2.\n");
         });
+    }
+
+    private String resolveTokenEndpoint() {
+        if (!isBlank(tokenEndpoint)) {
+            return tokenEndpoint;
+        }
+        if (!isBlank(authServerUrl)) {
+            return oidcDiscovery.discoverTokenEndpoint(authServerUrl);
+        }
+        throw new CliException(
+                "Specify --token-endpoint or --auth-server-url for OAuth2 authentication.",
+                VALIDATION_ERROR_RETURN_CODE);
     }
 
     private static String readSecret(final String prompt, final String noConsoleMessage,

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/OidcDiscovery.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/OidcDiscovery.java
@@ -1,0 +1,319 @@
+package io.apicurio.registry.cli.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apicurio.registry.cli.common.CliException;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.net.URI;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jboss.logging.Logger;
+
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+@ApplicationScoped
+public class OidcDiscovery {
+
+    private static final Logger log = Logger.getLogger(OidcDiscovery.class);
+    private static final String WELL_KNOWN_PATH = "/.well-known/openid-configuration";
+    private static final String TOKEN_ENDPOINT_FIELD = "token_endpoint";
+    private static final int DISCOVERY_TIMEOUT_SECONDS = 10;
+    private static final int HTTP_OK = 200;
+    private static final int MAX_REDIRECTS = 5;
+    private static final int MAX_RESPONSE_BYTES = 1_048_576; // 1 MB
+    private static final Set<Integer> HTTP_REDIRECT_CODES = Set.of(301, 302, 303, 307, 308);
+    private static final int DEFAULT_HTTP_PORT = 80;
+    private static final int DEFAULT_HTTPS_PORT = 443;
+    private static final int REQUEST_TIMEOUT_MS = 5_000;
+    private static final String HTTP_SCHEME = "http";
+    private static final String HTTPS_SCHEME = "https";
+
+    @Inject
+    Vertx vertx;
+
+    public String discoverTokenEndpoint(final String authServerUrl) {
+        final var baseUri = validateAuthServerUrl(authServerUrl);
+
+        final var basePath = baseUri.getPath();
+        final var normalizedPath = basePath != null && basePath.endsWith("/")
+                ? basePath.substring(0, basePath.length() - 1)
+                : basePath;
+        final var discoveryPath = (normalizedPath != null ? normalizedPath : "") + WELL_KNOWN_PATH;
+        final var discoveryUri = buildDiscoveryUri(baseUri, discoveryPath);
+        log.debugf("Discovering OIDC configuration from: %s", discoveryUri);
+
+        final var responseBody = fetchDiscoveryDocument(discoveryUri);
+        return extractTokenEndpoint(responseBody, authServerUrl, baseUri);
+    }
+
+    protected static URI validateAuthServerUrl(final String authServerUrl) {
+        return validateHttpUrl(authServerUrl, "Invalid --auth-server-url '" + authServerUrl + "'");
+    }
+
+    private static URI validateHttpUrl(final String url, final String errorPrefix) {
+        final URI uri;
+        try {
+            uri = new URI(url);
+        } catch (Exception ex) {
+            throw new CliException(errorPrefix + ": not a valid URL.", ex, VALIDATION_ERROR_RETURN_CODE);
+        }
+        if (uri.getScheme() == null
+                || (!HTTP_SCHEME.equalsIgnoreCase(uri.getScheme()) && !HTTPS_SCHEME.equalsIgnoreCase(uri.getScheme()))) {
+            throw new CliException(
+                    errorPrefix + ": must start with http:// or https://.", VALIDATION_ERROR_RETURN_CODE);
+        }
+        if (uri.getHost() == null || uri.getHost().isBlank()) {
+            throw new CliException(errorPrefix + ": missing hostname.", VALIDATION_ERROR_RETURN_CODE);
+        }
+        return uri;
+    }
+
+    private static URI buildDiscoveryUri(final URI baseUri, final String discoveryPath) {
+        try {
+            return new URI(baseUri.getScheme(), null, baseUri.getHost(),
+                    baseUri.getPort(), discoveryPath, baseUri.getQuery(), null);
+        } catch (Exception ex) {
+            throw new CliException("Invalid auth server URL: " + baseUri, ex,
+                    VALIDATION_ERROR_RETURN_CODE);
+        }
+    }
+
+    private String fetchDiscoveryDocument(final URI uri) {
+        final var clientOptions = new HttpClientOptions()
+                .setTrustAll(false)
+                .setVerifyHost(true);
+        final var httpClient = vertx.createHttpClient(clientOptions);
+        try {
+            final var future = new CompletableFuture<String>();
+            sendDiscoveryRequest(httpClient, uri, future);
+            return future.get(DISCOVERY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new CliException("OIDC discovery interrupted.", ex, APPLICATION_ERROR_RETURN_CODE);
+        } catch (TimeoutException ex) {
+            throw new CliException("OIDC discovery timed out after " + DISCOVERY_TIMEOUT_SECONDS
+                    + " seconds. Check that --auth-server-url is correct.", ex,
+                    APPLICATION_ERROR_RETURN_CODE);
+        } catch (CliException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw unwrapOrWrap(ex, uri);
+        } finally {
+            httpClient.close();
+        }
+    }
+
+    private void sendDiscoveryRequest(final HttpClient httpClient,
+                                      final URI uri, final CompletableFuture<String> future) {
+        sendDiscoveryRequestWithRedirects(httpClient, uri, uri, future, 0);
+    }
+
+    private void sendDiscoveryRequestWithRedirects(final HttpClient httpClient,
+                                                   final URI currentUri, final URI originalUri,
+                                                   final CompletableFuture<String> future,
+                                                   final int redirectCount) {
+        final boolean ssl = HTTPS_SCHEME.equalsIgnoreCase(currentUri.getScheme());
+        final int defaultPort = ssl ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
+        final int port = currentUri.getPort() != -1 ? currentUri.getPort() : defaultPort;
+        final var requestUri = currentUri.getRawPath()
+                + (currentUri.getRawQuery() != null ? "?" + currentUri.getRawQuery() : "");
+        final var requestOptions = new RequestOptions()
+                .setMethod(HttpMethod.GET)
+                .setPort(port)
+                .setHost(currentUri.getHost())
+                .setURI(requestUri)
+                .setSsl(ssl)
+                .setTimeout(REQUEST_TIMEOUT_MS);
+
+        httpClient.request(requestOptions)
+                .onSuccess(req -> {
+                    req.putHeader("Accept", "application/json");
+                    req.send()
+                        .onSuccess(response -> {
+                            final int statusCode = response.statusCode();
+                            if (HTTP_REDIRECT_CODES.contains(statusCode)) {
+                                handleRedirect(httpClient, response, currentUri, originalUri, future, redirectCount);
+                            } else {
+                                handleResponse(response, currentUri, future);
+                            }
+                        })
+                        .onFailure(future::completeExceptionally);
+                })
+                .onFailure(future::completeExceptionally);
+    }
+
+    private void handleRedirect(final HttpClient httpClient,
+                                final HttpClientResponse response,
+                                final URI currentUri, final URI originalUri,
+                                final CompletableFuture<String> future,
+                                final int redirectCount) {
+        if (redirectCount >= MAX_REDIRECTS) {
+            future.completeExceptionally(new CliException(
+                    "OIDC discovery exceeded maximum number of redirects (" + MAX_REDIRECTS + ").",
+                    APPLICATION_ERROR_RETURN_CODE));
+            return;
+        }
+        final var location = response.getHeader("Location");
+        if (location == null || location.isBlank()) {
+            future.completeExceptionally(new CliException(
+                    "OIDC discovery received a redirect with no Location header.",
+                    APPLICATION_ERROR_RETURN_CODE));
+            return;
+        }
+        final URI redirectUri;
+        try {
+            redirectUri = currentUri.resolve(location);
+        } catch (Exception ex) {
+            future.completeExceptionally(new CliException(
+                    "OIDC discovery received an invalid redirect Location: " + location,
+                    ex, APPLICATION_ERROR_RETURN_CODE));
+            return;
+        }
+        if (!originMatches(originalUri, redirectUri)) {
+            future.completeExceptionally(new CliException(
+                    "OIDC discovery redirect to '" + redirectUri + "' has a different origin than "
+                            + originOf(originalUri) + ". Refusing to follow.",
+                    APPLICATION_ERROR_RETURN_CODE));
+            return;
+        }
+        log.debugf("Following OIDC discovery redirect to: %s", redirectUri);
+        sendDiscoveryRequestWithRedirects(httpClient, redirectUri, originalUri, future, redirectCount + 1);
+    }
+
+    private static void handleResponse(final HttpClientResponse response,
+                                       final URI uri, final CompletableFuture<String> future) {
+        final int statusCode = response.statusCode();
+        if (statusCode != HTTP_OK) {
+            future.completeExceptionally(new CliException(
+                    "OIDC discovery failed: HTTP " + statusCode + " from " + uri,
+                    APPLICATION_ERROR_RETURN_CODE));
+            return;
+        }
+        if (exceedsMaxSizeByContentLength(response, uri, future)) {
+            return;
+        }
+        readBodyWithSizeLimit(response, uri, future);
+    }
+
+    private static boolean exceedsMaxSizeByContentLength(final HttpClientResponse response,
+                                                         final URI uri, final CompletableFuture<String> future) {
+        final var contentLength = response.getHeader("Content-Length");
+        if (contentLength == null) {
+            return false;
+        }
+        try {
+            if (Long.parseLong(contentLength) > MAX_RESPONSE_BYTES) {
+                future.completeExceptionally(new CliException(
+                        "OIDC discovery response from " + uri + " exceeds maximum size.",
+                        APPLICATION_ERROR_RETURN_CODE));
+                return true;
+            }
+        } catch (NumberFormatException ignored) {
+            log.debugf("Malformed Content-Length header '%s', falling back to streaming size check", contentLength);
+        }
+        return false;
+    }
+
+    private static void readBodyWithSizeLimit(final HttpClientResponse response,
+                                              final URI uri, final CompletableFuture<String> future) {
+        final var accumulated = Buffer.buffer();
+        final var cancelled = new AtomicBoolean(false);
+        response.handler(chunk -> {
+            if (cancelled.get()) {
+                return;
+            }
+            if (accumulated.length() + chunk.length() > MAX_RESPONSE_BYTES) {
+                cancelled.set(true);
+                future.completeExceptionally(new CliException(
+                        "OIDC discovery response from " + uri + " exceeds maximum size.",
+                        APPLICATION_ERROR_RETURN_CODE));
+                response.request().reset();
+            } else {
+                accumulated.appendBuffer(chunk);
+            }
+        });
+        response.endHandler(v -> {
+            if (!cancelled.get() && !future.isDone()) {
+                future.complete(accumulated.toString());
+            }
+        });
+        response.exceptionHandler(future::completeExceptionally);
+    }
+
+    private static CliException unwrapOrWrap(final Exception ex, final URI uri) {
+        if (ex.getCause() instanceof CliException ce) {
+            return ce;
+        }
+        return new CliException("OIDC discovery failed for '" + uri + "': " + ex.getMessage(), ex,
+                APPLICATION_ERROR_RETURN_CODE);
+    }
+
+    private static void validateTokenEndpointUrl(final String tokenEndpoint, final String authServerUrl,
+                                                    final URI authServerUri) {
+        final var tokenUri = validateHttpUrl(tokenEndpoint,
+                "OIDC discovery from '" + authServerUrl + "' returned an invalid token_endpoint '"
+                        + tokenEndpoint + "'");
+        if (!originMatches(authServerUri, tokenUri)) {
+            throw new CliException(
+                    "OIDC discovery from '" + authServerUrl + "' returned a token_endpoint '"
+                            + tokenEndpoint + "' with a different origin. Expected "
+                            + originOf(authServerUri) + " but got " + originOf(tokenUri) + ".",
+                    APPLICATION_ERROR_RETURN_CODE);
+        }
+    }
+
+    private static boolean originMatches(final URI a, final URI b) {
+        return a.getScheme().equalsIgnoreCase(b.getScheme())
+                && a.getHost().equalsIgnoreCase(b.getHost())
+                && effectivePort(a) == effectivePort(b);
+    }
+
+    private static int effectivePort(final URI uri) {
+        if (uri.getPort() != -1) {
+            return uri.getPort();
+        }
+        return HTTPS_SCHEME.equalsIgnoreCase(uri.getScheme()) ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
+    }
+
+    private static String originOf(final URI uri) {
+        final int port = effectivePort(uri);
+        return uri.getScheme().toLowerCase(Locale.ROOT) + "://" + uri.getHost() + ":" + port;
+    }
+
+    private String extractTokenEndpoint(final String responseBody, final String authServerUrl,
+                                        final URI authServerUri) {
+        try {
+            final JsonNode root = MAPPER.readTree(responseBody);
+            final JsonNode tokenEndpointNode = root.get(TOKEN_ENDPOINT_FIELD);
+            if (tokenEndpointNode == null || tokenEndpointNode.isNull() || tokenEndpointNode.asText().isBlank()) {
+                throw new CliException(
+                        "OIDC discovery response from '" + authServerUrl
+                                + "' does not contain a '" + TOKEN_ENDPOINT_FIELD + "' field.",
+                        APPLICATION_ERROR_RETURN_CODE);
+            }
+            final var tokenEndpoint = tokenEndpointNode.asText();
+            validateTokenEndpointUrl(tokenEndpoint, authServerUrl, authServerUri);
+            log.debugf("Discovered token endpoint: %s", tokenEndpoint);
+            return tokenEndpoint;
+        } catch (CliException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new CliException(
+                    "Failed to parse OIDC discovery response from '" + authServerUrl + "': " + ex.getMessage(),
+                    ex, APPLICATION_ERROR_RETURN_CODE);
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
@@ -68,6 +68,10 @@ public class ConfigModel {
         private String tokenEndpoint;
 
         @ToString.Exclude
+        @JsonProperty("authServerUrl")
+        private String authServerUrl;
+
+        @ToString.Exclude
         @JsonProperty("clientId")
         private String clientId;
 
@@ -82,6 +86,7 @@ public class ConfigModel {
             authType = null;
             username = null;
             tokenEndpoint = null;
+            authServerUrl = null;
             clientId = null;
             scope = null;
             unsafeCredentialStorage = false;

--- a/cli/src/test/java/io/apicurio/registry/cli/AuthCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/AuthCommandTest.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli;
 
 import io.apicurio.registry.cli.auth.CredentialProvider;
+import io.apicurio.registry.cli.auth.OidcDiscovery;
 import io.apicurio.registry.cli.config.ConfigModel;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -14,13 +15,18 @@ public class AuthCommandTest extends AbstractCLITest {
     @Inject
     CredentialProvider credentialProvider;
 
+    @Inject
+    OidcDiscovery oidcDiscovery;
+
     private static final String TOKEN_PATH = "/token";
+    private static final String DISCOVERED_TOKEN_PATH = "/protocol/openid-connect/token";
     private static final String TEST_CONTEXT = "test";
     private static final String TEST_USERNAME = "testuser";
     private static final String TEST_PASSWORD = "testpass";
     private static final String TEST_CLIENT_ID = "test-client";
     private static final String TEST_CLIENT_SECRET = "test-secret";
     private static final String TEST_SCOPE = "openid profile";
+    private static final String TEST_AUTH_SERVER_URL = "http://keycloak.example.com/realms/test";
 
     // -- Help --
 
@@ -48,7 +54,22 @@ public class AuthCommandTest extends AbstractCLITest {
 
     @Test
     public void testLoginOAuth2MissingClientId() {
+        out.getBuffer().setLength(0);
         executeAndAssertFailure("login", "--token-endpoint", tokenEndpoint());
+        assertThat(err.toString())
+                .as(withCliOutput("Should require --client-id"))
+                .contains("--client-id");
+    }
+
+    @Test
+    public void testLoginOAuth2ClientIdWithoutEndpoint() {
+        out.getBuffer().setLength(0);
+        executeAndAssertFailure("login", "--client-id", TEST_CLIENT_ID,
+                "--client-secret", TEST_CLIENT_SECRET);
+        assertThat(err.toString())
+                .as(withCliOutput("Should require --token-endpoint or --auth-server-url"))
+                .contains("--token-endpoint")
+                .contains("--auth-server-url");
     }
 
     @Test
@@ -155,18 +176,225 @@ public class AuthCommandTest extends AbstractCLITest {
         assertThat(context.getScope()).isNull();
     }
 
+    // -- OIDC discovery --
+
+    @Test
+    public void testLoginOAuth2WithAuthServerUrl() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("login", "--client-id", TEST_CLIENT_ID,
+                "--client-secret", TEST_CLIENT_SECRET,
+                "--auth-server-url", TEST_AUTH_SERVER_URL);
+        assertThat(out.toString())
+                .as(withCliOutput("Should confirm OAuth2 login via discovery"))
+                .contains("Logged in to context")
+                .contains("OAuth2");
+
+        var context = getTestContext();
+        assertThat(context.getAuthType()).isEqualTo(ConfigModel.AUTH_TYPE_OAUTH2);
+        assertThat(context.getAuthServerUrl()).isEqualTo(TEST_AUTH_SERVER_URL);
+        assertThat(context.getTokenEndpoint())
+                .isEqualTo(TEST_AUTH_SERVER_URL + DISCOVERED_TOKEN_PATH);
+        assertThat(context.getClientId()).isEqualTo(TEST_CLIENT_ID);
+        assertThat(context.getUsername()).isNull();
+    }
+
+    @Test
+    public void testLoginOAuth2TokenEndpointTakesPrecedence() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("login", "--client-id", TEST_CLIENT_ID,
+                "--client-secret", TEST_CLIENT_SECRET,
+                "--token-endpoint", tokenEndpoint(),
+                "--auth-server-url", TEST_AUTH_SERVER_URL);
+
+        var context = getTestContext();
+        assertThat(context.getTokenEndpoint())
+                .as(withCliOutput("--token-endpoint should take precedence over --auth-server-url"))
+                .isEqualTo(tokenEndpoint());
+        assertThat(context.getAuthServerUrl())
+                .as("authServerUrl should not be stored when --token-endpoint was explicit")
+                .isNull();
+    }
+
+    @Test
+    public void testLoginOAuth2WithAuthServerUrlAndScope() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("login", "--client-id", TEST_CLIENT_ID,
+                "--client-secret", TEST_CLIENT_SECRET,
+                "--auth-server-url", TEST_AUTH_SERVER_URL,
+                "--scope", TEST_SCOPE);
+
+        var context = getTestContext();
+        assertThat(context.getScope()).isEqualTo(TEST_SCOPE);
+        assertThat(context.getAuthServerUrl()).isEqualTo(TEST_AUTH_SERVER_URL);
+    }
+
+    @Test
+    public void testLogoutClearsAuthServerUrl() {
+        executeAndAssertSuccess("login", "--client-id", TEST_CLIENT_ID,
+                "--client-secret", TEST_CLIENT_SECRET,
+                "--auth-server-url", TEST_AUTH_SERVER_URL);
+
+        executeAndAssertSuccess("logout");
+
+        var context = getTestContext();
+        assertThat(context.getAuthServerUrl()).isNull();
+        assertThat(context.getTokenEndpoint()).isNull();
+    }
+
+    @Test
+    public void testLoginOAuth2DiscoveryFailure() {
+        final var testDiscovery = (TestOidcDiscovery) oidcDiscovery;
+        try {
+            testDiscovery.setFailOnDiscover(true);
+
+            out.getBuffer().setLength(0);
+            executeAndAssertFailure("login", "--client-id", TEST_CLIENT_ID,
+                    "--client-secret", TEST_CLIENT_SECRET,
+                    "--auth-server-url", TEST_AUTH_SERVER_URL);
+            assertThat(err.toString())
+                    .as(withCliOutput("Should report discovery failure"))
+                    .contains("OIDC discovery failed");
+
+            var context = getTestContext();
+            assertThat(context.getAuthType())
+                    .as("Auth type should not be set on failure")
+                    .isNull();
+        } finally {
+            testDiscovery.setFailOnDiscover(false);
+        }
+    }
+
+    @Test
+    public void testLoginOAuth2AuthServerUrlWithoutClientId() {
+        out.getBuffer().setLength(0);
+        executeAndAssertFailure("login", "--auth-server-url", TEST_AUTH_SERVER_URL);
+        assertThat(err.toString())
+                .as(withCliOutput("Should require --client-id"))
+                .contains("--client-id");
+    }
+
+    // -- OIDC discovery edge cases --
+
+    @Test
+    public void testLoginOAuth2InvalidAuthServerUrl() {
+        out.getBuffer().setLength(0);
+        executeAndAssertFailure("login", "--client-id", TEST_CLIENT_ID,
+                "--client-secret", TEST_CLIENT_SECRET,
+                "--auth-server-url", "not-a-url");
+        assertThat(err.toString())
+                .as(withCliOutput("Should reject invalid URL format"))
+                .contains("Invalid --auth-server-url");
+    }
+
+    @Test
+    public void testLoginOAuth2AuthServerUrlMissingScheme() {
+        out.getBuffer().setLength(0);
+        executeAndAssertFailure("login", "--client-id", TEST_CLIENT_ID,
+                "--client-secret", TEST_CLIENT_SECRET,
+                "--auth-server-url", "keycloak.example.com/realms/test");
+        assertThat(err.toString())
+                .as(withCliOutput("Should reject URL without http/https scheme"))
+                .contains("http://")
+                .contains("https://");
+    }
+
+    @Test
+    public void testLoginOAuth2DiscoveryReturnsNoTokenEndpoint() {
+        final var testDiscovery = (TestOidcDiscovery) oidcDiscovery;
+        try {
+            testDiscovery.setFailOnDiscover(true,
+                    "OIDC discovery response does not contain a 'token_endpoint' field.");
+
+            out.getBuffer().setLength(0);
+            executeAndAssertFailure("login", "--client-id", TEST_CLIENT_ID,
+                    "--client-secret", TEST_CLIENT_SECRET,
+                    "--auth-server-url", TEST_AUTH_SERVER_URL);
+            assertThat(err.toString())
+                    .as(withCliOutput("Should report missing token_endpoint"))
+                    .contains("token_endpoint");
+        } finally {
+            testDiscovery.setFailOnDiscover(false);
+        }
+    }
+
+    @Test
+    public void testLoginOAuth2DiscoveryReturnsInvalidTokenEndpointScheme() {
+        final var testDiscovery = (TestOidcDiscovery) oidcDiscovery;
+        try {
+            testDiscovery.setFailOnDiscover(true,
+                    "OIDC discovery from '" + TEST_AUTH_SERVER_URL
+                            + "' returned an invalid token_endpoint 'file:///etc/passwd'"
+                            + ": must start with http:// or https://.");
+
+            out.getBuffer().setLength(0);
+            executeAndAssertFailure("login", "--client-id", TEST_CLIENT_ID,
+                    "--client-secret", TEST_CLIENT_SECRET,
+                    "--auth-server-url", TEST_AUTH_SERVER_URL);
+            assertThat(err.toString())
+                    .as(withCliOutput("Should reject non-http/https token endpoint"))
+                    .contains("invalid token_endpoint")
+                    .contains("http://")
+                    .contains("https://");
+        } finally {
+            testDiscovery.setFailOnDiscover(false);
+        }
+    }
+
+    @Test
+    public void testLoginOAuth2DiscoveryFailureHttpStatus() {
+        final var testDiscovery = (TestOidcDiscovery) oidcDiscovery;
+        try {
+            testDiscovery.setFailOnDiscover(true,
+                    "OIDC discovery failed: HTTP 404 from " + TEST_AUTH_SERVER_URL);
+
+            out.getBuffer().setLength(0);
+            executeAndAssertFailure("login", "--client-id", TEST_CLIENT_ID,
+                    "--client-secret", TEST_CLIENT_SECRET,
+                    "--auth-server-url", TEST_AUTH_SERVER_URL);
+            assertThat(err.toString())
+                    .as(withCliOutput("Should report HTTP 404"))
+                    .contains("404");
+        } finally {
+            testDiscovery.setFailOnDiscover(false);
+        }
+    }
+
     // -- State transitions --
 
     @Test
-    public void testLoginUsernameAndTokenEndpoint() {
+    public void testLoginUsernameWithTokenEndpointConflicts() {
         out.getBuffer().setLength(0);
-        executeAndAssertSuccess("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD,
+        executeAndAssertFailure("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD,
                 "--token-endpoint", tokenEndpoint());
+        assertThat(err.toString())
+                .as(withCliOutput("Should reject conflicting --username and --token-endpoint"))
+                .contains("Cannot combine")
+                .contains("basic auth")
+                .contains("OAuth2");
+    }
 
-        var context = getTestContext();
-        assertThat(context.getAuthType())
-                .as(withCliOutput("--username should take precedence over --token-endpoint"))
-                .isEqualTo(ConfigModel.AUTH_TYPE_BASIC);
+    @Test
+    public void testLoginUsernameWithAuthServerUrlConflicts() {
+        out.getBuffer().setLength(0);
+        executeAndAssertFailure("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD,
+                "--auth-server-url", TEST_AUTH_SERVER_URL);
+        assertThat(err.toString())
+                .as(withCliOutput("Should reject conflicting --username and --auth-server-url"))
+                .contains("Cannot combine")
+                .contains("basic auth")
+                .contains("OAuth2");
+    }
+
+    @Test
+    public void testLoginUsernameWithClientIdConflicts() {
+        out.getBuffer().setLength(0);
+        executeAndAssertFailure("login", "--username", TEST_USERNAME, "--password", TEST_PASSWORD,
+                "--client-id", TEST_CLIENT_ID);
+        assertThat(err.toString())
+                .as(withCliOutput("Should reject conflicting --username and --client-id"))
+                .contains("Cannot combine")
+                .contains("basic auth")
+                .contains("OAuth2");
     }
 
     @Test

--- a/cli/src/test/java/io/apicurio/registry/cli/OidcDiscoveryHttpTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/OidcDiscoveryHttpTest.java
@@ -1,0 +1,210 @@
+package io.apicurio.registry.cli;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.apicurio.registry.cli.auth.OidcDiscovery;
+import io.apicurio.registry.cli.common.CliException;
+import io.vertx.core.Vertx;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class OidcDiscoveryHttpTest {
+
+    private static WireMockServer wireMock;
+    private static OidcDiscovery oidcDiscovery;
+    private static Vertx vertx;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        wireMock = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMock.start();
+
+        vertx = Vertx.vertx();
+        oidcDiscovery = new OidcDiscovery();
+        final Field vertxField = OidcDiscovery.class.getDeclaredField("vertx");
+        vertxField.setAccessible(true);
+        vertxField.set(oidcDiscovery, vertx);
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (wireMock != null) {
+            wireMock.stop();
+        }
+        if (vertx != null) {
+            vertx.close();
+        }
+    }
+
+    @BeforeEach
+    void resetStubs() {
+        wireMock.resetAll();
+    }
+
+    private static String authServerUrl() {
+        return "http://localhost:" + wireMock.port() + "/realms/test";
+    }
+
+    private static String tokenEndpointUrl() {
+        return "http://localhost:" + wireMock.port() + "/realms/test/protocol/openid-connect/token";
+    }
+
+    @Test
+    public void testDiscoveryHappyPath() {
+        wireMock.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"token_endpoint\": \"" + tokenEndpointUrl() + "\"}")));
+
+        final var result = oidcDiscovery.discoverTokenEndpoint(authServerUrl());
+        assertThat(result).isEqualTo(tokenEndpointUrl());
+    }
+
+    @Test
+    public void testDiscoveryFollowsRedirects() {
+        wireMock.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location", "http://localhost:" + wireMock.port()
+                                + "/realms/redirected/.well-known/openid-configuration")));
+
+        wireMock.stubFor(get(urlEqualTo("/realms/redirected/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"token_endpoint\": \"" + tokenEndpointUrl() + "\"}")));
+
+        final var result = oidcDiscovery.discoverTokenEndpoint(authServerUrl());
+        assertThat(result).isEqualTo(tokenEndpointUrl());
+    }
+
+    @Test
+    public void testDiscoveryReturns404() {
+        wireMock.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> oidcDiscovery.discoverTokenEndpoint(authServerUrl()))
+                .isInstanceOf(CliException.class)
+                .hasMessageContaining("HTTP 404");
+    }
+
+    @Test
+    public void testDiscoveryMissingTokenEndpoint() {
+        wireMock.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"issuer\": \"http://localhost\"}")));
+
+        assertThatThrownBy(() -> oidcDiscovery.discoverTokenEndpoint(authServerUrl()))
+                .isInstanceOf(CliException.class)
+                .hasMessageContaining("token_endpoint");
+    }
+
+    @Test
+    public void testDiscoveryInvalidTokenEndpointScheme() {
+        wireMock.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"token_endpoint\": \"file:///etc/passwd\"}")));
+
+        assertThatThrownBy(() -> oidcDiscovery.discoverTokenEndpoint(authServerUrl()))
+                .isInstanceOf(CliException.class)
+                .hasMessageContaining("must start with http:// or https://");
+    }
+
+    @Test
+    public void testDiscoveryOversizedResponseRejectedByContentLength() {
+        wireMock.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withHeader("Content-Length", "2097152")
+                        .withBody("{\"token_endpoint\": \"http://localhost/token\"}")));
+
+        assertThatThrownBy(() -> oidcDiscovery.discoverTokenEndpoint(authServerUrl()))
+                .isInstanceOf(CliException.class)
+                .hasMessageContaining("exceeds maximum size");
+    }
+
+    @Test
+    public void testDiscoveryOversizedChunkedResponseRejected() {
+        final var oversizedBody = "x".repeat(1_048_576 + 1);
+        wireMock.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(oversizedBody)));
+
+        assertThatThrownBy(() -> oidcDiscovery.discoverTokenEndpoint(authServerUrl()))
+                .isInstanceOf(CliException.class)
+                .hasMessageContaining("exceeds maximum size");
+    }
+
+    @Test
+    public void testDiscoveryInvalidJson() {
+        wireMock.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("not json")));
+
+        assertThatThrownBy(() -> oidcDiscovery.discoverTokenEndpoint(authServerUrl()))
+                .isInstanceOf(CliException.class)
+                .hasMessageContaining("Failed to parse");
+    }
+
+    @Test
+    public void testDiscoveryRejectsTokenEndpointFromDifferentOrigin() {
+        wireMock.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"token_endpoint\": \"https://attacker.example/token\"}")));
+
+        assertThatThrownBy(() -> oidcDiscovery.discoverTokenEndpoint(authServerUrl()))
+                .isInstanceOf(CliException.class)
+                .hasMessageContaining("different origin");
+    }
+
+    @Test
+    public void testDiscoveryFollowsRelativeRedirect() {
+        wireMock.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location",
+                                "/realms/test/canonical/.well-known/openid-configuration")));
+
+        wireMock.stubFor(get(urlEqualTo("/realms/test/canonical/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"token_endpoint\": \"" + tokenEndpointUrl() + "\"}")));
+
+        final var result = oidcDiscovery.discoverTokenEndpoint(authServerUrl());
+        assertThat(result).isEqualTo(tokenEndpointUrl());
+    }
+
+    @Test
+    public void testDiscoveryRejectsRedirectToDifferentHost() {
+        wireMock.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location", "http://attacker.example/steal")));
+
+        assertThatThrownBy(() -> oidcDiscovery.discoverTokenEndpoint(authServerUrl()))
+                .isInstanceOf(CliException.class)
+                .hasMessageContaining("different origin");
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/TestOidcDiscovery.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/TestOidcDiscovery.java
@@ -1,0 +1,52 @@
+package io.apicurio.registry.cli;
+
+import io.apicurio.registry.cli.auth.OidcDiscovery;
+import io.apicurio.registry.cli.common.CliException;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
+
+/**
+ * Test OIDC discovery that returns a canned token endpoint derived from the auth server URL.
+ * Replaces the real discovery bean so tests do not need a running OIDC provider.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class TestOidcDiscovery extends OidcDiscovery {
+
+    private static final String DISCOVERED_TOKEN_PATH = "/protocol/openid-connect/token";
+
+    private boolean failOnDiscover;
+    private String failMessage;
+
+    public void setFailOnDiscover(final boolean fail) {
+        this.failOnDiscover = fail;
+        this.failMessage = null;
+    }
+
+    public void setFailOnDiscover(final boolean fail, final String message) {
+        this.failOnDiscover = fail;
+        this.failMessage = message;
+    }
+
+    @Override
+    public String discoverTokenEndpoint(final String authServerUrl) {
+        final var uri = OidcDiscovery.validateAuthServerUrl(authServerUrl);
+
+        if (failOnDiscover) {
+            final var msg = failMessage != null ? failMessage
+                    : "OIDC discovery failed for '" + authServerUrl + "': simulated failure";
+            throw new CliException(msg, APPLICATION_ERROR_RETURN_CODE);
+        }
+        var path = uri.getPath() != null ? uri.getPath() : "";
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return uri.getScheme() + "://" + uri.getHost()
+                + (uri.getPort() != -1 ? ":" + uri.getPort() : "")
+                + path + DISCOVERED_TOKEN_PATH;
+    }
+}


### PR DESCRIPTION
## Summary

Makes `--token-endpoint` optional for OAuth2 login by adding OIDC discovery via `--auth-server-url`. The CLI fetches `.well-known/openid-configuration` to discover the token endpoint automatically.

Fixes #8379

## Usage

```bash
# OIDC discovery (recommended)
acr login --client-id my-client --auth-server-url https://keycloak.example.com/realms/myrealm

# With explicit token endpoint (backward compatible)
acr login --client-id my-client --token-endpoint https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token

# Non-interactive (CI/CD)
acr login --client-id my-client --client-secret my-secret --auth-server-url https://keycloak.example.com/realms/myrealm
```

## Behavior

| Scenario | Result |
|----------|--------|
| `--auth-server-url` + `--client-id` | Discovers token endpoint via `.well-known`, logs in |
| `--token-endpoint` + `--client-id` | Uses explicit token endpoint (backward compatible) |
| Both `--token-endpoint` + `--auth-server-url` | Explicit `--token-endpoint` takes precedence, `authServerUrl` not stored |
| `--auth-server-url` only (no `--client-id`) | Error: "--client-id is required" |
| `--username` + any OAuth2 option | Error: "Cannot combine" |
| `--client-secret` or `--scope` without `--client-id` | Error: "--client-id is required" |
| Invalid URL / missing scheme | Error with specific message |
| Discovery returns non-http token endpoint | Error: "must start with http:// or https://" |
| Discovery returns token endpoint from different origin | Error: "different origin" (RFC 8414 §3) |
| Discovery returns oversized response (>1MB) | Error: "exceeds maximum size" (Content-Length pre-check + streaming chunk handler) |
| OIDC server redirects (absolute or relative) | Follows up to 5 hops transparently, same-origin only |

## Security

- **Origin pinning** — Discovered `token_endpoint` must match `--auth-server-url` origin (scheme + host + port) per RFC 8414 §3
- **Redirect origin validation** — Each redirect hop validated against original host; relative `Location` headers resolved via `URI.resolve()` (RFC 7231 §7.1.2)
- **Explicit TLS** — `setTrustAll(false)` + `setVerifyHost(true)` on the HTTP client
- **Per-request timeout** — 5s per HTTP request (within 10s global timeout) to prevent slow/unresponsive servers from consuming the entire timeout budget
- **Streaming size limit** — Content-Length pre-check + streaming chunk handler with `AtomicBoolean` guard that aborts mid-stream via `request().reset()`
- **Redirect codes** — Only standard redirect codes (301, 302, 303, 307, 308); excludes 304 and other non-redirect 3xx
- **URL validation** — http/https scheme enforced, userInfo stripped from discovery URI
- **No credential leakage** — `authServerUrl` marked `@ToString.Exclude`, no secrets in error messages

## Changes

| File | Purpose |
|------|---------|
| `OidcDiscovery.java` | New — CDI bean: validates URL, fetches `.well-known/openid-configuration` via Vert.x HttpClient, extracts and validates `token_endpoint`. Origin pinning, manual redirect handling, streaming size limit, per-request timeout, explicit TLS config. |
| `LoginCommand.java` | Added `--auth-server-url` option, `resolveTokenEndpoint()` with precedence logic, conflict checks for all OAuth2 options |
| `ConfigModel.java` | Added `authServerUrl` field with `@ToString.Exclude`, included in `clearAuth()` |
| `OidcDiscoveryHttpTest.java` | New — 11 WireMock tests exercising the real HTTP code: happy path, redirect following (absolute + relative), 404, missing token_endpoint, invalid scheme, oversized response (Content-Length + chunked), invalid JSON, cross-origin token endpoint, cross-origin redirect |
| `TestOidcDiscovery.java` | New — CDI `@Alternative` test double with injectable failure mode |
| `AuthCommandTest.java` | 17 new tests: discovery happy path, precedence, scope, logout cleanup, failure modes, validation edge cases, conflict detection |
| `pom.xml` | Added WireMock test dependency |
| `README.md` | Updated OAuth2 examples with OIDC discovery, added CI/CD example and `--auth-server-url` note |

## Test plan

- [x] 338 unit tests pass (0 failures, 0 errors) — full CLI suite via Podman
- [x] Checkstyle: 0 violations
- [x] E2E against real Keycloak (Podman): OIDC discovery, explicit token endpoint, precedence, conflicts, error cases, logout — all pass
- [x] Security audit: origin pinning, TLS, redirect safety, credential handling — no issues