### PR TITLE
refactor(cli)!: use long-only options for name, description, and type. Fixes #8024

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -327,7 +327,7 @@ acr artifact
 **Create an artifact:**
 ```bash
 acr artifact create <artifact-id> -g <group-id> -f <file-path>
-acr artifact create <artifact-id> -g <group-id> -f <file-path> -t <artifact-type>
+acr artifact create <artifact-id> -g <group-id> -f <file-path> --type <artifact-type>
 
 # Read content from stdin:
 cat schema.json | acr artifact create <artifact-id> -g <group-id> -f -

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
@@ -46,7 +46,7 @@ public class ArtifactCreateCommand extends AbstractCommand {
     private String groupId;
 
     @Option(
-            names = {"-t", "--type"},
+            names = {"--type"},
             description = "Artifact type (e.g. AVRO, PROTOBUF, JSON, OPENAPI, ASYNCAPI, GRAPHQL, KCONNECT, WSDL, XSD, XML)."
     )
     private String artifactType;
@@ -58,13 +58,13 @@ public class ArtifactCreateCommand extends AbstractCommand {
     private String file;
 
     @Option(
-            names = {"-n", "--name"},
+            names = {"--name"},
             description = "Provide artifact name."
     )
     private String name;
 
     @Option(
-            names = {"-d", "--description"},
+            names = {"--description"},
             description = "Provide artifact description."
     )
     private String description;

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactUpdateCommand.java
@@ -35,13 +35,13 @@ public class ArtifactUpdateCommand extends AbstractCommand {
     private String groupId;
 
     @Option(
-            names = {"-n", "--name"},
+            names = {"--name"},
             description = "Updated artifact name."
     )
     private String name;
 
     @Option(
-            names = {"-d", "--description"},
+            names = {"--description"},
             description = "Updated artifact description."
     )
     private String description;

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupCreateCommand.java
@@ -34,7 +34,7 @@ public class GroupCreateCommand extends AbstractCommand {
     private String groupId;
 
     @Option(
-            names = {"-d", "--description"},
+            names = {"--description"},
             description = "Provide group description."
     )
     private String description;

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupUpdateCommand.java
@@ -28,7 +28,7 @@ public class GroupUpdateCommand extends AbstractCommand {
     private String groupId;
 
     @Option(
-            names = {"-d", "--description"},
+            names = {"--description"},
             description = "Updated group description."
     )
     private String description;

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionCreateCommand.java
@@ -55,13 +55,13 @@ public class VersionCreateCommand extends AbstractCommand {
     private String file;
 
     @Option(
-            names = {"-n", "--name"},
+            names = {"--name"},
             description = "Provide version name."
     )
     private String name;
 
     @Option(
-            names = {"-d", "--description"},
+            names = {"--description"},
             description = "Provide version description."
     )
     private String description;

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionUpdateCommand.java
@@ -46,13 +46,13 @@ public class VersionUpdateCommand extends AbstractCommand {
     private String artifactId;
 
     @Option(
-            names = {"-n", "--name"},
+            names = {"--name"},
             description = "Updated version name."
     )
     private String name;
 
     @Option(
-            names = {"-d", "--description"},
+            names = {"--description"},
             description = "Updated version description."
     )
     private String description;


### PR DESCRIPTION
## Summary

Short single-letter options are a limited resource, so they should be reserved for the most common properties. PR #7973 removed the `-d`, `-n`, and `-t` short options from the search commands for this reason. This change applies the same treatment to the remaining artifact, version, and group commands.

Fixes #8024.

## Changes

Remove the short options for the less common metadata properties, keeping the long forms:

- `-n` removed from `--name` (artifact create/update, version create/update)
- `-d` removed from `--description` (artifact create/update, version create/update, group create/update)
- `-t` removed from `--type` (artifact create)

Primary identifier and I/O options (`-g/--group`, `-a/--artifact`, `-v/--version`, `-f/--file`, `-l/--label`, `-o/--output-type`) are left unchanged, consistent with the options the search commands retained.

Also update the `acr artifact create` example in `cli/README.md` to use `--type` instead of the removed `-t`.

## Breaking change

This removes short options that existed in previous releases, so scripts using `acr artifact create ... -t AVRO -n <name> -d <desc>` (and the equivalent version/group invocations) will need to switch to `--type` / `--name` /
`--description`. This is an intentional, clean break rather than a deprecation cycle, consistent with the hard removal done in #7973. The CLI is still stabilizing as part of the native-build / Phase 2 work tracked in the epic (#7162) and is not yet treated as a stable interface, which is why no deprecation window is included.

## Notes

- No behavior change beyond dropping the short aliases; the long options are  unchanged.
- Existing CLI tests already use the long option forms, so no test changes are  required.
- A repo-wide grep of `cli/README.md`, `docs/`, and the example scripts found no  other `-t`/`-n`/`-d` usages in artifact/version/group command examples; the single README example was the only one and it is updated here.
- The shell completion script is generated at build time and is not checked in, so it picks up the change automatically.
