### PR TITLE
fix(ui): guard page data loaders against stale responses on route param changes

### DIFF
--- a/ui/ui-app/package-lock.json
+++ b/ui/ui-app/package-lock.json
@@ -57,7 +57,8 @@
         "typescript": "5.9.3",
         "typescript-eslint": "8.65.0",
         "vite": "7.3.6",
-        "vite-tsconfig-paths": "6.1.1"
+        "vite-tsconfig-paths": "6.1.1",
+        "vitest": "^4.1.10"
       }
     },
     "../../typescript-sdk": {
@@ -71,7 +72,7 @@
         "eslint": "9.39.5",
         "rimraf": "6.1.3",
         "typescript": "5.9.3",
-        "typescript-eslint": "8.64.0",
+        "typescript-eslint": "8.65.0",
         "uuid": "14.0.1",
         "vite": "7.3.6",
         "vite-plugin-dts": "4.5.4",
@@ -1601,6 +1602,12 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
     "node_modules/@std-uritemplate/std-uritemplate": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-2.0.8.tgz",
@@ -1707,9 +1714,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1727,9 +1731,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1747,9 +1748,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1767,9 +1765,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1787,9 +1782,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1807,9 +1799,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1887,6 +1876,16 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
@@ -1935,6 +1934,12 @@
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2314,6 +2319,112 @@
         "vite": "^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xyflow/react": {
       "version": "12.11.2",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
@@ -2440,6 +2551,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2620,6 +2740,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2969,6 +3098,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3235,6 +3370,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3243,6 +3387,15 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3924,6 +4077,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/marked": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
@@ -4076,6 +4238,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/oidc-client-ts": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
@@ -4224,6 +4399,12 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4603,6 +4784,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4613,11 +4800,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -4730,11 +4929,26 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
     "node_modules/tinyduration": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.4.1.tgz",
       "integrity": "sha512-NemFoamVYn7TmtwZKZ3OiliM9fZkr6EWiTM+wKknco6POSy2gS689xx/pXip0JYp40HXpUw6k65CUYHWYUXdaA==",
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -4751,6 +4965,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5008,6 +5231,95 @@
         "vite": "*"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5022,6 +5334,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/ui/ui-app/package.json
+++ b/ui/ui-app/package.json
@@ -11,7 +11,8 @@
     "clean": "rimraf dist",
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --report-unused-disable-directives"
+    "lint": "eslint . --report-unused-disable-directives",
+    "test": "vitest run"
   },
   "workspaces": [
     "../../typescript-sdk"
@@ -34,7 +35,8 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.65.0",
     "vite": "7.3.6",
-    "vite-tsconfig-paths": "6.1.1"
+    "vite-tsconfig-paths": "6.1.1",
+    "vitest": "4.1.10"
   },
   "dependencies": {
     "@apicurio/apicurio-registry-sdk": "3.3.1-Dev",

--- a/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
+++ b/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, useEffect, useState } from "react";
 import "./ArtifactPage.css";
+import { LoaderGuard, newLoaderGuard } from "@utils/loader.utils.ts";
 import { Breadcrumb, BreadcrumbItem, PageSection, Tab, Tabs } from "@patternfly/react-core";
 import { Link, useLocation, useParams } from "react-router";
 import { EXPLORE_PAGE_IDX, PageDataLoader, PageError, PageErrorHandler, PageProperties, toPageError } from "@app/pages";
@@ -83,7 +84,7 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
         activeTabKey = "usage";
     }
 
-    const createLoaders = (): Promise<any>[] => {
+    const createLoaders = (guard: LoaderGuard): Promise<any>[] => {
         let gid: string|null = groupId as string;
         if (gid == "default") {
             gid = null;
@@ -91,15 +92,15 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
         logger.info("Loading data for artifact: ", artifactId);
         return [
             groups.getArtifactMetaData(gid, artifactId as string)
-                .then(setArtifact)
-                .catch(error => {
+                .then(guard.wrap(setArtifact))
+                .catch(guard.wrap((error: any) => {
                     setPageError(toPageError(error, "Error loading page data."));
-                }),
+                })),
             groups.getArtifactRules(gid, artifactId as string)
-                .then(setRules)
-                .catch(error => {
+                .then(guard.wrap(setRules))
+                .catch(guard.wrap((error: any) => {
                     setPageError(toPageError(error, "Error loading page data."));
-                }),
+                })),
         ];
     };
 
@@ -360,7 +361,9 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
     };
 
     useEffect(() => {
-        setLoaders(createLoaders());
+        const guard: LoaderGuard = newLoaderGuard();
+        setLoaders(createLoaders(guard));
+        return () => guard.cancel();
     }, [groupId, artifactId]);
 
     const tabs: any[] = [

--- a/ui/ui-app/src/app/pages/branch/BranchPage.tsx
+++ b/ui/ui-app/src/app/pages/branch/BranchPage.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, useEffect, useState } from "react";
 import "./BranchPage.css";
+import { LoaderGuard, newLoaderGuard } from "@utils/loader.utils.ts";
 import { Breadcrumb, BreadcrumbItem, PageSection,  } from "@patternfly/react-core";
 import { Link, useParams } from "react-router";
 import {
@@ -37,7 +38,7 @@ export const BranchPage: FunctionComponent<PageProperties> = () => {
     const groups: GroupsService = useGroupsService();
     const { groupId, artifactId, branchId } = useParams();
 
-    const createLoaders = (): Promise<any>[] => {
+    const createLoaders = (guard: LoaderGuard): Promise<any>[] => {
         let gid: string|null = groupId as string;
         if (gid == "default") {
             gid = null;
@@ -45,15 +46,15 @@ export const BranchPage: FunctionComponent<PageProperties> = () => {
         logger.info("Loading data for artifact: ", artifactId);
         return [
             groups.getArtifactMetaData(gid, artifactId as string)
-                .then(setArtifact)
-                .catch(error => {
+                .then(guard.wrap(setArtifact))
+                .catch(guard.wrap((error: any) => {
                     setPageError(toPageError(error, "Error loading page data."));
-                }),
+                })),
             groups.getArtifactBranchMetaData(gid, artifactId as string, branchId as string)
-                .then(setBranch)
-                .catch(error => {
+                .then(guard.wrap(setBranch))
+                .catch(guard.wrap((error: any) => {
                     setPageError(toPageError(error, "Error loading page data."));
-                }),
+                })),
         ];
     };
 
@@ -117,7 +118,9 @@ export const BranchPage: FunctionComponent<PageProperties> = () => {
     };
 
     useEffect(() => {
-        setLoaders(createLoaders());
+        const guard: LoaderGuard = newLoaderGuard();
+        setLoaders(createLoaders(guard));
+        return () => guard.cancel();
     }, [groupId, artifactId, branchId]);
 
     const gid: string = groupId || "default";

--- a/ui/ui-app/src/app/pages/editor/EditorPage.tsx
+++ b/ui/ui-app/src/app/pages/editor/EditorPage.tsx
@@ -1,5 +1,6 @@
 import { CSSProperties, FunctionComponent, useEffect, useRef, useState } from "react";
 import "./EditorPage.css";
+import { LoaderGuard, newLoaderGuard } from "@utils/loader.utils.ts";
 import {
     EmptyState, EmptyStateBody,
     EmptyStateVariant,
@@ -165,34 +166,34 @@ export const EditorPage: FunctionComponent<PageProperties> = () => {
         persistDraftRecoverySnapshot
     });
 
-    const loadDraft = async (): Promise<void> => {
+    const loadDraft = async (guard: LoaderGuard): Promise<void> => {
         try {
             const loadedDraft = await drafts.getDraft(groupId, draftId, version);
-            setDraft(loadedDraft);
-            setDraftLoaded(true);
+            guard.wrap(setDraft)(loadedDraft);
+            guard.wrap(setDraftLoaded)(true);
         } catch (error) {
-            setPageError(toPageError(error, "Error loading page data."));
+            guard.wrap(setPageError)(toPageError(error, "Error loading page data."));
             await requestReauthenticationIfUnauthorized(error);
         }
     };
 
-    const loadDraftContent = async (): Promise<void> => {
+    const loadDraftContent = async (guard: LoaderGuard): Promise<void> => {
         try {
             const content = await drafts.getDraftContent(groupId, draftId, version);
-            setOriginalContent(content.content);
-            setCurrentContent(content.content);
-            setDraftContent(content);
-            setDraftContentLoaded(true);
+            guard.wrap(setOriginalContent)(content.content);
+            guard.wrap(setCurrentContent)(content.content);
+            guard.wrap(setDraftContent)(content);
+            guard.wrap(setDraftContentLoaded)(true);
         } catch (error) {
-            setPageError(toPageError(error, "Error loading page data."));
+            guard.wrap(setPageError)(toPageError(error, "Error loading page data."));
             await requestReauthenticationIfUnauthorized(error);
         }
     };
 
-    const createLoaders = (): Promise<any>[] => {
+    const createLoaders = (guard: LoaderGuard): Promise<any>[] => {
         return [
-            loadDraft(),
-            loadDraftContent(),
+            loadDraft(guard),
+            loadDraftContent(guard),
         ];
     };
 
@@ -204,7 +205,9 @@ export const EditorPage: FunctionComponent<PageProperties> = () => {
         setPageError(undefined);
         setIsContentConflicting(false);
         isAuthRedirectInProgressRef.current = false;
-        setLoaders(createLoaders());
+        const guard: LoaderGuard = newLoaderGuard();
+        setLoaders(createLoaders(guard));
+        return () => guard.cancel();
     }, [draftId, groupId, version]);
 
     useEffect(() => {

--- a/ui/ui-app/src/app/pages/group/GroupPage.tsx
+++ b/ui/ui-app/src/app/pages/group/GroupPage.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, useEffect, useState } from "react";
 import "./GroupPage.css";
+import { LoaderGuard, newLoaderGuard } from "@utils/loader.utils.ts";
 import { Breadcrumb, BreadcrumbItem, PageSection, PageSectionVariants, Tab, Tabs } from "@patternfly/react-core";
 import { Link, useLocation, useParams } from "react-router";
 import {
@@ -69,19 +70,19 @@ export const GroupPage: FunctionComponent<PageProperties> = () => {
         activeTabKey = "rules";
     }
 
-    const createLoaders = (): Promise<any>[] => {
+    const createLoaders = (guard: LoaderGuard): Promise<any>[] => {
         logger.info("Loading data for group: ", groupId);
         return [
             groups.getGroupMetaData(groupId as string)
-                .then(setGroup)
-                .catch(error => {
+                .then(guard.wrap(setGroup))
+                .catch(guard.wrap((error: any) => {
                     setPageError(toPageError(error, "Error loading page data."));
-                }),
+                })),
             groups.getGroupRules(groupId as string)
-                .then(setRules)
-                .catch(error => {
+                .then(guard.wrap(setRules))
+                .catch(guard.wrap((error: any) => {
                     setPageError(toPageError(error, "Error loading page data."));
-                }),
+                })),
         ];
     };
 
@@ -251,7 +252,9 @@ export const GroupPage: FunctionComponent<PageProperties> = () => {
     };
 
     useEffect(() => {
-        setLoaders(createLoaders());
+        const guard: LoaderGuard = newLoaderGuard();
+        setLoaders(createLoaders(guard));
+        return () => guard.cancel();
     }, [groupId]);
 
     const tabs: any[] = [

--- a/ui/ui-app/src/app/pages/version/VersionPage.tsx
+++ b/ui/ui-app/src/app/pages/version/VersionPage.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
 import "./VersionPage.css";
+import { LoaderGuard, newLoaderGuard } from "@utils/loader.utils.ts";
 import { Breadcrumb, BreadcrumbItem, PageSection, Tab, Tabs } from "@patternfly/react-core";
 import { Link, useLocation, useParams } from "react-router";
 import {
@@ -105,7 +106,7 @@ export const VersionPage: FunctionComponent<PageProperties> = () => {
         return false;
     };
 
-    const createLoaders = (): Promise<any>[] => {
+    const createLoaders = (guard: LoaderGuard): Promise<any>[] => {
         let gid: string|null = groupId as string;
         if (gid == "default") {
             gid = null;
@@ -113,18 +114,18 @@ export const VersionPage: FunctionComponent<PageProperties> = () => {
         logger.info("Loading data for artifact: ", artifactId);
         return [
             groups.getArtifactMetaData(gid, artifactId as string)
-                .then(setArtifact)
-                .catch(error => {
+                .then(guard.wrap(setArtifact))
+                .catch(guard.wrap((error: any) => {
                     setPageError(toPageError(error, "Error loading page data."));
-                }),
+                })),
             groups.getArtifactVersionMetaData(gid, artifactId as string, version as string)
-                .then(setArtifactVersion)
-                .catch(error => {
+                .then(guard.wrap(setArtifactVersion))
+                .catch(guard.wrap((error: any) => {
                     setPageError(toPageError(error, "Error loading page data."));
-                }),
+                })),
             groups.getArtifactVersionContent(gid, artifactId as string, version as string)
-                .then(setArtifactContent)
-                .catch(e => {
+                .then(guard.wrap(setArtifactContent))
+                .catch(guard.wrap((e: any) => {
                     logger.warn("Failed to get artifact content: ", e);
                     if (is404(e)) {
                         setArtifactContent("Artifact version content not available (404 Not Found).");
@@ -132,7 +133,7 @@ export const VersionPage: FunctionComponent<PageProperties> = () => {
                         const pageError: PageError = toPageError(e, "Error loading page data.");
                         setPageError(pageError);
                     }
-                }),
+                })),
         ];
     };
 
@@ -401,7 +402,9 @@ export const VersionPage: FunctionComponent<PageProperties> = () => {
     };
 
     useEffect(() => {
-        setLoaders(createLoaders());
+        const guard: LoaderGuard = newLoaderGuard();
+        setLoaders(createLoaders(guard));
+        return () => guard.cancel();
     }, [groupId, artifactId, version]);
 
     useEffect(() => {

--- a/ui/ui-app/src/utils/index.ts
+++ b/ui/ui-app/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "./content.utils";
 export * from "./labels.utils";
+export * from "./loader.utils";
 export * from "./object.utils";
 export * from "./rest.utils";
 export * from "./string.utils";

--- a/ui/ui-app/src/utils/loader.utils.test.ts
+++ b/ui/ui-app/src/utils/loader.utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { newLoaderGuard } from "./loader.utils";
+
+describe("newLoaderGuard", () => {
+    it("invokes a wrapped callback while the guard is active", () => {
+        const guard = newLoaderGuard();
+        const spy = vi.fn();
+
+        guard.wrap(spy)("value");
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith("value");
+    });
+
+    it("does not invoke a previously wrapped callback after cancel", () => {
+        const guard = newLoaderGuard();
+        const spy = vi.fn();
+        const wrapped = guard.wrap(spy);
+
+        guard.cancel();
+        wrapped("value");
+
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("does not invoke a callback wrapped after cancel", () => {
+        const guard = newLoaderGuard();
+        guard.cancel();
+        const spy = vi.fn();
+
+        guard.wrap(spy)("value");
+
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("keeps separate guards independent", () => {
+        const first = newLoaderGuard();
+        const second = newLoaderGuard();
+        const firstSpy = vi.fn();
+        const secondSpy = vi.fn();
+
+        first.cancel();
+        first.wrap(firstSpy)("a");
+        second.wrap(secondSpy)("b");
+
+        expect(firstSpy).not.toHaveBeenCalled();
+        expect(secondSpy).toHaveBeenCalledTimes(1);
+        expect(secondSpy).toHaveBeenCalledWith("b");
+    });
+});

--- a/ui/ui-app/src/utils/loader.utils.ts
+++ b/ui/ui-app/src/utils/loader.utils.ts
@@ -1,0 +1,22 @@
+export type LoaderCallback<T> = (value: T) => void;
+
+export interface LoaderGuard {
+    wrap: <T>(callback: LoaderCallback<T>) => LoaderCallback<T>;
+    cancel: () => void;
+}
+
+export function newLoaderGuard(): LoaderGuard {
+    let cancelled = false;
+    return {
+        wrap: <T>(callback: LoaderCallback<T>): LoaderCallback<T> => {
+            return (value: T): void => {
+                if (!cancelled) {
+                    callback(value);
+                }
+            };
+        },
+        cancel: (): void => {
+            cancelled = true;
+        }
+    };
+}

--- a/ui/ui-app/vite.config.mts
+++ b/ui/ui-app/vite.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
 import react from "@vitejs/plugin-react-swc";
 
@@ -9,6 +9,10 @@ export default defineConfig({
     plugins: [react(), tsconfigPaths()],
     server: {
         port: PORT
+    },
+    test: {
+        environment: "node",
+        include: ["src/**/*.test.ts", "src/**/*.test.tsx"]
     },
     // define: {
     //     "process.platform": {}


### PR DESCRIPTION
## What

Fixes a stale-response race in the page components of the UI (`ui-app`). When navigating between two resources on the same route, a page could end up displaying data that belongs to a different resource than the one in the URL.

Closes #8879.

## Why

The page components load their data through a `createLoaders()` helper that fires `service.getX(...).then(setX)` with no request cancellation and no `useEffect` cleanup. react-router keeps these components mounted while only the route params change, so the requests started for the previous params are never cancelled. If an earlier, slower request resolves after a newer one, its `setX` overwrites the page state with the wrong resource's data. The unguarded callbacks can also run after the component has unmounted.

A concrete trigger exists today: the References tab links from one version to another (`ReferenceList.tsx`), both rendered by `VersionPage`, so same-route navigation is reachable and `getArtifactVersionContent` responses can be large enough to arrive out of order.

## Changes

- Add `newLoaderGuard()` in `src/utils/loader.utils.ts`. It returns a guard whose `wrap()` turns a callback into a no-op once `cancel()` has been called.
- In every page whose loaders depend on route params, the loader effect now creates a guard, passes it to `createLoaders(guard)`, wraps each callback with `guard.wrap(...)`, and calls `guard.cancel()` in the effect cleanup. Only results for the current params are applied.
- Add Vitest and a unit test for `newLoaderGuard`.

## Coverage

A grep of `setLoaders(createLoaders` across `src/app/pages` shows five pages whose loaders are param-driven, and all five are now guarded:

| Page | effect deps |
|------|-------------|
| `ArtifactPage` | `[groupId, artifactId]` |
| `VersionPage` | `[groupId, artifactId, version]` |
| `GroupPage` | `[groupId]` |
| `BranchPage` | `[groupId, artifactId, branchId]` |
| `EditorPage` | `[draftId, groupId, version]` |

The remaining pages that use `createLoaders()` (`AgentsPage`, `DashboardPage`, `ExplorePage`, `SearchPage`, `RolesPage`, `RulesPage`, `SettingsPage`, `GlobalContractRulesPage`) load once with `[]` deps and do not reload on navigation, so they do not carry this race. On `EditorPage`, only the state updates are guarded; the reauthentication side effect is left intact so an expired session is still handled.

## Follow-up

The guard silences the superseded callback rather than aborting the underlying request, which is a minimal correctness fix. An `AbortController`-based version that also cancels the in-flight HTTP request would be a natural follow-up if request volume becomes a concern.

## Testing

- `eslint` passes on the changed files (`npm run lint`: 0 errors).
- `tsc` reports no type errors from this change. The only `tsc` errors in a fresh checkout come from the pre-existing `@sdk/lib/generated-client/models` module resolution, which requires running the SDK code generation and is present on unmodified `main` as well.
- `npm test` runs the new Vitest suite for `newLoaderGuard` (4 tests passing): active guard invokes the callback, a cancelled guard does not, a callback wrapped after cancel is a no-op, and separate guards stay independent.
