### PR TITLE
fix(rest): return 404 instead of 500 for a missing version comment

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
@@ -23,6 +23,7 @@ import io.apicurio.registry.storage.error.ArtifactAlreadyExistsException;
 import io.apicurio.registry.storage.error.ArtifactNotFoundException;
 import io.apicurio.registry.storage.error.BranchAlreadyExistsException;
 import io.apicurio.registry.storage.error.BranchNotFoundException;
+import io.apicurio.registry.storage.error.CommentNotFoundException;
 import io.apicurio.registry.storage.error.ConfigPropertyNotFoundException;
 import io.apicurio.registry.storage.error.ContentNotFoundException;
 import io.apicurio.registry.storage.error.ContentSearchNotSupportedException;
@@ -88,6 +89,7 @@ public class HttpStatusCodeMap {
         map.put(BadRequestException.class, HTTP_BAD_REQUEST);
         map.put(BranchAlreadyExistsException.class, HTTP_CONFLICT);
         map.put(BranchNotFoundException.class, HTTP_NOT_FOUND);
+        map.put(CommentNotFoundException.class, HTTP_NOT_FOUND);
         map.put(ConfigPropertyNotFoundException.class, HTTP_NOT_FOUND);
         map.put(ConflictException.class, HTTP_CONFLICT);
         map.put(ContentNotFoundException.class, HTTP_NOT_FOUND);

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -1728,6 +1729,29 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 });
         assertEquals(1, comments.size());
         assertEquals("COMMENT_1", comments.get(0).getValue());
+    }
+
+    @Test
+    public void testArtifactCommentNotFound() throws Exception {
+        String artifactId = "testArtifactCommentNotFound/EmptyAPI";
+        String artifactContent = resourceToString("openapi-empty.json");
+
+        // Create OpenAPI artifact
+        createArtifact(GROUP, artifactId, ArtifactType.OPENAPI, artifactContent,
+                ContentTypes.APPLICATION_JSON);
+
+        // Delete a non-existent comment -> should be 404, not 500
+        given().when().pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
+                .pathParam("commentId", "999999")
+                .delete("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/comments/{commentId}")
+                .then().statusCode(HTTP_NOT_FOUND);
+
+        // Update a non-existent comment -> should be 404, not 500
+        NewComment nc = NewComment.builder().value("COMMENT_UPDATED").build();
+        given().when().contentType(CT_JSON).pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
+                .pathParam("commentId", "999999").body(nc)
+                .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/comments/{commentId}")
+                .then().statusCode(HTTP_NOT_FOUND);
     }
 
     @Test


### PR DESCRIPTION
## What

Deleting or updating a version comment that does not exist now returns HTTP 404 (Not Found) instead of HTTP 500 (Internal Server Error).

Fixes #8843 

## Why

Internally these operations throw CommentNotFoundException, which extends NotFoundException and is meant to map to 404. The status code lookup in HttpStatusCodeMap matches exceptions by their exact class, and this particular exception was never registered in that map. Every other not found exception in the project (artifact, version, group, branch, and so on) already has its own entry, so this was simply a missed one. Without a matching entry the lookup fell back to the default of 500, which wrongly tells the client the server is broken when the comment just does not exist.

## Changes

- Registered CommentNotFoundException in HttpStatusCodeMap so it maps to 404, matching how the sibling not found exceptions are handled. This is a single map entry plus its import, and it keeps the existing exact class lookup untouched.
- Added a test in GroupsResourceTest that deletes and updates a non-existent comment and asserts a 404 response on both. The test fails on the old code (it returns 500) and passes with the fix.

## Testing

- checkstyle passes for the app module.
- The new test testArtifactCommentNotFound passes. The access logs confirm both the DELETE and the PUT now return 404 for a comment ID that does not exist.

Note: the fix lives at the REST exception mapping layer, so it is not storage specific. The v2 and ccompat APIs share the same mapping and are corrected by the same change, at no extra cost.
