### PR TITLE
fix(operator): backport OLM test diagnostic dumps to 3.2.x (#8658)

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/ClusterDiagnostics.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/ClusterDiagnostics.java
@@ -47,6 +47,7 @@ public final class ClusterDiagnostics {
         dumpNetworkPolicies(client, namespace);
         dumpPods(client, namespace);
         dumpEvents(client, namespace);
+        dumpImagePullEvents(client, namespace);
 
         if (isOLM) {
             dumpOLMResources(client, namespace);
@@ -232,9 +233,45 @@ public final class ClusterDiagnostics {
         }
     }
 
+    private static void dumpImagePullEvents(KubernetesClient client, String namespace) {
+        log.error("--- Image Pull Events ---");
+        try {
+            var events = client.v1().events().inNamespace(namespace).list().getItems();
+            var pullEvents = events.stream()
+                    .filter(e -> {
+                        var reason = e.getReason();
+                        return reason != null && (reason.contains("Pull") || reason.contains("BackOff")
+                                || reason.contains("ErrImage"));
+                    })
+                    .filter(e -> "Warning".equals(e.getType()))
+                    .sorted(Comparator.comparing(
+                            Event::getLastTimestamp,
+                            Comparator.nullsLast(Comparator.reverseOrder())))
+                    .toList();
+
+            if (pullEvents.isEmpty()) {
+                log.error("  (none)");
+                return;
+            }
+
+            for (var event : pullEvents) {
+                log.error("  {} | {} | {} | {}/{} | {}",
+                        event.getLastTimestamp(),
+                        event.getType(),
+                        event.getReason(),
+                        event.getInvolvedObject().getKind(),
+                        event.getInvolvedObject().getName(),
+                        event.getMessage());
+            }
+        } catch (Exception e) {
+            log.error("  Failed to list image pull events: {}", e.getMessage());
+        }
+    }
+
     private static void dumpOLMResources(KubernetesClient client, String namespace) {
         log.error("--- OLM Resources ---");
 
+        dumpGenericResources(client, "operators.coreos.com/v1alpha1", "CatalogSource", namespace);
         dumpGenericResources(client, "operators.coreos.com/v1alpha1", "Subscription", namespace);
         dumpGenericResources(client, "operators.coreos.com/v1alpha1", "InstallPlan", namespace);
         dumpGenericResources(client, "operators.coreos.com/v1alpha1", "ClusterServiceVersion", namespace);

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.OperatorException;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.utils.ClusterDiagnostics;
 import io.apicurio.registry.operator.utils.OperatorTestContext;
 import io.apicurio.registry.operator.utils.OperatorTestExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -70,6 +71,16 @@ public abstract class OLMITBase implements OperatorTestContext {
         ingressManager = new IngressManager(client, namespace);
         cleanup = ConfigProvider.getConfig().getValue(ITBase.CLEANUP, Boolean.class);
 
+        try {
+            setupOLMResources();
+        } catch (Exception e) {
+            log.error("OLM setup failed, dumping cluster diagnostics before propagating failure", e);
+            ClusterDiagnostics.dump(client, namespace, true);
+            throw e;
+        }
+    }
+
+    private static void setupOLMResources() throws Exception {
         int olmVersion = ConfigProvider.getConfig().getOptionalValue(OML_VERSION, Integer.class).orElse(0);
         if (olmVersion == 0) {
 


### PR DESCRIPTION
## Summary
Cherry-pick of #8660 (merged to main) onto the 3.2.x branch.

- Wrap `OLMITBase.beforeAll()` OLM setup in a try-catch that calls
  `ClusterDiagnostics.dump()` before rethrowing — fixes the `@BeforeAll`
  gap where `AfterTestExecutionCallback` never fires
- Add `CatalogSource` to the OLM resource dump
- Add dedicated `dumpImagePullEvents()` section for image-pull related
  failures

The `UpgradeOLMITTest` changes from #8660 are not included because that
file does not exist on 3.2.x.

## Related Issue
Backport of #8660. Fixes #8658.

## Test Plan
- [ ] Verify the `operator/controller` module compiles
- [ ] Verify the `operator/olm-tests` module compiles
- [ ] CI OLM test suite passes