### PR TITLE
test(operator): add the infra extension and share one operator (Phase 1)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -165,7 +165,7 @@ and tags starting with `3.`.
 | `update-openapi.yaml` | Push to main (openapi.json changes) | Auto-copies v3 OpenAPI spec to v2 path, commits if changed, then validates via `validate-openapi.yaml` | 10-15 min |
 | `update-website.yaml` | Release event, workflow_dispatch | Updates `latestRelease.json` on apicurio.github.io with release metadata | 5-10 min |
 | `publish-docs.yaml` | Push to main (docs/**), workflow_dispatch | Builds documentation via Antora playbook and publishes to apicurio.github.io | 15-30 min |
-| `operator.yaml` | Push/PR to main (operator/**) | Operator CI: build + push temp images to ttl.sh (8h TTL), 8-group test matrix on Minikube (smoke, kafka, auth, database, feature, feature-setup, OLM v0, OLM v1), publish to Quay.io on push. Cancels in-progress on new push | 45-90 min |
+| `operator.yaml` | Push/PR to main (operator/**) | Operator CI: build + push temp images to ttl.sh (8h TTL), 9-group test matrix on Minikube (smoke, kafka, auth, database, feature, feature-setup, operator-mutation, OLM v0, OLM v1), publish to Quay.io on push. Cancels in-progress on new push | 45-90 min |
 | `image-scan.yaml` | Daily at 06:00 UTC, workflow_dispatch | Trivy vulnerability scan on `latest-snapshot` image (CRITICAL + HIGH severity). Results uploaded to GitHub Security tab as SARIF | 5-10 min |
 
 ## Reusable Workflows

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -204,6 +204,11 @@ jobs:
             olm-enable: "false"
             olm-v1-enable: "false"
             extra-build-opts: ""
+          - name: operator-mutation
+            groups: "operator-mutation"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
           - name: olm-v1
             groups: "OLM"
             olm-enable: "true"

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -208,6 +208,11 @@ jobs:
             olm-enable: "false"
             olm-v1-enable: "false"
             extra-build-opts: ""
+          - name: operator-mutation
+            groups: "operator-mutation"
+            olm-enable: "false"
+            olm-v1-enable: "false"
+            extra-build-opts: ""
           - name: olm-v1
             groups: "OLM"
             olm-enable: "true"

--- a/operator/README.md
+++ b/operator/README.md
@@ -204,6 +204,78 @@ Available configuration options:
 | test.operator.ingress-host    | string             | -             | Used when testing Ingresses. For some clusters, you might need to provide the base hostname from where the applications on your cluster are accessible. |
 | test.operator.cleanup-enabled | `true` / `false`   | `true`        | Clean test namespaces from the cluster after the tests finish.                                                                                          |
 | test.operator.strimzi-namespace | string           | `strimzi-cluster-operator` | Dedicated long-lived namespace for the cluster-wide Strimzi operator used by the Kafka tests. Never deleted by cleanup; on persistent clusters remove it manually (see `controller/src/test/resources/strimzi/README.md`). |
+| test.operator.operator-namespace | string          | `apicurio-registry-operator-test` | Dedicated long-lived namespace for the shared cluster-wide Apicurio operator (remote tests). Never deleted by cleanup; on persistent clusters remove it manually along with the operator CRD, ClusterRole and ClusterRoleBinding. |
+
+### How the integration tests share an operator
+
+There's one operator for the whole test run, watching all namespaces, while each test class still gets
+its own throwaway namespace to create its CRs in. Remote tests install it once per cluster into
+`test.operator.operator-namespace`; local tests start one in-process operator per JVM. Neither gets torn
+down between classes, which is the whole point, since previously each of the ~28 classes was paying for
+a full operator deploy, wait-for-ready and undeploy on its own.
+
+Worth noting: the operator needs no config to watch all namespaces -- `App#start` calls
+`watchingAllNamespaces()` whenever `apicurio.operator.watched-namespaces` is blank.
+
+Three classes can't share it though, since they mutate the operator Deployment itself:
+`RestrictedNamespaceITTest`, `LeaderElectionITTest` and `OperatorConfigITTest`. These get
+`@DedicatedOperator`, so they spin up their own operator in their own namespace and run in a separate
+`operator-mutation` CI job. **They must not share a cluster with the shared operator** -- two operators
+would both end up reconciling the same CRs, and the install file's ClusterRoleBinding is a single
+cluster-scoped object that a second install would just rebind out from under the first.
+
+#### Writing a test against the infrastructure
+
+`OperatorInfraExtension` hands a test class its namespace, client and managers as parameters, so it
+doesn't need to extend `ITBase` at all:
+
+```java
+@QuarkusTest
+@ExtendWith({ OperatorInfraExtension.class, OperatorTestExtension.class })
+@Tag(FEATURE)
+public class MyITTest {
+
+    @Test
+    void test(KubernetesClient client, @TestNamespace String namespace, RegistryAssertions check) {
+        ...
+    }
+}
+```
+
+What you can inject: `KubernetesClient`, a `String` annotated `@TestNamespace`, `RegistryAssertions`,
+plus the `IngressManager`, `PortForwardManager`, `PodLogManager`, `JobManager` and `HostAliasManager`
+managers. The extension creates the namespace before the class and deletes it after, and cleans up the
+class's CRs between test methods so each one starts from an empty namespace (all of this subject to
+`test.operator.cleanup-enabled`). If a class needs Kafka, it just declares `@NeedsStrimzi` instead of
+installing it itself.
+
+`DisableUIITTest` is the worked example if you want to see it in practice. Most classes still extend
+`ITBase` though, and that's fine -- the two approaches coexist and share the one operator, so classes can
+be migrated one at a time rather than all at once. They're not duplicating logic either: `ITBase` keeps
+its `checkDeploymentExists(...)`-style helpers by delegating to the same `RegistryAssertions`, and both
+paths do their per-test cleanup through `ITBase.deleteRegistryCRs(...)`.
+
+#### Why these tests are not run in parallel
+
+These get parallelised by CI job, never by threads or forks inside one JVM. That's the project-wide rule
+for `@QuarkusTest` classes anyway, documented in `.github/workflows/README.md` ("Why not use
+forkCount > 1?"). Surefire's default `forkCount=1` already gives one JVM per module, and this Makefile
+passes `-T1` to override the repository's `-T 1C` (#8448).
+
+JUnit's own `junit.jupiter.execution.parallel.enabled` isn't an alternative here.
+`QuarkusTestExtension.ensureStarted()` isn't synchronised, so if two test classes run concurrently they
+each try to boot Quarkus, and the second boot dies with
+`Already a codec registered with name quarkus_default_local_codec`. Upstream is tracking the broader fix
+in quarkusio/quarkus#52992, still open as of writing. So for now, adding shards is really the only way to
+get more parallelism; see #7487 and #7494 for how the current jobs got split.
+
+One thing worth calling out: a `junit-platform.properties` holding those settings is deliberately **not**
+added to `controller/src/test/resources`. JUnit only reads the first such file it finds on the classpath,
+so adding one would shadow the copy shipped in `quarkus-junit-config` and drop Quarkus' own
+defaults -- `QuarkusClassOrderer`, which groups test classes to avoid needless Quarkus restarts, and
+extension autodetection. A file that just has to repeat someone else's defaults to avoid breaking them is
+worse than not having the file at all, especially since the settings it would carry are the platform
+defaults anyway.
 
 ### Remote Tests
 

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/Tags.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/Tags.java
@@ -28,6 +28,9 @@ public final class Tags {
     /** Feature tests with heavy infrastructure setup (multi-namespace, TLS, operator restarts) */
     public static final String FEATURE_SETUP = "feature-setup";
 
+    /** Tests that mutate the operator Deployment itself */
+    public static final String OPERATOR_MUTATION = "operator-mutation";
+
     /** Slow tests that take significant time */
     public static final String SLOW = "slow";
 

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/DedicatedOperator.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/DedicatedOperator.java
@@ -1,0 +1,13 @@
+package io.apicurio.registry.operator.it;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface DedicatedOperator {
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/DisableUIITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/DisableUIITTest.java
@@ -2,9 +2,12 @@ package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.apicurio.registry.operator.utils.OperatorTestExtension;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static io.apicurio.registry.operator.Tags.FEATURE;
 import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
@@ -12,11 +15,13 @@ import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_U
 import static io.apicurio.registry.operator.utils.K8sCell.k8sCellCreate;
 
 @QuarkusTest
+@ExtendWith({ OperatorInfraExtension.class, OperatorTestExtension.class })
 @Tag(FEATURE)
-public class DisableUIITTest extends ITBase {
+public class DisableUIITTest {
 
     @Test
-    void disableUITest() {
+    void disableUITest(KubernetesClient client, IngressManager ingressManager,
+            RegistryAssertions check) {
 
         final var registry = k8sCellCreate(client, () -> {
             var r = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml", ApicurioRegistry3.class);
@@ -27,33 +32,33 @@ public class DisableUIITTest extends ITBase {
             return r;
         });
 
-        checkDeploymentExists(registry.getCached(), COMPONENT_APP, 1);
-        checkDeploymentExists(registry.getCached(), COMPONENT_UI, 1);
-        checkServiceExists(registry.getCached(), COMPONENT_APP);
-        checkServiceExists(registry.getCached(), COMPONENT_UI);
-        checkIngressExists(registry.getCached(), COMPONENT_APP);
-        checkIngressExists(registry.getCached(), COMPONENT_UI);
+        check.checkDeploymentExists(registry.getCached(), COMPONENT_APP, 1);
+        check.checkDeploymentExists(registry.getCached(), COMPONENT_UI, 1);
+        check.checkServiceExists(registry.getCached(), COMPONENT_APP);
+        check.checkServiceExists(registry.getCached(), COMPONENT_UI);
+        check.checkIngressExists(registry.getCached(), COMPONENT_APP);
+        check.checkIngressExists(registry.getCached(), COMPONENT_UI);
 
         registry.update(r -> {
             r.getSpec().getUi().setEnabled(false);
         });
 
-        checkDeploymentExists(registry.getCached(), COMPONENT_APP, 1);
-        checkDeploymentDoesNotExist(registry.getCached(), COMPONENT_UI);
-        checkServiceExists(registry.getCached(), COMPONENT_APP);
-        checkServiceDoesNotExist(registry.getCached(), COMPONENT_UI);
-        checkIngressExists(registry.getCached(), COMPONENT_APP);
-        checkIngressDoesNotExist(registry.getCached(), COMPONENT_UI);
+        check.checkDeploymentExists(registry.getCached(), COMPONENT_APP, 1);
+        check.checkDeploymentDoesNotExist(registry.getCached(), COMPONENT_UI);
+        check.checkServiceExists(registry.getCached(), COMPONENT_APP);
+        check.checkServiceDoesNotExist(registry.getCached(), COMPONENT_UI);
+        check.checkIngressExists(registry.getCached(), COMPONENT_APP);
+        check.checkIngressDoesNotExist(registry.getCached(), COMPONENT_UI);
 
         registry.update(r -> {
             r.getSpec().getUi().setEnabled(true);
         });
 
-        checkDeploymentExists(registry.getCached(), COMPONENT_APP, 1);
-        checkDeploymentExists(registry.getCached(), COMPONENT_UI, 1);
-        checkServiceExists(registry.getCached(), COMPONENT_APP);
-        checkServiceExists(registry.getCached(), COMPONENT_UI);
-        checkIngressExists(registry.getCached(), COMPONENT_APP);
-        checkIngressExists(registry.getCached(), COMPONENT_UI);
+        check.checkDeploymentExists(registry.getCached(), COMPONENT_APP, 1);
+        check.checkDeploymentExists(registry.getCached(), COMPONENT_UI, 1);
+        check.checkServiceExists(registry.getCached(), COMPONENT_APP);
+        check.checkServiceExists(registry.getCached(), COMPONENT_UI);
+        check.checkIngressExists(registry.getCached(), COMPONENT_APP);
+        check.checkIngressExists(registry.getCached(), COMPONENT_UI);
     }
 }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -1,6 +1,5 @@
 package io.apicurio.registry.operator.it;
 
-import io.apicurio.registry.operator.App;
 import io.apicurio.registry.operator.OperatorException;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.apicurio.registry.operator.resource.Labels;
@@ -12,6 +11,7 @@ import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.apicurio.registry.operator.utils.OperatorTestContext;
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.restassured.RestAssured;
 import io.restassured.config.HttpClientConfig;
-import jakarta.enterprise.inject.spi.CDI;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -48,7 +46,6 @@ import static io.apicurio.registry.operator.resource.Labels.getOperatorManagedLa
 import static io.apicurio.registry.operator.utils.Mapper.toYAML;
 import static io.apicurio.registry.utils.Cell.cell;
 import static java.time.Duration.ofSeconds;
-import static java.util.Optional.ofNullable;
 import static org.apache.http.params.CoreConnectionPNames.CONNECTION_TIMEOUT;
 import static org.apache.http.params.CoreConnectionPNames.SO_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -94,9 +91,12 @@ public abstract class ITBase implements OperatorTestContext {
     protected String deploymentTarget;
     protected String namespace;
     protected boolean cleanup;
-    private App app;
     protected JobManager jobManager;
     protected HostAliasManager hostAliasManager;
+
+    protected RegistryAssertions assertions;
+    protected String operatorNamespace;
+    private static volatile boolean operatorDebugForwarded;
 
     @Override
     public KubernetesClient getClient() {
@@ -109,8 +109,13 @@ public abstract class ITBase implements OperatorTestContext {
     }
 
     @Override
-    public java.util.List<String> extraDiagnosticNamespaces() {
-        return java.util.List.of(StrimziClusterWideInstaller.strimziNamespace());
+    public List<String> extraDiagnosticNamespaces() {
+        return List.of(StrimziClusterWideInstaller.strimziNamespace(),
+                OperatorClusterWideInstaller.operatorNamespace());
+    }
+
+    private boolean usesDedicatedOperator() {
+        return getClass().isAnnotationPresent(DedicatedOperator.class);
     }
 
     @BeforeAll
@@ -132,11 +137,19 @@ public abstract class ITBase implements OperatorTestContext {
         hostAliasManager = new HostAliasManager(client);
         jobManager = new JobManager(client, hostAliasManager);
 
-        if (operatorDeployment == OperatorDeployment.remote) {
+        assertions = new RegistryAssertions(client, namespace);
+
+        if (operatorDeployment == OperatorDeployment.remote && usesDedicatedOperator()) {
+            operatorNamespace = namespace;
             createTestResources();
         } else {
-            createCRDs();
-            startOperator();
+            operatorNamespace = operatorDeployment == OperatorDeployment.remote
+                    ? OperatorClusterWideInstaller.operatorNamespace()
+                    : namespace;
+            SharedOperatorLifecycle.ensureStarted(client, operatorDeployment, deploymentTarget);
+        }
+        if (getClass().isAnnotationPresent(NeedsStrimzi.class)) {
+            StrimziClusterWideInstaller.ensureInstalled(client);
         }
         startOperatorPodLog();
     }
@@ -158,8 +171,9 @@ public abstract class ITBase implements OperatorTestContext {
     protected void startOperatorPodLog() {
         if (operatorDeployment == OperatorDeployment.remote) {
             var operatorPod = waitOnOperatorPodReady();
-            if (getConfig().getValue(REMOTE_DEBUG_PROP, Boolean.class)) {
+            if (getConfig().getValue(REMOTE_DEBUG_PROP, Boolean.class) && !operatorDebugForwarded) {
                 portForwardManager.startPodPortForward(operatorPod.getMetadata().getName(), 5005, 15005);
+                operatorDebugForwarded = true;
                 log.info("Remote debugging enabled. Attach your debugger to port 15005.");
             }
             podLogManager.startPodLog(ResourceID.fromResource(operatorPod));
@@ -171,90 +185,39 @@ public abstract class ITBase implements OperatorTestContext {
     }
 
     protected void checkDeploymentExists(ApicurioRegistry3 primary, String component, int replicas) {
-        await().atMost(MEDIUM_DURATION).ignoreExceptions().untilAsserted(() -> {
-            assertThat(client.apps().deployments()
-                    .inNamespace(ofNullable(primary.getMetadata().getNamespace()).orElse(namespace))
-                    .withName(primary.getMetadata().getName() + "-" + component + "-deployment").get()
-                    .getStatus().getReadyReplicas()).isEqualTo(replicas);
-        });
+        assertions.checkDeploymentExists(primary, component, replicas);
     }
 
     protected void checkDeploymentDoesNotExist(ApicurioRegistry3 primary, String component) {
-        Runnable check = () -> {
-            assertThat(client.apps().deployments()
-                    .inNamespace(ofNullable(primary.getMetadata().getNamespace()).orElse(namespace))
-                    .withName(primary.getMetadata().getName() + "-" + component + "-deployment").get())
-                    .isNull();
-        };
-        await().during(ofSeconds(10)).atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(check::run);
-        check.run();
+        assertions.checkDeploymentDoesNotExist(primary, component);
     }
 
     protected void checkServiceExists(ApicurioRegistry3 primary, String component) {
-        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
-            assertThat(client.services()
-                    .inNamespace(ofNullable(primary.getMetadata().getNamespace()).orElse(namespace))
-                    .withName(primary.getMetadata().getName() + "-" + component + "-service").get())
-                    .isNotNull();
-        });
+        assertions.checkServiceExists(primary, component);
     }
 
     protected void checkServiceDoesNotExist(ApicurioRegistry3 primary, String component) {
-        Runnable check = () -> {
-            assertThat(client.services()
-                    .inNamespace(ofNullable(primary.getMetadata().getNamespace()).orElse(namespace))
-                    .withName(primary.getMetadata().getName() + "-" + component + "-service").get()).isNull();
-        };
-        await().during(ofSeconds(10)).atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(check::run);
-        check.run();
+        assertions.checkServiceDoesNotExist(primary, component);
     }
 
     protected void checkIngressExists(ApicurioRegistry3 primary, String component) {
-        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
-            assertThat(client.network().v1().ingresses()
-                    .inNamespace(ofNullable(primary.getMetadata().getNamespace()).orElse(namespace))
-                    .withName(primary.getMetadata().getName() + "-" + component + "-ingress").get())
-                    .isNotNull();
-        });
+        assertions.checkIngressExists(primary, component);
     }
 
     protected void checkIngressDoesNotExist(ApicurioRegistry3 primary, String component) {
-        Runnable check = () -> {
-            assertThat(client.network().v1().ingresses()
-                    .inNamespace(ofNullable(primary.getMetadata().getNamespace()).orElse(namespace))
-                    .withName(primary.getMetadata().getName() + "-" + component + "-ingress").get()).isNull();
-        };
-        await().during(ofSeconds(10)).atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(check::run);
-        check.run();
+        assertions.checkIngressDoesNotExist(primary, component);
     }
 
     protected PodDisruptionBudget checkPodDisruptionBudgetExists(ApicurioRegistry3 primary,
-                                                                        String component) {
-        final Cell<PodDisruptionBudget> rval = cell();
-        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
-            PodDisruptionBudget pdb = client.policy().v1().podDisruptionBudget()
-                    .withName(primary.getMetadata().getName() + "-" + component + "-poddisruptionbudget")
-                    .get();
-            assertThat(pdb).isNotNull();
-            rval.set(pdb);
-        });
-
-        return rval.get();
+            String component) {
+        return assertions.checkPodDisruptionBudgetExists(primary, component);
     }
 
     protected NetworkPolicy checkNetworkPolicyExists(ApicurioRegistry3 primary, String component) {
-        final Cell<NetworkPolicy> rval = cell();
-        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
-            NetworkPolicy networkPolicy = client.network().v1().networkPolicies()
-                    .withName(primary.getMetadata().getName() + "-" + component + "-networkpolicy").get();
-            assertThat(networkPolicy).isNotNull();
-            rval.set(networkPolicy);
-        });
-
-        return rval.get();
+        return assertions.checkNetworkPolicyExists(primary, component);
     }
 
-    private void configureRestAssured() {
+    static void configureRestAssured() {
         RestAssured.config = RestAssured.config()
                 .httpClient(HttpClientConfig.httpClientConfig()
                         // Helps with port-forwarded connection issues.
@@ -276,7 +239,10 @@ public abstract class ITBase implements OperatorTestContext {
             var installFileRaw = Files.readString(installFilePath);
             // We're not editing the deserialized resources to replicate the user experience
             installFileRaw = installFileRaw.replace("PLACEHOLDER_NAMESPACE", namespace);
-            return Serialization.unmarshal(installFileRaw);
+            List<HasMetadata> resources = Serialization.unmarshal(installFileRaw);
+            resources.stream().filter(r -> r instanceof ClusterRoleBinding).forEach(
+                    r -> r.getMetadata().setName(r.getMetadata().getName() + "-" + namespace));
+            return resources;
         } catch (NoSuchFileException ex) {
             throw new OperatorException("Remote tests require an install file to be generated. " +
                     "Please run `make INSTALL_FILE=\"" + installFilePath + "\" dist-install-file` first, " +
@@ -306,6 +272,7 @@ public abstract class ITBase implements OperatorTestContext {
             operatorDeployments.clear();
             operatorDeployments.addAll(
                     client.apps().deployments()
+                            .inNamespace(operatorNamespace)
                             .withLabels(Labels.getOperatorSelectorLabels())
                             .list().getItems()
             );
@@ -321,6 +288,7 @@ public abstract class ITBase implements OperatorTestContext {
         // TODO: Allow configuring wait time dilatation.
         await().atMost(MEDIUM_DURATION.multipliedBy(2)).during(ofSeconds(15)).ignoreExceptions().untilAsserted(() -> {
             var operatorPods = client.pods()
+                    .inNamespace(operatorNamespace)
                     .withLabels(Labels.getOperatorSelectorLabels())
                     .list().getItems();
             assertThat(operatorPods)
@@ -341,39 +309,10 @@ public abstract class ITBase implements OperatorTestContext {
 
     private void cleanTestResources() throws Exception {
         if (cleanup) {
-            log.info("Deleting generated resources from Namespace {}", namespace);
-            loadTestResources().forEach(r -> {
-                client.resource(r).inNamespace(namespace).delete();
-            });
+            log.info("Deleting cluster-scoped resources generated for Namespace {}", namespace);
+            loadTestResources().stream().filter(ClusterRoleBinding.class::isInstance)
+                    .forEach(r -> client.resource(r).delete());
         }
-    }
-
-    private void createCRDs() {
-        log.info("Creating CRDs");
-        try {
-            var crd = client.load(new FileInputStream(CRD_FILE));
-            crd.createOrReplace();
-            await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
-                crd.resources().forEach(r -> assertThat(r.get()).isNotNull());
-            });
-        } catch (Exception e) {
-            log.warn("Failed to create the CRD, retrying", e);
-            createCRDs();
-        }
-    }
-
-    private void startOperator() {
-        app = CDI.current().select(App.class).get();
-        app.start(configOverride -> {
-            configOverride.withKubernetesClient(client);
-            configOverride.withUseSSAToPatchPrimaryResource(false);
-        });
-    }
-
-    // The Strimzi operator is installed once per cluster (watching all namespaces) into a dedicated
-    // namespace that afterAll never deletes; test classes only create their Kafka CRs.
-    void applyStrimziResources() throws IOException {
-        StrimziClusterWideInstaller.ensureInstalled(client);
     }
 
     /**
@@ -439,41 +378,40 @@ public abstract class ITBase implements OperatorTestContext {
     @AfterEach
     void afterEach() {
         if (cleanup) {
-            log.info("Deleting CRs");
-            client.resources(ApicurioRegistry3.class).delete();
-            try {
-                await().atMost(MEDIUM_DURATION).untilAsserted(() -> {
-                    assertThat(client.resources(ApicurioRegistry3.class).inNamespace(namespace)
-                            .list().getItems()).isEmpty();
-                });
-            } catch (org.awaitility.core.ConditionTimeoutException e) {
-                log.warn("Timed out waiting for graceful CR cleanup, force-removing finalizers");
-                client.resources(ApicurioRegistry3.class).list().getItems().forEach(cr -> {
-                    cr.getMetadata().setFinalizers(List.of());
-                    client.resource(cr).patch();
-                });
-                await().atMost(SHORT_DURATION).untilAsserted(() -> {
-                    assertThat(client.resources(ApicurioRegistry3.class).inNamespace(namespace)
-                            .list().getItems()).isEmpty();
-                });
-            }
+            deleteRegistryCRs(client, namespace);
+        }
+    }
+
+    static void deleteRegistryCRs(KubernetesClient client, String namespace) {
+        log.info("Deleting CRs");
+        client.resources(ApicurioRegistry3.class).delete();
+        try {
             await().atMost(MEDIUM_DURATION).untilAsserted(() -> {
-                var registryDeployments = client.apps().deployments().inNamespace(namespace)
-                        .withLabels(getOperatorManagedLabels()).list().getItems();
-                assertThat(registryDeployments.size()).isZero();
+                assertThat(client.resources(ApicurioRegistry3.class).inNamespace(namespace)
+                        .list().getItems()).isEmpty();
+            });
+        } catch (org.awaitility.core.ConditionTimeoutException e) {
+            log.warn("Timed out waiting for graceful CR cleanup, force-removing finalizers");
+            client.resources(ApicurioRegistry3.class).list().getItems().forEach(cr -> {
+                cr.getMetadata().setFinalizers(List.of());
+                client.resource(cr).patch();
+            });
+            await().atMost(SHORT_DURATION).untilAsserted(() -> {
+                assertThat(client.resources(ApicurioRegistry3.class).inNamespace(namespace)
+                        .list().getItems()).isEmpty();
             });
         }
+        await().atMost(MEDIUM_DURATION).untilAsserted(() -> {
+            var registryDeployments = client.apps().deployments().inNamespace(namespace)
+                    .withLabels(getOperatorManagedLabels()).list().getItems();
+            assertThat(registryDeployments.size()).isZero();
+        });
     }
 
     @AfterAll
     void afterAll() throws Exception {
         portForwardManager.close();
-        if (operatorDeployment == OperatorDeployment.local) {
-            app.stop();
-            log.info("Creating new K8s Client");
-            // create a new client bc operator has closed the old one
-            client = createK8sClient(namespace);
-        } else {
+        if (operatorDeployment == OperatorDeployment.remote && usesDedicatedOperator()) {
             cleanTestResources();
         }
         podLogManager.stopAndWait();

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlAccessITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlAccessITTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
+@NeedsStrimzi
 @Tag(KAFKA)
 @Tag(SLOW)
 public class KafkaSqlAccessITTest extends ITBase {
@@ -49,7 +50,6 @@ public class KafkaSqlAccessITTest extends ITBase {
 
     @BeforeAll
     public void beforeAll() throws Exception {
-        applyStrimziResources();
         if (!kafkaAccessOperatorInstalled) {
             installKafkaAccessOperator();
         }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlITTest.java
@@ -2,7 +2,6 @@ package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -13,16 +12,13 @@ import static io.apicurio.registry.operator.Tags.SLOW;
 import static io.apicurio.registry.operator.resource.ResourceFactory.deserialize;
 
 @QuarkusTest
+@NeedsStrimzi
 @Tag(KAFKA)
 @Tag(SLOW)
 public class KafkaSqlITTest extends ITBase {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaSqlITTest.class);
 
-    @BeforeAll
-    public void beforeAll() throws Exception {
-        applyStrimziResources();
-    }
 
     @Test
     void testKafkaSQLPlain() {

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlOAuthITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlOAuthITTest.java
@@ -2,7 +2,6 @@ package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -14,6 +13,7 @@ import static io.apicurio.registry.operator.Tags.SLOW;
 import static io.apicurio.registry.operator.resource.ResourceFactory.deserialize;
 
 @QuarkusTest
+@NeedsStrimzi
 @Tag(KAFKA)
 @Tag(AUTH)
 @Tag(SLOW)
@@ -21,10 +21,6 @@ public class KafkaSqlOAuthITTest extends BaseAuthITTest {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaSqlOAuthITTest.class);
 
-    @BeforeAll
-    public void beforeAll() throws Exception {
-        applyStrimziResources();
-    }
 
     @Test
     void testKafkaSQLOauth() {

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlTLSITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/KafkaSqlTLSITTest.java
@@ -2,7 +2,6 @@ package io.apicurio.registry.operator.it;
 
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -15,16 +14,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
+@NeedsStrimzi
 @Tag(KAFKA)
 @Tag(SLOW)
 public class KafkaSqlTLSITTest extends ITBase {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaSqlTLSITTest.class);
 
-    @BeforeAll
-    public void beforeAll() throws Exception {
-        applyStrimziResources();
-    }
 
     @Test
     void testKafkaSQLTLS() {

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/LeaderElectionITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/LeaderElectionITTest.java
@@ -14,8 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.apicurio.registry.operator.Tags.FEATURE;
-import static io.apicurio.registry.operator.Tags.FEATURE_SETUP;
+import static io.apicurio.registry.operator.Tags.OPERATOR_MUTATION;
 import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
 import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
 import static io.apicurio.registry.operator.utils.K8sCell.k8sCell;
@@ -24,8 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
-@Tag(FEATURE)
-@Tag(FEATURE_SETUP)
+@Tag(OPERATOR_MUTATION)
+@DedicatedOperator
 public class LeaderElectionITTest extends ITBase {
 
     private static final Logger log = LoggerFactory.getLogger(LeaderElectionITTest.class);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/NeedsStrimzi.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/NeedsStrimzi.java
@@ -1,0 +1,13 @@
+package io.apicurio.registry.operator.it;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface NeedsStrimzi {
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorClusterWideInstaller.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorClusterWideInstaller.java
@@ -1,0 +1,139 @@
+package io.apicurio.registry.operator.it;
+
+import io.apicurio.registry.operator.OperatorException;
+import io.apicurio.registry.operator.resource.Labels;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
+
+final class OperatorClusterWideInstaller {
+
+    private static final Logger log = LoggerFactory.getLogger(OperatorClusterWideInstaller.class);
+
+    static final String OPERATOR_NAMESPACE_PROP = "test.operator.operator-namespace";
+    static final String OPERATOR_NAMESPACE_DEFAULT = "apicurio-registry-operator-test";
+
+    private static final String PLACEHOLDER_NAMESPACE = "PLACEHOLDER_NAMESPACE";
+
+    private static boolean installedInThisJvm = false;
+
+    private OperatorClusterWideInstaller() {
+    }
+
+    static String operatorNamespace() {
+        return getConfig().getOptionalValue(OPERATOR_NAMESPACE_PROP, String.class)
+                .orElse(OPERATOR_NAMESPACE_DEFAULT);
+    }
+
+    static synchronized void ensureInstalled(KubernetesClient client, String deploymentTarget)
+            throws IOException {
+        if (installedInThisJvm) {
+            return;
+        }
+        var namespace = operatorNamespace();
+        if (isOperatorReady(client, namespace)) {
+            log.info("Operator already ready in namespace {}, skipping install", namespace);
+            installedInThisJvm = true;
+            return;
+        }
+        log.info("Installing cluster-wide operator into namespace {}", namespace);
+        ensureNamespace(client, namespace);
+        for (HasMetadata resource : loadInstallFile(namespace, deploymentTarget)) {
+            log.info("Creating operator resource kind {} name {}", resource.getKind(),
+                    resource.getMetadata().getName());
+            await().atMost(ITBase.SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
+                client.resource(resource).inNamespace(namespace).createOrReplace();
+                assertThat(client.resource(resource).inNamespace(namespace).get()).isNotNull();
+            });
+        }
+        waitForOperatorReady(client, namespace);
+        installedInThisJvm = true;
+    }
+
+    private static boolean isOperatorReady(KubernetesClient client, String namespace) {
+        var deployments = client.apps().deployments().inNamespace(namespace)
+                .withLabels(Labels.getOperatorSelectorLabels()).list().getItems();
+        if (deployments.size() != 1) {
+            return false;
+        }
+        var status = deployments.get(0).getStatus();
+        if (status == null) {
+            return false;
+        }
+        var readyReplicas = status.getReadyReplicas();
+        return readyReplicas != null && readyReplicas > 0;
+    }
+
+    private static void ensureNamespace(KubernetesClient client, String namespace) {
+        if (client.namespaces().withName(namespace).get() == null) {
+            try {
+                client.resource(new NamespaceBuilder().withNewMetadata()
+                        .addToLabels("app", "apicurio-registry-operator-test-operator").withName(namespace)
+                        .endMetadata().build()).create();
+            } catch (KubernetesClientException ex) {
+                if (ex.getStatus() == null || !"AlreadyExists".equals(ex.getStatus().getReason())) {
+                    throw ex;
+                }
+            }
+        }
+    }
+
+    private static List<HasMetadata> loadInstallFile(String namespace, String deploymentTarget)
+            throws IOException {
+        var installFilePath = Path.of(getConfig().getValue(ITBase.REMOTE_TESTS_INSTALL_FILE, String.class));
+        try {
+            return transformInstallFile(Files.readString(installFilePath), namespace, deploymentTarget);
+        } catch (NoSuchFileException ex) {
+            throw new OperatorException("Remote tests require an install file to be generated. "
+                    + "Please run `make INSTALL_FILE=\"" + installFilePath + "\" dist-install-file` first, "
+                    + "or see the README for more information.", ex);
+        }
+    }
+
+    static List<HasMetadata> transformInstallFile(String rawInstallFile, String namespace,
+            String deploymentTarget) {
+        List<HasMetadata> resources = Serialization
+                .unmarshal(rawInstallFile.replace(PLACEHOLDER_NAMESPACE, namespace));
+        resources.forEach(r -> {
+            retargetToNamespace(r, namespace);
+            if ("minikube".equals(deploymentTarget)) {
+                useLocallyBuiltImage(r);
+            }
+        });
+        return resources;
+    }
+
+    private static void retargetToNamespace(HasMetadata resource, String namespace) {
+        if (resource instanceof ClusterRoleBinding crb && crb.getSubjects() != null) {
+            crb.getSubjects().forEach(s -> s.setNamespace(namespace));
+        }
+    }
+
+    private static void useLocallyBuiltImage(HasMetadata resource) {
+        if (resource instanceof Deployment d) {
+            d.getSpec().getTemplate().getSpec().getContainers()
+                    .forEach(c -> c.setImagePullPolicy("IfNotPresent"));
+        }
+    }
+
+    private static void waitForOperatorReady(KubernetesClient client, String namespace) {
+        await().atMost(ITBase.LONG_DURATION).ignoreExceptions()
+                .untilAsserted(() -> assertThat(isOperatorReady(client, namespace)).isTrue());
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorClusterWideInstallerTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorClusterWideInstallerTest.java
@@ -1,0 +1,83 @@
+package io.apicurio.registry.operator.it;
+
+import io.apicurio.registry.operator.Tags;
+import io.apicurio.registry.operator.resource.Labels;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+@Tag(Tags.FEATURE)
+class OperatorClusterWideInstallerTest {
+
+    private static final String NS = "apicurio-operator-test-ns";
+    private static final String FIXTURE = "/operator-install/install-file-fixture.yaml";
+
+    private static List<HasMetadata> transform(String deploymentTarget) throws IOException {
+        try (InputStream in = OperatorClusterWideInstallerTest.class.getResourceAsStream(FIXTURE)) {
+            assertThat(in).as("fixture on classpath").isNotNull();
+            return OperatorClusterWideInstaller.transformInstallFile(
+                    new String(in.readAllBytes(), StandardCharsets.UTF_8), NS, deploymentTarget);
+        }
+    }
+
+    @Test
+    void bindsClusterRoleBindingSubjectToTheDedicatedNamespace() throws Exception {
+        var resources = transform("minikube");
+
+        var bindings = resources.stream().filter(ClusterRoleBinding.class::isInstance)
+                .map(ClusterRoleBinding.class::cast).toList();
+        assertThat(bindings).hasSize(1);
+        assertThat(bindings.get(0).getSubjects()).singleElement()
+                .satisfies(s -> {
+                    assertThat(s.getKind()).isEqualTo("ServiceAccount");
+                    assertThat(s.getNamespace()).isEqualTo(NS);
+                });
+        assertThat(bindings.get(0).getRoleRef().getName())
+                .isEqualTo("apicurio-registry-operator-clusterrole");
+    }
+
+    @Test
+    void placesNamespacedResourcesInTheDedicatedNamespace() throws Exception {
+        var resources = transform("minikube");
+
+        assertThat(resources).hasSize(5);
+        assertThat(resources.stream().filter(ServiceAccount.class::isInstance))
+                .singleElement()
+                .satisfies(sa -> assertThat(sa.getMetadata().getNamespace()).isEqualTo(NS));
+        assertThat(resources.stream().filter(Deployment.class::isInstance))
+                .singleElement()
+                .satisfies(d -> assertThat(d.getMetadata().getNamespace()).isEqualTo(NS));
+        assertThat(resources).noneSatisfy(r -> assertThat(r.getMetadata().getNamespace())
+                .isEqualTo("PLACEHOLDER_NAMESPACE"));
+    }
+
+    @Test
+    void keepsOperatorSelectorLabelsSoTheReadinessGuardCanFindTheDeployment() throws Exception {
+        var deployment = (Deployment) transform("minikube").stream()
+                .filter(Deployment.class::isInstance).findFirst().orElseThrow();
+
+        assertThat(deployment.getMetadata().getLabels())
+                .containsAllEntriesOf(Labels.getOperatorSelectorLabels());
+    }
+
+    @Test
+    void forcesLocalImageOnMinikubeOnly() throws Exception {
+        assertThat(imagePullPolicy(transform("minikube"))).isEqualTo("IfNotPresent");
+        assertThat(imagePullPolicy(transform("kubernetes"))).isEqualTo("Always");
+    }
+
+    private static String imagePullPolicy(List<HasMetadata> resources) {
+        var deployment = (Deployment) resources.stream().filter(Deployment.class::isInstance)
+                .findFirst().orElseThrow();
+        return deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy();
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorConfigITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorConfigITTest.java
@@ -9,14 +9,13 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.apicurio.registry.operator.Tags.FEATURE;
-import static io.apicurio.registry.operator.Tags.FEATURE_SETUP;
+import static io.apicurio.registry.operator.Tags.OPERATOR_MUTATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
-@Tag(FEATURE)
-@Tag(FEATURE_SETUP)
+@Tag(OPERATOR_MUTATION)
+@DedicatedOperator
 public class OperatorConfigITTest extends ITBase {
 
     private static final Logger log = LoggerFactory.getLogger(OperatorConfigITTest.class);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorInfraExtension.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorInfraExtension.java
@@ -1,0 +1,190 @@
+package io.apicurio.registry.operator.it;
+
+import io.apicurio.registry.operator.utils.OperatorTestContext;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static io.apicurio.registry.operator.it.ITBase.CLEANUP;
+import static io.apicurio.registry.operator.it.ITBase.DEPLOYMENT_TARGET;
+import static io.apicurio.registry.operator.it.ITBase.OPERATOR_DEPLOYMENT_PROP;
+import static io.apicurio.registry.operator.it.ITBase.calculateNamespace;
+import static io.apicurio.registry.operator.it.ITBase.configureRestAssured;
+import static io.apicurio.registry.operator.it.ITBase.createK8sClient;
+import static io.apicurio.registry.operator.it.ITBase.createNamespace;
+import static io.apicurio.registry.operator.it.ITBase.setDefaultAwaitilityTimings;
+import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
+
+public class OperatorInfraExtension
+        implements BeforeAllCallback, AfterEachCallback, AfterAllCallback, ParameterResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(OperatorInfraExtension.class);
+
+    private static final Namespace STORE = Namespace.create(OperatorInfraExtension.class);
+
+    private static final String SHARED_STRIMZI = "shared-strimzi";
+
+    private static final Map<Class<?>, Function<ClassInfra, Object>> INJECTABLE = Map.of(
+            KubernetesClient.class, infra -> infra.client,
+            RegistryAssertions.class, infra -> infra.assertions,
+            IngressManager.class, infra -> infra.ingressManager,
+            PortForwardManager.class, infra -> infra.portForwardManager,
+            PodLogManager.class, infra -> infra.podLogManager,
+            JobManager.class, infra -> infra.jobManager,
+            HostAliasManager.class, infra -> infra.hostAliasManager);
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        setDefaultAwaitilityTimings();
+        configureRestAssured();
+        var infra = new ClassInfra(context.getRequiredTestClass().getSimpleName());
+        context.getStore(STORE).put(ClassInfra.class, infra);
+        context.getStore(OperatorTestContext.STORE_NAMESPACE).put(OperatorTestContext.class, infra);
+        sharedOperator(context, infra);
+        if (context.getRequiredTestClass().isAnnotationPresent(NeedsStrimzi.class)) {
+            sharedStrimzi(context, infra);
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        var infra = classInfra(context);
+        if (infra.cleanup) {
+            ITBase.deleteRegistryCRs(infra.client, infra.namespace);
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        classInfra(context).tearDown();
+    }
+
+    private static ClassInfra classInfra(ExtensionContext context) {
+        var infra = context.getStore(STORE).get(ClassInfra.class, ClassInfra.class);
+        if (infra == null) {
+            throw new IllegalStateException("No infrastructure for "
+                    + context.getRequiredTestClass().getName()
+                    + ". Is @ExtendWith(OperatorInfraExtension.class) present on the test class?");
+        }
+        return infra;
+    }
+
+    private static void sharedOperator(ExtensionContext context, ClassInfra infra) {
+        context.getRoot().getStore(STORE).getOrComputeIfAbsent(SharedOperator.class,
+                key -> new SharedOperator(infra), SharedOperator.class);
+    }
+
+    private static void sharedStrimzi(ExtensionContext context, ClassInfra infra) {
+        context.getRoot().getStore(STORE).getOrComputeIfAbsent(SHARED_STRIMZI, key -> {
+            try {
+                StrimziClusterWideInstaller.ensureInstalled(infra.client);
+            } catch (IOException e) {
+                throw new IllegalStateException("Could not install Strimzi", e);
+            }
+            return Boolean.TRUE;
+        });
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        var type = parameterContext.getParameter().getType();
+        return type == String.class ? parameterContext.isAnnotated(TestNamespace.class)
+                : INJECTABLE.containsKey(type);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        var infra = classInfra(extensionContext);
+        var type = parameterContext.getParameter().getType();
+        return type == String.class ? infra.namespace : INJECTABLE.get(type).apply(infra);
+    }
+
+    static final class ClassInfra implements OperatorTestContext {
+
+        final ITBase.OperatorDeployment deploymentType;
+        final String deploymentTarget;
+        final boolean cleanup;
+        final String namespace;
+        final KubernetesClient client;
+        final RegistryAssertions assertions;
+        final PortForwardManager portForwardManager;
+        final IngressManager ingressManager;
+        final PodLogManager podLogManager;
+        final HostAliasManager hostAliasManager;
+        final JobManager jobManager;
+
+        ClassInfra(String testClassName) {
+            deploymentType = getConfig().getValue(OPERATOR_DEPLOYMENT_PROP, ITBase.OperatorDeployment.class);
+            deploymentTarget = getConfig().getValue(DEPLOYMENT_TARGET, String.class);
+            cleanup = getConfig().getValue(CLEANUP, Boolean.class);
+            namespace = calculateNamespace();
+            client = createK8sClient(namespace);
+            createNamespace(client, namespace);
+            log.info("Namespace {} created for {}", namespace, testClassName);
+            assertions = new RegistryAssertions(client, namespace);
+            portForwardManager = new PortForwardManager(namespace);
+            ingressManager = new IngressManager(client, namespace);
+            podLogManager = new PodLogManager(client);
+            hostAliasManager = new HostAliasManager(client);
+            jobManager = new JobManager(client, hostAliasManager);
+        }
+
+        @Override
+        public KubernetesClient getClient() {
+            return client;
+        }
+
+        @Override
+        public String getNamespace() {
+            return namespace;
+        }
+
+        @Override
+        public List<String> extraDiagnosticNamespaces() {
+            return List.of(StrimziClusterWideInstaller.strimziNamespace(),
+                    OperatorClusterWideInstaller.operatorNamespace());
+        }
+
+        void tearDown() throws Exception {
+            portForwardManager.close();
+            podLogManager.stopAndWait();
+            if (cleanup) {
+                log.info("Deleting namespace {}", namespace);
+                client.namespaces().withName(namespace).delete();
+            }
+            client.close();
+        }
+    }
+
+    static final class SharedOperator implements AutoCloseable {
+
+        SharedOperator(ClassInfra infra) {
+            try {
+                SharedOperatorLifecycle.ensureStarted(infra.client, infra.deploymentType,
+                        infra.deploymentTarget);
+            } catch (Exception e) {
+                throw new IllegalStateException("Could not start the shared operator", e);
+            }
+        }
+
+        @Override
+        public void close() {
+            SharedOperatorLifecycle.stopLocalOperator();
+        }
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorInfraExtensionTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorInfraExtensionTest.java
@@ -1,0 +1,89 @@
+package io.apicurio.registry.operator.it;
+
+import io.apicurio.registry.operator.Tags;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ParameterContext;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag(Tags.FEATURE)
+class OperatorInfraExtensionTest {
+
+    private final OperatorInfraExtension extension = new OperatorInfraExtension();
+
+    @SuppressWarnings("unused")
+    private static void injectable(KubernetesClient client, RegistryAssertions assertions,
+            IngressManager ingressManager, PortForwardManager portForwardManager,
+            PodLogManager podLogManager, JobManager jobManager, HostAliasManager hostAliasManager,
+            @TestNamespace String namespace, String unqualified, Integer unsupported) {
+    }
+
+    private static ParameterContext contextFor(int index) throws Exception {
+        Method method = OperatorInfraExtensionTest.class.getDeclaredMethod("injectable",
+                KubernetesClient.class, RegistryAssertions.class, IngressManager.class,
+                PortForwardManager.class, PodLogManager.class, JobManager.class, HostAliasManager.class,
+                String.class, String.class, Integer.class);
+        Parameter parameter = method.getParameters()[index];
+        return new ParameterContext() {
+            @Override
+            public Parameter getParameter() {
+                return parameter;
+            }
+
+            @Override
+            public int getIndex() {
+                return index;
+            }
+
+            @Override
+            public Optional<Object> getTarget() {
+                return Optional.empty();
+            }
+        };
+    }
+
+    private boolean supports(int index) throws Exception {
+        return extension.supportsParameter(contextFor(index), null);
+    }
+
+    @Test
+    void supportsEveryInfrastructureType() throws Exception {
+        for (int i = 0; i <= 6; i++) {
+            assertThat(supports(i)).as("parameter %d", i).isTrue();
+        }
+    }
+
+    @Test
+    void supportsNamespaceOnlyWhenQualified() throws Exception {
+        assertThat(supports(7)).as("@TestNamespace String").isTrue();
+        assertThat(supports(8)).as("unqualified String").isFalse();
+    }
+
+    @Test
+    void rejectsUnknownTypes() throws Exception {
+        assertThat(supports(9)).as("Integer").isFalse();
+    }
+
+    @Test
+    void needsStrimziIsInheritedAndDetectableOnTestClasses() {
+        assertThat(KafkaSqlITTest.class.isAnnotationPresent(NeedsStrimzi.class)).isTrue();
+        assertThat(KafkaSqlTLSITTest.class.isAnnotationPresent(NeedsStrimzi.class)).isTrue();
+        assertThat(KafkaSqlOAuthITTest.class.isAnnotationPresent(NeedsStrimzi.class)).isTrue();
+        assertThat(KafkaSqlAccessITTest.class.isAnnotationPresent(NeedsStrimzi.class)).isTrue();
+        assertThat(SmokeITTest.class.isAnnotationPresent(NeedsStrimzi.class)).isFalse();
+    }
+
+    @Test
+    void operatorMutatingTestsAreMarkedDedicated() {
+        assertThat(RestrictedNamespaceITTest.class.isAnnotationPresent(DedicatedOperator.class)).isTrue();
+        assertThat(LeaderElectionITTest.class.isAnnotationPresent(DedicatedOperator.class)).isTrue();
+        assertThat(OperatorConfigITTest.class.isAnnotationPresent(DedicatedOperator.class)).isTrue();
+        assertThat(SmokeITTest.class.isAnnotationPresent(DedicatedOperator.class)).isFalse();
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/RegistryAssertions.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/RegistryAssertions.java
@@ -1,0 +1,107 @@
+package io.apicurio.registry.operator.it;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.utils.Cell;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
+import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import static io.apicurio.registry.operator.it.ITBase.MEDIUM_DURATION;
+import static io.apicurio.registry.operator.it.ITBase.SHORT_DURATION;
+import static io.apicurio.registry.utils.Cell.cell;
+import static java.time.Duration.ofSeconds;
+import static java.util.Optional.ofNullable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class RegistryAssertions {
+
+    private final KubernetesClient client;
+    private final String namespace;
+
+    public RegistryAssertions(KubernetesClient client, String namespace) {
+        this.client = client;
+        this.namespace = namespace;
+    }
+
+    private String namespaceOf(ApicurioRegistry3 primary) {
+        return ofNullable(primary.getMetadata().getNamespace()).orElse(namespace);
+    }
+
+    private String resourceName(ApicurioRegistry3 primary, String component, String suffix) {
+        return primary.getMetadata().getName() + "-" + component + "-" + suffix;
+    }
+
+    public void checkDeploymentExists(ApicurioRegistry3 primary, String component, int replicas) {
+        await().atMost(MEDIUM_DURATION).ignoreExceptions().untilAsserted(() -> {
+            assertThat(client.apps().deployments().inNamespace(namespaceOf(primary))
+                    .withName(resourceName(primary, component, "deployment")).get()
+                    .getStatus().getReadyReplicas()).isEqualTo(replicas);
+        });
+    }
+
+    public void checkDeploymentDoesNotExist(ApicurioRegistry3 primary, String component) {
+        Runnable check = () -> {
+            assertThat(client.apps().deployments().inNamespace(namespaceOf(primary))
+                    .withName(resourceName(primary, component, "deployment")).get()).isNull();
+        };
+        await().during(ofSeconds(10)).atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(check::run);
+        check.run();
+    }
+
+    public void checkServiceExists(ApicurioRegistry3 primary, String component) {
+        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
+            assertThat(client.services().inNamespace(namespaceOf(primary))
+                    .withName(resourceName(primary, component, "service")).get()).isNotNull();
+        });
+    }
+
+    public void checkServiceDoesNotExist(ApicurioRegistry3 primary, String component) {
+        Runnable check = () -> {
+            assertThat(client.services().inNamespace(namespaceOf(primary))
+                    .withName(resourceName(primary, component, "service")).get()).isNull();
+        };
+        await().during(ofSeconds(10)).atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(check::run);
+        check.run();
+    }
+
+    public void checkIngressExists(ApicurioRegistry3 primary, String component) {
+        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
+            assertThat(client.network().v1().ingresses().inNamespace(namespaceOf(primary))
+                    .withName(resourceName(primary, component, "ingress")).get()).isNotNull();
+        });
+    }
+
+    public void checkIngressDoesNotExist(ApicurioRegistry3 primary, String component) {
+        Runnable check = () -> {
+            assertThat(client.network().v1().ingresses().inNamespace(namespaceOf(primary))
+                    .withName(resourceName(primary, component, "ingress")).get()).isNull();
+        };
+        await().during(ofSeconds(10)).atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(check::run);
+        check.run();
+    }
+
+    public PodDisruptionBudget checkPodDisruptionBudgetExists(ApicurioRegistry3 primary, String component) {
+        final Cell<PodDisruptionBudget> rval = cell();
+        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
+            PodDisruptionBudget pdb = client.policy().v1().podDisruptionBudget()
+                    .inNamespace(namespaceOf(primary))
+                    .withName(resourceName(primary, component, "poddisruptionbudget")).get();
+            assertThat(pdb).isNotNull();
+            rval.set(pdb);
+        });
+        return rval.get();
+    }
+
+    public NetworkPolicy checkNetworkPolicyExists(ApicurioRegistry3 primary, String component) {
+        final Cell<NetworkPolicy> rval = cell();
+        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
+            NetworkPolicy networkPolicy = client.network().v1().networkPolicies()
+                    .inNamespace(namespaceOf(primary))
+                    .withName(resourceName(primary, component, "networkpolicy")).get();
+            assertThat(networkPolicy).isNotNull();
+            rval.set(networkPolicy);
+        });
+        return rval.get();
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/RestrictedNamespaceITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/RestrictedNamespaceITTest.java
@@ -14,8 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-import static io.apicurio.registry.operator.Tags.FEATURE;
-import static io.apicurio.registry.operator.Tags.FEATURE_SETUP;
+import static io.apicurio.registry.operator.Tags.OPERATOR_MUTATION;
 import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
 import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
 import static io.apicurio.registry.operator.utils.K8sCell.k8sCell;
@@ -25,8 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
-@Tag(FEATURE)
-@Tag(FEATURE_SETUP)
+@Tag(OPERATOR_MUTATION)
+@DedicatedOperator
 public class RestrictedNamespaceITTest extends ITBase {
 
     private static final Logger log = LoggerFactory.getLogger(RestrictedNamespaceITTest.class);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/SharedOperatorLifecycle.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/SharedOperatorLifecycle.java
@@ -1,0 +1,74 @@
+package io.apicurio.registry.operator.it;
+
+import io.apicurio.registry.operator.App;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import jakarta.enterprise.inject.spi.CDI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import static io.apicurio.registry.operator.it.ITBase.CRD_FILE;
+import static io.apicurio.registry.operator.it.ITBase.SHORT_DURATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+final class SharedOperatorLifecycle {
+
+    private static final Logger log = LoggerFactory.getLogger(SharedOperatorLifecycle.class);
+
+    private static App localOperator;
+    private static KubernetesClient localOperatorClient;
+
+    private SharedOperatorLifecycle() {
+    }
+
+    static synchronized void ensureStarted(KubernetesClient client,
+            ITBase.OperatorDeployment deploymentType, String deploymentTarget) throws IOException {
+        if (deploymentType == ITBase.OperatorDeployment.remote) {
+            OperatorClusterWideInstaller.ensureInstalled(client, deploymentTarget);
+            return;
+        }
+        if (localOperator != null) {
+            return;
+        }
+        localOperatorClient = new KubernetesClientBuilder().build();
+        createCRDs(localOperatorClient);
+        var app = CDI.current().select(App.class).get();
+        app.start(configOverride -> {
+            configOverride.withKubernetesClient(localOperatorClient);
+            configOverride.withUseSSAToPatchPrimaryResource(false);
+        });
+        localOperator = app;
+        log.info("Started the shared in-process operator for this JVM");
+    }
+
+    static synchronized void stopLocalOperator() {
+        if (localOperator == null) {
+            return;
+        }
+        log.info("Stopping the shared in-process operator");
+        try {
+            localOperator.stop();
+        } finally {
+            localOperator = null;
+            localOperatorClient = null;
+        }
+    }
+
+    private static void createCRDs(KubernetesClient client) {
+        log.info("Creating CRDs");
+        try {
+            var crd = client.load(new FileInputStream(CRD_FILE));
+            crd.createOrReplace();
+            await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
+                crd.resources().forEach(r -> assertThat(r.get()).isNotNull());
+            });
+        } catch (Exception e) {
+            log.warn("Failed to create the CRD, retrying", e);
+            createCRDs(client);
+        }
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/SharedOperatorLifecycle.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/SharedOperatorLifecycle.java
@@ -60,15 +60,20 @@ final class SharedOperatorLifecycle {
 
     private static void createCRDs(KubernetesClient client) {
         log.info("Creating CRDs");
-        try {
-            var crd = client.load(new FileInputStream(CRD_FILE));
-            crd.createOrReplace();
-            await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
-                crd.resources().forEach(r -> assertThat(r.get()).isNotNull());
-            });
-        } catch (Exception e) {
-            log.warn("Failed to create the CRD, retrying", e);
-            createCRDs(client);
+        Exception last = null;
+        for (int attempt = 1; attempt <= 3; attempt++) {
+            try {
+                var crd = client.load(new FileInputStream(CRD_FILE));
+                crd.createOrReplace();
+                await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
+                    crd.resources().forEach(r -> assertThat(r.get()).isNotNull());
+                });
+                return;
+            } catch (Exception e) {
+                last = e;
+                log.warn("CRD creation attempt {}/3 failed", attempt, e);
+            }
         }
+        throw new IllegalStateException("Could not create the CRDs after 3 attempts", last);
     }
 }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/StrimziClusterWideInstaller.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/StrimziClusterWideInstaller.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -59,7 +60,7 @@ final class StrimziClusterWideInstaller {
     private static final String LEADER_ELECTION_ROLE_BINDING = "strimzi-cluster-operator-leader-election";
     // RoleBindings the watch-all-namespaces procedure converts to ClusterRoleBindings. Fail-fast on
     // anything else so a version bump cannot silently escalate a new namespaced binding to cluster scope.
-    private static final java.util.Set<String> CONVERTIBLE_ROLE_BINDINGS = java.util.Set.of(
+    private static final Set<String> CONVERTIBLE_ROLE_BINDINGS = Set.of(
             "strimzi-cluster-operator", "strimzi-cluster-operator-watched",
             "strimzi-cluster-operator-entity-operator-delegation");
 

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/StrimziClusterWideInstaller.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/StrimziClusterWideInstaller.java
@@ -94,7 +94,12 @@ final class StrimziClusterWideInstaller {
         for (HasMetadata resource : loadAndTransformManifest(namespace)) {
             log.info("Creating Strimzi resource kind {} name {}", resource.getKind(),
                     resource.getMetadata().getName());
-            client.resource(resource).inNamespace(namespace).createOrReplace();
+            // Retry each create so a transient API error on one resource does not abort the whole
+            // install; mirrors OperatorClusterWideInstaller. createOrReplace is idempotent on retry.
+            await().atMost(ITBase.SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
+                client.resource(resource).inNamespace(namespace).createOrReplace();
+                assertThat(client.resource(resource).inNamespace(namespace).get()).isNotNull();
+            });
         }
         waitForOperatorReady(client, namespace);
         installedInThisJvm = true;

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/TestNamespace.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/TestNamespace.java
@@ -1,0 +1,11 @@
+package io.apicurio.registry.operator.it;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface TestNamespace {
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestContext.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestContext.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.operator.utils;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Implemented by operator test base classes ({@code ITBase}, {@code OLMITBase}) to expose the Kubernetes
@@ -8,6 +9,8 @@ import io.fabric8.kubernetes.client.KubernetesClient;
  * infrastructure and allows the extension to dump cluster diagnostics on failure.
  */
 public interface OperatorTestContext {
+
+    ExtensionContext.Namespace STORE_NAMESPACE = ExtensionContext.Namespace.create(OperatorTestContext.class);
 
     KubernetesClient getClient();
 
@@ -21,10 +24,6 @@ public interface OperatorTestContext {
         return false;
     }
 
-    /**
-     * Additional namespaces whose diagnostics should be dumped when a test fails, beyond the test's
-     * own namespace (e.g. the dedicated namespace of a shared operator the test depends on).
-     */
     default java.util.List<String> extraDiagnosticNamespaces() {
         return java.util.List.of();
     }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestContext.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestContext.java
@@ -3,6 +3,8 @@ package io.apicurio.registry.operator.utils;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.util.List;
+
 /**
  * Implemented by operator test base classes ({@code ITBase}, {@code OLMITBase}) to expose the Kubernetes
  * client and namespace to the {@link OperatorTestExtension}. This avoids reflection for accessing test
@@ -24,7 +26,7 @@ public interface OperatorTestContext {
         return false;
     }
 
-    default java.util.List<String> extraDiagnosticNamespaces() {
-        return java.util.List.of();
+    default List<String> extraDiagnosticNamespaces() {
+        return List.of();
     }
 }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestExtension.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestExtension.java
@@ -91,14 +91,12 @@ public class OperatorTestExtension implements InvocationInterceptor, AfterTestEx
         if (context.getExecutionException().isEmpty()) {
             return;
         }
-        Object testInstance = context.getRequiredTestInstance();
-        if (testInstance instanceof OperatorTestContext ctx) {
+        OperatorTestContext ctx = resolveContext(context);
+        if (ctx != null) {
             var client = ctx.getClient();
             var namespace = ctx.getNamespace();
             if (client != null && namespace != null) {
                 ClusterDiagnostics.dump(client, namespace, ctx.isOLMTest());
-                // E.g. the shared Strimzi operator namespace: its reconcile logs are the primary
-                // diagnostic for Kafka CR failures in the test namespace.
                 for (String extra : ctx.extraDiagnosticNamespaces()) {
                     if (client.namespaces().withName(extra).get() != null) {
                         ClusterDiagnostics.dump(client, extra, false);
@@ -108,8 +106,16 @@ public class OperatorTestExtension implements InvocationInterceptor, AfterTestEx
                 log.warn("Cannot dump cluster diagnostics: client={}, namespace={}", client, namespace);
             }
         } else {
-            log.warn("Test class does not implement OperatorTestContext, skipping cluster diagnostics");
+            log.warn("No OperatorTestContext for this test, skipping cluster diagnostics");
         }
+    }
+
+    private OperatorTestContext resolveContext(ExtensionContext context) {
+        if (context.getRequiredTestInstance() instanceof OperatorTestContext ctx) {
+            return ctx;
+        }
+        return context.getStore(OperatorTestContext.STORE_NAMESPACE)
+                .get(OperatorTestContext.class, OperatorTestContext.class);
     }
 
     private void runCleanupBetweenRetries(ReflectiveInvocationContext<Method> invocationContext) {

--- a/operator/controller/src/test/resources/operator-install/install-file-fixture.yaml
+++ b/operator/controller/src/test/resources/operator-install/install-file-fixture.yaml
@@ -1,0 +1,90 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: apicurioregistries3.registry.apicur.io
+spec:
+  group: registry.apicur.io
+  names:
+    kind: ApicurioRegistry3
+    plural: apicurioregistries3
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: apicurio-registry-operator
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: apicurio-registry-operator
+    app.kubernetes.io/name: apicurio-registry-operator
+    app.kubernetes.io/part-of: apicurio-registry
+  name: apicurio-registry-operator
+  namespace: PLACEHOLDER_NAMESPACE
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: apicurio-registry-operator
+  name: apicurio-registry-operator-clusterrole
+rules:
+- apiGroups:
+  - registry.apicur.io
+  resources:
+  - apicurioregistries3
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: apicurio-registry-operator
+  name: apicurio-registry-operator-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: apicurio-registry-operator-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: apicurio-registry-operator
+  namespace: PLACEHOLDER_NAMESPACE
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: apicurio-registry-operator
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: apicurio-registry-operator
+    app.kubernetes.io/name: apicurio-registry-operator
+    app.kubernetes.io/part-of: apicurio-registry
+  name: apicurio-registry-operator
+  namespace: PLACEHOLDER_NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apicurio-registry-operator
+  template:
+    metadata:
+      labels:
+        app: apicurio-registry-operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: apicurio-registry-operator
+        app.kubernetes.io/name: apicurio-registry-operator
+        app.kubernetes.io/part-of: apicurio-registry
+    spec:
+      serviceAccountName: apicurio-registry-operator
+      containers:
+      - name: apicurio-registry-operator
+        image: quay.io/apicurio/apicurio-registry-operator:latest-snapshot
+        imagePullPolicy: Always


### PR DESCRIPTION
Phase 1 of #8495 introduces a shared cluster-wide operator and a JUnit 5 OperatorInfraExtension that provides test infrastructure through parameter injection rather than ITBase inheritance.

**Do not merge before #8686**. This PR extends its shared cluster-wide installation pattern to the Apicurio operator and I will re-target to main after #8686 merges. 

**How to Review: This is a large PR. I split the work into commits that each isolate one step, so reviewing the organized commit-by-commit (rather than the full diff at once) should make the changes easier to follow** 

---
**_Why_**:

Each of the approximately 28 operator IT classes redundantly installs and removes its own operator, causing cluster-scoped binding conflicts, preventing parallel execution, and contributing significantly to the 90+ minute CI runtime (see #7485) 

---

**_Changes:_**:

  **Shared operator** (`OperatorClusterWideInstaller`, `SharedOperatorLifecycle`)
  - Installs the operator once per cluster, watching all namespaces, into a dedicated long-lived namespace
    (`test.operator.operator-namespace`) that test teardown never deletes.
  - No operator configuration is needed for the cluster-wide watch: `App#start` already calls
    `watchingAllNamespaces()` whenever `apicurio.operator.watched-namespaces` is blank, which was an open
    question in the issue.
  - The install guard uses cluster state instead of a JVM flag to skip redundant installations across test groups reusing the same cluster, following the Strimzi #8686 pattern.
  - Local mode starts one in-process operator per JVM instead of one per class.

  **Operator-mutating tests get their own operator** (`@DedicatedOperator`)
  - Three tests mutate the operator Deployment, so they keep dedicated @DedicatedOperator installs in a separate operator-mutation CI job (both workflows, #7494 pattern), tearing down only their own suffixed ClusterRoleBinding.

  **Infrastructure extension** (`OperatorInfraExtension`)
  - OperatorInfraExtension injects the namespace, KubernetesClient, RegistryAssertions and the manager classes as test parameters, so a class no longer has to extend ITBase.
  - The operator and Strimzi are shared, lazy, and root-scoped; the namespace and its managers are per-class, torn down after, with CRs cleared between test methods.
  - Both entry points share one implementation (SharedOperatorLifecycle, RegistryAssertions, ITBase.deleteRegistryCRs), so a mixed run still has exactly one operator. DisableUIITTest is the worked example. 

---

| Issue item | Status |
  |---|---|
  | Root-scoped operator lifecycle (lazy start, closeable cleanup) | Done: `SharedOperatorLifecycle` + `SharedOperator` in JUnit's root store |
  | Per-class namespace creation/deletion | Done: `ClassInfra` |
  | `ParameterResolver` for `KubernetesClient`, namespace, managers | Done: `INJECTABLE` map in `OperatorInfraExtension` |
  | Root-scoped lazy Strimzi install + cleanup | Done |
  | `@NeedsStrimzi` annotation | Done |
  | CRD install once | Done: local: `createCRDs`; remote: install file |
  | Per-test CR cleanup between methods | Done: `ITBase.deleteRegistryCRs(...)`, shared by both paths |
  | RestAssured timeout config on the migrated path | Done: `ITBase.configureRestAssured()` made static, called from the extension|
  | `@DedicatedOperator` teardown scope | Done: deletes only its own `ClusterRoleBinding`, not the shared CRD/ClusterRole|
  | Install-file apply retry on transient errors | Done: `await().ignoreExceptions()`|
  | `junit-platform.properties` parallel config | **Deliberately omitted**: Rationale in `operator/README.md` |


  **Not included: `junit-platform.properties`**
  Deliberately left out.  https://github.com/Apicurio/apicurio-registry/issues/8495#issuecomment-4997794834 Two `@QuarkusTest` classes running concurrently race into the unsynchronized QuarkusTestExtension.ensureStarted(), and the second boot dies with Already a codec registered with name quarkus_default_local_codec, confirmed locally. Adding the file would also shadow Quarkus' own copy in quarkus-junit-config, losing QuarkusClassOrderer and extension autodetection. CI-level sharding remains the only safe way to parallelize these tests (`.github/workflows/README.md`); full rationale in `operator/README.md`

  ## Test plan

  - [x] `OperatorClusterWideInstallerTest`: unit-tests the install-file transform (ClusterRoleBinding
        subject rebinding, minikube image-pull-policy override, operator selector labels) against a
        structural fixture, no cluster needed.
  - [x] `OperatorInfraExtensionTest`: pins the extension's parameter-resolution contract and the
        `@NeedsStrimzi`/`@DedicatedOperator` annotations on the classes that need them.
  - [x] `./mvnw test -pl operator/controller -Dtest=OperatorClusterWideInstallerTest,OperatorInfraExtensionTest,StrimziClusterWideInstallerTest`: 10/10 passing.
  - [x] `./mvnw test-compile -pl operator/controller -am` compiles cleanly.
  - [x] `./mvnw checkstyle:check -pl operator/controller` passes.
