### PR TITLE
fix(kafkasql): retry topic config verification on UnknownTopicOrPartitionException

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
@@ -138,7 +138,6 @@ public class KafkaAdminUtil {
         var key = new ConfigResource(ConfigResource.Type.TOPIC, topic);
         // includeSynonyms should ensure we get effective values (including default configs).
         var options = new DescribeConfigsOptions().includeSynonyms(true);
-
         blockOn(toJavaFuture(adminClient.get().get().describeConfigs(singleton(key), options).all())
                 .thenAccept(d -> {
                     var config = d.get(key);

--- a/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
@@ -8,6 +8,7 @@ import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlKeyDeserializer;
 import io.apicurio.registry.storage.impl.kafkasql.v2compat.BootstrapKey;
 import io.apicurio.registry.storage.impl.kafkasql.v2compat.UpgraderKey;
 import io.quarkus.arc.lookup.LookupIfProperty;
+import io.smallrye.faulttolerance.api.ExponentialBackoff;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -17,6 +18,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.eclipse.microprofile.faulttolerance.Retry;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -130,35 +132,15 @@ public class KafkaAdminUtil {
      *
      * @param topic
      */
+    @Retry(retryOn = UnknownTopicOrPartitionException.class, maxRetries = 3, delay = 100, jitter = 50)
+    @ExponentialBackoff
     public void verifyTopicConfiguration(String topic) {
         var key = new ConfigResource(ConfigResource.Type.TOPIC, topic);
         // includeSynonyms should ensure we get effective values (including default configs).
         var options = new DescribeConfigsOptions().includeSynonyms(true);
 
-        int maxRetries = 3;
-        long backoffMs = 100;
-        for (int attempt = 0; attempt <= maxRetries; attempt++) {
-            try {
-                blockOn(toJavaFuture(adminClient.get().get().describeConfigs(singleton(key), options).all())
-                        .thenAccept(configs -> assertTopicConfiguration(topic, key, configs)));
-                break;
-            } catch (UnknownTopicOrPartitionException e) {
-                if (attempt < maxRetries) {
-                    log.warn(
-                            "Topic '{}' configuration is not yet visible to Kafka metadata ({}). Retrying configuration verification in {} ms (attempt {}/{}).",
-                            topic, e.getMessage(), backoffMs, attempt + 1, maxRetries);
-                    try {
-                        Thread.sleep(backoffMs);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        throw new RuntimeException(ie);
-                    }
-                    backoffMs *= 2;
-                } else {
-                    throw e;
-                }
-            }
-        }
+        blockOn(toJavaFuture(adminClient.get().get().describeConfigs(singleton(key), options).all())
+                .thenAccept(configs -> assertTopicConfiguration(topic, key, configs)));
     }
 
     private void assertTopicConfiguration(String topic, ConfigResource key, Map<ConfigResource, Config> configs) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
@@ -140,28 +140,26 @@ public class KafkaAdminUtil {
         var options = new DescribeConfigsOptions().includeSynonyms(true);
 
         blockOn(toJavaFuture(adminClient.get().get().describeConfigs(singleton(key), options).all())
-                .thenAccept(configs -> assertTopicConfiguration(topic, key, configs)));
-    }
+                .thenAccept(d -> {
+                    var config = d.get(key);
+                    assertConfiguration(topic, config, TopicConfig.CLEANUP_POLICY_CONFIG, "delete"::equals, """
+                            Topic must not have '%s=%s'. While Apicurio Registry will work with topic compaction, it will not have any effect. \
+                            Use '%s=delete', '%s=-1', and '%s=-1' to disable automatic deletion of messages, and perform any cleanup manually after a backup has been made\
+                            """.formatted(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT,
+                            TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
 
-    private void assertTopicConfiguration(String topic, ConfigResource key, Map<ConfigResource, Config> configs) {
-        var config = configs.get(key);
-        assertConfiguration(topic, config, TopicConfig.CLEANUP_POLICY_CONFIG, "delete"::equals, """
-                Topic must not have '%s=%s'. While Apicurio Registry will work with topic compaction, it will not have any effect. \
-                Use '%s=delete', '%s=-1', and '%s=-1' to disable automatic deletion of messages, and perform any cleanup manually after a backup has been made\
-                """.formatted(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT,
-                TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
+                    if (!topic.equals(configuration.get().getEventsTopic())) { // Events topic is allowed to use retention. If configured, old events should be eventually deleted.
+                        if (!configuration.get().isTopicConfigurationVerificationOverrideEnabled()) {
+                            assertConfiguration(topic, config, TopicConfig.RETENTION_MS_CONFIG, "-1"::equals,
+                                    "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
+                                            .formatted(TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
+                        }
 
-        if (!topic.equals(configuration.get().getEventsTopic())) {
-            if (!configuration.get().isTopicConfigurationVerificationOverrideEnabled()) {
-                assertConfiguration(topic, config, TopicConfig.RETENTION_MS_CONFIG, "-1"::equals,
-                        "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
-                                .formatted(TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
-            }
-
-            assertConfiguration(topic, config, TopicConfig.RETENTION_BYTES_CONFIG, "-1"::equals,
-                    "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
-                            .formatted(TopicConfig.RETENTION_BYTES_CONFIG, TopicConfig.RETENTION_MS_CONFIG));
-        }
+                        assertConfiguration(topic, config, TopicConfig.RETENTION_BYTES_CONFIG, "-1"::equals,
+                                "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
+                                        .formatted(TopicConfig.RETENTION_BYTES_CONFIG, TopicConfig.RETENTION_MS_CONFIG));
+                    }
+                }));
     }
 
     private static void assertConfiguration(String topic, Config config, String property, Predicate<String> condition, String errorMessage) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
@@ -16,6 +16,7 @@ import org.apache.kafka.clients.admin.DescribeConfigsOptions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -133,27 +134,52 @@ public class KafkaAdminUtil {
         var key = new ConfigResource(ConfigResource.Type.TOPIC, topic);
         // includeSynonyms should ensure we get effective values (including default configs).
         var options = new DescribeConfigsOptions().includeSynonyms(true);
-        blockOn(toJavaFuture(adminClient.get().get().describeConfigs(singleton(key), options).all())
-                .thenAccept(d -> {
-                    var config = d.get(key);
-                    assertConfiguration(topic, config, TopicConfig.CLEANUP_POLICY_CONFIG, "delete"::equals, """
-                            Topic must not have '%s=%s'. While Apicurio Registry will work with topic compaction, it will not have any effect. \
-                            Use '%s=delete', '%s=-1', and '%s=-1' to disable automatic deletion of messages, and perform any cleanup manually after a backup has been made\
-                            """.formatted(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT,
-                            TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
 
-                    if (!topic.equals(configuration.get().getEventsTopic())) { // Events topic is allowed to use retention. If configured, old events should be eventually deleted.
-                        if (!configuration.get().isTopicConfigurationVerificationOverrideEnabled()) {
-                            assertConfiguration(topic, config, TopicConfig.RETENTION_MS_CONFIG, "-1"::equals,
-                                    "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
-                                            .formatted(TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
-                        }
-
-                        assertConfiguration(topic, config, TopicConfig.RETENTION_BYTES_CONFIG, "-1"::equals,
-                                "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
-                                        .formatted(TopicConfig.RETENTION_BYTES_CONFIG, TopicConfig.RETENTION_MS_CONFIG));
+        int maxRetries = 3;
+        long backoffMs = 100;
+        for (int attempt = 0; attempt <= maxRetries; attempt++) {
+            try {
+                blockOn(toJavaFuture(adminClient.get().get().describeConfigs(singleton(key), options).all())
+                        .thenAccept(configs -> assertTopicConfiguration(topic, key, configs)));
+                break;
+            } catch (UnknownTopicOrPartitionException e) {
+                if (attempt < maxRetries) {
+                    log.warn(
+                            "Topic '{}' configuration is not yet visible to Kafka metadata ({}). Retrying configuration verification in {} ms (attempt {}/{}).",
+                            topic, e.getMessage(), backoffMs, attempt + 1, maxRetries);
+                    try {
+                        Thread.sleep(backoffMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(ie);
                     }
-                }));
+                    backoffMs *= 2;
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    private void assertTopicConfiguration(String topic, ConfigResource key, Map<ConfigResource, Config> configs) {
+        var config = configs.get(key);
+        assertConfiguration(topic, config, TopicConfig.CLEANUP_POLICY_CONFIG, "delete"::equals, """
+                Topic must not have '%s=%s'. While Apicurio Registry will work with topic compaction, it will not have any effect. \
+                Use '%s=delete', '%s=-1', and '%s=-1' to disable automatic deletion of messages, and perform any cleanup manually after a backup has been made\
+                """.formatted(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT,
+                TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
+
+        if (!topic.equals(configuration.get().getEventsTopic())) {
+            if (!configuration.get().isTopicConfigurationVerificationOverrideEnabled()) {
+                assertConfiguration(topic, config, TopicConfig.RETENTION_MS_CONFIG, "-1"::equals,
+                        "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
+                                .formatted(TopicConfig.RETENTION_MS_CONFIG, TopicConfig.RETENTION_BYTES_CONFIG));
+            }
+
+            assertConfiguration(topic, config, TopicConfig.RETENTION_BYTES_CONFIG, "-1"::equals,
+                    "Topic must have '%s=-1' and '%s=-1' to prevent accidental loss of data"
+                            .formatted(TopicConfig.RETENTION_BYTES_CONFIG, TopicConfig.RETENTION_MS_CONFIG));
+        }
     }
 
     private static void assertConfiguration(String topic, Config config, String property, Predicate<String> condition, String errorMessage) {

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
@@ -182,11 +182,10 @@ public class KafkaAdminUtilTest {
         DescribeConfigsResult success = buildSuccessResult();
         when(admin.describeConfigs(any(), any())).thenReturn(success);
 
-        retryOnUnknownTopic(() -> kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC), 3);
+        kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC);
 
         verify(admin, times(1)).describeConfigs(any(), any());
     }
-
 
     /**
      * Validates that {@code verifyTopicConfiguration()} throws
@@ -194,50 +193,12 @@ public class KafkaAdminUtilTest {
      * establishing the precondition for {@code @Retry(retryOn = UnknownTopicOrPartitionException.class)}
      * to be effective in production.
      *
-     * <p>The test also confirms that the method eventually succeeds once metadata becomes
-     * available (simulated here by the third {@code describeConfigs} call returning a valid
-     * result). The {@link #retryOnUnknownTopic(Runnable, int)} helper reproduces the retry
-     * semantics that the CDI interceptor would apply in a running container.
-     *
-     * <p><b>Note:</b> {@code @Retry} itself is a CDI interceptor and is inactive in plain JUnit.
-     * What this test proves is the exception contract — not that the annotation fired.
+     * <p>If the method caught and logged this exception internally, the CDI interceptor would never
+     * see it and retries would not fire. This test is a regression guard for that contract.
      */
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testVerifyTopicConfigurationThrowsUnknownTopicExceptionWhenMetadataUnavailable() throws Exception {
-        Admin admin = setUpAdminMock();
-        when(config.getEventsTopic()).thenReturn("events-topic");
-
-        DescribeConfigsResult fail = buildFailResult(new UnknownTopicOrPartitionException("topic not yet visible"));
-        DescribeConfigsResult success = buildSuccessResult();
-
-        when(admin.describeConfigs(any(), any()))
-                .thenReturn(fail)
-                .thenReturn(fail)
-                .thenReturn(success);
-
-        // Retries succeed on the third attempt — confirms the method is retryable
-        retryOnUnknownTopic(() -> kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC), 3);
-
-        verify(admin, times(3)).describeConfigs(any(), any());
-    }
-
-    /**
-     * Validates the retry budget declared by {@code @Retry(maxRetries = 3)}: when
-     * {@code describeConfigs} keeps throwing {@link UnknownTopicOrPartitionException} across all
-     * 4 attempts (1 initial + 3 retries), the exception must ultimately propagate to the caller.
-     *
-     * <p>This test confirms two things:
-     * <ol>
-     *   <li>The method does not swallow {@code UnknownTopicOrPartitionException} after exhausting
-     *       the retry budget.</li>
-     *   <li>Exactly 4 calls are made — matching the contract declared on the annotation —
-     *       so the retry budget is not exceeded and not under-consumed.</li>
-     * </ol>
-     */
-    @Test
-    @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testVerifyTopicConfigurationPropagatesAfterRetryBudgetExhausted() throws Exception {
+    void testVerifyTopicConfigurationPropagatesUnknownTopicOrPartitionException() throws Exception {
         Admin admin = setUpAdminMock();
         when(config.getEventsTopic()).thenReturn("events-topic");
 
@@ -245,10 +206,9 @@ public class KafkaAdminUtilTest {
         when(admin.describeConfigs(any(), any())).thenReturn(fail);
 
         assertThrows(UnknownTopicOrPartitionException.class, () ->
-                retryOnUnknownTopic(() -> kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC), 3));
+                kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC));
 
-        // 1 initial attempt + 3 retries = 4 total calls
-        verify(admin, times(4)).describeConfigs(any(), any());
+        verify(admin, times(1)).describeConfigs(any(), any());
     }
 
     /**
@@ -270,41 +230,10 @@ public class KafkaAdminUtilTest {
         when(admin.describeConfigs(any(), any())).thenReturn(fail);
 
         assertThrows(TopicExistsException.class, () ->
-                retryOnUnknownTopic(() -> kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC), 3));
+                kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC));
 
         // Must fail on the first call — no retries for non-retryable exceptions
         verify(admin, times(1)).describeConfigs(any(), any());
-    }
-
-    /**
-     * Reproduces the retry semantics of
-     * {@code @Retry(retryOn = UnknownTopicOrPartitionException.class, maxRetries = maxRetries)}
-     * without a CDI container.
-     *
-     * <p>This helper exists solely because {@code @Retry} is a CDI interceptor binding and
-     * therefore inert when the bean is instantiated with {@code new}. By driving the retry loop
-     * explicitly here, we can exercise multi-attempt exception-contract scenarios in plain JUnit.
-     *
-     * <ul>
-     *   <li>Only {@link UnknownTopicOrPartitionException} is retried.</li>
-     *   <li>All other exceptions propagate immediately (no retry).</li>
-     *   <li>After {@code maxRetries} unsuccessful retries the last exception is rethrown.</li>
-     * </ul>
-     *
-     * <p>Total attempts = 1 initial + {@code maxRetries}, matching
-     * {@code @Retry(maxRetries = maxRetries)} semantics.
-     */
-    private void retryOnUnknownTopic(Runnable action, int maxRetries) {
-        RuntimeException lastException = null;
-        for (int attempt = 0; attempt <= maxRetries; attempt++) {
-            try {
-                action.run();
-                return; // success
-            } catch (UnknownTopicOrPartitionException e) {
-                lastException = e;
-            }
-        }
-        throw lastException;
     }
 
     @SuppressWarnings("unchecked")
@@ -359,4 +288,3 @@ public class KafkaAdminUtilTest {
         field.set(kafkaAdminUtil, value);
     }
 }
-

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
@@ -15,15 +15,15 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.utils.Bytes;
-import org.eclipse.microprofile.faulttolerance.Retry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,8 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -168,50 +167,148 @@ public class KafkaAdminUtilTest {
     }
 
     /**
-     * Verifies that the topic configuration assertion works correctly (success path).
-     * The retry behavior on UnknownTopicOrPartitionException is handled by the
-     * {@code @Retry} annotation and tested separately.
+     * Happy path: describeConfigs succeeds on the very first attempt.
+     * No retries are needed and the method returns normally.
      */
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testVerifyTopicConfigurationAssertsConfig() throws Exception {
+    void testVerifyTopicConfigurationSucceedsOnFirstAttempt() throws Exception {
+        Admin admin = setUpAdminMock();
+        when(config.getEventsTopic()).thenReturn("events-topic");
+        DescribeConfigsResult success = buildSuccessResult();
+        when(admin.describeConfigs(any(), any())).thenReturn(success);
+
+        retryOnUnknownTopic(() -> kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC), 3);
+
+        verify(admin, times(1)).describeConfigs(any(), any());
+    }
+
+
+    /**
+     * Simulates the retry behaviour declared by
+     * {@code @Retry(retryOn = UnknownTopicOrPartitionException.class, maxRetries = 3)}:
+     * describeConfigs throws {@link UnknownTopicOrPartitionException} on the first two
+     * attempts and succeeds on the third. The operation must complete successfully.
+     *
+     * <p>Because {@code @Retry} is a CDI interceptor and therefore inactive in plain JUnit,
+     * the retry loop is driven by {@link #retryOnUnknownTopic(Runnable, int)}, which
+     * faithfully reproduces the declared retry semantics.
+     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void testVerifyTopicConfigurationRetriesOnUnknownTopicException() throws Exception {
+        Admin admin = setUpAdminMock();
+        when(config.getEventsTopic()).thenReturn("events-topic");
+
+        DescribeConfigsResult fail = buildFailResult(new UnknownTopicOrPartitionException("topic not yet visible"));
+        DescribeConfigsResult success = buildSuccessResult();
+
+        when(admin.describeConfigs(any(), any()))
+                .thenReturn(fail)
+                .thenReturn(fail)
+                .thenReturn(success);
+
+        retryOnUnknownTopic(() -> kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC), 3);
+
+        verify(admin, times(3)).describeConfigs(any(), any());
+    }
+
+    /**
+     * Verifies that when describeConfigs keeps throwing {@link UnknownTopicOrPartitionException}
+     * beyond the retry budget (maxRetries = 3), the exception is ultimately propagated to the caller.
+     * Total call count must be 4: 1 initial attempt + 3 retries.
+     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void testVerifyTopicConfigurationExhaustsRetriesAndPropagates() throws Exception {
+        Admin admin = setUpAdminMock();
+        when(config.getEventsTopic()).thenReturn("events-topic");
+
+        DescribeConfigsResult fail = buildFailResult(new UnknownTopicOrPartitionException("topic not yet visible"));
+        when(admin.describeConfigs(any(), any())).thenReturn(fail);
+
+        assertThrows(UnknownTopicOrPartitionException.class, () ->
+                retryOnUnknownTopic(() -> kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC), 3));
+
+        verify(admin, times(4)).describeConfigs(any(), any());
+    }
+
+    /**
+     * Verifies that exceptions other than {@link UnknownTopicOrPartitionException} are NOT
+     * retried and propagate immediately after the very first failure.
+     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void testVerifyTopicConfigurationDoesNotRetryOnOtherExceptions() throws Exception {
+        Admin admin = setUpAdminMock();
+        when(config.getEventsTopic()).thenReturn("events-topic");
+
+        DescribeConfigsResult fail = buildFailResult(new TopicExistsException("unexpected error"));
+        when(admin.describeConfigs(any(), any())).thenReturn(fail);
+
+        assertThrows(TopicExistsException.class, () ->
+                retryOnUnknownTopic(() -> kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC), 3));
+
+        // Must fail on the first call — no retries for non-retryable exceptions
+        verify(admin, times(1)).describeConfigs(any(), any());
+    }
+
+    /**
+     * Simulates the retry semantics of
+     * {@code @Retry(retryOn = UnknownTopicOrPartitionException.class, maxRetries = maxRetries)}.
+     * <ul>
+     *   <li>Only {@link UnknownTopicOrPartitionException} is retried.</li>
+     *   <li>All other exceptions propagate immediately.</li>
+     *   <li>After {@code maxRetries} unsuccessful attempts the last exception is rethrown.</li>
+     * </ul>
+     */
+    private void retryOnUnknownTopic(Runnable action, int maxRetries) {
+        RuntimeException lastException = null;
+        for (int attempt = 0; attempt <= maxRetries; attempt++) {
+            try {
+                action.run();
+                return; // success
+            } catch (UnknownTopicOrPartitionException e) {
+                lastException = e;
+            }
+        }
+        throw lastException;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Admin setUpAdminMock() throws Exception {
         Admin admin = mock(Admin.class);
         KafkaAdminClient adminClientResource = new KafkaAdminClient(() -> admin);
-        @SuppressWarnings("unchecked")
         Instance<KafkaAdminClient> adminClientInstance = mock(Instance.class);
         when(adminClientInstance.get()).thenReturn(adminClientResource);
         setField("adminClient", adminClientInstance);
+        return admin;
+    }
 
-        when(config.getEventsTopic()).thenReturn("events-topic");
-
+    /** Returns a {@link DescribeConfigsResult} that resolves to a valid, compliant topic config. */
+    private DescribeConfigsResult buildSuccessResult() {
         ConfigResource key = new ConfigResource(ConfigResource.Type.TOPIC, TEST_TOPIC);
         List<ConfigEntry> entries = List.of(
                 new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, "delete"),
                 new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, "-1"),
                 new ConfigEntry(TopicConfig.RETENTION_BYTES_CONFIG, "-1"));
         Config topicConfig = new Config(entries);
-        Map<ConfigResource, Config> configs = Map.of(key, topicConfig);
 
         DescribeConfigsResult result = mock(DescribeConfigsResult.class);
-        when(result.all()).thenReturn(KafkaFuture.completedFuture(configs));
-
-        when(admin.describeConfigs(any(), any())).thenReturn(result);
-
-        kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC);
-
-        verify(admin, times(1)).describeConfigs(any(), any());
+        when(result.all()).thenReturn(KafkaFuture.completedFuture(Map.of(key, topicConfig)));
+        return result;
     }
 
-    /**
-     * Verifies that {@code verifyTopicConfiguration} has the {@code @Retry} annotation
-     * configured to retry on {@code UnknownTopicOrPartitionException}.
-     */
-    @Test
-    void testVerifyTopicConfigurationHasRetryAnnotation() throws NoSuchMethodException {
-        Method method = KafkaAdminUtil.class.getMethod("verifyTopicConfiguration", String.class);
-        Retry retry = method.getAnnotation(Retry.class);
-        assertNotNull(retry, "@Retry annotation must be present on verifyTopicConfiguration");
-        assertTrue(retry.maxRetries() > 0, "@Retry must have maxRetries > 0");
+    private DescribeConfigsResult buildFailResult(RuntimeException exception) {
+        @SuppressWarnings("unchecked")
+        KafkaFuture<Map<ConfigResource, Config>> failedFuture =
+                KafkaFuture.completedFuture((Map<ConfigResource, Config>) null)
+                        .thenApply(ignored -> {
+                            throw exception;
+                        });
+        DescribeConfigsResult result = mock(DescribeConfigsResult.class);
+        when(result.all()).thenReturn(failedFuture);
+        return result;
     }
 
     private ConsumerRecords<Bytes, Bytes> createRecords(long startOffset, int count) {
@@ -230,3 +327,4 @@ public class KafkaAdminUtilTest {
         field.set(kafkaAdminUtil, value);
     }
 }
+

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
@@ -15,14 +15,15 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.utils.Bytes;
+import org.eclipse.microprofile.faulttolerance.Retry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,6 +32,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -165,14 +168,16 @@ public class KafkaAdminUtilTest {
     }
 
     /**
-     * Verifies that the topic configuration verification retries on UnknownTopicOrPartitionException,
-     * which can occur when Kafka topic metadata has not yet propagated to all brokers after topic creation.
+     * Verifies that the topic configuration assertion works correctly (success path).
+     * The retry behavior on UnknownTopicOrPartitionException is handled by the
+     * {@code @Retry} annotation and tested separately.
      */
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testVerifyTopicConfigurationRetriesOnUnknownTopicOrPartition() throws Exception {
+    void testVerifyTopicConfigurationAssertsConfig() throws Exception {
         Admin admin = mock(Admin.class);
         KafkaAdminClient adminClientResource = new KafkaAdminClient(() -> admin);
+        @SuppressWarnings("unchecked")
         Instance<KafkaAdminClient> adminClientInstance = mock(Instance.class);
         when(adminClientInstance.get()).thenReturn(adminClientResource);
         setField("adminClient", adminClientInstance);
@@ -187,17 +192,26 @@ public class KafkaAdminUtilTest {
         Config topicConfig = new Config(entries);
         Map<ConfigResource, Config> configs = Map.of(key, topicConfig);
 
-        DescribeConfigsResult failResult = mock(DescribeConfigsResult.class);
-        when(failResult.all()).thenThrow(new UnknownTopicOrPartitionException("test"));
+        DescribeConfigsResult result = mock(DescribeConfigsResult.class);
+        when(result.all()).thenReturn(KafkaFuture.completedFuture(configs));
 
-        DescribeConfigsResult successResult = mock(DescribeConfigsResult.class);
-        when(successResult.all()).thenReturn(KafkaFuture.completedFuture(configs));
-
-        when(admin.describeConfigs(any(), any())).thenReturn(failResult).thenReturn(successResult);
+        when(admin.describeConfigs(any(), any())).thenReturn(result);
 
         kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC);
 
-        verify(admin, times(2)).describeConfigs(any(), any());
+        verify(admin, times(1)).describeConfigs(any(), any());
+    }
+
+    /**
+     * Verifies that {@code verifyTopicConfiguration} has the {@code @Retry} annotation
+     * configured to retry on {@code UnknownTopicOrPartitionException}.
+     */
+    @Test
+    void testVerifyTopicConfigurationHasRetryAnnotation() throws NoSuchMethodException {
+        Method method = KafkaAdminUtil.class.getMethod("verifyTopicConfiguration", String.class);
+        Retry retry = method.getAnnotation(Retry.class);
+        assertNotNull(retry, "@Retry annotation must be present on verifyTopicConfiguration");
+        assertTrue(retry.maxRetries() > 0, "@Retry must have maxRetries > 0");
     }
 
     private ConsumerRecords<Bytes, Bytes> createRecords(long startOffset, int count) {

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
@@ -167,12 +167,16 @@ public class KafkaAdminUtilTest {
     }
 
     /**
-     * Happy path: describeConfigs succeeds on the very first attempt.
-     * No retries are needed and the method returns normally.
+     * Happy path: {@code verifyTopicConfiguration()} completes normally when Kafka metadata is
+     * immediately available.
+     *
+     * <p>This is the baseline case — no retries are needed. The test confirms that when
+     * {@code describeConfigs} succeeds on the first call the method returns without error and
+     * does not make unnecessary additional calls to the admin client.
      */
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testVerifyTopicConfigurationSucceedsOnFirstAttempt() throws Exception {
+    void testVerifyTopicConfigurationSucceedsImmediately() throws Exception {
         Admin admin = setUpAdminMock();
         when(config.getEventsTopic()).thenReturn("events-topic");
         DescribeConfigsResult success = buildSuccessResult();
@@ -185,18 +189,22 @@ public class KafkaAdminUtilTest {
 
 
     /**
-     * Simulates the retry behaviour declared by
-     * {@code @Retry(retryOn = UnknownTopicOrPartitionException.class, maxRetries = 3)}:
-     * describeConfigs throws {@link UnknownTopicOrPartitionException} on the first two
-     * attempts and succeeds on the third. The operation must complete successfully.
+     * Validates that {@code verifyTopicConfiguration()} throws
+     * {@link UnknownTopicOrPartitionException} when Kafka metadata has not yet propagated —
+     * establishing the precondition for {@code @Retry(retryOn = UnknownTopicOrPartitionException.class)}
+     * to be effective in production.
      *
-     * <p>Because {@code @Retry} is a CDI interceptor and therefore inactive in plain JUnit,
-     * the retry loop is driven by {@link #retryOnUnknownTopic(Runnable, int)}, which
-     * faithfully reproduces the declared retry semantics.
+     * <p>The test also confirms that the method eventually succeeds once metadata becomes
+     * available (simulated here by the third {@code describeConfigs} call returning a valid
+     * result). The {@link #retryOnUnknownTopic(Runnable, int)} helper reproduces the retry
+     * semantics that the CDI interceptor would apply in a running container.
+     *
+     * <p><b>Note:</b> {@code @Retry} itself is a CDI interceptor and is inactive in plain JUnit.
+     * What this test proves is the exception contract — not that the annotation fired.
      */
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testVerifyTopicConfigurationRetriesOnUnknownTopicException() throws Exception {
+    void testVerifyTopicConfigurationThrowsUnknownTopicExceptionWhenMetadataUnavailable() throws Exception {
         Admin admin = setUpAdminMock();
         when(config.getEventsTopic()).thenReturn("events-topic");
 
@@ -208,19 +216,28 @@ public class KafkaAdminUtilTest {
                 .thenReturn(fail)
                 .thenReturn(success);
 
+        // Retries succeed on the third attempt — confirms the method is retryable
         retryOnUnknownTopic(() -> kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC), 3);
 
         verify(admin, times(3)).describeConfigs(any(), any());
     }
 
     /**
-     * Verifies that when describeConfigs keeps throwing {@link UnknownTopicOrPartitionException}
-     * beyond the retry budget (maxRetries = 3), the exception is ultimately propagated to the caller.
-     * Total call count must be 4: 1 initial attempt + 3 retries.
+     * Validates the retry budget declared by {@code @Retry(maxRetries = 3)}: when
+     * {@code describeConfigs} keeps throwing {@link UnknownTopicOrPartitionException} across all
+     * 4 attempts (1 initial + 3 retries), the exception must ultimately propagate to the caller.
+     *
+     * <p>This test confirms two things:
+     * <ol>
+     *   <li>The method does not swallow {@code UnknownTopicOrPartitionException} after exhausting
+     *       the retry budget.</li>
+     *   <li>Exactly 4 calls are made — matching the contract declared on the annotation —
+     *       so the retry budget is not exceeded and not under-consumed.</li>
+     * </ol>
      */
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testVerifyTopicConfigurationExhaustsRetriesAndPropagates() throws Exception {
+    void testVerifyTopicConfigurationPropagatesAfterRetryBudgetExhausted() throws Exception {
         Admin admin = setUpAdminMock();
         when(config.getEventsTopic()).thenReturn("events-topic");
 
@@ -230,16 +247,22 @@ public class KafkaAdminUtilTest {
         assertThrows(UnknownTopicOrPartitionException.class, () ->
                 retryOnUnknownTopic(() -> kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC), 3));
 
+        // 1 initial attempt + 3 retries = 4 total calls
         verify(admin, times(4)).describeConfigs(any(), any());
     }
 
     /**
-     * Verifies that exceptions other than {@link UnknownTopicOrPartitionException} are NOT
-     * retried and propagate immediately after the very first failure.
+     * Validates the {@code retryOn} constraint declared by
+     * {@code @Retry(retryOn = UnknownTopicOrPartitionException.class)}: exceptions of any other
+     * type must propagate immediately without being retried.
+     *
+     * <p>This test uses {@link TopicExistsException} as a representative non-retryable exception.
+     * The method must fail on the very first call and must not make further attempts, proving
+     * that the retry contract does not silently absorb arbitrary exceptions.
      */
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testVerifyTopicConfigurationDoesNotRetryOnOtherExceptions() throws Exception {
+    void testVerifyTopicConfigurationPropagatesNonRetryableExceptionImmediately() throws Exception {
         Admin admin = setUpAdminMock();
         when(config.getEventsTopic()).thenReturn("events-topic");
 
@@ -254,13 +277,22 @@ public class KafkaAdminUtilTest {
     }
 
     /**
-     * Simulates the retry semantics of
-     * {@code @Retry(retryOn = UnknownTopicOrPartitionException.class, maxRetries = maxRetries)}.
+     * Reproduces the retry semantics of
+     * {@code @Retry(retryOn = UnknownTopicOrPartitionException.class, maxRetries = maxRetries)}
+     * without a CDI container.
+     *
+     * <p>This helper exists solely because {@code @Retry} is a CDI interceptor binding and
+     * therefore inert when the bean is instantiated with {@code new}. By driving the retry loop
+     * explicitly here, we can exercise multi-attempt exception-contract scenarios in plain JUnit.
+     *
      * <ul>
      *   <li>Only {@link UnknownTopicOrPartitionException} is retried.</li>
-     *   <li>All other exceptions propagate immediately.</li>
-     *   <li>After {@code maxRetries} unsuccessful attempts the last exception is rethrown.</li>
+     *   <li>All other exceptions propagate immediately (no retry).</li>
+     *   <li>After {@code maxRetries} unsuccessful retries the last exception is rethrown.</li>
      * </ul>
+     *
+     * <p>Total attempts = 1 initial + {@code maxRetries}, matching
+     * {@code @Retry(maxRetries = maxRetries)} semantics.
      */
     private void retryOnUnknownTopic(Runnable action, int maxRetries) {
         RuntimeException lastException = null;

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
@@ -1,22 +1,12 @@
 package io.apicurio.registry.storage.impl.kafkasql;
 
-import io.apicurio.registry.storage.impl.kafkasql.KafkaSqlFactory.KafkaAdminClient;
 import io.apicurio.registry.storage.impl.kafkasql.KafkaSqlFactory.KafkaSqlVerificationJournalConsumer;
 import io.apicurio.registry.storage.impl.util.KafkaAdminUtil;
 import jakarta.enterprise.inject.Instance;
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.clients.admin.ConfigEntry;
-import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.config.TopicConfig;
-import org.apache.kafka.common.errors.TopicExistsException;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -164,112 +153,6 @@ public class KafkaAdminUtilTest {
 
         // 2 polls: assignment + one empty poll in the loop
         verify(consumer, times(2)).poll(any(Duration.class));
-    }
-
-    /**
-     * Happy path: {@code verifyTopicConfiguration()} completes normally when Kafka metadata is
-     * immediately available.
-     *
-     * <p>This is the baseline case — no retries are needed. The test confirms that when
-     * {@code describeConfigs} succeeds on the first call the method returns without error and
-     * does not make unnecessary additional calls to the admin client.
-     */
-    @Test
-    @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testVerifyTopicConfigurationSucceedsImmediately() throws Exception {
-        Admin admin = setUpAdminMock();
-        when(config.getEventsTopic()).thenReturn("events-topic");
-        DescribeConfigsResult success = buildSuccessResult();
-        when(admin.describeConfigs(any(), any())).thenReturn(success);
-
-        kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC);
-
-        verify(admin, times(1)).describeConfigs(any(), any());
-    }
-
-    /**
-     * Validates that {@code verifyTopicConfiguration()} throws
-     * {@link UnknownTopicOrPartitionException} when Kafka metadata has not yet propagated —
-     * establishing the precondition for {@code @Retry(retryOn = UnknownTopicOrPartitionException.class)}
-     * to be effective in production.
-     *
-     * <p>If the method caught and logged this exception internally, the CDI interceptor would never
-     * see it and retries would not fire. This test is a regression guard for that contract.
-     */
-    @Test
-    @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testVerifyTopicConfigurationPropagatesUnknownTopicOrPartitionException() throws Exception {
-        Admin admin = setUpAdminMock();
-        when(config.getEventsTopic()).thenReturn("events-topic");
-
-        DescribeConfigsResult fail = buildFailResult(new UnknownTopicOrPartitionException("topic not yet visible"));
-        when(admin.describeConfigs(any(), any())).thenReturn(fail);
-
-        assertThrows(UnknownTopicOrPartitionException.class, () ->
-                kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC));
-
-        verify(admin, times(1)).describeConfigs(any(), any());
-    }
-
-    /**
-     * Validates the {@code retryOn} constraint declared by
-     * {@code @Retry(retryOn = UnknownTopicOrPartitionException.class)}: exceptions of any other
-     * type must propagate immediately without being retried.
-     *
-     * <p>This test uses {@link TopicExistsException} as a representative non-retryable exception.
-     * The method must fail on the very first call and must not make further attempts, proving
-     * that the retry contract does not silently absorb arbitrary exceptions.
-     */
-    @Test
-    @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void testVerifyTopicConfigurationPropagatesNonRetryableExceptionImmediately() throws Exception {
-        Admin admin = setUpAdminMock();
-        when(config.getEventsTopic()).thenReturn("events-topic");
-
-        DescribeConfigsResult fail = buildFailResult(new TopicExistsException("unexpected error"));
-        when(admin.describeConfigs(any(), any())).thenReturn(fail);
-
-        assertThrows(TopicExistsException.class, () ->
-                kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC));
-
-        // Must fail on the first call — no retries for non-retryable exceptions
-        verify(admin, times(1)).describeConfigs(any(), any());
-    }
-
-    @SuppressWarnings("unchecked")
-    private Admin setUpAdminMock() throws Exception {
-        Admin admin = mock(Admin.class);
-        KafkaAdminClient adminClientResource = new KafkaAdminClient(() -> admin);
-        Instance<KafkaAdminClient> adminClientInstance = mock(Instance.class);
-        when(adminClientInstance.get()).thenReturn(adminClientResource);
-        setField("adminClient", adminClientInstance);
-        return admin;
-    }
-
-    /** Returns a {@link DescribeConfigsResult} that resolves to a valid, compliant topic config. */
-    private DescribeConfigsResult buildSuccessResult() {
-        ConfigResource key = new ConfigResource(ConfigResource.Type.TOPIC, TEST_TOPIC);
-        List<ConfigEntry> entries = List.of(
-                new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, "delete"),
-                new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, "-1"),
-                new ConfigEntry(TopicConfig.RETENTION_BYTES_CONFIG, "-1"));
-        Config topicConfig = new Config(entries);
-
-        DescribeConfigsResult result = mock(DescribeConfigsResult.class);
-        when(result.all()).thenReturn(KafkaFuture.completedFuture(Map.of(key, topicConfig)));
-        return result;
-    }
-
-    private DescribeConfigsResult buildFailResult(RuntimeException exception) {
-        @SuppressWarnings("unchecked")
-        KafkaFuture<Map<ConfigResource, Config>> failedFuture =
-                KafkaFuture.completedFuture((Map<ConfigResource, Config>) null)
-                        .thenApply(ignored -> {
-                            throw exception;
-                        });
-        DescribeConfigsResult result = mock(DescribeConfigsResult.class);
-        when(result.all()).thenReturn(failedFuture);
-        return result;
     }
 
     private ConsumerRecords<Bytes, Bytes> createRecords(long startOffset, int count) {

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaAdminUtilTest.java
@@ -1,12 +1,21 @@
 package io.apicurio.registry.storage.impl.kafkasql;
 
+import io.apicurio.registry.storage.impl.kafkasql.KafkaSqlFactory.KafkaAdminClient;
 import io.apicurio.registry.storage.impl.kafkasql.KafkaSqlFactory.KafkaSqlVerificationJournalConsumer;
 import io.apicurio.registry.storage.impl.util.KafkaAdminUtil;
 import jakarta.enterprise.inject.Instance;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +44,9 @@ public class KafkaAdminUtilTest {
 
     private KafkaAdminUtil kafkaAdminUtil;
     private KafkaConsumer<Bytes, Bytes> consumer;
+    private KafkaSqlConfiguration config;
+    @SuppressWarnings("unchecked")
+    private Instance<KafkaSqlConfiguration> configInstance;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
@@ -47,11 +59,11 @@ public class KafkaAdminUtilTest {
         Instance<KafkaSqlVerificationJournalConsumer> verificationInstance = mock(Instance.class);
         when(verificationInstance.get()).thenReturn(verificationResource);
 
-        KafkaSqlConfiguration config = mock(KafkaSqlConfiguration.class);
+        config = mock(KafkaSqlConfiguration.class);
         when(config.getPollTimeout()).thenReturn(Duration.ofMillis(100));
         when(config.getTopic()).thenReturn(TEST_TOPIC);
 
-        Instance<KafkaSqlConfiguration> configInstance = mock(Instance.class);
+        configInstance = mock(Instance.class);
         when(configInstance.get()).thenReturn(config);
 
         kafkaAdminUtil = new KafkaAdminUtil();
@@ -150,6 +162,42 @@ public class KafkaAdminUtilTest {
 
         // 2 polls: assignment + one empty poll in the loop
         verify(consumer, times(2)).poll(any(Duration.class));
+    }
+
+    /**
+     * Verifies that the topic configuration verification retries on UnknownTopicOrPartitionException,
+     * which can occur when Kafka topic metadata has not yet propagated to all brokers after topic creation.
+     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void testVerifyTopicConfigurationRetriesOnUnknownTopicOrPartition() throws Exception {
+        Admin admin = mock(Admin.class);
+        KafkaAdminClient adminClientResource = new KafkaAdminClient(() -> admin);
+        Instance<KafkaAdminClient> adminClientInstance = mock(Instance.class);
+        when(adminClientInstance.get()).thenReturn(adminClientResource);
+        setField("adminClient", adminClientInstance);
+
+        when(config.getEventsTopic()).thenReturn("events-topic");
+
+        ConfigResource key = new ConfigResource(ConfigResource.Type.TOPIC, TEST_TOPIC);
+        List<ConfigEntry> entries = List.of(
+                new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, "delete"),
+                new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, "-1"),
+                new ConfigEntry(TopicConfig.RETENTION_BYTES_CONFIG, "-1"));
+        Config topicConfig = new Config(entries);
+        Map<ConfigResource, Config> configs = Map.of(key, topicConfig);
+
+        DescribeConfigsResult failResult = mock(DescribeConfigsResult.class);
+        when(failResult.all()).thenThrow(new UnknownTopicOrPartitionException("test"));
+
+        DescribeConfigsResult successResult = mock(DescribeConfigsResult.class);
+        when(successResult.all()).thenReturn(KafkaFuture.completedFuture(configs));
+
+        when(admin.describeConfigs(any(), any())).thenReturn(failResult).thenReturn(successResult);
+
+        kafkaAdminUtil.verifyTopicConfiguration(TEST_TOPIC);
+
+        verify(admin, times(2)).describeConfigs(any(), any());
     }
 
     private ConsumerRecords<Bytes, Bytes> createRecords(long startOffset, int count) {


### PR DESCRIPTION
## Description

- `describeConfigs()` in `verifyTopicConfiguration()` fails intermittently in CI with UnknownTopicOrPartitionException because Kafka's createTopics() is async, topic metadata may not be propagated to brokers yet when the verify call fires. On resource-constrained CI runners this race window widens.

- Added exponential backoff retry (3 retries, 100ms → 400ms) to KafkaAdminUtil.verifyTopicConfiguration() to tolerate transient metadata unavailability.

### Issue
fixes #8583 

### Proof Manifests

- All the affected now pass succesfully.
<img width="1065" height="353" alt="Screenshot 2026-07-14 at 02 20 10" src="https://github.com/user-attachments/assets/7022349a-0dc6-4230-ab81-8bae93c87619" />
<img width="1066" height="351" alt="Screenshot 2026-07-14 at 02 20 50" src="https://github.com/user-attachments/assets/fc4f349d-7f2d-4fd1-a545-f8ca6eaca75b" />