### PR TITLE
fix(operator): make OLM upgrade test timeout configurable (#8742)

### DIFF
--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
@@ -38,7 +38,8 @@ public class UpgradeOLMITTest implements OperatorTestContext {
     private static final String UPGRADE_START_VERSION_PROP = "test.operator.upgrade-start-version";
     // Must be present in both 3.x and 3.2.x channels in catalog.template.yaml
     private static final String UPGRADE_START_VERSION_DEFAULT = "3.2.4";
-    private static final Duration UPGRADE_TIMEOUT = Duration.ofMinutes(10);
+    private static final Duration UPGRADE_TIMEOUT = Duration.ofSeconds(
+            Integer.getInteger("test.operator.timeout.olm-upgrade", 900));
 
     private KubernetesClient client;
     private String namespace;


### PR DESCRIPTION
## Summary

- Make the hardcoded 10-minute `UPGRADE_TIMEOUT` in `UpgradeOLMITTest` configurable via system property `test.operator.timeout.olm-upgrade`
- Increase default from 600s to 900s (15 min) to accommodate OLM upgrade latency on CI runners
- Follows the established `ITBase` pattern (`Integer.getInteger("test.operator.timeout.*", default)`)

Fixes #8742

## Root Cause

`UpgradeOLMITTest.testManualApprovalUpgrade` times out intermittently because OLM operator upgrades involve multiple async steps (catalog indexing, InstallPlan creation/approval, operator pod creation) with variable latency on shared CI runners. The test timed out at 622s, exceeding the hardcoded 600s limit.

## Test plan

- [ ] CI passes (this is a test infrastructure change — the test itself validates the fix)
- [ ] Verify the property can be overridden: `-Dtest.operator.timeout.olm-upgrade=1200`