### PR TITLE
refactor(cli): simplify Config with property/context helpers and deferred flush

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/BrandedCommandLineProducer.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/BrandedCommandLineProducer.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli;
 
 import io.apicurio.registry.cli.config.Config;
+import io.apicurio.registry.cli.config.ConfigProperties;
 import io.quarkus.picocli.runtime.PicocliCommandLineFactory;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
@@ -28,7 +29,7 @@ public class BrandedCommandLineProducer {
 
     private String resolveProductName() {
         try {
-            var name = config.read().getConfig().get("internal.branding.product-name");
+            var name = config.getProperty(ConfigProperties.INTERNAL_BRANDING_PRODUCT_NAME);
             return name != null && !name.isEmpty() ? name : "Apicurio Registry CLI";
         } catch (Exception e) {
             log.debugf("Could not read branding config: %s", e.getMessage());

--- a/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/UpdateCommand.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.cli;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.config.ConfigProperties;
 import io.apicurio.registry.cli.services.CliVersion;
 import io.apicurio.registry.cli.services.Update;
 import io.apicurio.registry.cli.utils.FileUtils;
@@ -94,10 +95,8 @@ public class UpdateCommand extends AbstractCommand {
 
     private void handlePostpone(OutputBuffer output) {
         var hours = Math.min(postponeHours, MAX_POSTPONE_HOURS);
-        var configModel = config.read();
         var until = Instant.now().plusSeconds(hours * 3600L);
-        configModel.getConfig().put("internal.update.postponed-until", until.toString());
-        config.write(configModel);
+        config.setProperty(ConfigProperties.INTERNAL_UPDATE_POSTPONED_UNTIL, until.toString());
         output.writeStdOutLine("Update notifications postponed for %d hours.".formatted(postponeHours));
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
@@ -77,21 +77,20 @@ public class LoginCommand extends AbstractCommand {
 
     @Override
     public void run(final OutputBuffer output) throws Exception {
-        final var configModel = config.read();
-        final var contextName = configModel.getCurrentContext();
+        final var contextName = config.getCurrentContext();
         if (isBlank(contextName)) {
             throw new CliException("No current context is set. Create a context first with 'acr context create'.",
                     VALIDATION_ERROR_RETURN_CODE);
         }
-        final var context = Optional.ofNullable(configModel.getContext().get(contextName))
+        final var context = Optional.ofNullable(config.getContext(contextName))
                 .orElseThrow(() -> new CliException(
                         "Context '" + contextName + "' not found. Create it with 'acr context create'.",
                         VALIDATION_ERROR_RETURN_CODE));
 
         if (!isBlank(username)) {
-            loginBasic(output, configModel, context, contextName);
+            loginBasic(output, context, contextName);
         } else if (!isBlank(tokenEndpoint)) {
-            loginOAuth2(output, configModel, context, contextName);
+            loginOAuth2(output, context, contextName);
         } else {
             throw new CliException("Specify --username for basic auth or --token-endpoint for OAuth2.",
                     VALIDATION_ERROR_RETURN_CODE);
@@ -99,7 +98,6 @@ public class LoginCommand extends AbstractCommand {
     }
 
     private void loginBasic(final OutputBuffer output,
-                            final ConfigModel configModel,
                             final ConfigModel.Context context,
                             final String contextName) {
         var resolvedPassword = password;
@@ -114,11 +112,12 @@ public class LoginCommand extends AbstractCommand {
                 resolvedPassword, allowUnsafe);
         credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET);
 
-        context.clearAuth();
-        context.setAuthType(ConfigModel.AUTH_TYPE_BASIC);
-        context.setUsername(username);
-        context.setUnsafeCredentialStorage(usedFileFallback);
-        config.write(configModel);
+        config.updateContext(contextName, ctx -> {
+            ctx.clearAuth();
+            ctx.setAuthType(ConfigModel.AUTH_TYPE_BASIC);
+            ctx.setUsername(username);
+            ctx.setUnsafeCredentialStorage(usedFileFallback);
+        });
 
         if (usedFileFallback) {
             output.writeStdOutChunk(out ->
@@ -134,7 +133,6 @@ public class LoginCommand extends AbstractCommand {
     }
 
     private void loginOAuth2(final OutputBuffer output,
-                             final ConfigModel configModel,
                              final ConfigModel.Context context,
                              final String contextName) {
         if (isBlank(clientId)) {
@@ -153,13 +151,14 @@ public class LoginCommand extends AbstractCommand {
                 ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET, resolvedSecret, allowUnsafe);
         credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD);
 
-        context.clearAuth();
-        context.setAuthType(ConfigModel.AUTH_TYPE_OAUTH2);
-        context.setTokenEndpoint(tokenEndpoint);
-        context.setClientId(clientId);
-        context.setScope(scope);
-        context.setUnsafeCredentialStorage(usedFileFallback);
-        config.write(configModel);
+        config.updateContext(contextName, ctx -> {
+            ctx.clearAuth();
+            ctx.setAuthType(ConfigModel.AUTH_TYPE_OAUTH2);
+            ctx.setTokenEndpoint(tokenEndpoint);
+            ctx.setClientId(clientId);
+            ctx.setScope(scope);
+            ctx.setUnsafeCredentialStorage(usedFileFallback);
+        });
 
         if (usedFileFallback) {
             output.writeStdOutChunk(out ->

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/LogoutCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/LogoutCommand.java
@@ -25,12 +25,11 @@ public class LogoutCommand extends AbstractCommand {
 
     @Override
     public void run(final OutputBuffer output) throws Exception {
-        final var configModel = config.read();
-        final var contextName = configModel.getCurrentContext();
+        final var contextName = config.getCurrentContext();
         if (isBlank(contextName)) {
             throw new CliException("No current context is set.", VALIDATION_ERROR_RETURN_CODE);
         }
-        final var context = Optional.ofNullable(configModel.getContext().get(contextName))
+        final var context = Optional.ofNullable(config.getContext(contextName))
                 .orElseThrow(() -> new CliException(
                         "Context '" + contextName + "' not found.", VALIDATION_ERROR_RETURN_CODE));
 
@@ -44,8 +43,7 @@ public class LogoutCommand extends AbstractCommand {
         credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_PASSWORD);
         credentialStore.delete(contextName, ConfigModel.CREDENTIAL_KEY_CLIENT_SECRET);
 
-        context.clearAuth();
-        config.write(configModel);
+        config.updateContext(contextName, ConfigModel.Context::clearAuth);
 
         client.reset();
 

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -41,33 +41,43 @@ public abstract class AbstractCommand implements Callable<Integer> {
     @Override
     public Integer call() {
         var output = new OutputBuffer(config.getStdOut(), config.getStdErr());
+        var commandFailed = false;
         try {
             configureVerboseLogging();
             updateNotifier.checkAndNotify(getTopLevelCommandName());
             run(output);
             return OK_RETURN_CODE;
         } catch (CliException ex) {
+            commandFailed = true;
             handleCliException(output, ex);
             return ex.getCode();
         } catch (RuleViolationProblemDetails ex) {
+            commandFailed = true;
             handleRuleViolation(output, ex);
             return SERVER_ERROR_RETURN_CODE;
         } catch (ProblemDetails ex) {
+            commandFailed = true;
             handleProblemDetails(output, ex);
             return SERVER_ERROR_RETURN_CODE;
         } catch (Exception ex) {
+            commandFailed = true;
             log.error("Unexpected error", ex);
             output.writeStdErrChunk(out -> out.append("Unexpected error: ").append(ex.getMessage()).append("\n"));
             return APPLICATION_ERROR_RETURN_CODE;
         } finally {
-            persistConfig(output);
+            persistConfig(output, commandFailed);
             output.print();
         }
     }
 
-    // Runs in the finally block so config updates made before a failure are still saved.
-    private void persistConfig(final OutputBuffer output) {
+    // Runs in finally so config changes made before a failure are still saved. Commands update
+    // config only after their network/IO work succeeds, so a failure won't leave a partial config.
+    private void persistConfig(final OutputBuffer output, final boolean commandFailed) {
         try {
+            if (commandFailed && config.isDirty()) {
+                log.debugf("Command '%s' failed but had unsaved config changes; saving them anyway.",
+                        getTopLevelCommandName());
+            }
             config.flush();
         } catch (Exception ex) {
             log.error("Could not persist configuration changes", ex);

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -70,8 +70,9 @@ public abstract class AbstractCommand implements Callable<Integer> {
         }
     }
 
-    // Runs in finally so config changes made before a failure are still saved. Commands update
-    // config only after their network/IO work succeeds, so a failure won't leave a partial config.
+    // flush() runs regardless of command outcome, so config changes are saved even when the command
+    // fails. Commands are expected to change config only after their IO succeeds (a convention this
+    // class can't enforce), so a failure won't persist half-finished state.
     private void persistConfig(final OutputBuffer output, final boolean commandFailed) {
         try {
             if (commandFailed && config.isDirty()) {

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -60,7 +60,19 @@ public abstract class AbstractCommand implements Callable<Integer> {
             output.writeStdErrChunk(out -> out.append("Unexpected error: ").append(ex.getMessage()).append("\n"));
             return APPLICATION_ERROR_RETURN_CODE;
         } finally {
+            persistConfig(output);
             output.print();
+        }
+    }
+
+    // Runs in the finally block so config updates made before a failure are still saved.
+    private void persistConfig(final OutputBuffer output) {
+        try {
+            config.flush();
+        } catch (Exception ex) {
+            log.error("Could not persist configuration changes", ex);
+            output.writeStdErrChunk(out -> out.append(ERROR_PREFIX)
+                    .append("Could not persist configuration changes: ").append(ex.getMessage()).append("\n"));
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/config/AcrHomeConfigSource.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/AcrHomeConfigSource.java
@@ -2,6 +2,8 @@ package io.apicurio.registry.cli.config;
 
 import io.apicurio.registry.cli.common.CliException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -24,7 +26,8 @@ public class AcrHomeConfigSource implements ConfigSource {
             if (Config.instance == null) {
                 return Collections.emptyMap();
             }
-            return Config.instance.read().getConfig();
+            // read() returns the live cache now, so copy it in case a command mutates it later.
+            return new HashMap<>(Config.instance.read().getConfig());
         } catch (CliException e) {
             return Collections.emptyMap();
         }
@@ -36,7 +39,7 @@ public class AcrHomeConfigSource implements ConfigSource {
             if (Config.instance == null) {
                 return null;
             }
-            return Config.instance.read().getConfig().get(propertyName);
+            return Config.instance.getProperty(propertyName);
         } catch (CliException e) {
             return null;
         }
@@ -60,7 +63,7 @@ public class AcrHomeConfigSource implements ConfigSource {
             if (Config.instance == null) {
                 return Collections.emptySet();
             }
-            return Config.instance.read().getConfig().keySet();
+            return new HashSet<>(Config.instance.read().getConfig().keySet());
         } catch (CliException e) {
             return Collections.emptySet();
         }

--- a/cli/src/main/java/io/apicurio/registry/cli/config/AcrHomeConfigSource.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/AcrHomeConfigSource.java
@@ -26,7 +26,7 @@ public class AcrHomeConfigSource implements ConfigSource {
             if (Config.instance == null) {
                 return Collections.emptyMap();
             }
-            // read() returns the live cache now, so copy it in case a command mutates it later.
+            // Copy so a later command mutating the config can't affect what we return here.
             return new HashMap<>(Config.instance.read().getConfig());
         } catch (CliException e) {
             return Collections.emptyMap();

--- a/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
@@ -30,6 +30,7 @@ public class Config {
     // Loaded via SPI by AcrHomeConfigSource before CDI is available; commands should @Inject Config instead.
     static Config instance;
 
+    // Not synchronized; the CLI runs one command at a time on a single thread.
     private ConfigModel cachedConfig;
     private boolean dirty;
 
@@ -116,8 +117,25 @@ public class Config {
         return getAcrCurrentHomePath().resolve("config.json");
     }
 
-    // Returns the live cache, not a defensive copy. Mutating it directly requires calling markDirty().
+    /**
+     * Returns the live config object. Prefer the typed accessors ({@link #getProperty},
+     * {@link #setProperty}, {@link #putContext}, {@link #updateContext}, ...), which mark the config
+     * dirty so {@link #flush()} saves it.
+     *
+     * @deprecated Changes made directly on the returned object are not saved unless you also call
+     *     {@link #markDirty()}, which is easy to forget:
+     *     <pre>{@code
+     *       config.read().setCurrentContext("dev");   // not saved
+     *       config.setCurrentContext("dev");          // saved
+     *     }</pre>
+     */
+    @Deprecated
     public ConfigModel read() {
+        return cache();
+    }
+
+    // Loads and caches config.json on first use.
+    private ConfigModel cache() {
         if (cachedConfig == null) {
             var configPath = getConfigFilePath();
             try {
@@ -130,56 +148,56 @@ public class Config {
     }
 
     public String getProperty(final String key) {
-        return read().getConfig().get(key);
+        return cache().getConfig().get(key);
     }
 
     public boolean hasProperty(final String key) {
-        return read().getConfig().containsKey(key);
+        return cache().getConfig().containsKey(key);
     }
 
     public void setProperty(final String key, final String value) {
-        read().getConfig().put(key, value);
+        cache().getConfig().put(key, value);
         markDirty();
     }
 
     public String removeProperty(final String key) {
-        var previous = read().getConfig().remove(key);
+        var previous = cache().getConfig().remove(key);
         markDirty();
         return previous;
     }
 
     public String getCurrentContext() {
-        return read().getCurrentContext();
+        return cache().getCurrentContext();
     }
 
     public ConfigModel.Context getContext(final String name) {
-        return read().getContext().get(name);
+        return cache().getContext().get(name);
     }
 
     public void setCurrentContext(final String name) {
-        read().setCurrentContext(name);
+        cache().setCurrentContext(name);
         markDirty();
     }
 
     public void putContext(final String name, final ConfigModel.Context context) {
-        read().getContext().put(name, context);
+        cache().getContext().put(name, context);
         markDirty();
     }
 
     public ConfigModel.Context removeContext(final String name) {
-        var removed = read().getContext().remove(name);
+        var removed = cache().getContext().remove(name);
         markDirty();
         return removed;
     }
 
     public void clearContexts() {
-        read().getContext().clear();
+        cache().getContext().clear();
         markDirty();
     }
 
     // No-op (returns false) if no context with the given name exists.
     public boolean updateContext(final String name, final Consumer<ConfigModel.Context> mutation) {
-        var context = read().getContext().get(name);
+        var context = cache().getContext().get(name);
         if (context == null) {
             return false;
         }
@@ -190,6 +208,10 @@ public class Config {
 
     public void markDirty() {
         dirty = true;
+    }
+
+    public boolean isDirty() {
+        return dirty;
     }
 
     // Called once at the end of each command, from AbstractCommand.call().

--- a/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
@@ -11,12 +11,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.Setter;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
-import static io.apicurio.registry.cli.utils.Mapper.copy;
 import static io.apicurio.registry.cli.utils.Utils.isBlank;
 import static java.lang.System.err;
 import static java.lang.System.out;
@@ -24,13 +24,14 @@ import static java.lang.System.out;
 @ApplicationScoped
 public class Config {
 
-    /**
-     * Static reference for use by {@link AcrHomeConfigSource}, which is loaded via SPI
-     * before CDI is available. Commands should use {@code @Inject Config} instead.
-     */
+    public static final String ENV_ACR_CURRENT_HOME = "ACR_CURRENT_HOME";
+    public static final String ENV_ACR_HOME = "ACR_HOME";
+
+    // Loaded via SPI by AcrHomeConfigSource before CDI is available; commands should @Inject Config instead.
     static Config instance;
 
     private ConfigModel cachedConfig;
+    private boolean dirty;
 
     @Getter
     @Setter
@@ -39,9 +40,6 @@ public class Config {
     @Getter
     @Setter
     private Output stdErr = err::print;
-
-    @Setter
-    private Path acrCurrentHomePath;
 
     @ConfigProperty(name = "version")
     String cliVersion;
@@ -94,7 +92,7 @@ public class Config {
     }
 
     public Path getAcrHomePath() {
-        var home = getEnv("ACR_HOME");
+        var home = getEnv(ENV_ACR_HOME);
         if (isBlank(home)) {
             throw new CliException("ACR_HOME is not set. Please run the 'install' command first.", APPLICATION_ERROR_RETURN_CODE);
         }
@@ -107,22 +105,18 @@ public class Config {
     }
 
     public Path getAcrCurrentHomePath() {
-        if (acrCurrentHomePath != null) {
-            return acrCurrentHomePath;
-        } else {
-            var acrCurrentHome = System.getenv("ACR_CURRENT_HOME");
-            if (isBlank(acrCurrentHome)) {
-                throw new CliException("ACR_CURRENT_HOME environment variable is not set.", APPLICATION_ERROR_RETURN_CODE);
-            }
-            acrCurrentHomePath = Path.of(acrCurrentHome).normalize().toAbsolutePath();
+        var acrCurrentHome = getEnv(ENV_ACR_CURRENT_HOME);
+        if (isBlank(acrCurrentHome)) {
+            throw new CliException("ACR_CURRENT_HOME environment variable is not set.", APPLICATION_ERROR_RETURN_CODE);
         }
-        return acrCurrentHomePath;
+        return Path.of(acrCurrentHome).normalize().toAbsolutePath();
     }
 
     Path getConfigFilePath() {
         return getAcrCurrentHomePath().resolve("config.json");
     }
 
+    // Returns the live cache, not a defensive copy. Mutating it directly requires calling markDirty().
     public ConfigModel read() {
         if (cachedConfig == null) {
             var configPath = getConfigFilePath();
@@ -132,14 +126,81 @@ public class Config {
                 throw new CliException("Could not read config file '%s'.".formatted(configPath), ex, APPLICATION_ERROR_RETURN_CODE);
             }
         }
-        return copy(cachedConfig);
+        return cachedConfig;
     }
 
-    public void write(ConfigModel config) {
+    public String getProperty(final String key) {
+        return read().getConfig().get(key);
+    }
+
+    public boolean hasProperty(final String key) {
+        return read().getConfig().containsKey(key);
+    }
+
+    public void setProperty(final String key, final String value) {
+        read().getConfig().put(key, value);
+        markDirty();
+    }
+
+    public String removeProperty(final String key) {
+        var previous = read().getConfig().remove(key);
+        markDirty();
+        return previous;
+    }
+
+    public String getCurrentContext() {
+        return read().getCurrentContext();
+    }
+
+    public ConfigModel.Context getContext(final String name) {
+        return read().getContext().get(name);
+    }
+
+    public void setCurrentContext(final String name) {
+        read().setCurrentContext(name);
+        markDirty();
+    }
+
+    public void putContext(final String name, final ConfigModel.Context context) {
+        read().getContext().put(name, context);
+        markDirty();
+    }
+
+    public ConfigModel.Context removeContext(final String name) {
+        var removed = read().getContext().remove(name);
+        markDirty();
+        return removed;
+    }
+
+    public void clearContexts() {
+        read().getContext().clear();
+        markDirty();
+    }
+
+    // No-op (returns false) if no context with the given name exists.
+    public boolean updateContext(final String name, final Consumer<ConfigModel.Context> mutation) {
+        var context = read().getContext().get(name);
+        if (context == null) {
+            return false;
+        }
+        mutation.accept(context);
+        markDirty();
+        return true;
+    }
+
+    public void markDirty() {
+        dirty = true;
+    }
+
+    // Called once at the end of each command, from AbstractCommand.call().
+    public void flush() {
+        if (!dirty || cachedConfig == null) {
+            return;
+        }
         var configPath = getConfigFilePath();
         try {
-            Mapper.MAPPER.writeValue(configPath.toFile(), config);
-            cachedConfig = null;
+            Mapper.MAPPER.writeValue(configPath.toFile(), cachedConfig);
+            dirty = false;
         } catch (IOException ex) {
             throw new CliException("Could not write config file '%s'.".formatted(configPath), ex, APPLICATION_ERROR_RETURN_CODE);
         }
@@ -150,9 +211,9 @@ public class Config {
      */
     public void reset() {
         cachedConfig = null;
+        dirty = false;
         stdOut = out::print;
         stdErr = err::print;
-        acrCurrentHomePath = null;
         envOverrides.clear();
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigProperties.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigProperties.java
@@ -1,0 +1,23 @@
+package io.apicurio.registry.cli.config;
+
+// Keys for the properties stored in the "config" map of ConfigModel ($ACR_CURRENT_HOME/config.json).
+public final class ConfigProperties {
+
+    private ConfigProperties() {
+    }
+
+    // Hidden from the "acr config" listing.
+    public static final String INTERNAL_PREFIX = "internal.";
+
+    public static final String UPDATE_CHECK_ENABLED = "update.check-enabled";
+    public static final String UPDATE_TIMEOUT_SECONDS = "update.timeout-seconds";
+
+    public static final String INTERNAL_UPDATE_LAST_CHECK = INTERNAL_PREFIX + "update.last-check";
+    public static final String INTERNAL_UPDATE_POSTPONED_UNTIL = INTERNAL_PREFIX + "update.postponed-until";
+    public static final String INTERNAL_UPDATE_REPO_URL = INTERNAL_PREFIX + "update.repo-url";
+    public static final String INTERNAL_BRANDING_PRODUCT_NAME = INTERNAL_PREFIX + "branding.product-name";
+
+    public static boolean isInternal(final String key) {
+        return key != null && key.startsWith(INTERNAL_PREFIX);
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyCommand.java
@@ -19,8 +19,6 @@ import picocli.CommandLine.Mixin;
 )
 public class ConfigPropertyCommand extends AbstractCommand {
 
-    static final String INTERNAL_PREFIX = "internal.";
-
     @Mixin
     private ColumnsMixin columns;
 
@@ -30,7 +28,7 @@ public class ConfigPropertyCommand extends AbstractCommand {
             var table = new TableBuilder();
             table.addColumns("Property", "Value");
             config.read().getConfig().entrySet().stream()
-                    .filter(e -> !e.getKey().startsWith(INTERNAL_PREFIX))
+                    .filter(e -> !ConfigProperties.isInternal(e.getKey()))
                     .sorted(java.util.Map.Entry.comparingByKey())
                     .forEach(e -> table.addRow(e.getKey(), e.getValue()));
             table.setSelectedColumns(columns.getColumns());

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyDeleteCommand.java
@@ -24,7 +24,7 @@ public class ConfigPropertyDeleteCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
-        // Validate that every key exists before removing any, so the operation is atomic.
+        // Check all keys exist first so a missing one doesn't delete some and then fail.
         for (var key : keys) {
             if (!config.hasProperty(key)) {
                 throw new CliException("Property '" + key + "' is not set.", VALIDATION_ERROR_RETURN_CODE);

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyDeleteCommand.java
@@ -24,14 +24,13 @@ public class ConfigPropertyDeleteCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
-        var configModel = config.read();
+        // Validate that every key exists before removing any, so the operation is atomic.
         for (var key : keys) {
-            if (!configModel.getConfig().containsKey(key)) {
+            if (!config.hasProperty(key)) {
                 throw new CliException("Property '" + key + "' is not set.", VALIDATION_ERROR_RETURN_CODE);
             }
         }
-        keys.forEach(configModel.getConfig()::remove);
-        config.write(configModel);
+        keys.forEach(config::removeProperty);
         output.writeStdOutLine(keys.size() == 1 ? "Property deleted." : keys.size() + " properties deleted.");
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertyGetCommand.java
@@ -22,7 +22,7 @@ public class ConfigPropertyGetCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
-        var value = config.read().getConfig().get(key);
+        var value = config.getProperty(key);
         if (value == null) {
             throw new CliException("Property '" + key + "' is not set.", VALIDATION_ERROR_RETURN_CODE);
         }

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertySetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertySetCommand.java
@@ -3,7 +3,9 @@ package io.apicurio.registry.cli.config;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.utils.OutputBuffer;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
@@ -23,7 +25,9 @@ public class ConfigPropertySetCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
-        var configModel = config.read();
+        // Parse and validate every argument before applying any change so the operation is atomic:
+        // a malformed argument must not leave some properties already set.
+        final Map<String, String> parsed = new LinkedHashMap<>();
         for (var prop : properties) {
             var eqIndex = prop.indexOf('=');
             if (eqIndex < 1) {
@@ -31,9 +35,9 @@ public class ConfigPropertySetCommand extends AbstractCommand {
             }
             var key = prop.substring(0, eqIndex);
             var value = prop.substring(eqIndex + 1);
-            configModel.getConfig().put(key, value);
+            parsed.put(key, value);
         }
-        config.write(configModel);
+        parsed.forEach(config::setProperty);
         output.writeStdOutLine(properties.size() == 1 ? "Property set." : properties.size() + " properties set.");
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertySetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/ConfigPropertySetCommand.java
@@ -25,8 +25,7 @@ public class ConfigPropertySetCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
-        // Parse and validate every argument before applying any change so the operation is atomic:
-        // a malformed argument must not leave some properties already set.
+        // Parse all args first so a bad one doesn't leave some properties already set.
         final Map<String, String> parsed = new LinkedHashMap<>();
         for (var prop : properties) {
             var eqIndex = prop.indexOf('=');

--- a/cli/src/main/java/io/apicurio/registry/cli/context/ContextCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/context/ContextCreateCommand.java
@@ -46,25 +46,20 @@ public class ContextCreateCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
-        var configModel = config.read();
-        if (configModel.getContext().get(name) != null) {
+        if (config.getContext(name) != null) {
             throw new CliException("Context '" + name + "' already exists.", CliException.VALIDATION_ERROR_RETURN_CODE);
-        } else {
-            configModel.getContext().put(name, ConfigModel.Context.builder()
-                    .registryUrl(registryUrl)
-                    .groupId(groupId)
-                    .artifactId(artifactId)
-                    .build());
-            output.writeStdOutChunk(out -> {
-                if (!noSwitchCurrent) {
-                    configModel.setCurrentContext(name);
-                    out.append("Current context '").append(name).append("' added.");
-                } else {
-                    out.append("Context '").append(name).append("' added.");
-                }
-                out.append('\n');
-                config.write(configModel);
-            });
         }
+        config.putContext(name, ConfigModel.Context.builder()
+                .registryUrl(registryUrl)
+                .groupId(groupId)
+                .artifactId(artifactId)
+                .build());
+        if (!noSwitchCurrent) {
+            config.setCurrentContext(name);
+        }
+        output.writeStdOutChunk(out -> {
+            out.append(noSwitchCurrent ? "Context '" : "Current context '").append(name).append("' added.");
+            out.append('\n');
+        });
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/context/ContextDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/context/ContextDeleteCommand.java
@@ -32,8 +32,6 @@ public class ContextDeleteCommand extends AbstractCommand {
 
     @Override
     public void run(OutputBuffer output) throws Exception {
-        var configModel = config.read();
-
         if (all && name != null) {
             throw new CliException("Cannot specify both a context name and --all option.", VALIDATION_ERROR_RETURN_CODE);
         }
@@ -43,25 +41,23 @@ public class ContextDeleteCommand extends AbstractCommand {
 
         if (!all) {
             // Delete a specific context
-            if (!configModel.getContext().containsKey(name)) {
+            if (config.getContext(name) == null) {
                 throw new CliException("Context '" + name + "' does not exist.", VALIDATION_ERROR_RETURN_CODE);
             }
-            configModel.getContext().remove(name);
+            config.removeContext(name);
             // If the deleted context was the current context, clear it
-            if (name.equals(configModel.getCurrentContext())) {
-                configModel.setCurrentContext(null);
+            if (name.equals(config.getCurrentContext())) {
+                config.setCurrentContext(null);
             }
-            config.write(configModel);
             output.writeStdOutChunk(out -> out.append("Context '").append(name).append("' deleted.\n"));
         } else {
             // Delete all contexts
-            if (configModel.getContext().isEmpty()) {
+            var count = config.read().getContext().size();
+            if (count == 0) {
                 output.writeStdOutChunk(out -> out.append("No contexts to delete.\n"));
             } else {
-                int count = configModel.getContext().size();
-                configModel.getContext().clear();
-                configModel.setCurrentContext(null);
-                config.write(configModel);
+                config.clearContexts();
+                config.setCurrentContext(null);
                 output.writeStdOutChunk(out -> out.append("Deleted all ").append(count).append(" context(s).\n"));
             }
         }

--- a/cli/src/main/java/io/apicurio/registry/cli/context/ContextUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/context/ContextUpdateCommand.java
@@ -47,31 +47,30 @@ public class ContextUpdateCommand extends AbstractCommand {
             throw new CliException("At least one update option is required (--registry-url, --group, or --artifact).",
                     CliException.VALIDATION_ERROR_RETURN_CODE);
         }
-        final var configModel = config.read();
-        final var contextName = isBlank(name) ? configModel.getCurrentContext() : name;
+        final var contextName = isBlank(name) ? config.getCurrentContext() : name;
         if (isBlank(contextName)) {
             throw new CliException("No context specified and no current context is set.",
                     CliException.VALIDATION_ERROR_RETURN_CODE);
         }
-        final var context = configModel.getContext().get(contextName);
-        if (context == null) {
+        if (config.getContext(contextName) == null) {
             throw new CliException("Context '" + contextName + "' does not exist.",
                     CliException.VALIDATION_ERROR_RETURN_CODE);
         }
-        if (registryUrl != null) {
-            if (isBlank(registryUrl)) {
-                throw new CliException("Registry URL cannot be empty.",
-                        CliException.VALIDATION_ERROR_RETURN_CODE);
+        if (registryUrl != null && isBlank(registryUrl)) {
+            throw new CliException("Registry URL cannot be empty.",
+                    CliException.VALIDATION_ERROR_RETURN_CODE);
+        }
+        config.updateContext(contextName, context -> {
+            if (registryUrl != null) {
+                context.setRegistryUrl(registryUrl);
             }
-            context.setRegistryUrl(registryUrl);
-        }
-        if (groupId != null) {
-            context.setGroupId(groupId);
-        }
-        if (artifactId != null) {
-            context.setArtifactId(artifactId);
-        }
-        config.write(configModel);
+            if (groupId != null) {
+                context.setGroupId(groupId);
+            }
+            if (artifactId != null) {
+                context.setArtifactId(artifactId);
+            }
+        });
         output.writeStdOutChunk(out -> {
             out.append("Context '").append(contextName).append("' updated successfully.\n");
         });

--- a/cli/src/main/java/io/apicurio/registry/cli/context/ContextUseCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/context/ContextUseCommand.java
@@ -21,20 +21,18 @@ public class ContextUseCommand extends AbstractCommand {
 
     @Override
     public void run(final OutputBuffer output) throws Exception {
-        final var configModel = config.read();
-        if (!configModel.getContext().containsKey(name)) {
+        if (config.getContext(name) == null) {
             throw new CliException("Context '" + name + "' does not exist.",
                     CliException.VALIDATION_ERROR_RETURN_CODE);
         }
-        if (name.equals(configModel.getCurrentContext())) {
+        if (name.equals(config.getCurrentContext())) {
             output.writeStdOutChunk(out -> {
                 out.append("Context '").append(name).append("' is already the current context.\n");
             });
             return;
         }
-        final var previousContext = configModel.getCurrentContext();
-        configModel.setCurrentContext(name);
-        config.write(configModel);
+        final var previousContext = config.getCurrentContext();
+        config.setCurrentContext(name);
         output.writeStdOutChunk(out -> {
             out.append("Switched to context '").append(name).append("'");
             if (previousContext != null) {

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Update.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.cli.services;
 
 import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.config.Config;
+import io.apicurio.registry.cli.config.ConfigProperties;
 import io.apicurio.registry.cli.utils.PlatformUtils;
 import io.vertx.core.http.HttpMethod;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -40,7 +41,7 @@ public class Update {
 
     private int getTimeoutSeconds() {
         try {
-            var value = config.read().getConfig().get("update.timeout-seconds");
+            var value = config.getProperty(ConfigProperties.UPDATE_TIMEOUT_SECONDS);
             return value != null ? Integer.parseInt(value) : DEFAULT_TIMEOUT_SECONDS;
         } catch (Exception e) {
             return DEFAULT_TIMEOUT_SECONDS;
@@ -71,9 +72,7 @@ public class Update {
                 .sorted(CliVersion.COMPARATOR)
                 .collect(Collectors.toCollection(ArrayList::new));
 
-        var configModel = config.read();
-        configModel.getConfig().put("internal.update.last-check", Instant.now().toString());
-        config.write(configModel);
+        config.setProperty(ConfigProperties.INTERNAL_UPDATE_LAST_CHECK, Instant.now().toString());
 
         return new UpdateCheckResult(currentVersion, List.copyOf(parsed));
     }
@@ -141,7 +140,7 @@ public class Update {
     }
 
     private String getRepoUrl() {
-        String url = ConfigProvider.getConfig().getValue("internal.update.repo-url", String.class);
+        String url = ConfigProvider.getConfig().getValue(ConfigProperties.INTERNAL_UPDATE_REPO_URL, String.class);
         if (url == null || url.isBlank()) {
             throw new CliException("Update repository URL is not configured.");
         }

--- a/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
@@ -53,14 +53,12 @@ public class UpdateNotifier {
 
     private boolean shouldCheck() {
         try {
-            var props = config.read().getConfig();
-
-            if ("false".equalsIgnoreCase(props.get(ConfigProperties.UPDATE_CHECK_ENABLED))) {
+            if ("false".equalsIgnoreCase(config.getProperty(ConfigProperties.UPDATE_CHECK_ENABLED))) {
                 log.debugf("Update check skipped: update.check-enabled=false");
                 return false;
             }
 
-            var postponedUntil = props.get(ConfigProperties.INTERNAL_UPDATE_POSTPONED_UNTIL);
+            var postponedUntil = config.getProperty(ConfigProperties.INTERNAL_UPDATE_POSTPONED_UNTIL);
             if (postponedUntil != null) {
                 var until = Instant.parse(postponedUntil);
                 if (Instant.now().isBefore(until)) {
@@ -69,7 +67,7 @@ public class UpdateNotifier {
                 }
             }
 
-            var lastCheck = props.get(ConfigProperties.INTERNAL_UPDATE_LAST_CHECK);
+            var lastCheck = config.getProperty(ConfigProperties.INTERNAL_UPDATE_LAST_CHECK);
             if (lastCheck != null) {
                 var last = Instant.parse(lastCheck);
                 var elapsed = Duration.between(last, Instant.now());

--- a/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli.services;
 
 import io.apicurio.registry.cli.config.Config;
+import io.apicurio.registry.cli.config.ConfigProperties;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Duration;
@@ -52,15 +53,14 @@ public class UpdateNotifier {
 
     private boolean shouldCheck() {
         try {
-            var configModel = config.read();
-            var props = configModel.getConfig();
+            var props = config.read().getConfig();
 
-            if ("false".equalsIgnoreCase(props.get("update.check-enabled"))) {
+            if ("false".equalsIgnoreCase(props.get(ConfigProperties.UPDATE_CHECK_ENABLED))) {
                 log.debugf("Update check skipped: update.check-enabled=false");
                 return false;
             }
 
-            var postponedUntil = props.get("internal.update.postponed-until");
+            var postponedUntil = props.get(ConfigProperties.INTERNAL_UPDATE_POSTPONED_UNTIL);
             if (postponedUntil != null) {
                 var until = Instant.parse(postponedUntil);
                 if (Instant.now().isBefore(until)) {
@@ -69,7 +69,7 @@ public class UpdateNotifier {
                 }
             }
 
-            var lastCheck = props.get("internal.update.last-check");
+            var lastCheck = props.get(ConfigProperties.INTERNAL_UPDATE_LAST_CHECK);
             if (lastCheck != null) {
                 var last = Instant.parse(lastCheck);
                 var elapsed = Duration.between(last, Instant.now());
@@ -102,7 +102,7 @@ public class UpdateNotifier {
 
     private String getProductName() {
         try {
-            var name = config.read().getConfig().get("internal.branding.product-name");
+            var name = config.getProperty(ConfigProperties.INTERNAL_BRANDING_PRODUCT_NAME);
             return name != null ? name : "Apicurio Registry CLI";
         } catch (Exception e) {
             return "Apicurio Registry CLI";

--- a/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
@@ -87,7 +87,7 @@ public abstract class AbstractCLITest {
         if (!Files.exists(acrHome)) {
             throw new RuntimeException("Test resource 'acr-home' does not exist");
         }
-        // Start each test from a clean cache: read() now keeps a live cache across commands.
+        // Config caches state across commands, so clear it between tests.
         config.reset();
         config.setEnvOverride(Config.ENV_ACR_CURRENT_HOME, acrHome.toString());
 

--- a/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/AbstractCLITest.java
@@ -87,7 +87,9 @@ public abstract class AbstractCLITest {
         if (!Files.exists(acrHome)) {
             throw new RuntimeException("Test resource 'acr-home' does not exist");
         }
-        config.setAcrCurrentHomePath(acrHome);
+        // Start each test from a clean cache: read() now keeps a live cache across commands.
+        config.reset();
+        config.setEnvOverride(Config.ENV_ACR_CURRENT_HOME, acrHome.toString());
 
         client.reset();
         cmd = createCLI();

--- a/cli/src/test/java/io/apicurio/registry/cli/ConfigPropertyCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ConfigPropertyCommandTest.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli;
 
 import io.apicurio.registry.cli.config.Config;
+import io.apicurio.registry.cli.config.ConfigProperties;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.AfterEach;
@@ -34,9 +35,8 @@ public class ConfigPropertyCommandTest {
                                 .getResource("acr-home")
                                 .getPath())
                 .normalize();
-        config.setAcrCurrentHomePath(acrHome);
         config.reset();
-        config.setAcrCurrentHomePath(acrHome);
+        config.setEnvOverride(Config.ENV_ACR_CURRENT_HOME, acrHome.toString());
 
         cmd = new CommandLine(new Acr(), factory);
         out = new StringWriter();
@@ -71,9 +71,7 @@ public class ConfigPropertyCommandTest {
     @Test
     public void testConfigListHidesInternalProperties() {
         // Set an internal property
-        var configModel = config.read();
-        configModel.getConfig().put("internal.update.last-check", "2026-01-01T00:00:00Z");
-        config.write(configModel);
+        config.setProperty(ConfigProperties.INTERNAL_UPDATE_LAST_CHECK, "2026-01-01T00:00:00Z");
 
         int exitCode = cmd.execute("config");
         assertThat(exitCode).isEqualTo(0);
@@ -102,8 +100,7 @@ public class ConfigPropertyCommandTest {
         assertThat(out.toString()).contains("Property set");
 
         // Verify it was persisted
-        var configModel = config.read();
-        assertThat(configModel.getConfig().get("test.property")).isEqualTo("test-value");
+        assertThat(config.getProperty("test.property")).isEqualTo("test-value");
     }
 
     @Test
@@ -112,9 +109,8 @@ public class ConfigPropertyCommandTest {
         assertThat(exitCode).isEqualTo(0);
         assertThat(out.toString()).contains("2 properties set");
 
-        var configModel = config.read();
-        assertThat(configModel.getConfig().get("key1")).isEqualTo("value1");
-        assertThat(configModel.getConfig().get("key2")).isEqualTo("value2");
+        assertThat(config.getProperty("key1")).isEqualTo("value1");
+        assertThat(config.getProperty("key2")).isEqualTo("value2");
     }
 
     @Test
@@ -136,8 +132,7 @@ public class ConfigPropertyCommandTest {
         assertThat(exitCode).isEqualTo(0);
         assertThat(out.toString()).contains("Property deleted");
 
-        var configModel = config.read();
-        assertThat(configModel.getConfig().containsKey("to-delete")).isFalse();
+        assertThat(config.hasProperty("to-delete")).isFalse();
     }
 
     @Test

--- a/cli/src/test/java/io/apicurio/registry/cli/ConfigTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ConfigTest.java
@@ -1,0 +1,175 @@
+package io.apicurio.registry.cli;
+
+import io.apicurio.registry.cli.config.Config;
+import io.apicurio.registry.cli.config.ConfigModel;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+public class ConfigTest {
+
+    @Inject
+    Config config;
+
+    private Path homeDir;
+    private Path configFile;
+
+    @BeforeEach
+    public void setUp(@TempDir Path tempDir) throws IOException {
+        homeDir = tempDir;
+        configFile = tempDir.resolve("config.json");
+        Files.writeString(configFile, """
+                {
+                  "installation-version": 1,
+                  "config": {
+                    "a": "1",
+                    "update.check-enabled": "false"
+                  },
+                  "context": {}
+                }
+                """);
+
+        config.reset();
+        config.setEnvOverride(Config.ENV_ACR_CURRENT_HOME, homeDir.toString());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        config.reset();
+    }
+
+    @Test
+    public void testGetAcrCurrentHomePathUsesEnvOverride() {
+        assertThat(config.getAcrCurrentHomePath())
+                .isEqualTo(homeDir.normalize().toAbsolutePath());
+    }
+
+    @Test
+    public void testReadReturnsLiveCacheNotDefensiveCopy() {
+        var first = config.read();
+        var second = config.read();
+        assertThat(second).isSameAs(first);
+
+        first.getConfig().put("live", "yes");
+        assertThat(config.read().getConfig()).containsEntry("live", "yes");
+    }
+
+    @Test
+    public void testGetProperty() {
+        assertThat(config.getProperty("a")).isEqualTo("1");
+        assertThat(config.getProperty("missing")).isNull();
+    }
+
+    @Test
+    public void testHasProperty() {
+        assertThat(config.hasProperty("a")).isTrue();
+        assertThat(config.hasProperty("missing")).isFalse();
+    }
+
+    @Test
+    public void testSetPropertyPersistsOnlyAfterFlush() throws IOException {
+        config.setProperty("b", "2");
+
+        assertThat(config.getProperty("b")).isEqualTo("2");
+        assertThat(Files.readString(configFile)).doesNotContain("\"b\"");
+
+        config.flush();
+        assertThat(Files.readString(configFile)).contains("\"b\"").contains("\"2\"");
+    }
+
+    @Test
+    public void testRemovePropertyReturnsPreviousValueAndPersistsOnFlush() throws IOException {
+        assertThat(config.removeProperty("a")).isEqualTo("1");
+        assertThat(config.hasProperty("a")).isFalse();
+        assertThat(config.removeProperty("missing")).isNull();
+
+        config.flush();
+        assertThat(Files.readString(configFile)).doesNotContain("\"a\"");
+    }
+
+    @Test
+    public void testFlushIsNoOpWhenNotDirty() throws IOException {
+        config.read();
+        Files.delete(configFile);
+
+        config.flush();
+        assertThat(Files.exists(configFile)).isFalse();
+    }
+
+    @Test
+    public void testFlushClearsDirtyFlag() throws IOException {
+        config.setProperty("c", "3");
+        config.flush();
+        assertThat(Files.readString(configFile)).contains("\"c\"");
+
+        Files.delete(configFile);
+        config.flush();
+        assertThat(Files.exists(configFile)).isFalse();
+    }
+
+    @Test
+    public void testMarkDirtyCausesStructuralChangesToPersist() throws IOException {
+        config.read().setCurrentContext("ctx-1");
+        config.markDirty();
+        config.flush();
+
+        assertThat(Files.readString(configFile)).contains("ctx-1");
+    }
+
+    @Test
+    public void testPutGetAndSetCurrentContext() throws IOException {
+        assertThat(config.getContext("dev")).isNull();
+
+        config.putContext("dev", ConfigModel.Context.builder().registryUrl("http://dev").build());
+        config.setCurrentContext("dev");
+
+        assertThat(config.getContext("dev").getRegistryUrl()).isEqualTo("http://dev");
+        assertThat(config.getCurrentContext()).isEqualTo("dev");
+
+        config.flush();
+        assertThat(Files.readString(configFile)).contains("http://dev").contains("dev");
+    }
+
+    @Test
+    public void testUpdateContextAppliesMutationWhenPresent() {
+        config.putContext("dev", ConfigModel.Context.builder().registryUrl("http://dev").build());
+
+        var applied = config.updateContext("dev", ctx -> ctx.setGroupId("g1"));
+
+        assertThat(applied).isTrue();
+        assertThat(config.getContext("dev").getGroupId()).isEqualTo("g1");
+    }
+
+    @Test
+    public void testUpdateContextIsNoOpWhenAbsent() {
+        var applied = config.updateContext("missing", ctx -> ctx.setGroupId("g1"));
+
+        assertThat(applied).isFalse();
+        assertThat(config.getContext("missing")).isNull();
+    }
+
+    @Test
+    public void testRemoveContextReturnsRemovedAndClearContextsEmptiesAll() {
+        config.putContext("dev", ConfigModel.Context.builder().registryUrl("http://dev").build());
+        config.putContext("prod", ConfigModel.Context.builder().registryUrl("http://prod").build());
+
+        var removed = config.removeContext("dev");
+        assertThat(removed).isNotNull();
+        assertThat(removed.getRegistryUrl()).isEqualTo("http://dev");
+        assertThat(config.getContext("dev")).isNull();
+        assertThat(config.getContext("prod")).isNotNull();
+
+        config.clearContexts();
+        assertThat(config.read().getContext()).isEmpty();
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/ConfigTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ConfigTest.java
@@ -98,6 +98,17 @@ public class ConfigTest {
     }
 
     @Test
+    public void testIsDirtyReflectsPendingChanges() throws IOException {
+        assertThat(config.isDirty()).isFalse();
+
+        config.setProperty("b", "2");
+        assertThat(config.isDirty()).isTrue();
+
+        config.flush();
+        assertThat(config.isDirty()).isFalse();
+    }
+
+    @Test
     public void testFlushIsNoOpWhenNotDirty() throws IOException {
         config.read();
         Files.delete(configFile);

--- a/cli/src/test/java/io/apicurio/registry/cli/InstallCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/InstallCommandTest.java
@@ -74,7 +74,7 @@ public class InstallCommandTest {
         Files.writeString(acrHome.resolve(CONFIG_JSON), "{}");
 
         // Set up config to point to our test acr-home
-        config.setAcrCurrentHomePath(acrHome);
+        config.setEnvOverride(Config.ENV_ACR_CURRENT_HOME, acrHome.toString());
 
         // Set up environment variable overrides for testing
         config.setEnvOverride(ENV_HOME, userHome.toString());

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -364,7 +364,7 @@ The following {registry} configuration options are available for each component 
 |`boolean`
 |`true`
 |`3.2.0`
-|Provide higher quality ETags if possible, but they might be more expensive to compute. This feature trades more computation for potentially higher cacheability of some operations. 
+|Provide higher quality ETags if possible, but they might be more expensive to compute. This feature trades more computation for potentially higher cacheability of some operations.
 |`apicurio.http-caching.low-cacheability.max-age-seconds`
 |`long`
 |`10`
@@ -630,17 +630,17 @@ The following {registry} configuration options are available for each component 
 |`boolean`
 |`true`
 |`3.0.0`
-|When set to true, content IDs from the import file will be used (otherwise new IDs will be generated).  Defaults to 'true'.
+|When set to true, content IDs from the import file will be used (otherwise new IDs will be generated). Defaults to 'true'.
 |`apicurio.import.preserveGlobalId`
 |`boolean`
 |`true`
 |`3.0.0`
-|When set to true, global IDs from the import file will be used (otherwise new IDs will be generated).  Defaults to 'true'.
+|When set to true, global IDs from the import file will be used (otherwise new IDs will be generated). Defaults to 'true'.
 |`apicurio.import.requireEmptyRegistry`
 |`boolean`
 |`true`
 |`3.0.0`
-|When set to true, importing data will only work when the registry is empty.  Defaults to 'true'.
+|When set to true, importing data will only work when the registry is empty. Defaults to 'true'.
 |`apicurio.import.url`
 |`optional<url>`
 |
@@ -820,55 +820,48 @@ The following {registry} configuration options are available for each component 
 |`list<double>`
 |`0.5,0.95,0.99,0.9995`
 |`3.3.1`
-|        Comma-separated list of percentile values to pre-compute         for REST API request metrics.         Each value must be between 0.0 and 1.0 (e.g. 0.5 for the median,         0.95 for the 95th percentile).         These percentiles are computed client-side and exported as individual gauge metrics.
-
+|Comma-separated list of percentile values to pre-compute for REST API request metrics. Each value must be between 0.0 and 1.0 (e.g. 0.5 for the median, 0.95 for the 95th percentile). These percentiles are computed client-side and exported as individual gauge metrics.
 |`apicurio.metrics.rest.distribution.slo`
 |`list<double>`
 |`0.1,0.25,0.5,1.0,2.0,5.0,10.0`
 |`3.3.1`
-|        Comma-separated list of service level objective (SLO) boundary values         in seconds for REST API request histogram buckets.         Only used when the distribution type is `histogram`.         Each value defines a histogram bucket boundary.         Adjust these boundaries to match your monitoring system's expectations         for accurate percentile computation from histogram data.
-
+|Comma-separated list of service level objective (SLO) boundary values in seconds for REST API request histogram buckets. Only used when the distribution type is `histogram`. Each value defines a histogram bucket boundary. Adjust these boundaries to match your monitoring system's expectations for accurate percentile computation from histogram data.
 |`apicurio.metrics.rest.distribution.type`
 |`string`
 |`histogram`
 |`3.3.1`
-|        The distribution type for REST API request metrics.         Use `histogram` (default) for explicit bucket histogram with SLO boundaries         and pre-computed percentiles.         Use `summary` for pre-computed percentiles only, without histogram buckets.         Datadog users should use `summary` for accurate latency percentiles,         since Datadog re-computes percentiles from histogram buckets         and the default bucket boundaries may not provide sufficient granularity.
-
+|The distribution type for REST API request metrics. Use `histogram` (default) for explicit bucket histogram with SLO boundaries and pre-computed percentiles. Use `summary` for pre-computed percentiles only, without histogram buckets. Datadog users should use `summary` for accurate latency percentiles, since Datadog re-computes percentiles from histogram buckets and the default bucket boundaries may not provide sufficient granularity.
 |`apicurio.metrics.rest.enabled`
 |`boolean`
 |`true`
 |`3.1.1`
-|        Enable collecting metrics about REST API requests.
-
+|Enable collecting metrics about REST API requests.
 |`apicurio.metrics.rest.explicit-status-codes-list`
 |`list<string>`
 |`401`
 |`3.1.1`
-|        Only the general category of the HTTP status code is added as a tag/label on REST API request metrics,
-        e.g. `1xx`, `2xx`, ...         If you are interested in metrics for a specific status code, e.g. 401 for authentication errors,
-        this property allows you to specify a list of such codes.         Each request will be counted only once, i.e. either as the specific status code or in the general category. 
+|Only the general category of the HTTP status code is added as a tag/label on REST API request metrics,
+        e.g. `1xx`, `2xx`, ... If you are interested in metrics for a specific status code, e.g. 401 for authentication errors,
+        this property allows you to specify a list of such codes. Each request will be counted only once, i.e. either as the specific status code or in the general category.
 |`apicurio.metrics.rest.method-tag-enabled`
 |`boolean`
 |`true`
 |`3.1.1`
-|        Add the HTTP method tag/label on REST API request metrics.         You might disable this tag to reduce metrics cardinality.
-
+|Add the HTTP method tag/label on REST API request metrics. You might disable this tag to reduce metrics cardinality.
 |`apicurio.metrics.rest.path-filter-pattern`
 |`string`
 |`/apis/.*`
 |`3.1.1`
-|        Only requests with a path matching this pattern (Java syntax) will be considered for metrics collection.         The pattern is applied to the request path only,
+|Only requests with a path matching this pattern (Java syntax) will be considered for metrics collection. The pattern is applied to the request path only,
         e.g. `curl 'http://localhost:8080/apis/registry/v3/groups/default/artifacts?offset=42&limit=10'`
         will be matched against `/apis/registry/v3/groups/default/artifacts`.
-
 |`apicurio.metrics.rest.path-tag-enabled`
 |`boolean`
 |`true`
 |`3.1.1`
-|        Add the unsubstituted path tag/label on REST API request metrics,
-        e.g. `/apis/registry/v3/groups/{groupId}/artifacts/{artifactId}`.         You might disable this tag to reduce metrics cardinality.         When an unsubstituted REST API resource path could not be determined,
+|Add the unsubstituted path tag/label on REST API request metrics,
+        e.g. `/apis/registry/v3/groups/{groupId}/artifacts/{artifactId}`. You might disable this tag to reduce metrics cardinality. When an unsubstituted REST API resource path could not be determined,
         the tag value will be `(unspecified)`.
-
 |`quarkus.otel.enabled`
 |`boolean`
 |`true`


### PR DESCRIPTION
Closes #8030

## Description

The old `Config.read()`/`write()` pattern meant every command had to pull the
whole model, mutate the map by hand, and write it back. Easy to forget, easy
to get wrong.

## What changed

- Added direct accessors instead of read-mutate-write:
  - `getProperty` / `setProperty` / `removeProperty` / `hasProperty` for config values
  - `getContext` / `putContext` / `removeContext` / `clearContexts` / `setCurrentContext` / `updateContext` for contexts
- `read()` now returns the live in-memory cache instead of a defensive copy
- Config is flushed to disk **once**, automatically, at the end of each command so commands no longer call `write()` themselves
- `getAcrCurrentHomePath()` resolves through the same env-override path as everything else instead of keeping its own setter
- Added `ConfigProperties`, a constants class replacing scattered string literals for config keys

`config set` / `delete` still validate every argument before applying any
change, so a bad key in a batch doesn't leave things half-updated.

## Testing

- Added `ConfigTest.java` covering the caching, dirty-tracking, and flush behavior directly
- Existing CLI test suite updated to the new API (`AbstractCLITest`, `ConfigPropertyCommandTest`, `InstallCommandTest`)
