### PR TITLE
fix(search): return 400 for content search when Elasticsearch index i…

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecorator.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecorator.java
@@ -4,6 +4,7 @@ import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.SearchFilter;
 import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
+import io.apicurio.registry.storage.error.ContentSearchNotSupportedException;
 import io.apicurio.registry.storage.error.RegistryStorageException;
 import io.apicurio.registry.storage.impl.search.ElasticsearchSearchConfig;
 import io.apicurio.registry.storage.impl.search.ElasticsearchSearchService;
@@ -52,7 +53,7 @@ public class ElasticsearchSearchDecorator extends RegistryStorageDecoratorBase
             throws RegistryStorageException {
         if (searchService.requiresSearchIndex(filters)) {
             if (!startupIndexer.isReady()) {
-                throw new RegistryStorageException(
+                throw new ContentSearchNotSupportedException(
                         "Content search requires the Elasticsearch search index, which is not "
                         + "available. Enable the Elasticsearch search index to use content search.");
             }

--- a/app/src/test/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecoratorTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecoratorTest.java
@@ -1,0 +1,34 @@
+package io.apicurio.registry.storage.decorator;
+
+import io.apicurio.registry.storage.dto.SearchFilter;
+import io.apicurio.registry.storage.error.ContentSearchNotSupportedException;
+import io.apicurio.registry.storage.impl.search.ElasticsearchSearchService;
+import io.apicurio.registry.storage.impl.search.ElasticsearchStartupIndexer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ElasticsearchSearchDecoratorTest {
+
+    @Test
+    public void testContentSearchWhenIndexNotReadyThrowsContentSearchNotSupported() {
+        ElasticsearchSearchService searchService = mock(ElasticsearchSearchService.class);
+        ElasticsearchStartupIndexer startupIndexer = mock(ElasticsearchStartupIndexer.class);
+        when(searchService.requiresSearchIndex(any())).thenReturn(true);
+        when(startupIndexer.isReady()).thenReturn(false);
+
+        ElasticsearchSearchDecorator decorator = new ElasticsearchSearchDecorator();
+        decorator.searchService = searchService;
+        decorator.startupIndexer = startupIndexer;
+
+        Set<SearchFilter> filters = Set.of();
+        Assertions.assertThrows(ContentSearchNotSupportedException.class, () -> {
+            decorator.searchVersions(filters, null, null, 0, 20, false);
+        });
+    }
+}


### PR DESCRIPTION
Title:
```
fix(search): return 400 for content search when Elasticsearch index is not ready
```

Closes #8697

What's done:
- **Fix** in `ElasticsearchSearchDecorator` (line 56): throws `ContentSearchNotSupportedException` (mapped to 400) instead of `RegistryStorageException` (defaulted to 500), matching `SqlSearchRepository`. IOException path untouched. This is exactly the fix carlesarnal confirmed.
- **Test** `ElasticsearchSearchDecoratorTest` (Mockito), verified **before/after**:
  - Before (original): fails — `expected ContentSearchNotSupportedException but was RegistryStorageException`.
  - After (fix): passes.
- checkstyle clean, DCO sign-off, no code comments/emojis, committed (`fcd267f`) and pushed to your fork branch `fix/8697-elasticsearch-content-search-400`.