### PR TITLE
feat(a2a): add full-text search for agent discovery

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -188,14 +188,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
         Set<SearchFilter> filters = new HashSet<>();
         filters.add(SearchFilter.ofArtifactType(ArtifactType.AGENT_CARD));
 
-        // Query matches artifact metadata name and artifactId (not Agent Card JSON content).
-        // Full-text content search is tracked in #7230.
         if (!StringUtil.isEmpty(request.getQuery())) {
-            String q = request.getQuery().trim();
-            if (!q.contains("*")) {
-                q = "*" + q + "*";
-            }
-            filters.add(SearchFilter.ofName(q));
+            filters.add(SearchFilter.ofContent(request.getQuery().trim()));
         }
 
         AgentSearchFilters f = request.getFilters();
@@ -327,9 +321,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
         // Always filter by AGENT_CARD artifact type
         filters.add(SearchFilter.ofArtifactType(ArtifactType.AGENT_CARD));
 
-        // Filter by name if provided
         if (!StringUtil.isEmpty(name)) {
-            filters.add(SearchFilter.ofName(name));
+            filters.add(SearchFilter.ofContent(name));
         }
 
         // Filter by skills (indexed as structured content: agent_card:skill:<id>)

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/PostgreSQLSqlStatements.java
@@ -100,4 +100,21 @@ public class PostgreSQLSqlStatements extends CommonSqlStatements {
         return "SELECT CASE WHEN pg_advisory_unlock(1886352239) THEN 1 ELSE 0 END";
     }
 
+    @Override
+    public String fullTextSearchClause() {
+        return """
+                (to_tsvector('english', COALESCE(a.name, '') || ' ' || COALESCE(a.description, '')) \
+                @@ websearch_to_tsquery('english', ?) \
+                OR EXISTS ( \
+                SELECT 1 FROM versions fts_v JOIN content fts_c ON fts_c.contentId = fts_v.contentId \
+                WHERE fts_v.groupId = a.groupId AND fts_v.artifactId = a.artifactId \
+                AND to_tsvector('english', convert_from(fts_c.content, 'UTF8')) \
+                @@ websearch_to_tsquery('english', ?)))""";
+    }
+
+    @Override
+    public boolean supportsNativeFullTextSearch() {
+        return true;
+    }
+
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -850,4 +850,12 @@ public interface SqlStatements {
     String selectContractAuditLogCount();
 
     String deleteAllContractAuditEntries();
+
+    default String fullTextSearchClause() {
+        return "LOWER(COALESCE(a.name, '') || ' ' || COALESCE(a.description, '')) LIKE LOWER(?)";
+    }
+
+    default boolean supportsNativeFullTextSearch() {
+        return false;
+    }
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
@@ -8,7 +8,6 @@ import io.apicurio.registry.storage.dto.SearchFilter;
 import io.apicurio.registry.storage.dto.SearchedArtifactDto;
 import io.apicurio.registry.storage.dto.SearchedVersionDto;
 import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
-import io.apicurio.registry.storage.error.ContentSearchNotSupportedException;
 import io.apicurio.registry.storage.error.RegistryStorageException;
 import io.apicurio.registry.storage.impl.sql.HandleFactory;
 import io.apicurio.registry.storage.impl.sql.SqlStatements;
@@ -32,10 +31,6 @@ import static io.apicurio.registry.storage.impl.sql.RegistryContentUtils.normali
  * Extracted from AbstractSqlRegistryStorage to improve maintainability.
  */
 public class SqlSearchRepository {
-
-    private static final String CONTENT_SEARCH_UNSUPPORTED_MESSAGE =
-            "Content search requires the search index, which is not enabled. "
-            + "Enable the search index to use content search.";
 
     private final Logger log;
 
@@ -166,7 +161,16 @@ public class SqlSearchRepository {
                         where.append(")");
                         break;
                     case content:
-                        throw new ContentSearchNotSupportedException(CONTENT_SEARCH_UNSUPPORTED_MESSAGE);
+                        where.append(sqlStatements.fullTextSearchClause());
+                        String artContentSearch = filter.getStringValue();
+                        if (sqlStatements.supportsNativeFullTextSearch()) {
+                            binders.add((query, idx) -> query.bind(idx, artContentSearch));
+                            binders.add((query, idx) -> query.bind(idx, artContentSearch));
+                        } else {
+                            binders.add((query, idx) -> query.bind(idx,
+                                    "%" + artContentSearch + "%"));
+                        }
+                        break;
                     default:
                         throw new RegistryStorageException("Filter type not supported: " + filter.getType());
                 }
@@ -334,7 +338,16 @@ public class SqlSearchRepository {
                         where.append(")");
                         break;
                     case content:
-                        throw new ContentSearchNotSupportedException(CONTENT_SEARCH_UNSUPPORTED_MESSAGE);
+                        where.append(sqlStatements.fullTextSearchClause());
+                        String verContentSearch = filter.getStringValue();
+                        if (sqlStatements.supportsNativeFullTextSearch()) {
+                            binders.add((query, idx) -> query.bind(idx, verContentSearch));
+                            binders.add((query, idx) -> query.bind(idx, verContentSearch));
+                        } else {
+                            binders.add((query, idx) -> query.bind(idx,
+                                    "%" + verContentSearch + "%"));
+                        }
+                        break;
                     default:
                         throw new RegistryStorageException("Filter type not supported: " + filter.getType());
                 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -387,14 +387,14 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
     }
 
     @Test
-    public void testSearchAgentsAdvancedWithQueryByArtifactId() throws Exception {
+    public void testSearchAgentsAdvancedWithQueryByName() throws Exception {
         String groupId = TestUtils.generateGroupId();
 
-        createAgentCard(groupId, "my-search-target", AGENT_CARD_CONTENT);
+        createAgentCard(groupId, "query-name-agent", AGENT_CARD_CONTENT);
 
         String requestBody = """
                 {
-                    "query": "my-search-target",
+                    "query": "TestAgent",
                     "limit": 10,
                     "offset": 0
                 }
@@ -408,7 +408,56 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200)
                 .body("count", greaterThanOrEqualTo(1))
-                .body("agents.artifactId", hasItem("my-search-target"));
+                .body("agents.artifactId", hasItem("query-name-agent"));
+    }
+
+    @Test
+    public void testSearchAgentsAdvancedByDescription() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        createAgentCard(groupId, "desc-search-agent", STREAMING_AGENT_CARD);
+
+        String requestBody = """
+                {
+                    "query": "streaming capabilities",
+                    "limit": 10,
+                    "offset": 0
+                }
+                """;
+
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents.artifactId", hasItem("desc-search-agent"));
+    }
+
+    @Test
+    public void testSearchAgentsAdvancedNoMatch() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        createAgentCard(groupId, "no-match-agent", AGENT_CARD_CONTENT);
+
+        String requestBody = """
+                {
+                    "query": "xyznonexistent",
+                    "limit": 10,
+                    "offset": 0
+                }
+                """;
+
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", not(hasItem("no-match-agent")));
     }
 
     @Test
@@ -445,13 +494,13 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
     }
 
     @Test
-    public void testSearchAgentsAdvancedWithQueryWildcard() throws Exception {
+    public void testSearchAgentsAdvancedWithPartialQuery() throws Exception {
         String groupId = TestUtils.generateGroupId();
-        createAgentCard(groupId, "wildcard-target-agent", AGENT_CARD_CONTENT);
+        createAgentCard(groupId, "partial-query-agent", AGENT_CARD_CONTENT);
 
         String requestBody = """
                 {
-                    "query": "*wildcard-target*",
+                    "query": "test",
                     "limit": 10,
                     "offset": 0
                 }
@@ -465,7 +514,7 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200)
                 .body("count", greaterThanOrEqualTo(1))
-                .body("agents.artifactId", hasItem("wildcard-target-agent"));
+                .body("agents.artifactId", hasItem("partial-query-agent"));
     }
 
     @Test
@@ -539,6 +588,19 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
         CreateArtifact createArtifact = new CreateArtifact();
         createArtifact.setArtifactId(artifactId);
         createArtifact.setArtifactType(ArtifactType.AGENT_CARD);
+
+        try {
+            com.fasterxml.jackson.databind.JsonNode root = new com.fasterxml.jackson.databind.ObjectMapper()
+                    .readTree(content);
+            if (root.has("name")) {
+                createArtifact.setName(root.get("name").asText());
+            }
+            if (root.has("description")) {
+                createArtifact.setDescription(root.get("description").asText());
+            }
+        } catch (Exception e) {
+            // ignore parse failures in tests
+        }
 
         CreateVersion createVersion = new CreateVersion();
         VersionContent versionContent = new VersionContent();

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchVersionsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SearchVersionsTest.java
@@ -16,10 +16,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.containsStringIgnoringCase;
-import static org.hamcrest.Matchers.not;
 
 @QuarkusTest
 public class SearchVersionsTest extends AbstractResourceTestBase {
@@ -353,31 +349,24 @@ public class SearchVersionsTest extends AbstractResourceTestBase {
     }
 
     @Test
-    public void testSearchVersionsByContentFilterWithoutIndexIsBadRequest() throws Exception {
-        // The 'content' filter is served only by the Elasticsearch search index. With the index
-        // disabled (the default), it must return a 400 (client error) with a clear message, not a
-        // 500 that leaks the underlying SQL statement.
+    public void testSearchVersionsByContentFilterWithoutIndex() throws Exception {
+        // Content search is handled natively by SQL (full-text search on PostgreSQL,
+        // ILIKE fallback on other databases) even without the Elasticsearch index.
         given().when()
                 .queryParam("content", "anything")
                 .get("/registry/v3/search/versions")
                 .then()
-                .statusCode(400)
-                .body("detail", allOf(containsString("search index"),
-                        not(containsStringIgnoringCase("select"))));
+                .statusCode(200);
     }
 
     @Test
-    public void testSearchVersionsByContentFilterWithOtherFiltersIsBadRequest() throws Exception {
-        // The content filter must be rejected even when combined with other valid filters, so the
-        // exception is thrown regardless of which other filters are present in the request.
+    public void testSearchVersionsByContentFilterWithOtherFilters() throws Exception {
         given().when()
                 .queryParam("groupId", "some-group")
                 .queryParam("content", "anything")
                 .get("/registry/v3/search/versions")
                 .then()
-                .statusCode(400)
-                .body("detail", allOf(containsString("search index"),
-                        not(containsStringIgnoringCase("select"))));
+                .statusCode(200);
     }
 
     @Test

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AgentSearchIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AgentSearchIT.java
@@ -1,0 +1,219 @@
+package io.apicurio.tests.smokeTests.apicurio;
+
+import static io.apicurio.deployment.Constants.SMOKE;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.apicurio.tests.ApicurioRegistryBaseIT;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for agent full-text search. Exercises the PostgreSQL tsvector/tsquery path
+ * when running against a real PostgreSQL instance.
+ */
+@Tag(SMOKE)
+@QuarkusIntegrationTest
+class AgentSearchIT extends ApicurioRegistryBaseIT {
+
+    private static final String SENTIMENT_AGENT = """
+            {
+                "name": "SentimentAnalyzer",
+                "description": "Analyzes customer feedback to determine emotional tone and satisfaction levels",
+                "version": "1.0.0",
+                "supportedInterfaces": [
+                    { "url": "https://example.com/sentiment", "protocolBinding": "http+json", "protocolVersion": "1.0" }
+                ],
+                "capabilities": { "streaming": false, "pushNotifications": false },
+                "skills": [
+                    { "id": "sentiment-analysis", "name": "Sentiment Analysis", "description": "Detect emotions in text", "tags": ["nlp", "emotions"] },
+                    { "id": "satisfaction-scoring", "name": "Satisfaction Scoring", "description": "Score customer satisfaction", "tags": ["metrics"] }
+                ],
+                "defaultInputModes": ["text"],
+                "defaultOutputModes": ["text"]
+            }
+            """;
+
+    private static final String TRANSLATOR_AGENT = """
+            {
+                "name": "TranslatorBot",
+                "description": "Translates text between languages with high accuracy",
+                "version": "2.0.0",
+                "supportedInterfaces": [
+                    { "url": "https://example.com/translator", "protocolBinding": "http+json", "protocolVersion": "1.0" }
+                ],
+                "capabilities": { "streaming": true, "pushNotifications": false },
+                "skills": [
+                    { "id": "translate", "name": "Language Translation", "description": "Translate text between languages", "tags": ["translation", "i18n"] },
+                    { "id": "detect-language", "name": "Language Detection", "description": "Detect input language", "tags": ["detection"] }
+                ],
+                "defaultInputModes": ["text"],
+                "defaultOutputModes": ["text"]
+            }
+            """;
+
+    @Test
+    @Tag("acceptance")
+    void testSearchByAgentName() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        createAgentCard(groupId, "name-search-agent", SENTIMENT_AGENT);
+
+        given()
+                .baseUri(getRegistryBaseUrl())
+                .contentType(ContentType.JSON)
+                .body("""
+                        { "query": "SentimentAnalyzer", "limit": 10, "offset": 0 }
+                        """)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents.artifactId", hasItem("name-search-agent"));
+    }
+
+    @Test
+    @Tag("acceptance")
+    void testSearchByDescription() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        createAgentCard(groupId, "desc-search-agent", SENTIMENT_AGENT);
+
+        given()
+                .baseUri(getRegistryBaseUrl())
+                .contentType(ContentType.JSON)
+                .body("""
+                        { "query": "customer feedback", "limit": 10, "offset": 0 }
+                        """)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents.artifactId", hasItem("desc-search-agent"));
+    }
+
+    @Test
+    @Tag("acceptance")
+    void testSearchByDescriptionWords() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        createAgentCard(groupId, "desc-words-agent", TRANSLATOR_AGENT);
+
+        given()
+                .baseUri(getRegistryBaseUrl())
+                .contentType(ContentType.JSON)
+                .body("""
+                        { "query": "translates languages", "limit": 10, "offset": 0 }
+                        """)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents.artifactId", hasItem("desc-words-agent"));
+    }
+
+    @Test
+    void testSearchNoMatch() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        createAgentCard(groupId, "no-match-it-agent", SENTIMENT_AGENT);
+
+        given()
+                .baseUri(getRegistryBaseUrl())
+                .contentType(ContentType.JSON)
+                .body("""
+                        { "query": "xyznonexistentterm", "limit": 10, "offset": 0 }
+                        """)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", not(hasItem("no-match-it-agent")));
+    }
+
+    @Test
+    void testSearchDistinguishesAgents() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        createAgentCard(groupId, "sentiment-it-agent", SENTIMENT_AGENT);
+        createAgentCard(groupId, "translator-it-agent", TRANSLATOR_AGENT);
+
+        given()
+                .baseUri(getRegistryBaseUrl())
+                .contentType(ContentType.JSON)
+                .body("""
+                        { "query": "sentiment", "limit": 10, "offset": 0 }
+                        """)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem("sentiment-it-agent"))
+                .body("agents.artifactId", not(hasItem("translator-it-agent")));
+    }
+
+    @Test
+    void testSearchViaGetEndpoint() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        createAgentCard(groupId, "get-search-agent", TRANSLATOR_AGENT);
+
+        given()
+                .baseUri(getRegistryBaseUrl())
+                .queryParam("name", "TranslatorBot")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents.artifactId", hasItem("get-search-agent"));
+    }
+
+    @Test
+    void testSearchPagination() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        for (int i = 0; i < 3; i++) {
+            createAgentCard(groupId, "page-agent-" + i, SENTIMENT_AGENT);
+        }
+
+        given()
+                .baseUri(getRegistryBaseUrl())
+                .contentType(ContentType.JSON)
+                .body("""
+                        { "query": "SentimentAnalyzer", "limit": 2, "offset": 0 }
+                        """)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(3));
+    }
+
+    private void createAgentCard(String groupId, String artifactId, String content) throws Exception {
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactId(artifactId);
+        createArtifact.setArtifactType(ArtifactType.AGENT_CARD);
+
+        try {
+            com.fasterxml.jackson.databind.JsonNode root = new com.fasterxml.jackson.databind.ObjectMapper()
+                    .readTree(content);
+            if (root.has("name")) {
+                createArtifact.setName(root.get("name").asText());
+            }
+            if (root.has("description")) {
+                createArtifact.setDescription(root.get("description").asText());
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+
+        CreateVersion createVersion = new CreateVersion();
+        VersionContent versionContent = new VersionContent();
+        versionContent.setContent(content);
+        versionContent.setContentType(ContentTypes.APPLICATION_JSON);
+        createVersion.setContent(versionContent);
+        createArtifact.setFirstVersion(createVersion);
+
+        registryClient.groups().byGroupId(groupId).artifacts().post(createArtifact);
+    }
+}


### PR DESCRIPTION
## Summary

- Add PostgreSQL-native full-text search (`tsvector`/`websearch_to_tsquery`) to agent discovery endpoints (`POST /.well-known/agents/search`, `GET /.well-known/agents`)
- On PostgreSQL, searches agent name, description, AND content blob (skills, tags, capabilities embedded in the agent card JSON)
- On H2/MySQL/MSSQL, falls back to case-insensitive `LIKE` on name + description
- No schema changes — all query-time computation on existing columns

## What changed

**SQL layer** — `SqlStatements.fullTextSearchClause()` returns DB-specific SQL: PostgreSQL uses `to_tsvector`/`websearch_to_tsquery` with an EXISTS subquery on the content table for deep matching; other databases use `ILIKE` on artifact name + description. The `content` filter type in `SqlSearchRepository` now works natively instead of throwing `ContentSearchNotSupportedException`.

**REST layer** — `WellKnownResourceImpl` switches the query field from `SearchFilter.ofName()` (wildcard LIKE on artifactId/name) to `SearchFilter.ofContent()` (full-text search). Both POST and GET agent search endpoints are updated.

**Tests** — Unit tests (H2 path) verify name, description, partial match, and no-match search. Integration tests (`AgentSearchIT`, tagged `@Tag(SMOKE)`) verify the same scenarios against PostgreSQL in CI.

Closes #7230 (Phase 1)

## Test plan

- [x] `./mvnw test -pl app -Dtest=WellKnownResourceTest` — 26 tests pass (H2/ILIKE path)
- [x] `./mvnw checkstyle:check` — 0 violations on all changed files
- [ ] CI: `storage: postgresql` (`remote-sql`) — exercises tsvector/tsquery path
- [ ] CI: `storage: h2` (`remote-mem`) — exercises ILIKE fallback
- [ ] CI: `storage: kafkasql` (`remote-kafka`) — delegates to SQL, same path