### PR TITLE
fix(kafkasql): don't emit create events on a dryRun create

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -460,10 +460,12 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         Pair<ArtifactMetaDataDto, ArtifactVersionMetaDataDto> createdArtifact = (Pair<ArtifactMetaDataDto, ArtifactVersionMetaDataDto>) coordinator
                 .waitForResponse(uuid);
 
-        outboxEvent.fire(KafkaSqlOutboxEvent.of(ArtifactCreated.of(createdArtifact.getLeft())));
+        if (!dryRun) {
+            outboxEvent.fire(KafkaSqlOutboxEvent.of(ArtifactCreated.of(createdArtifact.getLeft())));
 
-        if (createdArtifact.getRight() != null) {
-            outboxEvent.fire(KafkaSqlOutboxEvent.of(ArtifactVersionCreated.of(createdArtifact.getRight())));
+            if (createdArtifact.getRight() != null) {
+                outboxEvent.fire(KafkaSqlOutboxEvent.of(ArtifactVersionCreated.of(createdArtifact.getRight())));
+            }
         }
 
         return createdArtifact;
@@ -506,7 +508,9 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var uuid = blockOnResult(submitter.submitMessage(message));
         ArtifactVersionMetaDataDto versionMetaDataDto = (ArtifactVersionMetaDataDto) coordinator
                 .waitForResponse(uuid);
-        outboxEvent.fire(KafkaSqlOutboxEvent.of(ArtifactVersionCreated.of(versionMetaDataDto)));
+        if (!dryRun) {
+            outboxEvent.fire(KafkaSqlOutboxEvent.of(ArtifactVersionCreated.of(versionMetaDataDto)));
+        }
         return versionMetaDataDto;
     }
 

--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateArtifactResponse;
+import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.EditableArtifactMetaData;
 import io.apicurio.registry.rest.client.models.EditableGroupMetaData;
 import io.apicurio.registry.rest.client.models.EditableVersionMetaData;
 import io.apicurio.registry.rest.client.models.GroupMetaData;
 import io.apicurio.registry.rest.client.models.Labels;
+import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.rest.client.models.VersionState;
 import io.apicurio.registry.rest.client.models.WrappedVersionState;
 import io.apicurio.registry.rules.validity.ValidityLevel;
@@ -266,6 +269,58 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
         Assertions.assertEquals(1, events.size());
         Assertions.assertEquals(groupId, updateEvent.get("groupId").asText());
         Assertions.assertEquals(ARTIFACT_VERSION_CREATED.name(), updateEvent.get("eventType").asText());
+    }
+
+    @Test
+    public void dryRunCreateArtifactEmitsNoEvent() throws Exception {
+        // Preparation
+        final String groupId = "dryRunCreateArtifact";
+        final String artifactId = generateArtifactId();
+
+        CreateArtifact dryRunCreate = buildCreateArtifact(artifactId, "dryRunLeakName");
+        clientV3.groups().byGroupId(groupId).artifacts().post(dryRunCreate,
+                config -> config.queryParameters.dryRun = true);
+
+        // Real create of the same id acts as a barrier: any leaked dry-run event precedes it.
+        CreateArtifact realCreate = buildCreateArtifact(artifactId, "realCreateName");
+        clientV3.groups().byGroupId(groupId).artifacts().post(realCreate);
+
+        List<JsonNode> events = lookupEvent(consumer, ARTIFACT_CREATED,
+                Map.of("groupId", groupId, "artifactId", artifactId));
+
+        Assertions.assertEquals(1, events.size());
+        Assertions.assertEquals("realCreateName", events.get(0).get("name").asText());
+        for (JsonNode event : events) {
+            Assertions.assertNotEquals("dryRunLeakName", event.get("name").asText());
+        }
+    }
+
+    @Test
+    public void dryRunCreateArtifactVersionEmitsNoEvent() throws Exception {
+        // Preparation
+        final String groupId = "dryRunCreateArtifactVersion";
+        final String artifactId = generateArtifactId();
+
+        ensureArtifactCreated(groupId, artifactId, "dryRunCreateArtifactVersionName",
+                "dryRunCreateArtifactVersionDescription");
+
+        CreateVersion dryRunVersion = buildCreateVersion("2", "dryRunLeakVersionName");
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                .post(dryRunVersion, config -> config.queryParameters.dryRun = true);
+
+        // Real create of version "2" acts as a barrier: any leaked dry-run event precedes it.
+        CreateVersion realVersion = buildCreateVersion("2", "realVersionName");
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                .post(realVersion);
+
+        List<JsonNode> events = lookupEvent(consumer, ARTIFACT_VERSION_CREATED,
+                Map.of("groupId", groupId, "artifactId", artifactId, "version", "2"));
+
+        Assertions.assertEquals(1, events.size());
+        Assertions.assertEquals("realVersionName", events.get(0).get("name").asText());
+        for (JsonNode event : events) {
+            Assertions.assertNotEquals("dryRunLeakVersionName", event.get("name").asText());
+        }
     }
 
     @Test
@@ -758,6 +813,30 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
         assertNotNull(created);
         assertEquals(groupId, created.getGroupId());
         assertEquals(description, created.getDescription());
+    }
+
+    private CreateArtifact buildCreateArtifact(String artifactId, String name) {
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactId(artifactId);
+        createArtifact.setArtifactType(ArtifactType.JSON);
+        createArtifact.setName(name);
+        createArtifact.setFirstVersion(buildCreateVersion(null, null));
+        return createArtifact;
+    }
+
+    private CreateVersion buildCreateVersion(String version, String name) {
+        CreateVersion createVersion = new CreateVersion();
+        if (version != null) {
+            createVersion.setVersion(version);
+        }
+        if (name != null) {
+            createVersion.setName(name);
+        }
+        VersionContent versionContent = new VersionContent();
+        versionContent.setContent(ARTIFACT_CONTENT);
+        versionContent.setContentType(ContentTypes.APPLICATION_JSON);
+        createVersion.setContent(versionContent);
+        return createVersion;
     }
 
     protected KafkaConsumer<String, String> getConsumer(String bootstrapServers) {


### PR DESCRIPTION
On the kafkasql variant, creating an artifact or version with `dryRun=true` still published an `ARTIFACT_CREATED` / `ARTIFACT_VERSION_CREATED` event to the `registry-events` topic, even though a dry run rolls back and saves nothing. A dry run should validate only and produce no side effects, so no event should be emitted.

`createArtifact` and `createArtifactVersion` fired the outbox events right after `waitForResponse` without checking `dryRun`. The sql variant doesn't have this problem, since it fires the event inside the transaction that `dryRun` rolls back, so nothing is emitted. There was also no test asserting a dryRun create stays silent, which is probably why it went unnoticed.

### Changes

- Guard the `outboxEvent.fire(...)` calls in `createArtifact` and `createArtifactVersion` with `if (!dryRun)`, so a dry run saves nothing and emits nothing, matching the sql variant.
- Add tests for both the artifact and version paths asserting a dryRun create emits no event. Each does a dryRun create with a marker name, then a real create as a barrier, and checks only the real event appears. They run under both the sql and kafkasql variants.

### Test plan

- [x] `KafkaSqlEventsTest` dryRun create tests (kafkasql): pass
- [x] `RegistryEventsTest` dryRun create tests (sql): pass, no regression
- [x] `mvnw checkstyle:check -pl app` clean

Closes #8825
