### PR TITLE
docs: add issue claiming protocol to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,17 @@ If you use different computers to contribute, please make sure the name is the s
 
 We may use this information to acknowledge your contributions!
 
+### Claiming an issue
+
+Before you start working on an issue, let us know so we don't end up with duplicate effort:
+
+1. **Comment on the issue** saying you'd like to work on it.
+2. **Wait for a maintainer to assign it to you.** We may have context on scope, dependencies, or ongoing work that affects the approach.
+3. **If someone is already assigned**, don't open a competing PR — ask in the issue whether they need help or have moved on.
+4. **Stale assignments:** if an assigned issue has no PR and no update for two weeks, comment asking for a status update. If there's no response within a few days, a maintainer can reassign it.
+
+Opening a PR on an issue that's assigned to someone else without checking first is likely to get your PR closed.
+
 ### Code reviews
 
 All submissions, including submissions by project members, need to be reviewed by at least one Apicurio committer before being merged.


### PR DESCRIPTION
## Summary

Adds a "Claiming an issue" section to CONTRIBUTING.md, documenting the protocol for signaling intent to work on an issue before opening a PR.

Prompted by a contributor conflict on #8717 where two contributors ended up working on the same issue independently. We had no documented rules about this.

## Changes

- New section under "Before you contribute" covering: comment to signal intent, wait for assignment, respect existing assignees, two-week stale policy.

## Feedback requested

@carlesarnal @EricWittmann @jsenko — does this match how you'd want to handle it? Anything to add or soften?