### PR TITLE
ci(operator): add explicit resource limits and JVM tuning to test Kafka CRs

### DIFF
--- a/operator/controller/src/test/resources/k8s/examples/kafkasql/access/example-cluster.kafka.yaml
+++ b/operator/controller/src/test/resources/k8s/examples/kafkasql/access/example-cluster.kafka.yaml
@@ -10,6 +10,16 @@ spec:
   roles:
     - controller
     - broker
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: 500m
+    limits:
+      memory: 1Gi
+      cpu: 1000m
+  jvmOptions:
+    -Xms: 512m
+    -Xmx: 512m
   storage:
     type: ephemeral
 ---
@@ -37,6 +47,10 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
+      num.network.threads: 2
+      num.io.threads: 2
+      log.retention.hours: 1
+      log.segment.bytes: 52428800
     storage:
       type: ephemeral
   entityOperator:

--- a/operator/controller/src/test/resources/k8s/examples/kafkasql/oauth/oauth-example-cluster.yaml
+++ b/operator/controller/src/test/resources/k8s/examples/kafkasql/oauth/oauth-example-cluster.yaml
@@ -17,6 +17,16 @@ spec:
   roles:
     - controller
     - broker
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: 500m
+    limits:
+      memory: 1Gi
+      cpu: 1000m
+  jvmOptions:
+    -Xms: 512m
+    -Xmx: 512m
   storage:
     type: ephemeral
 ---
@@ -53,5 +63,9 @@ spec:
       transaction.state.log.min.isr: 1
       sasl.enabled.mechanisms: OAUTHBEARER
       listener.name.tls.sasl.enabled.mechanisms: OAUTHBEARER
+      num.network.threads: 2
+      num.io.threads: 2
+      log.retention.hours: 1
+      log.segment.bytes: 52428800
     storage:
       type: ephemeral

--- a/operator/controller/src/test/resources/k8s/examples/kafkasql/plain/example-cluster.kafka.yaml
+++ b/operator/controller/src/test/resources/k8s/examples/kafkasql/plain/example-cluster.kafka.yaml
@@ -10,6 +10,16 @@ spec:
   roles:
     - controller
     - broker
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: 500m
+    limits:
+      memory: 1Gi
+      cpu: 1000m
+  jvmOptions:
+    -Xms: 512m
+    -Xmx: 512m
   storage:
     type: ephemeral
 ---
@@ -33,7 +43,9 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
+      num.network.threads: 2
+      num.io.threads: 2
+      log.retention.hours: 1
+      log.segment.bytes: 52428800
     storage:
       type: ephemeral
-  entityOperator:
-    topicOperator: {}

--- a/operator/controller/src/test/resources/k8s/examples/kafkasql/tls/example-cluster.kafka.yaml
+++ b/operator/controller/src/test/resources/k8s/examples/kafkasql/tls/example-cluster.kafka.yaml
@@ -10,6 +10,16 @@ spec:
   roles:
     - controller
     - broker
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: 500m
+    limits:
+      memory: 1Gi
+      cpu: 1000m
+  jvmOptions:
+    -Xms: 512m
+    -Xmx: 512m
   storage:
     type: ephemeral
 ---
@@ -37,6 +47,10 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
+      num.network.threads: 2
+      num.io.threads: 2
+      log.retention.hours: 1
+      log.segment.bytes: 52428800
     storage:
       type: ephemeral
   entityOperator:


### PR DESCRIPTION
## Summary

Adds explicit resource requests/limits and JVM heap tuning to all 4 test Kafka CR YAML files. Strimzi sets NO resource limits by default — the broker auto-detects available memory and over-allocates, starving other pods on CI runners.

## Changes

All 4 files in `operator/controller/src/test/resources/k8s/examples/kafkasql/`:

**KafkaNodePool** (added to each):
- `resources.requests`: 1Gi memory, 500m CPU
- `resources.limits`: 1Gi memory, 1000m CPU  
- `jvmOptions`: -Xms 512m, -Xmx 512m

**Kafka config** (added to each):
- `num.network.threads: 2` (default 3)
- `num.io.threads: 2` (default 8)
- `log.retention.hours: 1`
- `log.segment.bytes: 52428800` (50MB, default 1GB)

**Entity Operator**:
- Removed from `plain/` (saves ~256 MB RAM — no KafkaTopic/KafkaUser in that test)
- Kept in `tls/`, `access/` (need KafkaUser)
- N/A for `oauth/` (never had one)

**Total Kafka footprint**: ~1.3 Gi (broker + operator) vs unbounded previously.

## Test plan

- [ ] All 4 KafkaSql operator tests pass in CI
- [ ] Kafka broker starts within the timeout window
- [ ] No behavioral change to test assertions