### PR TITLE
fix(serde): add deserializer error handler to prevent endless rebalance loop

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
@@ -373,6 +373,43 @@ The `DefaultFallbackArtifactProvider` uses the following properties to configure
 |None
 |===
 
+**Configuration for deserializer error handling**
+
+By default, a deserializer throws when a record's artifact/schema reference cannot be determined or
+resolved (for example, a mismatched `ENABLE_HEADERS` setting between producer and consumer, or a
+deleted schema). Because such a record is never successfully consumed, it is redelivered and fails
+again on every subsequent poll. If your application retries around a failing `poll()` call, the
+cumulative retry time can exceed `max.poll.interval.ms`, causing the consumer to be repeatedly
+evicted from its group and forced to rejoin.
+
+You can configure a `DeserializerErrorHandler` to skip a record like this instead of throwing:
+
+[source,properties]
+----
+props.putIfAbsent(SerdeConfig.DESERIALIZER_ERROR_HANDLER,
+        "io.apicurio.registry.serde.error.LoggingDeserializerErrorHandler");
+----
+
+`LoggingDeserializerErrorHandler` logs the skipped record at `WARN` and returns `null` from
+`deserialize()`, the same way a tombstone (null-valued) record is handled. To customize this
+behavior, for example to publish skipped records to a dead-letter topic, implement
+`DeserializerErrorHandler` yourself.
+
+.Configuration property for deserializer error handling
+[.table-expandable,width="100%",cols="5,5,5,3,5",options="header"]
+|===
+|Constant
+|Property
+|Description
+|Type
+|Default
+|`DESERIALIZER_ERROR_HANDLER`
+|`apicurio.registry.deserializer.error-handler`
+|Used by deserializers only. Fully qualified Java class name of a class that implements `DeserializerErrorHandler`. Called when a record's artifact/schema reference cannot be resolved, after any configured `FALLBACK_ARTIFACT_PROVIDER` has also failed. Unset by default, meaning no handler is used and the deserializer always throws, matching prior behavior.
+|`String`
+|None
+|===
+
 You can configure application properties as Java system properties or include them in the Quarkus
 `application.properties` file.
 For more details, see the https://quarkus.io/guides/config#overriding-properties-at-runtime[Quarkus documentation].

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/HeadersMismatchRebalanceIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/HeadersMismatchRebalanceIT.java
@@ -1,0 +1,223 @@
+package io.apicurio.tests.serdes.apicurio;
+
+import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
+import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
+import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.serde.error.LoggingDeserializerErrorHandler;
+import io.apicurio.registry.serde.kafka.config.KafkaSerdeConfig;
+import io.apicurio.registry.serde.strategy.TopicIdStrategy;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.apicurio.tests.ApicurioRegistryBaseIT;
+import io.apicurio.tests.utils.KafkaFacade;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.apicurio.deployment.Constants.SERDES;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduces the failure mechanism behind
+ * <a href="https://github.com/Apicurio/apicurio-registry/issues/3662">#3662</a> ("endless rebalance
+ * loop"): a consumer configured with {@code apicurio.registry.headers.enabled} mismatched relative
+ * to the producer receives a record it can never deserialize. Because the deserializer offers no
+ * poison-pill handling, the same record is redelivered on every poll with no forward progress. Once
+ * a realistic per-record backoff is layered on top (as most consumer applications do around a
+ * failing record), the cumulative retry time exceeds {@code max.poll.interval.ms} and the consumer
+ * is repeatedly evicted from its group and forced to rejoin.
+ */
+@Tag(SERDES)
+@QuarkusIntegrationTest
+public class HeadersMismatchRebalanceIT extends ApicurioRegistryBaseIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HeadersMismatchRebalanceIT.class);
+
+    private final KafkaFacade kafkaCluster = KafkaFacade.getInstance();
+
+    @BeforeAll
+    void setupEnvironment() {
+        kafkaCluster.startIfNeeded();
+    }
+
+    @AfterAll
+    void teardownEnvironment() throws Exception {
+        kafkaCluster.stopIfPossible();
+    }
+
+    @Test
+    void headersMismatchCausesEndlessRebalance() throws Exception {
+        String topicName = TestUtils.generateTopic();
+        kafkaCluster.createTopic(topicName, 1, 1);
+
+        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("poisonPillRecord",
+                List.of("key1" + System.currentTimeMillis()));
+
+        KafkaSerdesTester<String, GenericRecord, GenericRecord> tester = new KafkaSerdesTester<>();
+
+        // Producer: headers enabled, matching the buggy 2.4.3-2.6.x default (id carried in headers,
+        // payload has no magic-byte/id prefix).
+        Properties producerProps = new Properties();
+        producerProps.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+        producerProps.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
+        Producer<String, GenericRecord> producer = tester.createProducer(producerProps,
+                StringSerializer.class, AvroKafkaSerializer.class, topicName, TopicIdStrategy.class);
+        tester.produceMessages(producer, topicName, avroSchema::generateRecord, 1, false);
+
+        // Consumer: headers disabled, matching a client that only understands the payload-embedded id
+        // (e.g. a pre-2.4.3 client, or any client that never opted into headers mode).
+        Properties consumerProps = new Properties();
+        consumerProps.put(KafkaSerdeConfig.ENABLE_HEADERS, "false");
+        // Deliberately shorter than the per-record retry backoff below (2000ms) so that a realistic
+        // app-level retry cadence around a poison-pill record reliably exceeds it, the same way a much
+        // larger real-world max.poll.interval.ms (default 300000ms) would eventually be exceeded by a
+        // slow/retried resolution call or a longer application backoff.
+        consumerProps.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "1000");
+        consumerProps.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "6000");
+        consumerProps.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "1000");
+        consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1");
+        consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        Consumer<String, GenericRecord> consumer = tester.createConsumer(consumerProps,
+                StringDeserializer.class, AvroKafkaDeserializer.class, topicName);
+
+        // NOTE: onPartitionsRevoked also fires during a clean consumer.close(), so counting revocations
+        // alone can't distinguish an involuntary broker-side eviction from a graceful shutdown. What
+        // *can't* happen during a graceful shutdown (we only close once, after the loop below exits) is
+        // a second onPartitionsAssigned callback -- that only happens if the group coordinator forced
+        // this consumer out and it had to rejoin. So assignedCount >= 2, observed strictly *before* we
+        // ever call close(), is the real signal of an involuntary rebalance.
+        AtomicInteger assignedCount = new AtomicInteger();
+        consumer.subscribe(Collections.singletonList(topicName), new ConsumerRebalanceListener() {
+            @Override
+            public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                LOGGER.info("Partitions revoked: {}", partitions);
+            }
+
+            @Override
+            public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+                if (!partitions.isEmpty()) {
+                    int n = assignedCount.incrementAndGet();
+                    LOGGER.info("Partitions assigned (assignment #{}): {}", n, partitions);
+                }
+            }
+        });
+
+        int failureCount = 0;
+        long start = System.currentTimeMillis();
+        long deadline = start + 60_000;
+        while (assignedCount.get() < 2 && System.currentTimeMillis() < deadline) {
+            try {
+                consumer.poll(Duration.ofSeconds(2));
+                LOGGER.info("poll() returned without error (unexpected for the poison-pill record)");
+            } catch (Exception e) {
+                failureCount++;
+                LOGGER.info("poll() failed as expected ({}), t+{}ms: {}", failureCount,
+                        System.currentTimeMillis() - start, e.getClass().getSimpleName());
+                // Model a realistic consumer application: don't skip the offending record, just
+                // back off briefly and retry. This backoff is what tips the cumulative retry time
+                // over max.poll.interval.ms in real deployments.
+                Thread.sleep(2000);
+            }
+        }
+        int assignedBeforeClose = assignedCount.get();
+        consumer.close(Duration.ofSeconds(5));
+
+        assertTrue(failureCount > 0,
+                "Expected the mismatched consumer to fail deserializing the poison-pill record at least once");
+        assertTrue(assignedBeforeClose >= 2, "Expected the consumer to be involuntarily evicted from its "
+                + "group and forced to rejoin (endless rebalance) before we ever closed it, but only "
+                + "observed " + assignedBeforeClose + " assignment(s)");
+    }
+
+    /**
+     * Same scenario as {@link #headersMismatchCausesEndlessRebalance()}, but with
+     * {@link SerdeConfig#DESERIALIZER_ERROR_HANDLER} configured to skip unresolvable records. Proves
+     * the fix: the consumer never fails to poll and is never evicted from its group.
+     */
+    @Test
+    void configuredErrorHandlerPreventsEndlessRebalance() throws Exception {
+        String topicName = TestUtils.generateTopic();
+        kafkaCluster.createTopic(topicName, 1, 1);
+
+        AvroGenericRecordSchemaFactory avroSchema = new AvroGenericRecordSchemaFactory("poisonPillRecord",
+                List.of("key1" + System.currentTimeMillis()));
+
+        KafkaSerdesTester<String, GenericRecord, GenericRecord> tester = new KafkaSerdesTester<>();
+
+        Properties producerProps = new Properties();
+        producerProps.put(KafkaSerdeConfig.ENABLE_HEADERS, "true");
+        producerProps.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
+        Producer<String, GenericRecord> producer = tester.createProducer(producerProps,
+                StringSerializer.class, AvroKafkaSerializer.class, topicName, TopicIdStrategy.class);
+        tester.produceMessages(producer, topicName, avroSchema::generateRecord, 1, false);
+
+        Properties consumerProps = new Properties();
+        consumerProps.put(KafkaSerdeConfig.ENABLE_HEADERS, "false");
+        consumerProps.put(SerdeConfig.DESERIALIZER_ERROR_HANDLER, LoggingDeserializerErrorHandler.class.getName());
+        consumerProps.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "1000");
+        consumerProps.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "6000");
+        consumerProps.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "1000");
+        consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1");
+        consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        Consumer<String, GenericRecord> consumer = tester.createConsumer(consumerProps,
+                StringDeserializer.class, AvroKafkaDeserializer.class, topicName);
+
+        AtomicInteger assignedCount = new AtomicInteger();
+        consumer.subscribe(Collections.singletonList(topicName), new ConsumerRebalanceListener() {
+            @Override
+            public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                LOGGER.info("Partitions revoked: {}", partitions);
+            }
+
+            @Override
+            public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+                if (!partitions.isEmpty()) {
+                    int n = assignedCount.incrementAndGet();
+                    LOGGER.info("Partitions assigned (assignment #{}): {}", n, partitions);
+                }
+            }
+        });
+
+        int failureCount = 0;
+        long start = System.currentTimeMillis();
+        // Long enough to comfortably cover several multiples of the endless-rebalance cadence
+        // observed in headersMismatchCausesEndlessRebalance() with the same max.poll.interval.ms.
+        long deadline = start + 20_000;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                consumer.poll(Duration.ofSeconds(2));
+            } catch (Exception e) {
+                failureCount++;
+                LOGGER.info("Unexpected poll() failure ({}): {}", failureCount, e.getClass().getSimpleName());
+            }
+        }
+        int assignedBeforeClose = assignedCount.get();
+        consumer.close(Duration.ofSeconds(5));
+
+        assertEquals(0, failureCount,
+                "Expected poll() to never fail once the poison-pill record is skipped by the configured handler");
+        assertEquals(1, assignedBeforeClose,
+                "Expected exactly the initial assignment and no involuntary rebalance once the poison-pill "
+                        + "record is skipped by the configured handler");
+    }
+}

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractDeserializer.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/AbstractDeserializer.java
@@ -17,6 +17,7 @@ import io.apicurio.registry.resolver.utils.Utils;
 import io.apicurio.registry.rest.client.models.ContractRuleSet;
 import io.apicurio.registry.serde.config.SerdeConfig;
 import io.apicurio.registry.serde.config.SerdeDeserializerConfig;
+import io.apicurio.registry.serde.error.DeserializerErrorHandler;
 import io.apicurio.registry.serde.fallback.DefaultFallbackArtifactProvider;
 import io.apicurio.registry.serde.fallback.FallbackArtifactProvider;
 import io.apicurio.registry.serde.tracing.SerDesAttributes;
@@ -48,6 +49,7 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
     private final ConcurrentHashMap<SchemaCacheKey, SchemaLookupResult<T>> fastPathCache = new ConcurrentHashMap<>();
 
     private FallbackArtifactProvider fallbackArtifactProvider;
+    private DeserializerErrorHandler deserializerErrorHandler;
     private final BaseSerde<T, U> baseSerde;
     private boolean contractRulesEnabled = false;
     private boolean contractRulesFailOnError = true;
@@ -124,6 +126,20 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
                 fallbackArtifactProvider = null;
             }
         }
+
+        Object errorHandler = deserializerConfig.getDeserializerErrorHandler();
+        Utils.instantiate(DeserializerErrorHandler.class, errorHandler, this::setDeserializerErrorHandler);
+        if (deserializerErrorHandler != null) {
+            deserializerErrorHandler.configure(config.originals(), isKey);
+        }
+    }
+
+    public DeserializerErrorHandler getDeserializerErrorHandler() {
+        return deserializerErrorHandler;
+    }
+
+    public void setDeserializerErrorHandler(DeserializerErrorHandler deserializerErrorHandler) {
+        this.deserializerErrorHandler = deserializerErrorHandler;
     }
 
     public abstract SchemaParser<T, U> schemaParser();
@@ -135,13 +151,24 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
         return tracer.traceDeserialize(topic, span -> {
             span.setAttribute(SerDesAttributes.DATA_SIZE, (long) data.length);
 
-            ByteBuffer buffer = getByteBuffer(data);
+            ByteBuffer buffer;
+            try {
+                buffer = getByteBuffer(data);
+            } catch (RuntimeException e) {
+                if (shouldSkip(topic, data, e)) {
+                    return null;
+                }
+                throw e;
+            }
             ArtifactReference artifactReference = baseSerde.getIdHandler().readId(buffer);
 
             SchemaCacheKey cacheKey = getCacheKey(artifactReference);
             boolean cacheHit = cacheKey != null && fastPathCache.containsKey(cacheKey);
 
             SchemaLookupResult<T> schema = resolve(topic, data, artifactReference);
+            if (schema == null) {
+                return null;
+            }
             SerDesTracer.setSchemaAttributes(span, schema, cacheHit);
 
             int length = buffer.limit() - 1 - baseSerde.getIdHandler().idSize(artifactReference, buffer);
@@ -161,6 +188,9 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
 
     public U readData(String topic, byte[] data, ArtifactReference artifactReference) {
         SchemaLookupResult<T> schema = resolve(topic, data, artifactReference);
+        if (schema == null) {
+            return null;
+        }
 
         ByteBuffer buffer = ByteBuffer.wrap(data);
         int length = buffer.limit();
@@ -198,6 +228,9 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
             return result;
         } catch (RuntimeException e) {
             if (getFallbackArtifactProvider() == null) {
+                if (shouldSkip(topic, data, e)) {
+                    return null;
+                }
                 throw e;
             } else {
                 try {
@@ -211,10 +244,23 @@ public abstract class AbstractDeserializer<T, U> implements AutoCloseable {
                     return result;
                 } catch (RuntimeException fe) {
                     fe.addSuppressed(e);
+                    if (shouldSkip(topic, data, fe)) {
+                        return null;
+                    }
                     throw fe;
                 }
             }
         }
+    }
+
+    /**
+     * Consults the configured {@link DeserializerErrorHandler}, if any, for a record whose
+     * artifact/schema reference could not be resolved.
+     *
+     * @return true if the record should be skipped (deserialize() returns null instead of throwing)
+     */
+    private boolean shouldSkip(String topic, byte[] data, RuntimeException cause) {
+        return deserializerErrorHandler != null && deserializerErrorHandler.handle(topic, data, cause);
     }
 
     /**

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/config/SerdeConfig.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/config/SerdeConfig.java
@@ -6,6 +6,7 @@ import io.apicurio.registry.resolver.config.SchemaResolverConfig;
 import io.apicurio.registry.resolver.data.Metadata;
 import io.apicurio.registry.serde.Default4ByteIdHandler;
 import io.apicurio.registry.serde.IdHandler;
+import io.apicurio.registry.serde.error.DeserializerErrorHandler;
 import io.apicurio.registry.serde.fallback.DefaultFallbackArtifactProvider;
 import io.apicurio.registry.serde.fallback.FallbackArtifactProvider;
 import io.apicurio.registry.serde.strategy.TopicIdStrategy;
@@ -142,6 +143,15 @@ public class SerdeConfig extends SchemaResolverConfig {
     public static final String FALLBACK_ARTIFACT_PROVIDER = "apicurio.registry.fallback.provider";
     public static final String FALLBACK_ARTIFACT_PROVIDER_DEFAULT = DefaultFallbackArtifactProvider.class
             .getName();
+
+    /**
+     * Only applicable for deserializers. Optional, fully qualified Java classname of a class that
+     * implements {@link DeserializerErrorHandler}. When a record's artifact/schema reference cannot be
+     * resolved (after any configured {@link #FALLBACK_ARTIFACT_PROVIDER} has also failed), the handler
+     * is given the chance to skip the record instead of the deserializer throwing. Unset by default,
+     * meaning no handler is used and the deserializer always throws, matching prior behavior.
+     */
+    public static final String DESERIALIZER_ERROR_HANDLER = "apicurio.registry.deserializer.error-handler";
 
     /**
      * Fully qualified Java classname of a class that will be used as the return type for the deserializer.

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/config/SerdeDeserializerConfig.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/config/SerdeDeserializerConfig.java
@@ -3,6 +3,7 @@ package io.apicurio.registry.serde.config;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.apicurio.registry.serde.config.SerdeConfig.DESERIALIZER_ERROR_HANDLER;
 import static io.apicurio.registry.serde.config.SerdeConfig.FALLBACK_ARTIFACT_PROVIDER;
 import static io.apicurio.registry.serde.config.SerdeConfig.FALLBACK_ARTIFACT_PROVIDER_DEFAULT;
 import static java.util.Map.entry;
@@ -20,6 +21,10 @@ public class SerdeDeserializerConfig extends SerdeConfig {
 
     public Object getFallbackArtifactProvider() {
         return this.getObject(FALLBACK_ARTIFACT_PROVIDER);
+    }
+
+    public Object getDeserializerErrorHandler() {
+        return this.getObject(DESERIALIZER_ERROR_HANDLER);
     }
 
     @Override

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/error/DeserializerErrorHandler.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/error/DeserializerErrorHandler.java
@@ -1,0 +1,29 @@
+package io.apicurio.registry.serde.error;
+
+import java.util.Map;
+
+/**
+ * Interface for handling records whose artifact/schema reference could not be determined or
+ * resolved (e.g. a headers/payload format mismatch, a deleted schema, or an unresolvable id). By
+ * default, deserializers throw when this happens; a configured handler allows a record to be
+ * skipped instead, so a single permanently-unresolvable record doesn't block consumption forever.
+ */
+public interface DeserializerErrorHandler {
+
+    default void configure(Map<String, Object> configs, boolean isKey) {
+    }
+
+    /**
+     * Called after all normal resolution (including any configured FallbackArtifactProvider) has
+     * failed for a record. Return true to have the deserializer swallow the error and skip the
+     * record (deserialize() returns null); return false to preserve the default behavior of
+     * throwing the original exception.
+     *
+     * @param topic the topic the record was read from
+     * @param data the raw record payload that could not be resolved
+     * @param cause the exception that resolution failed with
+     * @return true to skip the record, false to rethrow {@code cause}
+     */
+    boolean handle(String topic, byte[] data, Exception cause);
+
+}

--- a/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/error/LoggingDeserializerErrorHandler.java
+++ b/serdes/generic/serde-common/src/main/java/io/apicurio/registry/serde/error/LoggingDeserializerErrorHandler.java
@@ -1,0 +1,22 @@
+package io.apicurio.registry.serde.error;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default {@link DeserializerErrorHandler} implementation: logs the unresolvable record at WARN
+ * level and skips it.
+ */
+public class LoggingDeserializerErrorHandler implements DeserializerErrorHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(LoggingDeserializerErrorHandler.class);
+
+    @Override
+    public boolean handle(String topic, byte[] data, Exception cause) {
+        int dataLength = data == null ? 0 : data.length;
+        log.warn("Skipping unresolvable record on topic '{}' ({} bytes): {}", topic, dataLength,
+                cause.getMessage(), cause);
+        return true;
+    }
+
+}

--- a/serdes/generic/serde-common/src/test/java/io/apicurio/registry/serde/AbstractDeserializerErrorHandlerTest.java
+++ b/serdes/generic/serde-common/src/test/java/io/apicurio/registry/serde/AbstractDeserializerErrorHandlerTest.java
@@ -1,0 +1,114 @@
+package io.apicurio.registry.serde;
+
+import io.apicurio.registry.resolver.ParsedSchema;
+import io.apicurio.registry.resolver.SchemaLookupResult;
+import io.apicurio.registry.resolver.SchemaParser;
+import io.apicurio.registry.resolver.SchemaResolver;
+import io.apicurio.registry.resolver.client.RegistryClientFacade;
+import io.apicurio.registry.resolver.data.Record;
+import io.apicurio.registry.resolver.strategy.ArtifactReference;
+import io.apicurio.registry.resolver.strategy.ArtifactReferenceResolverStrategy;
+import io.apicurio.registry.serde.error.DeserializerErrorHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that a configured {@link DeserializerErrorHandler} can skip a record whose artifact
+ * reference cannot be resolved, and that the default (unconfigured) behavior is unchanged: throw.
+ * This is the mechanism behind the fix for the "endless rebalance loop" in
+ * https://github.com/Apicurio/apicurio-registry/issues/3662.
+ */
+public class AbstractDeserializerErrorHandlerTest {
+
+    private static final class ThrowingSchemaResolver implements SchemaResolver<String, String> {
+        @Override
+        public void setClientFacade(RegistryClientFacade clientFacade) {
+        }
+
+        @Override
+        public void setArtifactResolverStrategy(
+                ArtifactReferenceResolverStrategy<String, String> artifactResolverStrategy) {
+        }
+
+        @Override
+        public SchemaParser<String, String> getSchemaParser() {
+            return null;
+        }
+
+        @Override
+        public SchemaLookupResult<String> resolveSchema(Record<String> data) {
+            throw new IllegalStateException("should not be called in this test");
+        }
+
+        @Override
+        public SchemaLookupResult<String> resolveSchemaByArtifactReference(ArtifactReference reference) {
+            throw new IllegalStateException("artifact reference cannot be null");
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static final class TestDeserializer extends AbstractDeserializer<String, String> {
+        TestDeserializer(SchemaResolver<String, String> resolver) {
+            super(resolver);
+            getSerdeConfigurer().setIdHandler(new Default4ByteIdHandler());
+        }
+
+        @Override
+        public SchemaParser<String, String> schemaParser() {
+            return null;
+        }
+
+        @Override
+        protected String readData(ParsedSchema<String> schema, ByteBuffer buffer, int start, int length) {
+            return "decoded";
+        }
+    }
+
+    private TestDeserializer deserializer;
+
+    @BeforeEach
+    void setup() {
+        deserializer = new TestDeserializer(new ThrowingSchemaResolver());
+    }
+
+    private byte[] recordWithMagicByteAndId(int id) {
+        ByteBuffer buffer = ByteBuffer.allocate(5);
+        buffer.put(BaseSerde.MAGIC_BYTE);
+        buffer.putInt(id);
+        return buffer.array();
+    }
+
+    @Test
+    void byDefaultUnresolvableRecordThrows() {
+        byte[] data = recordWithMagicByteAndId(1);
+        assertThrows(IllegalStateException.class, () -> deserializer.deserializeData("topic", data));
+    }
+
+    @Test
+    void configuredHandlerCanSkipUnresolvableRecord() {
+        deserializer.setDeserializerErrorHandler((topic, data, cause) -> true);
+
+        byte[] data = recordWithMagicByteAndId(1);
+        assertNull(deserializer.deserializeData("topic", data));
+    }
+
+    @Test
+    void handlerReturningFalseStillThrows() {
+        deserializer.setDeserializerErrorHandler((topic, data, cause) -> false);
+
+        byte[] data = recordWithMagicByteAndId(1);
+        assertThrows(IllegalStateException.class, () -> deserializer.deserializeData("topic", data));
+    }
+}

--- a/serdes/kafka/serde-kafka-common/src/main/java/io/apicurio/registry/serde/kafka/KafkaDeserializer.java
+++ b/serdes/kafka/serde-kafka-common/src/main/java/io/apicurio/registry/serde/kafka/KafkaDeserializer.java
@@ -7,6 +7,7 @@ import io.apicurio.registry.serde.AbstractDeserializer;
 import io.apicurio.registry.serde.BaseSerde;
 import io.apicurio.registry.serde.Default4ByteIdHandler;
 import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.serde.error.DeserializerErrorHandler;
 import io.apicurio.registry.serde.kafka.config.BaseKafkaSerDeConfig;
 import io.apicurio.registry.serde.kafka.headers.HeadersHandler;
 import org.apache.kafka.common.header.Headers;
@@ -50,7 +51,12 @@ public class KafkaDeserializer<T, U> implements Deserializer<U> {
         if (data[0] == BaseSerde.MAGIC_BYTE) {
             return deserialize(topic, data);
         } else if (headers == null) {
-            throw new IllegalStateException("Headers cannot be null");
+            IllegalStateException e = new IllegalStateException("Headers cannot be null");
+            DeserializerErrorHandler errorHandler = delegatedDeserializer.getDeserializerErrorHandler();
+            if (errorHandler != null && errorHandler.handle(topic, data, e)) {
+                return null;
+            }
+            throw e;
         } else {
             // try to read data even if artifactReference has no value, maybe there is a
             // fallbackArtifactProvider configured


### PR DESCRIPTION
## Summary

Adds an opt-in `DeserializerErrorHandler` extension point so a permanently-unresolvable Kafka record (headers/payload mismatch, deleted schema, corrupt payload) can be skipped instead of causing an endless consumer-group rebalance loop.

Fixes #3662

## Root Cause

`AbstractDeserializer` and `KafkaDeserializer` throw whenever a record's artifact/schema reference cannot be resolved, with no way to recover. Because the exception happens before the record is considered processed, the exact same record is redelivered on every subsequent `poll()` with zero forward progress. Any consumer that retries with backoff around a failing `poll()` — a very common pattern — eventually pushes the time between successive polls past `max.poll.interval.ms`. The broker then evicts the consumer from its group; it rejoins, immediately re-fetches the same unresolvable record, fails again, and the cycle repeats indefinitely.

Reproduced end-to-end against a real Kafka broker and a real registry (mismatched `apicurio.registry.headers.enabled` between producer/consumer). Kafka's own client confirms the mechanism in its logs: `consumer poll timeout has expired. This means the time between subsequent calls to poll() was longer than the configured max.poll.interval.ms...`

This isn't specific to the historical headers-default bug (fixed in 3.0) — any permanently-unresolvable record triggers the same failure mode today.

## Changes

- **`serdes/generic/serde-common/.../serde/error/DeserializerErrorHandler.java`** (new) — interface: `handle(topic, data, cause)` returns `true` to skip the record, `false` to preserve the original throw behavior.
- **`serdes/generic/serde-common/.../serde/error/LoggingDeserializerErrorHandler.java`** (new) — default implementation: logs at `WARN` and skips.
- **`serdes/generic/serde-common/.../serde/config/SerdeConfig.java`** — new config constant `DESERIALIZER_ERROR_HANDLER` (`apicurio.registry.deserializer.error-handler`), unset by default.
- **`serdes/generic/serde-common/.../serde/config/SerdeDeserializerConfig.java`** — `getDeserializerErrorHandler()` accessor.
- **`serdes/generic/serde-common/.../serde/AbstractDeserializer.java`** — wires the handler into every resolution-failure throw site: the malformed-payload path in `deserializeData()`, and both the primary and fallback-provider failure paths in `doResolve()`.
- **`serdes/kafka/serde-kafka-common/.../serde/kafka/KafkaDeserializer.java`** — wires the handler into the Kafka-specific "Headers cannot be null" throw site, which bypasses `AbstractDeserializer.resolve()` entirely.
- **`docs/.../assembly-configuring-kafka-client-serdes.adoc`** — new "Configuration for deserializer error handling" section with usage example and config property reference table.

Behavior is unchanged for any deployment that doesn't set `DESERIALIZER_ERROR_HANDLER` — the field stays `null` and every throw site behaves exactly as before.

## Test plan

- [x] New unit tests in `serde-common` (`AbstractDeserializerErrorHandlerTest`, 3/3 passing): default behavior still throws; configured handler skips; handler returning `false` still throws.
- [x] New integration test `HeadersMismatchRebalanceIT` against a real Kafka broker + real registry, with two scenarios:
  - `headersMismatchCausesEndlessRebalance` — reproduces the bug: proves a genuine involuntary consumer-group eviction/rejoin (via `onPartitionsAssigned` count, not `onPartitionsRevoked`, since the latter also fires on normal `close()`).
  - `configuredErrorHandlerPreventsEndlessRebalance` — identical scenario with the handler configured: zero poll failures, zero rebalances.
- [x] Existing serde test suites re-run with no regressions: `serde-common` (37/37), `serde-common-avro` (13/13), `serde-common-protobuf` (23/23), `serde-kafka-common` (27/27).
- [x] Checkstyle clean across all touched modules.
- [ ] Storage variant testing — not applicable; this change is entirely client-side Kafka SerDes code, no storage layer involved.
