### PR TITLE
feat(a2a): add watsonx Orchestrate integration for agent discovery and governance

### DIFF
--- a/app/src/main/java/io/apicurio/registry/a2a/A2AConfig.java
+++ b/app/src/main/java/io/apicurio/registry/a2a/A2AConfig.java
@@ -76,6 +76,10 @@ public class A2AConfig {
     @Info(category = CATEGORY_A2A, description = "Default visibility for new Agent Card artifacts (public, entitled, private)", availableSince = "3.0.0")
     String defaultVisibility;
 
+    @ConfigProperty(name = "apicurio.a2a.agent.auth.api-key.enabled", defaultValue = "false")
+    @Info(category = CATEGORY_A2A, description = "Advertise API key authentication in the agent card security schemes", availableSince = "3.3.1")
+    boolean apiKeyAuthEnabled;
+
     @ConfigProperty(name = "apicurio.a2a.agent.protocol-version", defaultValue = "1.0")
     @Info(category = CATEGORY_A2A, description = "A2A protocol version supported by the registry agent", availableSince = "3.0.0")
     String protocolVersion;
@@ -146,5 +150,9 @@ public class A2AConfig {
 
     public String getDefaultVisibility() {
         return defaultVisibility;
+    }
+
+    public boolean isApiKeyAuthEnabled() {
+        return apiKeyAuthEnabled;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/a2a/RegistryAgentCardBuilder.java
+++ b/app/src/main/java/io/apicurio/registry/a2a/RegistryAgentCardBuilder.java
@@ -124,6 +124,9 @@ public class RegistryAgentCardBuilder {
         if (authConfig.isBasicAuthEnabled()) {
             schemes.put("basic", SecurityScheme.httpAuth("Basic"));
         }
+        if (a2aConfig.isApiKeyAuthEnabled()) {
+            schemes.put("apiKey", SecurityScheme.apiKey("X-API-Key", "header"));
+        }
 
         return schemes;
     }

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
@@ -53,6 +53,16 @@ public interface WellKnownResource {
     AgentCard getAgentCardV1();
 
     /**
+     * Returns the Agent Card for this Apicurio Registry instance.
+     * Alias for compatibility with watsonx Orchestrate, which discovers agents
+     * at /.well-known/agent-card.json by default.
+     */
+    @GET
+    @Path("/agent-card.json")
+    @Produces(MediaType.APPLICATION_JSON)
+    AgentCard getAgentCardForOrchestrate();
+
+    /**
      * Returns a specific registered Agent Card by group and artifact ID.
      * This enables proxying/serving of registered agent cards stored in the registry.
      *

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -121,6 +121,12 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
     @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.None)
+    public AgentCard getAgentCardForOrchestrate() {
+        return getAgentCard();
+    }
+
+    @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.None)
     public AgentSearchResults getPublicAgents(Integer offset, Integer limit) {
         if (!a2aConfig.isEnabled() || !a2aConfig.isPublicDiscoveryEnabled()) {
             throw new NotFoundException("Public agent discovery is disabled");

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -535,6 +535,57 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
         clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).put(meta);
     }
 
+    @Test
+    public void testGetAgentCardViaOrchestrateAlias() {
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .get("/.well-known/agent-card.json")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("Apicurio Registry"))
+                .body("supportedInterfaces", hasSize(1))
+                .body("skills", hasSize(5))
+                .body("skills.id", hasItem("schema-validation"))
+                .body("skills.id", hasItem("agent-discovery"));
+    }
+
+    @Test
+    public void testOrchestrateAliasMatchesCanonicalEndpoint() {
+        String canonical = givenAtRoot()
+                .when()
+                .get("/.well-known/agent.json")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        String alias = givenAtRoot()
+                .when()
+                .get("/.well-known/agent-card.json")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        org.junit.jupiter.api.Assertions.assertEquals(canonical, alias);
+    }
+
+    @Test
+    public void testSearchAgentsReturnsInterfaceUrls() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        createAgentCard(groupId, "url-agent", AGENT_CARD_CONTENT);
+
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("agents.find { it.artifactId == 'url-agent' }.supportedInterfaces[0].url",
+                        equalTo("https://example.com/agent"))
+                .body("agents.find { it.artifactId == 'url-agent' }.supportedInterfaces[0].protocolVersion",
+                        equalTo("1.0"));
+    }
+
     private void createAgentCard(String groupId, String artifactId, String content) throws Exception {
         CreateArtifact createArtifact = new CreateArtifact();
         createArtifact.setArtifactId(artifactId);

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -12,6 +12,11 @@ The following {registry} configuration options are available for each component 
 |Default
 |Available from
 |Description
+|`apicurio.a2a.agent.auth.api-key.enabled`
+|`boolean`
+|`false`
+|`3.3.1`
+|Advertise API key authentication in the agent card security schemes
 |`apicurio.a2a.agent.capabilities.push-notifications`
 |`boolean`
 |`false`

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -38,11 +38,19 @@
         <!--
         The stdio transport enables communication through standard input and output streams.
         This is particularly useful for local integrations and command-line tools.
-        This project does not currently use the SSE transport.
         -->
         <dependency>
             <groupId>io.quarkiverse.mcp</groupId>
             <artifactId>quarkus-mcp-server-stdio</artifactId>
+        </dependency>
+
+        <!--
+        The SSE transport enables communication over HTTP using Server-Sent Events.
+        This is required for remote integrations such as watsonx Orchestrate toolkit import.
+        -->
+        <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-sse</artifactId>
         </dependency>
 
         <dependency>

--- a/mcp/src/main/java/io/apicurio/registry/mcp/RegistryService.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/RegistryService.java
@@ -465,6 +465,67 @@ public class RegistryService {
         return client.admin().config().properties().byPropertyName(propertyName).get();
     }
 
+    // ---- Well-known agent/MCP tool endpoints (no SDK support, use raw HTTP) ----
+
+    private static final java.net.http.HttpClient wellKnownHttpClient = java.net.http.HttpClient.newBuilder()
+            .connectTimeout(java.time.Duration.ofSeconds(10))
+            .build();
+
+    public String searchAgentCards(String name, String skill, String capability) throws Exception {
+        StringBuilder url = new StringBuilder(rawBaseUrl).append("/.well-known/agents?limit=50");
+        if (name != null && !name.isBlank()) {
+            url.append("&name=").append(java.net.URLEncoder.encode(name, StandardCharsets.UTF_8));
+        }
+        if (skill != null && !skill.isBlank()) {
+            url.append("&skill=").append(java.net.URLEncoder.encode(skill, StandardCharsets.UTF_8));
+        }
+        if (capability != null && !capability.isBlank()) {
+            url.append("&capability=").append(java.net.URLEncoder.encode(capability, StandardCharsets.UTF_8));
+        }
+        return fetchWellKnownEndpoint(url.toString());
+    }
+
+    public String getAgentCard(String groupId, String artifactId) throws Exception {
+        String url = rawBaseUrl + "/.well-known/agents/"
+                + java.net.URLEncoder.encode(groupId, StandardCharsets.UTF_8) + "/"
+                + java.net.URLEncoder.encode(artifactId, StandardCharsets.UTF_8);
+        return fetchWellKnownEndpoint(url);
+    }
+
+    public String searchMcpTools(String name, String parameter) throws Exception {
+        StringBuilder url = new StringBuilder(rawBaseUrl).append("/.well-known/mcp-tools?limit=50");
+        if (name != null && !name.isBlank()) {
+            url.append("&name=").append(java.net.URLEncoder.encode(name, StandardCharsets.UTF_8));
+        }
+        if (parameter != null && !parameter.isBlank()) {
+            url.append("&parameter=").append(java.net.URLEncoder.encode(parameter, StandardCharsets.UTF_8));
+        }
+        return fetchWellKnownEndpoint(url.toString());
+    }
+
+    public String getMcpTool(String groupId, String artifactId) throws Exception {
+        String url = rawBaseUrl + "/.well-known/mcp-tools/"
+                + java.net.URLEncoder.encode(groupId, StandardCharsets.UTF_8) + "/"
+                + java.net.URLEncoder.encode(artifactId, StandardCharsets.UTF_8);
+        return fetchWellKnownEndpoint(url);
+    }
+
+    private String fetchWellKnownEndpoint(String url) throws Exception {
+        var request = java.net.http.HttpRequest.newBuilder()
+                .uri(java.net.URI.create(url))
+                .header("Accept", "application/json")
+                .timeout(java.time.Duration.ofSeconds(30))
+                .GET()
+                .build();
+        var response = wellKnownHttpClient.send(request,
+                java.net.http.HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 400) {
+            throw new ToolCallException("Registry returned HTTP " + response.statusCode()
+                    + " for " + url);
+        }
+        return response.body();
+    }
+
     public void updateConfigurationProperty(String propertyName, String propertyValue) {
         if (config.safeMode() && !List.of(
                 "apicurio.rest.mutability.artifact-version-content.enabled"

--- a/mcp/src/main/java/io/apicurio/registry/mcp/servers/AgentsMCPServer.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/servers/AgentsMCPServer.java
@@ -1,0 +1,60 @@
+package io.apicurio.registry.mcp.servers;
+
+import io.apicurio.registry.mcp.RegistryService;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import jakarta.inject.Inject;
+
+import static io.apicurio.registry.mcp.Descriptions.ARTIFACT_ID;
+import static io.apicurio.registry.mcp.Descriptions.GROUP_ID;
+import static io.apicurio.registry.mcp.Utils.handleError;
+
+public class AgentsMCPServer {
+
+    @Inject
+    RegistryService service;
+
+    @Tool(description = """
+            Discover A2A agent cards registered in the Apicurio Registry. \
+            Returns a list of agents matching the search criteria. \
+            Each result includes the agent's name, description, skills, \
+            capabilities, and the URL where the agent can be reached.""")
+    String discover_agents(
+            @ToolArg(description = "Filter agents by name (partial match)", required = false) String name,
+            @ToolArg(description = "Filter agents by skill ID", required = false) String skill,
+            @ToolArg(description = "Filter agents by capability (e.g. 'streaming:true')", required = false) String capability
+    ) {
+        return handleError(() -> service.searchAgentCards(name, skill, capability));
+    }
+
+    @Tool(description = """
+            Get a specific A2A agent card registered in the Apicurio Registry. \
+            Returns the full agent card JSON including the agent's URL, skills, \
+            capabilities, security schemes, and supported interfaces.""")
+    String get_agent_card(
+            @ToolArg(description = GROUP_ID) String groupId,
+            @ToolArg(description = ARTIFACT_ID) String artifactId
+    ) {
+        return handleError(() -> service.getAgentCard(groupId, artifactId));
+    }
+
+    @Tool(description = """
+            Search for MCP tool definitions registered in the Apicurio Registry. \
+            Returns a list of MCP tools matching the search criteria.""")
+    String search_mcp_tools(
+            @ToolArg(description = "Filter tools by name (partial match)", required = false) String name,
+            @ToolArg(description = "Filter tools by input parameter name", required = false) String parameter
+    ) {
+        return handleError(() -> service.searchMcpTools(name, parameter));
+    }
+
+    @Tool(description = """
+            Get a specific MCP tool definition registered in the Apicurio Registry. \
+            Returns the full MCP tool JSON including input schema and parameters.""")
+    String get_mcp_tool(
+            @ToolArg(description = GROUP_ID) String groupId,
+            @ToolArg(description = ARTIFACT_ID) String artifactId
+    ) {
+        return handleError(() -> service.getMcpTool(groupId, artifactId));
+    }
+}

--- a/mcp/src/main/resources/application.properties
+++ b/mcp/src/main/resources/application.properties
@@ -1,5 +1,16 @@
 quarkus.package.jar.type=fast-jar
 
+# =============================================================================
+# Transport Configuration
+# =============================================================================
+# Both stdio and SSE transports are available.
+# - stdio: for local CLI integration (e.g., Claude Desktop)
+# - SSE: for remote HTTP-based integration (e.g., watsonx Orchestrate toolkit)
+#
+# The SSE endpoint is served at /mcp/sse by default.
+# quarkus.mcp.server.sse.root-path=/mcp/sse
+# =============================================================================
+
 %test.quarkus.log.category."io.apicurio".level=debug
 
 # =============================================================================

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/extract/AgentCardStructuredContentExtractor.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/extract/AgentCardStructuredContentExtractor.java
@@ -37,6 +37,7 @@ public class AgentCardStructuredContentExtractor implements StructuredContentExt
             extractProtocolBindings(root, elements);
             extractSecuritySchemeTypes(root, elements);
             extractTags(root, elements);
+            extractProtocolVersion(root, elements);
 
             return elements;
         } catch (Exception e) {
@@ -97,6 +98,14 @@ public class AgentCardStructuredContentExtractor implements StructuredContentExt
                     elements.add(new StructuredElement("protocolbinding",
                             iface.get("protocolBinding").asText()));
                 }
+                if (iface.has("protocolVersion") && iface.get("protocolVersion").isTextual()) {
+                    elements.add(new StructuredElement("protocolversion",
+                            iface.get("protocolVersion").asText()));
+                }
+                if (iface.has("url") && iface.get("url").isTextual()) {
+                    elements.add(new StructuredElement("url",
+                            iface.get("url").asText()));
+                }
             }
         }
     }
@@ -106,6 +115,13 @@ public class AgentCardStructuredContentExtractor implements StructuredContentExt
         if (!schemes.isMissingNode() && schemes.isObject()) {
             schemes.fieldNames().forEachRemaining(name ->
                     elements.add(new StructuredElement("securityscheme", name)));
+        }
+    }
+
+    private void extractProtocolVersion(JsonNode root, List<StructuredElement> elements) {
+        JsonNode version = root.path("protocolVersion");
+        if (!version.isMissingNode() && version.isTextual()) {
+            elements.add(new StructuredElement("protocolversion", version.asText()));
         }
     }
 


### PR DESCRIPTION
## Summary

Add agent discovery endpoints, MCP tools, and sync tooling for watsonx Orchestrate integration, enabling Apicurio Registry to serve as the federated agent catalog that Orchestrate discovers agents from.

- Add `/.well-known/agent-card.json` endpoint alias (Orchestrate discovers agents at this path)
- Add `API_KEY` security scheme to Agent Card builder (Orchestrate supports Bearer, API Key, None)
- Index `protocolVersion` and `url` from agent cards for structured search
- Add SSE transport to MCP server for remote toolkit integration
- Add 4 agent-specific MCP tools: `discover_agents`, `get_agent_card`, `search_mcp_tools`, `get_mcp_tool`
- Add Python sync scripts for bulk polling and event-driven (Kafka) agent catalog sync
- Add 30-test end-to-end suite

## Motivation

watsonx Orchestrate has an Agent Catalog, but its discovery model is URL-based (one agent at a time). Apicurio Registry adds what Orchestrate lacks at scale: version history, compatibility checking, bulk federated discovery, visibility controls (public/entitled/private), and audit trails for agent cards.

This integration has been tested end-to-end against an IBM Cloud watsonx Orchestrate instance — agents stored in Apicurio were successfully imported into Orchestrate via the sync tooling.

## Architecture

```
Apicurio Registry          watsonx Orchestrate           Agent Servers
┌──────────────┐   discover   ┌──────────────────┐   task execution   ┌─────────────┐
│ Agent Cards  │──────────────▶│  Agent Catalog   │──────────────────▶│ LangGraph   │
│ + versions   │  with URLs   │                  │    (direct)       │ CrewAI      │
│ + compat     │              │                  │                   │ BeeAI       │
│ + visibility │              │                  │                   │ Custom      │
└──────────────┘              └──────────────────┘                   └─────────────┘
```

Apicurio is the catalog and governance layer. Agent servers handle task execution. Orchestrate talks to agent servers directly.

## Changes

### Registry (`app/`)
- `WellKnownResource.java` / `WellKnownResourceImpl.java` — `/.well-known/agent-card.json` alias endpoint
- `A2AConfig.java` — `apicurio.a2a.agent.auth.api-key.enabled` config property
- `RegistryAgentCardBuilder.java` — API_KEY security scheme
- `AgentCardStructuredContentExtractor.java` — index `protocolVersion`, `url` from interfaces
- `WellKnownResourceTest.java` — 3 new tests (alias, canonical match, interface URLs in search)

### MCP Server (`mcp/`)
- `pom.xml` — add `quarkus-mcp-server-sse` dependency (HTTP-based transport for remote integration)
- `AgentsMCPServer.java` — 4 new `@Tool` methods for agent/MCP tool discovery
- `RegistryService.java` — methods for `/.well-known/` endpoints via raw HTTP
- `application.properties` — SSE transport documentation

### Examples (`examples/watsonx-orchestrate/`)
- `sync-agents.py` — bulk polling sync (one-shot or `--watch` mode)
- `register-agent.py` — reads agents from registry, generates Orchestrate YAML, imports via CLI
- `catalog-sync.py` — event-driven sync consuming `registry-events` Kafka topic
- `e2e-test.sh` — 30-test end-to-end suite
- `README.md` — setup and usage guide

## Test plan

- [x] `WellKnownResourceTest` — 24 tests pass (including 3 new Orchestrate-specific tests)
- [x] MCP module compiles with SSE transport
- [x] `sync-agents.py --dry-run` discovers agents from registry
- [x] `register-agent.py --output-dir` generates valid Orchestrate YAML
- [x] End-to-end: agents imported into live IBM Cloud watsonx Orchestrate instance (ca-tor)
- [x] `e2e-test.sh` — 30/30 tests pass