### PR TITLE
fix(gitops): trust configured repositories with arbitrary UIDs

### DIFF
--- a/distro/gitops/README.md
+++ b/distro/gitops/README.md
@@ -260,6 +260,14 @@ docker buildx build --push \
 The build context is self-contained — it only needs the files in `distro/gitops/` (Dockerfile,
 entrypoint script, and config templates). No Maven build step is required.
 
+## Tests
+
+Run the Git `safe.directory` configuration tests from the repository root:
+
+```bash
+bash distro/gitops/tests/test-safe-directory.sh
+```
+
 ## Related Documentation
 
 - [GitOps Storage Overview](../../app/src/main/java/io/apicurio/registry/storage/impl/gitops/README.md) — architecture, configuration, management API, data format, error handling

--- a/distro/gitops/entrypoint.sh
+++ b/distro/gitops/entrypoint.sh
@@ -247,6 +247,34 @@ validate_repo_list() {
     done
 }
 
+# Trust only the workspace paths managed by this sidecar. Environment-based
+# configuration works with OpenShift arbitrary UIDs even when $HOME is not
+# writable, unlike `git config --global`.
+configure_git_safe_directories() {
+    local config_count="${GIT_CONFIG_COUNT:-0}"
+    local repo_dir repo_path
+    local workspace_path="${WORKSPACE%/}"
+    [ -n "${workspace_path}" ] || workspace_path="/"
+
+    export "GIT_CONFIG_KEY_${config_count}=safe.directory"
+    export "GIT_CONFIG_VALUE_${config_count}=${workspace_path}"
+    config_count=$((config_count + 1))
+
+    for repo_dir in "${REPO_DIRS[@]}"; do
+        # The workspace entry above already covers a repo configured with dir=.
+        if [ "${repo_dir}" = "." ]; then
+            continue
+        fi
+
+        repo_path="${workspace_path%/}/${repo_dir}"
+        export "GIT_CONFIG_KEY_${config_count}=safe.directory"
+        export "GIT_CONFIG_VALUE_${config_count}=${repo_path}"
+        config_count=$((config_count + 1))
+    done
+
+    export GIT_CONFIG_COUNT="${config_count}"
+}
+
 # ---------------------------------------------------------------------------
 # Security validation
 # ---------------------------------------------------------------------------
@@ -713,6 +741,7 @@ main() {
     log "Apicurio Registry GitOps sidecar starting"
 
     build_repo_list
+    configure_git_safe_directories
 
     log "  Workspace:     ${WORKSPACE}"
     log "  Security:      ${SECURITY}"

--- a/distro/gitops/entrypoint.sh
+++ b/distro/gitops/entrypoint.sh
@@ -253,8 +253,13 @@ validate_repo_list() {
 configure_git_safe_directories() {
     local config_count="${GIT_CONFIG_COUNT:-0}"
     local repo_dir repo_path
-    local workspace_path="${WORKSPACE%/}"
+    local workspace_path="${WORKSPACE:-}"
     [ -n "${workspace_path}" ] || workspace_path="/"
+
+    # Strip all trailing slashes (${var%/} only removes one). Keeps "/" intact.
+    while [ "${workspace_path}" != "/" ] && [ "${workspace_path%/}" != "${workspace_path}" ]; do
+        workspace_path="${workspace_path%/}"
+    done
 
     export "GIT_CONFIG_KEY_${config_count}=safe.directory"
     export "GIT_CONFIG_VALUE_${config_count}=${workspace_path}"
@@ -266,7 +271,11 @@ configure_git_safe_directories() {
             continue
         fi
 
-        repo_path="${workspace_path%/}/${repo_dir}"
+        if [ "${workspace_path}" = "/" ]; then
+            repo_path="/${repo_dir}"
+        else
+            repo_path="${workspace_path}/${repo_dir}"
+        fi
         export "GIT_CONFIG_KEY_${config_count}=safe.directory"
         export "GIT_CONFIG_VALUE_${config_count}=${repo_path}"
         config_count=$((config_count + 1))

--- a/distro/gitops/tests/test-safe-directory.sh
+++ b/distro/gitops/tests/test-safe-directory.sh
@@ -14,6 +14,9 @@ if [[ ! -f "${ENTRYPOINT}" ]]; then
 fi
 
 # Load only the function under test to avoid running sidecar startup side effects.
+# Coupled to entrypoint.sh layout: sed extracts from the function header through the
+# first line that is exactly '}'. Keep configure_git_safe_directories() as a flat
+# function (no nested '}' at column 0) or update this regex when refactoring.
 eval "$(sed -n '/^configure_git_safe_directories()/,/^}/p' "${ENTRYPOINT}")"
 
 if ! declare -F configure_git_safe_directories >/dev/null; then
@@ -87,6 +90,15 @@ configure_git_safe_directories
 
 assert_eq "empty-workspace val0" "/" "${GIT_CONFIG_VALUE_0}"
 assert_eq "empty-workspace val1" "/default" "${GIT_CONFIG_VALUE_1}"
+
+# --- repeated trailing slashes collapse via while-strip ---
+reset_git_config_env
+WORKSPACE="/repos//"
+REPO_DIRS=("default")
+configure_git_safe_directories
+
+assert_eq "double-slash val0" "/repos" "${GIT_CONFIG_VALUE_0}"
+assert_eq "double-slash val1" "/repos/default" "${GIT_CONFIG_VALUE_1}"
 
 if [[ "${failures}" -ne 0 ]]; then
     echo "FAILED: ${failures} assertion(s)" >&2

--- a/distro/gitops/tests/test-safe-directory.sh
+++ b/distro/gitops/tests/test-safe-directory.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Unit tests for configure_git_safe_directories() in entrypoint.sh.
+# Run: bash distro/gitops/tests/test-safe-directory.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT="${SCRIPT_DIR}/../entrypoint.sh"
+
+if [[ ! -f "${ENTRYPOINT}" ]]; then
+    echo "ERROR: entrypoint not found: ${ENTRYPOINT}" >&2
+    exit 1
+fi
+
+# Load only the function under test to avoid running sidecar startup side effects.
+eval "$(sed -n '/^configure_git_safe_directories()/,/^}/p' "${ENTRYPOINT}")"
+
+if ! declare -F configure_git_safe_directories >/dev/null; then
+    echo "ERROR: failed to load configure_git_safe_directories from ${ENTRYPOINT}" >&2
+    exit 1
+fi
+
+failures=0
+
+assert_eq() {
+    local name="$1" expected="$2" actual="$3"
+    if [[ "${expected}" != "${actual}" ]]; then
+        echo "FAIL: ${name}: expected='${expected}' actual='${actual}'" >&2
+        failures=$((failures + 1))
+        return 1
+    fi
+    echo "PASS: ${name}"
+}
+
+reset_git_config_env() {
+    unset GIT_CONFIG_COUNT || true
+    local i
+    for i in $(seq 0 20); do
+        unset "GIT_CONFIG_KEY_${i}" "GIT_CONFIG_VALUE_${i}" 2>/dev/null || true
+    done
+}
+
+# --- workspace + named repo ---
+reset_git_config_env
+WORKSPACE="/repos"
+REPO_DIRS=("default")
+configure_git_safe_directories
+
+assert_eq "named-repo count" "2" "${GIT_CONFIG_COUNT}"
+assert_eq "named-repo key0" "safe.directory" "${GIT_CONFIG_KEY_0}"
+assert_eq "named-repo val0" "/repos" "${GIT_CONFIG_VALUE_0}"
+assert_eq "named-repo key1" "safe.directory" "${GIT_CONFIG_KEY_1}"
+assert_eq "named-repo val1" "/repos/default" "${GIT_CONFIG_VALUE_1}"
+
+# --- dir=. must not duplicate the workspace entry ---
+reset_git_config_env
+WORKSPACE="/repos/"
+REPO_DIRS=(".")
+configure_git_safe_directories
+
+assert_eq "dot-dir count" "1" "${GIT_CONFIG_COUNT}"
+assert_eq "dot-dir key0" "safe.directory" "${GIT_CONFIG_KEY_0}"
+assert_eq "dot-dir val0" "/repos" "${GIT_CONFIG_VALUE_0}"
+
+# --- multi-repo + preserve pre-existing GIT_CONFIG_* ---
+reset_git_config_env
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0="user.name"
+export GIT_CONFIG_VALUE_0="test"
+WORKSPACE="/data"
+REPO_DIRS=("a" "b")
+configure_git_safe_directories
+
+assert_eq "preserve count" "4" "${GIT_CONFIG_COUNT}"
+assert_eq "preserve key0" "user.name" "${GIT_CONFIG_KEY_0}"
+assert_eq "preserve val0" "test" "${GIT_CONFIG_VALUE_0}"
+assert_eq "preserve val1" "/data" "${GIT_CONFIG_VALUE_1}"
+assert_eq "preserve val2" "/data/a" "${GIT_CONFIG_VALUE_2}"
+assert_eq "preserve val3" "/data/b" "${GIT_CONFIG_VALUE_3}"
+
+# --- empty WORKSPACE normalizes to / ---
+reset_git_config_env
+WORKSPACE=""
+REPO_DIRS=("default")
+configure_git_safe_directories
+
+assert_eq "empty-workspace val0" "/" "${GIT_CONFIG_VALUE_0}"
+assert_eq "empty-workspace val1" "/default" "${GIT_CONFIG_VALUE_1}"
+
+if [[ "${failures}" -ne 0 ]]; then
+    echo "FAILED: ${failures} assertion(s)" >&2
+    exit 1
+fi
+
+echo "All safe.directory tests passed."


### PR DESCRIPTION
## Summary

- Configure Git `safe.directory` entries for the GitOps workspace and configured repositories.
- Use environment-based Git configuration so the fix works when `/home/git` is not writable.
- Support repositories configured at the workspace root with `dir: .`.
- Avoid the unrestricted `safe.directory=*` setting.

Fixes #<issue-number>

## Problem

When the GitOps repository is configured with `dir: .`, its root is the `/repos` volume mount point. Kubernetes or OpenShift may assign ownership of this directory to root or another UID.

Git 2.35.2+ then rejects fetch operations with:

```text
fatal: detected dubious ownership in repository at '/repos'