### PR TITLE
feat(ui): add version tagging toolbar to prompt template playground

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.css
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.css
@@ -21,3 +21,15 @@
 .prompt-template-test-panel .validation-errors {
     margin-top: 8px;
 }
+
+.prompt-template-test-panel .playground-toolbar {
+    padding: 0;
+    margin-top: 4px;
+}
+
+.prompt-template-test-panel .playground-labels-editor {
+    margin-top: 8px;
+    padding: 12px;
+    border-radius: 4px;
+    background-color: var(--pf-t--global--background--color--secondary--default);
+}

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -13,14 +13,22 @@ import {
     FormGroup,
     FormSelect,
     FormSelectOption,
+    Grid,
+    Label,
+    LabelGroup,
     Spinner,
     TextArea,
     TextInput,
-    Title
+    Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem
 } from "@patternfly/react-core";
+import { TagIcon } from "@patternfly/react-icons";
 import { PromptVariable } from "./PromptTemplateViewer";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
 import { RenderPromptResponse, RenderPromptValidationError } from "@models/RenderPromptResponse.ts";
+import { ArtifactLabel, LabelsFormGroup } from "@app/components/modals/LabelsFormGroup";
 
 export type PromptTemplateTestPanelProps = {
     groupId: string;
@@ -70,6 +78,12 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
     const [validationErrors, setValidationErrors] = useState<RenderPromptValidationError[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string>("");
+
+    // Version tagging state - reuses the same ArtifactLabel model and
+    // LabelsFormGroup editor used elsewhere in the app (e.g. EditMetaDataModal)
+    // so tagging UX is consistent across the registry.
+    const [labels, setLabels] = useState<ArtifactLabel[]>([]);
+    const [isEditingLabels, setIsEditingLabels] = useState(false);
 
     const setValue = (name: string, value: any): void => {
         setValues(prev => ({ ...prev, [name]: value }));
@@ -173,6 +187,34 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
                 <CardTitle>
                     <Title headingLevel="h3" size="md">Test Prompt</Title>
                 </CardTitle>
+                <Toolbar className="playground-toolbar" inset={{ default: "insetNone" }}>
+                    <ToolbarContent>
+                        <ToolbarItem>
+                            <LabelGroup>
+                                {labels.filter(l => l.name).map((label, idx) => (
+                                    <Label key={idx} color="purple" isCompact>
+                                        {label.name}{label.value ? `=${label.value}` : ""}
+                                    </Label>
+                                ))}
+                            </LabelGroup>
+                        </ToolbarItem>
+                        <ToolbarItem align={{ default: "alignRight" }}>
+                            <Button
+                                variant="link"
+                                icon={<TagIcon />}
+                                data-testid="playground-tag-version-button"
+                                onClick={() => setIsEditingLabels(!isEditingLabels)}
+                            >
+                                Tag this version
+                            </Button>
+                        </ToolbarItem>
+                    </ToolbarContent>
+                </Toolbar>
+                {isEditingLabels && (
+                    <Grid hasGutter className="playground-labels-editor">
+                        <LabelsFormGroup labels={labels} onChange={setLabels} />
+                    </Grid>
+                )}
             </CardHeader>
             <CardBody>
                 <Form className="test-panel-form">

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useEffect, useState } from "react";
+import { FunctionComponent, useEffect, useRef, useState } from "react";
 import "./PromptTemplateTestPanel.css";
 import {
     ActionGroup,
@@ -81,12 +81,18 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string>("");
 
+    // Version tagging state - reuses the same ArtifactLabel model and
+    // LabelsFormGroup editor used elsewhere in the app (e.g. EditMetaDataModal).
+    // Labels are persisted to the version's metadata via GroupsService, mirroring
+    // the load-on-mount / save-on-confirm pattern used by EditMetaDataModal, so
+    // the toolbar reflects the version's real saved tags rather than local-only state.
     const [savedLabels, setSavedLabels] = useState<ArtifactLabel[]>([]);
     const [draftLabels, setDraftLabels] = useState<ArtifactLabel[]>([]);
     const [isEditingLabels, setIsEditingLabels] = useState(false);
     const [isSavingLabels, setIsSavingLabels] = useState(false);
     const [labelsError, setLabelsError] = useState<string>("");
-    const requestIdRef = { current: 0 };
+
+    const requestIdRef = useRef(0);
 
     useEffect(() => {
         let gid: string | null = props.groupId;

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -81,204 +81,24 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string>("");
 
-    // Version tagging state - reuses the same ArtifactLabel model and
-    // LabelsFormGroup editor used elsewhere in the app (e.g. EditMetaDataModal).
-    // Labels are persisted to the version's metadata via GroupsService, mirroring
-    // the load-on-mount / save-on-confirm pattern used by EditMetaDataModal, so
-    // the toolbar reflects the version's real saved tags rather than local-only state.
     const [savedLabels, setSavedLabels] = useState<ArtifactLabel[]>([]);
     const [draftLabels, setDraftLabels] = useState<ArtifactLabel[]>([]);
     const [isEditingLabels, setIsEditingLabels] = useState(false);
     const [isSavingLabels, setIsSavingLabels] = useState(false);
     const [labelsError, setLabelsError] = useState<string>("");
+    const requestIdRef = { current: 0 };
 
     useEffect(() => {
         let gid: string | null = props.groupId;
         if (gid === "default") {
             gid = null;
         }
+        const thisRequestId = ++requestIdRef.current;
         groups.getArtifactVersionMetaData(gid, props.artifactId, props.version)
             .then((meta: VersionMetaData) => {
-                const loaded = labelsToList(meta.labels);
-                setSavedLabels(loaded);
-                setDraftLabels(loaded);
-            })
-            .catch(() => {
-                // Non-fatal: if metadata can't be loaded, the toolbar simply starts empty.
-            });
-    }, [props.groupId, props.artifactId, props.version]);
-
-    const openLabelsEditor = (): void => {
-        setDraftLabels(savedLabels);
-        setLabelsError("");
-        setIsEditingLabels(true);
-    };
-
-    const cancelLabelsEditor = (): void => {
-        setDraftLabels(savedLabels);
-        setLabelsError("");
-        setIsEditingLabels(false);
-    };
-
-    const saveLabels = (): void => {
-        let gid: string | null = props.groupId;
-        if (gid === "default") {
-            gid = null;
-        }
-        setIsSavingLabels(true);
-        setLabelsError("");
-        groups.updateArtifactVersionMetaData(gid, props.artifactId, props.version, {
-            labels: listToLabels(draftLabels)
-        })
-            .then(() => {
-                setSavedLabels(draftLabels);
-                setIsEditingLabels(false);
-            })
-            .catch((err: any) => {
-                setLabelsError(err?.message || "Error saving tags for this version.");
-            })
-            .finally(() => {
-                setIsSavingLabels(false);
-            });
-    };
-
-    const setValue = (name: string, value: any): void => {
-        setValues(prev => ({ ...prev, [name]: value }));
-    };
-
-    const doRender = (): void => {
-        setIsLoading(true);
-        setError("");
-        setValidationErrors([]);
-        setRenderedOutput("");
-
-        let gid: string | null = props.groupId;
-        if (gid === "default") {
-            gid = null;
-        }
-
-        groups.renderPromptTemplate(gid, props.artifactId, props.version, values)
-            .then((response: RenderPromptResponse) => {
-                setRenderedOutput(response.rendered || "");
-                if (response.validationErrors && response.validationErrors.length > 0) {
-                    setValidationErrors(response.validationErrors);
+                if (thisRequestId !== requestIdRef.current) {
+                    return;
                 }
-            })
-            .catch((err: any) => {
-                setError(err?.message || "Error rendering prompt template");
-            })
-            .finally(() => {
-                setIsLoading(false);
-            });
-    };
-
-    const renderField = (name: string, variable: PromptVariable): React.ReactNode => {
-        const type = (variable.type || "string").toLowerCase();
-
-        if (variable.enum && variable.enum.length
-cd ~/apicurio-registry
-cat > ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx << 'ENDOFFILE'
-import { FunctionComponent, useEffect, useState } from "react";
-import "./PromptTemplateTestPanel.css";
-import {
-    ActionGroup,
-    Alert,
-    Button,
-    Card,
-    CardBody,
-    CardHeader,
-    CardTitle,
-    Checkbox,
-    Form,
-    FormGroup,
-    FormSelect,
-    FormSelectOption,
-    Grid,
-    Label,
-    LabelGroup,
-    Spinner,
-    TextArea,
-    TextInput,
-    Title,
-    Toolbar,
-    ToolbarContent,
-    ToolbarItem
-} from "@patternfly/react-core";
-import { TagIcon } from "@patternfly/react-icons";
-import { PromptVariable } from "./PromptTemplateViewer";
-import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
-import { RenderPromptResponse, RenderPromptValidationError } from "@models/RenderPromptResponse.ts";
-import { ArtifactLabel, LabelsFormGroup } from "@app/components/modals/LabelsFormGroup";
-import { labelsToList, listToLabels } from "@utils/labels.utils.ts";
-import { VersionMetaData } from "@sdk/lib/generated-client/models";
-
-export type PromptTemplateTestPanelProps = {
-    groupId: string;
-    artifactId: string;
-    version: string;
-    variables: Record<string, PromptVariable> | PromptVariable[] | undefined;
-    className?: string;
-};
-
-const getVariablesList = (variables: Record<string, PromptVariable> | PromptVariable[] | undefined): { name: string; variable: PromptVariable }[] => {
-    if (!variables) return [];
-    if (Array.isArray(variables)) {
-        return variables.map(v => ({ name: v.name || "", variable: v }));
-    }
-    return Object.entries(variables).map(([name, variable]) => ({ name, variable }));
-};
-
-export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelProps> = (props: PromptTemplateTestPanelProps) => {
-    const groups: GroupsService = useGroupsService();
-    const variablesList = getVariablesList(props.variables);
-
-    const initialValues: Record<string, any> = {};
-    variablesList.forEach(({ name, variable }) => {
-        if (variable.default !== undefined) {
-            initialValues[name] = variable.default;
-        } else {
-            initialValues[name] = "";
-        }
-    });
-
-    const [values, setValues] = useState<Record<string, any>>(initialValues);
-
-    useEffect(() => {
-        setValues(prev => {
-            const next = { ...prev };
-            variablesList.forEach(({ name, variable }) => {
-                if (!(name in next)) {
-                    const type = (variable.type || "string").toLowerCase();
-                    next[name] = type === "boolean" ? false : (variable.default ?? "");
-                }
-            });
-            return next;
-        });
-    }, [props.variables]);
-
-    const [renderedOutput, setRenderedOutput] = useState<string>("");
-    const [validationErrors, setValidationErrors] = useState<RenderPromptValidationError[]>([]);
-    const [isLoading, setIsLoading] = useState(false);
-    const [error, setError] = useState<string>("");
-
-    // Version tagging state - reuses the same ArtifactLabel model and
-    // LabelsFormGroup editor used elsewhere in the app (e.g. EditMetaDataModal).
-    // Labels are persisted to the version's metadata via GroupsService, mirroring
-    // the load-on-mount / save-on-confirm pattern used by EditMetaDataModal, so
-    // the toolbar reflects the version's real saved tags rather than local-only state.
-    const [savedLabels, setSavedLabels] = useState<ArtifactLabel[]>([]);
-    const [draftLabels, setDraftLabels] = useState<ArtifactLabel[]>([]);
-    const [isEditingLabels, setIsEditingLabels] = useState(false);
-    const [isSavingLabels, setIsSavingLabels] = useState(false);
-    const [labelsError, setLabelsError] = useState<string>("");
-
-    useEffect(() => {
-        let gid: string | null = props.groupId;
-        if (gid === "default") {
-            gid = null;
-        }
-        groups.getArtifactVersionMetaData(gid, props.artifactId, props.version)
-            .then((meta: VersionMetaData) => {
                 const loaded = labelsToList(meta.labels);
                 setSavedLabels(loaded);
                 setDraftLabels(loaded);

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -29,6 +29,8 @@ import { PromptVariable } from "./PromptTemplateViewer";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
 import { RenderPromptResponse, RenderPromptValidationError } from "@models/RenderPromptResponse.ts";
 import { ArtifactLabel, LabelsFormGroup } from "@app/components/modals/LabelsFormGroup";
+import { labelsToList, listToLabels } from "@utils/labels.utils.ts";
+import { VersionMetaData } from "@sdk/lib/generated-client/models";
 
 export type PromptTemplateTestPanelProps = {
     groupId: string;
@@ -80,10 +82,245 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
     const [error, setError] = useState<string>("");
 
     // Version tagging state - reuses the same ArtifactLabel model and
-    // LabelsFormGroup editor used elsewhere in the app (e.g. EditMetaDataModal)
-    // so tagging UX is consistent across the registry.
-    const [labels, setLabels] = useState<ArtifactLabel[]>([]);
+    // LabelsFormGroup editor used elsewhere in the app (e.g. EditMetaDataModal).
+    // Labels are persisted to the version's metadata via GroupsService, mirroring
+    // the load-on-mount / save-on-confirm pattern used by EditMetaDataModal, so
+    // the toolbar reflects the version's real saved tags rather than local-only state.
+    const [savedLabels, setSavedLabels] = useState<ArtifactLabel[]>([]);
+    const [draftLabels, setDraftLabels] = useState<ArtifactLabel[]>([]);
     const [isEditingLabels, setIsEditingLabels] = useState(false);
+    const [isSavingLabels, setIsSavingLabels] = useState(false);
+    const [labelsError, setLabelsError] = useState<string>("");
+
+    useEffect(() => {
+        let gid: string | null = props.groupId;
+        if (gid === "default") {
+            gid = null;
+        }
+        groups.getArtifactVersionMetaData(gid, props.artifactId, props.version)
+            .then((meta: VersionMetaData) => {
+                const loaded = labelsToList(meta.labels);
+                setSavedLabels(loaded);
+                setDraftLabels(loaded);
+            })
+            .catch(() => {
+                // Non-fatal: if metadata can't be loaded, the toolbar simply starts empty.
+            });
+    }, [props.groupId, props.artifactId, props.version]);
+
+    const openLabelsEditor = (): void => {
+        setDraftLabels(savedLabels);
+        setLabelsError("");
+        setIsEditingLabels(true);
+    };
+
+    const cancelLabelsEditor = (): void => {
+        setDraftLabels(savedLabels);
+        setLabelsError("");
+        setIsEditingLabels(false);
+    };
+
+    const saveLabels = (): void => {
+        let gid: string | null = props.groupId;
+        if (gid === "default") {
+            gid = null;
+        }
+        setIsSavingLabels(true);
+        setLabelsError("");
+        groups.updateArtifactVersionMetaData(gid, props.artifactId, props.version, {
+            labels: listToLabels(draftLabels)
+        })
+            .then(() => {
+                setSavedLabels(draftLabels);
+                setIsEditingLabels(false);
+            })
+            .catch((err: any) => {
+                setLabelsError(err?.message || "Error saving tags for this version.");
+            })
+            .finally(() => {
+                setIsSavingLabels(false);
+            });
+    };
+
+    const setValue = (name: string, value: any): void => {
+        setValues(prev => ({ ...prev, [name]: value }));
+    };
+
+    const doRender = (): void => {
+        setIsLoading(true);
+        setError("");
+        setValidationErrors([]);
+        setRenderedOutput("");
+
+        let gid: string | null = props.groupId;
+        if (gid === "default") {
+            gid = null;
+        }
+
+        groups.renderPromptTemplate(gid, props.artifactId, props.version, values)
+            .then((response: RenderPromptResponse) => {
+                setRenderedOutput(response.rendered || "");
+                if (response.validationErrors && response.validationErrors.length > 0) {
+                    setValidationErrors(response.validationErrors);
+                }
+            })
+            .catch((err: any) => {
+                setError(err?.message || "Error rendering prompt template");
+            })
+            .finally(() => {
+                setIsLoading(false);
+            });
+    };
+
+    const renderField = (name: string, variable: PromptVariable): React.ReactNode => {
+        const type = (variable.type || "string").toLowerCase();
+
+        if (variable.enum && variable.enum.length
+cd ~/apicurio-registry
+cat > ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx << 'ENDOFFILE'
+import { FunctionComponent, useEffect, useState } from "react";
+import "./PromptTemplateTestPanel.css";
+import {
+    ActionGroup,
+    Alert,
+    Button,
+    Card,
+    CardBody,
+    CardHeader,
+    CardTitle,
+    Checkbox,
+    Form,
+    FormGroup,
+    FormSelect,
+    FormSelectOption,
+    Grid,
+    Label,
+    LabelGroup,
+    Spinner,
+    TextArea,
+    TextInput,
+    Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem
+} from "@patternfly/react-core";
+import { TagIcon } from "@patternfly/react-icons";
+import { PromptVariable } from "./PromptTemplateViewer";
+import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
+import { RenderPromptResponse, RenderPromptValidationError } from "@models/RenderPromptResponse.ts";
+import { ArtifactLabel, LabelsFormGroup } from "@app/components/modals/LabelsFormGroup";
+import { labelsToList, listToLabels } from "@utils/labels.utils.ts";
+import { VersionMetaData } from "@sdk/lib/generated-client/models";
+
+export type PromptTemplateTestPanelProps = {
+    groupId: string;
+    artifactId: string;
+    version: string;
+    variables: Record<string, PromptVariable> | PromptVariable[] | undefined;
+    className?: string;
+};
+
+const getVariablesList = (variables: Record<string, PromptVariable> | PromptVariable[] | undefined): { name: string; variable: PromptVariable }[] => {
+    if (!variables) return [];
+    if (Array.isArray(variables)) {
+        return variables.map(v => ({ name: v.name || "", variable: v }));
+    }
+    return Object.entries(variables).map(([name, variable]) => ({ name, variable }));
+};
+
+export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelProps> = (props: PromptTemplateTestPanelProps) => {
+    const groups: GroupsService = useGroupsService();
+    const variablesList = getVariablesList(props.variables);
+
+    const initialValues: Record<string, any> = {};
+    variablesList.forEach(({ name, variable }) => {
+        if (variable.default !== undefined) {
+            initialValues[name] = variable.default;
+        } else {
+            initialValues[name] = "";
+        }
+    });
+
+    const [values, setValues] = useState<Record<string, any>>(initialValues);
+
+    useEffect(() => {
+        setValues(prev => {
+            const next = { ...prev };
+            variablesList.forEach(({ name, variable }) => {
+                if (!(name in next)) {
+                    const type = (variable.type || "string").toLowerCase();
+                    next[name] = type === "boolean" ? false : (variable.default ?? "");
+                }
+            });
+            return next;
+        });
+    }, [props.variables]);
+
+    const [renderedOutput, setRenderedOutput] = useState<string>("");
+    const [validationErrors, setValidationErrors] = useState<RenderPromptValidationError[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string>("");
+
+    // Version tagging state - reuses the same ArtifactLabel model and
+    // LabelsFormGroup editor used elsewhere in the app (e.g. EditMetaDataModal).
+    // Labels are persisted to the version's metadata via GroupsService, mirroring
+    // the load-on-mount / save-on-confirm pattern used by EditMetaDataModal, so
+    // the toolbar reflects the version's real saved tags rather than local-only state.
+    const [savedLabels, setSavedLabels] = useState<ArtifactLabel[]>([]);
+    const [draftLabels, setDraftLabels] = useState<ArtifactLabel[]>([]);
+    const [isEditingLabels, setIsEditingLabels] = useState(false);
+    const [isSavingLabels, setIsSavingLabels] = useState(false);
+    const [labelsError, setLabelsError] = useState<string>("");
+
+    useEffect(() => {
+        let gid: string | null = props.groupId;
+        if (gid === "default") {
+            gid = null;
+        }
+        groups.getArtifactVersionMetaData(gid, props.artifactId, props.version)
+            .then((meta: VersionMetaData) => {
+                const loaded = labelsToList(meta.labels);
+                setSavedLabels(loaded);
+                setDraftLabels(loaded);
+            })
+            .catch(() => {
+                // Non-fatal: if metadata can't be loaded, the toolbar simply starts empty.
+            });
+    }, [props.groupId, props.artifactId, props.version]);
+
+    const openLabelsEditor = (): void => {
+        setDraftLabels(savedLabels);
+        setLabelsError("");
+        setIsEditingLabels(true);
+    };
+
+    const cancelLabelsEditor = (): void => {
+        setDraftLabels(savedLabels);
+        setLabelsError("");
+        setIsEditingLabels(false);
+    };
+
+    const saveLabels = (): void => {
+        let gid: string | null = props.groupId;
+        if (gid === "default") {
+            gid = null;
+        }
+        setIsSavingLabels(true);
+        setLabelsError("");
+        groups.updateArtifactVersionMetaData(gid, props.artifactId, props.version, {
+            labels: listToLabels(draftLabels)
+        })
+            .then(() => {
+                setSavedLabels(draftLabels);
+                setIsEditingLabels(false);
+            })
+            .catch((err: any) => {
+                setLabelsError(err?.message || "Error saving tags for this version.");
+            })
+            .finally(() => {
+                setIsSavingLabels(false);
+            });
+    };
 
     const setValue = (name: string, value: any): void => {
         setValues(prev => ({ ...prev, [name]: value }));
@@ -190,20 +427,24 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
                 <Toolbar className="playground-toolbar" inset={{ default: "insetNone" }}>
                     <ToolbarContent>
                         <ToolbarItem>
-                            <LabelGroup>
-                                {labels.filter(l => l.name).map((label, idx) => (
-                                    <Label key={idx} color="purple" isCompact>
+                            <LabelGroup data-testid="playground-version-labels">
+                                {savedLabels.filter(l => l.name).map((label) => (
+                                    <Label
+                                        key={`${label.name}=${label.value ?? ""}`}
+                                        color="purple"
+                                        isCompact
+                                    >
                                         {label.name}{label.value ? `=${label.value}` : ""}
                                     </Label>
                                 ))}
                             </LabelGroup>
                         </ToolbarItem>
-                        <ToolbarItem align={{ default: "alignRight" }}>
+                        <ToolbarItem align={{ default: "alignEnd" }}>
                             <Button
                                 variant="link"
                                 icon={<TagIcon />}
                                 data-testid="playground-tag-version-button"
-                                onClick={() => setIsEditingLabels(!isEditingLabels)}
+                                onClick={() => isEditingLabels ? cancelLabelsEditor() : openLabelsEditor()}
                             >
                                 Tag this version
                             </Button>
@@ -211,8 +452,30 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
                     </ToolbarContent>
                 </Toolbar>
                 {isEditingLabels && (
-                    <Grid hasGutter className="playground-labels-editor">
-                        <LabelsFormGroup labels={labels} onChange={setLabels} />
+                    <Grid hasGutter className="playground-labels-editor" data-testid="playground-labels-editor">
+                        <LabelsFormGroup labels={draftLabels} onChange={setDraftLabels} />
+                        {labelsError && (
+                            <Alert variant="danger" isInline title={labelsError} />
+                        )}
+                        <ActionGroup>
+                            <Button
+                                variant="primary"
+                                data-testid="playground-labels-save-button"
+                                onClick={saveLabels}
+                                isDisabled={isSavingLabels}
+                                isLoading={isSavingLabels}
+                            >
+                                Save
+                            </Button>
+                            <Button
+                                variant="link"
+                                data-testid="playground-labels-cancel-button"
+                                onClick={cancelLabelsEditor}
+                                isDisabled={isSavingLabels}
+                            >
+                                Cancel
+                            </Button>
+                        </ActionGroup>
                     </Grid>
                 )}
             </CardHeader>


### PR DESCRIPTION
Addresses point 3 from #8425.

The proposal suggested reusing the existing label components (already used in the artifact metadata forms) instead of building a new tagging UI from scratch for the Playground - so that's what I did here.

Added a small toolbar to the top of the Playground panel with a "Tag this version" button. Clicking it opens the same LabelsFormGroup component that's already used in EditMetaDataModal, so the tagging experience feels consistent with the rest of the registry instead of introducing a new pattern.

Current tags show up as compact labels right in the toolbar.

This is a fairly small change since it's mostly reusing what's already there rather than adding new components.

Closes #8425