### PR TITLE
fix(protobuf): ignore google/protobuf imports in ALL_REFS_MAPPED integrity checks

### DIFF
--- a/schema-util/protobuf/src/main/java/io/apicurio/registry/protobuf/rules/validity/ProtobufContentValidator.java
+++ b/schema-util/protobuf/src/main/java/io/apicurio/registry/protobuf/rules/validity/ProtobufContentValidator.java
@@ -4,6 +4,8 @@ import com.squareup.wire.schema.SchemaException;
 import com.squareup.wire.schema.internal.parser.MessageElement;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.content.refs.ExternalReference;
+import io.apicurio.registry.protobuf.content.refs.ProtobufReferenceFinder;
 import io.apicurio.registry.rest.v3.beans.ArtifactReference;
 import io.apicurio.registry.rules.validity.AbstractContentValidator;
 import io.apicurio.registry.rules.validity.ValidityLevel;
@@ -13,7 +15,6 @@ import io.apicurio.registry.utils.protobuf.schema.FileDescriptorUtils;
 import io.apicurio.registry.utils.protobuf.schema.ProtobufFile;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -113,13 +114,15 @@ public class ProtobufContentValidator extends AbstractContentValidator {
     public void validateReferences(TypedContent content, List<ArtifactReference> references)
             throws RuleViolationException {
         try {
-            ProtoFileElement protoFileElement = ProtobufFile
-                    .toProtoFileElement(content.getContent().content());
-            Set<String> allImports = new HashSet<>();
-            allImports.addAll(protoFileElement.getImports());
-            allImports.addAll(protoFileElement.getPublicImports());
+            // Reuse ProtobufReferenceFinder so well-known google/protobuf/* imports
+            // (descriptor, timestamp, etc.) are excluded — same as auto-ref discovery.
+            // Those are provided by the protobuf runtime and must not require registry mappings.
+            ProtobufReferenceFinder referenceFinder = new ProtobufReferenceFinder();
+            Set<String> requiredReferenceNames = referenceFinder.findExternalReferences(content).stream()
+                    .map(ExternalReference::getResource)
+                    .collect(Collectors.toSet());
 
-            validateMappedReferences(references, allImports, "Unmapped reference detected.");
+            validateMappedReferences(references, requiredReferenceNames, "Unmapped reference detected.");
         }
         catch (RuleViolationException rve) {
             throw rve;

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/ProtobufContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/ProtobufContentValidatorTest.java
@@ -775,4 +775,56 @@ public class ProtobufContentValidatorTest extends ArtifactUtilProviderTestBase {
         });
     }
 
+    /**
+     * Regression for #4877: well-known google/protobuf imports must not require registry
+     * mappings under ALL_REFS_MAPPED / validateReferences.
+     */
+    @Test
+    public void testValidateReferencesIgnoresGoogleProtobufImports() throws Exception {
+        String schema = """
+                syntax = "proto3";
+                package sample;
+                import "google/protobuf/descriptor.proto";
+                import "google/protobuf/timestamp.proto";
+                extend google.protobuf.FileOptions {
+                  string version = 99999;
+                }
+                message Event {
+                  google.protobuf.Timestamp created_at = 1;
+                }
+                """;
+        TypedContent content = TypedContent.create(ContentHandle.create(schema),
+                ContentTypes.APPLICATION_PROTOBUF);
+        ProtobufContentValidator validator = new ProtobufContentValidator();
+
+        // Empty mappings must succeed — google/protobuf/* are runtime-provided.
+        validator.validateReferences(content, List.of());
+    }
+
+    @Test
+    public void testValidateReferencesStillRequiresCustomImportsWithGoogleOnes() throws Exception {
+        String schema = """
+                syntax = "proto3";
+                package sample;
+                import "google/protobuf/timestamp.proto";
+                import "message2.proto";
+                message Wrapper {
+                  google.protobuf.Timestamp created_at = 1;
+                }
+                """;
+        TypedContent content = TypedContent.create(ContentHandle.create(schema),
+                ContentTypes.APPLICATION_PROTOBUF);
+        ProtobufContentValidator validator = new ProtobufContentValidator();
+
+        // Custom import still must be mapped.
+        Assertions.assertThrows(RuleViolationException.class,
+                () -> validator.validateReferences(content, List.of()));
+
+        // Mapping only the custom import is enough (google import ignored).
+        List<ArtifactReference> references = new ArrayList<>();
+        references.add(ArtifactReference.builder().groupId("default").artifactId("message2.proto")
+                .version("1.0").name("message2.proto").build());
+        validator.validateReferences(content, references);
+    }
+
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/ProtobufContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/ProtobufContentValidatorTest.java
@@ -797,7 +797,7 @@ public class ProtobufContentValidatorTest extends ArtifactUtilProviderTestBase {
                 ContentTypes.APPLICATION_PROTOBUF);
         ProtobufContentValidator validator = new ProtobufContentValidator();
 
-        // Empty mappings must succeed — google/protobuf/* are runtime-provided.
+        // Empty mappings must succeed - google/protobuf/* are runtime-provided.
         validator.validateReferences(content, List.of());
     }
 


### PR DESCRIPTION
Fixes #4877

Reopens work from #8560 

## What
\ALL_REFS_MAPPED\ was treating well-known \google/protobuf/*\ imports as unmapped references. Reuse \ProtobufReferenceFinder\ in \ProtobufContentValidator.validateReferences\ (same pattern as avro).

## Testing
- \ProtobufContentValidatorTest#testValidateReferencesIgnoresGoogleProtobufImports\
- \ProtobufContentValidatorTest#testValidateReferencesStillRequiresCustomImportsWithGoogleOnes\
- both pass locally