### PR TITLE
fix(ui): fix scrolling hang in Create Artifact dropdown

### DIFF
--- a/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
+++ b/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
@@ -426,7 +426,6 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
                                 itemIsDivider={(item) => item.isDivider}
                                 itemToTestId={(item) => `create-artifact-modal-${item.value}`}
                                 itemToString={(item) => item.label}
-                                appendTo="document"
                             />
                             <FormHelperText>
                                 <HelperText>


### PR DESCRIPTION
### Description

This PR fixes a bug in the **Create Artifact** wizard where the "Type" dropdown (`ObjectSelect`) fails to scroll and causes the UI to hang/freeze. 

#### Cause
The `ObjectSelect` component was previously rendering with the `appendTo="document"` property. In PatternFly 6, when a `Select` dropdown with `appendTo="document"` is rendered inside a `Modal` or `Wizard` component, the modal's scroll lock and focus trap conflict with the dropdown menu's scrolling, causing the browser to freeze/hang.

#### Fix
Removed the `appendTo="document"` property from the `ObjectSelect` field for Artifact Type in `CreateArtifactModal.tsx`. By falling back to the default inline append behavior, the dropdown now scrolls smoothly without conflicting with the modal's focus/scroll management.

### Related Issue
Fixes #8870

### Verification

After fix:

[Screencast from 2026-07-24 02-36-09.webm](https://github.com/user-attachments/assets/c8b0c139-2d21-479d-8e85-e7da98f69d5e)

- [x] Started the UI server locally.
- [x] Clicked "Create Artifact" and opened the "Type" dropdown.
- [x] Verified that the dropdown scrolls smoothly and the UI does not hang.
- [x] Checked that no other modal layouts were negatively affected.
