### PR TITLE
fix(ui): prevent duplicate skill IDs in Agent Card SkillEditor

### DIFF
--- a/ui/ui-app/src/app/components/agentCard/SkillEditor.tsx
+++ b/ui/ui-app/src/app/components/agentCard/SkillEditor.tsx
@@ -4,6 +4,9 @@ import {
     Button,
     Form,
     FormGroup,
+    FormHelperText,
+    HelperText,
+    HelperTextItem,
     TextArea,
     TextInput,
     Title,
@@ -47,6 +50,9 @@ export const SkillEditor: FunctionComponent<SkillEditorProps> = (props: SkillEdi
         tags: []
     };
 
+    const isDuplicateSkillId: boolean =
+        isAdding && !!editingSkill?.id && skills.some(s => s.id === editingSkill?.id);
+
     const handleAddSkill = (): void => {
         setEditingSkill({ ...emptySkill });
         setIsAdding(true);
@@ -64,6 +70,10 @@ export const SkillEditor: FunctionComponent<SkillEditorProps> = (props: SkillEdi
 
     const handleSaveSkill = (): void => {
         if (!editingSkill || !editingSkill.id || !editingSkill.name) {
+            return;
+        }
+
+        if (isDuplicateSkillId) {
             return;
         }
 
@@ -109,7 +119,17 @@ export const SkillEditor: FunctionComponent<SkillEditorProps> = (props: SkillEdi
                         onChange={(_event, value) => setEditingSkill({ ...editingSkill, id: value })}
                         placeholder="e.g., schema-validation"
                         isDisabled={!isAdding}
+                        validated={isDuplicateSkillId ? "error" : "default"}
                     />
+                    {isDuplicateSkillId && (
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem variant="error">
+                                    A skill with this ID already exists.
+                                </HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
+                    )}
                 </FormGroup>
                 <FormGroup label="Name" isRequired fieldId="skill-name">
                     <TextInput
@@ -165,7 +185,7 @@ export const SkillEditor: FunctionComponent<SkillEditorProps> = (props: SkillEdi
                     )}
                 </FormGroup>
                 <ActionGroup>
-                    <Button variant="primary" onClick={handleSaveSkill}>
+                    <Button variant="primary" onClick={handleSaveSkill} isDisabled={isDuplicateSkillId}>
                         {isAdding ? "Add Skill" : "Save Changes"}
                     </Button>
                     <Button variant="link" onClick={handleCancelEdit}>


### PR DESCRIPTION
## What
Fixes a data-integrity bug in the Agent Card editor: `SkillEditor` allowed two skills to share the same `id`, which corrupted edit and delete. Closes #8882.

## Why
The skill `id` is used both as the React list `key` and as the record identity for edit and delete. Adding a skill validated only that `id`/`name` were non-empty, not that `id` was unique. With two skills sharing an `id`: React logs a duplicate-key warning, deleting one removed both, and editing one overwrote both. Duplicate ids are also reachable by importing an agent card whose JSON already has repeated skill ids.

## Changes
`SkillEditor.tsx`: compute `isDuplicateSkillId` while adding; block the save and disable the primary button when the id exists; show an inline error on the Skill ID field using the existing PatternFly FormHelperText/HelperText/HelperTextItem pattern. Editing an existing skill is unaffected.

## Testing
eslint passes; tsc reports no new errors (only pre-existing `@sdk` resolution errors present on main); verified the guard by running the save logic in isolation (duplicate add is a no-op; unique add and edit still work). ui-app has no unit-test runner yet (proposed in #8880); a focused test would be a natural follow-up.