### PR TITLE
Add Apicurio Agent Card to Kubernetes sync controller PoC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,8 @@
     <module>utils/importexport</module>
     <module>utils/protobuf-schema-utilities</module>
     <module>utils/tests</module>
+    <module>utils/agent-card-sync</module>
+
 
     <!-- modules for implementing ArtifactTypeUtilProvider -->
     <module>schema-util/asyncapi</module>

--- a/utils/agent-card-sync/pom.xml
+++ b/utils/agent-card-sync/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.apicurio</groupId>
+    <artifactId>apicurio-registry</artifactId>
+    <version>3.3.1-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>apicurio-registry-utils-agent-card-sync</artifactId>
+  <packaging>jar</packaging>
+  <name>Registry :: Utils :: Agent Card Sync</name>
+
+  <properties>
+    <projectRoot>${project.basedir}/../..</projectRoot>
+  </properties>
+
+  <dependencies>
+
+    <!-- Apicurio Common -->
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <!-- Apicurio Java SDK -->
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-java-sdk</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-java-sdk-adapter-vertx</artifactId>
+    </dependency>
+
+    <!-- Quarkus Core & Scheduler -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-scheduler</artifactId>
+    </dependency>
+
+    <!-- Kubernetes Client -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-kubernetes-client</artifactId>
+    </dependency>
+
+    <!-- JSON / Jackson -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <!-- Lombok -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kubernetes-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/client/ApicurioAgentCardClient.java
+++ b/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/client/ApicurioAgentCardClient.java
@@ -1,0 +1,158 @@
+package io.apicurio.registry.sync.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.client.RegistryClientFactory;
+import io.apicurio.registry.client.common.RegistryClientOptions;
+
+import io.apicurio.registry.rest.client.models.SearchedVersion;
+import io.apicurio.registry.rest.client.models.VersionSearchResults;
+
+import io.apicurio.registry.sync.model.ApicurioAgentCardSpec;
+import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@ApplicationScoped
+public class ApicurioAgentCardClient {
+
+    private static final Logger log = LoggerFactory.getLogger(ApicurioAgentCardClient.class);
+
+    @ConfigProperty(name = "apicurio.registry.url", defaultValue = "http://localhost:8080/apis/registry/v3")
+    public String registryUrl;
+
+    @ConfigProperty(name = "apicurio.registry.auth.username")
+    Optional<String> username;
+
+    @ConfigProperty(name = "apicurio.registry.auth.password")
+    Optional<String> password;
+
+    @Inject
+    public Vertx vertx;
+
+    @Inject
+    public ObjectMapper objectMapper;
+
+    private RegistryClient client;
+
+    // Cache to prevent unnecessary Kubernetes updates
+    // Map of artifactId -> CacheEntry containing globalId, contentId, and modifiedOn timestamp
+    private final Map<String, CacheEntry> syncCache = new ConcurrentHashMap<>();
+
+    public synchronized RegistryClient getClient() {
+        if (client == null) {
+            log.info("Initializing Apicurio Registry client targeting: {}", registryUrl);
+            RegistryClientOptions options = RegistryClientOptions.create()
+                    .registryUrl(registryUrl)
+                    .vertx(vertx);
+            if (username != null && username.isPresent() && !username.get().trim().isEmpty()) {
+                options.basicAuth(username.get(), password != null ? password.orElse("") : "");
+            }
+
+
+            client = RegistryClientFactory.create(options);
+        }
+        return client;
+    }
+
+    public List<AgentCardVersionInfo> getAgentCardVersions() {
+        try {
+            log.debug("Polling Apicurio Registry for AGENT_CARD artifacts");
+            VersionSearchResults results = getClient().search().versions().get(config -> {
+                config.queryParameters.artifactType = "AGENT_CARD";
+            });
+
+            if (results == null || results.getVersions() == null) {
+                return Collections.emptyList();
+            }
+
+            List<AgentCardVersionInfo> list = new ArrayList<>();
+            for (SearchedVersion version : results.getVersions()) {
+                list.add(new AgentCardVersionInfo(
+                        version.getGroupId(),
+                        version.getArtifactId(),
+                        version.getVersion(),
+                        version.getGlobalId(),
+                        version.getContentId(),
+                        version.getModifiedOn() != null ? version.getModifiedOn().toInstant().toEpochMilli() : 0L
+
+                ));
+            }
+            return list;
+        } catch (Exception e) {
+            log.error("Failed to query AGENT_CARD versions from Apicurio Registry", e);
+            throw new RuntimeException("Failed to query AGENT_CARD versions from Apicurio Registry", e);
+        }
+    }
+
+    public ApicurioAgentCardSpec fetchAgentCardSpec(String groupId, String artifactId, String versionExpression) {
+        try {
+            log.debug("Fetching content for agent card artifactId: {}, version: {}", artifactId, versionExpression);
+            String resolvedGroupId = (groupId == null || groupId.trim().isEmpty()) ? "default" : groupId;
+            try (InputStream is = getClient().groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(artifactId)
+                    .versions().byVersionExpression(versionExpression).content().get()) {
+                return objectMapper.readValue(is, ApicurioAgentCardSpec.class);
+            }
+        } catch (Exception e) {
+            log.error("Failed to fetch agent card spec for artifact: {}", artifactId, e);
+            return null;
+        }
+    }
+
+    public boolean isChanged(String artifactId, long globalId, long contentId, long modifiedOn) {
+        CacheEntry cached = syncCache.get(artifactId);
+        if (cached == null || cached.globalId != globalId || cached.contentId != contentId || cached.modifiedOn != modifiedOn) {
+            return true;
+        }
+        return false;
+    }
+
+    public void updateCache(String artifactId, long globalId, long contentId, long modifiedOn) {
+        syncCache.put(artifactId, new CacheEntry(globalId, contentId, modifiedOn));
+    }
+
+    public void evictCache(String artifactId) {
+        syncCache.remove(artifactId);
+    }
+
+    private static class CacheEntry {
+        final long globalId;
+        final long contentId;
+        final long modifiedOn;
+
+        CacheEntry(long globalId, long contentId, long modifiedOn) {
+            this.globalId = globalId;
+            this.contentId = contentId;
+            this.modifiedOn = modifiedOn;
+        }
+    }
+
+    public static class AgentCardVersionInfo {
+        public final String groupId;
+        public final String artifactId;
+        public final String version;
+        public final long globalId;
+        public final long contentId;
+        public final long modifiedOn;
+
+        public AgentCardVersionInfo(String groupId, String artifactId, String version, long globalId, long contentId, long modifiedOn) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+            this.version = version;
+            this.globalId = globalId;
+            this.contentId = contentId;
+            this.modifiedOn = modifiedOn;
+        }
+    }
+}

--- a/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/controller/AgentCardSyncController.java
+++ b/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/controller/AgentCardSyncController.java
@@ -1,0 +1,160 @@
+package io.apicurio.registry.sync.controller;
+
+import io.apicurio.registry.sync.client.ApicurioAgentCardClient;
+import io.apicurio.registry.sync.client.ApicurioAgentCardClient.AgentCardVersionInfo;
+import io.apicurio.registry.sync.model.ApicurioAgentCard;
+import io.apicurio.registry.sync.model.ApicurioAgentCardSpec;
+import io.apicurio.registry.sync.model.ApicurioAgentCardStatus;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class AgentCardSyncController {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentCardSyncController.class);
+
+    public static final String MANAGED_ANNOTATION_KEY = "apicurio.io/managed";
+    public static final String MANAGED_ANNOTATION_VALUE = "true";
+
+    @ConfigProperty(name = "apicurio.sync.namespace", defaultValue = "default")
+    String namespace;
+
+    @Inject
+    ApicurioAgentCardClient apicurioClient;
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @Scheduled(every = "${apicurio.sync.interval:10s}", delay = 2, delayUnit = java.util.concurrent.TimeUnit.SECONDS, concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    public void sync() {
+        log.info("Starting synchronization cycle...");
+        try {
+            List<AgentCardVersionInfo> activeCards = apicurioClient.getAgentCardVersions();
+            Set<String> activeK8sNames = new HashSet<>();
+
+            // 1. Process active cards
+            for (AgentCardVersionInfo cardInfo : activeCards) {
+                String k8sName = normalizeK8sName(cardInfo.artifactId);
+                activeK8sNames.add(k8sName);
+
+                boolean changed = apicurioClient.isChanged(cardInfo.artifactId, cardInfo.globalId, cardInfo.contentId, cardInfo.modifiedOn);
+                if (changed) {
+                    log.info("Change detected for artifact: {}. Fetching spec...", cardInfo.artifactId);
+                    ApicurioAgentCardSpec spec = apicurioClient.fetchAgentCardSpec(cardInfo.groupId, cardInfo.artifactId, cardInfo.version);
+                    if (spec != null) {
+                        syncToKubernetes(k8sName, cardInfo.artifactId, spec);
+                        apicurioClient.updateCache(cardInfo.artifactId, cardInfo.globalId, cardInfo.contentId, cardInfo.modifiedOn);
+                    }
+                } else {
+                    log.debug("Artifact: {} is up to date, skipping", cardInfo.artifactId);
+                }
+            }
+
+            // 2. Mark deleted/deprecated cards as stale
+            handleStaleCards(activeK8sNames);
+
+            log.info("Synchronization cycle completed successfully.");
+        } catch (Exception e) {
+            log.error("Error occurred during synchronization cycle", e);
+        }
+    }
+
+    private void syncToKubernetes(String name, String artifactId, ApicurioAgentCardSpec spec) {
+        log.info("Applying ApicurioAgentCard CRD to Kubernetes: {}/{}", namespace, name);
+
+        ApicurioAgentCard crd = new ApicurioAgentCard();
+        crd.setMetadata(new ObjectMetaBuilder()
+                .withName(name)
+                .withNamespace(namespace)
+                .addToAnnotations(MANAGED_ANNOTATION_KEY, MANAGED_ANNOTATION_VALUE)
+                .addToAnnotations("apicurio.io/artifact-id", artifactId)
+                .build());
+        crd.setSpec(spec);
+
+        // Perform createOrReplace to create/update the CRD
+        ApicurioAgentCard applied = kubernetesClient.resources(ApicurioAgentCard.class)
+                .inNamespace(namespace)
+                .resource(crd)
+                .createOrReplace();
+
+
+        // Update status indicating active synchronization
+        ApicurioAgentCardStatus status = ApicurioAgentCardStatus.builder()
+                .syncStatus("Active")
+                .lastSynced(Instant.now().toString())
+                .message("Synchronized successfully with Apicurio Registry")
+                .build();
+        applied.setStatus(status);
+
+        kubernetesClient.resources(ApicurioAgentCard.class)
+                .inNamespace(namespace)
+                .resource(applied)
+                .updateStatus(applied);
+        
+        log.info("Successfully applied and updated status for ApicurioAgentCard: {}", name);
+    }
+
+    private void handleStaleCards(Set<String> activeK8sNames) {
+        log.debug("Scanning for stale ApicurioAgentCard CRDs in namespace: {}", namespace);
+        try {
+            List<ApicurioAgentCard> currentCRDs = kubernetesClient.resources(ApicurioAgentCard.class)
+                    .inNamespace(namespace)
+                    .list()
+                    .getItems();
+
+            List<ApicurioAgentCard> managedCRDs = currentCRDs.stream()
+                    .filter(crd -> crd.getMetadata().getAnnotations() != null
+                            && MANAGED_ANNOTATION_VALUE.equals(crd.getMetadata().getAnnotations().get(MANAGED_ANNOTATION_KEY)))
+                    .collect(Collectors.toList());
+
+            for (ApicurioAgentCard crd : managedCRDs) {
+                String name = crd.getMetadata().getName();
+                if (!activeK8sNames.contains(name)) {
+                    ApicurioAgentCardStatus status = crd.getStatus();
+                    if (status == null || !"Stale".equals(status.getSyncStatus())) {
+                        log.warn("CRD: {} is no longer active in Apicurio Registry. Marking as Stale.", name);
+                        ApicurioAgentCardStatus staleStatus = ApicurioAgentCardStatus.builder()
+                                .syncStatus("Stale")
+                                .lastSynced(Instant.now().toString())
+                                .message("Artifact was deleted or is no longer present in Apicurio Registry")
+                                .build();
+                        crd.setStatus(staleStatus);
+                        kubernetesClient.resources(ApicurioAgentCard.class)
+                                .inNamespace(namespace)
+                                .resource(crd)
+                                .updateStatus(crd);
+                        
+                        String artifactId = name;
+                        if (crd.getMetadata().getAnnotations() != null) {
+                            artifactId = crd.getMetadata().getAnnotations().getOrDefault("apicurio.io/artifact-id", name);
+                        }
+                        apicurioClient.evictCache(artifactId);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to process stale AgentCard CRDs", e);
+        }
+    }
+
+    private String normalizeK8sName(String artifactId) {
+        String normalized = artifactId == null ? "" : artifactId.toLowerCase().replaceAll("[^a-z0-9.-]", "-");
+        normalized = normalized.replaceAll("^[^a-z0-9]+", "").replaceAll("[^a-z0-9]+$", "");
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("artifactId cannot be normalized to a valid Kubernetes resource name");
+        }
+        return normalized.length() > 253 ? normalized.substring(0, 253).replaceAll("[^a-z0-9]+$", "") : normalized;
+    }
+}

--- a/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/AgentCapabilities.java
+++ b/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/AgentCapabilities.java
@@ -1,0 +1,15 @@
+package io.apicurio.registry.sync.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AgentCapabilities {
+    private boolean streaming;
+    private boolean pushNotifications;
+}

--- a/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/AgentSkill.java
+++ b/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/AgentSkill.java
@@ -1,0 +1,19 @@
+package io.apicurio.registry.sync.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AgentSkill {
+    private String id;
+    private String name;
+    private String description;
+    private List<String> tags;
+}

--- a/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/ApicurioAgentCard.java
+++ b/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/ApicurioAgentCard.java
@@ -1,0 +1,12 @@
+package io.apicurio.registry.sync.model;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("apicurio.io")
+@Version("v1alpha1")
+public class ApicurioAgentCard extends CustomResource<ApicurioAgentCardSpec, ApicurioAgentCardStatus>
+        implements Namespaced {
+}

--- a/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/ApicurioAgentCardSpec.java
+++ b/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/ApicurioAgentCardSpec.java
@@ -1,0 +1,23 @@
+package io.apicurio.registry.sync.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApicurioAgentCardSpec {
+    private String name;
+    private String description;
+    private String version;
+    private List<SupportedInterface> supportedInterfaces;
+    private AgentCapabilities capabilities;
+    private List<AgentSkill> skills;
+    private List<String> defaultInputModes;
+    private List<String> defaultOutputModes;
+}

--- a/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/ApicurioAgentCardStatus.java
+++ b/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/ApicurioAgentCardStatus.java
@@ -1,0 +1,16 @@
+package io.apicurio.registry.sync.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApicurioAgentCardStatus {
+    private String syncStatus; // e.g., "Active", "Stale"
+    private String lastSynced; // Timestamp
+    private String message;    // Additional details
+}

--- a/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/SupportedInterface.java
+++ b/utils/agent-card-sync/src/main/java/io/apicurio/registry/sync/model/SupportedInterface.java
@@ -1,0 +1,16 @@
+package io.apicurio.registry.sync.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SupportedInterface {
+    private String url;
+    private String protocolBinding;
+    private String protocolVersion;
+}

--- a/utils/agent-card-sync/src/main/resources/apicurioagentcard.crd.yaml
+++ b/utils/agent-card-sync/src/main/resources/apicurioagentcard.crd.yaml
@@ -1,0 +1,82 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: apicurioagentcards.apicurio.io
+spec:
+  group: apicurio.io
+  names:
+    kind: ApicurioAgentCard
+    listKind: ApicurioAgentCardList
+    plural: apicurioagentcards
+    singular: apicurioagentcard
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                version:
+                  type: string
+                supportedInterfaces:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      protocolBinding:
+                        type: string
+                      protocolVersion:
+                        type: string
+                capabilities:
+                  type: object
+                  properties:
+                    streaming:
+                      type: boolean
+                    pushNotifications:
+                      type: boolean
+                skills:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      description:
+                        type: string
+                      tags:
+                        type: array
+                        items:
+                          type: string
+                defaultInputModes:
+                  type: array
+                  items:
+                    type: string
+                defaultOutputModes:
+                  type: array
+                  items:
+                    type: string
+            status:
+              type: object
+              properties:
+                syncStatus:
+                  type: string
+                lastSynced:
+                  type: string
+                message:
+                  type: string

--- a/utils/agent-card-sync/src/test/java/io/apicurio/registry/sync/controller/AgentCardSyncControllerTest.java
+++ b/utils/agent-card-sync/src/test/java/io/apicurio/registry/sync/controller/AgentCardSyncControllerTest.java
@@ -1,0 +1,161 @@
+package io.apicurio.registry.sync.controller;
+
+import io.apicurio.registry.sync.client.ApicurioAgentCardClient;
+import io.apicurio.registry.sync.client.ApicurioAgentCardClient.AgentCardVersionInfo;
+import io.apicurio.registry.sync.model.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
+import java.util.Collections;
+import java.util.List;
+
+@QuarkusTest
+@QuarkusTestResource(KubernetesServerTestResource.class)
+public class AgentCardSyncControllerTest {
+
+
+    @Inject
+    AgentCardSyncController controller;
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @InjectMock
+    ApicurioAgentCardClient apicurioClient;
+
+    @BeforeEach
+    void cleanUp() {
+        try {
+            kubernetesClient.resources(ApicurioAgentCard.class).inNamespace("default").delete();
+        } catch (Exception e) {
+            // Ignore if CRD is not supported or registered in mock server
+        }
+    }
+
+
+    @Test
+    void testSyncNewCard() {
+        String artifactId = "test-agent-1";
+        AgentCardVersionInfo versionInfo = new AgentCardVersionInfo("default", artifactId, "1.0.0", 1L, 1L, 1000L);
+
+        ApicurioAgentCardSpec spec = ApicurioAgentCardSpec.builder()
+                .name("TestAgent")
+                .description("A test agent card")
+                .version("1.0.0")
+                .supportedInterfaces(List.of(SupportedInterface.builder()
+                        .url("https://example.com/agent")
+                        .protocolBinding("http+json")
+                        .protocolVersion("1.0")
+                        .build()))
+                .capabilities(AgentCapabilities.builder()
+                        .streaming(false)
+                        .pushNotifications(false)
+                        .build())
+                .skills(List.of(AgentSkill.builder()
+                        .id("test-skill")
+                        .name("Test Skill")
+                        .description("A test skill")
+                        .tags(List.of("tag1"))
+                        .build()))
+                .defaultInputModes(List.of("text"))
+                .defaultOutputModes(List.of("text"))
+                .build();
+
+        Mockito.when(apicurioClient.getAgentCardVersions()).thenReturn(List.of(versionInfo));
+        Mockito.when(apicurioClient.isChanged(artifactId, 1L, 1L, 1000L)).thenReturn(true);
+        Mockito.when(apicurioClient.fetchAgentCardSpec("default", artifactId, "1.0.0")).thenReturn(spec);
+
+        // Run sync
+        controller.sync();
+
+        // Verify CRD was created in cluster
+        List<ApicurioAgentCard> list = kubernetesClient.resources(ApicurioAgentCard.class).inNamespace("default").list().getItems();
+        Assertions.assertEquals(1, list.size());
+        ApicurioAgentCard crd = list.get(0);
+        Assertions.assertEquals("test-agent-1", crd.getMetadata().getName());
+        Assertions.assertEquals("true", crd.getMetadata().getAnnotations().get("apicurio.io/managed"));
+        Assertions.assertEquals("test-agent-1", crd.getMetadata().getAnnotations().get("apicurio.io/artifact-id"));
+        Assertions.assertEquals("TestAgent", crd.getSpec().getName());
+        Assertions.assertEquals("Active", crd.getStatus().getSyncStatus());
+    }
+
+    @Test
+    void testSyncStaleCard() {
+        // First sync creates the card
+        String artifactId = "test-agent-stale";
+        String normalizedName = "test-agent-stale";
+        
+        ApicurioAgentCard crd = new ApicurioAgentCard();
+        crd.setMetadata(new io.fabric8.kubernetes.api.model.ObjectMetaBuilder()
+                .withName(normalizedName)
+                .withNamespace("default")
+                .addToAnnotations(AgentCardSyncController.MANAGED_ANNOTATION_KEY, AgentCardSyncController.MANAGED_ANNOTATION_VALUE)
+                .addToAnnotations("apicurio.io/artifact-id", artifactId)
+                .build());
+        crd.setSpec(ApicurioAgentCardSpec.builder().name("StaleAgent").build());
+        crd.setStatus(ApicurioAgentCardStatus.builder().syncStatus("Active").build());
+
+        kubernetesClient.resources(ApicurioAgentCard.class).inNamespace("default").resource(crd).create();
+        kubernetesClient.resources(ApicurioAgentCard.class).inNamespace("default").resource(crd).updateStatus(crd);
+
+        // Mock empty list (card deleted in registry)
+        Mockito.when(apicurioClient.getAgentCardVersions()).thenReturn(Collections.emptyList());
+
+        // Run sync
+        controller.sync();
+
+        // Verify CRD is marked as Stale
+        List<ApicurioAgentCard> list = kubernetesClient.resources(ApicurioAgentCard.class).inNamespace("default").list().getItems();
+        Assertions.assertEquals(1, list.size());
+        ApicurioAgentCard updated = list.get(0);
+        Assertions.assertEquals("Stale", updated.getStatus().getSyncStatus());
+        Assertions.assertTrue(updated.getStatus().getMessage().contains("deleted"));
+        Mockito.verify(apicurioClient).evictCache(artifactId);
+    }
+
+    @Test
+    void testSyncUpdateCardStableName() {
+        String artifactId = "test-agent-update-stable";
+        AgentCardVersionInfo v1 = new AgentCardVersionInfo("default", artifactId, "1", 1L, 1L, 1000L);
+        ApicurioAgentCardSpec spec1 = ApicurioAgentCardSpec.builder().name("OriginalAgent").build();
+
+        Mockito.when(apicurioClient.getAgentCardVersions()).thenReturn(List.of(v1));
+        Mockito.when(apicurioClient.isChanged(artifactId, 1L, 1L, 1000L)).thenReturn(true);
+        Mockito.when(apicurioClient.fetchAgentCardSpec("default", artifactId, "1")).thenReturn(spec1);
+
+        // Run first sync
+        controller.sync();
+
+        // Verify CRD was created with normalized artifactId
+        List<ApicurioAgentCard> list1 = kubernetesClient.resources(ApicurioAgentCard.class).inNamespace("default").list().getItems();
+        Assertions.assertEquals(1, list1.size());
+        Assertions.assertEquals("test-agent-update-stable", list1.get(0).getMetadata().getName());
+        Assertions.assertEquals("OriginalAgent", list1.get(0).getSpec().getName());
+
+        // Now mock version 2 with updated spec content (spec.name changed to "UpdatedAgent")
+        AgentCardVersionInfo v2 = new AgentCardVersionInfo("default", artifactId, "2", 2L, 2L, 2000L);
+        ApicurioAgentCardSpec spec2 = ApicurioAgentCardSpec.builder().name("UpdatedAgent").build();
+
+        Mockito.when(apicurioClient.getAgentCardVersions()).thenReturn(List.of(v2));
+        Mockito.when(apicurioClient.isChanged(artifactId, 2L, 2L, 2000L)).thenReturn(true);
+        Mockito.when(apicurioClient.fetchAgentCardSpec("default", artifactId, "2")).thenReturn(spec2);
+
+        // Run second sync
+        controller.sync();
+
+        // Verify only 1 CRD exists, and its spec name was updated while metadata name remains stable
+        List<ApicurioAgentCard> list2 = kubernetesClient.resources(ApicurioAgentCard.class).inNamespace("default").list().getItems();
+        Assertions.assertEquals(1, list2.size());
+        ApicurioAgentCard finalCr = list2.get(0);
+        Assertions.assertEquals("test-agent-update-stable", finalCr.getMetadata().getName());
+        Assertions.assertEquals("UpdatedAgent", finalCr.getSpec().getName());
+    }
+}

--- a/utils/agent-card-sync/src/test/java/io/apicurio/registry/sync/controller/RealClusterVerificationIT.java
+++ b/utils/agent-card-sync/src/test/java/io/apicurio/registry/sync/controller/RealClusterVerificationIT.java
@@ -1,0 +1,71 @@
+package io.apicurio.registry.sync.controller;
+
+import io.apicurio.registry.sync.client.ApicurioAgentCardClient;
+import io.apicurio.registry.sync.client.ApicurioAgentCardClient.AgentCardVersionInfo;
+import io.apicurio.registry.sync.model.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+@QuarkusTest
+@org.junit.jupiter.api.Disabled("Requires a real Kubernetes cluster (e.g. kind); not intended to run during the build.")
+public class RealClusterVerificationIT {
+
+    @Inject
+    AgentCardSyncController controller;
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @InjectMock
+    ApicurioAgentCardClient apicurioClient;
+
+    @Test
+    void verifyRealClusterSync() {
+        // 1. Setup mock Apicurio response
+        String artifactId = "real-agent-card";
+        AgentCardVersionInfo versionInfo = new AgentCardVersionInfo("default", artifactId, "1.0.0", 1L, 1L, 1000L);
+
+        ApicurioAgentCardSpec spec = ApicurioAgentCardSpec.builder()
+                .name("RealClusterAgent")
+                .description("Verified on real cluster")
+                .version("1.0.0")
+                .supportedInterfaces(List.of(SupportedInterface.builder()
+                        .url("https://example.com/agent")
+                        .protocolBinding("http+json")
+                        .protocolVersion("1.0")
+                        .build()))
+                .build();
+
+        Mockito.when(apicurioClient.getAgentCardVersions()).thenReturn(List.of(versionInfo));
+        Mockito.when(apicurioClient.isChanged(artifactId, 1L, 1L, 1000L)).thenReturn(true);
+        Mockito.when(apicurioClient.fetchAgentCardSpec("default", artifactId, "1.0.0")).thenReturn(spec);
+
+        // Clean up any existing CRD instance for this artifactId
+        try {
+            kubernetesClient.resources(ApicurioAgentCard.class).inNamespace("default").withName(artifactId).delete();
+        } catch (Exception e) {
+            // Ignore if resource does not exist yet
+        }
+
+        // 2. Run the sync controller
+        controller.sync();
+
+        // 3. Assert CRD was created in the real cluster!
+        List<ApicurioAgentCard> list = kubernetesClient.resources(ApicurioAgentCard.class).inNamespace("default").list().getItems();
+        Assertions.assertEquals(1, list.size());
+        
+        ApicurioAgentCard crd = list.get(0);
+        Assertions.assertEquals("real-agent-card", crd.getMetadata().getName());
+        Assertions.assertEquals("RealClusterAgent", crd.getSpec().getName());
+        Assertions.assertEquals("Active", crd.getStatus().getSyncStatus());
+        
+        System.out.println("VERIFICATION SUCCESSFUL: ApicurioAgentCard CR created in Kind cluster!");
+    }
+}

--- a/utils/agent-card-sync/src/test/java/io/apicurio/registry/sync/controller/VerifyEndToEnd.java
+++ b/utils/agent-card-sync/src/test/java/io/apicurio/registry/sync/controller/VerifyEndToEnd.java
@@ -1,0 +1,281 @@
+package io.apicurio.registry.sync.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.client.RegistryClientFactory;
+import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.rest.client.RegistryClient;
+
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import io.apicurio.registry.sync.client.ApicurioAgentCardClient;
+import io.apicurio.registry.sync.model.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.vertx.core.Vertx;
+
+public class VerifyEndToEnd {
+    public static void main(String[] args) {
+        System.out.println("Starting End-to-End Verification...");
+        
+        String registryUrl = "http://localhost:8081/apis/registry/v3";
+        String groupId = "default";
+        long uniqueTime = System.currentTimeMillis();
+        String artifactId = "e2e-agent-card-" + uniqueTime;
+        String k8sName = "e2e-agent-card-" + uniqueTime;
+        String namespace = "default";
+
+        Vertx vertx = Vertx.vertx();
+        try (KubernetesClient k8sClient = new KubernetesClientBuilder().build()) {
+            
+            // Clean up K8s cluster
+            try {
+                k8sClient.resources(ApicurioAgentCard.class).inNamespace(namespace).withName(k8sName).delete();
+                System.out.println("Cleaned up existing K8s CR.");
+            } catch (Exception e) {}
+
+            // Initialize Apicurio Registry SDK Client
+            System.out.println("Initializing Apicurio Registry Client targeting: " + registryUrl);
+            RegistryClientOptions options = RegistryClientOptions.create()
+                    .registryUrl(registryUrl)
+                    .vertx(vertx);
+            RegistryClient registryClient = RegistryClientFactory.create(options);
+
+            // Step 1: Post Agent Card to Apicurio Registry
+            System.out.println("Step 1: Posting AGENT_CARD artifact to Apicurio Registry...");
+            String agentJson = "{"
+                    + "\"name\": \"E2EAgent\","
+                    + "\"description\": \"End to End Verified Agent\","
+                    + "\"version\": \"1.0.0\","
+                    + "\"supportedInterfaces\": [{"
+                    + "  \"url\": \"https://example.com/e2e-agent\","
+                    + "  \"protocolBinding\": \"http+json\","
+                    + "  \"protocolVersion\": \"1.0\""
+                    + "}]"
+                    + "}";
+
+            CreateArtifact createArtifact = new CreateArtifact();
+            createArtifact.setArtifactId(artifactId);
+            createArtifact.setArtifactType("AGENT_CARD");
+            
+            CreateVersion createVersion = new CreateVersion();
+            VersionContent versionContent = new VersionContent();
+            versionContent.setContent(agentJson);
+            versionContent.setContentType("application/json");
+            createVersion.setContent(versionContent);
+            createArtifact.setFirstVersion(createVersion);
+
+            try {
+                registryClient.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).delete();
+            } catch (Exception e) {}
+
+            try {
+                registryClient.groups().byGroupId(groupId).artifacts().post(createArtifact);
+                System.out.println("Successfully posted artifact to registry.");
+            } catch (Exception e) {
+                System.err.println("Exception type: " + e.getClass().getName());
+                System.err.println("Exception message: " + e.getMessage());
+                if (e instanceof com.microsoft.kiota.ApiException) {
+                    com.microsoft.kiota.ApiException apiEx = (com.microsoft.kiota.ApiException) e;
+                    System.err.println("HTTP Response Status: " + apiEx.getResponseStatusCode());
+                }
+                if (e instanceof io.apicurio.registry.rest.client.models.ProblemDetails) {
+                    io.apicurio.registry.rest.client.models.ProblemDetails pd = (io.apicurio.registry.rest.client.models.ProblemDetails) e;
+                    System.err.println("Problem Title: " + pd.getTitle());
+                    System.err.println("Problem Detail: " + pd.getDetail());
+                }
+                throw e;
+            }
+
+            // Wait for artifact to be indexed
+            System.out.println("Waiting for artifact to be indexed...");
+            boolean indexed = false;
+            for (int i = 0; i < 15; i++) {
+                var results = registryClient.search().versions().get(config -> {
+                    config.queryParameters.artifactType = "AGENT_CARD";
+                });
+                if (results != null && results.getVersions() != null && !results.getVersions().isEmpty()) {
+                    boolean found = results.getVersions().stream()
+                            .anyMatch(v -> artifactId.equals(v.getArtifactId()));
+                    if (found) {
+                        indexed = true;
+                        break;
+                    }
+                }
+                Thread.sleep(1000);
+            }
+            if (!indexed) {
+                throw new RuntimeException("E2E Verification Failed: Artifact was not indexed by Apicurio Registry.");
+            }
+            System.out.println("Artifact indexed successfully.");
+
+            // Initialize our Sync Client & Controller programmatically
+            ApicurioAgentCardClient syncClient = new ApicurioAgentCardClient();
+            syncClient.registryUrl = registryUrl;
+            syncClient.vertx = vertx;
+            syncClient.objectMapper = new ObjectMapper();
+
+            System.out.println("Invoking syncClient.getAgentCardVersions() directly...");
+            var cards = syncClient.getAgentCardVersions();
+            System.out.println("Direct syncClient cards count: " + cards.size());
+            for (var c : cards) {
+                System.out.println("  ArtifactId: " + c.artifactId + ", version: " + c.version + ", globalId: " + c.globalId);
+                try {
+                    ApicurioAgentCardSpec spec = syncClient.fetchAgentCardSpec(c.groupId, c.artifactId, c.version);
+                    System.out.println("    Spec: " + (spec == null ? "null" : spec.getName() + " - " + spec.getDescription()));
+                } catch (Exception ex) {
+                    System.out.println("    Failed to fetch spec: " + ex.getMessage());
+                    ex.printStackTrace();
+                }
+            }
+
+            AgentCardSyncController controller = new AgentCardSyncController();
+            controller.apicurioClient = syncClient;
+            controller.kubernetesClient = k8sClient;
+            controller.namespace = namespace;
+
+            // Step 2: Run synchronization cycle
+            System.out.println("Step 2: Running sync controller cycle...");
+            controller.sync();
+
+            // Assert CR was created on K8s cluster
+            ApicurioAgentCard cr = k8sClient.resources(ApicurioAgentCard.class)
+                    .inNamespace(namespace)
+                    .withName(k8sName)
+                    .get();
+            if (cr == null) {
+                throw new RuntimeException("E2E Verification Failed: CR was not created on the cluster.");
+            }
+            System.out.println("SUCCESS: ApicurioAgentCard CR created in K8s. Resource Name: " + cr.getMetadata().getName() + ", Spec Name: " + cr.getSpec().getName());
+            if (!"Active".equals(cr.getStatus().getSyncStatus())) {
+                throw new RuntimeException("E2E Verification Failed: CR status is not Active.");
+            }
+
+            // Step 3: Update version in Apicurio Registry
+            System.out.println("Step 3: Updating artifact in Apicurio Registry...");
+            String updatedAgentJson = "{"
+                    + "\"name\": \"E2EAgent-Updated\","
+                    + "\"description\": \"End to End Verified Agent - Version 2\","
+                    + "\"version\": \"2.0.0\","
+                    + "\"supportedInterfaces\": [{"
+                    + "  \"url\": \"https://example.com/e2e-agent-v2\","
+                    + "  \"protocolBinding\": \"http+json\","
+                    + "  \"protocolVersion\": \"2.0\""
+                    + "}]"
+                    + "}";
+
+            CreateVersion updateVersion = new CreateVersion();
+            VersionContent updateContent = new VersionContent();
+            updateContent.setContent(updatedAgentJson);
+            updateContent.setContentType("application/json");
+            updateVersion.setContent(updateContent);
+
+            registryClient.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions().post(updateVersion);
+            System.out.println("Posted version 2 to registry.");
+
+            // Wait for version update to be indexed
+            System.out.println("Waiting for version update to be indexed...");
+            boolean versionIndexed = false;
+            for (int i = 0; i < 15; i++) {
+                var results = registryClient.search().versions().get(config -> {
+                    config.queryParameters.artifactType = "AGENT_CARD";
+                });
+                if (results != null && results.getVersions() != null) {
+                    boolean found = results.getVersions().stream()
+                            .anyMatch(v -> artifactId.equals(v.getArtifactId()) && "2".equals(v.getVersion()));
+                    if (found) {
+                        versionIndexed = true;
+                        break;
+                    }
+                }
+                Thread.sleep(1000);
+            }
+            if (!versionIndexed) {
+                throw new RuntimeException("E2E Verification Failed: Updated version was not indexed by Apicurio Registry.");
+            }
+            System.out.println("Updated version indexed successfully.");
+
+            // Run sync controller cycle again
+            System.out.println("Running sync controller cycle after update...");
+            controller.sync();
+
+            // Assert CR spec was updated on K8s cluster
+            ApicurioAgentCard updatedCr = k8sClient.resources(ApicurioAgentCard.class)
+                    .inNamespace(namespace)
+                    .withName(k8sName)
+                    .get();
+            if (updatedCr == null || !"2.0.0".equals(updatedCr.getSpec().getVersion())) {
+                throw new RuntimeException("E2E Verification Failed: CR spec was not updated on the cluster.");
+            }
+            System.out.println("SUCCESS: ApicurioAgentCard CR updated in K8s. Resource Name: " + updatedCr.getMetadata().getName() + ", Spec Name: " + updatedCr.getSpec().getName());
+
+            // Step 4: Delete card from Apicurio Registry
+            System.out.println("Step 4: Deleting artifact from Apicurio Registry...");
+            try {
+                registryClient.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).delete();
+                System.out.println("Deleted artifact from registry.");
+            } catch (Exception e) {
+                System.err.println("Exception type: " + e.getClass().getName());
+                System.err.println("Exception message: " + e.getMessage());
+                if (e instanceof com.microsoft.kiota.ApiException) {
+                    com.microsoft.kiota.ApiException apiEx = (com.microsoft.kiota.ApiException) e;
+                    System.err.println("HTTP Response Status: " + apiEx.getResponseStatusCode());
+                }
+                if (e instanceof io.apicurio.registry.rest.client.models.ProblemDetails) {
+                    io.apicurio.registry.rest.client.models.ProblemDetails pd = (io.apicurio.registry.rest.client.models.ProblemDetails) e;
+                    System.err.println("Problem Title: " + pd.getTitle());
+                    System.err.println("Problem Detail: " + pd.getDetail());
+                }
+                throw e;
+            }
+
+            // Wait for deletion to be indexed
+            System.out.println("Waiting for deletion to be indexed...");
+            boolean deletionIndexed = false;
+            for (int i = 0; i < 15; i++) {
+                var results = registryClient.search().versions().get(config -> {
+                    config.queryParameters.artifactType = "AGENT_CARD";
+                });
+                if (results == null || results.getVersions() == null || results.getVersions().isEmpty()) {
+                    deletionIndexed = true;
+                    break;
+                }
+                boolean found = results.getVersions().stream()
+                        .anyMatch(v -> artifactId.equals(v.getArtifactId()));
+                if (!found) {
+                    deletionIndexed = true;
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+            if (!deletionIndexed) {
+                throw new RuntimeException("E2E Verification Failed: Deleted artifact was still returned by search API.");
+            }
+            System.out.println("Deletion indexed successfully.");
+
+            // Run sync controller cycle again
+            System.out.println("Running sync controller cycle after deletion...");
+            controller.sync();
+
+            // Assert CR status is marked as Stale on K8s cluster
+            ApicurioAgentCard staleCr = k8sClient.resources(ApicurioAgentCard.class)
+                    .inNamespace(namespace)
+                    .withName(k8sName)
+                    .get();
+            if (staleCr == null || !"Stale".equals(staleCr.getStatus().getSyncStatus())) {
+                throw new RuntimeException("E2E Verification Failed: CR was not marked as Stale on deletion.");
+            }
+            System.out.println("SUCCESS: ApicurioAgentCard CR marked as Stale in K8s: " + staleCr.getStatus().getMessage());
+
+            // Clean up
+            k8sClient.resources(ApicurioAgentCard.class).inNamespace(namespace).withName(k8sName).delete();
+            System.out.println("E2E VERIFICATION COMPLETED SUCCESSFULLY!");
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
+        } finally {
+            vertx.close();
+            System.exit(0);
+        }
+    }
+}

--- a/utils/agent-card-sync/src/test/java/io/apicurio/registry/sync/controller/VerifyRealCluster.java
+++ b/utils/agent-card-sync/src/test/java/io/apicurio/registry/sync/controller/VerifyRealCluster.java
@@ -1,0 +1,68 @@
+package io.apicurio.registry.sync.controller;
+
+import io.apicurio.registry.sync.model.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import java.util.List;
+
+public class VerifyRealCluster {
+    public static void main(String[] args) {
+        System.out.println("Starting real cluster verification...");
+        try (KubernetesClient client = new KubernetesClientBuilder().build()) {
+            String namespace = "default";
+            String name = "real-agent-card-manual";
+
+            System.out.println("Creating test card spec...");
+            ApicurioAgentCardSpec spec = ApicurioAgentCardSpec.builder()
+                    .name("ManualVerificationAgent")
+                    .description("Created by direct client verification")
+                    .version("1.0.0")
+                    .supportedInterfaces(List.of(SupportedInterface.builder()
+                            .url("https://example.com/agent")
+                            .protocolBinding("http+json")
+                            .protocolVersion("1.0")
+                            .build()))
+                    .build();
+
+            ApicurioAgentCard crd = new ApicurioAgentCard();
+            crd.setMetadata(new io.fabric8.kubernetes.api.model.ObjectMetaBuilder()
+                    .withName(name)
+                    .withNamespace(namespace)
+                    .addToAnnotations(AgentCardSyncController.MANAGED_ANNOTATION_KEY, AgentCardSyncController.MANAGED_ANNOTATION_VALUE)
+                    .build());
+            crd.setSpec(spec);
+
+            System.out.println("Applying CR to kind cluster...");
+            ApicurioAgentCard applied = client.resources(ApicurioAgentCard.class)
+                    .inNamespace(namespace)
+                    .resource(crd)
+                    .createOrReplace();
+
+            ApicurioAgentCardStatus status = ApicurioAgentCardStatus.builder()
+                    .syncStatus("Active")
+                    .lastSynced(java.time.Instant.now().toString())
+                    .message("Synchronized successfully")
+                    .build();
+            applied.setStatus(status);
+
+            client.resources(ApicurioAgentCard.class)
+                    .inNamespace(namespace)
+                    .resource(applied)
+                    .updateStatus(applied);
+
+            System.out.println("Verifying CR was written...");
+            ApicurioAgentCard fetched = client.resources(ApicurioAgentCard.class)
+                    .inNamespace(namespace)
+                    .withName(name)
+                    .get();
+
+            if (fetched != null && "ManualVerificationAgent".equals(fetched.getSpec().getName())) {
+                System.out.println("SUCCESS: ApicurioAgentCard verified on real kind cluster!");
+            } else {
+                System.err.println("FAILURE: Resource spec mismatch or not found.");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/utils/agent-card-sync/src/test/resources/application.properties
+++ b/utils/agent-card-sync/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.scheduler.enabled=false


### PR DESCRIPTION
## Summary

This PR adds a standalone Quarkus module (`utils/agent-card-sync`) implementing a Phase 1 proof of concept for one-way synchronization from Apicurio Registry to Kubernetes. It periodically polls Apicurio Registry for `AGENT_CARD` artifacts and mirrors them as `ApicurioAgentCard` custom resources.

### What's included

- New `utils/agent-card-sync` module, added to the root Maven reactor.
- `ApicurioAgentCard` CRD (`apicurio.io/v1alpha1`) with an A2A v1.0-aligned spec (`name`, `description`, `version`, `supportedInterfaces`, `capabilities`, `skills`, `defaultInputModes`, `defaultOutputModes`) and a status subresource (`syncStatus`, `lastSynced`, `message`).
- Sync controller using the Kiota-generated `apicurio-registry-java-sdk`.
- Change detection based on `globalId`, `contentId`, and `modifiedOn` to avoid unnecessary Kubernetes updates.
- Automatic create/update of resources via `createOrReplace` and marking CRs as `Stale` when the source artifact is removed from the registry.
- CRD manifest for the new resource type.

### Why a separate CRD?

This PR introduces a separate `ApicurioAgentCard` CRD instead of writing directly to Kagenti's `AgentCard`. Kagenti's operator currently owns and manages its own `AgentCard` resources through pod discovery, so using a separate kind keeps this PoC self-contained and avoids cross-repository changes. Aligning with Kagenti's native CRD can be considered in a later phase once ownership semantics are agreed upon.

### Testing

- Unit and integration tests using Fabric8 Mock Kubernetes Server (`quarkus.scheduler.enabled=false` during tests).
- Manual end-to-end verification against a live Apicurio Registry v3 and a Kind cluster covering create, update, delete, and stale transitions.
- Verified that `agentcards.agent.kagenti.dev` and `apicurioagentcards.apicurio.io` CRDs coexist without conflicts.
### Explicitly out of scope

This PR is a Phase 1 PoC. The following items are intentionally deferred:

- [ ] Retry/backoff on registry unavailability.
- [ ] Draft vs. production artifact filtering.
- [ ] Multi-namespace or cluster-wide synchronization.
- [ ] Structured `Failed` status for schema validation errors.
- [ ] Server-Side Apply (currently using `createOrReplace`).
- [ ] Verification against a live `kagenti-operator` controller.
- [ ] Registry authentication (token/TLS).
- [ ] Cross-cluster kubeconfig support.

#### Related issue
Part of: https://github.com/Apicurio/apicurio-registry/issues/8407