### PR TITLE
test(events): add RegistryEventsTest coverage for contract events

### DIFF
--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -768,17 +768,8 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
         List<JsonNode> events = lookupEvent(consumer, CONTRACT_RULESET_CONFIGURED,
                 Map.of("groupId", groupId, "artifactId", artifactId));
 
-        JsonNode event = null;
-        for (JsonNode e : events) {
-            if (e.get("groupId").asText().equals(groupId)
-                    && e.get("artifactId").asText().equals(artifactId)
-                    && e.get("eventType").asText().equals(CONTRACT_RULESET_CONFIGURED.name())) {
-                event = e;
-            }
-        }
-
         Assertions.assertEquals(1, events.size());
-        Assertions.assertNotNull(event);
+        JsonNode event = events.get(0);
         Assertions.assertEquals(CONTRACT_RULESET_CONFIGURED.name(), event.get("eventType").asText());
         Assertions.assertEquals(groupId, event.get("groupId").asText());
         Assertions.assertEquals(artifactId, event.get("artifactId").asText());
@@ -808,17 +799,8 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
         List<JsonNode> events = lookupEvent(consumer, CONTRACT_METADATA_UPDATED,
                 Map.of("groupId", groupId, "artifactId", artifactId));
 
-        JsonNode event = null;
-        for (JsonNode e : events) {
-            if (e.get("groupId").asText().equals(groupId)
-                    && e.get("artifactId").asText().equals(artifactId)
-                    && e.get("eventType").asText().equals(CONTRACT_METADATA_UPDATED.name())) {
-                event = e;
-            }
-        }
-
         Assertions.assertEquals(1, events.size());
-        Assertions.assertNotNull(event);
+        JsonNode event = events.get(0);
         Assertions.assertEquals(CONTRACT_METADATA_UPDATED.name(), event.get("eventType").asText());
         Assertions.assertEquals(groupId, event.get("groupId").asText());
         Assertions.assertEquals(artifactId, event.get("artifactId").asText());
@@ -858,17 +840,8 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
         List<JsonNode> events = lookupEvent(consumer, CONTRACT_STATUS_CHANGED,
                 Map.of("groupId", groupId, "artifactId", artifactId));
 
-        JsonNode event = null;
-        for (JsonNode e : events) {
-            if (e.get("groupId").asText().equals(groupId)
-                    && e.get("artifactId").asText().equals(artifactId)
-                    && e.get("eventType").asText().equals(CONTRACT_STATUS_CHANGED.name())) {
-                event = e;
-            }
-        }
-
         Assertions.assertEquals(1, events.size());
-        Assertions.assertNotNull(event);
+        JsonNode event = events.get(0);
         Assertions.assertEquals(CONTRACT_STATUS_CHANGED.name(), event.get("eventType").asText());
         Assertions.assertEquals(groupId, event.get("groupId").asText());
         Assertions.assertEquals(artifactId, event.get("artifactId").asText());

--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -15,6 +15,9 @@ import io.apicurio.registry.rest.client.models.Labels;
 import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.rest.client.models.VersionState;
 import io.apicurio.registry.rest.client.models.WrappedVersionState;
+import io.apicurio.registry.rest.v3.beans.ContractRuleSet;
+import io.apicurio.registry.rest.v3.beans.ContractStatusTransition;
+import io.apicurio.registry.rest.v3.beans.EditableContractMetadata;
 import io.apicurio.registry.rules.validity.ValidityLevel;
 import io.apicurio.registry.storage.StorageEventType;
 import io.apicurio.registry.types.ArtifactType;
@@ -759,7 +762,7 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .contentType(CT_JSON)
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
-                .body("{\"domainRules\":[],\"migrationRules\":[]}")
+                .body(new ContractRuleSet().domainRules(List.of()).migrationRules(List.of()))
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
                 .then()
                 .statusCode(200);
@@ -790,7 +793,7 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .contentType(CT_JSON)
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
-                .body("{\"status\":\"DRAFT\",\"ownerTeam\":\"platform-team\"}")
+                .body(new EditableContractMetadata().status("DRAFT").ownerTeam("platform-team"))
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then()
                 .statusCode(200);
@@ -821,7 +824,7 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .contentType(CT_JSON)
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
-                .body("{\"status\":\"DRAFT\"}")
+                .body(new EditableContractMetadata().status("DRAFT"))
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then()
                 .statusCode(200);
@@ -831,7 +834,7 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .contentType(CT_JSON)
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
-                .body("{\"status\":\"STABLE\"}")
+                .body(new ContractStatusTransition().status("STABLE"))
                 .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/status")
                 .then()
                 .statusCode(200);

--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -15,6 +15,7 @@ import io.apicurio.registry.rest.client.models.Labels;
 import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.rest.client.models.VersionState;
 import io.apicurio.registry.rest.client.models.WrappedVersionState;
+import io.apicurio.registry.rest.v3.beans.ContractRule;
 import io.apicurio.registry.rest.v3.beans.ContractRuleSet;
 import io.apicurio.registry.rest.v3.beans.ContractStatusTransition;
 import io.apicurio.registry.rest.v3.beans.EditableContractMetadata;
@@ -757,9 +758,7 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
 
         ensureArtifactCreated(groupId, artifactId, "1", name, description);
 
-        ContractRuleSet ruleSet = new ContractRuleSet();
-        ruleSet.setDomainRules(List.of());
-        ruleSet.setMigrationRules(List.of());
+        ContractRuleSet ruleSet = newRuleSet("contractRulesetConfiguredRule");
 
         // Set an artifact-level contract ruleset
         given()
@@ -771,7 +770,9 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200);
 
-        // Verify the contract ruleset was persisted (KafkaSql replication)
+        // Verify the written rule content was persisted (KafkaSql replication), not just that
+        // the GET returns 200 -- an empty/default ruleset also returns 200, so we assert on the
+        // actual rule name to distinguish a replicated write from the pre-write default state.
         Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
             ContractRuleSet retrieved = given()
                     .pathParam("groupId", groupId)
@@ -779,12 +780,14 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                     .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
                     .then()
                     .extract().as(ContractRuleSet.class);
-            return retrieved != null && retrieved.getDomainRules() != null && retrieved.getMigrationRules() != null;
+            return retrieved != null && retrieved.getDomainRules() != null
+                    && retrieved.getDomainRules().size() == 1
+                    && "contractRulesetConfiguredRule".equals(retrieved.getDomainRules().get(0).getName());
         });
 
         // Consume the event from the broker
         List<JsonNode> events = lookupEvent(consumer, CONTRACT_RULESET_CONFIGURED,
-                Map.of("groupId", groupId, "artifactId", artifactId));
+                Map.of("groupId", groupId, "artifactId", artifactId, "action", "SET"));
 
         Assertions.assertEquals(1, events.size());
         JsonNode event = events.get(0);
@@ -792,6 +795,298 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
         Assertions.assertEquals(groupId, event.get("groupId").asText());
         Assertions.assertEquals(artifactId, event.get("artifactId").asText());
         Assertions.assertEquals("SET", event.get("action").asText());
+    }
+
+    @Test
+    public void artifactContractRulesetDeleted() throws Exception {
+        // Preparation
+        final String groupId = "artifactContractRulesetDeleted";
+        final String artifactId = generateArtifactId();
+        final String name = "artifactContractRulesetDeletedName";
+        final String description = "artifactContractRulesetDeletedDescription";
+
+        ensureArtifactCreated(groupId, artifactId, "1", name, description);
+
+        ContractRuleSet ruleSet = newRuleSet("artifactContractRulesetDeletedRule");
+
+        // Set an artifact-level contract ruleset so there is something to delete
+        given()
+                .contentType(CT_JSON)
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .body(ruleSet)
+                .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
+                .then()
+                .statusCode(200);
+
+        // Confirm the ruleset was actually replicated before deleting it
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            ContractRuleSet retrieved = given()
+                    .pathParam("groupId", groupId)
+                    .pathParam("artifactId", artifactId)
+                    .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
+                    .then()
+                    .extract().as(ContractRuleSet.class);
+            return retrieved != null && retrieved.getDomainRules() != null
+                    && retrieved.getDomainRules().size() == 1;
+        });
+
+        // Delete the artifact-level contract ruleset
+        given()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .delete("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
+                .then()
+                .statusCode(204);
+
+        // Confirm the delete was replicated: since we already confirmed the non-empty state
+        // above, seeing an empty ruleset here is a genuine post-delete signal, not stale data.
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            ContractRuleSet retrieved = given()
+                    .pathParam("groupId", groupId)
+                    .pathParam("artifactId", artifactId)
+                    .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
+                    .then()
+                    .extract().as(ContractRuleSet.class);
+            return retrieved != null && (retrieved.getDomainRules() == null
+                    || retrieved.getDomainRules().isEmpty());
+        });
+
+        // Consume the delete event from the broker
+        List<JsonNode> events = lookupEvent(consumer, CONTRACT_RULESET_CONFIGURED,
+                Map.of("groupId", groupId, "artifactId", artifactId, "action", "DELETE"));
+
+        Assertions.assertEquals(1, events.size());
+        JsonNode event = events.get(0);
+        Assertions.assertEquals(CONTRACT_RULESET_CONFIGURED.name(), event.get("eventType").asText());
+        Assertions.assertEquals(groupId, event.get("groupId").asText());
+        Assertions.assertEquals(artifactId, event.get("artifactId").asText());
+        Assertions.assertEquals("DELETE", event.get("action").asText());
+    }
+
+    @Test
+    public void versionContractRulesetConfigured() throws Exception {
+        // Preparation
+        final String groupId = "versionContractRulesetConfigured";
+        final String artifactId = generateArtifactId();
+        final String version = "1";
+        final String name = "versionContractRulesetConfiguredName";
+        final String description = "versionContractRulesetConfiguredDescription";
+
+        ensureArtifactCreated(groupId, artifactId, version, name, description);
+
+        ContractRuleSet ruleSet = newRuleSet("versionContractRulesetConfiguredRule");
+
+        // Set a version-level contract ruleset
+        given()
+                .contentType(CT_JSON)
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .pathParam("versionExpression", version)
+                .body(ruleSet)
+                .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{versionExpression}/contract/ruleset")
+                .then()
+                .statusCode(200);
+
+        // Verify the written rule content was persisted (KafkaSql replication)
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            ContractRuleSet retrieved = given()
+                    .pathParam("groupId", groupId)
+                    .pathParam("artifactId", artifactId)
+                    .pathParam("versionExpression", version)
+                    .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{versionExpression}/contract/ruleset")
+                    .then()
+                    .extract().as(ContractRuleSet.class);
+            return retrieved != null && retrieved.getDomainRules() != null
+                    && retrieved.getDomainRules().size() == 1
+                    && "versionContractRulesetConfiguredRule".equals(retrieved.getDomainRules().get(0).getName());
+        });
+
+        // Consume the event from the broker
+        List<JsonNode> events = lookupEvent(consumer, CONTRACT_RULESET_CONFIGURED,
+                Map.of("groupId", groupId, "artifactId", artifactId, "version", version, "action", "SET"));
+
+        Assertions.assertEquals(1, events.size());
+        JsonNode event = events.get(0);
+        Assertions.assertEquals(CONTRACT_RULESET_CONFIGURED.name(), event.get("eventType").asText());
+        Assertions.assertEquals(groupId, event.get("groupId").asText());
+        Assertions.assertEquals(artifactId, event.get("artifactId").asText());
+        Assertions.assertEquals(version, event.get("version").asText());
+        Assertions.assertEquals("SET", event.get("action").asText());
+    }
+
+    @Test
+    public void versionContractRulesetDeleted() throws Exception {
+        // Preparation
+        final String groupId = "versionContractRulesetDeleted";
+        final String artifactId = generateArtifactId();
+        final String version = "1";
+        final String name = "versionContractRulesetDeletedName";
+        final String description = "versionContractRulesetDeletedDescription";
+
+        ensureArtifactCreated(groupId, artifactId, version, name, description);
+
+        ContractRuleSet ruleSet = newRuleSet("versionContractRulesetDeletedRule");
+
+        // Set a version-level contract ruleset so there is something to delete
+        given()
+                .contentType(CT_JSON)
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .pathParam("versionExpression", version)
+                .body(ruleSet)
+                .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{versionExpression}/contract/ruleset")
+                .then()
+                .statusCode(200);
+
+        // Confirm the ruleset was actually replicated before deleting it
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            ContractRuleSet retrieved = given()
+                    .pathParam("groupId", groupId)
+                    .pathParam("artifactId", artifactId)
+                    .pathParam("versionExpression", version)
+                    .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{versionExpression}/contract/ruleset")
+                    .then()
+                    .extract().as(ContractRuleSet.class);
+            return retrieved != null && retrieved.getDomainRules() != null
+                    && retrieved.getDomainRules().size() == 1;
+        });
+
+        // Delete the version-level contract ruleset
+        given()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .pathParam("versionExpression", version)
+                .delete("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{versionExpression}/contract/ruleset")
+                .then()
+                .statusCode(204);
+
+        // Confirm the delete was replicated
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            ContractRuleSet retrieved = given()
+                    .pathParam("groupId", groupId)
+                    .pathParam("artifactId", artifactId)
+                    .pathParam("versionExpression", version)
+                    .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{versionExpression}/contract/ruleset")
+                    .then()
+                    .extract().as(ContractRuleSet.class);
+            return retrieved != null && (retrieved.getDomainRules() == null
+                    || retrieved.getDomainRules().isEmpty());
+        });
+
+        // Consume the delete event from the broker
+        List<JsonNode> events = lookupEvent(consumer, CONTRACT_RULESET_CONFIGURED,
+                Map.of("groupId", groupId, "artifactId", artifactId, "version", version, "action", "DELETE"));
+
+        Assertions.assertEquals(1, events.size());
+        JsonNode event = events.get(0);
+        Assertions.assertEquals(CONTRACT_RULESET_CONFIGURED.name(), event.get("eventType").asText());
+        Assertions.assertEquals(groupId, event.get("groupId").asText());
+        Assertions.assertEquals(artifactId, event.get("artifactId").asText());
+        Assertions.assertEquals(version, event.get("version").asText());
+        Assertions.assertEquals("DELETE", event.get("action").asText());
+    }
+
+    @Test
+    public void globalContractRulesetConfigured() throws Exception {
+        // Preparation
+        final String ruleName = "globalContractRulesetConfiguredRule-" + UUID.randomUUID();
+        ContractRuleSet ruleSet = newRuleSet(ruleName);
+
+        // Set the global contract ruleset
+        given()
+                .contentType(CT_JSON)
+                .body(ruleSet)
+                .put("/registry/v3/admin/contracts/ruleset")
+                .then()
+                .statusCode(200);
+
+        // Verify the written rule content was persisted (KafkaSql replication)
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            ContractRuleSet retrieved = given()
+                    .get("/registry/v3/admin/contracts/ruleset")
+                    .then()
+                    .extract().as(ContractRuleSet.class);
+            return retrieved != null && retrieved.getDomainRules() != null
+                    && retrieved.getDomainRules().stream().anyMatch(r -> ruleName.equals(r.getName()));
+        });
+
+        // Consume the event from the broker
+        List<JsonNode> events = lookupEvent(consumer, CONTRACT_RULESET_CONFIGURED,
+                Map.of("groupId", "__GLOBAL__", "artifactId", "__GLOBAL__", "action", "SET"));
+
+        Assertions.assertEquals(1, events.size());
+        JsonNode event = events.get(0);
+        Assertions.assertEquals(CONTRACT_RULESET_CONFIGURED.name(), event.get("eventType").asText());
+        Assertions.assertEquals("__GLOBAL__", event.get("groupId").asText());
+        Assertions.assertEquals("__GLOBAL__", event.get("artifactId").asText());
+        Assertions.assertEquals("SET", event.get("action").asText());
+    }
+
+    @Test
+    public void globalContractRulesetDeleted() throws Exception {
+        // Preparation
+        final String ruleName = "globalContractRulesetDeletedRule-" + UUID.randomUUID();
+        ContractRuleSet ruleSet = newRuleSet(ruleName);
+
+        // Set the global contract ruleset so there is something to delete
+        given()
+                .contentType(CT_JSON)
+                .body(ruleSet)
+                .put("/registry/v3/admin/contracts/ruleset")
+                .then()
+                .statusCode(200);
+
+        // Confirm the ruleset was actually replicated before deleting it
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            ContractRuleSet retrieved = given()
+                    .get("/registry/v3/admin/contracts/ruleset")
+                    .then()
+                    .extract().as(ContractRuleSet.class);
+            return retrieved != null && retrieved.getDomainRules() != null
+                    && retrieved.getDomainRules().stream().anyMatch(r -> ruleName.equals(r.getName()));
+        });
+
+        // Delete the global contract ruleset
+        given()
+                .delete("/registry/v3/admin/contracts/ruleset")
+                .then()
+                .statusCode(204);
+
+        // Confirm the delete was replicated: the rule we just confirmed present must be gone
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            ContractRuleSet retrieved = given()
+                    .get("/registry/v3/admin/contracts/ruleset")
+                    .then()
+                    .extract().as(ContractRuleSet.class);
+            return retrieved != null && (retrieved.getDomainRules() == null
+                    || retrieved.getDomainRules().stream().noneMatch(r -> ruleName.equals(r.getName())));
+        });
+
+        // Consume the delete event from the broker
+        List<JsonNode> events = lookupEvent(consumer, CONTRACT_RULESET_CONFIGURED,
+                Map.of("groupId", "__GLOBAL__", "artifactId", "__GLOBAL__", "action", "DELETE"));
+
+        Assertions.assertEquals(1, events.size());
+        JsonNode event = events.get(0);
+        Assertions.assertEquals(CONTRACT_RULESET_CONFIGURED.name(), event.get("eventType").asText());
+        Assertions.assertEquals("__GLOBAL__", event.get("groupId").asText());
+        Assertions.assertEquals("__GLOBAL__", event.get("artifactId").asText());
+        Assertions.assertEquals("DELETE", event.get("action").asText());
+    }
+
+    private ContractRuleSet newRuleSet(String ruleName) {
+        ContractRule rule = new ContractRule();
+        rule.setName(ruleName);
+        rule.setKind(ContractRule.Kind.CONDITION);
+        rule.setType("CEL");
+        rule.setMode(ContractRule.Mode.WRITE);
+        rule.setExpr("true");
+
+        ContractRuleSet ruleSet = new ContractRuleSet();
+        ruleSet.setDomainRules(List.of(rule));
+        ruleSet.setMigrationRules(List.of());
+        return ruleSet;
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -771,6 +771,14 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200);
 
+        // Verify the contract ruleset was persisted (KafkaSql replication)
+        given()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
+                .then()
+                .statusCode(200);
+
         // Consume the event from the broker
         List<JsonNode> events = lookupEvent(consumer, CONTRACT_RULESET_CONFIGURED,
                 Map.of("groupId", groupId, "artifactId", artifactId));
@@ -804,6 +812,14 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .pathParam("artifactId", artifactId)
                 .body(metadata)
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
+                .then()
+                .statusCode(200);
+
+        // Verify the contract metadata was persisted (KafkaSql replication)
+        given()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then()
                 .statusCode(200);
 
@@ -841,6 +857,14 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200);
 
+        // Verify the initial DRAFT status was persisted (KafkaSql replication)
+        given()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
+                .then()
+                .statusCode(200);
+
         ContractStatusTransition transition = new ContractStatusTransition();
         transition.setStatus(ContractStatusTransition.Status.STABLE);
 
@@ -851,6 +875,14 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .pathParam("artifactId", artifactId)
                 .body(transition)
                 .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/status")
+                .then()
+                .statusCode(200);
+
+        // Verify the status transition was persisted (KafkaSql replication)
+        given()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then()
                 .statusCode(200);
 

--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -51,11 +51,15 @@ import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_CRE
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_DELETED;
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_METADATA_UPDATED;
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_STATE_CHANGED;
+import static io.apicurio.registry.storage.StorageEventType.CONTRACT_METADATA_UPDATED;
+import static io.apicurio.registry.storage.StorageEventType.CONTRACT_RULESET_CONFIGURED;
+import static io.apicurio.registry.storage.StorageEventType.CONTRACT_STATUS_CHANGED;
 import static io.apicurio.registry.storage.StorageEventType.GLOBAL_RULE_CONFIGURED;
 import static io.apicurio.registry.storage.StorageEventType.GROUP_CREATED;
 import static io.apicurio.registry.storage.StorageEventType.GROUP_DELETED;
 import static io.apicurio.registry.storage.StorageEventType.GROUP_METADATA_UPDATED;
 import static io.apicurio.registry.storage.StorageEventType.GROUP_RULE_CONFIGURED;
+import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -738,6 +742,138 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
         Assertions.assertEquals(ValidityLevel.NONE.name(), updateEvent.get("rule").asText());
         Assertions.assertEquals(groupId, updateEvent.get("groupId").asText());
         Assertions.assertEquals(artifactId, updateEvent.get("artifactId").asText());
+    }
+
+    @Test
+    public void contractRulesetConfigured() throws Exception {
+        // Preparation
+        final String groupId = "contractRulesetConfigured";
+        final String artifactId = generateArtifactId();
+        final String name = "contractRulesetConfiguredName";
+        final String description = "contractRulesetConfiguredDescription";
+
+        ensureArtifactCreated(groupId, artifactId, "1", name, description);
+
+        // Set an artifact-level contract ruleset
+        given()
+                .contentType(CT_JSON)
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .body("{\"domainRules\":[],\"migrationRules\":[]}")
+                .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
+                .then()
+                .statusCode(200);
+
+        // Consume the event from the broker
+        List<JsonNode> events = lookupEvent(consumer, CONTRACT_RULESET_CONFIGURED,
+                Map.of("groupId", groupId, "artifactId", artifactId));
+
+        JsonNode event = null;
+        for (JsonNode e : events) {
+            if (e.get("groupId").asText().equals(groupId)
+                    && e.get("artifactId").asText().equals(artifactId)
+                    && e.get("eventType").asText().equals(CONTRACT_RULESET_CONFIGURED.name())) {
+                event = e;
+            }
+        }
+
+        Assertions.assertEquals(1, events.size());
+        Assertions.assertNotNull(event);
+        Assertions.assertEquals(CONTRACT_RULESET_CONFIGURED.name(), event.get("eventType").asText());
+        Assertions.assertEquals(groupId, event.get("groupId").asText());
+        Assertions.assertEquals(artifactId, event.get("artifactId").asText());
+    }
+
+    @Test
+    public void contractMetadataUpdated() throws Exception {
+        // Preparation
+        final String groupId = "contractMetadataUpdated";
+        final String artifactId = generateArtifactId();
+        final String name = "contractMetadataUpdatedName";
+        final String description = "contractMetadataUpdatedDescription";
+
+        ensureArtifactCreated(groupId, artifactId, "1", name, description);
+
+        // Update contract metadata
+        given()
+                .contentType(CT_JSON)
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .body("{\"status\":\"DRAFT\",\"ownerTeam\":\"platform-team\"}")
+                .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
+                .then()
+                .statusCode(200);
+
+        // Consume the event from the broker
+        List<JsonNode> events = lookupEvent(consumer, CONTRACT_METADATA_UPDATED,
+                Map.of("groupId", groupId, "artifactId", artifactId));
+
+        JsonNode event = null;
+        for (JsonNode e : events) {
+            if (e.get("groupId").asText().equals(groupId)
+                    && e.get("artifactId").asText().equals(artifactId)
+                    && e.get("eventType").asText().equals(CONTRACT_METADATA_UPDATED.name())) {
+                event = e;
+            }
+        }
+
+        Assertions.assertEquals(1, events.size());
+        Assertions.assertNotNull(event);
+        Assertions.assertEquals(CONTRACT_METADATA_UPDATED.name(), event.get("eventType").asText());
+        Assertions.assertEquals(groupId, event.get("groupId").asText());
+        Assertions.assertEquals(artifactId, event.get("artifactId").asText());
+    }
+
+    @Test
+    public void contractStatusChanged() throws Exception {
+        // Preparation
+        final String groupId = "contractStatusChanged";
+        final String artifactId = generateArtifactId();
+        final String name = "contractStatusChangedName";
+        final String description = "contractStatusChangedDescription";
+
+        ensureArtifactCreated(groupId, artifactId, "1", name, description);
+
+        // Set initial DRAFT status so a transition is possible
+        given()
+                .contentType(CT_JSON)
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .body("{\"status\":\"DRAFT\"}")
+                .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
+                .then()
+                .statusCode(200);
+
+        // Transition from DRAFT to STABLE
+        given()
+                .contentType(CT_JSON)
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", artifactId)
+                .body("{\"status\":\"STABLE\"}")
+                .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/status")
+                .then()
+                .statusCode(200);
+
+        // Consume the event from the broker
+        List<JsonNode> events = lookupEvent(consumer, CONTRACT_STATUS_CHANGED,
+                Map.of("groupId", groupId, "artifactId", artifactId));
+
+        JsonNode event = null;
+        for (JsonNode e : events) {
+            if (e.get("groupId").asText().equals(groupId)
+                    && e.get("artifactId").asText().equals(artifactId)
+                    && e.get("eventType").asText().equals(CONTRACT_STATUS_CHANGED.name())) {
+                event = e;
+            }
+        }
+
+        Assertions.assertEquals(1, events.size());
+        Assertions.assertNotNull(event);
+        Assertions.assertEquals(CONTRACT_STATUS_CHANGED.name(), event.get("eventType").asText());
+        Assertions.assertEquals(groupId, event.get("groupId").asText());
+        Assertions.assertEquals(artifactId, event.get("artifactId").asText());
+        Assertions.assertEquals("DRAFT", event.get("fromStatus").asText());
+        Assertions.assertEquals("STABLE", event.get("toStatus").asText());
     }
 
     private void checkGroupEvent(String groupId, List<JsonNode> events) {

--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -780,6 +780,7 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
         Assertions.assertEquals(CONTRACT_RULESET_CONFIGURED.name(), event.get("eventType").asText());
         Assertions.assertEquals(groupId, event.get("groupId").asText());
         Assertions.assertEquals(artifactId, event.get("artifactId").asText());
+        Assertions.assertEquals("SET", event.get("action").asText());
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -771,15 +771,16 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200);
 
-        // Wait until the write is visible on the read side (ensures KafkaSql replication
-        // has completed before polling for the outbox event).
-        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () ->
-                given()
-                        .pathParam("groupId", groupId)
-                        .pathParam("artifactId", artifactId)
-                        .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
-                        .then()
-                        .extract().statusCode() == 200);
+        // Verify the contract ruleset was persisted (KafkaSql replication)
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            ContractRuleSet retrieved = given()
+                    .pathParam("groupId", groupId)
+                    .pathParam("artifactId", artifactId)
+                    .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
+                    .then()
+                    .extract().as(ContractRuleSet.class);
+            return retrieved != null && retrieved.getDomainRules() != null && retrieved.getMigrationRules() != null;
+        });
 
         // Consume the event from the broker
         List<JsonNode> events = lookupEvent(consumer, CONTRACT_RULESET_CONFIGURED,

--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -771,13 +771,15 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200);
 
-        // Verify the contract ruleset was persisted (KafkaSql replication)
-        given()
-                .pathParam("groupId", groupId)
-                .pathParam("artifactId", artifactId)
-                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
-                .then()
-                .statusCode(200);
+        // Wait until the write is visible on the read side (ensures KafkaSql replication
+        // has completed before polling for the outbox event).
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () ->
+                given()
+                        .pathParam("groupId", groupId)
+                        .pathParam("artifactId", artifactId)
+                        .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
+                        .then()
+                        .extract().statusCode() == 200);
 
         // Consume the event from the broker
         List<JsonNode> events = lookupEvent(consumer, CONTRACT_RULESET_CONFIGURED,
@@ -815,13 +817,17 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200);
 
-        // Verify the contract metadata was persisted (KafkaSql replication)
-        given()
-                .pathParam("groupId", groupId)
-                .pathParam("artifactId", artifactId)
-                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
-                .then()
-                .statusCode(200);
+        // Wait until the written ownerTeam value is visible on the read side (ensures
+        // KafkaSql replication has completed before polling for the outbox event).
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            String ownerTeam = given()
+                    .pathParam("groupId", groupId)
+                    .pathParam("artifactId", artifactId)
+                    .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
+                    .then()
+                    .extract().path("ownerTeam");
+            return "platform-team".equals(ownerTeam);
+        });
 
         // Consume the event from the broker
         List<JsonNode> events = lookupEvent(consumer, CONTRACT_METADATA_UPDATED,
@@ -857,13 +863,16 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200);
 
-        // Verify the initial DRAFT status was persisted (KafkaSql replication)
-        given()
-                .pathParam("groupId", groupId)
-                .pathParam("artifactId", artifactId)
-                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
-                .then()
-                .statusCode(200);
+        // Wait until DRAFT status is visible (ensures KafkaSql replication completed)
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            String status = given()
+                    .pathParam("groupId", groupId)
+                    .pathParam("artifactId", artifactId)
+                    .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
+                    .then()
+                    .extract().path("status");
+            return "DRAFT".equals(status);
+        });
 
         ContractStatusTransition transition = new ContractStatusTransition();
         transition.setStatus(ContractStatusTransition.Status.STABLE);
@@ -878,13 +887,17 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200);
 
-        // Verify the status transition was persisted (KafkaSql replication)
-        given()
-                .pathParam("groupId", groupId)
-                .pathParam("artifactId", artifactId)
-                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
-                .then()
-                .statusCode(200);
+        // Wait until STABLE status is visible (ensures KafkaSql replication completed
+        // before polling for the CONTRACT_STATUS_CHANGED outbox event).
+        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
+            String status = given()
+                    .pathParam("groupId", groupId)
+                    .pathParam("artifactId", artifactId)
+                    .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
+                    .then()
+                    .extract().path("status");
+            return "STABLE".equals(status);
+        });
 
         // Consume the event from the broker
         List<JsonNode> events = lookupEvent(consumer, CONTRACT_STATUS_CHANGED,

--- a/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/event/sql/RegistryEventsTest.java
@@ -757,12 +757,16 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
 
         ensureArtifactCreated(groupId, artifactId, "1", name, description);
 
+        ContractRuleSet ruleSet = new ContractRuleSet();
+        ruleSet.setDomainRules(List.of());
+        ruleSet.setMigrationRules(List.of());
+
         // Set an artifact-level contract ruleset
         given()
                 .contentType(CT_JSON)
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
-                .body(new ContractRuleSet().domainRules(List.of()).migrationRules(List.of()))
+                .body(ruleSet)
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
                 .then()
                 .statusCode(200);
@@ -788,12 +792,16 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
 
         ensureArtifactCreated(groupId, artifactId, "1", name, description);
 
+        EditableContractMetadata metadata = new EditableContractMetadata();
+        metadata.setStatus(EditableContractMetadata.Status.DRAFT);
+        metadata.setOwnerTeam("platform-team");
+
         // Update contract metadata
         given()
                 .contentType(CT_JSON)
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
-                .body(new EditableContractMetadata().status("DRAFT").ownerTeam("platform-team"))
+                .body(metadata)
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then()
                 .statusCode(200);
@@ -819,22 +827,28 @@ public class RegistryEventsTest extends AbstractResourceTestBase {
 
         ensureArtifactCreated(groupId, artifactId, "1", name, description);
 
+        EditableContractMetadata metadata = new EditableContractMetadata();
+        metadata.setStatus(EditableContractMetadata.Status.DRAFT);
+
         // Set initial DRAFT status so a transition is possible
         given()
                 .contentType(CT_JSON)
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
-                .body(new EditableContractMetadata().status("DRAFT"))
+                .body(metadata)
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then()
                 .statusCode(200);
+
+        ContractStatusTransition transition = new ContractStatusTransition();
+        transition.setStatus(ContractStatusTransition.Status.STABLE);
 
         // Transition from DRAFT to STABLE
         given()
                 .contentType(CT_JSON)
                 .pathParam("groupId", groupId)
                 .pathParam("artifactId", artifactId)
-                .body(new ContractStatusTransition().status("STABLE"))
+                .body(transition)
                 .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/status")
                 .then()
                 .statusCode(200);


### PR DESCRIPTION
While looking through `RegistryEventsTest`, I noticed that the contract-related events introduced by the contract subsystem weren't covered by the existing integration tests. This PR adds coverage for those missing cases.

The new tests verify that the expected events are published when:

* an artifact contract ruleset is configured (`CONTRACT_RULESET_CONFIGURED`),
* contract metadata is updated (`CONTRACT_METADATA_UPDATED`), and
* a contract transitions between statuses (`CONTRACT_STATUS_CHANGED`).

Each test exercises the corresponding REST API, waits for the event on the Kafka outbox topic, and validates the key event fields to ensure the emitted payload matches the operation performed.

The tests use the existing `EventsTestProfile`, so they run alongside the rest of the registry event integration tests without introducing any additional test infrastructure.

Closes #8858.
