### PR TITLE
fix(deps): update Quarkus to 3.33.2.1 (LTS security patch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <!--
     WARNING: The following group of dependencies has to be aligned with the best corresponding Quarkus version.
     -->
-    <quarkus.version>3.33.2</quarkus.version>
+    <quarkus.version>3.33.2.1</quarkus.version>
     <!--
     # QOSDK
 
@@ -218,8 +218,8 @@
     <json-sKema.version>0.31.0</json-sKema.version>
     <!-- TODO unification -->
     <org.json.version>20250517</org.json.version>
-    <jackson-datatype-json-org.version>2.18.8</jackson-datatype-json-org.version>
-    <jackson-dataformat-yaml.version>2.18.2</jackson-dataformat-yaml.version>
+    <jackson-datatype-json-org.version>2.21.2</jackson-datatype-json-org.version>
+    <jackson-dataformat-yaml.version>2.21.2</jackson-dataformat-yaml.version>
 
     <!-- OpenAPI -->
     <openapi-diff.version>2.1.7</openapi-diff.version>


### PR DESCRIPTION
## Summary
- Bumps Quarkus from 3.33.2 to 3.33.2.1 (LTS security patch released June 17, 2026)
- Aligns Jackson versions (2.18.x -> 2.21.2) to match the Quarkus 3.33.2.1 BOM
- Netty and SLF4J were already aligned — no changes needed

## Test plan
- [ ] CI passes with the updated dependency versions