### PR TITLE
feat(cli): Add cross-platform colored output with Jansi 

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
-            <version>2.4.0</version>
+            <version>${version.jansi}</version>
         </dependency>
         
         <dependency>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -29,6 +29,12 @@
     <dependencies>
 
         <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+        
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-picocli</artifactId>
         </dependency>

--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -16,6 +16,7 @@ import io.apicurio.registry.cli.serverconfig.ServerConfigCommand;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import lombok.Getter;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 
 import static picocli.CommandLine.Option;
 import static picocli.CommandLine.ScopeType.INHERIT;
@@ -74,4 +75,13 @@ public class Acr {
             scope = INHERIT
     )
     private boolean _ignored;
+
+    @Option(
+            names = {"--no-color"},
+            description = "Disable colored output.",
+            scope = INHERIT
+    )
+    @Getter
+    private boolean noColor;
+    
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -16,7 +16,6 @@ import io.apicurio.registry.cli.serverconfig.ServerConfigCommand;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import lombok.Getter;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
 
 import static picocli.CommandLine.Option;
 import static picocli.CommandLine.ScopeType.INHERIT;

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/LoginCommand.java
@@ -121,13 +121,12 @@ public class LoginCommand extends AbstractCommand {
         config.write(configModel);
 
         if (usedFileFallback) {
-            output.writeStdOutChunk(out ->
-                    out.append(UNSAFE_STORAGE_WARNING));
+            output.writeWarning(out -> out.append(UNSAFE_STORAGE_WARNING));
         }
 
         client.reset();
 
-        output.writeStdOutChunk(out -> {
+        output.writeSuccess(out -> {
             out.append("Logged in to context '").append(contextName)
                     .append("' as '").append(username).append("'.\n");
         });
@@ -168,7 +167,7 @@ public class LoginCommand extends AbstractCommand {
 
         client.reset();
 
-        output.writeStdOutChunk(out -> {
+        output.writeSuccess(out -> {
             out.append("Logged in to context '").append(contextName).append("' via OAuth2.\n");
         });
     }

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -41,22 +41,15 @@ public abstract class AbstractCommand implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        ColorUtil.init();
         var output = new OutputBuffer(config.getStdOut(), config.getStdErr());
+
         boolean noColorEnv = System.getenv("NO_COLOR") != null;
-        boolean isTty = System.console() != null;
-        boolean globalNoColor = false;
-        try {
-            var root = spec.root().userObject();
-            if (root instanceof Acr acr) {
-                globalNoColor = acr.isNoColor();
-            }
-        } catch (Exception e) {
-            
-        }
-        boolean colorsEnabled = !globalNoColor && !noColorEnv && isTty;
-        io.apicurio.registry.cli.utils.ColorUtil.setEnabled(colorsEnabled);
-        
+        boolean stdoutTty = isStdoutTerminal();
+        boolean globalNoColor = spec.root().userObject() instanceof Acr acr && acr.isNoColor();
+        boolean colorsEnabled = shouldEnableColors(globalNoColor, noColorEnv, stdoutTty);
+
+        ColorUtil.init(colorsEnabled);
+
         try {
             configureVerboseLogging();
             updateNotifier.checkAndNotify(getTopLevelCommandName());
@@ -77,10 +70,32 @@ public abstract class AbstractCommand implements Callable<Integer> {
             return APPLICATION_ERROR_RETURN_CODE;
         } finally {
             output.print();
+            ColorUtil.shutdown();
         }
     }
 
+    private boolean isStdoutTerminal() {
+        try {
+            Class<?> cLibrary = Class.forName("org.fusesource.jansi.internal.CLibrary");
+            var isatty = cLibrary.getMethod("isatty", int.class);
+            Object result = isatty.invoke(null, 1); // STDOUT file descriptor
+            if (result instanceof Integer value) {
+                return value == 1;
+            }
+            if (result instanceof Boolean value) {
+                return value;
+            }
+        } catch (ReflectiveOperationException ex) {
+            log.debug("Could not resolve stdout TTY via Jansi CLibrary, falling back to System.console().", ex);
+        }
+        return System.console() != null;
+    }
+ 
     public abstract void run(OutputBuffer output) throws Exception;
+
+    static boolean shouldEnableColors(boolean globalNoColor, boolean noColorEnv, boolean stdoutTty) {
+        return !globalNoColor && !noColorEnv && stdoutTty;
+    }
 
     private static void handleCliException(final OutputBuffer output, final CliException ex) {
         if (!ex.isQuiet()) {
@@ -115,11 +130,8 @@ public abstract class AbstractCommand implements Callable<Integer> {
     private void configureVerboseLogging() {
         var root = spec.root().userObject();
         if (root instanceof Acr acr && acr.isVerbose()) {
-            // Set the root logger level to FINE (DEBUG equivalent)
             var rootLogger = java.util.logging.Logger.getLogger("");
             rootLogger.setLevel(java.util.logging.Level.FINE);
-            // Also lower handler levels — Quarkus sets quarkus.log.level=WARN on the
-            // console handler, which filters debug messages even when the logger allows them.
             for (var handler : rootLogger.getHandlers()) {
                 handler.setLevel(java.util.logging.Level.FINE);
             }

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -4,6 +4,7 @@ import io.apicurio.registry.cli.Acr;
 import io.apicurio.registry.cli.config.Config;
 import io.apicurio.registry.cli.services.Client;
 import io.apicurio.registry.cli.services.UpdateNotifier;
+import io.apicurio.registry.cli.utils.ColorUtil;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.models.ProblemDetails;
 import io.apicurio.registry.rest.client.models.RuleViolationProblemDetails;
@@ -40,7 +41,22 @@ public abstract class AbstractCommand implements Callable<Integer> {
 
     @Override
     public Integer call() {
+        ColorUtil.init();
         var output = new OutputBuffer(config.getStdOut(), config.getStdErr());
+        boolean noColorEnv = System.getenv("NO_COLOR") != null;
+        boolean isTty = System.console() != null;
+        boolean globalNoColor = false;
+        try {
+            var root = spec.root().userObject();
+            if (root instanceof Acr acr) {
+                globalNoColor = acr.isNoColor();
+            }
+        } catch (Exception e) {
+            
+        }
+        boolean colorsEnabled = !globalNoColor && !noColorEnv && isTty;
+        io.apicurio.registry.cli.utils.ColorUtil.setEnabled(colorsEnabled);
+        
         try {
             configureVerboseLogging();
             updateNotifier.checkAndNotify(getTopLevelCommandName());
@@ -68,7 +84,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
 
     private static void handleCliException(final OutputBuffer output, final CliException ex) {
         if (!ex.isQuiet()) {
-            output.writeStdErrChunk(out -> out.append(ERROR_PREFIX).append(ex.getMessage()).append("\n"));
+            output.writeError(out -> out.append(ERROR_PREFIX).append(ex.getMessage()).append("\n"));
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommandColorDecisionTest.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommandColorDecisionTest.java
@@ -1,0 +1,33 @@
+package io.apicurio.registry.cli.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractCommandColorDecisionTest {
+
+    @Test
+    public void testEnableWhenNoDisablersAndStdoutIsTty() {
+        assertThat(AbstractCommand.shouldEnableColors(false, false, true)).isTrue();
+    }
+
+    @Test
+    public void testDisableWhenNoColorFlagIsSet() {
+        assertThat(AbstractCommand.shouldEnableColors(true, false, true)).isFalse();
+    }
+
+    @Test
+    public void testDisableWhenNoColorEnvIsSet() {
+        assertThat(AbstractCommand.shouldEnableColors(false, true, true)).isFalse();
+    }
+
+    @Test
+    public void testDisableWhenStdoutIsNotTty() {
+        assertThat(AbstractCommand.shouldEnableColors(false, false, false)).isFalse();
+    }
+
+    @Test
+    public void testDisableWhenMultipleDisablersAreSet() {
+        assertThat(AbstractCommand.shouldEnableColors(true, true, false)).isFalse();
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/context/ContextCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/context/ContextCreateCommand.java
@@ -55,7 +55,7 @@ public class ContextCreateCommand extends AbstractCommand {
                     .groupId(groupId)
                     .artifactId(artifactId)
                     .build());
-            output.writeStdOutChunk(out -> {
+            output.writeSuccess(out -> {
                 if (!noSwitchCurrent) {
                     configModel.setCurrentContext(name);
                     out.append("Current context '").append(name).append("' added.");

--- a/cli/src/main/java/io/apicurio/registry/cli/context/ContextUseCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/context/ContextUseCommand.java
@@ -35,7 +35,7 @@ public class ContextUseCommand extends AbstractCommand {
         final var previousContext = configModel.getCurrentContext();
         configModel.setCurrentContext(name);
         config.write(configModel);
-        output.writeStdOutChunk(out -> {
+        output.writeSuccess(out -> {
             out.append("Switched to context '").append(name).append("'");
             if (previousContext != null) {
                 out.append(" from '").append(previousContext).append("'");

--- a/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/UpdateNotifier.java
@@ -97,7 +97,7 @@ public class UpdateNotifier {
         }
         result.formatMessage(sb);
         sb.append("Run 'acr update --postpone' to postpone for 5 days.\n");
-        config.getStdErr().print(sb.toString());
+        config.getStdErr().print(io.apicurio.registry.cli.utils.ColorUtil.colorizeWarning(sb.toString()));
     }
 
     private String getProductName() {

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/ColorUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/ColorUtil.java
@@ -9,9 +9,21 @@ public final class ColorUtil {
     }
 
     private static volatile boolean enabled = true;
+    private static volatile boolean installed = false;
 
-    public static void init() {
-        AnsiConsole.systemInstall();
+    public static synchronized void init(boolean on) {
+        enabled = on;
+        if (on && !installed) {
+            AnsiConsole.systemInstall();
+            installed = true;
+        }
+    }
+
+    public static synchronized void shutdown() {
+        if (installed) {
+            AnsiConsole.systemUninstall();
+            installed = false;
+        }
     }
 
     public static void setEnabled(boolean on) {

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/ColorUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/ColorUtil.java
@@ -1,0 +1,45 @@
+package io.apicurio.registry.cli.utils;
+
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.AnsiConsole;
+
+public final class ColorUtil {
+
+    private ColorUtil() {
+    }
+
+    private static volatile boolean enabled = true;
+
+    public static void init() {
+        AnsiConsole.systemInstall();
+    }
+
+    public static void setEnabled(boolean on) {
+        enabled = on;
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    public static String colorizeSuccess(String text) {
+        if (!enabled || text == null || text.isBlank()) {
+            return text;
+        }
+        return Ansi.ansi().fg(Ansi.Color.GREEN).a(text).reset().toString();
+    }
+
+    public static String colorizeError(String text) {
+        if (!enabled || text == null || text.isBlank()) {
+            return text;
+        }
+        return Ansi.ansi().fg(Ansi.Color.RED).a(text).reset().toString();
+    }
+
+    public static String colorizeWarning(String text) {
+        if (!enabled || text == null || text.isBlank()) {
+            return text;
+        }
+        return Ansi.ansi().fg(Ansi.Color.YELLOW).a(text).reset().toString();
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/ColorUtilTest.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/ColorUtilTest.java
@@ -1,0 +1,64 @@
+package io.apicurio.registry.cli.utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ColorUtilTest {
+
+    @AfterEach
+    public void resetColorEnabled() {
+        ColorUtil.setEnabled(true);
+    }
+
+    @Test
+    public void testColorizeSuccessWhenDisabled() {
+        ColorUtil.setEnabled(false);
+        assertThat(ColorUtil.colorizeSuccess("ok")).isEqualTo("ok");
+    }
+
+    @Test
+    public void testColorizeErrorWhenDisabled() {
+        ColorUtil.setEnabled(false);
+        assertThat(ColorUtil.colorizeError("boom")).isEqualTo("boom");
+    }
+
+    @Test
+    public void testColorizeWarningWhenDisabled() {
+        ColorUtil.setEnabled(false);
+        assertThat(ColorUtil.colorizeWarning("warn")).isEqualTo("warn");
+    }
+
+    @Test
+    public void testColorizePassThroughForNullAndBlank() {
+        ColorUtil.setEnabled(true);
+        assertThat(ColorUtil.colorizeSuccess(null)).isNull();
+        assertThat(ColorUtil.colorizeError("")).isEqualTo("");
+        assertThat(ColorUtil.colorizeWarning("   ")).isEqualTo("   ");
+    }
+
+    @Test
+    public void testColorizeSuccessWhenEnabled() {
+        ColorUtil.setEnabled(true);
+        String value = ColorUtil.colorizeSuccess("ok");
+        assertThat(value).contains("ok");
+        assertThat(value).contains("\u001B[");
+    }
+
+    @Test
+    public void testColorizeErrorWhenEnabled() {
+        ColorUtil.setEnabled(true);
+        String value = ColorUtil.colorizeError("boom");
+        assertThat(value).contains("boom");
+        assertThat(value).contains("\u001B[");
+    }
+
+    @Test
+    public void testColorizeWarningWhenEnabled() {
+        ColorUtil.setEnabled(true);
+        String value = ColorUtil.colorizeWarning("warn");
+        assertThat(value).contains("warn");
+        assertThat(value).contains("\u001B[");
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/OutputBuffer.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/OutputBuffer.java
@@ -10,11 +10,8 @@ import lombok.Getter;
 public class OutputBuffer {
 
     private final Output stdOut;
-
     private final Output stdErr;
-
     private final StringBuilder buffer = new StringBuilder();
-
     private final List<Chunk> chunks = new ArrayList<>();
     private int printedUpTo = 0;
 
@@ -29,7 +26,7 @@ public class OutputBuffer {
 
     public void writeStdOutChunk(Utils.Function0<StringBuilder> action) {
         action.run(buffer);
-        chunks.add(new Chunk(buffer.toString(), Chunk.Target.STDOUT));
+        chunks.add(new Chunk(buffer.toString(), Chunk.Target.STDOUT, Severity.INFO));
         buffer.setLength(0);
     }
 
@@ -52,16 +49,45 @@ public class OutputBuffer {
 
     public void writeStdErrChunk(Consumer<StringBuilder> action) {
         action.accept(buffer);
-        chunks.add(new Chunk(buffer.toString(), Chunk.Target.STDERR));
+        chunks.add(new Chunk(buffer.toString(), Chunk.Target.STDERR, Severity.INFO));
+        buffer.setLength(0);
+    }
+
+    public void writeSuccess(Consumer<StringBuilder> action) {
+        action.accept(buffer);
+        chunks.add(new Chunk(buffer.toString(), Chunk.Target.STDOUT, Severity.SUCCESS));
+        buffer.setLength(0);
+    }
+
+    public void writeWarning(Consumer<StringBuilder> action) {
+        action.accept(buffer);
+        chunks.add(new Chunk(buffer.toString(), Chunk.Target.STDERR, Severity.WARNING));
+        buffer.setLength(0);
+    }
+
+    public void writeError(Consumer<StringBuilder> action) {
+        action.accept(buffer);
+        chunks.add(new Chunk(buffer.toString(), Chunk.Target.STDERR, Severity.ERROR));
         buffer.setLength(0);
     }
 
     public void print() {
         for (int i = printedUpTo; i < chunks.size(); i++) {
             var chunk = chunks.get(i);
+            String outText = chunk.getOutput();
+
+            switch (chunk.getSeverity()) {
+                case SUCCESS -> outText = ColorUtil.colorizeSuccess(outText);
+                case WARNING -> outText = ColorUtil.colorizeWarning(outText);
+                case ERROR -> outText = ColorUtil.colorizeError(outText);
+                case INFO, NONE -> {
+
+                }
+            }
+
             switch (chunk.getTarget()) {
-                case STDOUT -> stdOut.print(chunk.getOutput());
-                case STDERR -> stdErr.print(chunk.getOutput());
+                case STDOUT -> stdOut.print(outText);
+                case STDERR -> stdErr.print(outText);
             }
         }
         printedUpTo = chunks.size();
@@ -70,10 +96,9 @@ public class OutputBuffer {
     @AllArgsConstructor
     @Getter
     private static class Chunk {
-
         private String output;
-
         private Target target;
+        private Severity severity;
 
         private enum Target {
             STDOUT,
@@ -81,9 +106,12 @@ public class OutputBuffer {
         }
     }
 
+    private enum Severity {
+        NONE, INFO, SUCCESS, WARNING, ERROR
+    }
+
     @AllArgsConstructor
     private static class WrappedException extends RuntimeException {
-
         @Getter
         private final Exception wrapped;
     }

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/OutputBufferTest.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/OutputBufferTest.java
@@ -1,0 +1,76 @@
+package io.apicurio.registry.cli.utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OutputBufferTest {
+
+    @AfterEach
+    public void resetColorEnabled() {
+        ColorUtil.setEnabled(true);
+    }
+
+    @Test
+    public void testSeverityRoutingWithColorsEnabled() {
+        var out = new StringBuilder();
+        var err = new StringBuilder();
+        var buffer = new OutputBuffer(out::append, err::append);
+
+        buffer.writeStdOutChunk(sb -> sb.append("plain-out"));
+        buffer.writeStdErrChunk(sb -> sb.append("plain-err"));
+        buffer.writeSuccess(sb -> sb.append("success"));
+        buffer.writeWarning(sb -> sb.append("warning"));
+        buffer.writeError(sb -> sb.append("error"));
+
+        buffer.print();
+
+        String stdout = out.toString();
+        String stderr = err.toString();
+
+        assertThat(stdout).contains("plain-out");
+        assertThat(stdout).contains("success");
+        assertThat(stderr).contains("plain-err");
+        assertThat(stderr).contains("warning");
+        assertThat(stderr).contains("error");
+
+        // Colorized severities should include ANSI prefix when enabled
+        assertThat(stdout).contains("\u001B[");
+        assertThat(stderr).contains("\u001B[");
+    }
+
+    @Test
+    public void testSeverityRoutingWithColorsDisabled() {
+        ColorUtil.setEnabled(false);
+
+        var out = new StringBuilder();
+        var err = new StringBuilder();
+        var buffer = new OutputBuffer(out::append, err::append);
+
+        buffer.writeSuccess(sb -> sb.append("success"));
+        buffer.writeWarning(sb -> sb.append("warning"));
+        buffer.writeError(sb -> sb.append("error"));
+
+        buffer.print();
+
+        assertThat(out.toString()).isEqualTo("success");
+        assertThat(err.toString()).isEqualTo("warningerror");
+        assertThat(out.toString()).doesNotContain("\u001B[");
+        assertThat(err.toString()).doesNotContain("\u001B[");
+    }
+
+    @Test
+    public void testPrintIsIncremental() {
+        var out = new StringBuilder();
+        var err = new StringBuilder();
+        var buffer = new OutputBuffer(out::append, err::append);
+
+        buffer.writeStdOutLine("one");
+        buffer.print();
+        buffer.print(); // should not print the same chunk again
+
+        assertThat(out.toString()).isEqualTo("one\n");
+        assertThat(err.toString()).isEmpty();
+    }
+}


### PR DESCRIPTION
 #8648 
- Colorize success (green), error (red), warning (yellow) messages
- Respect NO_COLOR environment variable
- Disable colors when output is piped (non-TTY)
- Support --no-color flag
- GraalVM native image compatible