### PR TITLE
fix(maven-plugin): close FileInputStream when registering from a file

### DIFF
--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
@@ -619,11 +619,12 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
     }
 
     private VersionMetaData registerArtifact(RegistryClient registryClient, RegisterArtifact artifact,
-                                             List<ArtifactReference> references) throws FileNotFoundException, ExecutionException,
+                                             List<ArtifactReference> references) throws IOException, ExecutionException,
             InterruptedException, MojoExecutionException, MojoFailureException {
         if (artifact.getFile() != null) {
-            return registerArtifact(registryClient, artifact, new FileInputStream(artifact.getFile()),
-                    references);
+            try (InputStream artifactContent = new FileInputStream(artifact.getFile())) {
+                return registerArtifact(registryClient, artifact, artifactContent, references);
+            }
         } else {
             return getArtifactVersionMetadata(registryClient, artifact);
         }
@@ -840,7 +841,7 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
     }
 
     private List<ArtifactReference> processArtifactReferences(RegistryClient registryClient,
-                                                              List<RegisterArtifactReference> referencedArtifacts) throws FileNotFoundException,
+                                                              List<RegisterArtifactReference> referencedArtifacts) throws IOException,
             ExecutionException, InterruptedException, MojoExecutionException, MojoFailureException {
         List<ArtifactReference> references = new ArrayList<>();
         for (RegisterArtifactReference artifact : referencedArtifacts) {


### PR DESCRIPTION
The `register` goal opens a `FileInputStream` per artifact file and, on the
default path, never closes it.

In `RegisterRegistryMojo`, the reference-resolving overload opens the stream and
hands it to the `InputStream` overload, which reads it one of two ways:

- `minify=true` → Jackson reads and closes the stream itself (fine)
- default → `readAllBytes()`, which leaves the stream open

Since `minify` is unset by default, the leaking branch is the normal one. In
practice the build JVM is short-lived and `FileInputStream`'s Cleaner closes the
fd on GC, so it only risks "Too many open files" when registering a very large
number of file artifacts in one run but it's still a resource we open and don't
close.

### Fix

Wrap the stream in try-with-resources at the call site so it's closed on every
path. `close()` can throw `IOException`, so the two methods that propagate it
(`registerArtifact` and `processArtifactReferences`) now declare `throws
IOException` instead of `FileNotFoundException`; all callers already handle it.

No behavior change beyond closing the stream.
