### PR TITLE
Fix config property aria labels

### DIFF
--- a/ui/ui-app/src/app/components/common/SortOrderToggle.tsx
+++ b/ui/ui-app/src/app/components/common/SortOrderToggle.tsx
@@ -18,7 +18,7 @@ export const SortOrderToggle: FunctionComponent<SortOrderToggleProps> = (props: 
     );
 
     return (
-        <Button icon={icon} variant="plain" aria-label={props.sortOrder === SortOrder.asc ? "sort ascending" : "sort descending"} onClick={() => {
+        <Button icon={icon} variant="plain" aria-label={props.sortOrder === SortOrder.asc ? "Sort descending" : "Sort ascending"} onClick={() => {
             props.onChange(props.sortOrder === SortOrder.asc ? SortOrder.desc : SortOrder.asc);
         }} />
     );

--- a/ui/ui-app/src/app/pages/settings/components/ConfigProperty.tsx
+++ b/ui/ui-app/src/app/pages/settings/components/ConfigProperty.tsx
@@ -95,11 +95,11 @@ export const ConfigProperty: FunctionComponent<ConfigPropertyProps> = ({ propert
                 </FlexItem>
                 <FlexItem className="actions" align={{ default: "alignRight" }}>
                     <If condition={!isEditing}>
-                        <Button icon={<PencilAltIcon />} variant="plain" className="action single" onClick={onStartEditing} />
+                        <Button icon={<PencilAltIcon />} variant="plain" aria-label="Edit configuration property" className="action single" onClick={onStartEditing} />
                     </If>
                     <If condition={isEditing}>
-                        <Button icon={<CheckIcon />} variant="plain" className="action" onClick={onSavePropertyValue} isDisabled={!isValid} />
-                        <Button icon={<CloseIcon />} variant="plain" className="action" onClick={onCancelEdit} />
+                        <Button icon={<CheckIcon />} variant="plain" aria-label="Save configuration property" className="action" onClick={onSavePropertyValue} isDisabled={!isValid} />
+                        <Button icon={<CloseIcon />} variant="plain" aria-label="Cancel editing configuration property" className="action" onClick={onCancelEdit} />
                     </If>
                 </FlexItem>
             </Flex>


### PR DESCRIPTION
I noticed that the Edit, Save, and Cancel icon buttons inside the ConfigProperty component were missing aria-label attributes, making them inaccessible to screen readers. I've added descriptive aria-labels to all three buttons to ensure they are properly described to visually impaired users. This is my second PR as part of applying for the LFX mentorship.