### PR TITLE
fix(rules): detect MCP tool parameter type and enum breaking changes

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -18,6 +18,8 @@ import java.util.Set;
  * - Adding required parameters: Backward incompatible
  * - Removing required parameters: Backward incompatible
  * - Changing inputSchema type: Backward incompatible
+ * - Changing an existing parameter's type: Backward incompatible
+ * - Narrowing an existing parameter's enum: Backward incompatible
  * - Changing name, title, description, annotations: Always compatible
  */
 public class McpToolCompatibilityChecker
@@ -39,6 +41,9 @@ public class McpToolCompatibilityChecker
 
             // Check removed properties
             checkPropertyRemovals(existingNode, proposedNode, differences);
+
+            // Check per-property schema changes for properties present in both versions
+            checkPropertySchemaChanges(existingNode, proposedNode, differences);
 
             // Check added required parameters
             checkRequiredParamAdditions(existingNode, proposedNode, differences);
@@ -80,6 +85,79 @@ public class McpToolCompatibilityChecker
                         "Input property '" + prop + "' was removed"));
             }
         }
+    }
+
+    private void checkPropertySchemaChanges(JsonNode existing, JsonNode proposed,
+            Set<McpToolCompatibilityDifference> differences) {
+        JsonNode existingProps = getInputSchemaProperties(existing);
+        JsonNode proposedProps = getInputSchemaProperties(proposed);
+        if (existingProps == null || proposedProps == null) {
+            return;
+        }
+
+        Iterator<String> existingNames = existingProps.fieldNames();
+        while (existingNames.hasNext()) {
+            String propName = existingNames.next();
+            if (!proposedProps.has(propName)) {
+                continue;
+            }
+            JsonNode existingProp = existingProps.get(propName);
+            JsonNode proposedProp = proposedProps.get(propName);
+            checkPropertyTypeChange(propName, existingProp, proposedProp, differences);
+            checkEnumNarrowing(propName, existingProp, proposedProp, differences);
+        }
+    }
+
+    private void checkPropertyTypeChange(String propName, JsonNode existingProp, JsonNode proposedProp,
+            Set<McpToolCompatibilityDifference> differences) {
+        String existingType = getTextValue(existingProp, "type");
+        String proposedType = getTextValue(proposedProp, "type");
+        if (existingType != null && proposedType != null && !existingType.equals(proposedType)) {
+            differences.add(new McpToolCompatibilityDifference(
+                    McpToolCompatibilityDifference.Type.PROPERTY_TYPE_CHANGED,
+                    "Input property '" + propName + "' type changed from '" + existingType
+                            + "' to '" + proposedType + "'"));
+        }
+    }
+
+    private void checkEnumNarrowing(String propName, JsonNode existingProp, JsonNode proposedProp,
+            Set<McpToolCompatibilityDifference> differences) {
+        JsonNode existingEnum = existingProp.get("enum");
+        JsonNode proposedEnum = proposedProp.get("enum");
+        if (existingEnum == null || !existingEnum.isArray()
+                || proposedEnum == null || !proposedEnum.isArray()) {
+            return;
+        }
+
+        Set<String> proposedValues = new HashSet<>();
+        for (JsonNode val : proposedEnum) {
+            proposedValues.add(val.asText());
+        }
+
+        for (JsonNode val : existingEnum) {
+            if (!proposedValues.contains(val.asText())) {
+                differences.add(new McpToolCompatibilityDifference(
+                        McpToolCompatibilityDifference.Type.ENUM_VALUE_REMOVED,
+                        "Input property '" + propName + "' enum value '" + val.asText()
+                                + "' was removed"));
+            }
+        }
+    }
+
+    private JsonNode getInputSchemaProperties(JsonNode node) {
+        JsonNode inputSchema = node.get("inputSchema");
+        if (inputSchema != null && inputSchema.isObject()) {
+            JsonNode props = inputSchema.get("properties");
+            if (props != null && props.isObject()) {
+                return props;
+            }
+        }
+        return null;
+    }
+
+    private String getTextValue(JsonNode node, String fieldName) {
+        JsonNode field = node.get(fieldName);
+        return (field != null && field.isTextual()) ? field.asText() : null;
     }
 
     private void checkRequiredParamAdditions(JsonNode existing, JsonNode proposed,

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apicurio.registry.content.TypedContent;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -32,6 +33,12 @@ public class McpToolCompatibilityChecker
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
+    private static final String FIELD_INPUT_SCHEMA = "inputSchema";
+    private static final String FIELD_PROPERTIES = "properties";
+    private static final String FIELD_TYPE = "type";
+    private static final String FIELD_ENUM = "enum";
+    private static final String FIELD_REQUIRED = "required";
+
     @Override
     public CompatibilityExecutionResult testCompatibility(CompatibilityLevel compatibilityLevel,
             List<TypedContent> existingArtifacts, TypedContent proposedArtifact,
@@ -52,34 +59,26 @@ public class McpToolCompatibilityChecker
 
         switch (compatibilityLevel) {
             case BACKWARD:
-                incompatibleDiffs = doCompatibilityCheck(lastExistingSchema, proposedArtifactContent,
-                        resolvedReferences, false);
+                incompatibleDiffs = doCompatibilityCheck(lastExistingSchema, proposedArtifactContent, false);
                 break;
             case BACKWARD_TRANSITIVE:
-                incompatibleDiffs = transitivelyCheck(existingArtifacts, proposedArtifactContent,
-                        resolvedReferences, false);
+                incompatibleDiffs = transitivelyCheck(existingArtifacts, proposedArtifactContent, false);
                 break;
             case FORWARD:
-                incompatibleDiffs = doCompatibilityCheck(proposedArtifactContent, lastExistingSchema,
-                        resolvedReferences, true);
+                incompatibleDiffs = doCompatibilityCheck(proposedArtifactContent, lastExistingSchema, true);
                 break;
             case FORWARD_TRANSITIVE:
-                incompatibleDiffs = transitivelyCheck(existingArtifacts, proposedArtifactContent,
-                        resolvedReferences, true);
+                incompatibleDiffs = transitivelyCheck(existingArtifacts, proposedArtifactContent, true);
                 break;
             case FULL:
-                incompatibleDiffs = unionOf(
-                        doCompatibilityCheck(lastExistingSchema, proposedArtifactContent,
-                                resolvedReferences, false),
-                        doCompatibilityCheck(proposedArtifactContent, lastExistingSchema,
-                                resolvedReferences, true));
+                incompatibleDiffs = mergeDifferenceSets(
+                        doCompatibilityCheck(lastExistingSchema, proposedArtifactContent, false),
+                        doCompatibilityCheck(proposedArtifactContent, lastExistingSchema, true));
                 break;
             case FULL_TRANSITIVE:
-                incompatibleDiffs = unionOf(
-                        transitivelyCheck(existingArtifacts, proposedArtifactContent,
-                                resolvedReferences, false),
-                        transitivelyCheck(existingArtifacts, proposedArtifactContent,
-                                resolvedReferences, true));
+                incompatibleDiffs = mergeDifferenceSets(
+                        transitivelyCheck(existingArtifacts, proposedArtifactContent, false),
+                        transitivelyCheck(existingArtifacts, proposedArtifactContent, true));
                 break;
             case NONE:
                 break;
@@ -91,24 +90,22 @@ public class McpToolCompatibilityChecker
     }
 
     private Set<McpToolCompatibilityDifference> transitivelyCheck(List<TypedContent> existingArtifacts,
-            String proposedArtifactContent, Map<String, TypedContent> resolvedReferences,
-            boolean forwardEnumCheck) {
+            String proposedArtifactContent, boolean forwardEnumCheck) {
         Set<McpToolCompatibilityDifference> result = new HashSet<>();
         for (int i = existingArtifacts.size() - 1; i >= 0; i--) {
             String existing = existingArtifacts.get(i).getContent().content();
             if (forwardEnumCheck) {
-                result.addAll(doCompatibilityCheck(proposedArtifactContent, existing,
-                        resolvedReferences, true));
+                result.addAll(doCompatibilityCheck(proposedArtifactContent, existing, true));
             } else {
-                result.addAll(doCompatibilityCheck(existing, proposedArtifactContent,
-                        resolvedReferences, false));
+                result.addAll(doCompatibilityCheck(existing, proposedArtifactContent, false));
             }
         }
         return result;
     }
 
     @SafeVarargs
-    private Set<McpToolCompatibilityDifference> unionOf(Set<McpToolCompatibilityDifference>... from) {
+    private Set<McpToolCompatibilityDifference> mergeDifferenceSets(
+            Set<McpToolCompatibilityDifference>... from) {
         Set<McpToolCompatibilityDifference> result = new HashSet<>();
         for (Set<McpToolCompatibilityDifference> set : from) {
             result.addAll(set);
@@ -119,11 +116,11 @@ public class McpToolCompatibilityChecker
     @Override
     protected Set<McpToolCompatibilityDifference> isBackwardsCompatibleWith(String existing,
             String proposed, Map<String, TypedContent> resolvedReferences) {
-        return doCompatibilityCheck(existing, proposed, resolvedReferences, false);
+        return doCompatibilityCheck(existing, proposed, false);
     }
 
     private Set<McpToolCompatibilityDifference> doCompatibilityCheck(String existing, String proposed,
-            Map<String, TypedContent> resolvedReferences, boolean forwardEnumCheck) {
+            boolean forwardEnumCheck) {
         Set<McpToolCompatibilityDifference> differences = new HashSet<>();
 
         try {
@@ -189,6 +186,7 @@ public class McpToolCompatibilityChecker
             return;
         }
 
+        // Only iterate existing property names; additions are handled elsewhere.
         Iterator<String> existingNames = existingProps.fieldNames();
         while (existingNames.hasNext()) {
             String propName = existingNames.next();
@@ -208,7 +206,7 @@ public class McpToolCompatibilityChecker
             Set<McpToolCompatibilityDifference> differences) {
         Set<String> fromTypes = getTypeValues(fromProp);
         Set<String> toTypes = getTypeValues(toProp);
-        if (fromTypes == null || toTypes == null) {
+        if (fromTypes.isEmpty() || toTypes.isEmpty()) {
             return;
         }
 
@@ -224,8 +222,8 @@ public class McpToolCompatibilityChecker
 
     private void checkEnumNarrowing(String propName, JsonNode fromProp, JsonNode toProp,
             Set<McpToolCompatibilityDifference> differences) {
-        JsonNode fromEnum = fromProp.get("enum");
-        JsonNode toEnum = toProp.get("enum");
+        JsonNode fromEnum = fromProp.get(FIELD_ENUM);
+        JsonNode toEnum = toProp.get(FIELD_ENUM);
         if (fromEnum == null || !fromEnum.isArray() || toEnum == null || !toEnum.isArray()) {
             return;
         }
@@ -246,9 +244,9 @@ public class McpToolCompatibilityChecker
     }
 
     private JsonNode getInputSchemaProperties(JsonNode node) {
-        JsonNode inputSchema = node.get("inputSchema");
+        JsonNode inputSchema = node.get(FIELD_INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
-            JsonNode props = inputSchema.get("properties");
+            JsonNode props = inputSchema.get(FIELD_PROPERTIES);
             if (props != null && props.isObject()) {
                 return props;
             }
@@ -257,9 +255,9 @@ public class McpToolCompatibilityChecker
     }
 
     private Set<String> getTypeValues(JsonNode node) {
-        JsonNode typeNode = node.get("type");
+        JsonNode typeNode = node.get(FIELD_TYPE);
         if (typeNode == null || typeNode.isNull()) {
-            return null;
+            return Collections.emptySet();
         }
         if (typeNode.isTextual()) {
             return Set.of(typeNode.asText());
@@ -271,9 +269,9 @@ public class McpToolCompatibilityChecker
                     types.add(item.asText());
                 }
             }
-            return types.isEmpty() ? null : types;
+            return types;
         }
-        return null;
+        return Collections.emptySet();
     }
 
     private void checkRequiredParamAdditions(JsonNode existing, JsonNode proposed,
@@ -305,9 +303,9 @@ public class McpToolCompatibilityChecker
     }
 
     private String getInputSchemaType(JsonNode node) {
-        JsonNode inputSchema = node.get("inputSchema");
+        JsonNode inputSchema = node.get(FIELD_INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
-            JsonNode type = inputSchema.get("type");
+            JsonNode type = inputSchema.get(FIELD_TYPE);
             if (type != null && type.isTextual()) {
                 return type.asText();
             }
@@ -317,9 +315,9 @@ public class McpToolCompatibilityChecker
 
     private Set<String> extractPropertyNames(JsonNode node) {
         Set<String> properties = new HashSet<>();
-        JsonNode inputSchema = node.get("inputSchema");
+        JsonNode inputSchema = node.get(FIELD_INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
-            JsonNode props = inputSchema.get("properties");
+            JsonNode props = inputSchema.get(FIELD_PROPERTIES);
             if (props != null && props.isObject()) {
                 Iterator<String> fieldNames = props.fieldNames();
                 while (fieldNames.hasNext()) {
@@ -332,9 +330,9 @@ public class McpToolCompatibilityChecker
 
     private Set<String> extractRequiredParams(JsonNode node) {
         Set<String> required = new HashSet<>();
-        JsonNode inputSchema = node.get("inputSchema");
+        JsonNode inputSchema = node.get(FIELD_INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
-            JsonNode requiredNode = inputSchema.get("required");
+            JsonNode requiredNode = inputSchema.get(FIELD_REQUIRED);
             if (requiredNode != null && requiredNode.isArray()) {
                 for (JsonNode item : requiredNode) {
                     if (item.isTextual()) {

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -6,8 +6,12 @@ import io.apicurio.registry.content.TypedContent;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Compatibility checker for MCP tool definition artifacts.
@@ -20,6 +24,7 @@ import java.util.Set;
  * - Changing inputSchema type: Backward incompatible
  * - Changing an existing parameter's type: Backward incompatible
  * - Narrowing an existing parameter's enum: Backward incompatible
+ * - Narrowing an existing parameter's enum relative to the prior version: Forward incompatible
  * - Changing name, title, description, annotations: Always compatible
  */
 public class McpToolCompatibilityChecker
@@ -28,8 +33,97 @@ public class McpToolCompatibilityChecker
     private static final ObjectMapper mapper = new ObjectMapper();
 
     @Override
+    public CompatibilityExecutionResult testCompatibility(CompatibilityLevel compatibilityLevel,
+            List<TypedContent> existingArtifacts, TypedContent proposedArtifact,
+            Map<String, TypedContent> resolvedReferences) {
+        requireNonNull(compatibilityLevel, "compatibilityLevel MUST NOT be null");
+        requireNonNull(existingArtifacts, "existingSchemas MUST NOT be null");
+        requireNonNull(proposedArtifact, "proposedSchema MUST NOT be null");
+
+        if (existingArtifacts.isEmpty()) {
+            return CompatibilityExecutionResult.compatible();
+        }
+
+        final String proposedArtifactContent = proposedArtifact.getContent().content();
+        String lastExistingSchema = existingArtifacts.get(existingArtifacts.size() - 1).getContent()
+                .content();
+
+        Set<McpToolCompatibilityDifference> incompatibleDiffs = new HashSet<>();
+
+        switch (compatibilityLevel) {
+            case BACKWARD:
+                incompatibleDiffs = doCompatibilityCheck(lastExistingSchema, proposedArtifactContent,
+                        resolvedReferences, false);
+                break;
+            case BACKWARD_TRANSITIVE:
+                incompatibleDiffs = transitivelyCheck(existingArtifacts, proposedArtifactContent,
+                        resolvedReferences, false);
+                break;
+            case FORWARD:
+                incompatibleDiffs = doCompatibilityCheck(proposedArtifactContent, lastExistingSchema,
+                        resolvedReferences, true);
+                break;
+            case FORWARD_TRANSITIVE:
+                incompatibleDiffs = transitivelyCheck(existingArtifacts, proposedArtifactContent,
+                        resolvedReferences, true);
+                break;
+            case FULL:
+                incompatibleDiffs = unionOf(
+                        doCompatibilityCheck(lastExistingSchema, proposedArtifactContent,
+                                resolvedReferences, false),
+                        doCompatibilityCheck(proposedArtifactContent, lastExistingSchema,
+                                resolvedReferences, true));
+                break;
+            case FULL_TRANSITIVE:
+                incompatibleDiffs = unionOf(
+                        transitivelyCheck(existingArtifacts, proposedArtifactContent,
+                                resolvedReferences, false),
+                        transitivelyCheck(existingArtifacts, proposedArtifactContent,
+                                resolvedReferences, true));
+                break;
+            case NONE:
+                break;
+        }
+
+        Set<CompatibilityDifference> diffs = incompatibleDiffs.stream().map(this::transform)
+                .collect(Collectors.toSet());
+        return CompatibilityExecutionResult.incompatibleOrEmpty(diffs);
+    }
+
+    private Set<McpToolCompatibilityDifference> transitivelyCheck(List<TypedContent> existingArtifacts,
+            String proposedArtifactContent, Map<String, TypedContent> resolvedReferences,
+            boolean forwardEnumCheck) {
+        Set<McpToolCompatibilityDifference> result = new HashSet<>();
+        for (int i = existingArtifacts.size() - 1; i >= 0; i--) {
+            String existing = existingArtifacts.get(i).getContent().content();
+            if (forwardEnumCheck) {
+                result.addAll(doCompatibilityCheck(proposedArtifactContent, existing,
+                        resolvedReferences, true));
+            } else {
+                result.addAll(doCompatibilityCheck(existing, proposedArtifactContent,
+                        resolvedReferences, false));
+            }
+        }
+        return result;
+    }
+
+    @SafeVarargs
+    private Set<McpToolCompatibilityDifference> unionOf(Set<McpToolCompatibilityDifference>... from) {
+        Set<McpToolCompatibilityDifference> result = new HashSet<>();
+        for (Set<McpToolCompatibilityDifference> set : from) {
+            result.addAll(set);
+        }
+        return result;
+    }
+
+    @Override
     protected Set<McpToolCompatibilityDifference> isBackwardsCompatibleWith(String existing,
             String proposed, Map<String, TypedContent> resolvedReferences) {
+        return doCompatibilityCheck(existing, proposed, resolvedReferences, false);
+    }
+
+    private Set<McpToolCompatibilityDifference> doCompatibilityCheck(String existing, String proposed,
+            Map<String, TypedContent> resolvedReferences, boolean forwardEnumCheck) {
         Set<McpToolCompatibilityDifference> differences = new HashSet<>();
 
         try {
@@ -43,7 +137,7 @@ public class McpToolCompatibilityChecker
             checkPropertyRemovals(existingNode, proposedNode, differences);
 
             // Check per-property schema changes for properties present in both versions
-            checkPropertySchemaChanges(existingNode, proposedNode, differences);
+            checkPropertySchemaChanges(existingNode, proposedNode, differences, forwardEnumCheck);
 
             // Check added required parameters
             checkRequiredParamAdditions(existingNode, proposedNode, differences);
@@ -88,7 +182,7 @@ public class McpToolCompatibilityChecker
     }
 
     private void checkPropertySchemaChanges(JsonNode existing, JsonNode proposed,
-            Set<McpToolCompatibilityDifference> differences) {
+            Set<McpToolCompatibilityDifference> differences, boolean forwardEnumCheck) {
         JsonNode existingProps = getInputSchemaProperties(existing);
         JsonNode proposedProps = getInputSchemaProperties(proposed);
         if (existingProps == null || proposedProps == null) {
@@ -103,39 +197,46 @@ public class McpToolCompatibilityChecker
             }
             JsonNode existingProp = existingProps.get(propName);
             JsonNode proposedProp = proposedProps.get(propName);
-            checkPropertyTypeChange(propName, existingProp, proposedProp, differences);
-            checkEnumNarrowing(propName, existingProp, proposedProp, differences);
+            JsonNode fromProp = forwardEnumCheck ? proposedProp : existingProp;
+            JsonNode toProp = forwardEnumCheck ? existingProp : proposedProp;
+            checkPropertyTypeNarrowing(propName, fromProp, toProp, differences);
+            checkEnumNarrowing(propName, fromProp, toProp, differences);
         }
     }
 
-    private void checkPropertyTypeChange(String propName, JsonNode existingProp, JsonNode proposedProp,
+    private void checkPropertyTypeNarrowing(String propName, JsonNode fromProp, JsonNode toProp,
             Set<McpToolCompatibilityDifference> differences) {
-        String existingType = getTextValue(existingProp, "type");
-        String proposedType = getTextValue(proposedProp, "type");
-        if (existingType != null && proposedType != null && !existingType.equals(proposedType)) {
-            differences.add(new McpToolCompatibilityDifference(
-                    McpToolCompatibilityDifference.Type.PROPERTY_TYPE_CHANGED,
-                    "Input property '" + propName + "' type changed from '" + existingType
-                            + "' to '" + proposedType + "'"));
-        }
-    }
-
-    private void checkEnumNarrowing(String propName, JsonNode existingProp, JsonNode proposedProp,
-            Set<McpToolCompatibilityDifference> differences) {
-        JsonNode existingEnum = existingProp.get("enum");
-        JsonNode proposedEnum = proposedProp.get("enum");
-        if (existingEnum == null || !existingEnum.isArray()
-                || proposedEnum == null || !proposedEnum.isArray()) {
+        Set<String> fromTypes = getTypeValues(fromProp);
+        Set<String> toTypes = getTypeValues(toProp);
+        if (fromTypes == null || toTypes == null) {
             return;
         }
 
-        Set<String> proposedValues = new HashSet<>();
-        for (JsonNode val : proposedEnum) {
-            proposedValues.add(val.asText());
+        for (String type : fromTypes) {
+            if (!toTypes.contains(type)) {
+                differences.add(new McpToolCompatibilityDifference(
+                        McpToolCompatibilityDifference.Type.PROPERTY_TYPE_CHANGED,
+                        "Input property '" + propName + "' no longer allows type '" + type + "'"));
+                return;
+            }
+        }
+    }
+
+    private void checkEnumNarrowing(String propName, JsonNode fromProp, JsonNode toProp,
+            Set<McpToolCompatibilityDifference> differences) {
+        JsonNode fromEnum = fromProp.get("enum");
+        JsonNode toEnum = toProp.get("enum");
+        if (fromEnum == null || !fromEnum.isArray() || toEnum == null || !toEnum.isArray()) {
+            return;
         }
 
-        for (JsonNode val : existingEnum) {
-            if (!proposedValues.contains(val.asText())) {
+        Set<String> toValues = new HashSet<>();
+        for (JsonNode val : toEnum) {
+            toValues.add(val.asText());
+        }
+
+        for (JsonNode val : fromEnum) {
+            if (!toValues.contains(val.asText())) {
                 differences.add(new McpToolCompatibilityDifference(
                         McpToolCompatibilityDifference.Type.ENUM_VALUE_REMOVED,
                         "Input property '" + propName + "' enum value '" + val.asText()
@@ -155,9 +256,24 @@ public class McpToolCompatibilityChecker
         return null;
     }
 
-    private String getTextValue(JsonNode node, String fieldName) {
-        JsonNode field = node.get(fieldName);
-        return (field != null && field.isTextual()) ? field.asText() : null;
+    private Set<String> getTypeValues(JsonNode node) {
+        JsonNode typeNode = node.get("type");
+        if (typeNode == null || typeNode.isNull()) {
+            return null;
+        }
+        if (typeNode.isTextual()) {
+            return Set.of(typeNode.asText());
+        }
+        if (typeNode.isArray()) {
+            Set<String> types = new HashSet<>();
+            for (JsonNode item : typeNode) {
+                if (item.isTextual()) {
+                    types.add(item.asText());
+                }
+            }
+            return types.isEmpty() ? null : types;
+        }
+        return null;
     }
 
     private void checkRequiredParamAdditions(JsonNode existing, JsonNode proposed,

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -26,6 +26,8 @@ import static java.util.Objects.requireNonNull;
  * - Changing an existing parameter's type: Backward incompatible
  * - Narrowing an existing parameter's enum: Backward incompatible
  * - Narrowing an existing parameter's enum relative to the prior version: Forward incompatible
+ * - Adding enum values or widening JSON Schema type unions (e.g. {@code string} to
+ *   {@code ["string","null"]}): Forward compatible under {@code FORWARD}/{@code FULL}
  * - Changing name, title, description, annotations: Always compatible
  */
 public class McpToolCompatibilityChecker

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityDifference.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityDifference.java
@@ -9,13 +9,15 @@ import java.util.Objects;
  */
 public class McpToolCompatibilityDifference implements CompatibilityDifference {
 
+    static final String INPUT_SCHEMA_PROPERTIES_CONTEXT = "inputSchema/properties";
+
     public enum Type {
         REQUIRED_PARAM_ADDED("inputSchema/required"),
         REQUIRED_PARAM_REMOVED("inputSchema/required"),
         INPUT_SCHEMA_TYPE_CHANGED("inputSchema/type"),
-        PROPERTY_REMOVED("inputSchema/properties"),
-        PROPERTY_TYPE_CHANGED("inputSchema/properties"),
-        ENUM_VALUE_REMOVED("inputSchema/properties"),
+        PROPERTY_REMOVED(INPUT_SCHEMA_PROPERTIES_CONTEXT),
+        PROPERTY_TYPE_CHANGED(INPUT_SCHEMA_PROPERTIES_CONTEXT),
+        ENUM_VALUE_REMOVED(INPUT_SCHEMA_PROPERTIES_CONTEXT),
         PARSE_ERROR("document");
 
         private final String context;

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityDifference.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityDifference.java
@@ -14,6 +14,8 @@ public class McpToolCompatibilityDifference implements CompatibilityDifference {
         REQUIRED_PARAM_REMOVED("inputSchema/required"),
         INPUT_SCHEMA_TYPE_CHANGED("inputSchema/type"),
         PROPERTY_REMOVED("inputSchema/properties"),
+        PROPERTY_TYPE_CHANGED("inputSchema/properties"),
+        ENUM_VALUE_REMOVED("inputSchema/properties"),
         PARSE_ERROR("document");
 
         private final String context;

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -559,4 +559,148 @@ class McpToolCompatibilityCheckerTest {
         assertTrue(result.isCompatible(),
                 "Adding a property while leaving shared property schemas unchanged should be compatible");
     }
+
+    @Test
+    void testForwardCompatibleEnumValueAddition() {
+        String existing = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": { "type": "string", "enum": ["json"] }
+                        },
+                        "required": ["format"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": { "type": "string", "enum": ["json", "xml"] }
+                        },
+                        "required": ["format"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.FORWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Adding an enum value should be forward compatible");
+    }
+
+    @Test
+    void testForwardIncompatibleEnumNarrowing() {
+        String existing = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": { "type": "string", "enum": ["json", "xml"] }
+                        },
+                        "required": ["format"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": { "type": "string", "enum": ["json"] }
+                        },
+                        "required": ["format"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.FORWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Narrowing an enum relative to the prior version should be forward incompatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleArrayTypeNarrowing() {
+        String existing = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": ["string", "null"] }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Removing null from an array-typed property type should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardCompatibleArrayTypeWidening() {
+        String existing = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": ["string", "null"] }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Adding null to an array-typed property type should be backward compatible");
+    }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -344,4 +344,76 @@ class McpToolCompatibilityCheckerTest {
 
         assertTrue(result.isCompatible(), "Identical schema with description change should be fully compatible");
     }
+
+    @Test
+    void testBackwardIncompatibleParameterTypeChange() {
+        String existing = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "integer" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Changing an existing parameter type should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleEnumNarrowing() {
+        String existing = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": { "type": "string", "enum": ["json", "xml", "csv"] }
+                        },
+                        "required": ["format"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": { "type": "string", "enum": ["json"] }
+                        },
+                        "required": ["format"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Narrowing an existing parameter enum should be backward incompatible");
+    }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -416,4 +416,147 @@ class McpToolCompatibilityCheckerTest {
         assertFalse(result.isCompatible(),
                 "Narrowing an existing parameter enum should be backward incompatible");
     }
+
+    @Test
+    void testCompatibleWhenPropertyTypeIsNull() {
+        String existing = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "description": "free-form query" }
+                        }
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Missing/null property type on one side should not be treated as a type change");
+    }
+
+    @Test
+    void testCompatibleWhenPropertyEnumIsNull() {
+        String existing = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": { "type": "string", "enum": ["json", "xml"] }
+                        }
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": { "type": "string" }
+                        }
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Missing/null enum on one side should not be treated as enum narrowing");
+    }
+
+    @Test
+    void testBackwardIncompatibleCombinedTypeChangeAndEnumNarrowing() {
+        String existing = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" },
+                            "format": { "type": "string", "enum": ["json", "xml", "csv"] }
+                        },
+                        "required": ["query", "format"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "integer" },
+                            "format": { "type": "string", "enum": ["json"] }
+                        },
+                        "required": ["query", "format"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Combined parameter type change and enum narrowing should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardCompatibleAddingPropertyWithUnchangedSharedSchema() {
+        String existing = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string", "enum": ["q1", "q2"] }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "search_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string", "enum": ["q1", "q2"] },
+                            "limit": { "type": "integer" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Adding a property while leaving shared property schemas unchanged should be compatible");
+    }
 }


### PR DESCRIPTION
## Problem
`McpToolCompatibilityChecker` only compared parameter names, the `required` list, and the top-level `inputSchema.type`. Parameter type changes and enum narrowing were treated as compatible under BACKWARD/FORWARD/FULL.

## Approach
For properties present in both versions, compare each property schema the same way `PromptTemplateCompatibilityChecker` does for template variables:
- flag `type` changes
- flag enum narrowing (removed enum values)

Added `PROPERTY_TYPE_CHANGED` and `ENUM_VALUE_REMOVED` difference types, plus unit tests for both cases.

## Test plan
- [x] `./mvnw -pl schema-util/util-provider -am test -Dtest=McpToolCompatibilityCheckerTest -Dsurefire.failIfNoSpecifiedTests=false` (11 tests, 0 failures)

Fixes #8661
