### PR TITLE
fix(cli): apply per-package log levels from config (#8645)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -183,6 +183,27 @@ acr config delete <property-name>
 | `update.check-enabled`   | `true`  | Enable automatic update checks      |
 | `update.timeout-seconds` | `60`    | Timeout for update network requests |
 
+#### Logging
+
+Use `--verbose` to enable debug logging:
+
+```bash
+acr --verbose artifact get my-artifact -g my-group
+```
+
+Verbose output can be noisy. To quiet a specific package while keeping the rest, set a
+per-package level using the `quarkus.log.category."<package>".level` config key:
+
+```bash
+acr config set 'quarkus.log.category."io.netty".level=WARNING'
+```
+
+Per-package levels only take effect together with `--verbose`. Without it the CLI stays quiet,
+whatever the config contains.
+
+Accepted level names are `OFF`, `FATAL`, `ERROR`, `SEVERE`, `WARN`, `WARNING`, `INFO`, `CONFIG`,
+`DEBUG`, `FINE`, `FINER`, `TRACE`, `FINEST` and `ALL`.
+
 ### Context Management
 
 Contexts allow you to work with multiple Apicurio Registry instances. Each context stores the Registry URL and optional authentication settings.

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -42,7 +42,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
     public Integer call() {
         var output = new OutputBuffer(config.getStdOut(), config.getStdErr());
         try {
-            configureVerboseLogging();
+            configureLogging();
             updateNotifier.checkAndNotify(getTopLevelCommandName());
             run(output);
             return OK_RETURN_CODE;
@@ -96,18 +96,56 @@ public abstract class AbstractCommand implements Callable<Integer> {
         return current.name();
     }
 
-    private void configureVerboseLogging() {
+    private static final String LOG_CATEGORY_PREFIX = "quarkus.log.category.\"";
+    private static final String LOG_CATEGORY_SUFFIX = "\".level";
+
+    // Applied at runtime because the packaged CLI ships quarkus.log.level=OFF and Quarkus
+    // resolves quarkus.log.* at build time, so per-package levels in the CLI config are
+    // never picked up by Quarkus's own logging setup.
+    private void configureLogging() {
+        var rootLogger = java.util.logging.Logger.getLogger("");
+        java.util.logging.Level finest = null;
+
         var root = spec.root().userObject();
         if (root instanceof Acr acr && acr.isVerbose()) {
-            // Set the root logger level to FINE (DEBUG equivalent)
-            var rootLogger = java.util.logging.Logger.getLogger("");
             rootLogger.setLevel(java.util.logging.Level.FINE);
-            // Also lower handler levels — Quarkus sets quarkus.log.level=WARN on the
-            // console handler, which filters debug messages even when the logger allows them.
-            for (var handler : rootLogger.getHandlers()) {
-                handler.setLevel(java.util.logging.Level.FINE);
-            }
-            log.debug("Verbose logging enabled.");
+            finest = java.util.logging.Level.FINE;
         }
+
+        for (var entry : readLogCategoryLevels().entrySet()) {
+            java.util.logging.Level level;
+            try {
+                level = java.util.logging.Level.parse(entry.getValue().trim());
+            } catch (IllegalArgumentException ex) {
+                log.warnf("Ignoring invalid log level '%s' for category '%s'.", entry.getValue(), entry.getKey());
+                continue;
+            }
+            java.util.logging.Logger.getLogger(entry.getKey()).setLevel(level);
+            if (finest == null || level.intValue() < finest.intValue()) {
+                finest = level;
+            }
+        }
+
+        // Handlers filter by their own level, so open them to the finest level we enabled.
+        if (finest != null) {
+            for (var handler : rootLogger.getHandlers()) {
+                handler.setLevel(finest);
+            }
+        }
+    }
+
+    private java.util.Map<String, String> readLogCategoryLevels() {
+        java.util.Map<String, String> levels = new java.util.HashMap<>();
+        try {
+            config.read().getConfig().forEach((key, value) -> {
+                if (key.startsWith(LOG_CATEGORY_PREFIX) && key.endsWith(LOG_CATEGORY_SUFFIX)
+                        && key.length() > LOG_CATEGORY_PREFIX.length() + LOG_CATEGORY_SUFFIX.length()) {
+                    levels.put(key.substring(LOG_CATEGORY_PREFIX.length(), key.length() - LOG_CATEGORY_SUFFIX.length()), value);
+                }
+            });
+        } catch (CliException ex) {
+            // Config not available yet (e.g. before install) — logging config is best-effort.
+        }
+        return levels;
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -126,10 +126,11 @@ public abstract class AbstractCommand implements Callable<Integer> {
             }
         }
 
-        // Handlers filter by their own level, so open them to the finest level we enabled.
+        // Handlers filter by their own level, so lower them to reveal the finest level we enabled.
+        // Only ever lower, never raise, so we don't suppress unrelated channels the user didn't touch.
         if (finest != null) {
             for (var handler : rootLogger.getHandlers()) {
-                handler.setLevel(finest);
+                handler.setLevel(loweredHandlerLevel(handler.getLevel(), finest));
             }
         }
     }
@@ -164,5 +165,14 @@ public abstract class AbstractCommand implements Callable<Integer> {
             case "ALL" -> java.util.logging.Level.ALL;
             default -> throw new IllegalArgumentException("Unknown log level: " + value);
         };
+    }
+
+    // Returns floor only when the handler is currently coarser (or unset), so a handler is never
+    // raised (which would hide records from channels the user did not configure).
+    static java.util.logging.Level loweredHandlerLevel(java.util.logging.Level current, java.util.logging.Level floor) {
+        if (current == null || current.intValue() > floor.intValue()) {
+            return floor;
+        }
+        return current;
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -115,7 +115,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
         for (var entry : readLogCategoryLevels().entrySet()) {
             java.util.logging.Level level;
             try {
-                level = java.util.logging.Level.parse(entry.getValue().trim());
+                level = toJulLevel(entry.getValue());
             } catch (IllegalArgumentException ex) {
                 log.warnf("Ignoring invalid log level '%s' for category '%s'.", entry.getValue(), entry.getKey());
                 continue;
@@ -147,5 +147,22 @@ public abstract class AbstractCommand implements Callable<Integer> {
             // Config not available yet (e.g. before install) — logging config is best-effort.
         }
         return levels;
+    }
+
+    // Maps Quarkus/JBoss level names (DEBUG, TRACE, WARN, ...) to plain JUL levels. The packaged
+    // CLI runs on plain JUL, where Level.parse does not recognise DEBUG/TRACE.
+    static java.util.logging.Level toJulLevel(String value) {
+        return switch (value.trim().toUpperCase(java.util.Locale.ROOT)) {
+            case "OFF" -> java.util.logging.Level.OFF;
+            case "FATAL", "ERROR", "SEVERE" -> java.util.logging.Level.SEVERE;
+            case "WARN", "WARNING" -> java.util.logging.Level.WARNING;
+            case "INFO" -> java.util.logging.Level.INFO;
+            case "CONFIG" -> java.util.logging.Level.CONFIG;
+            case "DEBUG", "FINE" -> java.util.logging.Level.FINE;
+            case "FINER" -> java.util.logging.Level.FINER;
+            case "TRACE", "FINEST" -> java.util.logging.Level.FINEST;
+            case "ALL" -> java.util.logging.Level.ALL;
+            default -> throw new IllegalArgumentException("Unknown log level: " + value);
+        };
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -8,8 +8,12 @@ import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.models.RuleViolationProblemDetails;
 import jakarta.inject.Inject;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
 import org.jboss.logging.Logger;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
@@ -99,21 +103,30 @@ public abstract class AbstractCommand implements Callable<Integer> {
     private static final String LOG_CATEGORY_PREFIX = "quarkus.log.category.\"";
     private static final String LOG_CATEGORY_SUFFIX = "\".level";
 
-    // Applied at runtime because the packaged CLI ships quarkus.log.level=OFF and Quarkus
-    // resolves quarkus.log.* at build time, so per-package levels in the CLI config are
-    // never picked up by Quarkus's own logging setup.
+    /**
+     * Configures logging for the current command.
+     * <p>
+     * Logging is only configured when {@code --verbose} is set. Verbose raises the root logger to
+     * {@link Level#FINE}, and the per-package levels from the CLI config are then applied on top of
+     * it, which is how a noisy package can be suppressed (for example {@code io.netty=WARNING}).
+     * Without {@code --verbose} nothing is touched, whatever the config contains.
+     * <p>
+     * The levels are applied at runtime because the packaged CLI ships {@code quarkus.log.level=OFF}
+     * and Quarkus resolves {@code quarkus.log.*} at build time, so per-package levels in the CLI
+     * config are never picked up by Quarkus's own logging setup.
+     */
     private void configureLogging() {
-        var rootLogger = java.util.logging.Logger.getLogger("");
-        java.util.logging.Level finest = null;
-
         var root = spec.root().userObject();
-        if (root instanceof Acr acr && acr.isVerbose()) {
-            rootLogger.setLevel(java.util.logging.Level.FINE);
-            finest = java.util.logging.Level.FINE;
+        if (!(root instanceof Acr acr) || !acr.isVerbose()) {
+            return;
         }
 
+        var rootLogger = java.util.logging.Logger.getLogger("");
+        rootLogger.setLevel(Level.FINE);
+        var finest = Level.FINE;
+
         for (var entry : readLogCategoryLevels().entrySet()) {
-            java.util.logging.Level level;
+            Level level;
             try {
                 level = toJulLevel(entry.getValue());
             } catch (IllegalArgumentException ex) {
@@ -121,22 +134,25 @@ public abstract class AbstractCommand implements Callable<Integer> {
                 continue;
             }
             java.util.logging.Logger.getLogger(entry.getKey()).setLevel(level);
-            if (finest == null || level.intValue() < finest.intValue()) {
+            if (level.intValue() < finest.intValue()) {
                 finest = level;
             }
         }
 
         // Handlers filter by their own level, so lower them to reveal the finest level we enabled.
         // Only ever lower, never raise, so we don't suppress unrelated channels the user didn't touch.
-        if (finest != null) {
-            for (var handler : rootLogger.getHandlers()) {
-                handler.setLevel(loweredHandlerLevel(handler.getLevel(), finest));
-            }
+        for (var handler : rootLogger.getHandlers()) {
+            handler.setLevel(loweredHandlerLevel(handler.getLevel(), finest));
         }
     }
 
-    private java.util.Map<String, String> readLogCategoryLevels() {
-        java.util.Map<String, String> levels = new java.util.HashMap<>();
+    /**
+     * Reads the per-package log levels from the CLI config, keyed by package name.
+     * <p>
+     * Reading is best-effort, because commands that run before install have no config yet.
+     */
+    private Map<String, String> readLogCategoryLevels() {
+        Map<String, String> levels = new HashMap<>();
         try {
             config.read().getConfig().forEach((key, value) -> {
                 if (key.startsWith(LOG_CATEGORY_PREFIX) && key.endsWith(LOG_CATEGORY_SUFFIX)
@@ -145,31 +161,37 @@ public abstract class AbstractCommand implements Callable<Integer> {
                 }
             });
         } catch (CliException ex) {
-            // Config not available yet (e.g. before install) — logging config is best-effort.
+            // Config not available yet, e.g. before install.
         }
         return levels;
     }
 
-    // Maps Quarkus/JBoss level names (DEBUG, TRACE, WARN, ...) to plain JUL levels. The packaged
-    // CLI runs on plain JUL, where Level.parse does not recognise DEBUG/TRACE.
-    static java.util.logging.Level toJulLevel(String value) {
-        return switch (value.trim().toUpperCase(java.util.Locale.ROOT)) {
-            case "OFF" -> java.util.logging.Level.OFF;
-            case "FATAL", "ERROR", "SEVERE" -> java.util.logging.Level.SEVERE;
-            case "WARN", "WARNING" -> java.util.logging.Level.WARNING;
-            case "INFO" -> java.util.logging.Level.INFO;
-            case "CONFIG" -> java.util.logging.Level.CONFIG;
-            case "DEBUG", "FINE" -> java.util.logging.Level.FINE;
-            case "FINER" -> java.util.logging.Level.FINER;
-            case "TRACE", "FINEST" -> java.util.logging.Level.FINEST;
-            case "ALL" -> java.util.logging.Level.ALL;
+    /**
+     * Maps Quarkus/JBoss level names (DEBUG, TRACE, WARN, ...) to plain JUL levels. The packaged CLI
+     * runs on plain JUL, where {@code Level.parse} does not recognise DEBUG/TRACE.
+     *
+     * @throws IllegalArgumentException if the value is not a recognised level name
+     */
+    static Level toJulLevel(String value) {
+        return switch (value.trim().toUpperCase(Locale.ROOT)) {
+            case "OFF" -> Level.OFF;
+            case "FATAL", "ERROR", "SEVERE" -> Level.SEVERE;
+            case "WARN", "WARNING" -> Level.WARNING;
+            case "INFO" -> Level.INFO;
+            case "CONFIG" -> Level.CONFIG;
+            case "DEBUG", "FINE" -> Level.FINE;
+            case "FINER" -> Level.FINER;
+            case "TRACE", "FINEST" -> Level.FINEST;
+            case "ALL" -> Level.ALL;
             default -> throw new IllegalArgumentException("Unknown log level: " + value);
         };
     }
 
-    // Returns floor only when the handler is currently coarser (or unset), so a handler is never
-    // raised (which would hide records from channels the user did not configure).
-    static java.util.logging.Level loweredHandlerLevel(java.util.logging.Level current, java.util.logging.Level floor) {
+    /**
+     * Returns {@code floor} only when the handler is currently coarser (or unset), so a handler is
+     * never raised, which would hide records from channels the user did not configure.
+     */
+    static Level loweredHandlerLevel(Level current, Level floor) {
         if (current == null || current.intValue() > floor.intValue()) {
             return floor;
         }

--- a/cli/src/test/java/io/apicurio/registry/cli/LoggingConfigTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/LoggingConfigTest.java
@@ -69,10 +69,8 @@ public class LoggingConfigTest {
         int exitCode = cmd.execute("config", "get", "update.check-enabled");
         assertThat(exitCode).isEqualTo(0);
 
-        assertThat(Logger.getLogger(CONFIGURED_CATEGORY).getLevel())
-                .isNotNull()
-                .extracting(Level::getName)
-                .isEqualTo("DEBUG");
+        // DEBUG maps to the portable JUL level FINE (see AbstractCommand.toJulLevel).
+        assertThat(Logger.getLogger(CONFIGURED_CATEGORY).getLevel()).isEqualTo(Level.FINE);
     }
 
     @Test

--- a/cli/src/test/java/io/apicurio/registry/cli/LoggingConfigTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/LoggingConfigTest.java
@@ -1,0 +1,93 @@
+package io.apicurio.registry.cli;
+
+import io.apicurio.registry.cli.config.Config;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+public class LoggingConfigTest {
+
+    // Matches the category key in test resource acr-home-logging/config.json.
+    private static final String CONFIGURED_CATEGORY = "io.apicurio.registry.cli.services";
+    private static final String UNCONFIGURED_CATEGORY = "io.apicurio.registry.cli.loggingtest.unconfigured";
+
+    @Inject
+    Config config;
+
+    @Inject
+    CommandLine.IFactory factory;
+
+    private CommandLine cmd;
+    private StringWriter out;
+    private StringWriter err;
+    private Level originalRootLevel;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        originalRootLevel = Logger.getLogger("").getLevel();
+        Logger.getLogger(CONFIGURED_CATEGORY).setLevel(null);
+        Logger.getLogger(UNCONFIGURED_CATEGORY).setLevel(null);
+
+        var acrHome = Path.of(
+                        getClass().getClassLoader().getResource("acr-home-logging").toURI())
+                .normalize();
+        config.setAcrCurrentHomePath(acrHome);
+        config.reset();
+        config.setAcrCurrentHomePath(acrHome);
+
+        cmd = new CommandLine(new Acr(), factory);
+        out = new StringWriter();
+        err = new StringWriter();
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(err));
+        config.setStdOut(value -> out.write(value));
+        config.setStdErr(value -> err.write(value));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Logger.getLogger("").setLevel(originalRootLevel);
+        Logger.getLogger(CONFIGURED_CATEGORY).setLevel(null);
+        Logger.getLogger(UNCONFIGURED_CATEGORY).setLevel(null);
+        config.reset();
+    }
+
+    @Test
+    public void perPackageLevelFromConfigIsApplied() {
+        int exitCode = cmd.execute("config", "get", "update.check-enabled");
+        assertThat(exitCode).isEqualTo(0);
+
+        assertThat(Logger.getLogger(CONFIGURED_CATEGORY).getLevel())
+                .isNotNull()
+                .extracting(Level::getName)
+                .isEqualTo("DEBUG");
+    }
+
+    @Test
+    public void unconfiguredPackageIsUntouched() {
+        int exitCode = cmd.execute("config", "get", "update.check-enabled");
+        assertThat(exitCode).isEqualTo(0);
+
+        assertThat(Logger.getLogger(UNCONFIGURED_CATEGORY).getLevel()).isNull();
+    }
+
+    @Test
+    public void verboseRaisesRootLoggerToFine() {
+        int exitCode = cmd.execute("--verbose", "config", "get", "update.check-enabled");
+        assertThat(exitCode).isEqualTo(0);
+
+        assertThat(Logger.getLogger("").getLevel()).isEqualTo(Level.FINE);
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/LoggingConfigTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/LoggingConfigTest.java
@@ -19,8 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @QuarkusTest
 public class LoggingConfigTest {
 
-    // Matches the category key in test resource acr-home-logging/config.json.
+    // Match the category keys in test resource acr-home-logging/config.json.
     private static final String CONFIGURED_CATEGORY = "io.apicurio.registry.cli.services";
+    private static final String NOISY_CATEGORY = "io.apicurio.registry.cli.loggingtest.noisy";
     private static final String UNCONFIGURED_CATEGORY = "io.apicurio.registry.cli.loggingtest.unconfigured";
 
     @Inject
@@ -38,6 +39,7 @@ public class LoggingConfigTest {
     public void setUp() throws Exception {
         originalRootLevel = Logger.getLogger("").getLevel();
         Logger.getLogger(CONFIGURED_CATEGORY).setLevel(null);
+        Logger.getLogger(NOISY_CATEGORY).setLevel(null);
         Logger.getLogger(UNCONFIGURED_CATEGORY).setLevel(null);
 
         var acrHome = Path.of(
@@ -60,13 +62,14 @@ public class LoggingConfigTest {
     public void tearDown() {
         Logger.getLogger("").setLevel(originalRootLevel);
         Logger.getLogger(CONFIGURED_CATEGORY).setLevel(null);
+        Logger.getLogger(NOISY_CATEGORY).setLevel(null);
         Logger.getLogger(UNCONFIGURED_CATEGORY).setLevel(null);
         config.reset();
     }
 
     @Test
     public void perPackageLevelFromConfigIsApplied() {
-        int exitCode = cmd.execute("config", "get", "update.check-enabled");
+        int exitCode = cmd.execute("--verbose", "config", "get", "update.check-enabled");
         assertThat(exitCode).isEqualTo(0);
 
         // DEBUG maps to the portable JUL level FINE (see AbstractCommand.toJulLevel).
@@ -74,8 +77,28 @@ public class LoggingConfigTest {
     }
 
     @Test
-    public void unconfiguredPackageIsUntouched() {
+    public void perPackageLevelIsIgnoredWithoutVerbose() {
         int exitCode = cmd.execute("config", "get", "update.check-enabled");
+        assertThat(exitCode).isEqualTo(0);
+
+        // Per-package config only takes effect together with --verbose.
+        assertThat(Logger.getLogger(CONFIGURED_CATEGORY).getLevel()).isNull();
+        assertThat(Logger.getLogger(NOISY_CATEGORY).getLevel()).isNull();
+    }
+
+    @Test
+    public void noisyPackageIsSuppressedUnderVerbose() {
+        int exitCode = cmd.execute("--verbose", "config", "get", "update.check-enabled");
+        assertThat(exitCode).isEqualTo(0);
+
+        // --verbose turns on debug globally, and a coarser per-package level quiets that package.
+        assertThat(Logger.getLogger("").getLevel()).isEqualTo(Level.FINE);
+        assertThat(Logger.getLogger(NOISY_CATEGORY).getLevel()).isEqualTo(Level.WARNING);
+    }
+
+    @Test
+    public void unconfiguredPackageIsUntouched() {
+        int exitCode = cmd.execute("--verbose", "config", "get", "update.check-enabled");
         assertThat(exitCode).isEqualTo(0);
 
         assertThat(Logger.getLogger(UNCONFIGURED_CATEGORY).getLevel()).isNull();

--- a/cli/src/test/java/io/apicurio/registry/cli/common/LogLevelMappingTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/common/LogLevelMappingTest.java
@@ -1,0 +1,39 @@
+package io.apicurio.registry.cli.common;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Plain JUnit (no @QuarkusTest) so it runs on plain JUL, proving the Quarkus-style
+ * level names resolve to portable JUL levels without relying on JBoss LogManager.
+ */
+public class LogLevelMappingTest {
+
+    @Test
+    public void mapsQuarkusStyleNamesToJulLevels() {
+        assertThat(AbstractCommand.toJulLevel("DEBUG")).isEqualTo(Level.FINE);
+        assertThat(AbstractCommand.toJulLevel("TRACE")).isEqualTo(Level.FINEST);
+        assertThat(AbstractCommand.toJulLevel("WARN")).isEqualTo(Level.WARNING);
+        assertThat(AbstractCommand.toJulLevel("ERROR")).isEqualTo(Level.SEVERE);
+        assertThat(AbstractCommand.toJulLevel("FATAL")).isEqualTo(Level.SEVERE);
+        assertThat(AbstractCommand.toJulLevel("INFO")).isEqualTo(Level.INFO);
+        assertThat(AbstractCommand.toJulLevel("OFF")).isEqualTo(Level.OFF);
+    }
+
+    @Test
+    public void acceptsNativeJulNamesAndIsCaseAndWhitespaceInsensitive() {
+        assertThat(AbstractCommand.toJulLevel("FINE")).isEqualTo(Level.FINE);
+        assertThat(AbstractCommand.toJulLevel("finest")).isEqualTo(Level.FINEST);
+        assertThat(AbstractCommand.toJulLevel(" debug ")).isEqualTo(Level.FINE);
+    }
+
+    @Test
+    public void rejectsUnknownLevel() {
+        assertThatThrownBy(() -> AbstractCommand.toJulLevel("BOGUS"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/common/LogLevelMappingTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/common/LogLevelMappingTest.java
@@ -36,4 +36,18 @@ public class LogLevelMappingTest {
         assertThatThrownBy(() -> AbstractCommand.toJulLevel("BOGUS"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    public void handlerLevelOnlyLowersNeverRaises() {
+        // Coarser handler is lowered to reveal the configured level.
+        assertThat(AbstractCommand.loweredHandlerLevel(Level.INFO, Level.FINE)).isEqualTo(Level.FINE);
+        // Handler is never raised, so unrelated channels are not suppressed.
+        assertThat(AbstractCommand.loweredHandlerLevel(Level.INFO, Level.SEVERE)).isEqualTo(Level.INFO);
+        // The permissive default (ALL) is left untouched rather than raised to the floor.
+        assertThat(AbstractCommand.loweredHandlerLevel(Level.ALL, Level.FINE)).isEqualTo(Level.ALL);
+        // An unset handler level takes the floor.
+        assertThat(AbstractCommand.loweredHandlerLevel(null, Level.FINE)).isEqualTo(Level.FINE);
+        // Equal levels stay put.
+        assertThat(AbstractCommand.loweredHandlerLevel(Level.FINE, Level.FINE)).isEqualTo(Level.FINE);
+    }
 }

--- a/cli/src/test/resources/acr-home-logging/config.json
+++ b/cli/src/test/resources/acr-home-logging/config.json
@@ -1,0 +1,8 @@
+{
+  "installation-version": 1,
+  "config": {
+    "update.check-enabled": "false",
+    "quarkus.log.category.\"io.apicurio.registry.cli.services\".level": "DEBUG"
+  },
+  "context": {}
+}

--- a/cli/src/test/resources/acr-home-logging/config.json
+++ b/cli/src/test/resources/acr-home-logging/config.json
@@ -2,7 +2,8 @@
   "installation-version": 1,
   "config": {
     "update.check-enabled": "false",
-    "quarkus.log.category.\"io.apicurio.registry.cli.services\".level": "DEBUG"
+    "quarkus.log.category.\"io.apicurio.registry.cli.services\".level": "DEBUG",
+    "quarkus.log.category.\"io.apicurio.registry.cli.loggingtest.noisy\".level": "WARNING"
   },
   "context": {}
 }


### PR DESCRIPTION
## What

`--verbose` enables debug logging, and per-package levels in the CLI config let you quiet
individual packages while it is on. For example, with
`quarkus.log.category."io.netty".level=WARNING` in the config, `acr --verbose ...` shows debug
output for everything except `io.netty`.

Per-package levels only take effect together with `--verbose`. Without it the CLI stays quiet,
whatever the config contains.

## Why

`AbstractCommand.configureVerboseLogging()` only raised the root logger when `--verbose` was
set. There was no code path that read or applied per-package configuration. The packaged CLI
ships `quarkus.log.level=OFF`, and since Quarkus resolves `quarkus.log.*` at build time,
per-package levels supplied at runtime were never picked up by Quarkus's own logging setup.
They have to be applied programmatically, the same way `--verbose` already was.

## How

Renamed the hook to `configureLogging()`. It returns early unless `--verbose` is set. When it
is, it raises the root logger to `FINE`, then reads the `quarkus.log.category."<pkg>".level`
keys from the CLI config and applies each one to its named logger, so a coarser entry
suppresses that package. `toJulLevel(...)` maps Quarkus style names (`DEBUG`, `TRACE`, `WARN`,
...) to plain JUL levels, since the packaged CLI runs on plain JUL where `Level.parse` does
not recognise them. Console handler levels are only ever lowered, never raised, via
`loweredHandlerLevel(...)`, so channels the user did not configure are never suppressed.
Reading the config is guarded so commands that run before install don't regress.

## Testing

`LoggingConfigTest` (`@QuarkusTest`) covers per-package levels applied under `--verbose`,
ignored without it, a noisy package suppressed while the root logger stays at `FINE`, an
unconfigured package left untouched, and `--verbose` raising the root logger.

`LogLevelMappingTest` runs on plain JUL with no JBoss LogManager and covers the level name
mapping plus the only-ever-lowering handler rule.

`cli/README.md` documents the config key format, the `--verbose` requirement and the accepted
level names.

`checkstyle:check` passes.

Closes #8645
