### PR TITLE
build: add maven-enforcer-plugin with version and duplicate-dep rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,7 @@
     <version.surefire.plugin>3.5.2</version.surefire.plugin>
     <version.jar.plugin>3.4.2</version.jar.plugin>
     <version.checkstyle.plugin>3.6.0</version.checkstyle.plugin>
+    <version.enforcer.plugin>3.6.3</version.enforcer.plugin>
     <version.properties.plugin>1.3.0</version.properties.plugin>
     <version.dependency.plugin>3.8.1</version.dependency.plugin>
     <version.assembly.plugin>3.7.1</version.assembly.plugin>
@@ -1071,6 +1072,11 @@
           <version>${version.checkstyle.plugin}</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${version.enforcer.plugin}</version>
+        </plugin>
+        <plugin>
           <groupId>io.smallrye</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
           <version>${jandex.version}</version>
@@ -1262,6 +1268,27 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.9.8,)</version>
+                </requireMavenVersion>
+                <banDuplicatePomDependencyVersions/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
         <version>${version.maven-antrun.plugin}</version>
         <executions>
@@ -1352,6 +1379,7 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.source.skip>true</maven.source.skip>
         <checkstyle.skip>true</checkstyle.skip>
+        <enforcer.skip>true</enforcer.skip>
         <assembly.skipAssembly>true</assembly.skipAssembly>
       </properties>
     </profile>


### PR DESCRIPTION
## Summary

Adds maven-enforcer-plugin to the root POM to catch build configuration drift that currently goes undetected.

## Changes

Two rules enabled in the `validate` phase:
- **requireMavenVersion** — `[3.9.8,)` matching the wrapper, prevents building with an older Maven
- **banDuplicatePomDependencyVersions** — catches duplicate dependency entries in any POM

Follows the existing checkstyle-plugin pattern: version in `pluginManagement`, execution in `build/plugins`, skipped by `-Dlocal` for fast local builds.

## Testing

- `./mvnw validate -pl app -am` passes across all modules
- `./mvnw validate -Dlocal` correctly skips enforcer (`Skipping Rule Enforcement.`)
- No existing violations found