### PR TITLE
fix(test): make KafkaSqlStartupVerificationIT timeouts configurable (#8404)

### DIFF
--- a/utils/extra-tests/src/test/java/io/apicurio/registry/utils/tests/infra/AbstractRegistryInfra.java
+++ b/utils/extra-tests/src/test/java/io/apicurio/registry/utils/tests/infra/AbstractRegistryInfra.java
@@ -11,15 +11,16 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 public abstract class AbstractRegistryInfra {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractRegistryInfra.class);
 
     // KafkaSQL bootstrap involves sequential Kafka consumer polls at 5s intervals
-    // plus SQL initialization. 75s provides margin over observed ~49s worst case
-    // under CI load without masking genuinely hung containers.
-    private static final Duration KAFKASQL_STARTUP_TIMEOUT = Duration.ofSeconds(75);
+    // plus SQL initialization. Configurable via -Dtest.extra.timeout.kafkasql-startup=<seconds>.
+    private static final Duration KAFKASQL_STARTUP_TIMEOUT = Duration.ofSeconds(
+            Integer.getInteger("test.extra.timeout.kafkasql-startup", 120));
 
     private final String name;
 
@@ -50,6 +51,14 @@ public abstract class AbstractRegistryInfra {
             registryContainer.followOutput(new Slf4jLogConsumer(log).withPrefix(name));
             return true;
         } catch (ContainerLaunchException ex) {
+            if (ex.getCause() instanceof TimeoutException) {
+                throw new AssertionError(
+                        "Registry container '" + name + "' startup timed out after "
+                                + KAFKASQL_STARTUP_TIMEOUT.toSeconds() + "s"
+                                + " — this is an infrastructure issue, not a validation failure. "
+                                + "Override with -Dtest.extra.timeout.kafkasql-startup=<seconds>",
+                        ex);
+            }
             log.error("Error starting {} container: {}", name, ex.getMessage(), ex);
             return false;
         }

--- a/utils/extra-tests/src/test/java/io/apicurio/registry/utils/tests/infra/KafkaInfra.java
+++ b/utils/extra-tests/src/test/java/io/apicurio/registry/utils/tests/infra/KafkaInfra.java
@@ -49,7 +49,9 @@ public class KafkaInfra implements AutoCloseable {
                     .withNumberOfBrokers(1) // required
                     .withSharedNetwork()
                     .build();
+            long startTime = System.currentTimeMillis();
             kafkaCluster.start();
+            log.info("Kafka cluster started in {} ms", System.currentTimeMillis() - startTime);
         }
     }
 


### PR DESCRIPTION
## Summary

- Make `KAFKASQL_STARTUP_TIMEOUT` configurable via `-Dtest.extra.timeout.kafkasql-startup=<seconds>` (default bumped from 75s to 120s)
- Distinguish timeout exceptions from validation failures — timeouts now throw `AssertionError` with a clear diagnostic message instead of returning `false` (which was indistinguishable from a genuine topic config validation failure)
- Add Kafka cluster startup timing log for diagnosing startup performance

Fixes #8404

## Root Cause

Two failure modes, both infrastructure flakes on resource-constrained CI runners:

1. **Kafka container startup timeout** — `StrimziKafkaCluster` exceeds Testcontainers default timeout (~60s)
2. **Registry container startup timeout** — Registry doesn't emit the bootstrap log message within the hardcoded 75s `KAFKASQL_STARTUP_TIMEOUT`

The critical bug was that `startRegistryContainer` caught `ContainerLaunchException` (including timeouts) and returned `false` — the same value returned for invalid topic configurations. This made infrastructure flakes appear as expected test failures in CI reports.

## Test plan

- [ ] CI passes (`-Dfull` profile includes `utils/extra-tests`)
- [ ] Verify the property can be overridden: `-Dtest.extra.timeout.kafkasql-startup=180`
- [ ] Timeout failures now show clear diagnostic message instead of `expected true but was false`