### PR TITLE
feat(cli): include 'default' group in listings with implicit marker

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/search/SearchGroupsCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/search/SearchGroupsCommand.java
@@ -10,6 +10,7 @@ import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
 import io.apicurio.registry.rest.client.search.groups.GroupsRequestBuilder;
 import io.apicurio.registry.rest.v3.beans.GroupSearchResults;
+import io.apicurio.registry.rest.v3.beans.SearchedGroup;
 import java.util.List;
 import java.util.Optional;
 import picocli.CommandLine.Command;
@@ -68,7 +69,37 @@ public class SearchGroupsCommand extends AbstractCommand {
             //noinspection ConstantConditions
             applyFilters(r.queryParameters);
         }));
+        injectDefaultGroupIfNeeded(results);
         printResults(output, results);
+    }
+
+    private void injectDefaultGroupIfNeeded(GroupSearchResults results) {
+        boolean shouldInject = true;
+        if (groupId != null && !groupId.equals("default")) {
+            shouldInject = false;
+        }
+        if (description != null) {
+            shouldInject = false;
+        }
+        if (labels != null && !labels.isEmpty()) {
+            shouldInject = false;
+        }
+        if (pagination.getPage() > 1) {
+            shouldInject = false;
+        }
+        if (shouldInject) {
+            SearchedGroup defaultGroup = new SearchedGroup();
+            defaultGroup.setGroupId("default (implicit)");
+            java.util.List<SearchedGroup> newGroups = new java.util.ArrayList<>();
+            newGroups.add(defaultGroup);
+            if (results.getGroups() != null) {
+                newGroups.addAll(results.getGroups());
+            }
+            results.setGroups(newGroups);
+            if (results.getCount() != null) {
+                results.setCount(results.getCount() + 1);
+            }
+        }
     }
 
     private void applyFilters(final GroupsRequestBuilder.GetQueryParameters params) {

--- a/cli/src/test/java/io/apicurio/registry/cli/SearchCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/SearchCommandTest.java
@@ -61,6 +61,9 @@ public class SearchCommandTest extends AbstractCLITest {
         assertThat(results.getGroups())
                 .as(withCliOutput("Search should return at least the test group"))
                 .isNotEmpty();
+        assertThat(results.getGroups())
+                .as(withCliOutput("Search should contain the default implicit group"))
+                .anyMatch(g -> "default (implicit)".equals(g.getGroupId()));
     }
 
     @Test
@@ -96,6 +99,9 @@ public class SearchCommandTest extends AbstractCLITest {
         assertThat(out.toString())
                 .as(withCliOutput("Table output should contain column headers"))
                 .contains("Group ID");
+        assertThat(out.toString())
+                .as(withCliOutput("Table output should contain default implicit group"))
+                .contains("default (implicit)");
     }
 
     @Test
@@ -106,8 +112,8 @@ public class SearchCommandTest extends AbstractCLITest {
         var results = MAPPER.readValue(out.toString(), GroupSearchResults.class);
 
         assertThat(results.getGroups())
-                .as(withCliOutput("Paginated search should return at most 1 result"))
-                .hasSizeLessThanOrEqualTo(1);
+                .as(withCliOutput("Paginated search should return at most 2 results (1 from server + 1 implicit default)"))
+                .hasSizeLessThanOrEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
Fixes #8643

### What
- Updates the `SearchGroupsCommand` in the CLI to inject a virtual `default (implicit)` group into the search results.
- Ensures the default group is only injected when applicable (i.e., it is skipped if the user filters by a specific description, labels, or a non-default group ID, or if viewing paginated results past the first page).
- Updates CLI integration tests in `SearchCommandTest` to verify the implicit default group appears in both JSON and table output formats.

### Why
- The `default` group is implicit and not stored server-side, which previously caused it to be hidden from `acr group list` results.
- Because users can create artifacts in the default group without explicitly specifying a group, hiding it created confusion about where those artifacts lived.
- Displaying it with the `(implicit)` suffix makes it discoverable to users while clearly indicating that it isn't a standard, server-persisted group.
