### PR TITLE
fix: number input fields reject zero value in Prompt Template test panel

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -120,8 +120,11 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
                 return (
                     <TextInput
                         type="number"
-                        value={values[name] || ""}
-                        onChange={(_event, val) => setValue(name, type === "integer" ? parseInt(val) || "" : parseFloat(val) || "")}
+                        value={values[name] ?? ""}
+                        onChange={(_event, val) => {
+                            const n = type === "integer" ? parseInt(val) : parseFloat(val);
+                            setValue(name, isNaN(n) ? "" : n);
+                        }}
                         aria-label={name}
                     />
                 );


### PR DESCRIPTION


Fixes #8678 

### What this PR does

Fixes a bug where users cannot enter `0` as a value for numeric template variables in the Prompt Template test panel.

#### Root cause

Both the `value` prop and the `onChange` handler use the `||` (logical OR) operator for fallback. Since `0` is falsy in JavaScript, `0 || ""` evaluates to `""`, causing zero to be rejected as both a display value and a state value.

#### Fix

Replace `||` with `??` (nullish coalescing) for the display value, and use explicit `isNaN()` for the setter:

` ` `diff
 case "integer":
 case "number":
     return (
         <TextInput
             type="number"
-            value={values[name] || ""}
-            onChange={(_event, val) => setValue(name, type === "integer" ? parseInt(val) || "" : parseFloat(val) || "")}
+            value={values[name] ?? ""}
+            onChange={(_event, val) => {
+                const n = type === "integer" ? parseInt(val) : parseFloat(val);
+                setValue(name, isNaN(n) ? "" : n);
+            }}
             aria-label={name}
         />
     );
` ` `

#### Input trace verification

| Input | parseInt | isNaN? | setValue | value display (`?? ""`) |
|-------|---------|--------|---------|------------------------|
| `"0"` | `0` | `false` | `0` | `0` ✅ |
| `"42"` | `42` | `false` | `42` | `42` ✅ |
| `""` | `NaN` | `true` | `""` | `""` ✅ |
| `"abc"` | `NaN` | `true` | `""` | `""` ✅ |
| `"-5"` | `-5` | `false` | `-5` | `-5` ✅ |
| `"3.5"` (integer) | `3` | `false` | `3` | `3` ✅ |
| `"3.5"` (number) | `3.5` | `false` | `3.5` | `3.5` ✅ |

#### Files changed

- `ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx`