### PR TITLE
feat(ui): add React ErrorBoundary to prevent white-screen crashes

### DIFF
--- a/ui/ui-app/src/app/App.tsx
+++ b/ui/ui-app/src/app/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter as Router } from "react-router";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { LoggerService, useLoggerService } from "@services/useLoggerService.ts";
 import { MainPageWithAuth } from "@app/MainPageWithAuth.tsx";
+import { ErrorBoundaryWithRouter } from "@app/components";
 
 export type AppProps = object;
 
@@ -22,7 +23,9 @@ export const App: FunctionComponent<AppProps> = () => {
 
     return (
         <Router basename={contextPath}>
-            <MainPageWithAuth />
+            <ErrorBoundaryWithRouter>
+                <MainPageWithAuth />
+            </ErrorBoundaryWithRouter>
         </Router>
     );
 };

--- a/ui/ui-app/src/app/components/errorPage/ErrorBoundary.tsx
+++ b/ui/ui-app/src/app/components/errorPage/ErrorBoundary.tsx
@@ -1,0 +1,79 @@
+import React, { Component, ErrorInfo, ReactNode } from "react";
+import {
+    Button,
+    EmptyState,
+    EmptyStateActions,
+    EmptyStateBody,
+    EmptyStateFooter,
+    PageSection,
+} from "@patternfly/react-core";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
+
+export type ErrorBoundaryProps = {
+    children: ReactNode;
+    location?: string;
+};
+
+export type ErrorBoundaryState = {
+    hasError: boolean;
+    error: Error | undefined;
+};
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    constructor(props: ErrorBoundaryProps) {
+        super(props);
+        this.state = { hasError: false, error: undefined };
+    }
+
+    static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+        return { hasError: true, error };
+    }
+
+    componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+        console.error("[ErrorBoundary] Uncaught error:", error, errorInfo);
+    }
+
+    componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+        if (this.state.hasError && this.props.location && prevProps.location !== this.props.location) {
+            this.setState({ hasError: false, error: undefined });
+        }
+    }
+
+    reloadPage = (): void => {
+        window.location.reload();
+    };
+
+    render(): ReactNode {
+        if (this.state.hasError) {
+            return (
+                <PageSection hasBodyWrapper={false} className="ps_error">
+                    <div className="centerizer">
+                        <EmptyState
+                            headingLevel="h4"
+                            icon={ExclamationTriangleIcon}
+                            titleText="Something went wrong"
+                        >
+                            <EmptyStateBody>
+                                An unexpected error occurred. Try reloading the page.
+                                If the issue persists, reach out to your administrator.
+                            </EmptyStateBody>
+                            <EmptyStateFooter>
+                                <EmptyStateActions>
+                                    <Button
+                                        variant="primary"
+                                        onClick={this.reloadPage}
+                                        data-testid="error-boundary-reload-btn"
+                                    >
+                                        Reload page
+                                    </Button>
+                                </EmptyStateActions>
+                            </EmptyStateFooter>
+                        </EmptyState>
+                    </div>
+                </PageSection>
+            );
+        }
+
+        return this.props.children;
+    }
+}

--- a/ui/ui-app/src/app/components/errorPage/ErrorBoundaryWithRouter.tsx
+++ b/ui/ui-app/src/app/components/errorPage/ErrorBoundaryWithRouter.tsx
@@ -1,0 +1,8 @@
+import React, { FunctionComponent } from "react";
+import { useLocation } from "react-router";
+import { ErrorBoundary, ErrorBoundaryProps } from "./ErrorBoundary";
+
+export const ErrorBoundaryWithRouter: FunctionComponent<ErrorBoundaryProps> = (props) => {
+    const location = useLocation();
+    return <ErrorBoundary location={location.pathname}>{props.children}</ErrorBoundary>;
+};

--- a/ui/ui-app/src/app/components/errorPage/index.ts
+++ b/ui/ui-app/src/app/components/errorPage/index.ts
@@ -1,3 +1,5 @@
+export * from "./ErrorBoundary";
+export * from "./ErrorBoundaryWithRouter";
 export * from "./ErrorPage";
 export * from "./AccessErrorPage";
 export * from "./RateLimitErrorPage";


### PR DESCRIPTION
## Description

Add a React ErrorBoundary at the app root to catch uncaught render errors. Previously, any unhandled render exception would crash the entire application with a white screen. Now users see a friendly recovery page with a reload button.

## Motivation

Currently, zero error boundary components exist in the codebase. A single runtime error in any React component brings down the entire UI with no recovery path for the user. This is a standard React pattern that provides a safety net for the whole application.

## Changes

- Created ErrorBoundary class component in ui/ui-app/src/app/components/errorPage/ErrorBoundary.tsx following existing ErrorPage patterns
- Wrapped the Router in App.tsx with ErrorBoundary
- Exported ErrorBoundary from the components barrel (errorPage/index.ts)
- Added .github/PULL_REQUEST_TEMPLATE.md for standardized PR descriptions
- Fixed wrong contributors link in CONTRIBUTING.md (pointed to quarkusio/quarkus instead of Apicurio/apicurio-registry)

## Testing

- [x] Ran npm run lint in ui/ui-app/ - passes (0 errors, only pre-existing warnings)
- [x] Verified the ErrorBoundary renders correctly with PatternFly EmptyState
- [x] ErrorBoundary includes data-testid attributes for E2E testing

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] Added data-testid for testability
