### PR TITLE
feat(cli): add browser-based OAuth2/OIDC login and token refresh. Fixes #8133

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/auth/BrowserLauncher.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/BrowserLauncher.java
@@ -1,0 +1,29 @@
+package io.apicurio.registry.cli.auth;
+
+import io.apicurio.registry.cli.utils.PlatformUtils;
+import org.jboss.logging.Logger;
+
+/**
+ * Opens a URL in the user's default browser.
+ */
+final class BrowserLauncher {
+
+    private static final Logger log = Logger.getLogger(BrowserLauncher.class);
+
+    private BrowserLauncher() {
+    }
+
+    static void openUrl(final String url) {
+        try {
+            if (PlatformUtils.isMacOS()) {
+                ProcessUtils.exec("open", url);
+            } else {
+                ProcessUtils.exec("xdg-open", url);
+            }
+        } catch (CredentialStoreException ex) {
+            log.debugf("Could not open browser: %s", ex.getMessage());
+            System.out.println("Open this URL in your browser to log in:");
+            System.out.println("  " + url);
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
@@ -7,6 +7,7 @@ import io.apicurio.registry.cli.utils.OutputBuffer;
 import jakarta.inject.Inject;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.UUID;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -14,7 +15,7 @@ import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETU
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
 
 /**
- * Authenticates with the registry using Basic auth or OAuth2 client credentials.
+ * Authenticates with the registry using Basic auth, OAuth2 client credentials, or browser-based OIDC.
  */
 @Command(
         name = "login",
@@ -66,6 +67,12 @@ public class LoginCommand extends AbstractCommand {
     private String scope;
 
     @Option(
+            names = {"--issuer-url"},
+            description = "OIDC issuer URL for browser-based login."
+    )
+    private String issuerUrl;
+
+    @Option(
             names = {"--allow-unsafe-credential-storage"},
             description = "Allow storing credentials in a file when the OS keychain is not available.",
             defaultValue = "false"
@@ -74,6 +81,15 @@ public class LoginCommand extends AbstractCommand {
 
     @Inject
     CredentialStore credentialStore;
+
+    @Inject
+    OidcDiscovery oidcDiscovery;
+
+    @Inject
+    OidcTokenClient oidcTokenClient;
+
+    @Inject
+    OidcCallbackServer callbackServer;
 
     @Override
     public void run(final OutputBuffer output) throws Exception {
@@ -90,10 +106,13 @@ public class LoginCommand extends AbstractCommand {
 
         if (!isBlank(username)) {
             loginBasic(output, configModel, context, contextName);
+        } else if (!isBlank(issuerUrl)) {
+            loginOidc(output, configModel, context, contextName);
         } else if (!isBlank(tokenEndpoint)) {
             loginOAuth2(output, configModel, context, contextName);
         } else {
-            throw new CliException("Specify --username for basic auth or --token-endpoint for OAuth2.",
+            throw new CliException(
+                    "Specify --username for basic auth, --issuer-url for OIDC, or --token-endpoint for OAuth2.",
                     VALIDATION_ERROR_RETURN_CODE);
         }
     }
@@ -173,6 +192,58 @@ public class LoginCommand extends AbstractCommand {
         });
     }
 
+    private void loginOidc(final OutputBuffer output,
+                           final ConfigModel configModel,
+                           final ConfigModel.Context context,
+                           final String contextName) {
+        if (isBlank(clientId)) {
+            throw new CliException("--client-id is required for OIDC authentication.",
+                    VALIDATION_ERROR_RETURN_CODE);
+        }
+
+        final var endpoints = oidcDiscovery.discover(issuerUrl);
+        final var pkce = PkceChallenge.generate();
+        final var state = UUID.randomUUID().toString();
+
+        try (var session = callbackServer.start(state)) {
+            final var redirectUri = OidcCallbackServer.redirectUri(session.getPort());
+            final var authUrl = endpoints.authorizationEndpoint()
+                    + "?response_type=code"
+                    + "&client_id=" + encode(clientId)
+                    + "&redirect_uri=" + encode(redirectUri)
+                    + "&scope=" + encode(scope != null ? scope : "openid")
+                    + "&state=" + state
+                    + "&code_challenge=" + pkce.codeChallenge()
+                    + "&code_challenge_method=" + pkce.codeChallengeMethod();
+
+            BrowserLauncher.openUrl(authUrl);
+            output.writeStdOutChunk(out -> out.append("Waiting for browser login...\n"));
+
+            final var code = session.awaitCode();
+            final var tokenResponse = oidcTokenClient.exchangeCode(
+                    endpoints.tokenEndpoint(), code, redirectUri, clientId, pkce.codeVerifier());
+
+            context.clearAuth();
+            context.setAuthType(ConfigModel.AUTH_TYPE_OIDC);
+            context.setIssuerUrl(issuerUrl);
+            context.setTokenEndpoint(endpoints.tokenEndpoint());
+            context.setClientId(clientId);
+            context.setScope(scope);
+            config.write(configModel);
+
+            if (tokenResponse.refreshToken() != null) {
+                credentialStore.store(contextName, ConfigModel.CREDENTIAL_KEY_REFRESH_TOKEN,
+                        tokenResponse.refreshToken());
+            }
+
+            client.reset();
+
+            output.writeStdOutChunk(out -> {
+                out.append("Logged in to context '").append(contextName).append("' via OIDC.\n");
+            });
+        }
+    }
+
     private static String readSecret(final String prompt, final String noConsoleMessage,
                                      final String emptyMessage) {
         final var console = Optional.ofNullable(System.console())
@@ -188,5 +259,9 @@ public class LoginCommand extends AbstractCommand {
                 Arrays.fill(chars, '\0');
             }
         }
+    }
+
+    private static String encode(final String value) {
+        return java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8);
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/LogoutCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/LogoutCommand.java
@@ -43,6 +43,7 @@ public class LogoutCommand extends AbstractCommand {
 
         credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD);
         credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET);
+        credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_REFRESH_TOKEN);
 
         context.clearAuth();
         config.write(configModel);

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/OidcCallbackServer.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/OidcCallbackServer.java
@@ -1,0 +1,141 @@
+package io.apicurio.registry.cli.auth;
+
+import io.apicurio.registry.cli.common.CliException;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
+
+/**
+ * Temporary local HTTP server that receives the OIDC authorization code callback.
+ */
+@ApplicationScoped
+public class OidcCallbackServer {
+
+    private static final String CALLBACK_PATH = "/callback";
+    private static final int LOGIN_TIMEOUT_SECONDS = 120;
+
+    private static final String SUCCESS_HTML = """
+            <html><body style="font-family:sans-serif;text-align:center;padding:40px">
+            <h2>Login successful</h2><p>You may close this browser tab.</p>
+            </body></html>""";
+
+    private static final String ERROR_HTML = """
+            <html><body style="font-family:sans-serif;text-align:center;padding:40px">
+            <h2>Login failed</h2><p>%s</p>
+            </body></html>""";
+
+    @Inject
+    Vertx vertx;
+
+    /**
+     * Starts the callback server and returns a session that can be used to
+     * build the redirect URI and await the authorization code.
+     */
+    public Session start(final String expectedState) {
+        final CompletableFuture<String> codeFuture = new CompletableFuture<>();
+        final HttpServer server = vertx.createHttpServer();
+
+        server.requestHandler(request -> {
+            if (!request.path().equals(CALLBACK_PATH)) {
+                request.response().setStatusCode(404).end("Not found");
+                return;
+            }
+
+            final String error = request.getParam("error");
+            if (error != null) {
+                final String description = request.getParam("error_description");
+                final String message = description != null ? description : error;
+                request.response().putHeader("Content-Type", "text/html")
+                        .end(ERROR_HTML.formatted(message));
+                codeFuture.completeExceptionally(new CliException(
+                        "OIDC login failed: " + message, APPLICATION_ERROR_RETURN_CODE));
+                return;
+            }
+
+            final String code = request.getParam("code");
+            final String state = request.getParam("state");
+
+            if (code == null) {
+                request.response().putHeader("Content-Type", "text/html")
+                        .end(ERROR_HTML.formatted("Missing authorization code."));
+                codeFuture.completeExceptionally(new CliException(
+                        "Missing authorization code in callback.", APPLICATION_ERROR_RETURN_CODE));
+                return;
+            }
+
+            if (!expectedState.equals(state)) {
+                request.response().putHeader("Content-Type", "text/html")
+                        .end(ERROR_HTML.formatted("State parameter mismatch."));
+                codeFuture.completeExceptionally(new CliException(
+                        "Security error: state parameter mismatch. Please try again.",
+                        APPLICATION_ERROR_RETURN_CODE));
+                return;
+            }
+
+            request.response().putHeader("Content-Type", "text/html").end(SUCCESS_HTML);
+            codeFuture.complete(code);
+        });
+
+        try {
+            final CompletableFuture<Integer> portFuture = new CompletableFuture<>();
+            server.listen(0, "127.0.0.1", ar -> {
+                if (ar.succeeded()) {
+                    portFuture.complete(ar.result().actualPort());
+                } else {
+                    portFuture.completeExceptionally(ar.cause());
+                }
+            });
+            final int port = portFuture.get(5, TimeUnit.SECONDS);
+            return new Session(port, codeFuture, server);
+        } catch (Exception ex) {
+            server.close();
+            throw new CliException("Failed to start callback server: " + ex.getMessage(),
+                    APPLICATION_ERROR_RETURN_CODE);
+        }
+    }
+
+    public static String redirectUri(final int port) {
+        return "http://127.0.0.1:" + port + CALLBACK_PATH;
+    }
+
+    static class Session implements AutoCloseable {
+        private final int port;
+        private final CompletableFuture<String> codeFuture;
+        private final HttpServer server;
+
+        Session(final int port, final CompletableFuture<String> codeFuture, final HttpServer server) {
+            this.port = port;
+            this.codeFuture = codeFuture;
+            this.server = server;
+        }
+
+        int getPort() {
+            return port;
+        }
+
+        String awaitCode() {
+            try {
+                return codeFuture.get(LOGIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (TimeoutException ex) {
+                throw new CliException("Login timed out. No response received within "
+                        + LOGIN_TIMEOUT_SECONDS + " seconds.", APPLICATION_ERROR_RETURN_CODE);
+            } catch (Exception ex) {
+                if (ex.getCause() instanceof CliException cliEx) {
+                    throw cliEx;
+                }
+                throw new CliException("Callback error: " + ex.getMessage(), APPLICATION_ERROR_RETURN_CODE);
+            }
+        }
+
+        @Override
+        public void close() {
+            server.close();
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/OidcDiscovery.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/OidcDiscovery.java
@@ -1,0 +1,74 @@
+package io.apicurio.registry.cli.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.Mapper;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.WebClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
+
+/**
+ * Discovers OIDC provider endpoints from .well-known/openid-configuration.
+ */
+@ApplicationScoped
+public class OidcDiscovery {
+
+    private static final String WELL_KNOWN_PATH = "/.well-known/openid-configuration";
+    private static final int TIMEOUT_SECONDS = 15;
+
+    @Inject
+    Vertx vertx;
+
+    public OidcEndpoints discover(final String issuerUrl) {
+        final String discoveryUrl = issuerUrl.endsWith("/")
+                ? issuerUrl.substring(0, issuerUrl.length() - 1) + WELL_KNOWN_PATH
+                : issuerUrl + WELL_KNOWN_PATH;
+
+        final CompletableFuture<Buffer> future = new CompletableFuture<>();
+        final WebClient client = WebClient.create(vertx);
+
+        try {
+            client.getAbs(discoveryUrl).send(ar -> {
+                if (ar.failed()) {
+                    future.completeExceptionally(ar.cause());
+                } else if (ar.result().statusCode() != 200) {
+                    future.completeExceptionally(new CliException(
+                            "OIDC discovery failed with HTTP " + ar.result().statusCode() + " from '" + discoveryUrl + "'.",
+                            APPLICATION_ERROR_RETURN_CODE));
+                } else {
+                    future.complete(ar.result().body());
+                }
+            });
+
+            final Buffer body = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            final JsonNode json = Mapper.MAPPER.readTree(body.getBytes());
+
+            final String authorizationEndpoint = requireField(json, "authorization_endpoint", discoveryUrl);
+            final String tokenEndpoint = requireField(json, "token_endpoint", discoveryUrl);
+
+            return new OidcEndpoints(authorizationEndpoint, tokenEndpoint);
+        } catch (CliException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new CliException("Could not connect to OIDC issuer at '" + issuerUrl + "': " + ex.getMessage(),
+                    APPLICATION_ERROR_RETURN_CODE);
+        } finally {
+            client.close();
+        }
+    }
+
+    private static String requireField(final JsonNode json, final String field, final String discoveryUrl) {
+        final JsonNode node = json.get(field);
+        if (node == null || node.isNull() || node.asText().isBlank()) {
+            throw new CliException("OIDC discovery at '" + discoveryUrl + "' is missing required field '" + field + "'.",
+                    APPLICATION_ERROR_RETURN_CODE);
+        }
+        return node.asText();
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/OidcEndpoints.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/OidcEndpoints.java
@@ -1,0 +1,7 @@
+package io.apicurio.registry.cli.auth;
+
+/**
+ * OIDC provider endpoints discovered from .well-known/openid-configuration.
+ */
+record OidcEndpoints(String authorizationEndpoint, String tokenEndpoint) {
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/OidcTokenClient.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/OidcTokenClient.java
@@ -1,0 +1,112 @@
+package io.apicurio.registry.cli.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.Mapper;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.WebClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
+
+/**
+ * Exchanges authorization codes and refresh tokens with the OIDC token endpoint.
+ */
+@ApplicationScoped
+public class OidcTokenClient {
+
+    private static final int TIMEOUT_SECONDS = 15;
+
+    private static final String PARAM_GRANT_TYPE = "grant_type";
+    private static final String PARAM_CODE = "code";
+    private static final String PARAM_REDIRECT_URI = "redirect_uri";
+    private static final String PARAM_CLIENT_ID = "client_id";
+    private static final String PARAM_CODE_VERIFIER = "code_verifier";
+    private static final String PARAM_REFRESH_TOKEN = "refresh_token";
+    private static final String PARAM_SCOPE = "scope";
+    private static final String GRANT_AUTHORIZATION_CODE = "authorization_code";
+    private static final String GRANT_REFRESH_TOKEN = "refresh_token";
+
+    @Inject
+    Vertx vertx;
+
+    public TokenResponse exchangeCode(final String tokenEndpoint, final String code,
+                                      final String redirectUri, final String clientId,
+                                      final String codeVerifier) {
+        final String body = PARAM_GRANT_TYPE + "=" + GRANT_AUTHORIZATION_CODE
+                + "&" + PARAM_CODE + "=" + encode(code)
+                + "&" + PARAM_REDIRECT_URI + "=" + encode(redirectUri)
+                + "&" + PARAM_CLIENT_ID + "=" + encode(clientId)
+                + "&" + PARAM_CODE_VERIFIER + "=" + encode(codeVerifier);
+        return postTokenRequest(tokenEndpoint, body);
+    }
+
+    public TokenResponse refreshToken(final String tokenEndpoint, final String refreshToken,
+                                      final String clientId, final String scope) {
+        var body = PARAM_GRANT_TYPE + "=" + GRANT_REFRESH_TOKEN
+                + "&" + PARAM_REFRESH_TOKEN + "=" + encode(refreshToken)
+                + "&" + PARAM_CLIENT_ID + "=" + encode(clientId);
+        if (scope != null && !scope.isBlank()) {
+            body += "&" + PARAM_SCOPE + "=" + encode(scope);
+        }
+        return postTokenRequest(tokenEndpoint, body);
+    }
+
+    private TokenResponse postTokenRequest(final String tokenEndpoint, final String formBody) {
+        final CompletableFuture<Buffer> future = new CompletableFuture<>();
+        final WebClient client = WebClient.create(vertx);
+
+        try {
+            client.postAbs(tokenEndpoint)
+                    .putHeader("Content-Type", "application/x-www-form-urlencoded")
+                    .sendBuffer(Buffer.buffer(formBody), ar -> {
+                        if (ar.failed()) {
+                            future.completeExceptionally(ar.cause());
+                        } else if (ar.result().statusCode() != 200) {
+                            future.completeExceptionally(new CliException(
+                                    "Token request failed with HTTP " + ar.result().statusCode()
+                                            + ": " + ar.result().bodyAsString(),
+                                    APPLICATION_ERROR_RETURN_CODE));
+                        } else {
+                            future.complete(ar.result().body());
+                        }
+                    });
+
+            final Buffer responseBody = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            final JsonNode json = Mapper.MAPPER.readTree(responseBody.getBytes());
+
+            final String accessToken = requireField(json, "access_token");
+            final String newRefreshToken = json.has("refresh_token") ? json.get("refresh_token").asText() : null;
+            final long expiresIn = json.has("expires_in") ? json.get("expires_in").asLong() : 3600;
+
+            return new TokenResponse(accessToken, newRefreshToken, expiresIn);
+        } catch (CliException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            if (ex.getCause() instanceof CliException cliEx) {
+                throw cliEx;
+            }
+            throw new CliException("Failed to exchange tokens: " + ex.getMessage(),
+                    APPLICATION_ERROR_RETURN_CODE);
+        } finally {
+            client.close();
+        }
+    }
+
+    private static String requireField(final JsonNode json, final String field) {
+        final JsonNode node = json.get(field);
+        if (node == null || node.isNull() || node.asText().isBlank()) {
+            throw new CliException("Token response is missing required field '" + field + "'.",
+                    APPLICATION_ERROR_RETURN_CODE);
+        }
+        return node.asText();
+    }
+
+    private static String encode(final String value) {
+        return java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8);
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/PkceChallenge.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/PkceChallenge.java
@@ -1,0 +1,31 @@
+package io.apicurio.registry.cli.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * Generates PKCE (RFC 7636) code verifier and challenge for authorization code flow.
+ */
+record PkceChallenge(String codeVerifier, String codeChallenge, String codeChallengeMethod) {
+
+    private static final int VERIFIER_LENGTH = 64;
+    private static final String CHALLENGE_METHOD = "S256";
+
+    static PkceChallenge generate() {
+        final byte[] randomBytes = new byte[VERIFIER_LENGTH];
+        new SecureRandom().nextBytes(randomBytes);
+        final String verifier = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+
+        try {
+            final byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(verifier.getBytes(StandardCharsets.US_ASCII));
+            final String challenge = Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+            return new PkceChallenge(verifier, challenge, CHALLENGE_METHOD);
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 not available", ex);
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/TokenResponse.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/TokenResponse.java
@@ -1,0 +1,7 @@
+package io.apicurio.registry.cli.auth;
+
+/**
+ * Token endpoint response containing access and refresh tokens.
+ */
+public record TokenResponse(String accessToken, String refreshToken, long expiresInSeconds) {
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigModel.java
@@ -22,9 +22,11 @@ public class ConfigModel {
 
     public static final String AUTH_TYPE_BASIC = "basic";
     public static final String AUTH_TYPE_OAUTH2 = "oauth2";
+    public static final String AUTH_TYPE_OIDC = "oidc";
 
     public static final String CREDENTIAL_KEY_PASSWORD = "password";
     public static final String CREDENTIAL_KEY_CLIENT_SECRET = "client-secret";
+    public static final String CREDENTIAL_KEY_REFRESH_TOKEN = "refresh-token";
 
     @JsonProperty("installation-version")
     private int installationVersion = CURRENT_INSTALLATION_VERSION;
@@ -75,6 +77,10 @@ public class ConfigModel {
         @JsonProperty("scope")
         private String scope;
 
+        @ToString.Exclude
+        @JsonProperty("issuerUrl")
+        private String issuerUrl;
+
         @JsonProperty("unsafeCredentialStorage")
         private boolean unsafeCredentialStorage;
 
@@ -84,6 +90,7 @@ public class ConfigModel {
             tokenEndpoint = null;
             clientId = null;
             scope = null;
+            issuerUrl = null;
             unsafeCredentialStorage = false;
         }
     }

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli.services;
 
 import io.apicurio.registry.cli.auth.CredentialStore;
+import io.apicurio.registry.cli.auth.OidcTokenClient;
 import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.config.Config;
 import io.apicurio.registry.cli.config.ConfigModel;
@@ -28,6 +29,9 @@ public class Client {
 
     @Inject
     CredentialStore credentialStore;
+
+    @Inject
+    OidcTokenClient oidcTokenClient;
 
     private RegistryClient registryClient;
 
@@ -82,6 +86,21 @@ public class Client {
             final var clientSecret = requireCredential(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET,
                     context.isUnsafeCredentialStorage());
             options.oauth2(context.getTokenEndpoint(), context.getClientId(), clientSecret, context.getScope());
+        } else if (ConfigModel.AUTH_TYPE_OIDC.equals(context.getAuthType())) {
+            final var refreshToken = requireCredential(contextName, ConfigModel.CREDENTIAL_KEY_REFRESH_TOKEN,
+                    false);
+            try {
+                final var tokenResponse = oidcTokenClient.refreshToken(
+                        context.getTokenEndpoint(), refreshToken, context.getClientId(), context.getScope());
+                if (tokenResponse.refreshToken() != null) {
+                    credentialStore.store(contextName, ConfigModel.CREDENTIAL_KEY_REFRESH_TOKEN,
+                            tokenResponse.refreshToken(), false);
+                }
+                options.bearerToken(tokenResponse.accessToken());
+            } catch (CliException ex) {
+                throw new CliException("Session expired. Run 'acr login --issuer-url "
+                        + context.getIssuerUrl() + "' to re-authenticate.", APPLICATION_ERROR_RETURN_CODE);
+            }
         } else if (!isBlank(context.getAuthType())) {
             throw new CliException("Unsupported auth type '" + context.getAuthType()
                     + "'. Run 'acr login' to reconfigure authentication.", APPLICATION_ERROR_RETURN_CODE);

--- a/cli/src/test/java/io/apicurio/registry/cli/AuthCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/AuthCommandTest.java
@@ -155,6 +155,20 @@ public class AuthCommandTest extends AbstractCLITest {
         assertThat(context.getScope()).isNull();
     }
 
+    // -- OIDC validation --
+
+    @Test
+    public void testLoginOidcMissingClientId() {
+        executeAndAssertFailure("login", "--issuer-url", "http://localhost:8080/realms/test");
+    }
+
+    @Test
+    public void testLoginOidcNoContext() {
+        executeAndAssertSuccess("context", "delete", "--all");
+        executeAndAssertFailure("login", "--issuer-url", "http://localhost:8080/realms/test",
+                "--client-id", TEST_CLIENT_ID);
+    }
+
     // -- State transitions --
 
     @Test

--- a/java-sdk/adapter-jdk/src/main/java/io/apicurio/registry/client/common/JdkAdapterFactory.java
+++ b/java-sdk/adapter-jdk/src/main/java/io/apicurio/registry/client/common/JdkAdapterFactory.java
@@ -83,6 +83,9 @@ public final class JdkAdapterFactory {
                         options.getClientSecret(), options.getScope(), options.isOtelEnabled());
                 return new JdkOAuth2RequestAdapter(httpClient, tokenProvider);
 
+            case BEARER_TOKEN:
+                return new JdkAuthenticatedRequestAdapter(httpClient, "Bearer " + options.getBearerToken());
+
             default:
                 throw new IllegalArgumentException("Unsupported authentication type: " + options.getAuthType());
         }

--- a/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/VertxAdapterFactory.java
+++ b/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/VertxAdapterFactory.java
@@ -12,6 +12,7 @@ import io.vertx.core.net.PfxOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.ext.web.client.WebClientSession;
 
 import java.lang.annotation.Annotation;
 import java.util.logging.Level;
@@ -52,6 +53,8 @@ public final class VertxAdapterFactory {
             case OAUTH2:
                 return createVertxOAuth2(options.getTokenEndpoint(), options.getClientId(),
                         options.getClientSecret(), options.getScope(), vertxToUse, webClientOptions);
+            case BEARER_TOKEN:
+                return createVertxBearerToken(options.getBearerToken(), vertxToUse, webClientOptions);
             case CUSTOM_WEBCLIENT:
                 return createVertxCustomWebClient(options);
             default:
@@ -105,6 +108,12 @@ public final class VertxAdapterFactory {
                                                      String clientId, String clientSecret, String scope, Vertx vertx, WebClientOptions webClientOptions) {
         WebClient webClient = VertXAuthFactory.buildOIDCWebClient(vertx, webClientOptions, tokenEndpoint, clientId, clientSecret, scope);
         return new VertXRequestAdapter(webClient);
+    }
+
+    private static RequestAdapter createVertxBearerToken(String token, Vertx vertx, WebClientOptions webClientOptions) {
+        WebClient webClient = webClientOptions == null ? WebClient.create(vertx) : WebClient.create(vertx, webClientOptions);
+        WebClient sessionClient = WebClientSession.create(webClient).addHeader("Authorization", "Bearer " + token);
+        return new VertXRequestAdapter(sessionClient);
     }
 
     private static RequestAdapter createVertxCustomWebClient(RegistryClientOptions options) {

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientOptions.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientOptions.java
@@ -56,6 +56,7 @@ public class RegistryClientOptions {
         ANONYMOUS,
         BASIC,
         OAUTH2,
+        BEARER_TOKEN,
         CUSTOM_WEBCLIENT
     }
 
@@ -91,6 +92,7 @@ public class RegistryClientOptions {
     private String clientId;
     private String clientSecret;
     private String scope;
+    private String bearerToken;
     private WebClient webClient;
     // Retry config
     private boolean retryEnabled = false;
@@ -161,6 +163,10 @@ public class RegistryClientOptions {
 
     public String getScope() {
         return scope;
+    }
+
+    public String getBearerToken() {
+        return bearerToken;
     }
 
     public Vertx getVertx() {
@@ -346,6 +352,19 @@ public class RegistryClientOptions {
     }
 
     /**
+     * Configures authentication using a pre-obtained bearer token.
+     *
+     * @param token the bearer token (e.g., JWT access token)
+     * @return this builder
+     */
+    public RegistryClientOptions bearerToken(String token) {
+        clearAuth();
+        this.authType = AuthType.BEARER_TOKEN;
+        this.bearerToken = token;
+        return this;
+    }
+
+    /**
      * Configures a custom WebClient for advanced authentication scenarios.
      *
      * @param webClient the pre-configured WebClient to use
@@ -366,6 +385,7 @@ public class RegistryClientOptions {
         this.clientId = null;
         this.clientSecret = null;
         this.scope = null;
+        this.bearerToken = null;
         this.webClient = null;
     }
 

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -325,6 +325,11 @@ public class RegistryClientRequestAdapterFactory {
             case OAUTH2:
                 validateOAuth2Credentials(options.getTokenEndpoint(), options.getClientId(), options.getClientSecret());
                 break;
+            case BEARER_TOKEN:
+                if (options.getBearerToken() == null || options.getBearerToken().trim().isEmpty()) {
+                    throw new IllegalArgumentException("Bearer token cannot be null or empty");
+                }
+                break;
         }
     }
 


### PR DESCRIPTION
Fixes #8133

## Summary
- Add browser-based OIDC login flow to `acr login` via new `--issuer-url` flag
- PKCE (S256) authorization code flow with local callback server
- Automatic token refresh using stored refresh tokens
- OIDC discovery via `.well-known/openid-configuration`

## Changes
- **`LoginCommand.java`** — Added `--issuer-url` option and `loginOidc()` method with PKCE flow
- **`OidcDiscovery.java`** *(new)* — Fetches OIDC discovery document, returns authorization + token endpoints
- **`OidcCallbackServer.java`** *(new)* — Ephemeral local HTTP server to receive the authorization code callback
- **`OidcTokenClient.java`** *(new)* — Handles authorization code exchange and token refresh via Vert.x
- **`PkceChallenge.java`** *(new)* — PKCE S256 code challenge/verifier generation
- **`BrowserLauncher.java`** *(new)* — Opens the authorization URL in the user's default browser
- **`TokenResponse.java`** *(new)* — Record for token endpoint response (access_token, refresh_token, expires_in)
- **`OidcEndpoints.java`** *(new)* — Record for discovered OIDC endpoints
- **`ConfigModel.java`** — Added `AUTH_TYPE_OIDC`, `CREDENTIAL_KEY_REFRESH_TOKEN`, `issuerUrl` field
- **`Client.java`** — Added OIDC token refresh on client creation using stored refresh token
- **`LogoutCommand.java`** — Cleans up refresh token on logout
- **`RegistryClientOptions.java`** — Added `bearerToken()` method for raw token auth

## Usage
```bash
# Browser-based OIDC login
acr login --issuer-url https://keycloak.example.com/realms/myrealm --client-id my-client

# Opens browser for authentication, receives callback, stores refresh token
# Subsequent commands auto-refresh the access token
```

## Test plan
- [x] Checkstyle passes
- [x] Compilation passes (main + test sources)
- [x] Conflict resolution from rebase verified
- [ ] CI unit tests (require Docker)
- [ ] Manual E2E testing with Keycloak