### PR TITLE
feat(operator): decouple registry version from operator via spec.version field

### DIFF
--- a/operator/controller/src/main/java/io/apicurio/registry/operator/ApicurioRegistry3Reconciler.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/ApicurioRegistry3Reconciler.java
@@ -197,6 +197,8 @@ public class ApicurioRegistry3Reconciler implements Reconciler<ApicurioRegistry3
 
         log.trace("Reconciling Apicurio Registry: {}", primary);
 
+        io.apicurio.registry.operator.resource.ResourceFactory.validateSpecVersion(primary);
+
         // Some of the fields in the CR have been deprecated and another fields should be used instead.
         // Operator will attempt to update the CR to use the newer fields if possible.
         // This has to be done first, so subsequent functionality can deal with new fields only.

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/Configuration.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/Configuration.java
@@ -4,6 +4,7 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 
 public class Configuration {
 
@@ -38,6 +39,42 @@ public class Configuration {
     public static String getRegistryVersion() {
         return config.getOptionalValue("registry.version", String.class)
                 .orElseThrow(() -> new OperatorException("Required configuration option 'registry.version' is not set."));
+    }
+
+    /**
+     * Return the image with its tag replaced by the given version. If version is null or blank, returns the
+     * base image unchanged.
+     */
+    public static String getImageForVersion(String baseImage, String version) {
+        if (version == null || version.isBlank()) {
+            return baseImage;
+        }
+        int colon = baseImage.lastIndexOf(':');
+        String repo = (colon > 0) ? baseImage.substring(0, colon) : baseImage;
+        return repo + ":" + version;
+    }
+
+    /**
+     * Compare two version strings (e.g. "3.0.3" or "3.3.1-SNAPSHOT"). Strips any suffix after a hyphen
+     * before comparing. Returns empty if either version is not a valid numeric semver. Otherwise returns
+     * negative if v1 < v2, zero if equal, positive if v1 > v2.
+     */
+    public static OptionalInt compareVersions(String v1, String v2) {
+        try {
+            String[] parts1 = v1.split("-")[0].split("\\.");
+            String[] parts2 = v2.split("-")[0].split("\\.");
+            int len = Math.max(parts1.length, parts2.length);
+            for (int i = 0; i < len; i++) {
+                int n1 = i < parts1.length ? Integer.parseInt(parts1[i]) : 0;
+                int n2 = i < parts2.length ? Integer.parseInt(parts2[i]) : 0;
+                if (n1 != n2) {
+                    return OptionalInt.of(Integer.compare(n1, n2));
+                }
+            }
+            return OptionalInt.of(0);
+        } catch (NumberFormatException e) {
+            return OptionalInt.empty();
+        }
     }
 
     public static String getDefaultBaseHost() {

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/Configuration.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/Configuration.java
@@ -49,6 +49,10 @@ public class Configuration {
         if (version == null || version.isBlank()) {
             return baseImage;
         }
+        // Digest-pinned images (e.g. repo@sha256:...) cannot have their tag replaced.
+        if (baseImage.contains("@")) {
+            return baseImage;
+        }
         int colon = baseImage.lastIndexOf(':');
         String repo = (colon > 0) ? baseImage.substring(0, colon) : baseImage;
         return repo + ":" + version;

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/resource/ResourceFactory.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/resource/ResourceFactory.java
@@ -53,6 +53,39 @@ public class ResourceFactory {
 
     public static final ResourceFactory INSTANCE = new ResourceFactory();
 
+    private static String getSpecVersion(ApicurioRegistry3 primary) {
+        return ofNullable(primary.getSpec())
+                .map(ApicurioRegistry3Spec::getVersion)
+                .orElse(null);
+    }
+
+    /**
+     * Validate spec.version against the operator's bundled version. Records a validation error if
+     * spec.version is newer than the operator (unsupported) or not a valid semver. Logs a warning
+     * for intentional downgrades since those are the expected staged-upgrade workflow.
+     */
+    static void validateSpecVersion(ApicurioRegistry3 primary) {
+        var specVersion = getSpecVersion(primary);
+        if (specVersion == null) {
+            return;
+        }
+        var operatorVersion = Configuration.getRegistryVersion();
+        var cmp = Configuration.compareVersions(specVersion, operatorVersion);
+        if (cmp.isEmpty()) {
+            StatusManager.get(primary).getConditionManager(ValidationErrorConditionManager.class)
+                    .recordError("spec.version (%s) is not a valid version format. "
+                            + "Expected numeric semver (e.g. 3.0.3).", specVersion);
+        } else if (cmp.getAsInt() > 0) {
+            StatusManager.get(primary).getConditionManager(ValidationErrorConditionManager.class)
+                    .recordError("spec.version (%s) is newer than the operator version (%s). "
+                            + "The operator may not support managing a newer registry version.",
+                            specVersion, operatorVersion);
+        } else if (cmp.getAsInt() < 0) {
+            log.warn("spec.version ({}) is older than the operator version ({}). "
+                    + "This is a downgrade. Ensure this is intentional.", specVersion, operatorVersion);
+        }
+    }
+
     public static final String COMPONENT_APP = "app";
     public static final String COMPONENT_UI = "ui";
     public static final String COMPONENT_CONSOLE_PLUGIN = "console-plugin";
@@ -70,6 +103,8 @@ public class ResourceFactory {
     public static final String RESOURCE_TYPE_HORIZONTAL_POD_AUTOSCALER = "horizontalpodautoscaler";
 
     public Deployment getDefaultAppDeployment(ApicurioRegistry3 primary) {
+        validateSpecVersion(primary);
+
         var autoscaling = ofNullable(primary.getSpec()).map(ApicurioRegistry3Spec::getApp)
                 .map(ComponentSpec::getAutoscaling).orElse(null);
         boolean autoscalingEnabled = ofNullable(autoscaling).map(AutoscalingSpec::getEnabled)
@@ -128,7 +163,7 @@ public class ResourceFactory {
                 primary,
                 r.getSpec().getTemplate(),
                 REGISTRY_APP_CONTAINER_NAME,
-                Configuration.getAppImage(),
+                Configuration.getImageForVersion(Configuration.getAppImage(), getSpecVersion(primary)),
                 containerPort,
                 readinessProbe,
                 livenessProbe,
@@ -143,6 +178,8 @@ public class ResourceFactory {
     }
 
     public Deployment getDefaultUIDeployment(ApicurioRegistry3 primary) {
+        validateSpecVersion(primary);
+
         var uiAutoscaling = ofNullable(primary.getSpec()).map(ApicurioRegistry3Spec::getUi)
                 .map(ComponentSpec::getAutoscaling).orElse(null);
         boolean uiAutoscalingEnabled = ofNullable(uiAutoscaling).map(AutoscalingSpec::getEnabled)
@@ -173,7 +210,7 @@ public class ResourceFactory {
                 primary,
                 r.getSpec().getTemplate(),
                 REGISTRY_UI_CONTAINER_NAME,
-                Configuration.getUIImage(),
+                Configuration.getImageForVersion(Configuration.getUIImage(), getSpecVersion(primary)),
                 List.of(new ContainerPortBuilder().withName("http").withProtocol("TCP").withContainerPort(8080).build()),
                 new ProbeBuilder().withHttpGet(new HTTPGetActionBuilder().withPath("/config.js").withPort(new IntOrString(8080)).withScheme("HTTP").build()).build(),
                 new ProbeBuilder().withHttpGet(new HTTPGetActionBuilder().withPath("/config.js").withPort(new IntOrString(8080)).withScheme("HTTP").build()).build(),
@@ -464,12 +501,13 @@ public class ResourceFactory {
     }
 
     private void addDefaultLabels(Map<String, String> labels, ApicurioRegistry3 primary, String component) {
+        var version = ofNullable(getSpecVersion(primary)).orElse(Configuration.getRegistryVersion());
         labels.putAll(Map.of(
                 "app", primary.getMetadata().getName(),
                 "app.kubernetes.io/name", "apicurio-registry",
                 "app.kubernetes.io/component", component,
                 "app.kubernetes.io/instance", primary.getMetadata().getName(),
-                "app.kubernetes.io/version", Configuration.getRegistryVersion(),
+                "app.kubernetes.io/version", version,
                 "app.kubernetes.io/part-of", "apicurio-registry",
                 "app.kubernetes.io/managed-by", "apicurio-registry-operator"
         ));

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/resource/ResourceFactory.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/resource/ResourceFactory.java
@@ -64,7 +64,7 @@ public class ResourceFactory {
      * spec.version is newer than the operator (unsupported) or not a valid semver. Logs a warning
      * for intentional downgrades since those are the expected staged-upgrade workflow.
      */
-    static void validateSpecVersion(ApicurioRegistry3 primary) {
+    public static void validateSpecVersion(ApicurioRegistry3 primary) {
         var specVersion = getSpecVersion(primary);
         if (specVersion == null) {
             return;
@@ -72,9 +72,8 @@ public class ResourceFactory {
         var operatorVersion = Configuration.getRegistryVersion();
         var cmp = Configuration.compareVersions(specVersion, operatorVersion);
         if (cmp.isEmpty()) {
-            StatusManager.get(primary).getConditionManager(ValidationErrorConditionManager.class)
-                    .recordError("spec.version (%s) is not a valid version format. "
-                            + "Expected numeric semver (e.g. 3.0.3).", specVersion);
+            log.warn("spec.version ({}) is not a recognized numeric format. "
+                    + "Using as-is for image tag.", specVersion);
         } else if (cmp.getAsInt() > 0) {
             StatusManager.get(primary).getConditionManager(ValidationErrorConditionManager.class)
                     .recordError("spec.version (%s) is newer than the operator version (%s). "
@@ -103,8 +102,6 @@ public class ResourceFactory {
     public static final String RESOURCE_TYPE_HORIZONTAL_POD_AUTOSCALER = "horizontalpodautoscaler";
 
     public Deployment getDefaultAppDeployment(ApicurioRegistry3 primary) {
-        validateSpecVersion(primary);
-
         var autoscaling = ofNullable(primary.getSpec()).map(ApicurioRegistry3Spec::getApp)
                 .map(ComponentSpec::getAutoscaling).orElse(null);
         boolean autoscalingEnabled = ofNullable(autoscaling).map(AutoscalingSpec::getEnabled)
@@ -178,8 +175,6 @@ public class ResourceFactory {
     }
 
     public Deployment getDefaultUIDeployment(ApicurioRegistry3 primary) {
-        validateSpecVersion(primary);
-
         var uiAutoscaling = ofNullable(primary.getSpec()).map(ApicurioRegistry3Spec::getUi)
                 .map(ComponentSpec::getAutoscaling).orElse(null);
         boolean uiAutoscalingEnabled = ofNullable(uiAutoscaling).map(AutoscalingSpec::getEnabled)

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/unit/ConfigurationTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/unit/ConfigurationTest.java
@@ -1,0 +1,95 @@
+package io.apicurio.registry.operator.unit;
+
+import io.apicurio.registry.operator.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigurationTest {
+
+    @Test
+    public void testGetImageForVersion_swapsTag() {
+        assertThat(Configuration.getImageForVersion("quay.io/apicurio/apicurio-registry:3.0.6", "3.0.3"))
+                .isEqualTo("quay.io/apicurio/apicurio-registry:3.0.3");
+    }
+
+    @Test
+    public void testGetImageForVersion_nullVersionReturnsBaseImage() {
+        assertThat(Configuration.getImageForVersion("quay.io/apicurio/apicurio-registry:3.0.6", null))
+                .isEqualTo("quay.io/apicurio/apicurio-registry:3.0.6");
+    }
+
+    @Test
+    public void testGetImageForVersion_blankVersionReturnsBaseImage() {
+        assertThat(Configuration.getImageForVersion("quay.io/apicurio/apicurio-registry:3.0.6", "  "))
+                .isEqualTo("quay.io/apicurio/apicurio-registry:3.0.6");
+    }
+
+    @Test
+    public void testGetImageForVersion_imageWithoutTag() {
+        assertThat(Configuration.getImageForVersion("quay.io/apicurio/apicurio-registry", "3.0.3"))
+                .isEqualTo("quay.io/apicurio/apicurio-registry:3.0.3");
+    }
+
+    @Test
+    public void testGetImageForVersion_latestSnapshotTag() {
+        assertThat(Configuration.getImageForVersion("quay.io/apicurio/apicurio-registry:latest-snapshot", "3.0.3"))
+                .isEqualTo("quay.io/apicurio/apicurio-registry:3.0.3");
+    }
+
+    @Test
+    public void testGetImageForVersion_uiImage() {
+        assertThat(Configuration.getImageForVersion("quay.io/apicurio/apicurio-registry-ui:3.0.6", "3.0.3"))
+                .isEqualTo("quay.io/apicurio/apicurio-registry-ui:3.0.3");
+    }
+
+    @Test
+    public void testCompareVersions_equal() {
+        assertThat(Configuration.compareVersions("3.0.3", "3.0.3")).hasValue(0);
+    }
+
+    @Test
+    public void testCompareVersions_olderPatch() {
+        assertThat(Configuration.compareVersions("3.0.3", "3.0.6").getAsInt()).isNegative();
+    }
+
+    @Test
+    public void testCompareVersions_newerPatch() {
+        assertThat(Configuration.compareVersions("3.0.6", "3.0.3").getAsInt()).isPositive();
+    }
+
+    @Test
+    public void testCompareVersions_olderMinor() {
+        assertThat(Configuration.compareVersions("3.0.3", "3.3.1").getAsInt()).isNegative();
+    }
+
+    @Test
+    public void testCompareVersions_newerMajor() {
+        assertThat(Configuration.compareVersions("4.0.0", "3.0.6").getAsInt()).isPositive();
+    }
+
+    @Test
+    public void testCompareVersions_snapshotSuffix() {
+        assertThat(Configuration.compareVersions("3.3.1-SNAPSHOT", "3.3.1")).hasValue(0);
+    }
+
+    @Test
+    public void testCompareVersions_differentLengths() {
+        assertThat(Configuration.compareVersions("3.0", "3.0.0")).hasValue(0);
+    }
+
+    @Test
+    public void testCompareVersions_nonNumericReturnsEmpty() {
+        assertThat(Configuration.compareVersions("latest", "3.0.3")).isEmpty();
+    }
+
+    @Test
+    public void testCompareVersions_qualifierReturnsEmpty() {
+        assertThat(Configuration.compareVersions("3.0.6.Final", "3.0.3")).isEmpty();
+    }
+
+    @Test
+    public void testCompareVersions_alphaPartReturnsEmpty() {
+        assertThat(Configuration.compareVersions("3.x", "3.0.3")).isEmpty();
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/unit/ConfigurationTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/unit/ConfigurationTest.java
@@ -44,6 +44,13 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void testGetImageForVersion_digestPinnedImageUnchanged() {
+        assertThat(Configuration.getImageForVersion(
+                "registry.redhat.io/apicurio/apicurio-registry-rhel9@sha256:7d4a8f6e", "3.0.3"))
+                .isEqualTo("registry.redhat.io/apicurio/apicurio-registry-rhel9@sha256:7d4a8f6e");
+    }
+
+    @Test
     public void testCompareVersions_equal() {
         assertThat(Configuration.compareVersions("3.0.3", "3.0.3")).hasValue(0);
     }

--- a/operator/install/install.yaml
+++ b/operator/install/install.yaml
@@ -7242,6 +7242,11 @@ spec:
                     description: Number of replicas for the component
                     type: integer
                 type: object
+              version:
+                description: Override the registry version deployed by this operator.
+                  When set, the operator replaces the image tag with this value. When
+                  not set, defaults to the version bundled with the operator.
+                type: string
             type: object
           status:
             properties:

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/ApicurioRegistry3Spec.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/ApicurioRegistry3Spec.java
@@ -13,7 +13,7 @@ import static com.fasterxml.jackson.annotation.Nulls.SKIP;
 import static lombok.AccessLevel.PRIVATE;
 
 @JsonInclude(NON_NULL)
-@JsonPropertyOrder({"app", "ui", "consolePlugin"})
+@JsonPropertyOrder({"version", "app", "ui", "consolePlugin"})
 @JsonDeserialize(using = None.class)
 @NoArgsConstructor
 @AllArgsConstructor(access = PRIVATE)
@@ -23,6 +23,18 @@ import static lombok.AccessLevel.PRIVATE;
 @EqualsAndHashCode
 @ToString
 public class ApicurioRegistry3Spec {
+
+    /**
+     * Override the registry version deployed by this operator. When set, the operator replaces the image tag
+     * with this value. When not set, defaults to the version bundled with the operator.
+     */
+    @JsonProperty("version")
+    @JsonPropertyDescription("""
+            Override the registry version deployed by this operator. \
+            When set, the operator replaces the image tag with this value. \
+            When not set, defaults to the version bundled with the operator.""")
+    @JsonSetter(nulls = SKIP)
+    private String version;
 
     /**
      * Configure Apicurio Registry backend (app) component.


### PR DESCRIPTION
fixes: #7635 
### Description

Currently, the Apicurio Registry version is tightly coupled to the operator version. This means upgrading the operator automatically forces an upgrade of the registry in a single step, which increases risk during cluster maintenance.

This PR adds a `spec.version` field to the `ApicurioRegistry3` custom resource that allows users to explicitly control which version of the registry is deployed, independently of the operator version. This enables a staged upgrade process (Operator first, verify, then Registry).


### Changes Made

* Added an optional `spec.version` field to the `ApicurioRegistry3Spec` model.
* Updated `ResourceFactory.java` to inject the user-specified `spec.version` into the Application and UI container images instead of strictly defaulting to the operator's bundled version.
* Included a `compareVersions` utility in `Configuration.java` to handle numerical semver comparisons (handling `-SNAPSHOT` tags appropriately).
* Injected validation checks into `ResourceFactory` that automatically record `ValidationErrorCondition` messages:
    * errors if `spec.version` is newer than the operator version (operator may not support it).
    * warns if `spec.version` is older than the operator version (intentional downgrades).
*  Added unit tests in `ConfigurationTest.java` validating version comparisons and image tag replacement logic.
