### PR TITLE
fix(kafkasql): journal global contract ruleset operations so they replicate across nodes

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -733,12 +733,16 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
     @Override
     public void setGlobalContractRuleset(io.apicurio.registry.storage.dto.ContractRuleSetDto ruleset)
             throws RegistryStorageException {
-        sqlStore.setGlobalContractRuleset(ruleset);
+        var message = new SetGlobalContractRuleset1Message(ruleset);
+        var uuid = blockOnResult(submitter.submitMessage(message));
+        coordinator.waitForResponse(uuid);
     }
 
     @Override
     public void deleteGlobalContractRuleset() throws RegistryStorageException {
-        sqlStore.deleteGlobalContractRuleset();
+        var message = new DeleteGlobalContractRuleset0Message();
+        var uuid = blockOnResult(submitter.submitMessage(message));
+        coordinator.waitForResponse(uuid);
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/DeleteGlobalContractRuleset0Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/DeleteGlobalContractRuleset0Message.java
@@ -1,0 +1,24 @@
+package io.apicurio.registry.storage.impl.kafkasql.messages;
+
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.impl.kafkasql.AbstractMessage;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class DeleteGlobalContractRuleset0Message extends AbstractMessage {
+
+    /**
+     * @see io.apicurio.registry.storage.impl.kafkasql.KafkaSqlMessage#dispatchTo(io.apicurio.registry.storage.RegistryStorage)
+     */
+    @Override
+    public Object dispatchTo(RegistryStorage storage) {
+        storage.deleteGlobalContractRuleset();
+        return null;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/SetGlobalContractRuleset1Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/SetGlobalContractRuleset1Message.java
@@ -1,0 +1,33 @@
+package io.apicurio.registry.storage.impl.kafkasql.messages;
+
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.dto.ContractRuleSetDto;
+import io.apicurio.registry.storage.impl.kafkasql.AbstractMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class SetGlobalContractRuleset1Message extends AbstractMessage {
+
+    private ContractRuleSetDto ruleset;
+
+    /**
+     * @see io.apicurio.registry.storage.impl.kafkasql.KafkaSqlMessage#dispatchTo(io.apicurio.registry.storage.RegistryStorage)
+     */
+    @Override
+    public Object dispatchTo(RegistryStorage storage) {
+        storage.setGlobalContractRuleset(ruleset);
+        return null;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/serde/KafkaSqlMessageIndex.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/serde/KafkaSqlMessageIndex.java
@@ -60,6 +60,8 @@ public class KafkaSqlMessageIndex {
                 DeleteArtifactContractRuleset2Message.class,
                 SetVersionContractRuleset4Message.class,
                 DeleteVersionContractRuleset3Message.class,
+                SetGlobalContractRuleset1Message.class,
+                DeleteGlobalContractRuleset0Message.class,
                 MergeArtifactLabels4Message.class,
                 MergeVersionLabels5Message.class);
     }

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlGlobalContractRulesetJournalTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlGlobalContractRulesetJournalTest.java
@@ -1,0 +1,85 @@
+package io.apicurio.registry.storage.impl.kafkasql;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.storage.dto.ContractRuleSetDto;
+import io.apicurio.registry.storage.impl.kafkasql.messages.DeleteGlobalContractRuleset0Message;
+import io.apicurio.registry.storage.impl.kafkasql.messages.SetGlobalContractRuleset1Message;
+import io.apicurio.registry.utils.tests.KafkasqlTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@QuarkusTest
+@TestProfile(KafkasqlTestProfile.class)
+public class KafkaSqlGlobalContractRulesetJournalTest extends AbstractResourceTestBase {
+
+    private static final String JOURNAL_TOPIC = "kafkasql-journal";
+
+    @Inject
+    KafkaSqlRegistryStorage kafkaSqlRegistryStorage;
+
+    @Test
+    public void testSetGlobalContractRulesetIsJournaled() {
+        ContractRuleSetDto ruleset = ContractRuleSetDto.builder().domainRules(List.of())
+                .migrationRules(List.of()).build();
+        assertOperationIsJournaled(() -> kafkaSqlRegistryStorage.setGlobalContractRuleset(ruleset),
+                SetGlobalContractRuleset1Message.class.getSimpleName());
+    }
+
+    @Test
+    public void testDeleteGlobalContractRulesetIsJournaled() {
+        assertOperationIsJournaled(() -> kafkaSqlRegistryStorage.deleteGlobalContractRuleset(),
+                DeleteGlobalContractRuleset0Message.class.getSimpleName());
+    }
+
+    /**
+     * Runs the given storage operation and asserts that a message of the expected type is produced to
+     * the KafkaSQL journal topic.
+     */
+    private void assertOperationIsJournaled(Runnable operation, String expectedType) {
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(
+                Map.of(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                        System.getProperty("bootstrap.servers.external"),
+                        ConsumerConfig.GROUP_ID_CONFIG, "tc-" + UUID.randomUUID(),
+                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
+                new StringDeserializer(), new StringDeserializer());
+        try {
+            consumer.subscribe(List.of(JOURNAL_TOPIC));
+
+            operation.run();
+
+            long deadline = System.currentTimeMillis() + 15000;
+            boolean found = false;
+            while (System.currentTimeMillis() < deadline && !found) {
+                for (ConsumerRecord<String, String> record : consumer.poll(Duration.ofMillis(500))) {
+                    Header header = record.headers().lastHeader(KafkaSqlSubmitter.MESSAGE_TYPE_HEADER);
+                    if (header != null
+                            && expectedType.equals(new String(header.value(), StandardCharsets.UTF_8))) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            Assertions.assertTrue(found, "Expected a " + expectedType
+                    + " message to be produced to the KafkaSQL journal topic, but none was found. "
+                    + "This means the operation bypassed the journal and would not be replicated "
+                    + "across nodes (issue #8848).");
+        } finally {
+            consumer.close();
+        }
+    }
+}


### PR DESCRIPTION
Fixes Apicurio/apicurio-registry#8848.

## Problem

In the KafkaSQL storage variant, `setGlobalContractRuleset` and `deleteGlobalContractRuleset` in `KafkaSqlRegistryStorage` write directly to the node-local SQL store instead of submitting a message to the KafkaSQL journal. The artifact-level and version-level contract ruleset operations in the same class go through the journal, so the global operations are the only contract ruleset writes that bypass it.

Because each KafkaSQL node builds its state from the journal, a write that skips the journal is not replicated to the other nodes and is not restored when the node restarts.

## Fix

Route `setGlobalContractRuleset` and `deleteGlobalContractRuleset` through the journal, consistent with the existing contract ruleset operations:

- Add `SetGlobalContractRuleset1Message` and `DeleteGlobalContractRuleset0Message`, following the existing contract ruleset message classes.
- Submit these messages via the submitter and wait on the coordinator, as `setArtifactContractRuleset` and the related operations already do.
- Register both message types in `KafkaSqlMessageIndex`.

## Testing

Added `KafkaSqlGlobalContractRulesetJournalTest`, which sets a global contract ruleset and asserts that a `SetGlobalContractRuleset1Message` is produced to the KafkaSQL journal topic. The test fails on the previous implementation (no journal message is produced) and passes with this change. It passes locally along with `checkstyle:check` for the `app` module.

## Notes

This change is intentionally scoped to the KafkaSQL implementation addressed by #8848. The SQL storage implementation already journals these operations. The KafkaSQL contract audit path (`insertContractAuditEntry`) follows a similar direct-write pattern and is left for a separate change to keep this PR focused.