### PR TITLE
docs(ui): update outdated PatternFly and Node.js versions in ui-app README

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -15,8 +15,8 @@ components (for example `ui-docs`) provide specific functionality extracted and 
 reasons mentioned above.
 
 ## Building the UI
-**Note**: You will need to have Node/NPM installed to work with the UI.  Version 16 or later of Node.js 
-should be sufficient.
+**Note**: You will need to have Node/NPM installed to work with the UI.  Node.js `^20.19.0 || >=22.12.0`
+is required (the engine requirement of Vite 7), along with npm 10 or later.
 
 ### Install Dependencies
 

--- a/ui/ui-app/README.md
+++ b/ui/ui-app/README.md
@@ -1,9 +1,9 @@
 # Apicurio Registry UI
 
-Apicurio Registry UI is a React based Single Page Application based on Patternfly 5.
+Apicurio Registry UI is a React based Single Page Application based on PatternFly 6.
 
 ## Requirements
-This project requires node version 16.x.x and npm version > 8.3.x.
+This project requires Node.js `^20.19.0 || >=22.12.0` (the engine requirement of Vite 7) and npm 10 or later.
 Prior to building this project make sure you have these applications installed.
 
 ## Development Scripts

--- a/ui/ui-docs/README.md
+++ b/ui/ui-docs/README.md
@@ -4,7 +4,7 @@ Apicurio Registry UI Docs View is a React application that is used to render the
 in the Registry UI.
 
 ## Requirements
-This project requires node version 16.x.x and npm version > 8.3.x.
+This project requires Node.js `^20.19.0 || >=22.12.0` (the engine requirement of Vite 7) and npm 10 or later.
 Prior to building this project make sure you have these applications installed.
 
 ## Development Scripts


### PR DESCRIPTION
The ui-app README documented PatternFly 5 and Node.js 16.x, neither of which matches the project.

- All `@patternfly/*` dependencies in `ui/ui-app/package.json` are on 6.6.0, so the PatternFly 5 reference is updated to 6.
- Vite 7.3.6 declares `engines.node: ^20.19.0 || >=22.12.0`, so Node 16 cannot build the UI. The requirement now matches Vite's engine range; for reference, CI (`verify-build.yaml`) defaults to Node 20.

Fixes #8689