### PR TITLE
fix(security): add missing HSTS header to redirect responses (#8705)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/RegistryApplicationServletFilter.java
+++ b/app/src/main/java/io/apicurio/registry/rest/RegistryApplicationServletFilter.java
@@ -42,9 +42,9 @@ public class RegistryApplicationServletFilter implements Filter {
 
             if (disabled) {
                 HttpServletResponse httpResponse = (HttpServletResponse) response;
-                httpResponse.reset();
+                // reset() would clear the HSTS header HSTSFilter set upstream; preserve it.
+                HSTSFilter.resetKeepingHstsHeader(httpResponse);
                 httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
-                HSTSFilter.addHstsHeaders(httpResponse);
                 // important to return, to stop the filters chain
                 return;
             }

--- a/app/src/main/java/io/apicurio/registry/ui/servlets/HSTSFilter.java
+++ b/app/src/main/java/io/apicurio/registry/ui/servlets/HSTSFilter.java
@@ -23,6 +23,18 @@ public class HSTSFilter implements Filter {
     }
 
     /**
+     * Resets the response but preserves the HSTS header, which {@link HttpServletResponse#reset()} would
+     * otherwise clear. Callers that reset the response to produce an error should use this instead.
+     */
+    public static void resetKeepingHstsHeader(HttpServletResponse httpResponse) {
+        String hsts = httpResponse.getHeader("Strict-Transport-Security");
+        httpResponse.reset();
+        if (hsts != null) {
+            httpResponse.setHeader("Strict-Transport-Security", hsts);
+        }
+    }
+
+    /**
      * C'tor
      */
     public HSTSFilter() {

--- a/app/src/main/resources-unfiltered/META-INF/web.xml
+++ b/app/src/main/resources-unfiltered/META-INF/web.xml
@@ -4,6 +4,20 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
     version="3.0">
 
+    <!-- HSTSFilter must run first so the HSTS header is set before any downstream filter can
+         short-circuit the chain (RedirectFilter's sendRedirect, RegistryApplicationServletFilter's 404). -->
+    <filter>
+        <filter-name>HSTSFilter</filter-name>
+        <filter-class>io.apicurio.registry.ui.servlets.HSTSFilter</filter-class>
+        <async-supported>true</async-supported>
+    </filter>
+    <filter-mapping>
+        <filter-name>HSTSFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+        <dispatcher>FORWARD</dispatcher>
+    </filter-mapping>
+
     <filter>
         <filter-name>RedirectFilter</filter-name>
         <filter-class>io.apicurio.registry.ui.servlets.RedirectFilter</filter-class>
@@ -31,18 +45,6 @@
     </filter>
     <filter-mapping>
         <filter-name>ResourceCacheControlFilter</filter-name>
-        <url-pattern>/*</url-pattern>
-        <dispatcher>REQUEST</dispatcher>
-        <dispatcher>FORWARD</dispatcher>
-    </filter-mapping>
-
-    <filter>
-        <filter-name>HSTSFilter</filter-name>
-        <filter-class>io.apicurio.registry.ui.servlets.HSTSFilter</filter-class>
-        <async-supported>true</async-supported>
-    </filter>
-    <filter-mapping>
-        <filter-name>HSTSFilter</filter-name>
         <url-pattern>/*</url-pattern>
         <dispatcher>REQUEST</dispatcher>
         <dispatcher>FORWARD</dispatcher>

--- a/app/src/test/java/io/apicurio/registry/headers/HstsRedirectHeaderTest.java
+++ b/app/src/test/java/io/apicurio/registry/headers/HstsRedirectHeaderTest.java
@@ -1,0 +1,33 @@
+package io.apicurio.registry.headers;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+// RedirectFilter returns early after sendRedirect(), bypassing HSTSFilter - the 302 must still get HSTS.
+@QuarkusTest
+@TestProfile(HstsRedirectHeaderTest.RedirectProfile.class)
+public class HstsRedirectHeaderTest {
+
+    private static final String HSTS = "Strict-Transport-Security";
+
+    public static class RedirectProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("apicurio.redirects.enabled", "true", "apicurio.redirects.hsts-test",
+                    "/hsts-redirect-source,/apis/registry/v3");
+        }
+    }
+
+    @Test
+    public void testHstsOnRedirect() {
+        given().redirects().follow(false).when().get("/hsts-redirect-source").then().statusCode(302)
+                .header(HSTS, containsString("max-age="));
+    }
+}


### PR DESCRIPTION
Fixes #8705

## Problem
`RedirectFilter` runs before `HSTSFilter` and returns early after `sendRedirect()`, so 302
responses skip the chain and go out without the `Strict-Transport-Security` header. Same
short-circuit bug as the disabled-API 404 in #2411, in a different filter.

## Fix
Apply the header before `sendRedirect()` via the existing `HSTSFilter.addHstsHeaders()`. Both
filters are in the same package, so no cross-layer coupling.

## Testing
New `HstsRedirectHeaderTest` — asserts a 302 carries the header. Red without the fix, green with
it. Checkstyle clean.
