### PR TITLE
fix(rest): apply partial match to name filter on well-known discovery endpoints

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -337,9 +337,14 @@ public class WellKnownResourceImpl implements WellKnownResource {
         // Always filter by AGENT_CARD artifact type
         filters.add(SearchFilter.ofArtifactType(ArtifactType.AGENT_CARD));
 
-        // Filter by name if provided
+        // Filter by name if provided. The name filter is documented as a partial match, so
+        // wrap the value in wildcards unless the caller supplied their own.
         if (!StringUtil.isEmpty(name)) {
-            filters.add(SearchFilter.ofName(name));
+            String nameFilter = name.trim();
+            if (!nameFilter.contains("*")) {
+                nameFilter = "*" + nameFilter + "*";
+            }
+            filters.add(SearchFilter.ofName(nameFilter));
         }
 
         // Filter by skills (indexed as structured content: agent_card:skill:<id>)
@@ -540,8 +545,14 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
         filters.add(SearchFilter.ofArtifactType(ArtifactType.MCP_TOOL));
 
+        // The name filter is documented as a partial match, so wrap the value in wildcards
+        // unless the caller supplied their own.
         if (!StringUtil.isEmpty(name)) {
-            filters.add(SearchFilter.ofName(name));
+            String nameFilter = name.trim();
+            if (!nameFilter.contains("*")) {
+                nameFilter = "*" + nameFilter + "*";
+            }
+            filters.add(SearchFilter.ofName(nameFilter));
         }
 
         if (parameters != null && !parameters.isEmpty()) {

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -201,11 +201,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
         // Query matches artifact metadata name and artifactId (not Agent Card JSON content).
         // Full-text content search is tracked in #7230.
         if (!StringUtil.isEmpty(request.getQuery())) {
-            String q = request.getQuery().trim();
-            if (!q.contains("*")) {
-                q = "*" + q + "*";
-            }
-            filters.add(SearchFilter.ofName(q));
+            filters.add(SearchFilter.ofPartialName(request.getQuery()));
         }
 
         AgentSearchFilters f = request.getFilters();
@@ -340,11 +336,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
         // Filter by name if provided. The name filter is documented as a partial match, so
         // wrap the value in wildcards unless the caller supplied their own.
         if (!StringUtil.isEmpty(name)) {
-            String nameFilter = name.trim();
-            if (!nameFilter.contains("*")) {
-                nameFilter = "*" + nameFilter + "*";
-            }
-            filters.add(SearchFilter.ofName(nameFilter));
+            filters.add(SearchFilter.ofPartialName(name));
         }
 
         // Filter by skills (indexed as structured content: agent_card:skill:<id>)
@@ -548,11 +540,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
         // The name filter is documented as a partial match, so wrap the value in wildcards
         // unless the caller supplied their own.
         if (!StringUtil.isEmpty(name)) {
-            String nameFilter = name.trim();
-            if (!nameFilter.contains("*")) {
-                nameFilter = "*" + nameFilter + "*";
-            }
-            filters.add(SearchFilter.ofName(nameFilter));
+            filters.add(SearchFilter.ofPartialName(name));
         }
 
         if (parameters != null && !parameters.isEmpty()) {

--- a/app/src/main/java/io/apicurio/registry/storage/dto/SearchFilter.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/SearchFilter.java
@@ -50,6 +50,21 @@ public class SearchFilter {
         return new SearchFilter(SearchFilterType.name, value);
     }
 
+    /**
+     * Creates a name filter for a partial (substring) match. The value is wrapped in wildcards unless the
+     * caller already supplied one, so that a caller-provided prefix ("weather*") or suffix ("*weather")
+     * search is preserved as-is.
+     *
+     * @param value the name to match on
+     */
+    public static SearchFilter ofPartialName(String value) {
+        String name = value.trim();
+        if (!name.contains("*")) {
+            name = "*" + name + "*";
+        }
+        return ofName(name);
+    }
+
     public static SearchFilter ofDescription(String value) {
         return new SearchFilter(SearchFilterType.description, value);
     }

--- a/app/src/main/java/io/apicurio/registry/storage/dto/SearchFilter.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/SearchFilter.java
@@ -59,6 +59,9 @@ public class SearchFilter {
      */
     public static SearchFilter ofPartialName(String value) {
         String name = value.trim();
+        if (name.isEmpty()) {
+            return ofName("");
+        }
         if (!name.contains("*")) {
             name = "*" + name + "*";
         }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/ExperimentalFeaturesEnabledProfile.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/ExperimentalFeaturesEnabledProfile.java
@@ -5,8 +5,8 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import java.util.Map;
 
 /**
- * Test profile that enables the experimental features gate, A2A, and MCP tools so that
- * well-known discovery endpoints are accessible.
+ * Test profile that enables the experimental features gate, A2A, and MCP tools so that the
+ * corresponding well-known endpoints are accessible.
  */
 public class ExperimentalFeaturesEnabledProfile implements QuarkusTestProfile {
 

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -347,6 +347,18 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void testSearchAgentsWhitespaceNameDoesNotMatchAll() throws Exception {
+        // Whitespace-only name should be trimmed to empty string rather than wrapped into "**".
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("name", "   ")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
     public void testSearchAgentsWithPagination() throws Exception {
         String groupId = TestUtils.generateGroupId();
 

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -103,6 +103,20 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
             }
             """;
 
+    private static final String MCP_TOOL_CONTENT = """
+            {
+                "name": "get_weather",
+                "description": "Get the current weather for a city",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "city": { "type": "string" }
+                    },
+                    "required": ["city"]
+                }
+            }
+            """;
+
     @Test
     public void testGetAgentCard() {
         givenAtRoot()
@@ -244,6 +258,61 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
                 .statusCode(200)
                 .body("count", greaterThanOrEqualTo(2))
                 .body("agents", notNullValue());
+    }
+
+    @Test
+    public void testSearchAgentsPartialNameMatch() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        createAgentCard(groupId, "partialmatchagent-alpha", AGENT_CARD_CONTENT);
+
+        // The name filter is documented as a partial match, so a substring should match even
+        // though the caller did not supply any wildcards.
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("name", "partialmatchagent")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents.artifactId", hasItem("partialmatchagent-alpha"));
+    }
+
+    @Test
+    public void testSearchAgentsExplicitWildcardIsPreserved() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        createAgentCard(groupId, "explicitwildcardagent-alpha", AGENT_CARD_CONTENT);
+
+        // A caller-supplied wildcard must still work (the value is not wrapped a second time).
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("name", "*explicitwildcardagent*")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("agents.artifactId", hasItem("explicitwildcardagent-alpha"));
+    }
+
+    @Test
+    public void testSearchMcpToolsPartialNameMatch() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        createMcpTool(groupId, "partialmatchtool-alpha", MCP_TOOL_CONTENT);
+
+        // Same partial-match behaviour is documented for the MCP tool discovery endpoint.
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("name", "partialmatchtool")
+                .get("/.well-known/mcp-tools")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(1))
+                .body("tools.artifactId", hasItem("partialmatchtool-alpha"));
     }
 
     @Test
@@ -641,6 +710,21 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
         CreateArtifact createArtifact = new CreateArtifact();
         createArtifact.setArtifactId(artifactId);
         createArtifact.setArtifactType(ArtifactType.AGENT_CARD);
+
+        CreateVersion createVersion = new CreateVersion();
+        VersionContent versionContent = new VersionContent();
+        versionContent.setContent(content);
+        versionContent.setContentType(ContentTypes.APPLICATION_JSON);
+        createVersion.setContent(versionContent);
+        createArtifact.setFirstVersion(createVersion);
+
+        clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+    }
+
+    private void createMcpTool(String groupId, String artifactId, String content) throws Exception {
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactId(artifactId);
+        createArtifact.setArtifactType(ArtifactType.MCP_TOOL);
 
         CreateVersion createVersion = new CreateVersion();
         VersionContent versionContent = new VersionContent();

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -298,6 +298,37 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void testSearchAgentsPartialWildcardIsPreserved() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        createAgentCard(groupId, "boundedwildcardagent-alpha", AGENT_CARD_CONTENT);
+        createAgentCard(groupId, "zzz-boundedwildcardagent-beta", AGENT_CARD_CONTENT);
+
+        // A prefix-only search stays a prefix search - if the value were wrapped again it would
+        // also match the agent that only contains the term in the middle.
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("name", "boundedwildcardagent*")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem("boundedwildcardagent-alpha"))
+                .body("agents.artifactId", not(hasItem("zzz-boundedwildcardagent-beta")));
+
+        // Same for a suffix-only search.
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("name", "*boundedwildcardagent-beta")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem("zzz-boundedwildcardagent-beta"))
+                .body("agents.artifactId", not(hasItem("boundedwildcardagent-alpha")));
+    }
+
+    @Test
     public void testSearchMcpToolsPartialNameMatch() throws Exception {
         String groupId = TestUtils.generateGroupId();
 


### PR DESCRIPTION
The `name` filter on `/.well-known/agents` and `/.well-known/mcp-tools` is documented as a partial match, but the raw value was passed to `SearchFilter.ofName`, so it only matched exactly. `?name=weather` returned nothing while `?name=*weather*` worked.

This wraps the value in wildcards unless the caller supplied their own, the same way `searchAgentsAdvanced` already does.

Two notes:

- Kept `contains("*")` so the behaviour matches the existing `searchAgentsAdvanced` rather than widening the change. There is a discussion on #8703 about using `startsWith`/`endsWith` instead, which would also mean touching `searchAgentsAdvanced`. Happy to switch if you prefer that.
- Case sensitivity left as is, per #8703.

Tests added:

- partial name match on agents
- partial name match on mcp-tools
- explicit `*` is not wrapped twice

`apicurio.mcp-tools.enabled` is used in `ExperimentalFeaturesEnabledProfile` so the mcp-tools endpoint is reachable in the test. That profile is only used by `WellKnownResourceTest`.

Checked locally: `?name=weather` matches, `?name=<full-artifact-id>` still matches exactly, `?name=zzzznope` returns nothing. 24 tests pass, checkstyle clean.

Fixes #8703
