### PR TITLE
ci: add shard guard and split app-security from app-other

### DIFF
--- a/.github/scripts/check-shard-coverage.sh
+++ b/.github/scripts/check-shard-coverage.sh
@@ -12,8 +12,6 @@ APP_TEST_DIR="app/src/test/java"
 # ── Positive-match shards ────────────────────────────────────────────────────
 # Each entry is: SHARD_NAME  PATTERN1 PATTERN2 …
 # Patterns use Java-style "**" globs (translated to regex below).
-# The catch-all shard (app-other) is NOT listed here — it covers whatever the
-# positive shards don't, so it is derived automatically.
 SHARDS=(
   "app-rest|io.apicurio.registry.noprofile.rest.**|io.apicurio.registry.noprofile.ccompat.**"
   "app-sql|io.apicurio.registry.storage.impl.sql.**|io.apicurio.registry.storage.impl.search.**|io.apicurio.registry.storage.impl.polling.**|io.apicurio.registry.storage.impl.readonly.**|io.apicurio.registry.storage.decorator.**|io.apicurio.registry.storage.dto.**|io.apicurio.registry.event.sql.**"
@@ -21,6 +19,20 @@ SHARDS=(
   "app-gitops|io.apicurio.registry.storage.impl.gitops.**"
   "app-kubernetesops|io.apicurio.registry.storage.impl.kubernetesops.**"
   "app-security|io.apicurio.registry.auth.**|io.apicurio.registry.rbac.**|io.apicurio.registry.tls.**|io.apicurio.registry.cors.**"
+)
+
+# ── app-other exclusion patterns ─────────────────────────────────────────────
+# Must match the negation list in verify-unit-tests.yaml's app-other shard.
+# A class matching zero positive shards AND matching one of these is UNCOVERED.
+APP_OTHER_EXCLUSIONS=(
+  "io.apicurio.registry.noprofile.rest.**"
+  "io.apicurio.registry.noprofile.ccompat.**"
+  "io.apicurio.registry.storage.**"
+  "io.apicurio.registry.event.**"
+  "io.apicurio.registry.auth.**"
+  "io.apicurio.registry.rbac.**"
+  "io.apicurio.registry.tls.**"
+  "io.apicurio.registry.cors.**"
 )
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -58,11 +70,17 @@ for entry in "${SHARDS[@]}"; do
   IFS='|' read -ra parts <<< "$entry"
   SHARD_NAMES+=("${parts[0]}")
   combined=""
-  for ((i=1; i<${#parts[@]}; i++)); do
+  for pattern in "${parts[@]:1}"; do
     [[ -n "$combined" ]] && combined+="|"
-    combined+="$(glob_to_regex "${parts[$i]}")"
+    combined+="$(glob_to_regex "$pattern")"
   done
   SHARD_REGEXES+=("$combined")
+done
+
+other_exclusion_regex=""
+for pattern in "${APP_OTHER_EXCLUSIONS[@]}"; do
+  [[ -n "$other_exclusion_regex" ]] && other_exclusion_regex+="|"
+  other_exclusion_regex+="$(glob_to_regex "$pattern")"
 done
 
 # ── Check each class ────────────────────────────────────────────────────────
@@ -72,26 +90,28 @@ for f in "${TEST_FILES[@]}"; do
   fqcn="$(fqcn_from_path "$f")"
   matched=()
   for idx in "${!SHARD_NAMES[@]}"; do
-    if echo "$fqcn" | grep -qE "${SHARD_REGEXES[$idx]}"; then
+    if [[ "$fqcn" =~ ${SHARD_REGEXES[$idx]} ]]; then
       matched+=("${SHARD_NAMES[$idx]}")
     fi
   done
 
   if [[ ${#matched[@]} -eq 0 ]]; then
-    # Falls into the catch-all (app-other) — this is valid
+    if [[ "$fqcn" =~ $other_exclusion_regex ]]; then
+      echo "UNCOVERED: $fqcn (excluded by app-other but not claimed by any positive shard)"
+      ((errors++))
+    fi
     continue
   elif [[ ${#matched[@]} -gt 1 ]]; then
     echo "MULTI-MATCH: $fqcn → ${matched[*]}"
     ((errors++))
   fi
-  # Exactly one match — correct
 done
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 
-echo "Checked ${#TEST_FILES[@]} test classes against ${#SHARD_NAMES[@]} shards."
+echo "Checked ${#TEST_FILES[@]} test classes against ${#SHARD_NAMES[@]} shards + app-other exclusions."
 if [[ $errors -gt 0 ]]; then
-  echo "FAILED: $errors class(es) matched multiple shards."
+  echo "FAILED: $errors class(es) uncovered or multi-matched."
   exit 1
 fi
 echo "OK: every class is covered by exactly one shard."

--- a/.github/scripts/check-shard-coverage.sh
+++ b/.github/scripts/check-shard-coverage.sh
@@ -38,7 +38,7 @@ APP_OTHER_EXCLUSIONS=(
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 glob_to_regex() {
-  # io.apicurio.registry.auth.**  →  ^io\.apicurio\.registry\.auth\..*$
+  # Only handles ** (match any depth). Single * is not used in shard patterns.
   local g="$1"
   g="${g//./\\.}"       # escape dots
   g="${g//\*\*/.*}"     # ** → .*

--- a/.github/scripts/check-shard-coverage.sh
+++ b/.github/scripts/check-shard-coverage.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validates that every test class in the app module is claimed by exactly one
+# unit-test shard.  Run from the repository root.
+#
+# Exit 0  – all classes covered by exactly one shard
+# Exit 1  – at least one class is uncovered or multi-covered
+
+APP_TEST_DIR="app/src/test/java"
+
+# ── Positive-match shards ────────────────────────────────────────────────────
+# Each entry is: SHARD_NAME  PATTERN1 PATTERN2 …
+# Patterns use Java-style "**" globs (translated to regex below).
+# The catch-all shard (app-other) is NOT listed here — it covers whatever the
+# positive shards don't, so it is derived automatically.
+SHARDS=(
+  "app-rest|io.apicurio.registry.noprofile.rest.**|io.apicurio.registry.noprofile.ccompat.**"
+  "app-sql|io.apicurio.registry.storage.impl.sql.**|io.apicurio.registry.storage.impl.search.**|io.apicurio.registry.storage.impl.polling.**|io.apicurio.registry.storage.impl.readonly.**|io.apicurio.registry.storage.decorator.**|io.apicurio.registry.storage.dto.**|io.apicurio.registry.event.sql.**"
+  "app-kafkasql|io.apicurio.registry.storage.impl.kafkasql.**|io.apicurio.registry.event.kafkasql.**"
+  "app-gitops|io.apicurio.registry.storage.impl.gitops.**"
+  "app-kubernetesops|io.apicurio.registry.storage.impl.kubernetesops.**"
+  "app-security|io.apicurio.registry.auth.**|io.apicurio.registry.rbac.**|io.apicurio.registry.tls.**|io.apicurio.registry.cors.**"
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+glob_to_regex() {
+  # io.apicurio.registry.auth.**  →  ^io\.apicurio\.registry\.auth\..*$
+  local g="$1"
+  g="${g//./\\.}"       # escape dots
+  g="${g//\*\*/.*}"     # ** → .*
+  echo "^${g}$"
+}
+
+fqcn_from_path() {
+  # app/src/test/java/io/apicurio/registry/auth/FooTest.java → io.apicurio.registry.auth.FooTest
+  local p="${1#${APP_TEST_DIR}/}"
+  p="${p%.java}"
+  echo "${p//\//.}"
+}
+
+# ── Collect test classes ─────────────────────────────────────────────────────
+
+mapfile -t TEST_FILES < <(find "$APP_TEST_DIR" \( -name '*Test.java' -o -name '*IT.java' \) -type f | sort)
+
+if [[ ${#TEST_FILES[@]} -eq 0 ]]; then
+  echo "ERROR: no test classes found under $APP_TEST_DIR"
+  exit 1
+fi
+
+# ── Build compiled regexes per shard ─────────────────────────────────────────
+
+declare -a SHARD_NAMES=()
+declare -a SHARD_REGEXES=()
+
+for entry in "${SHARDS[@]}"; do
+  IFS='|' read -ra parts <<< "$entry"
+  SHARD_NAMES+=("${parts[0]}")
+  combined=""
+  for ((i=1; i<${#parts[@]}; i++)); do
+    [[ -n "$combined" ]] && combined+="|"
+    combined+="$(glob_to_regex "${parts[$i]}")"
+  done
+  SHARD_REGEXES+=("$combined")
+done
+
+# ── Check each class ────────────────────────────────────────────────────────
+
+errors=0
+for f in "${TEST_FILES[@]}"; do
+  fqcn="$(fqcn_from_path "$f")"
+  matched=()
+  for idx in "${!SHARD_NAMES[@]}"; do
+    if echo "$fqcn" | grep -qE "${SHARD_REGEXES[$idx]}"; then
+      matched+=("${SHARD_NAMES[$idx]}")
+    fi
+  done
+
+  if [[ ${#matched[@]} -eq 0 ]]; then
+    # Falls into the catch-all (app-other) — this is valid
+    continue
+  elif [[ ${#matched[@]} -gt 1 ]]; then
+    echo "MULTI-MATCH: $fqcn → ${matched[*]}"
+    ((errors++))
+  fi
+  # Exactly one match — correct
+done
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo "Checked ${#TEST_FILES[@]} test classes against ${#SHARD_NAMES[@]} shards."
+if [[ $errors -gt 0 ]]; then
+  echo "FAILED: $errors class(es) matched multiple shards."
+  exit 1
+fi
+echo "OK: every class is covered by exactly one shard."

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -46,9 +46,13 @@ jobs:
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=io.apicurio.registry.storage.impl.kubernetesops.**"
             maven-opts: "-Xmx4g -Dassembly.skipAssembly=true"
+          - name: app-security
+            modules: "-pl app -am -Dfull -DcliSkipNative"
+            test-filter: "-Dtest=io.apicurio.registry.auth.**,io.apicurio.registry.rbac.**,io.apicurio.registry.tls.**,io.apicurio.registry.cors.**"
+            maven-opts: "-Xmx4g -Dassembly.skipAssembly=true"
           - name: app-other
             modules: "-pl app -am -Dfull -DcliSkipNative"
-            test-filter: "-Dtest=!io.apicurio.registry.noprofile.rest.**,!io.apicurio.registry.noprofile.ccompat.**,!io.apicurio.registry.storage.**,!io.apicurio.registry.event.**"
+            test-filter: "-Dtest=!io.apicurio.registry.noprofile.rest.**,!io.apicurio.registry.noprofile.ccompat.**,!io.apicurio.registry.storage.**,!io.apicurio.registry.event.**,!io.apicurio.registry.auth.**,!io.apicurio.registry.rbac.**,!io.apicurio.registry.tls.**,!io.apicurio.registry.cors.**"
             maven-opts: "-Xmx4g -Dassembly.skipAssembly=true"
           - name: non-app
             modules: "-Dfull -DcliSkipNative -pl !app,!distro/docker,!docs,!docs/config-generator,!docs/rest-api"

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -50,6 +50,8 @@ jobs:
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=io.apicurio.registry.auth.**,io.apicurio.registry.rbac.**,io.apicurio.registry.tls.**,io.apicurio.registry.cors.**"
             maven-opts: "-Xmx4g -Dassembly.skipAssembly=true"
+          # SYNC: if you change these exclusions, also update APP_OTHER_EXCLUSIONS
+          # in .github/scripts/check-shard-coverage.sh
           - name: app-other
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=!io.apicurio.registry.noprofile.rest.**,!io.apicurio.registry.noprofile.ccompat.**,!io.apicurio.registry.storage.**,!io.apicurio.registry.event.**,!io.apicurio.registry.auth.**,!io.apicurio.registry.rbac.**,!io.apicurio.registry.tls.**,!io.apicurio.registry.cors.**"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -272,6 +272,9 @@ jobs:
       - name: Run linter
         run: ./scripts/validate-files.sh
 
+      - name: Verify shard coverage
+        run: .github/scripts/check-shard-coverage.sh
+
       - name: Verify docs generation
         run: |
           if [ -n "$(git status --untracked-files=no --porcelain docs)" ]; then


### PR DESCRIPTION
## Summary

- Adds a shard coverage guard script that validates every app test class is claimed by exactly one unit-test shard, catching silent coverage gaps from the negative filter pattern in app-other
- Splits `app-security` shard out of `app-other`, moving auth, rbac, tls, and cors test classes (~24 classes) to reduce `app-other` wall-clock from ~13min

## Related Issues

- Backlog REG-15 (shard guard)
- Backlog REG-14 (split app-other)

## Changes

- **New file**: `.github/scripts/check-shard-coverage.sh` — enumerates test classes, matches against shard filter patterns, fails on zero-match or multi-match
- **Modified**: `.github/workflows/verify.yaml` — runs the guard in the Lint and Validate job
- **Modified**: `.github/workflows/verify-unit-tests.yaml` — adds `app-security` shard, updates `app-other` exclusions

## Testing

- Guard script passes locally: 229 test classes, 6 shards, zero overlaps
- CI will validate: app-security shard runs green, app-other timing drops, guard step passes
- Compare app-other wall-clock before/after across 2 runs