### PR TITLE
fix(examples): upgrade camel-quarkus-kafka to Quarkus 3.33 for Apicurio v3 compatibility

### DIFF
--- a/examples/camel-quarkus-kafka/pom.xml
+++ b/examples/camel-quarkus-kafka/pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <projectRoot>${project.basedir}/../..</projectRoot>
-        <quarkus.version>3.27.0</quarkus.version>
-        <camel-quarkus.version>3.27.1</camel-quarkus.version>
+        <quarkus.version>3.33.1</quarkus.version>
+        <camel-quarkus.version>3.33.1</camel-quarkus.version>
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <maven.compiler.release>17</maven.compiler.release>
         <skipITs>true</skipITs>
@@ -70,6 +70,13 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-apicurio-registry-avro</artifactId>
+        </dependency>
+
+        <!-- Kafka clients (explicit version to align with Quarkus 3.33) -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>4.1.1</version>
         </dependency>
 
         <!-- Avro -->

--- a/examples/camel-quarkus-kafka/src/main/resources/application.properties
+++ b/examples/camel-quarkus-kafka/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Quarkus
 quarkus.application.name=camel-quarkus-kafka-example
+quarkus.devservices.enabled=false
 quarkus.log.level=INFO
 quarkus.log.category."io.apicurio".level=INFO
 quarkus.log.category."org.apache.camel".level=INFO


### PR DESCRIPTION
## Summary

Follow-up to #8675. The original quickstart used Quarkus 3.27, whose `quarkus-apicurio-registry-avro` extension targets Apicurio 2.x. This caused `IncompatibleClassChangeError` at runtime because the monorepo has 3.x classes.

- Upgrade to Quarkus 3.33.1 + Camel Quarkus 3.33.1 (includes the Apicurio v3-compatible extension from quarkusio/quarkus#51008)
- Pin `kafka-clients` to 4.1.1 to match the Quarkus 3.33 BOM (the parent POM's `kafka.version=3.9.2` otherwise wins)
- Disable Dev Services so the example uses its own `docker-compose.yml` infrastructure

## Test plan

- [x] `mvn clean compile -DskipTests` builds successfully
- [x] `docker-compose up -d` + `mvn quarkus:dev` starts both Camel routes
- [x] Producer sends greeting messages: `Sending greeting for Alice: Hello from Camel!`
- [x] Avro schema auto-registered as `greetings-value` in Registry