### PR TITLE
fix(examples): migrate debezium-otel-tracing example to Apicurio Registry 3.x API endpoints

### DIFF
--- a/examples/debezium-otel-tracing/README.md
+++ b/examples/debezium-otel-tracing/README.md
@@ -178,7 +178,7 @@ order-service: POST /orders
 ├── create-order-entity (database insert)
 │
 └── debezium-server: debezium-cdc-orders (custom OTEL SMT)
-    ├── POST apicurio-registry/apis/registry/v2/... (schema registration)
+    ├── POST apicurio-registry/apis/registry/v3/... (schema registration)
     │   └── apicurio-registry: createArtifact
     ├── Kafka producer send
     │

--- a/examples/debezium-otel-tracing/debezium-server/application.properties
+++ b/examples/debezium-otel-tracing/debezium-server/application.properties
@@ -55,7 +55,7 @@ debezium.transforms.unwrap.add.fields=op
 # Note: Using base URL only - Debezium Server's Avro format internally appends the API path
 debezium.format.key=json
 debezium.format.value=avro
-debezium.format.value.apicurio.registry.url=http://apicurio-registry:8080/apis/registry/v2
+debezium.format.value.apicurio.registry.url=http://apicurio-registry:8080/apis/registry/v3
 debezium.format.value.apicurio.registry.auto-register=true
 # Enable global ID in message body (Confluent-compatible wire format)
 debezium.format.value.apicurio.registry.use-id=globalId


### PR DESCRIPTION
## Summary
This PR migrates the \examples/debezium-otel-tracing\ example to be fully compatible with Apicurio Registry 3.x.

## Changes Made
- Updated \debezium.format.value.apicurio.registry.url\ in \debezium-server/application.properties\ to point to \/apis/registry/v3\ instead of legacy \/apis/registry/v2\.
- Updated trace propagation diagram in \examples/debezium-otel-tracing/README.md\ to reflect \/apis/registry/v3\ schema registration endpoint.

Follow-up to #8709.