### PR TITLE
fix(kafkasql): emit ARTIFACT_VERSION_STATE_CHANGED event on version state update

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -9,6 +9,7 @@ import io.apicurio.registry.events.ArtifactRuleConfigured;
 import io.apicurio.registry.events.ArtifactVersionCreated;
 import io.apicurio.registry.events.ArtifactVersionDeleted;
 import io.apicurio.registry.events.ArtifactVersionMetadataUpdated;
+import io.apicurio.registry.events.ArtifactVersionStateChanged;
 import io.apicurio.registry.events.GlobalRuleConfigured;
 import io.apicurio.registry.events.GroupCreated;
 import io.apicurio.registry.events.GroupDeleted;
@@ -782,12 +783,23 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
                 .of(ArtifactVersionMetadataUpdated.of(groupId, artifactId, version, metaData)));
     }
 
+    /**
+     * @see io.apicurio.registry.storage.RegistryStorage#updateArtifactVersionState(java.lang.String,
+     *      java.lang.String, java.lang.String, io.apicurio.registry.types.VersionState, boolean)
+     */
     @Override
     public void updateArtifactVersionState(String groupId, String artifactId, String version,
             VersionState newState, boolean dryRun) {
+        // Capture the previous state before submitting the message, since the outbox event carries it.
+        VersionState oldState = getArtifactVersionState(groupId, artifactId, version);
         var message = new UpdateArtifactVersionState5Message(groupId, artifactId, version, newState, dryRun);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        // A dry run performs no committed state change, so no event should be emitted (matches SQL).
+        if (!dryRun) {
+            outboxEvent.fire(KafkaSqlOutboxEvent
+                    .of(ArtifactVersionStateChanged.of(groupId, artifactId, version, oldState, newState)));
+        }
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -10,6 +10,8 @@ import io.apicurio.registry.rest.client.models.EditableGroupMetaData;
 import io.apicurio.registry.rest.client.models.EditableVersionMetaData;
 import io.apicurio.registry.rest.client.models.GroupMetaData;
 import io.apicurio.registry.rest.client.models.Labels;
+import io.apicurio.registry.rest.client.models.VersionState;
+import io.apicurio.registry.rest.client.models.WrappedVersionState;
 import io.apicurio.registry.rules.validity.ValidityLevel;
 import io.apicurio.registry.storage.StorageEventType;
 import io.apicurio.registry.types.ArtifactType;
@@ -45,6 +47,7 @@ import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_RULE_CONFIG
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_CREATED;
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_DELETED;
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_METADATA_UPDATED;
+import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_STATE_CHANGED;
 import static io.apicurio.registry.storage.StorageEventType.GLOBAL_RULE_CONFIGURED;
 import static io.apicurio.registry.storage.StorageEventType.GROUP_CREATED;
 import static io.apicurio.registry.storage.StorageEventType.GROUP_DELETED;
@@ -300,6 +303,46 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 updateEvent.get("eventType").asText());
         Assertions.assertEquals("updateArtifactVersionMetadataEventDescriptionEdited",
                 updateEvent.get("description").asText());
+    }
+
+    @Test
+    public void updateArtifactVersionState() throws Exception {
+        // Preparation
+        final String groupId = "updateArtifactVersionState";
+        final String artifactId = generateArtifactId();
+
+        String name = "updateArtifactVersionStateName";
+        String description = "updateArtifactVersionStateDescription";
+
+        ensureArtifactCreated(groupId, artifactId, name, description);
+
+        // A freshly created version is ENABLED; transition it to DEPRECATED.
+        WrappedVersionState newState = new WrappedVersionState();
+        newState.setState(VersionState.DEPRECATED);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                .byVersionExpression("1").state().put(newState);
+
+        // The state change must produce an ARTIFACT_VERSION_STATE_CHANGED event.
+        List<JsonNode> events = lookupEvent(consumer, ARTIFACT_VERSION_STATE_CHANGED,
+                Map.of("groupId", groupId, "artifactId", artifactId));
+
+        JsonNode stateEvent = null;
+
+        for (JsonNode event : events) {
+            if (event.get("groupId").asText().equals(groupId)
+                    && event.get("eventType").asText().equals(ARTIFACT_VERSION_STATE_CHANGED.name())) {
+                stateEvent = event;
+            }
+        }
+
+        Assertions.assertEquals(1, events.size());
+        Assertions.assertEquals(groupId, stateEvent.get("groupId").asText());
+        Assertions.assertEquals(artifactId, stateEvent.get("artifactId").asText());
+        Assertions.assertEquals(ARTIFACT_VERSION_STATE_CHANGED.name(),
+                stateEvent.get("eventType").asText());
+        Assertions.assertEquals("1", stateEvent.get("version").asText());
+        Assertions.assertEquals(VersionState.ENABLED.name(), stateEvent.get("oldState").asText());
+        Assertions.assertEquals(VersionState.DEPRECATED.name(), stateEvent.get("newState").asText());
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -346,6 +346,56 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void updateArtifactVersionStateDryRun() throws Exception {
+        // Preparation
+        final String groupId = "updateArtifactVersionStateDryRun";
+        final String artifactId = generateArtifactId();
+
+        String name = "updateArtifactVersionStateDryRunName";
+        String description = "updateArtifactVersionStateDryRunDescription";
+
+        ensureArtifactCreated(groupId, artifactId, name, description);
+
+        // A dry-run state change must NOT emit an event. Target DISABLED so that a leaked
+        // dry-run event would be distinguishable from the real change below.
+        WrappedVersionState disabled = new WrappedVersionState();
+        disabled.setState(VersionState.DISABLED);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                .byVersionExpression("1").state()
+                .put(disabled, config -> config.queryParameters.dryRun = true);
+
+        // A real state change to DEPRECATED, used as a deterministic barrier: since events are
+        // produced in submission order to a single partition, a leaked dry-run event (if any)
+        // would already be on the topic by the time this real event is consumed.
+        WrappedVersionState deprecated = new WrappedVersionState();
+        deprecated.setState(VersionState.DEPRECATED);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                .byVersionExpression("1").state().put(deprecated);
+
+        List<JsonNode> events = lookupEvent(consumer, ARTIFACT_VERSION_STATE_CHANGED,
+                Map.of("groupId", groupId, "artifactId", artifactId));
+
+        JsonNode stateEvent = null;
+
+        for (JsonNode event : events) {
+            if (event.get("groupId").asText().equals(groupId)
+                    && event.get("eventType").asText().equals(ARTIFACT_VERSION_STATE_CHANGED.name())) {
+                stateEvent = event;
+            }
+            // The dry-run transition to DISABLED must never have produced an event.
+            Assertions.assertNotEquals(VersionState.DISABLED.name(), event.get("newState").asText());
+        }
+
+        // Only the real DEPRECATED change is emitted; the dry-run produced nothing. The
+        // oldState is ENABLED (not DISABLED), which also confirms the dry-run did not persist.
+        Assertions.assertEquals(1, events.size());
+        Assertions.assertEquals(ARTIFACT_VERSION_STATE_CHANGED.name(),
+                stateEvent.get("eventType").asText());
+        Assertions.assertEquals(VersionState.ENABLED.name(), stateEvent.get("oldState").asText());
+        Assertions.assertEquals(VersionState.DEPRECATED.name(), stateEvent.get("newState").asText());
+    }
+
+    @Test
     public void deleteArtifactVersion() throws Exception {
         // Preparation
         final String groupId = "createArtifactVersion";


### PR DESCRIPTION
On the kafkasql variant, changing an artifact version's state didn't emit an `ARTIFACT_VERSION_STATE_CHANGED` event to the `registry-events` topic, even though the sql variant does. `updateArtifactVersionState` submitted the journal message but never fired a `KafkaSqlOutboxEvent`, unlike the other version and rule operations in the same class. There was also no test covering this event on either variant, which is likely why it went unnoticed.

### Changes

- Fire `ArtifactVersionStateChanged` from `KafkaSqlRegistryStorage.updateArtifactVersionState` after `waitForResponse`, using the same factory as the sql variant so the payload matches.
- Read the previous state before submitting the message (the event carries `oldState`), the same way `SearchIndexEventDecorator` does.
- Skip the event on `dryRun`, since a dry run doesn't commit a state change (matches sql).
- Add a test asserting the event (including `oldState`/`newState`) that runs under both the sql and kafkasql variants.

### Test plan

- [x] `KafkaSqlEventsTest#updateArtifactVersionState` (kafkasql): failed before, passes after
- [x] `RegistryEventsTest#updateArtifactVersionState` (sql): passes, no regression
- [x] `mvnw checkstyle:check` clean

Closes #8763