### PR TITLE
refactor(rest): remove unreachable else-if in label parsing for group…

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
@@ -230,8 +230,8 @@ public class SearchResourceImpl implements SearchResource {
                 }
                 // If the delimiter is missing or simply exists at the end of the label filter with no value, then
                 // use null for the value (will match all groups containing a label with the key and *any* value).
-                if ((delimiterIndex == (prop.length() - 1)) || delimiterIndex < 0) {
-                    labelKey = prop.replace(":", "");
+                if (delimiterIndex < 0) {
+                    labelKey = prop;
                     labelValue = null;
                 } else if (delimiterIndex == (prop.length() - 1)) {
                     labelKey = prop.substring(0, delimiterIndex);
@@ -300,8 +300,8 @@ public class SearchResourceImpl implements SearchResource {
                 }
                 // If the delimiter is missing or simply exists at the end of the label filter with no value, then
                 // use null for the value (will match all versions containing a label with the key and *any* value).
-                if ((delimiterIndex == (prop.length() - 1)) || delimiterIndex < 0) {
-                    labelKey = prop.replace(":", "");
+                if (delimiterIndex < 0) {
+                    labelKey = prop;
                     labelValue = null;
                 } else if (delimiterIndex == (prop.length() - 1)) {
                     labelKey = prop.substring(0, delimiterIndex);

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchGroupsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchGroupsTest.java
@@ -113,6 +113,12 @@ public class SearchGroupsTest extends AbstractResourceTestBase {
         });
         Assertions.assertEquals(1, results.getGroups().size());
         Assertions.assertEquals("testSearchGroupsByLabels3", results.getGroups().get(0).getGroupId());
+
+        results = clientV3.search().groups().get(request -> {
+            request.queryParameters.labels = new String[] { "byLabels-3:" };
+        });
+        Assertions.assertEquals(1, results.getGroups().size());
+        Assertions.assertEquals("testSearchGroupsByLabels3", results.getGroups().get(0).getGroupId());
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchVersionsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchVersionsTest.java
@@ -300,6 +300,11 @@ public class SearchVersionsTest extends AbstractResourceTestBase {
         Assertions.assertEquals(0, results.getCount());
 
         results = clientV3.search().versions().get(config -> {
+            config.queryParameters.labels = new String[] { "key-1:" };
+        });
+        Assertions.assertEquals(2, results.getCount());
+
+        results = clientV3.search().versions().get(config -> {
             config.queryParameters.labels = new String[] { "id:testSearchVersionsByIds_Group1_Artifact_1" };
         });
         Assertions.assertEquals(1, results.getCount());


### PR DESCRIPTION
…s and version search

The label-parsing blocks in searchGroups and searchVersions guarded the first branch with (delimiterIndex == prop.length() - 1 || delimiterIndex < 0), which already subsumed the following else-if testing the identical delimiterIndex == prop.length() - 1 condition, making that branch dead code.

Align both blocks with the non-overlapping structure already used by searchArtifacts so the three label parsers are consistent. The change is behavior-preserving: for delimiterIndex < 0 no colon is present so prop.replace(":", "") equals prop, and the trailing-colon case yields the same key via substring.