### PR TITLE
fix(ui): avoid duplicate label on boolean prompt variables

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -112,7 +112,7 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
                         id={`var-${name}`}
                         isChecked={!!values[name]}
                         onChange={(_event, checked) => setValue(name, checked)}
-                        label={name}
+                        label={variable.description ? `${name} - ${variable.description}` : name}
                     />
                 );
             case "integer":
@@ -162,16 +162,19 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
             </CardHeader>
             <CardBody>
                 <Form className="test-panel-form">
-                    {variablesList.map(({ name, variable }, index) => (
-                        <FormGroup
-                            key={index}
-                            label={variable.description ? `${name} - ${variable.description}` : name}
-                            isRequired={variable.required}
-                            fieldId={`var-${name}`}
-                        >
-                            {renderField(name, variable)}
-                        </FormGroup>
-                    ))}
+                    {variablesList.map(({ name, variable }, index) => {
+                        const isBoolean = (variable.type || "string").toLowerCase() === "boolean";
+                        return (
+                            <FormGroup
+                                key={index}
+                                label={isBoolean ? undefined : (variable.description ? `${name} - ${variable.description}` : name)}
+                                isRequired={variable.required}
+                                fieldId={`var-${name}`}
+                            >
+                                {renderField(name, variable)}
+                            </FormGroup>
+                        );
+                    })}
                     <ActionGroup>
                         <Button
                             variant="primary"


### PR DESCRIPTION
Fixes #8790

Boolean fields in the Test Prompt panel rendered their name twice — once as the FormGroup label above the field, and once as the Checkbox's own inline label. Other field types use `aria-label` for the name, so only the FormGroup label was visible for them; the checkbox is the only widget whose `label` prop is visible inline.

Moved the "name - description" text onto the Checkbox itself and skipped the FormGroup label for booleans. Other field types are unchanged.