### PR TITLE
fix(operator): make database datasource test timeout configurable (#8837)

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -85,6 +85,8 @@ public abstract class ITBase implements OperatorTestContext {
             Integer.getInteger("test.operator.timeout.kafka-broker", 600));
     public static final Duration KAFKA_REGISTRY_READY_TIMEOUT = ofSeconds(
             Integer.getInteger("test.operator.timeout.kafka-registry", 480));
+    public static final Duration DATABASE_TIMEOUT = ofSeconds(
+            Integer.getInteger("test.operator.timeout.database", 900));
 
     public enum OperatorDeployment {
         local, remote

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/MysqlDataSourceITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/MysqlDataSourceITTest.java
@@ -26,7 +26,7 @@ public class MysqlDataSourceITTest extends ITBase {
         client.load(MysqlDataSourceITTest.class
                 .getResourceAsStream("/k8s/examples/mysql/example-mysql-database.yaml")).create();
         // await for MySQL to be available
-        await().ignoreExceptions().until(() -> (1 == client.apps().statefulSets().inNamespace(namespace)
+        await().atMost(DATABASE_TIMEOUT).ignoreExceptions().until(() -> (1 == client.apps().statefulSets().inNamespace(namespace)
                 .withName("example-mysql-database").get().getStatus().getReadyReplicas()));
 
         var registry = ResourceFactory.deserialize(
@@ -36,7 +36,7 @@ public class MysqlDataSourceITTest extends ITBase {
 
         client.resource(registry).create();
 
-        await().ignoreExceptions().until(() -> {
+        await().atMost(DATABASE_TIMEOUT).ignoreExceptions().until(() -> {
             assertThat(client.apps().deployments().inNamespace(namespace)
                     .withName(registry.getMetadata().getName() + "-app-deployment").get().getStatus()
                     .getReadyReplicas().intValue()).isEqualTo(1);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/PostgresqlDataSourceITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/PostgresqlDataSourceITTest.java
@@ -26,7 +26,7 @@ public class PostgresqlDataSourceITTest extends ITBase {
         client.load(PostgresqlDataSourceITTest.class
                 .getResourceAsStream("/k8s/examples/postgresql/example-postgresql-database.yaml")).create();
         // await for postgres to be available
-        await().ignoreExceptions().until(() -> (1 == client.apps().statefulSets().inNamespace(namespace)
+        await().atMost(DATABASE_TIMEOUT).ignoreExceptions().until(() -> (1 == client.apps().statefulSets().inNamespace(namespace)
                 .withName("example-postgresql-database").get().getStatus().getReadyReplicas()));
 
         var registry = ResourceFactory.deserialize(
@@ -36,7 +36,7 @@ public class PostgresqlDataSourceITTest extends ITBase {
 
         client.resource(registry).create();
 
-        await().ignoreExceptions().until(() -> {
+        await().atMost(DATABASE_TIMEOUT).ignoreExceptions().until(() -> {
             assertThat(client.apps().deployments().inNamespace(namespace)
                     .withName(registry.getMetadata().getName() + "-app-deployment").get().getStatus()
                     .getReadyReplicas().intValue()).isEqualTo(1);


### PR DESCRIPTION
## Summary

- Add `DATABASE_TIMEOUT` constant to `ITBase` (900s default, configurable via `-Dtest.operator.timeout.database`)
- Apply explicit `.atMost(DATABASE_TIMEOUT)` to all four `await()` calls in `MysqlDataSourceITTest` and `PostgresqlDataSourceITTest`
- Both tests previously relied on Awaitility's global default (7 min), which was insufficient for MySQL container startup on CI runners

Fixes #8837

## Root Cause

`MysqlDataSourceITTest.testMysqlDatasource` used bare `await().ignoreExceptions()` without an explicit timeout, inheriting Awaitility's global default (`LONG_DURATION` = 420s). MySQL container startup + registry bootstrap exceeds this on resource-constrained CI runners. The same pattern existed in `PostgresqlDataSourceITTest` — fixed proactively.

## Test plan

- [ ] CI passes — operator database tests should no longer flake on slow runners
- [ ] Verify the property can be overridden: `-Dtest.operator.timeout.database=1200`