### PR TITLE
fix(storage): bind searchVersions globalId and contentId filters as long

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
@@ -277,6 +277,16 @@ public class SqlSearchRepository {
                         break;
                     case contentId:
                     case globalId:
+                        op = filter.isNot() ? "!=" : "=";
+                        where.append("v.");
+                        where.append(filter.getType().name());
+                        where.append(" ");
+                        where.append(op);
+                        where.append(" ?");
+                        binders.add((query, idx) -> {
+                            query.bind(idx, filter.getNumberValue().longValue());
+                        });
+                        break;
                     case state:
                     case version:
                         op = filter.isNot() ? "!=" : "=";

--- a/app/src/test/java/io/apicurio/registry/storage/impl/sql/VersionSearchByIdPostgresqlTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/sql/VersionSearchByIdPostgresqlTest.java
@@ -1,0 +1,96 @@
+package io.apicurio.registry.storage.impl.sql;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.cdi.Current;
+import io.apicurio.registry.rest.client.models.CreateArtifactResponse;
+import io.apicurio.registry.rest.client.models.VersionSearchResults;
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.dto.OrderBy;
+import io.apicurio.registry.storage.dto.OrderDirection;
+import io.apicurio.registry.storage.dto.SearchFilter;
+import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
+import io.apicurio.registry.storage.util.PostgresqlTestProfile;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.ApicurioTestTags;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+@QuarkusTest
+@Tag(ApicurioTestTags.SLOW)
+@TestProfile(PostgresqlTestProfile.class)
+public class VersionSearchByIdPostgresqlTest extends AbstractResourceTestBase {
+
+    @Inject
+    @Current
+    RegistryStorage storage;
+
+    @Test
+    void testSearchVersionsByGlobalIdOnPostgresql() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        CreateArtifactResponse car1 = createArtifact(groupId, "global-id-artifact-1", ArtifactType.JSON,
+                "{}", ContentTypes.APPLICATION_JSON);
+        CreateArtifactResponse car2 = createArtifact(groupId, "global-id-artifact-2", ArtifactType.JSON,
+                "{\"type\":\"string\"}", ContentTypes.APPLICATION_JSON);
+
+        VersionSearchResults results = clientV3.search().versions().get(config -> {
+            config.queryParameters.groupId = groupId;
+            config.queryParameters.globalId = car1.getVersion().getGlobalId();
+        });
+        Assertions.assertNotNull(results);
+        Assertions.assertEquals(1, results.getCount());
+        Assertions.assertEquals(car1.getVersion().getGlobalId(),
+                results.getVersions().get(0).getGlobalId());
+
+        TestUtils.retry(() -> {
+            VersionSearchResultsDto negated = storage.searchVersions(
+                    Set.of(SearchFilter.ofGroupId(groupId),
+                            SearchFilter.ofGlobalId(car1.getVersion().getGlobalId()).negated()),
+                    OrderBy.globalId, OrderDirection.asc, 0, 10, false);
+            Assertions.assertNotNull(negated);
+            Assertions.assertEquals(1, negated.getCount());
+            Assertions.assertEquals(car2.getVersion().getGlobalId(),
+                    negated.getVersions().get(0).getGlobalId());
+        });
+    }
+
+    @Test
+    void testSearchVersionsByContentIdOnPostgresql() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        CreateArtifactResponse car1 = createArtifact(groupId, "content-id-artifact-1", ArtifactType.JSON,
+                "{}", ContentTypes.APPLICATION_JSON);
+        CreateArtifactResponse car2 = createArtifact(groupId, "content-id-artifact-2", ArtifactType.JSON,
+                "{\"type\":\"string\"}", ContentTypes.APPLICATION_JSON);
+
+        VersionSearchResults results = clientV3.search().versions().get(config -> {
+            config.queryParameters.groupId = groupId;
+            config.queryParameters.contentId = car1.getVersion().getContentId();
+        });
+        Assertions.assertNotNull(results);
+        Assertions.assertEquals(1, results.getCount());
+        Assertions.assertEquals(car1.getVersion().getContentId(),
+                results.getVersions().get(0).getContentId());
+
+        TestUtils.retry(() -> {
+            VersionSearchResultsDto negated = storage.searchVersions(
+                    Set.of(SearchFilter.ofGroupId(groupId),
+                            SearchFilter.ofContentId(car1.getVersion().getContentId()).negated()),
+                    OrderBy.globalId, OrderDirection.asc, 0, 10, false);
+            Assertions.assertNotNull(negated);
+            Assertions.assertEquals(1, negated.getCount());
+            Assertions.assertEquals("content-id-artifact-2",
+                    negated.getVersions().get(0).getArtifactId());
+            Assertions.assertEquals(car2.getVersion().getContentId(),
+                    negated.getVersions().get(0).getContentId());
+        });
+    }
+}


### PR DESCRIPTION
SqlSearchRepository.searchVersions() grouped contentId and globalId into the same switch arm as state and version, binding every value with filter.getStringValue(). For contentId and globalId the filter value is a Long, so it was bound as a VARCHAR against the BIGINT columns v.contentId and v.globalId. On PostgreSQL this fails with "operator does not exist: bigint = character varying" and surfaces as a 500; databases with implicit coercion may instead return wrong results.

Split contentId and globalId into their own arm and bind with filter.getNumberValue().longValue(), matching searchArtifacts(). state and version keep string binding.

Add VersionSearchByIdPostgresqlTest under PostgresqlTestProfile so the regression is caught on PostgreSQL, where the type mismatch actually occurs (H2 coerces VARCHAR to BIGINT and would pass either way). It covers the positive filter via the REST search API and the negated filter via the storage layer, for both globalId and contentId.