### PR TITLE
chore(deps): exclude console plugin workflow from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,8 @@
     "examples/**",
     "utils/maven-plugin/src/test/resources/test-builds",
     "support-chat/**",
-    "console-plugin/**"
+    "console-plugin/**",
+    ".github/workflows/verify-console-plugin.yaml"
   ],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 10,


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/verify-console-plugin.yaml` to the Renovate `ignorePaths` list
- The `console-plugin/**` directory was already excluded, but the CI workflow file lives
  under `.github/workflows/` so Renovate was still bumping its Node.js version
- This prevents unwanted PRs like #8850

## Test plan
- [ ] Verify Renovate no longer creates PRs for `verify-console-plugin.yaml`
- [ ] Close PR #8850 after this is merged