### PR TITLE
ci(operator): add Awaitility timeout and Failsafe retry for flaky Kafka tests

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -238,6 +238,8 @@ jobs:
           name: operator-test-images
           path: /tmp/
 
+      # driver=none: Kubernetes runs directly on the host, sharing all runner
+      # resources (4 vCPU / 16 GB) and the host network (localhost:5000 registry).
       - uses: apicurio/apicurio-github-actions/setup-minikube@97d452c41f1abd7142c0ce2ac37e87922e35e71d # v2
         with:
           driver: 'none'
@@ -269,10 +271,14 @@ jobs:
           docker push "$REGISTRY_GITOPS_SYNC_IMAGE"
           docker push "$IMAGE"
 
+      # -Dawaitility.defaultTimeout=PT10M: extend default poll timeout from 7 min to 10 min
+      #   for slow Kafka/OLM startups on shared runners.
+      # -Dfailsafe.rerunFailingTestsCount=1: retry failed tests once as a safety net for
+      #   transient resource-related flakes.
       - name: Run ${{ matrix.name }} tests on Minikube
         working-directory: operator
         run: |
-          make BUILD_OPTS="--no-transfer-progress -Daether.syncContext.named.factory=noop -Dtest.operator.deployment-target=minikube ${{ matrix.extra-build-opts }}" \
+          make BUILD_OPTS="--no-transfer-progress -Daether.syncContext.named.factory=noop -Dtest.operator.deployment-target=minikube -Dawaitility.defaultTimeout=PT10M -Dfailsafe.rerunFailingTestsCount=1 ${{ matrix.extra-build-opts }}" \
             REMOTE_TESTS_ALL_INSTALL_FILE=controller/target/test-install.yaml \
             GROUPS="${{ matrix.groups }}" \
             EXCLUDED_GROUPS="${{ matrix.excluded-groups }}" \

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -271,14 +271,15 @@ jobs:
           docker push "$REGISTRY_GITOPS_SYNC_IMAGE"
           docker push "$IMAGE"
 
-      # -Dawaitility.defaultTimeout=PT10M: extend default poll timeout from 7 min to 10 min
-      #   for slow Kafka/OLM startups on shared runners.
+      # -Dtest.operator.timeout.long=600: extend default Awaitility timeout from 420s (7 min)
+      #   to 600s (10 min) for slow Kafka/OLM startups on shared runners. This is read by
+      #   ITBase.LONG_DURATION via Integer.getInteger().
       # -Dfailsafe.rerunFailingTestsCount=1: retry failed tests once as a safety net for
       #   transient resource-related flakes.
       - name: Run ${{ matrix.name }} tests on Minikube
         working-directory: operator
         run: |
-          make BUILD_OPTS="--no-transfer-progress -Daether.syncContext.named.factory=noop -Dtest.operator.deployment-target=minikube -Dawaitility.defaultTimeout=PT10M -Dfailsafe.rerunFailingTestsCount=1 ${{ matrix.extra-build-opts }}" \
+          make BUILD_OPTS="--no-transfer-progress -Daether.syncContext.named.factory=noop -Dtest.operator.deployment-target=minikube -Dtest.operator.timeout.long=600 -Dfailsafe.rerunFailingTestsCount=1 ${{ matrix.extra-build-opts }}" \
             REMOTE_TESTS_ALL_INSTALL_FILE=controller/target/test-install.yaml \
             GROUPS="${{ matrix.groups }}" \
             EXCLUDED_GROUPS="${{ matrix.excluded-groups }}" \


### PR DESCRIPTION
## Summary

Adds two resilience flags to the operator test Maven command to reduce flaky Kafka test failures:
- `-Dawaitility.defaultTimeout=PT10M`: extends default poll timeout from 7 to 10 minutes for slow broker startups
- `-Dfailsafe.rerunFailingTestsCount=1`: retries failed tests once as a safety net

## Problem

Operator Kafka tests (`KafkaSqlITTest`, `KafkaSqlTLSITTest`, `KafkaSqlOAuthITTest`) intermittently time out on GitHub Actions runners. The Strimzi/Kafka broker sometimes needs longer than 7 minutes to start under CI load. These two flags provide immediate relief while deeper fixes (REG-10 Kafka CR tuning, REG-17 image pre-loading) are implemented.

## Why NOT change the Minikube driver

The operator workflow uses `driver: none` (bare-metal K8s), which gives full access to all runner resources (4 vCPU / 16 GB). Switching to `driver: docker` would break the `localhost:5000` registry used for test image pulls. The `--cpus=max --memory=max` flags are redundant with `driver: none`.

## Test plan

- [ ] Operator Kafka tests pass in CI
- [ ] Awaitility timeout visible in Maven logs (`-Dawaitility.defaultTimeout=PT10M`)
- [ ] Failed tests show retry attempt in surefire reports