### PR TITLE
docs(resolver): fix typo in ParsedSchema Javadoc

### DIFF
--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/ParsedSchema.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/ParsedSchema.java
@@ -15,7 +15,7 @@ public interface ParsedSchema<T> {
     public byte[] getRawSchema();
 
     /**
-     * @return the the schema references (if any)
+     * @return the schema references (if any)
      */
     public List<ParsedSchema<T>> getSchemaReferences();
 


### PR DESCRIPTION
I have fixed a typo in  `ParsedSchema.java` 

``` diff
-  * @return the the schema references (if any)
+  * @return the schema references (if any)

