### PR TITLE
CLI: Move conversion utility methods to Java SDK (#8644)

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
@@ -1,6 +1,8 @@
 package io.apicurio.registry.cli.utils;
 
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.client.common.util.DateTimeConversions;
+import io.apicurio.registry.client.util.LabelsUtil;
 import io.apicurio.registry.rest.client.models.Labels;
 import io.apicurio.registry.rest.v3.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
@@ -14,31 +16,31 @@ import io.apicurio.registry.rest.v3.beans.SearchedVersion;
 import io.apicurio.registry.rest.v3.beans.VersionMetaData;
 import io.apicurio.registry.rest.v3.beans.VersionSearchResults;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
 
-// TODO: Move some of these to the Java SDK.
+// The generic (non-bean-mapping) conversions have been moved to the Java SDK, see
+// io.apicurio.registry.client.util.LabelsUtil and
+// io.apicurio.registry.client.common.util.DateTimeConversions (#8644). The remaining
+// methods here map generated SDK client models to this module's internal
+// io.apicurio.registry.rest.v3.beans / io.apicurio.registry.types beans, which live in the
+// apicurio-registry-common module. Those stay in the CLI: moving them to the SDK would
+// require the (standalone, dependency-light) Java SDK to depend on apicurio-registry-common,
+// which is the wrong direction (common/app depend on the SDK, not vice versa).
 public final class Conversions {
 
-    private static final char ESCAPE_CHAR = '\\';
-    private static final char LABEL_SEPARATOR = '=';
     private static final String API_LABEL_SEPARATOR = ":";
 
     private Conversions() {
     }
 
+    // Moved to the Java SDK, see io.apicurio.registry.client.util.LabelsUtil (#8644).
     public static Map<String, String> convert(io.apicurio.registry.rest.client.models.Labels labels) {
-        return ofNullable(labels)
-                .map(Labels::getAdditionalData)
-                .map(x -> (Map<String, String>) (Map<String, ?>) x)
-                .orElse(Map.of());
+        return LabelsUtil.toMap(labels);
     }
 
     public static GroupMetaData convert(io.apicurio.registry.rest.client.models.GroupMetaData group) {
@@ -178,38 +180,35 @@ public final class Conversions {
                 .build();
     }
 
+    // Moved to the Java SDK, see io.apicurio.registry.client.common.util.DateTimeConversions (#8644).
     public static String convertToString(OffsetDateTime ts) {
         if (ts == null) {
             return "";
         }
-        return ts.atZoneSameInstant(ZoneId.systemDefault())
-                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        return DateTimeConversions.toIsoLocalDateTimeString(ts);
     }
 
+    // Moved to the Java SDK, see io.apicurio.registry.client.common.util.DateTimeConversions (#8644).
     public static String convertToString(Date ts) {
         if (ts == null) {
             return "";
         }
-        return ts.toInstant()
-                .atZone(ZoneId.systemDefault())
-                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        return DateTimeConversions.toIsoLocalDateTimeString(ts);
     }
 
+    // Moved to the Java SDK, see io.apicurio.registry.client.common.util.DateTimeConversions (#8644).
     public static Date convert(OffsetDateTime ts) {
-        return Date.from(ts.toInstant());
+        return DateTimeConversions.toDate(ts);
     }
 
+    // Moved to the Java SDK, see io.apicurio.registry.client.util.LabelsUtil (#8644).
     public static String convertToString(Labels labels) {
-        return ofNullable(labels)
-                .map(Labels::getAdditionalData)
-                .map(Conversions::convertToString)
-                .orElse("");
+        return LabelsUtil.toDisplayString(labels);
     }
 
+    // Moved to the Java SDK, see io.apicurio.registry.client.util.LabelsUtil (#8644).
     public static String convertToString(Map<String, ?> labels) {
-        return labels.entrySet().stream()
-                .map(e -> e.getKey() + "=" + e.getValue())
-                .collect(Collectors.joining(","));
+        return LabelsUtil.toDisplayString(labels);
     }
 
     public static io.apicurio.registry.types.VersionState convertState(
@@ -227,13 +226,9 @@ public final class Conversions {
         return ofNullable(value).map(String::valueOf).orElse("");
     }
 
+    // Moved to the Java SDK, see io.apicurio.registry.client.util.LabelsUtil (#8644).
     public static Map<String, String> parseLabels(final List<String> labels) {
-        final Map<String, String> result = new LinkedHashMap<>();
-        for (final String label : labels) {
-            final LabelParts parts = splitLabel(label);
-            result.put(parts.key(), parts.value());
-        }
-        return result;
+        return LabelsUtil.parseLabels(labels);
     }
 
     public static String[] convertLabelsForApi(final List<String> labels) {
@@ -242,62 +237,15 @@ public final class Conversions {
                 .toArray(String[]::new);
     }
 
-    private record LabelParts(String key, String value) {}
-
     private static String convertLabelForApi(final String label) {
-        final LabelParts parts = splitLabel(label);
-        if (parts.key().contains(API_LABEL_SEPARATOR)) {
-            throw new CliException("Label key '" + parts.key() + "' must not contain colons. Colons are reserved by the REST API.",
+        final Map.Entry<String, String> parts = LabelsUtil.splitLabel(label);
+        if (parts.getKey().contains(API_LABEL_SEPARATOR)) {
+            throw new CliException("Label key '" + parts.getKey() + "' must not contain colons. Colons are reserved by the REST API.",
                     CliException.VALIDATION_ERROR_RETURN_CODE);
         }
-        if (parts.value().isEmpty()) {
-            return parts.key();
+        if (parts.getValue().isEmpty()) {
+            return parts.getKey();
         }
-        return parts.key() + API_LABEL_SEPARATOR + parts.value();
-    }
-
-    private static LabelParts splitLabel(final String label) {
-        final int separatorIndex = findUnescapedEquals(label);
-        if (separatorIndex < 0) {
-            return new LabelParts(unescape(label), "");
-        }
-        final String key = unescape(label.substring(0, separatorIndex));
-        final String value = label.substring(separatorIndex + 1);
-        return new LabelParts(key, value);
-    }
-
-    private static String unescape(final String input) {
-        final StringBuilder result = new StringBuilder(input.length());
-        boolean escaped = false;
-        for (int index = 0; index < input.length(); index++) {
-            final char ch = input.charAt(index);
-            if (escaped) {
-                result.append(ch);
-                escaped = false;
-            } else if (ch == ESCAPE_CHAR) {
-                escaped = true;
-            } else {
-                result.append(ch);
-            }
-        }
-        if (escaped) {
-            result.append(ESCAPE_CHAR);
-        }
-        return result.toString();
-    }
-
-    private static int findUnescapedEquals(final String label) {
-        boolean escaped = false;
-        for (int index = 0; index < label.length(); index++) {
-            final char ch = label.charAt(index);
-            if (escaped) {
-                escaped = false;
-            } else if (ch == ESCAPE_CHAR) {
-                escaped = true;
-            } else if (ch == LABEL_SEPARATOR) {
-                return index;
-            }
-        }
-        return -1;
+        return parts.getKey() + API_LABEL_SEPARATOR + parts.getValue();
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
@@ -182,17 +182,11 @@ public final class Conversions {
 
     // Moved to the Java SDK, see io.apicurio.registry.client.common.util.DateTimeConversions (#8644).
     public static String convertToString(OffsetDateTime ts) {
-        if (ts == null) {
-            return "";
-        }
         return DateTimeConversions.toIsoLocalDateTimeString(ts);
     }
 
     // Moved to the Java SDK, see io.apicurio.registry.client.common.util.DateTimeConversions (#8644).
     public static String convertToString(Date ts) {
-        if (ts == null) {
-            return "";
-        }
         return DateTimeConversions.toIsoLocalDateTimeString(ts);
     }
 

--- a/java-sdk/client/src/main/java/io/apicurio/registry/client/util/LabelsUtil.java
+++ b/java-sdk/client/src/main/java/io/apicurio/registry/client/util/LabelsUtil.java
@@ -1,0 +1,150 @@
+package io.apicurio.registry.client.util;
+
+import io.apicurio.registry.rest.client.models.Labels;
+
+import java.util.AbstractMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.Optional.ofNullable;
+
+/**
+ * Utility methods for working with the generated {@link Labels} client model and with the
+ * {@code key=value} label syntax used across SDK consumers (e.g. the CLI).
+ * <p>
+ * {@link Labels} is a Kiota "additional data" model: its entries are not typed fields but
+ * are instead stored in a generic {@code Map<String, Object>}. Consumers of the SDK
+ * generally want a plain {@code Map<String, String>} or a simple display string instead, so
+ * these conversions are centralized here rather than being duplicated by every caller.
+ *
+ * @see <a href="https://github.com/Apicurio/apicurio-registry/issues/8644">#8644</a>
+ */
+public final class LabelsUtil {
+
+    private static final char ESCAPE_CHAR = '\\';
+    private static final char LABEL_SEPARATOR = '=';
+
+    private LabelsUtil() {
+    }
+
+    /**
+     * Converts a {@link Labels} instance (as returned by the generated REST client) into a
+     * plain {@code Map<String, String>}. Returns an empty map if {@code labels} is
+     * {@code null} or has no additional data.
+     *
+     * @param labels the labels model returned by the SDK, may be {@code null}
+     * @return a non-null map of label key/value pairs
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, String> toMap(Labels labels) {
+        return ofNullable(labels)
+                .map(Labels::getAdditionalData)
+                .map(additionalData -> (Map<String, String>) (Map<String, ?>) additionalData)
+                .orElse(Map.of());
+    }
+
+    /**
+     * Formats a {@link Labels} instance as a comma-separated {@code key=value} string,
+     * suitable for simple display purposes (e.g. CLI table output). Returns an empty
+     * string if {@code labels} is {@code null} or has no additional data.
+     *
+     * @param labels the labels model returned by the SDK, may be {@code null}
+     * @return a non-null, comma-separated {@code key=value} string
+     */
+    public static String toDisplayString(Labels labels) {
+        return ofNullable(labels)
+                .map(Labels::getAdditionalData)
+                .map(LabelsUtil::toDisplayString)
+                .orElse("");
+    }
+
+    /**
+     * Formats a generic label map as a comma-separated {@code key=value} string, suitable
+     * for simple display purposes (e.g. CLI table output). Returns an empty string if
+     * {@code labels} is {@code null}.
+     *
+     * @param labels the label map to format, may be {@code null}
+     * @return a non-null, comma-separated {@code key=value} string
+     */
+    public static String toDisplayString(Map<String, ?> labels) {
+        return ofNullable(labels)
+                .map(map -> map.entrySet().stream()
+                        .map(entry -> entry.getKey() + "=" + entry.getValue())
+                        .collect(Collectors.joining(",")))
+                .orElse("");
+    }
+
+    /**
+     * Parses a list of {@code key=value} (or bare {@code key}) label strings, as typically
+     * supplied via repeated CLI flags, into a label map. Supports {@code \} as an escape
+     * character so that keys or values containing literal {@code =} or {@code \} can be
+     * expressed as {@code \=} / {@code \\}.
+     *
+     * @param labels the raw {@code key=value} strings to parse, must not be {@code null}
+     * @return a non-null, insertion-ordered map of label key/value pairs
+     */
+    public static Map<String, String> parseLabels(final List<String> labels) {
+        final Map<String, String> result = new LinkedHashMap<>();
+        for (final String label : labels) {
+            final Map.Entry<String, String> entry = splitLabel(label);
+            result.put(entry.getKey(), entry.getValue());
+        }
+        return result;
+    }
+
+    /**
+     * Splits a single {@code key=value} (or bare {@code key}) label string into its key and
+     * value, honoring {@code \} as an escape character in the key portion. If there is no
+     * unescaped {@code =}, the whole (unescaped) string is treated as the key with an empty
+     * value.
+     *
+     * @param label the raw label string to split, must not be {@code null}
+     * @return a non-null key/value entry
+     */
+    public static Map.Entry<String, String> splitLabel(final String label) {
+        final int separatorIndex = findUnescapedEquals(label);
+        if (separatorIndex < 0) {
+            return new AbstractMap.SimpleImmutableEntry<>(unescape(label), "");
+        }
+        final String key = unescape(label.substring(0, separatorIndex));
+        final String value = label.substring(separatorIndex + 1);
+        return new AbstractMap.SimpleImmutableEntry<>(key, value);
+    }
+
+    private static String unescape(final String input) {
+        final StringBuilder result = new StringBuilder(input.length());
+        boolean escaped = false;
+        for (int index = 0; index < input.length(); index++) {
+            final char ch = input.charAt(index);
+            if (escaped) {
+                result.append(ch);
+                escaped = false;
+            } else if (ch == ESCAPE_CHAR) {
+                escaped = true;
+            } else {
+                result.append(ch);
+            }
+        }
+        if (escaped) {
+            result.append(ESCAPE_CHAR);
+        }
+        return result.toString();
+    }
+
+    private static int findUnescapedEquals(final String label) {
+        boolean escaped = false;
+        for (int index = 0; index < label.length(); index++) {
+            final char ch = label.charAt(index);
+            if (escaped) {
+                escaped = false;
+            } else if (ch == ESCAPE_CHAR) {
+                escaped = true;
+            } else if (ch == LABEL_SEPARATOR) {
+                return index;
+            }
+        }
+        return -1;
+    }
+}

--- a/java-sdk/client/src/test/java/io/apicurio/registry/client/util/LabelsUtilTest.java
+++ b/java-sdk/client/src/test/java/io/apicurio/registry/client/util/LabelsUtilTest.java
@@ -1,0 +1,127 @@
+package io.apicurio.registry.client.util;
+
+import io.apicurio.registry.rest.client.models.Labels;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LabelsUtilTest {
+
+    @Test
+    public void testToMap_null() {
+        assertEquals(Map.of(), LabelsUtil.toMap(null));
+    }
+
+    @Test
+    public void testToMap_noAdditionalData() {
+        Labels labels = new Labels();
+        assertEquals(Map.of(), LabelsUtil.toMap(labels));
+    }
+
+    @Test
+    public void testToMap_withData() {
+        Labels labels = new Labels();
+        Map<String, Object> additionalData = new LinkedHashMap<>();
+        additionalData.put("env", "prod");
+        additionalData.put("team", "platform");
+        labels.setAdditionalData(additionalData);
+
+        Map<String, String> result = LabelsUtil.toMap(labels);
+
+        assertEquals(2, result.size());
+        assertEquals("prod", result.get("env"));
+        assertEquals("platform", result.get("team"));
+    }
+
+    @Test
+    public void testToDisplayString_labels_null() {
+        assertEquals("", LabelsUtil.toDisplayString((Labels) null));
+    }
+
+    @Test
+    public void testToDisplayString_labels_withData() {
+        Labels labels = new Labels();
+        Map<String, Object> additionalData = new LinkedHashMap<>();
+        additionalData.put("env", "prod");
+        additionalData.put("team", "platform");
+        labels.setAdditionalData(additionalData);
+
+        String result = LabelsUtil.toDisplayString(labels);
+
+        assertEquals("env=prod,team=platform", result);
+    }
+
+    @Test
+    public void testToDisplayString_map_withData() {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+
+        String result = LabelsUtil.toDisplayString(map);
+
+        assertEquals("key1=value1,key2=value2", result);
+    }
+
+    @Test
+    public void testToDisplayString_map_empty() {
+        assertTrue(LabelsUtil.toDisplayString(Map.of()).isEmpty());
+    }
+
+    @Test
+    public void testToDisplayString_map_null() {
+        assertEquals("", LabelsUtil.toDisplayString((Map<String, ?>) null));
+    }
+
+    @Test
+    public void testParseLabels_simple() {
+        Map<String, String> result = LabelsUtil.parseLabels(List.of("env=prod", "team=platform"));
+
+        assertEquals(2, result.size());
+        assertEquals("prod", result.get("env"));
+        assertEquals("platform", result.get("team"));
+    }
+
+    @Test
+    public void testParseLabels_bareKeyNoValue() {
+        Map<String, String> result = LabelsUtil.parseLabels(List.of("standalone"));
+
+        assertEquals(1, result.size());
+        assertEquals("", result.get("standalone"));
+    }
+
+    @Test
+    public void testParseLabels_preservesInsertionOrder() {
+        Map<String, String> result = LabelsUtil.parseLabels(List.of("b=2", "a=1"));
+
+        assertEquals(List.of("b", "a"), List.copyOf(result.keySet()));
+    }
+
+    @Test
+    public void testSplitLabel_escapedEquals() {
+        Map.Entry<String, String> entry = LabelsUtil.splitLabel("weird\\=key=value");
+
+        assertEquals("weird=key", entry.getKey());
+        assertEquals("value", entry.getValue());
+    }
+
+    @Test
+    public void testSplitLabel_escapedBackslash() {
+        Map.Entry<String, String> entry = LabelsUtil.splitLabel("path\\\\to=value");
+
+        assertEquals("path\\to", entry.getKey());
+        assertEquals("value", entry.getValue());
+    }
+
+    @Test
+    public void testSplitLabel_trailingBackslash() {
+        Map.Entry<String, String> entry = LabelsUtil.splitLabel("trailing\\");
+
+        assertEquals("trailing\\", entry.getKey());
+        assertEquals("", entry.getValue());
+    }
+}

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/util/DateTimeConversions.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/util/DateTimeConversions.java
@@ -1,0 +1,57 @@
+package io.apicurio.registry.client.common.util;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+/**
+ * Generic date/time conversion and formatting helpers shared by SDK consumers (CLI, tests,
+ * integrations). These are intentionally simple, dependency-free conversions between
+ * {@link OffsetDateTime}, {@link Date}, and {@link String}.
+ * <p>
+ * For parsing dates coming out of the generated REST client (including legacy date format
+ * fallback), see {@link DateTimeUtil} instead.
+ *
+ * @see <a href="https://github.com/Apicurio/apicurio-registry/issues/8644">#8644</a>
+ */
+public final class DateTimeConversions {
+
+    private DateTimeConversions() {
+    }
+
+    /**
+     * Converts an {@link OffsetDateTime} to a {@link Date}.
+     *
+     * @param timestamp the timestamp to convert, must not be {@code null}
+     * @return the equivalent {@link Date}
+     */
+    public static Date toDate(OffsetDateTime timestamp) {
+        return Date.from(timestamp.toInstant());
+    }
+
+    /**
+     * Formats an {@link OffsetDateTime} as an ISO local date-time string (using the JVM's
+     * default time zone), e.g. {@code 2026-07-16T10:15:30}.
+     *
+     * @param timestamp the timestamp to format, must not be {@code null}
+     * @return the formatted date-time string
+     */
+    public static String toIsoLocalDateTimeString(OffsetDateTime timestamp) {
+        return timestamp.atZoneSameInstant(ZoneId.systemDefault())
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+
+    /**
+     * Formats a {@link Date} as an ISO local date-time string (using the JVM's default time
+     * zone), e.g. {@code 2026-07-16T10:15:30}.
+     *
+     * @param timestamp the timestamp to format, must not be {@code null}
+     * @return the formatted date-time string
+     */
+    public static String toIsoLocalDateTimeString(Date timestamp) {
+        return timestamp.toInstant()
+                .atZone(ZoneId.systemDefault())
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+}

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/util/DateTimeConversions.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/util/DateTimeConversions.java
@@ -34,10 +34,13 @@ public final class DateTimeConversions {
      * Formats an {@link OffsetDateTime} as an ISO local date-time string (using the JVM's
      * default time zone), e.g. {@code 2026-07-16T10:15:30}.
      *
-     * @param timestamp the timestamp to format, must not be {@code null}
-     * @return the formatted date-time string
+     * @param timestamp the timestamp to format, may be {@code null}
+     * @return the formatted date-time string, or an empty string if {@code timestamp} is {@code null}
      */
     public static String toIsoLocalDateTimeString(OffsetDateTime timestamp) {
+        if (timestamp == null) {
+            return "";
+        }
         return timestamp.atZoneSameInstant(ZoneId.systemDefault())
                 .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     }
@@ -46,10 +49,13 @@ public final class DateTimeConversions {
      * Formats a {@link Date} as an ISO local date-time string (using the JVM's default time
      * zone), e.g. {@code 2026-07-16T10:15:30}.
      *
-     * @param timestamp the timestamp to format, must not be {@code null}
-     * @return the formatted date-time string
+     * @param timestamp the timestamp to format, may be {@code null}
+     * @return the formatted date-time string, or an empty string if {@code timestamp} is {@code null}
      */
     public static String toIsoLocalDateTimeString(Date timestamp) {
+        if (timestamp == null) {
+            return "";
+        }
         return timestamp.toInstant()
                 .atZone(ZoneId.systemDefault())
                 .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);

--- a/java-sdk/common/src/test/java/io/apicurio/registry/client/common/util/DateTimeConversionsTest.java
+++ b/java-sdk/common/src/test/java/io/apicurio/registry/client/common/util/DateTimeConversionsTest.java
@@ -1,0 +1,72 @@
+package io.apicurio.registry.client.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DateTimeConversionsTest {
+
+    // Matches an ISO local date-time string, e.g. "2026-07-16T10:15:30". Used to
+    // independently verify the *shape* of the output without relying on
+    // DateTimeFormatter.ISO_LOCAL_DATE_TIME, the same API the code under test uses to
+    // produce it.
+    private static final Pattern ISO_LOCAL_DATE_TIME_PATTERN =
+            Pattern.compile("^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})$");
+
+    @Test
+    public void testToDate() {
+        OffsetDateTime ts = OffsetDateTime.of(2026, 7, 16, 10, 15, 30, 0, ZoneOffset.UTC);
+
+        Date result = DateTimeConversions.toDate(ts);
+
+        assertEquals(ts.toInstant(), result.toInstant());
+    }
+
+    @Test
+    public void testToIsoLocalDateTimeString_offsetDateTime() {
+        OffsetDateTime ts = OffsetDateTime.of(2026, 7, 16, 10, 15, 30, 0, ZoneOffset.UTC);
+
+        String result = DateTimeConversions.toIsoLocalDateTimeString(ts);
+
+        assertMatchesIndependentlyComputedLocalDateTime(ts.toInstant(), result);
+    }
+
+    @Test
+    public void testToIsoLocalDateTimeString_date() {
+        OffsetDateTime ts = OffsetDateTime.of(2026, 7, 16, 10, 15, 30, 0, ZoneOffset.UTC);
+        Date date = Date.from(ts.toInstant());
+
+        String result = DateTimeConversions.toIsoLocalDateTimeString(date);
+
+        assertMatchesIndependentlyComputedLocalDateTime(ts.toInstant(), result);
+    }
+
+    /**
+     * Verifies the formatted string against a value assembled by hand from the
+     * individual {@link LocalDateTime} fields (year/month/day/hour/minute/second),
+     * rather than by calling the same {@code DateTimeFormatter} the code under test
+     * uses. This catches regressions (e.g. wrong zone conversion, truncated seconds,
+     * wrong field order) that a "recompute with the identical formatter" assertion
+     * would not.
+     */
+    private static void assertMatchesIndependentlyComputedLocalDateTime(java.time.Instant instant, String actual) {
+        LocalDateTime expectedLocal = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+        String expected = String.format("%04d-%02d-%02dT%02d:%02d:%02d",
+                expectedLocal.getYear(), expectedLocal.getMonthValue(), expectedLocal.getDayOfMonth(),
+                expectedLocal.getHour(), expectedLocal.getMinute(), expectedLocal.getSecond());
+
+        assertEquals(expected, actual);
+
+        Matcher matcher = ISO_LOCAL_DATE_TIME_PATTERN.matcher(actual);
+        assertTrue(matcher.matches(), "Expected an ISO local date-time string, got: " + actual);
+    }
+}

--- a/java-sdk/common/src/test/java/io/apicurio/registry/client/common/util/DateTimeConversionsTest.java
+++ b/java-sdk/common/src/test/java/io/apicurio/registry/client/common/util/DateTimeConversionsTest.java
@@ -50,6 +50,20 @@ public class DateTimeConversionsTest {
         assertMatchesIndependentlyComputedLocalDateTime(ts.toInstant(), result);
     }
 
+    @Test
+    public void testToIsoLocalDateTimeString_nullOffsetDateTime() {
+        String result = DateTimeConversions.toIsoLocalDateTimeString((OffsetDateTime) null);
+
+        assertEquals("", result);
+    }
+
+    @Test
+    public void testToIsoLocalDateTimeString_nullDate() {
+        String result = DateTimeConversions.toIsoLocalDateTimeString((Date) null);
+
+        assertEquals("", result);
+    }
+
     /**
      * Verifies the formatted string against a value assembled by hand from the
      * individual {@link LocalDateTime} fields (year/month/day/hour/minute/second),


### PR DESCRIPTION
Description: Closes #8644.

This PR cleans up cli/utils/Conversions.java by moving the generic, reusable conversions into the Java SDK .
What changed:

Added LabelsUtil to java-sdk/client: Handles all label parsing, key=value string splitting (with escape character support), and map conversions.
Added DateTimeConversions to java-sdk/common: Handles simple OffsetDateTime / Date / String formatting.
Updated CLI: Conversions.java now delegates to these new SDK utilities instead of duplicating the logic. Method signatures in the CLI were kept identical so no other CLI code had to change.
Added full unit test coverage for the new SDK utils (including edge cases for label escape sequences and independent date verification).
Why some methods stayed in the CLI: I intentionally left the bean-mapping methods (e.g., convert(GroupMetaData)) in the CLI. Those depend on io.apicurio.registry.rest.v3.beans.* which live in apicurio-registry-common. The Java SDK shouldn't depend on common, so moving them would mess up the dependency tree.

Tested locally and confirmed no regressions in CLI behavior.