### PR TITLE
feat(cli): unify handling of the default group. Fixes #8025

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/common/IdUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/IdUtil.java
@@ -11,7 +11,7 @@ import static io.apicurio.registry.cli.utils.Utils.isBlank;
  */
 public final class IdUtil {
 
-    private static final String DEFAULT_GROUP = "default";
+    public static final String DEFAULT_GROUP = "default";
 
     private IdUtil() {
     }

--- a/cli/src/main/java/io/apicurio/registry/cli/common/RuleUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/RuleUtil.java
@@ -35,7 +35,6 @@ public final class RuleUtil {
                     .map(Enum::name).toList()
     );
 
-    private static final String DEFAULT_GROUP = "default";
 
     private RuleUtil() {
     }
@@ -61,7 +60,7 @@ public final class RuleUtil {
     }
 
     public static void rejectDefaultGroup(final String groupId) {
-        if (DEFAULT_GROUP.equals(groupId)) {
+        if (IdUtil.DEFAULT_GROUP.equals(groupId)) {
             throw new CliException(
                     "Group rules are not available for the 'default' group. Use global rules or specify a custom group with -g.",
                     VALIDATION_ERROR_RETURN_CODE

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupCreateCommand.java
@@ -1,6 +1,8 @@
 package io.apicurio.registry.cli.group;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
@@ -47,6 +49,10 @@ public class GroupCreateCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
+        if (IdUtil.DEFAULT_GROUP.equals(groupId)) {
+            throw new CliException("The 'default' group is implicit and cannot be created.",
+                    CliException.VALIDATION_ERROR_RETURN_CODE);
+        }
         var newGroup = new CreateGroup();
         newGroup.setGroupId(groupId);
         if (!isBlank(description)) {

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupDeleteCommand.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.cli.group;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.ArtifactSortBy;
 import io.apicurio.registry.rest.client.models.SortOrder;
@@ -11,6 +12,7 @@ import picocli.CommandLine.Parameters;
 
 import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
 import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+import static io.apicurio.registry.cli.utils.Utils.isBlank;
 import static java.util.Optional.ofNullable;
 
 @Command(
@@ -35,6 +37,13 @@ public class GroupDeleteCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
+        if (isBlank(groupId)) {
+            throw new CliException("Group ID cannot be empty.", VALIDATION_ERROR_RETURN_CODE);
+        }
+        if (IdUtil.DEFAULT_GROUP.equals(groupId)) {
+            throw new CliException("The 'default' group is implicit and cannot be deleted.",
+                    VALIDATION_ERROR_RETURN_CODE);
+        }
         // Check if the group exists
         client.getRegistryClient().groups().byGroupId(groupId).get();
 

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupGetCommand.java
@@ -2,6 +2,8 @@ package io.apicurio.registry.cli.group;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
@@ -22,6 +24,7 @@ import static io.apicurio.registry.cli.utils.Columns.MODIFIED_ON;
 import static io.apicurio.registry.cli.utils.Columns.OWNER;
 import static io.apicurio.registry.cli.utils.Columns.VALUE;
 import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Utils.isBlank;
 import static io.apicurio.registry.cli.utils.Conversions.convertToString;
 import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
 
@@ -45,9 +48,15 @@ public class GroupGetCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
+        if (isBlank(groupId)) {
+            throw new CliException("Group ID cannot be empty.", CliException.VALIDATION_ERROR_RETURN_CODE);
+        }
+        if (IdUtil.DEFAULT_GROUP.equals(groupId)) {
+            throw new CliException("The 'default' group is implicit and cannot be retrieved directly.",
+                    CliException.VALIDATION_ERROR_RETURN_CODE);
+        }
         //noinspection ConstantConditions
         var group = convert(client.getRegistryClient().groups().byGroupId(groupId).get());
-        // TODO: Should we include the `default` group in the list?
         printGroup(output, group, outputType);
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupUpdateCommand.java
@@ -1,6 +1,8 @@
 package io.apicurio.registry.cli.group;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.EditableGroupMetaData;
@@ -44,6 +46,13 @@ public class GroupUpdateCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
+        if (isBlank(groupId)) {
+            throw new CliException("Group ID cannot be empty.", CliException.VALIDATION_ERROR_RETURN_CODE);
+        }
+        if (IdUtil.DEFAULT_GROUP.equals(groupId)) {
+            throw new CliException("The 'default' group is implicit and cannot be updated.",
+                    CliException.VALIDATION_ERROR_RETURN_CODE);
+        }
         var group = client.getRegistryClient().groups().byGroupId(groupId).get();
         var updatedGroup = new EditableGroupMetaData();
         updatedGroup.setDescription(group.getDescription());

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli.utils;
 
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.rest.client.models.Labels;
 import io.apicurio.registry.rest.v3.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static io.apicurio.registry.cli.utils.Utils.isBlank;
 import static java.util.Optional.ofNullable;
 
 // TODO: Move some of these to the Java SDK.
@@ -43,7 +45,7 @@ public final class Conversions {
 
     public static GroupMetaData convert(io.apicurio.registry.rest.client.models.GroupMetaData group) {
         return GroupMetaData.builder()
-                .groupId(group.getGroupId())
+                .groupId(normalizeGroupId(group.getGroupId()))
                 .description(group.getDescription())
                 .createdOn(convert(group.getCreatedOn()))
                 .owner(group.getOwner())
@@ -55,7 +57,7 @@ public final class Conversions {
 
     public static SearchedGroup convert(io.apicurio.registry.rest.client.models.SearchedGroup group) {
         return SearchedGroup.builder()
-                .groupId(group.getGroupId())
+                .groupId(normalizeGroupId(group.getGroupId()))
                 .description(group.getDescription())
                 .createdOn(convert(group.getCreatedOn()))
                 .owner(group.getOwner())
@@ -190,7 +192,7 @@ public final class Conversions {
     }
 
     public static Date convert(OffsetDateTime ts) {
-        return Date.from(ts.toInstant());
+        return ts != null ? Date.from(ts.toInstant()) : null;
     }
 
     public static String convertToString(Labels labels) {
@@ -219,6 +221,10 @@ public final class Conversions {
 
     public static String convertToString(Long value) {
         return ofNullable(value).map(String::valueOf).orElse("");
+    }
+
+    private static String normalizeGroupId(final String groupId) {
+        return isBlank(groupId) ? IdUtil.DEFAULT_GROUP : groupId;
     }
 
     public static Map<String, String> parseLabels(final List<String> labels) {


### PR DESCRIPTION
Fixes #8025

## Summary
- Unify the handling of the `default` group across all CLI group commands
- Prevent creating, deleting, or updating the implicit `default` group with clear error messages
- Centralize the `DEFAULT_GROUP` constant in `IdUtil` (was duplicated in `RuleUtil`)
- Add blank group ID validation to group get/delete/update commands
- Display `default` instead of `null` for the default group in output

## Changes
- **`IdUtil.java`** — Made `DEFAULT_GROUP` constant public
- **`RuleUtil.java`** — Removed duplicate `DEFAULT_GROUP`, references `IdUtil.DEFAULT_GROUP`
- **`GroupCreateCommand.java`** — Reject creating the `default` group
- **`GroupDeleteCommand.java`** — Reject deleting the `default` group, validate blank group ID
- **`GroupGetCommand.java`** — Validate blank group ID, handle `default` group display
- **`GroupUpdateCommand.java`** — Reject updating the `default` group, validate blank group ID
- **`Conversions.java`** — Display `default` instead of `null` for default group in output

## Test plan
- [x] Checkstyle passes
- [x] All 278 tests pass (0 failures, 0 errors, 3 skipped)