### PR TITLE
perf(ui): cache HTTP code dropdown options in editors

### DIFF
--- a/ui/ui-editors/src/app/editor/_services/httpcode.service.ts
+++ b/ui/ui-editors/src/app/editor/_services/httpcode.service.ts
@@ -111,6 +111,8 @@ export class HttpCodeService {
         new HttpCode(511, "Network Authentication Required")
     ];
 
+    private static cachedDropDownOptions: DropDownOption[] | null = null;
+
     /**
      * Returns the list of commonly used HTTP codes.
      */
@@ -152,7 +154,10 @@ export class HttpCodeService {
      * Called to generate an array of dropdown options for all of the HTTP codes.
      */
     public static generateDropDownOptions(): DropDownOption[] {
-        // TODO cache this?
+        if (HttpCodeService.cachedDropDownOptions !== null) {
+            return HttpCodeService.cachedDropDownOptions;
+        }
+
         let res: DropDownOption[] = HttpCodeService.HTTP_CODE_LIST_COMMON.map(e => {
             let strcode = String(e.getCode());
             return new DropDownOptionValue(strcode + " " + e.getName(), strcode);
@@ -169,6 +174,7 @@ export class HttpCodeService {
             res.push(new DropDownOptionValue(strcode + " " + e.getName(), strcode));
         });
 
-        return res.filter(e => e.isDivider() || HttpCodeService.isAprilFirst() || e.getValue() !== "418");
+        HttpCodeService.cachedDropDownOptions = res.filter(e => e.isDivider() || HttpCodeService.isAprilFirst() || e.getValue() !== "418");
+        return HttpCodeService.cachedDropDownOptions;
     }
 }


### PR DESCRIPTION
Description:

What does this PR do?
This PR introduces a memoization mechanism in the HttpCodeService to cache the generated dropdown options for HTTP codes. It also removes the stale // TODO cache this? comment from the codebase.

Why is this necessary?
Previously, the generateDropDownOptions() method recalculated the dropdown mapping and filtering over the entire list of 60+ HTTP status codes on every invocation. By storing the parsed output in a static variable, we reduce unnecessary CPU cycles in the browser, providing a small but clean performance optimization (O(1) retrieval after the first load).

Testing / Verification
Verified that npm run build succeeds without issues in ui/ui-editors.
Manually confirmed TypeScript compilation.
Related Issue
Fixes #8831 