### PR TITLE
fix(operator): add diagnostic dumps for OLM test setup failures (#8658)

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/ClusterDiagnostics.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/ClusterDiagnostics.java
@@ -47,6 +47,7 @@ public final class ClusterDiagnostics {
         dumpNetworkPolicies(client, namespace);
         dumpPods(client, namespace);
         dumpEvents(client, namespace);
+        dumpImagePullEvents(client, namespace);
 
         if (isOLM) {
             dumpOLMResources(client, namespace);
@@ -232,9 +233,48 @@ public final class ClusterDiagnostics {
         }
     }
 
+    private static void dumpImagePullEvents(KubernetesClient client, String namespace) {
+        log.error("--- Image Pull Events ---");
+        try {
+            var events = client.v1().events().inNamespace(namespace).list().getItems();
+            var pullEvents = events.stream()
+                    .filter(e -> {
+                        var reason = e.getReason();
+                        return reason != null && (reason.contains("Pull") || reason.contains("BackOff")
+                                || reason.contains("ErrImage"));
+                    })
+                    .filter(e -> {
+                        var type = e.getType();
+                        return "Warning".equals(type) || "Failed".equalsIgnoreCase(e.getReason());
+                    })
+                    .sorted(Comparator.comparing(
+                            (Event e) -> e.getLastTimestamp() != null ? e.getLastTimestamp() : "",
+                            Comparator.reverseOrder()))
+                    .toList();
+
+            if (pullEvents.isEmpty()) {
+                log.error("  (none)");
+                return;
+            }
+
+            for (var event : pullEvents) {
+                log.error("  {} | {} | {} | {}/{} | {}",
+                        event.getLastTimestamp(),
+                        event.getType(),
+                        event.getReason(),
+                        event.getInvolvedObject().getKind(),
+                        event.getInvolvedObject().getName(),
+                        event.getMessage());
+            }
+        } catch (Exception e) {
+            log.error("  Failed to list image pull events: {}", e.getMessage());
+        }
+    }
+
     private static void dumpOLMResources(KubernetesClient client, String namespace) {
         log.error("--- OLM Resources ---");
 
+        dumpGenericResources(client, "operators.coreos.com/v1alpha1", "CatalogSource", namespace);
         dumpGenericResources(client, "operators.coreos.com/v1alpha1", "Subscription", namespace);
         dumpGenericResources(client, "operators.coreos.com/v1alpha1", "InstallPlan", namespace);
         dumpGenericResources(client, "operators.coreos.com/v1alpha1", "ClusterServiceVersion", namespace);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/ClusterDiagnostics.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/ClusterDiagnostics.java
@@ -243,13 +243,10 @@ public final class ClusterDiagnostics {
                         return reason != null && (reason.contains("Pull") || reason.contains("BackOff")
                                 || reason.contains("ErrImage"));
                     })
-                    .filter(e -> {
-                        var type = e.getType();
-                        return "Warning".equals(type) || "Failed".equalsIgnoreCase(e.getReason());
-                    })
+                    .filter(e -> "Warning".equals(e.getType()))
                     .sorted(Comparator.comparing(
-                            (Event e) -> e.getLastTimestamp() != null ? e.getLastTimestamp() : "",
-                            Comparator.reverseOrder()))
+                            Event::getLastTimestamp,
+                            Comparator.nullsLast(Comparator.reverseOrder())))
                     .toList();
 
             if (pullEvents.isEmpty()) {

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.OperatorException;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.utils.ClusterDiagnostics;
 import io.apicurio.registry.operator.utils.OperatorTestContext;
 import io.apicurio.registry.operator.utils.OperatorTestExtension;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -66,6 +67,16 @@ public abstract class OLMITBase implements OperatorTestContext {
         ingressManager = new IngressManager(client, namespace);
         cleanup = ConfigProvider.getConfig().getValue(ITBase.CLEANUP, Boolean.class);
 
+        try {
+            setupOLMResources();
+        } catch (Exception e) {
+            log.error("OLM setup failed, dumping cluster diagnostics before propagating failure", e);
+            ClusterDiagnostics.dump(client, namespace, true);
+            throw e;
+        }
+    }
+
+    private static void setupOLMResources() throws Exception {
         int olmVersion = ConfigProvider.getConfig().getOptionalValue(OML_VERSION, Integer.class).orElse(0);
         if (olmVersion == 0) {
 

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.operator.it;
 
+import io.apicurio.registry.operator.utils.ClusterDiagnostics;
 import io.apicurio.registry.operator.utils.OperatorTestContext;
 import io.apicurio.registry.operator.utils.OperatorTestExtension;
 import io.apicurio.registry.operator.utils.RetryTest;
@@ -12,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 
@@ -422,16 +422,22 @@ public class UpgradeOLMITTest implements OperatorTestContext {
         log.info("Manual approval upgrade succeeded: {} -> {}", startVersion, minorHead);
     }
 
-    private void deployCatalogAndSubscribe(String channel, String startVersion) throws IOException {
-        createResource(client, namespace, "olmv0/catalog-source.yaml");
-        waitForCatalogPodReady(client, namespace);
-        createResource(client, namespace, "olmv0/operator-group.yaml");
+    private void deployCatalogAndSubscribe(String channel, String startVersion) throws Exception {
+        try {
+            createResource(client, namespace, "olmv0/catalog-source.yaml");
+            waitForCatalogPodReady(client, namespace);
+            createResource(client, namespace, "olmv0/operator-group.yaml");
 
-        var extraVars = Map.of(
-                "${PLACEHOLDER_UPGRADE_CHANNEL}", channel,
-                "${PLACEHOLDER_UPGRADE_START_CSV}", csvName(startVersion));
-        var raw = loadRawResource("olmv0/subscription-upgrade.yaml");
-        client.resource(replaceVars(raw, namespace, extraVars)).create();
+            var extraVars = Map.of(
+                    "${PLACEHOLDER_UPGRADE_CHANNEL}", channel,
+                    "${PLACEHOLDER_UPGRADE_START_CSV}", csvName(startVersion));
+            var raw = loadRawResource("olmv0/subscription-upgrade.yaml");
+            client.resource(replaceVars(raw, namespace, extraVars)).create();
+        } catch (Exception e) {
+            log.error("OLM catalog/subscription setup failed, dumping cluster diagnostics", e);
+            ClusterDiagnostics.dump(client, namespace, true);
+            throw e;
+        }
     }
 
     private void waitForOperatorVersion(String version) {


### PR DESCRIPTION
## Summary
- Wrap `OLMITBase.beforeAll()` OLM setup in a try-catch that calls
  `ClusterDiagnostics.dump()` before rethrowing — the core fix for the
  `@BeforeAll` gap where `AfterTestExecutionCallback` never fires
- Add `CatalogSource` (`operators.coreos.com/v1alpha1`) to the OLM resource
  dump — previously missing from `dumpOLMResources()`
- Add dedicated `dumpImagePullEvents()` section that filters for image-pull
  related failures (`ErrImagePull`, `ImagePullBackOff`, `BackOff`) for easy
  scanning of the most common downstream failure mode
- Wrap `UpgradeOLMITTest.deployCatalogAndSubscribe()` with the same
  diagnostic dump pattern for OLM setup failures during upgrade tests

## Related Issue
Fixes #8658

## Test Plan
- [ ] Verify the `operator/controller` module compiles with `./mvnw compile -pl operator/controller -am -DskipTests`
- [ ] Verify the `operator/olm-tests` module compiles with `./mvnw compile -pl operator/olm-tests -am -DskipTests`
- [ ] Review that `ClusterDiagnostics.dump()` is called in the `catch` block of `OLMITBase.beforeAll()` before the exception is rethrown
- [ ] Review that CatalogSource is now included in `dumpOLMResources()`
- [ ] Review that image pull events are filtered and displayed in a dedicated section
- [ ] CI OLM test suite passes (functional verification requires a Kubernetes cluster with OLM)