### PR TITLE
feat(examples): add Camel Quarkus Kafka + Apicurio SerDe quickstart

### DIFF
--- a/examples/camel-quarkus-kafka/README.md
+++ b/examples/camel-quarkus-kafka/README.md
@@ -1,0 +1,186 @@
+# Camel Quarkus Kafka with Apicurio Registry Example
+
+This example demonstrates how to use Apache Camel Quarkus with the Kafka component and Apicurio Registry
+Avro SerDe for schema-managed messaging. Unlike the `kafka-order-processing` example (which uses raw Kafka
+clients), this quickstart shows the fully declarative Camel approach — serializer/deserializer configuration
+lives entirely in `application.properties`.
+
+## Architecture Overview
+
+```
+┌─────────────────────┐
+│  Timer (5 seconds)  │
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐       ┌─────────────────┐
+│  Camel Producer     │──────>│  Apache Kafka    │
+│  Route              │       │  (greetings)     │
+└─────────────────────┘       └────────┬─────────┘
+         │                             │
+         ▼                             ▼
+┌─────────────────────┐       ┌─────────────────────┐
+│  Apicurio Registry  │<──────│  Camel Consumer     │
+│  (Schema Store)     │       │  Route              │
+└─────────────────────┘       └─────────────────────┘
+```
+
+### Components
+
+1. **Camel Producer Route** — A timer-triggered route that creates `Greeting` objects every 5 seconds and
+   sends them to Kafka, serialized as Avro with the schema auto-registered in Apicurio Registry.
+
+2. **Camel Consumer Route** — Reads from the same Kafka topic and logs the deserialized `Greeting` objects.
+
+3. **Apicurio Registry** — Central schema registry storing and versioning the Avro schema.
+
+4. **Apicurio Registry UI** — Web interface for browsing schemas.
+
+5. **Apache Kafka** — Message broker.
+
+## Greeting Schema
+
+A simple Avro record with three fields:
+
+- `name` (string) — Name of the person being greeted
+- `message` (string) — The greeting message
+- `timestamp` (long) — When the greeting was created (epoch millis)
+
+## Prerequisites
+
+- Java 21 or later
+- Maven 3.8+
+- Docker and Docker Compose
+- At least 4GB of available RAM for Docker containers
+
+## Quick Start
+
+### 1. Start Infrastructure
+
+Start Kafka, Zookeeper, Apicurio Registry, and the Registry UI:
+
+```bash
+cd examples/camel-quarkus-kafka
+docker-compose up -d
+```
+
+Wait for all services to be healthy (~30-60 seconds):
+
+```bash
+docker-compose ps
+```
+
+Verify Apicurio Registry is running:
+
+```bash
+curl http://localhost:8080/apis/registry/v3/groups
+```
+
+### 2. Build the Application
+
+```bash
+mvn clean package
+```
+
+This compiles the Avro schema into a Java class and builds the Quarkus application.
+
+### 3. Run the Application
+
+```bash
+mvn quarkus:dev
+```
+
+Both the producer and consumer routes run in the same application. You should see output like:
+
+```
+Sending greeting for Alice: Hello from Camel!
+Received greeting — name: Alice, message: Hello from Camel!, timestamp: 1706450000000
+```
+
+## Verifying Schema Registration
+
+### Using the Web UI
+
+Open http://localhost:8888 in your browser. You should see the `Greeting` schema listed as an artifact.
+
+### Using the REST API
+
+```bash
+# List all artifacts
+curl http://localhost:8080/apis/registry/v3/groups/default/artifacts
+
+# Get schema content
+curl http://localhost:8080/apis/registry/v3/groups/default/artifacts/greetings-value/versions/1/content
+```
+
+## Configuration
+
+All configuration is in `src/main/resources/application.properties`:
+
+| Property | Description | Default |
+|----------|-------------|---------|
+| `camel.component.kafka.brokers` | Kafka broker address | `localhost:9092` |
+| `camel.component.kafka.value-serializer` | Avro serializer class | `AvroKafkaSerializer` |
+| `camel.component.kafka.value-deserializer` | Avro deserializer class | `AvroKafkaDeserializer` |
+| `...additional-properties[apicurio.registry.url]` | Registry API URL | `http://localhost:8080/apis/registry/v3` |
+| `...additional-properties[apicurio.registry.auto-register]` | Auto-register schemas | `true` |
+| `...additional-properties[apicurio.registry.avro-datum-provider]` | Avro datum provider | `ReflectAvroDatumProvider` |
+
+The `additional-properties[...]` syntax passes properties through the Camel Kafka component directly to the
+underlying Kafka producer/consumer, where the Apicurio SerDe classes read them.
+
+## Key Features Demonstrated
+
+1. **Declarative SerDe Configuration** — No programmatic Kafka client setup; everything is configured via
+   `application.properties` through the Camel Kafka component.
+
+2. **Schema Auto-Registration** — The producer automatically registers the Avro schema on first use.
+
+3. **Avro Code Generation** — The `avro-maven-plugin` generates the `Greeting` class from the `.avsc` schema
+   at build time.
+
+4. **Camel Quarkus Integration** — Routes are discovered automatically by Camel Quarkus CDI integration.
+
+5. **Quarkus Apicurio Extension** — Uses the `quarkus-apicurio-registry-avro` extension for proper Quarkus
+   integration with the Apicurio Avro SerDe.
+
+## Stopping the Demo
+
+1. Stop the application (Ctrl+C or press `q` in Quarkus dev mode)
+
+2. Stop the infrastructure:
+
+```bash
+docker-compose down
+```
+
+To remove all data and start fresh:
+
+```bash
+docker-compose down -v
+```
+
+## Troubleshooting
+
+### Kafka Connection Issues
+
+- Ensure Docker containers are running: `docker-compose ps`
+- Check Kafka logs: `docker-compose logs kafka`
+- Verify port 9092 is not in use by another process
+
+### Schema Registration Failures
+
+- Verify Apicurio Registry is accessible: `curl http://localhost:8080/apis/registry/v3/groups`
+- Check registry logs: `docker-compose logs apicurio-registry`
+
+### Consumer Not Receiving Messages
+
+- Verify the topic exists: `docker exec camel-demo-kafka bin/kafka-topics.sh --list --bootstrap-server localhost:9092`
+- The consumer route starts at the same time as the producer; messages appear after the first timer tick (5s)
+
+## Additional Resources
+
+- [Apache Camel Quarkus Kafka](https://camel.apache.org/camel-quarkus/latest/reference/extensions/kafka.html)
+- [Apicurio Registry Documentation](https://www.apicur.io/registry/docs/)
+- [Apache Avro Documentation](https://avro.apache.org/docs/)
+- [Quarkus Documentation](https://quarkus.io/guides/)

--- a/examples/camel-quarkus-kafka/docker-compose.yml
+++ b/examples/camel-quarkus-kafka/docker-compose.yml
@@ -1,0 +1,64 @@
+version: '3.8'
+
+services:
+  zookeeper:
+    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
+    container_name: camel-demo-zookeeper
+    command: [
+      "sh", "-c",
+      "bin/zookeeper-server-start.sh config/zookeeper.properties"
+    ]
+    ports:
+      - "2181:2181"
+    environment:
+      LOG_DIR: /tmp/logs
+    networks:
+      - camel-demo-network
+
+  kafka:
+    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
+    container_name: camel-demo-kafka
+    command: [
+      "sh", "-c",
+      "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"
+    ]
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      LOG_DIR: "/tmp/logs"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    networks:
+      - camel-demo-network
+
+  apicurio-registry:
+    image: apicurio/apicurio-registry:latest-snapshot
+    container_name: camel-demo-registry
+    depends_on:
+      - kafka
+    ports:
+      - "8080:8080"
+    environment:
+      apicurio.rest.deletion.group.enabled: "true"
+      apicurio.rest.deletion.artifact.enabled: "true"
+      apicurio.rest.deletion.artifact-version.enabled: "true"
+      QUARKUS_HTTP_CORS_ORIGINS: "*"
+    networks:
+      - camel-demo-network
+
+  apicurio-registry-ui:
+    image: apicurio/apicurio-registry-ui:latest-snapshot
+    container_name: camel-demo-registry-ui
+    depends_on:
+      - apicurio-registry
+    ports:
+      - "8888:8080"
+    networks:
+      - camel-demo-network
+
+networks:
+  camel-demo-network:
+    driver: bridge

--- a/examples/camel-quarkus-kafka/pom.xml
+++ b/examples/camel-quarkus-kafka/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.apicurio</groupId>
+        <artifactId>apicurio-registry-examples</artifactId>
+        <version>3.3.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>apicurio-registry-examples-camel-quarkus-kafka</artifactId>
+    <packaging>jar</packaging>
+    <name>Registry :: Examples :: Camel Quarkus Kafka</name>
+    <description>Camel Quarkus example using Kafka with Apicurio Registry Avro SerDe</description>
+
+    <properties>
+        <projectRoot>${project.basedir}/../..</projectRoot>
+        <quarkus.version>3.27.0</quarkus.version>
+        <camel-quarkus.version>3.27.1</camel-quarkus.version>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <skipITs>true</skipITs>
+        <surefire-plugin.version>3.5.2</surefire-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${camel-quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Quarkus -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <!-- Camel Quarkus -->
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-timer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-bean</artifactId>
+        </dependency>
+
+        <!-- Apicurio Registry Avro SerDe (Quarkus extension) -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-apicurio-registry-avro</artifactId>
+        </dependency>
+
+        <!-- Avro -->
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${version.avro}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <version>${version.avro}</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>schema</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>${project.basedir}/src/main/resources/avro</sourceDirectory>
+                            <outputDirectory>${project.build.directory}/generated-sources/avro</outputDirectory>
+                            <stringType>String</stringType>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/examples/camel-quarkus-kafka/src/main/java/io/apicurio/registry/examples/camelkafka/GreetingFactory.java
+++ b/examples/camel-quarkus-kafka/src/main/java/io/apicurio/registry/examples/camelkafka/GreetingFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.examples.camelkafka;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
+
+@ApplicationScoped
+@Named("greetingFactory")
+public class GreetingFactory {
+
+    private static final String[] NAMES = {
+        "Alice", "Bob", "Charlie", "Diana", "Eve", "Frank", "Grace", "Henry"
+    };
+
+    private static final String[] MESSAGES = {
+        "Hello from Camel!", "Greetings via Kafka!", "Good day!",
+        "Welcome to Apicurio!", "Hi there!", "Howdy!",
+        "Salutations!", "Hey, nice to meet you!"
+    };
+
+    private int counter = 0;
+
+    public Greeting create() {
+        int index = counter++ % NAMES.length;
+        return Greeting.newBuilder()
+                .setName(NAMES[index])
+                .setMessage(MESSAGES[index])
+                .setTimestamp(System.currentTimeMillis())
+                .build();
+    }
+}

--- a/examples/camel-quarkus-kafka/src/main/java/io/apicurio/registry/examples/camelkafka/GreetingRouteBuilder.java
+++ b/examples/camel-quarkus-kafka/src/main/java/io/apicurio/registry/examples/camelkafka/GreetingRouteBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.examples.camelkafka;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class GreetingRouteBuilder extends RouteBuilder {
+
+    @Override
+    public void configure() {
+        from("timer:greeting?period=5000")
+                .bean("greetingFactory", "create")
+                .log("Sending greeting for ${body.name}: ${body.message}")
+                .to("kafka:greetings");
+
+        from("kafka:greetings?groupId=camel-greeting-consumer")
+                .log("Received greeting — name: ${body.name}, message: ${body.message}, timestamp: ${body.timestamp}");
+    }
+}

--- a/examples/camel-quarkus-kafka/src/main/resources/application.properties
+++ b/examples/camel-quarkus-kafka/src/main/resources/application.properties
@@ -1,0 +1,22 @@
+# Quarkus
+quarkus.application.name=camel-quarkus-kafka-example
+quarkus.log.level=INFO
+quarkus.log.category."io.apicurio".level=INFO
+quarkus.log.category."org.apache.camel".level=INFO
+
+# Kafka broker
+camel.component.kafka.brokers=localhost:9092
+
+# Value serializer/deserializer: Apicurio Avro SerDe
+camel.component.kafka.value-serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer
+camel.component.kafka.value-deserializer=io.apicurio.registry.serde.avro.AvroKafkaDeserializer
+
+# Key serializer/deserializer: plain String
+camel.component.kafka.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+camel.component.kafka.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+
+# Apicurio Registry configuration (passed as additional Kafka properties)
+camel.component.kafka.additional-properties[apicurio.registry.url]=http://localhost:8080/apis/registry/v3
+camel.component.kafka.additional-properties[apicurio.registry.auto-register]=true
+camel.component.kafka.additional-properties[apicurio.registry.auto-register.if-exists]=FIND_OR_CREATE_VERSION
+camel.component.kafka.additional-properties[apicurio.registry.avro-datum-provider]=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider

--- a/examples/camel-quarkus-kafka/src/main/resources/avro/greeting.avsc
+++ b/examples/camel-quarkus-kafka/src/main/resources/avro/greeting.avsc
@@ -1,0 +1,23 @@
+{
+  "type": "record",
+  "name": "Greeting",
+  "namespace": "io.apicurio.registry.examples.camelkafka",
+  "doc": "A simple greeting message for the Camel Quarkus Kafka example",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string",
+      "doc": "Name of the person being greeted"
+    },
+    {
+      "name": "message",
+      "type": "string",
+      "doc": "The greeting message"
+    },
+    {
+      "name": "timestamp",
+      "type": "long",
+      "doc": "Timestamp when the greeting was created (milliseconds since epoch)"
+    }
+  ]
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -60,6 +60,7 @@
     <module>otel-tracing</module>
     <module>debezium-otel-tracing</module>
     <module>kafka-order-processing</module>
+    <module>camel-quarkus-kafka</module>
     <module>a2a-real-world-integration</module>
     <module>odcs-data-contracts</module>
   </modules>


### PR DESCRIPTION
## Summary

Closes #8670

- Add a new `camel-quarkus-kafka` example demonstrating Apache Camel Quarkus with the Kafka component and Apicurio Registry Avro SerDe
- Single-module Quarkus application with a timer-driven producer route and a consumer route
- All serializer/deserializer configuration is declarative via `application.properties` (no programmatic Kafka client setup)
- Uses `quarkus-apicurio-registry-avro` extension for proper Quarkus integration
- Includes `docker-compose.yml` (Zookeeper + Kafka + Registry + Registry UI) and full README

## Test plan

- [ ] Build succeeds: `cd examples/camel-quarkus-kafka && mvn clean package -DskipTests`
- [ ] Start infrastructure: `docker-compose up -d`
- [ ] Run application: `mvn quarkus:dev`
- [ ] Verify producer sends greeting messages every 5 seconds
- [ ] Verify consumer logs deserialized greeting messages
- [ ] Verify Avro schema auto-registered in Registry UI at `http://localhost:8888`