### PR TITLE
fix(rest): reject null or non-string prompt template field (#8669)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
+++ b/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
@@ -86,8 +86,10 @@ public class PromptRenderingService {
      */
     private String extractTemplateText(JsonNode templateNode) {
         JsonNode templateField = templateNode.path("template");
-        if (templateField.isMissingNode()) {
-            throw new InvalidContentException("Prompt template is missing 'template' field");
+        // Must be a string. A missing key, an explicit null, or a non-textual value all fail
+        // isTextual() — otherwise e.g. {"template": null} slips through and renders the literal "null".
+        if (!templateField.isTextual()) {
+            throw new InvalidContentException("Prompt template 'template' field is missing or not a string");
         }
         return templateField.asText();
     }

--- a/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
@@ -545,6 +545,36 @@ public class PromptRenderingServiceTest {
     }
 
     @Test
+    public void testNullTemplateField() {
+        // {"template": null} is a NullNode, not a MissingNode, so it must still be rejected
+        // rather than silently rendering the literal string "null".
+        String jsonContent = """
+            {"templateId": "null-template", "name": "Null Template", "template": null}
+            """;
+
+        ContentHandle content = ContentHandle.create(jsonContent);
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            renderingService.render(content, variables, "default", "null-template", "1.0");
+        });
+    }
+
+    @Test
+    public void testNonStringTemplateField() {
+        String jsonContent = """
+            {"templateId": "num-template", "name": "Numeric Template", "template": 123}
+            """;
+
+        ContentHandle content = ContentHandle.create(jsonContent);
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            renderingService.render(content, variables, "default", "num-template", "1.0");
+        });
+    }
+
+    @Test
     public void testInvalidYamlContent() {
         String invalidContent = "{{{{not valid yaml or json}}}}";
 


### PR DESCRIPTION
What
A` PROMPT_TEMPLATE` with` {"template": null} `content rendered the literal string` "null"` instead of failing. Null and non-string template values are now rejected with a 400.

Why
`PromptRenderingService.extractTemplateText `guarded the `template` field only with `isMissingNode(), `which is true only for an absent key. A present-but-null value is a `NullNode`, so it passed the guard and `NullNode.asText()` returned `"null".` Non-string values (numbers, objects) had the same silent-wrong-output problem. This is the same class of issue as #8620, which made invalid prompt templates return a 400 rather than silently succeeding or 500ing.

How
Changed the guard to require a textual node `(!templateField.isTextual())`, which rejects a missing key, an explicit null, and any non-string value in a single check, throwing `InvalidContentException` (mapped to 400).

Testing
Added` testNullTemplateField` and `testNonStringTemplateField` to `PromptRenderingServiceTest`, both asserting `InvalidContentException.` Full class passes (29 tests) and `checkstyle:check` is clean.

Closes #8669