### PR TITLE
fix(tests): disable tests for local deployment in ITBase class

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -112,6 +112,10 @@ public abstract class ITBase implements OperatorTestContext {
         return namespace;
     }
 
+    static boolean isLocalDeployment() {
+        return getConfig().getValue(OPERATOR_DEPLOYMENT_PROP, OperatorDeployment.class) == OperatorDeployment.local;
+    }
+
     @BeforeAll
     public void before() throws Exception {
         operatorDeployment = getConfig().getValue(OPERATOR_DEPLOYMENT_PROP,

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/LeaderElectionITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/LeaderElectionITTest.java
@@ -11,6 +11,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,12 +37,8 @@ public class LeaderElectionITTest extends ITBase {
     private static final String DEFAULT_LEASE_NAME = "apicurio-registry-operator-lease";
 
     @Test
+    @DisabledIf("io.apicurio.registry.operator.it.ITBase#isLocalDeployment")
     void testLeaderElectionCreatesLease() {
-        if (operatorDeployment == OperatorDeployment.local) {
-            log.warn("This test requires an ability to edit the operator Deployment, so it's not supported when running locally.");
-            return;
-        }
-
         var operatorDeploymentCell = k8sCell(client, this::getOperatorDeployment);
         Cell<EnvVar> originalEnabledEnvVar = cell();
 
@@ -110,12 +107,8 @@ public class LeaderElectionITTest extends ITBase {
     }
 
     @Test
+    @DisabledIf("io.apicurio.registry.operator.it.ITBase#isLocalDeployment")
     void testLeaderElectionCustomLeaseName() {
-        if (operatorDeployment == OperatorDeployment.local) {
-            log.warn("This test requires an ability to edit the operator Deployment, so it's not supported when running locally.");
-            return;
-        }
-
         var operatorDeploymentCell = k8sCell(client, this::getOperatorDeployment);
         Cell<EnvVar> originalEnabledEnvVar = cell();
         Cell<EnvVar> originalLeaseNameEnvVar = cell();

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorConfigITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/OperatorConfigITTest.java
@@ -4,10 +4,9 @@ import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.apicurio.registry.operator.resource.ResourceFactory;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static io.apicurio.registry.operator.Tags.FEATURE;
 import static io.apicurio.registry.operator.Tags.FEATURE_SETUP;
@@ -19,15 +18,9 @@ import static org.awaitility.Awaitility.await;
 @Tag(FEATURE_SETUP)
 public class OperatorConfigITTest extends ITBase {
 
-    private static final Logger log = LoggerFactory.getLogger(OperatorConfigITTest.class);
-
     @Test
+    @DisabledIf("io.apicurio.registry.operator.it.ITBase#isLocalDeployment")
     void testOperatorConfig() {
-        if (operatorDeployment == OperatorDeployment.local) {
-            log.warn("Test requires an operator pod, so it's not supported when running locally.");
-            return;
-        }
-
         var configMap = ResourceFactory
                 .deserialize("/k8s/examples/config/operator-config.configmap.yaml", ConfigMap.class);
         var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml", ApicurioRegistry3.class);

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/RestrictedNamespaceITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/RestrictedNamespaceITTest.java
@@ -7,6 +7,7 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -41,16 +42,11 @@ public class RestrictedNamespaceITTest extends ITBase {
     }
 
     @Test
+    @DisabledIf("io.apicurio.registry.operator.it.ITBase#isLocalDeployment")
     void smoke() {
         // We will create 3 namespaces, and specify that the operator should watch 2 of them.
         // We need to set the env. variable of the operator deployment, which we can't do with OLM or local deployment,
         // unless we pass the variable in another way. TODO ConfigMap?
-        if (operatorDeployment == OperatorDeployment.local) {
-            log.warn("This test requires an ability to edit the operator Deployment, so it's not supported when running locally.");
-            // TODO: For OLM Deployment, try ConfigMap or annotations.
-            return;
-        }
-
         var operatorDeploymentCell = k8sCell(client, this::getOperatorDeployment);
 
         var namespace1 = calculateNamespace();


### PR DESCRIPTION
## Description

Several operator integration tests (RestrictedNamespaceITTest, OperatorConfigITTest, LeaderElectionITTest) skip execution in local deployment mode using log.warn() + early return inside test bodies, causing JUnit to report them as passed rather than skipped hiding coverage gaps.

### Changes
- Adds a shared isLocalDeployment() condition method to ITBase
- Replaces the manual skip blocks with @DisabledIf annotations pointing to the shared condition
- Removes the now-unused Logger field from OperatorConfigITTest
- Tests requiring a remote operator deployment are now declaratively skipped and correctly reported by JUnit.

### Issue
fixes #7892 

### Proof Manifests
All the affected tests are now skipped as expected
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/04f118a7-b019-4577-96c7-0ea7bd71e054" />