### PR TITLE
fix(ui): guard direct navigation to /agents when Agents feature is disabled

### DIFF
--- a/ui/ui-app/src/app/MainPageWithAuth.tsx
+++ b/ui/ui-app/src/app/MainPageWithAuth.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from "react";
 import { Page } from "@patternfly/react-core";
 import { AppHeader } from "@app/components";
-import { Route, Routes } from "react-router";
+import { Navigate, Route, Routes } from "react-router";
 import {
     AgentsPage,
     ArtifactPage,
@@ -71,7 +71,7 @@ export const MainPageWithAuth: FunctionComponent<MainPageWithAuthProps> = () => 
                         <Route path="/search" element={ <SearchPage /> } />
                         <Route path="/drafts" element={ <DraftsPage /> } />
                         <Route path="/explore" element={ <ExplorePage /> } />
-                        <Route path="/agents" element={ <AgentsPage /> } />
+                        <Route path="/agents" element={ config.featureAgents() ? <AgentsPage /> : <Navigate to={appNav.createLink("/dashboard")} replace /> } />
 
                         <Route
                             path="/explore/:groupId"


### PR DESCRIPTION
## Summary

Fixes the direct navigation issue reported in #8747.

When the Agents feature is disabled, the navigation item is correctly hidden from the UI, but users could still directly access `/agents` by entering the URL manually or using a bookmarked/shared link. This resulted in the Agents page initializing and displaying an error screen.

This change guards the `/agents` route using the existing `config.featureAgents()` feature flag. When the feature is disabled, the route now redirects to the dashboard instead of attempting to render the Agents page.

## Changes

- Added `Navigate` from `react-router`
- Guarded the `/agents` route using the existing feature flag
- Redirect to the dashboard when the feature is disabled
- No backend changes
- No new dependencies
- Minimal localized change

## Testing

- [x] Feature disabled → navigating directly to `/agents` redirects to `/dashboard`
- [x] Feature disabled → normal navigation remains unchanged
- [x] Feature enabled → `/agents` loads normally
- [x] Existing routing behavior verified

Fixes #8747