### PR TITLE
 fix(rules): resolve locale-sensitive toUpperCase and remove unused field in RulesPropertiesImpl

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rules/RulesPropertiesImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rules/RulesPropertiesImpl.java
@@ -3,21 +3,21 @@ package io.apicurio.registry.rules;
 import io.apicurio.registry.storage.dto.RuleConfigurationDto;
 import io.apicurio.registry.types.RuleType;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class RulesPropertiesImpl implements RulesProperties {
-    @SuppressWarnings("unused")
-    private final Properties properties;
+    
     private final Map<RuleType, String> defaultGlobalRules;
 
     public RulesPropertiesImpl(Properties properties) {
         this.properties = properties;
         this.defaultGlobalRules = properties.stringPropertyNames().stream()
                 .collect(Collectors.toMap(
-                        rulePropertyName -> RuleType.fromValue(rulePropertyName.toUpperCase()),
+                        rulePropertyName -> RuleType.fromValue(rulePropertyName.toUpperCase(Locale.ROOT)),
                         properties::getProperty));
     }
 

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/ParsedSchema.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/ParsedSchema.java
@@ -15,7 +15,7 @@ public interface ParsedSchema<T> {
     public byte[] getRawSchema();
 
     /**
-     * @return the the schema references (if any)
+     * @return the schema references (if any)
      */
     public List<ParsedSchema<T>> getSchemaReferences();
 


### PR DESCRIPTION
### PR Description

This pull request improves the quality and maintainability of `RulesPropertiesImpl.java` by making the following changes:

1. **Locale-safe capitalization**

   * Replaced `rulePropertyName.toUpperCase()` with `rulePropertyName.toUpperCase(Locale.ROOT)` to ensure locale-independent behavior and prevent OS-specific issues (such as the Turkish dotted/dotless `I` case conversion), in accordance with the project's guidelines in `CLAUDE.md`.

2. **Code cleanup**

   * Removed the unused `properties` field along with its associated `@SuppressWarnings` annotation, reducing unnecessary code and improving maintainability.

### Closes :  #8886