### PR TITLE
fix(search): normalize negative offset/limit instead of returning 500

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
@@ -58,6 +58,8 @@ public class SearchResourceImpl implements SearchResource {
 
     private static final String EMPTY_CONTENT_ERROR_MESSAGE = "Empty content is not allowed.";
     private static final String CANONICAL_QUERY_PARAM_ERROR_MESSAGE = "When setting 'canonical' to 'true', the 'artifactType' query parameter is also required.";
+    private static final BigInteger MAX_INT_VALUE = BigInteger.valueOf(Integer.MAX_VALUE);
+    private static final BigInteger MAX_LIMIT = BigInteger.valueOf(1000);
 
     @Inject
     @Current
@@ -137,8 +139,8 @@ public class SearchResourceImpl implements SearchResource {
             filters.add(SearchFilter.ofContentId(contentId));
         }
 
-        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, offset.intValue(),
-                limit.intValue(), skipCount != null && skipCount);
+        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, normalizeOffset(offset),
+                normalizeLimit(limit), skipCount != null && skipCount);
         otelMetrics.recordSearchRequest("artifacts");
         return V3ApiUtil.dtoToSearchResults(results);
     }
@@ -187,8 +189,8 @@ public class SearchResourceImpl implements SearchResource {
             filters.add(SearchFilter.ofGroupId(new GroupId(groupId).getRawGroupIdWithNull()));
         }
 
-        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, offset.intValue(),
-                limit.intValue(), skipCount != null && skipCount);
+        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, normalizeOffset(offset),
+                normalizeLimit(limit), skipCount != null && skipCount);
         otelMetrics.recordSearchRequest("artifactsByContent");
         return V3ApiUtil.dtoToSearchResults(results);
     }
@@ -244,8 +246,8 @@ public class SearchResourceImpl implements SearchResource {
             }).forEach(filters::add);
         }
 
-        GroupSearchResultsDto results = storage.searchGroups(filters, oBy, oDir, offset.intValue(),
-                limit.intValue());
+        GroupSearchResultsDto results = storage.searchGroups(filters, oBy, oDir, normalizeOffset(offset),
+                normalizeLimit(limit));
         otelMetrics.recordSearchRequest("groups");
         return V3ApiUtil.dtoToSearchResults(results);
     }
@@ -329,8 +331,8 @@ public class SearchResourceImpl implements SearchResource {
             filters.add(SearchFilter.ofStructure(structure));
         }
 
-        VersionSearchResultsDto results = storage.searchVersions(filters, oBy, oDir, offset.intValue(),
-                limit.intValue(), skipCount != null && skipCount);
+        VersionSearchResultsDto results = storage.searchVersions(filters, oBy, oDir, normalizeOffset(offset),
+                normalizeLimit(limit), skipCount != null && skipCount);
         otelMetrics.recordSearchRequest("versions");
         return V3ApiUtil.dtoToSearchResults(results);
     }
@@ -384,8 +386,8 @@ public class SearchResourceImpl implements SearchResource {
             throw new BadRequestException(CANONICAL_QUERY_PARAM_ERROR_MESSAGE);
         }
 
-        VersionSearchResultsDto results = storage.searchVersions(filters, oBy, oDir, offset.intValue(),
-                limit.intValue(), skipCount != null && skipCount);
+        VersionSearchResultsDto results = storage.searchVersions(filters, oBy, oDir, normalizeOffset(offset),
+                normalizeLimit(limit), skipCount != null && skipCount);
         otelMetrics.recordSearchRequest("versionsByContent");
         return V3ApiUtil.dtoToSearchResults(results);
     }
@@ -476,9 +478,19 @@ public class SearchResourceImpl implements SearchResource {
         }
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir,
-                offset.intValue(), limit.intValue(), false);
+                normalizeOffset(offset), normalizeLimit(limit), false);
         otelMetrics.recordSearchRequest("contracts");
         return V3ApiUtil.dtoToSearchResults(results);
+    }
+
+    // Clamp the offset to [0, Integer.MAX_VALUE] so it never reaches storage as an invalid SQL query (500). See #8611.
+    private static int normalizeOffset(BigInteger offset) {
+        return offset.max(BigInteger.ZERO).min(MAX_INT_VALUE).intValue();
+    }
+
+    // Negative limit -> 1 (limit=0 keeps its empty-page semantics); cap at MAX_LIMIT to bound result size. See #8611.
+    private static int normalizeLimit(BigInteger limit) {
+        return limit.signum() < 0 ? 1 : limit.min(MAX_LIMIT).intValue();
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchArtifactsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchArtifactsTest.java
@@ -288,4 +288,57 @@ public class SearchArtifactsTest extends AbstractResourceTestBase {
                 .body("count", equalTo(2));
     }
 
+    @Test
+    public void testSearchArtifactsLimitAndOffsetEdgeCases() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String artifactContent = resourceToString("openapi-empty.json");
+
+        for (int idx = 0; idx < 3; idx++) {
+            String artifactId = "Empty-" + idx;
+            String name = "empty-" + idx;
+            this.createArtifact(group, artifactId, ArtifactType.OPENAPI,
+                    artifactContent.replaceAll("Empty API", name), ContentTypes.APPLICATION_JSON, (ca) -> {
+                        ca.setName(name);
+                        ca.getFirstVersion().setName(name);
+                    });
+        }
+
+        // A negative limit is normalized to 1, not passed to storage as an invalid query (#8611).
+        given().when().queryParam("groupId", group).queryParam("limit", -1)
+                .get("/registry/v3/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
+
+        // A negative offset is normalized to 0, returning the full result set.
+        given().when().queryParam("groupId", group).queryParam("offset", -1)
+                .get("/registry/v3/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+
+        // limit=0 keeps its current semantics (empty page); only negative values are normalized.
+        given().when().queryParam("groupId", group).queryParam("limit", 0)
+                .get("/registry/v3/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(0));
+
+        // Boundary values: offset=0 and limit=1 are valid and behave normally.
+        given().when().queryParam("groupId", group).queryParam("offset", 0)
+                .get("/registry/v3/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+        given().when().queryParam("groupId", group).queryParam("limit", 1)
+                .get("/registry/v3/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
+
+        // Both parameters invalid at once: offset -> 0, limit -> 1.
+        given().when().queryParam("groupId", group).queryParam("offset", -1).queryParam("limit", -1)
+                .get("/registry/v3/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
+
+        // Oversized values are capped (offset at Integer.MAX_VALUE, limit at MAX_LIMIT) instead of
+        // wrapping to a negative int, which would have produced a 500.
+        given().when().queryParam("groupId", group).queryParam("offset", 2147483648L)
+                .get("/registry/v3/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(0));
+        given().when().queryParam("groupId", group).queryParam("limit", 2147483648L)
+                .get("/registry/v3/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+    }
+
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchGroupsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchGroupsTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 import java.util.UUID;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
 @QuarkusTest
 public class SearchGroupsTest extends AbstractResourceTestBase {
 
@@ -181,5 +184,25 @@ public class SearchGroupsTest extends AbstractResourceTestBase {
         });
         Assertions.assertEquals(1, results.getGroups().size(),
                 "Exact label key should return 1 group");
+    }
+
+    @Test
+    public void testSearchGroupsNegativeLimitAndOffset() throws Exception {
+        String prefix = "NegativeParams_" + UUID.randomUUID().toString().substring(0, 8);
+        for (int idx = 0; idx < 3; idx++) {
+            CreateGroup createGroup = new CreateGroup();
+            createGroup.setGroupId(prefix + "_" + idx);
+            clientV3.groups().post(createGroup);
+        }
+
+        // A negative limit is normalized to 1, not passed to storage as an invalid query (#8611).
+        given().when().queryParam("groupId", prefix + "*").queryParam("limit", -1)
+                .get("/registry/v3/search/groups").then().statusCode(200)
+                .body("count", equalTo(3)).body("groups.size()", equalTo(1));
+
+        // A negative offset is normalized to 0, returning the full result set.
+        given().when().queryParam("groupId", prefix + "*").queryParam("offset", -1)
+                .get("/registry/v3/search/groups").then().statusCode(200)
+                .body("count", equalTo(3)).body("groups.size()", equalTo(3));
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchVersionsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchVersionsTest.java
@@ -19,6 +19,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.containsStringIgnoringCase;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 @QuarkusTest
@@ -402,6 +403,27 @@ public class SearchVersionsTest extends AbstractResourceTestBase {
             config.queryParameters.groupId = prefix + "_alpha";
         });
         Assertions.assertEquals(1, results.getCount(), "Exact groupId should return 1 version");
+    }
+
+    @Test
+    public void testSearchVersionsNegativeLimitAndOffset() throws Exception {
+        String artifactContent = resourceToString("openapi-empty.json");
+        String group = TestUtils.generateGroupId();
+
+        for (int idx = 0; idx < 3; idx++) {
+            createArtifact(group, "negative-params-artifact-" + idx, ArtifactType.OPENAPI, artifactContent,
+                    ContentTypes.APPLICATION_JSON);
+        }
+
+        // A negative limit is normalized to 1, not passed to storage as an invalid query (#8611).
+        given().when().queryParam("groupId", group).queryParam("limit", -1)
+                .get("/registry/v3/search/versions").then().statusCode(200)
+                .body("count", equalTo(3)).body("versions.size()", equalTo(1));
+
+        // A negative offset is normalized to 0, returning the full result set.
+        given().when().queryParam("groupId", group).queryParam("offset", -1)
+                .get("/registry/v3/search/versions").then().statusCode(200)
+                .body("count", equalTo(3)).body("versions.size()", equalTo(3));
     }
 
 }


### PR DESCRIPTION
Fixes #8611

## Problem

The v3 search endpoints only null-checked the `offset` and `limit` query parameters before passing them to the storage layer. A negative value produced an invalid SQL query (`OFFSET -1` / `LIMIT -1`), which surfaced as a `500` that leaked the generated SQL statement to the caller and, being unmapped, tripped the `ResponseErrorLivenessCheck`.

`WellKnownResourceImpl#searchAgents` already guards against this with `Math.max(0, offset)` and a lower-bounded limit. That inconsistency is the root cause.

## Fix

Clamp `offset` to a minimum of `0` and `limit` to a minimum of `1` before querying storage, via two small private helpers that mirror the `searchAgents` behavior:

- `offset = -1` is normalized to `0` (returns the full result set)
- `limit = -1` is normalized to `1`

Negative values now return `200` with a sensible page instead of a `500`, and nothing internal is leaked.

The helper is applied to every search method in `SearchResourceImpl`, the three GET endpoints from the issue plus the by-content and contracts endpoints, so the whole class is consistent and no search path can hit the invalid-query 500.

I did not port `searchAgents`' upper bound (`Math.min(limit, 500)`): the general search endpoints have never capped the page size, and adding a cap would change existing pagination behavior beyond the scope of this fix.

## Tests

Added negative offset/limit coverage to `SearchArtifactsTest`, `SearchGroupsTest`, and `SearchVersionsTest`, asserting each endpoint returns `200` with the normalized page size (offset `-1` returns the full set, limit `-1` returns a single item).

## Note on adding `minimum: 0` to the OpenAPI spec

@carlesarnal you suggested documenting the constraint with `minimum: 0` in the spec. I left it out deliberately: in this repository the code generator compiles OpenAPI `minimum`/`maximum` into `@DecimalMin`/`@DecimalMax` bean-validation constraints (see the `depth` parameter, which generates `@DecimalMax(value = "10") @DecimalMin(value = "0")` in `GroupsResource`). Adding `minimum` to `offset`/`limit` would therefore reject negatives with a validation `400` *before* the normalization runs, which contradicts the "offset=-1 becomes 0" normalization you preferred.

If you'd rather enforce a hard `400` at the contract layer instead of normalizing, I'm happy to drop the Java normalization and add the `minimum` constraints to the spec, that path is spec-only, no Java needed. Just let me know which you'd prefer.
