### PR TITLE
fix(ui): resolve scroll conflict inside CreateArtifactModal (#8870)

### DIFF
--- a/ui/ui-app/src/app/components/modals/AddVersionToBranchModal.tsx
+++ b/ui/ui-app/src/app/components/modals/AddVersionToBranchModal.tsx
@@ -98,7 +98,6 @@ export const AddVersionToBranchModal: FunctionComponent<AddVersionToBranchModalP
                                 itemToString={item => item.branchId}
                                 itemToTestId={item => `branch-${shash(item.branchId)}`}
                                 toggleId="select-branch-toggle"
-                                appendTo="document"
                             />
                         </FormGroup>
                     </Form>

--- a/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
+++ b/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
@@ -426,7 +426,6 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
                                 itemIsDivider={(item) => item.isDivider}
                                 itemToTestId={(item) => `create-artifact-modal-${item.value}`}
                                 itemToString={(item) => item.label}
-                                appendTo="document"
                             />
                             <FormHelperText>
                                 <HelperText>

--- a/ui/ui-app/src/app/components/modals/GenerateClientModal.tsx
+++ b/ui/ui-app/src/app/components/modals/GenerateClientModal.tsx
@@ -247,7 +247,6 @@ export const GenerateClientModal: FunctionComponent<GenerateClientModalProps> = 
                                         onSelect={onLanguageSelect}
                                         itemToString={item => item.id}
                                         itemToTestId={item => item.testId}
-                                        appendTo="document"
                                         testId="select-language"
                                         toggleId="select-language-toggle"
                                     />

--- a/ui/ui-app/src/app/pages/drafts/components/modals/CreateDraftModal.tsx
+++ b/ui/ui-app/src/app/pages/drafts/components/modals/CreateDraftModal.tsx
@@ -432,7 +432,6 @@ export const CreateDraftModal: FunctionComponent<CreateDraftModalProps> = (props
                                 itemIsDivider={(item) => item.isDivider}
                                 itemToTestId={(item) => `create-draft-modal-${item.value}`}
                                 itemToString={(item) => item.label}
-                                appendTo="document"
                             />
                         </FormGroup>
                     </Form>


### PR DESCRIPTION
# Description

This PR resolves scroll locking and focus trap conflicts within all select dropdowns (`ObjectSelect`) rendered inside modal/wizard components. Originally reported for the "Create Artifact" modal (#8870), this pattern has been fixed globally across all modal/wizard views in the project.

## What

Removed `appendTo="document"` from the `ObjectSelect` components in the following files:
- `CreateArtifactModal.tsx` (Artifact Type select)
- `CreateDraftModal.tsx` (Draft Type select)
- `GenerateClientModal.tsx` (Language select)
- `AddVersionToBranchModal.tsx` (Branch select)

## Why

In PatternFly 6, when rendering a dropdown using `appendTo="document"` inside a component with a focus trap or scroll lock (such as standard Modals or Wizards), scrolling the dropdown menu conflicts with the parent container's focus and scroll locking. This prevents users from scrolling dropdown lists (such as artifact types) and can freeze the UI. 

Removing `appendTo="document"` forces the select dropdown to render inline within the Modal DOM hierarchy, allowing it to inherit focus management and scroll boundaries correctly.

## Verification

Manual verification was performed for each modal:
- Opened **Create Artifact**, **Create Draft**, **Generate Client**, and **Add Version to Branch** modals.
- Verified that all select dropdowns open, align, and scroll smoothly without any focus trap or scrolling locks.

Fixes #8870
