### PR TITLE
fix(rest): return 404 instead of 500 for a missing version comment

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
@@ -23,6 +23,7 @@ import io.apicurio.registry.storage.error.ArtifactAlreadyExistsException;
 import io.apicurio.registry.storage.error.ArtifactNotFoundException;
 import io.apicurio.registry.storage.error.BranchAlreadyExistsException;
 import io.apicurio.registry.storage.error.BranchNotFoundException;
+import io.apicurio.registry.storage.error.CommentNotFoundException;
 import io.apicurio.registry.storage.error.ConfigPropertyNotFoundException;
 import io.apicurio.registry.storage.error.ContentNotFoundException;
 import io.apicurio.registry.storage.error.ContentSearchNotSupportedException;
@@ -88,6 +89,7 @@ public class HttpStatusCodeMap {
         map.put(BadRequestException.class, HTTP_BAD_REQUEST);
         map.put(BranchAlreadyExistsException.class, HTTP_CONFLICT);
         map.put(BranchNotFoundException.class, HTTP_NOT_FOUND);
+        map.put(CommentNotFoundException.class, HTTP_NOT_FOUND);
         map.put(ConfigPropertyNotFoundException.class, HTTP_NOT_FOUND);
         map.put(ConflictException.class, HTTP_CONFLICT);
         map.put(ContentNotFoundException.class, HTTP_NOT_FOUND);

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
@@ -55,6 +55,7 @@ import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.anything;
@@ -1728,6 +1729,19 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 });
         assertEquals(1, comments.size());
         assertEquals("COMMENT_1", comments.get(0).getValue());
+
+        // Try to update a comment that does not exist (should return 404)
+        nc = NewComment.builder().value("COMMENT_NON_EXISTENT").build();
+        given().when().contentType(CT_JSON).pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
+                .pathParam("commentId", "999999").body(nc)
+                .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/comments/{commentId}")
+                .then().statusCode(HTTP_NOT_FOUND);
+
+        // Try to delete a comment that does not exist (should return 404)
+        given().when().pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
+                .pathParam("commentId", "999999")
+                .delete("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/comments/{commentId}")
+                .then().statusCode(HTTP_NOT_FOUND);
     }
 
     @Test


### PR DESCRIPTION
## What
Deleting or updating a version comment that does not exist now returns HTTP 404 (Not Found) instead of HTTP 500 (Internal Server Error).

Fixes #8843

## Why
CommentNotFoundException extends NotFoundException, which is already mapped to HTTP 404 in HttpStatusCodeMap. The status code lookup matches exceptions by their exact class, and CommentNotFoundException was never added as its own entry. Every other not-found exception in the project (artifact, version, group, branch, etc.) already has its own entry; this was simply a missed registration. Without a matching entry the lookup fell back to the default of 500, which wrongly tells the client the server is broken when the comment just does not exist.

## Changes
- Registered CommentNotFoundException in HttpStatusCodeMap so it maps to 404, consistent with how all sibling not-found exceptions are handled. This is a single map entry plus its import, with no changes to the existing lookup logic.
- Extended 	estArtifactComments in GroupsResourceTest with assertions that DELETE and PUT against a non-existent comment ID both return 404.

## Testing
- ./mvnw checkstyle:check -pl app passes with 0 violations.
- The new assertions fail on the old code (returns 500) and pass with the fix applied.
- The fix is at the REST exception mapping layer and is not storage specific; v2 and ccompat APIs share the same map and are corrected by the same single change.