### PR TITLE
fix(security): HSTS header uses incorrect includeSubdomains directive

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ui/servlets/HSTSFilter.java
+++ b/app/src/main/java/io/apicurio/registry/ui/servlets/HSTSFilter.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 public class HSTSFilter implements Filter {
 
     private static final long MAX_AGE = 31536000; // one year
-    private static final String HSTS_HEADER = "max-age=" + MAX_AGE + "; includeSubdomains";
+    private static final String HSTS_HEADER = "max-age=" + MAX_AGE + "; includeSubDomains";
 
     public static void addHstsHeaders(HttpServletResponse httpResponse) {
         httpResponse.setHeader("Strict-Transport-Security", HSTS_HEADER);

--- a/app/src/test/java/io/apicurio/registry/headers/HstsError500Test.java
+++ b/app/src/test/java/io/apicurio/registry/headers/HstsError500Test.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 // Verifies the HSTS header on a 500 response (#2411). A 500 has no natural trigger, so HstsBoomResource
 // provides a test-only endpoint that throws, enabled only for this test via the alternative below.
@@ -29,5 +30,12 @@ public class HstsError500Test {
     public void testHstsOnInternalServerError500() {
         given().when().get("/apis/test/hsts-500-boom").then().statusCode(500).header(HSTS,
                 containsString("max-age="));
+    }
+
+    // #8713: pin the exact directive casing on 500 responses too, not just success responses.
+    @Test
+    public void testHstsDirectiveCasingIsRfcCompliantOn500() {
+        given().when().get("/apis/test/hsts-500-boom").then().statusCode(500).header(HSTS,
+                equalTo("max-age=31536000; includeSubDomains"));
     }
 }

--- a/app/src/test/java/io/apicurio/registry/headers/HstsHeaderTest.java
+++ b/app/src/test/java/io/apicurio/registry/headers/HstsHeaderTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 // #2411: the HSTS header is set by a servlet filter, so error responses that bypass the chain lose it.
 @QuarkusTest
@@ -28,6 +29,14 @@ public class HstsHeaderTest {
     public void testHstsOnSuccessResponse() {
         given().when().get("/apis/registry/v3/groups").then().statusCode(200).header(HSTS,
                 containsString("max-age="));
+    }
+
+    // #8713: RFC 6797 defines the directive as "includeSubDomains" (capital D); pin the exact
+    // value so a regression to the invalid "includeSubdomains" casing is caught.
+    @Test
+    public void testHstsDirectiveCasingIsRfcCompliant() {
+        given().when().get("/apis/registry/v3/groups").then().statusCode(200).header(HSTS,
+                equalTo("max-age=31536000; includeSubDomains"));
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/headers/HstsHeaderTest.java
+++ b/app/src/test/java/io/apicurio/registry/headers/HstsHeaderTest.java
@@ -45,6 +45,14 @@ public class HstsHeaderTest {
                 .then().statusCode(404).header(HSTS, containsString("max-age="));
     }
 
+    // #8713: the filter chain (see #2411) also covers error responses, so pin the exact
+    // directive casing there too, not just on success responses.
+    @Test
+    public void testHstsDirectiveCasingIsRfcCompliantOn404() {
+        given().when().get("/apis/registry/v3/groups/default/artifacts/does-not-exist-" + System.nanoTime())
+                .then().statusCode(404).header(HSTS, equalTo("max-age=31536000; includeSubDomains"));
+    }
+
     @Test
     public void testHstsOnUnknownPath404() {
         given().when().get("/this-path-does-not-exist").then().statusCode(404).header(HSTS,


### PR DESCRIPTION
Fixes #8713

## Problem
`HSTSFilter` sets the `Strict-Transport-Security` response header with the directive
`includeSubdomains` (lowercase `d`). RFC 6797 §6.1.2 defines this directive as
`includeSubDomains` (capital `D`), case-sensitively. The invalid casing may cause
browsers to ignore the directive, so the intended subdomain protection may not apply.

## Fix
Corrected the casing in `HSTSFilter.java` to `includeSubDomains`, matching RFC 6797.

## Testing
Added a regression test (`testHstsDirectiveCasingIsRfcCompliant`) in `HstsHeaderTest`
that asserts the exact header value, so a future regression to the invalid casing
will be caught. All existing HSTS-related tests (`HstsHeaderTest`, `HstsAuthHeaderTest`,
`HstsError500Test`) pass locally.