### PR TITLE
docs: update Contributor Checklist with patterns from 31 rejected PRs

### DIFF
--- a/.claude/agents/contributor-guide.md
+++ b/.claude/agents/contributor-guide.md
@@ -29,6 +29,7 @@ These are agent-only — they go beyond the checklist items:
 - Missing null-safety on `KubernetesClientException.getStatus()`? Flag it.
 - New SQL under `storage/impl/` without a migration script? Flag it.
 - Assertions using only `assertNotNull` or `assertTrue(list.size() > 0)` instead of specific values? MAJOR.
+- Tests for CDI interceptor annotations (`@Retry`, `@CircuitBreaker`, `@Timeout`, `@Fallback`) using plain JUnit with `new`-constructed beans instead of `@QuarkusTest` with CDI injection? MAJOR — the annotations are inert without CDI. Either use `@QuarkusTest` or reframe as unit tests of exception behavior.
 - PR doing too much (unrelated changes, whitespace-only diffs in untouched files)? Flag and suggest splitting.
 
 ## Severity rules

--- a/.claude/agents/contributor-guide.md
+++ b/.claude/agents/contributor-guide.md
@@ -7,46 +7,40 @@ tools: Read, Grep, Glob, Bash
 You are a contribution quality gate for Apicurio Registry. Your job is to catch
 problems BEFORE the PR is opened, saving the contributor and maintainers time.
 
-Read the Contributor Checklist in the repo-root CLAUDE.md and enforce every item
+Enforce every item in the **Contributor Checklist** (repo-root `CLAUDE.md`)
 against the current diff (`git diff main...HEAD`).
 
-## What to check
+## Enforcement steps
 
-### Issue and approval
-- Is there a linked issue? Does it have a comment from a project maintainer?
-- Are there other open PRs for the same issue? (Search with `gh pr list --search`)
+1. **One PR at a time** (most common rejection — 31 PRs closed for this in July 2026).
+   Run `gh pr list --author <login> --state open`. If any open PR exists: BLOCKER.
 
-### Configuration properties
-- Any `@ConfigProperty` using `quarkus.*` prefix instead of `apicurio.*`? Flag it.
-- Any `@ConfigProperty` in `app/` module missing `@Info` annotation? Flag it.
-- Defaults in `application.properties` instead of `@ConfigProperty(defaultValue=)`? Flag it.
-  Reference: `.claude/rules/config-properties.md`
+2. **Issue approval.** The linked issue must have a maintainer comment.
+   Check Discussion #8364 "Tried & Rejected" section for previously rejected approaches.
 
-### Security
-- Auth/authz changes without tests? BLOCKER.
-- API error responses that include usernames, class names, or stack traces? BLOCKER.
-- Hand-rolled security logic (circuit breakers, token caching, crypto) when Quarkus/MicroProfile provides it? MAJOR.
-- New `synchronized` blocks in async/reactive code paths? MAJOR.
+3. **Walk the diff** against every Code / Tests / Submission item in the checklist.
+   Apply the severity rules below.
 
-### Storage
-- New features or behavioral changes under `storage/impl/` that aren't variant-specific must work across all 4 variants. Variant-specific fixes (e.g., a PostgreSQL dialect tweak) are fine.
-- New SQL without migration scripts? Flag it.
+## Additional checks not in the checklist
 
-### Testing
-- New code paths without tests? BLOCKER.
-- Assertions that check only `assertNotNull` or `assertTrue(list.size() > 0)`? MAJOR — must assert specific values.
-- Security changes without negative test cases (unauthorized → 403)? BLOCKER.
-- CI failure on a test unrelated to the PR? Flag it for separate investigation — don't just retry.
+These are agent-only — they go beyond the checklist items:
 
-### Code style
-- Star imports? BLOCKER (checkstyle will catch this, but flag it early).
-- `toUpperCase()` / `toLowerCase()` without `Locale.ROOT`? Flag it.
-- Missing Apache 2.0 license header on new Java files? Flag it.
-- Missing DCO sign-off on commits? Flag it.
+- `securityIdentity.getPrincipal()` without null guard? Flag it — anonymous access is possible.
+- Missing null-safety on `KubernetesClientException.getStatus()`? Flag it.
+- New SQL under `storage/impl/` without a migration script? Flag it.
+- Assertions using only `assertNotNull` or `assertTrue(list.size() > 0)` instead of specific values? MAJOR.
+- PR doing too much (unrelated changes, whitespace-only diffs in untouched files)? Flag and suggest splitting.
 
-### Scope
-- Unrelated changes (whitespace, import reordering in untouched files)? Flag and ask to remove.
-- PR doing too much? Suggest splitting.
+## Severity rules
+
+- Config property using `quarkus.*` prefix or missing `@Info` in `app/`: BLOCKER.
+- Auth/authz changes without positive+negative tests: BLOCKER.
+- API error response exposing internal state: BLOCKER.
+  Wrong: `"User " + currentUser + " is not authorized"` — Correct: `"Not authorized"`.
+- Star imports, missing license header, missing DCO sign-off: BLOCKER.
+- Hand-rolled logic that Quarkus/MicroProfile already provides: MAJOR.
+- `synchronized` in reactive/async code: MAJOR.
+- Changed default config values not the explicit goal of the PR: MAJOR.
 
 ## Output format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ Project committers have more latitude but should still follow the Code and Tests
 - [ ] Every new code path has tests. Missing tests = automatic rejection.
 - [ ] Test assertions check **specific values** ("counter is 3"), not just existence ("counter is not null").
 - [ ] Security tests cover: authorized access, unauthorized access (403), edge cases (null tokens, expired sessions).
+- [ ] Tests for CDI annotations (`@Retry`, `@CircuitBreaker`, `@Timeout`) use `@QuarkusTest` with injected beans — plain JUnit with `new` bypasses interceptors.
 - [ ] If CI fails on a test unrelated to your change, report it as a separate issue with the flaky test class, error message, and CI run link.
 
 ### Submission

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Project committers have more latitude but should still follow the Code and Tests
 - [ ] Check the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364) — some optimizations have already been evaluated and rejected with evidence. Don't re-implement them.
 
 ### Code
-- [ ] Config properties follow `.claude/rules/config-properties.md` (`apicurio.*` prefix, `@Info` in `app` module).
+- [ ] Config properties follow `.claude/rules/config-properties.md` (`apicurio.*` prefix, `@Info` in `app` module). If you changed `@ConfigProperty` or `@Info`, regenerate config docs: `./mvnw clean install -pl :apicurio-registry-config-generator -am -DskipTests` and commit the updated `ref-registry-all-configs.adoc`.
 - [ ] API error responses never expose internal state (usernames, stack traces, class names).
 - [ ] Use Quarkus/MicroProfile facilities (`@CircuitBreaker`, `@Retry`, `@Timeout`) instead of hand-rolled equivalents.
 - [ ] Use `Locale.ROOT` with `toUpperCase()` / `toLowerCase()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,21 +78,28 @@ Types: `feat`, `fix`, `chore`, `docs`, `ci`, `test`, `refactor`
 - Profiles: `local-tests`, `remote-mem`, `remote-sql`, `remote-kafka`
 - Storage-touching features must work across all variants
 
-## Contributor Checklist
+## Contributor Checklist (external contributors)
 
 Before opening a PR, verify every item. PRs that skip these get sent back.
+Project committers have more latitude but should still follow the Code and Tests sections.
 
 ### Before writing code
-- [ ] The linked issue has **maintainer approval** (a comment from a project maintainer). Implementing an unapproved feature request wastes everyone's time.
+- [ ] **One PR at a time.** Do not open a second PR until your first one is merged. Maintainers will close additional PRs with "one PR at a time" — no exceptions, even if the work is ready.
+- [ ] The linked issue has **maintainer approval** (a comment from a project maintainer). Implementing an unapproved feature request wastes everyone's time. Issues with zero maintainer comments are not approved.
 - [ ] Check for **overlapping PRs** — search open PRs for your issue number and keywords. Duplicate work gets the later PR closed.
+- [ ] Check the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364) — some optimizations have already been evaluated and rejected with evidence. Don't re-implement them.
 
 ### Code
-- [ ] Config properties follow `.claude/rules/config-properties.md` (`apicurio.*` prefix, `@Info` annotation in `app` module, run config doc generator).
-- [ ] API error responses never expose internal state — no usernames, stack traces, or class names. Use generic messages.
-- [ ] Never hand-roll what Quarkus or MicroProfile already provides (circuit breakers, retry, fault tolerance, health checks). Check existing dependencies first.
-- [ ] New features or behavioral changes under `storage/impl/` that aren't variant-specific must be implemented across all 4 storage variants.
-- [ ] Auth changes require tests for both **positive** (authorized → succeeds) and **negative** (unauthorized → 403) cases.
+- [ ] Config properties follow `.claude/rules/config-properties.md` (`apicurio.*` prefix, `@Info` in `app` module).
+- [ ] API error responses never expose internal state (usernames, stack traces, class names).
+- [ ] Use Quarkus/MicroProfile facilities (`@CircuitBreaker`, `@Retry`, `@Timeout`) instead of hand-rolled equivalents.
+- [ ] Use `Locale.ROOT` with `toUpperCase()` / `toLowerCase()`.
+- [ ] Non-variant-specific changes under `storage/impl/` must work across all 4 storage variants.
+- [ ] Auth changes require both positive and negative (403) test cases.
 - [ ] New Java files include the Apache 2.0 license header.
+- [ ] Don't change default config values unless that is the explicit goal of the PR.
+- [ ] Use Fabric8 Kubernetes client API idiomatically (`ex.getStatus().getReason()`, not `ex.getMessage().contains(...)`).
+- [ ] No `synchronized` in reactive/async code paths (`Uni<>`, Mutiny) — use `AtomicReference` + CAS or framework-provided mechanisms.
 
 ### Tests
 - [ ] Every new code path has tests. Missing tests = automatic rejection.


### PR DESCRIPTION
## Summary

Follow-up to #8626. Updates the Contributor Checklist and contributor-guide agent with patterns and antipatterns observed from the July 2026 contributor wave (31 PRs closed by Carles for "one PR at a time" alone).

## New rules added (from real rejections)

| Rule | Source | Frequency |
|------|--------|-----------|
| **One PR at a time** | Carles closed 31 PRs for this | Most common rejection |
| **Check Tried & Rejected list** | #8556 re-implemented already-rejected GCS mirror (#8411) | Repeated work |
| **Don't change default config values** | #8614 changed auth mechanism priority default | Behavioral regression |
| **Use Fabric8 idiomatically** | #8686 review (getStatus().getReason() not getMessage().contains()) | K8s client correctness |
| **No synchronized in reactive code** | #8554 used synchronized in Uni<> auth pipeline | Performance |
| **Use @CircuitBreaker not hand-rolled** | #8554 hand-rolled circuit breaker despite MicroProfile dep | Framework reuse |
| **Generic error messages** | #8615 leaked username in ForbiddenException | Security |

## Framing

The checklist is explicitly scoped to **external contributors**. Project committers have more latitude (e.g., multiple PRs) but should still follow the Code and Tests sections.

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | Expanded Contributor Checklist with 7 new rules from real review data |
| `.claude/agents/contributor-guide.md` | Updated agent with same rules + severity ratings |

cc @carlesarnal @EricWittmann