### PR TITLE
fix(app): reject null and non-string prompt template field

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
+++ b/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
@@ -89,6 +89,9 @@ public class PromptRenderingService {
         if (templateField.isMissingNode()) {
             throw new InvalidContentException("Prompt template is missing 'template' field");
         }
+        if (!templateField.isTextual()) {
+            throw new InvalidContentException("Prompt template 'template' field must be a string");
+        }
         return templateField.asText();
     }
 

--- a/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
+++ b/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
@@ -89,10 +89,17 @@ public class PromptRenderingService {
         if (templateField.isMissingNode()) {
             throw new InvalidContentException("Prompt template is missing 'template' field");
         }
+        if (templateField.isNull()) {
+            throw new InvalidContentException("Prompt template 'template' field must not be null");
+        }
         if (!templateField.isTextual()) {
             throw new InvalidContentException("Prompt template 'template' field must be a string");
         }
-        return templateField.asText();
+        String templateText = templateField.asText();
+        if (templateText.isBlank()) {
+            throw new InvalidContentException("Prompt template 'template' field must not be blank");
+        }
+        return templateText;
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
@@ -545,6 +545,55 @@ public class PromptRenderingServiceTest {
     }
 
     @Test
+    public void testNullTemplateFieldJson() {
+        String jsonContent = """
+            {
+              "templateId": "null-template",
+              "template": null
+            }
+            """;
+
+        ContentHandle content = ContentHandle.create(jsonContent);
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            renderingService.render(content, variables, "default", "null-template", "1.0");
+        });
+    }
+
+    @Test
+    public void testNullTemplateFieldYaml() {
+        String yamlContent = """
+            templateId: null-template
+            template: null
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            renderingService.render(content, variables, "default", "null-template", "1.0");
+        });
+    }
+
+    @Test
+    public void testNonStringTemplateField() {
+        String jsonContent = """
+            {
+              "templateId": "numeric-template",
+              "template": 123
+            }
+            """;
+
+        ContentHandle content = ContentHandle.create(jsonContent);
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            renderingService.render(content, variables, "default", "numeric-template", "1.0");
+        });
+    }
+
+    @Test
     public void testInvalidYamlContent() {
         String invalidContent = "{{{{not valid yaml or json}}}}";
 

--- a/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
@@ -594,6 +594,40 @@ public class PromptRenderingServiceTest {
     }
 
     @Test
+    public void testEmptyTemplateField() {
+        String jsonContent = """
+            {
+              "templateId": "empty-template",
+              "template": ""
+            }
+            """;
+
+        ContentHandle content = ContentHandle.create(jsonContent);
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            renderingService.render(content, variables, "default", "empty-template", "1.0");
+        });
+    }
+
+    @Test
+    public void testWhitespaceTemplateField() {
+        String jsonContent = """
+            {
+              "templateId": "whitespace-template",
+              "template": "   "
+            }
+            """;
+
+        ContentHandle content = ContentHandle.create(jsonContent);
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            renderingService.render(content, variables, "default", "whitespace-template", "1.0");
+        });
+    }
+
+    @Test
     public void testInvalidYamlContent() {
         String invalidContent = "{{{{not valid yaml or json}}}}";
 

--- a/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
@@ -628,6 +628,40 @@ public class PromptRenderingServiceTest {
     }
 
     @Test
+    public void testArrayTemplateField() {
+        String jsonContent = """
+            {
+              "templateId": "array-template",
+              "template": ["a", "b"]
+            }
+            """;
+
+        ContentHandle content = ContentHandle.create(jsonContent);
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            renderingService.render(content, variables, "default", "array-template", "1.0");
+        });
+    }
+
+    @Test
+    public void testObjectTemplateField() {
+        String jsonContent = """
+            {
+              "templateId": "object-template",
+              "template": { "nested": "value" }
+            }
+            """;
+
+        ContentHandle content = ContentHandle.create(jsonContent);
+        Map<String, Object> variables = Map.of();
+
+        Assertions.assertThrows(InvalidContentException.class, () -> {
+            renderingService.render(content, variables, "default", "object-template", "1.0");
+        });
+    }
+
+    @Test
     public void testInvalidYamlContent() {
         String invalidContent = "{{{{not valid yaml or json}}}}";
 


### PR DESCRIPTION
## What

`PromptRenderingService.extractTemplateText` guarded a missing `template` field with `isMissingNode()`, which only returns true for a `MissingNode` (an absent key). A stored `PROMPT_TEMPLATE` artifact with content like `{"template": null}` parses to a `NullNode`, for which `isMissingNode()` is `false`, so the guard was skipped and `NullNode.asText()` returned the literal 4-character string `"null"`. The render endpoint then silently succeeded and returned `rendered: "null"` instead of reporting an error.

This adds a check that the `template` field is textual. A missing key keeps its existing "missing 'template' field" error, and an explicit null or any non-string value (number, boolean, object, array) is now rejected with `InvalidContentException`, which maps to a 400 the same way as the other invalid-content cases in this service.

## Why

An invalid prompt template should fail loudly with a validation error, not silently render the string `"null"` (or a numeric/boolean value coerced via `asText()`). This closes the `NullNode`/non-string gap left by the `isMissingNode()`-only guard.

## Tests

Added three regression tests to `PromptRenderingServiceTest`:
- `testNullTemplateFieldJson` — `{"template": null}` throws `InvalidContentException`
- `testNullTemplateFieldYaml` — YAML `template: null` throws `InvalidContentException`
- `testNonStringTemplateField` — `{"template": 123}` throws `InvalidContentException`

All three fail against the previous code (which rendered `"null"`/`"123"`) and pass with this change. `./mvnw checkstyle:check -pl app` passes.

Closes #8669
