### PR TITLE
fix(ui): sync test panel state when variables load asynchronously

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useState } from "react";
+import { FunctionComponent, useEffect, useState } from "react";
 import "./PromptTemplateTestPanel.css";
 import {
     ActionGroup,
@@ -52,6 +52,20 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
     });
 
     const [values, setValues] = useState<Record<string, any>>(initialValues);
+
+    useEffect(() => {
+        setValues(prev => {
+            const next = { ...prev };
+            variablesList.forEach(({ name, variable }) => {
+                if (!(name in next)) {
+                    const type = (variable.type || "string").toLowerCase();
+                    next[name] = type === "boolean" ? false : (variable.default ?? "");
+                }
+            });
+            return next;
+        });
+    }, [props.variables]);
+
     const [renderedOutput, setRenderedOutput] = useState<string>("");
     const [validationErrors, setValidationErrors] = useState<RenderPromptValidationError[]>([]);
     const [isLoading, setIsLoading] = useState(false);


### PR DESCRIPTION
Fixes #8765

For PROMPT_TEMPLATE artifacts, `DocumentationTabContent` starts with empty content and fetches the real content async. By the time variables arrive, `useState` in `PromptTemplateTestPanel` has already locked its initial value as `{}`. Field labels render fine, but the form state never picks up the new keys — so untouched fields are missing from the render request.

This is most visible with boolean variables: the checkbox shows unchecked (implying `false`), but the value is silently omitted from the payload instead of being sent as `false`.

Added a `useEffect` that watches `props.variables` and seeds any missing keys into form state. Booleans default to `false`, other types use their declared default or empty string. Already-interacted fields are left untouched.