### PR TITLE
fix(ui): add aria-label to SortOrderToggle button for screen reader a…

### DIFF
--- a/ui/ui-app/src/app/components/common/SortOrderToggle.tsx
+++ b/ui/ui-app/src/app/components/common/SortOrderToggle.tsx
@@ -18,7 +18,7 @@ export const SortOrderToggle: FunctionComponent<SortOrderToggleProps> = (props: 
     );
 
     return (
-        <Button icon={icon} variant="plain" aria-label="Toggle sort order" onClick={() => {
+        <Button icon={icon} variant="plain" aria-label={props.sortOrder === SortOrder.asc ? "sort ascending" : "sort descending"} onClick={() => {
             props.onChange(props.sortOrder === SortOrder.asc ? SortOrder.desc : SortOrder.asc);
         }} />
     );

--- a/ui/ui-app/src/app/components/common/SortOrderToggle.tsx
+++ b/ui/ui-app/src/app/components/common/SortOrderToggle.tsx
@@ -18,7 +18,7 @@ export const SortOrderToggle: FunctionComponent<SortOrderToggleProps> = (props: 
     );
 
     return (
-        <Button icon={icon} variant="plain"  onClick={() => {
+        <Button icon={icon} variant="plain" aria-label="Toggle sort order" onClick={() => {
             props.onChange(props.sortOrder === SortOrder.asc ? SortOrder.desc : SortOrder.asc);
         }} />
     );


### PR DESCRIPTION
I noticed that the SortOrderToggle icon button was missing an aria-label, making it inaccessible to screen readers. I've added an appropriate aria-label to ensure it is properly described to visually impaired users. This is my first PR as part of applying for the LFX mentorship.