### PR TITLE
fix(ci): fetch base branch so Scalpel can detect affected modules

### DIFF
--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -61,6 +61,12 @@ jobs:
           # Full history only needed when Scalpel is enabled (git diff against base branch)
           fetch-depth: ${{ inputs.scalpel-enabled == 'true' && 0 || 1 }}
 
+      - name: Fetch base branch for Scalpel
+        if: inputs.scalpel-enabled == 'true'
+        run: |
+          BASE_REF="${GITHUB_BASE_REF:-main}"
+          git fetch origin "$BASE_REF" --depth=1
+
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -61,12 +61,6 @@ jobs:
           # Full history only needed when Scalpel is enabled (git diff against base branch)
           fetch-depth: ${{ inputs.scalpel-enabled == 'true' && 0 || 1 }}
 
-      - name: Fetch base branch for Scalpel
-        if: inputs.scalpel-enabled == 'true'
-        run: |
-          BASE_REF="${GITHUB_BASE_REF:-main}"
-          git fetch origin "$BASE_REF" --depth=1
-
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -11,5 +11,8 @@
 # skipTestsForUpstream: upstream deps of -pl target compile but skip tests.
 # Works because non-app shard always tests upstream modules independently.
 -Dscalpel.skipTestsForUpstream=true
+# fetchBaseBranch: let Scalpel fetch origin/<base> itself via JGit (no shallow grafts).
+# Requires fetch-depth: 0 in the checkout step so full history is available.
+-Dscalpel.fetchBaseBranch=true
 # failSafe: on any Scalpel error, fall back to a full build instead of failing
 -Dscalpel.failSafe=true


### PR DESCRIPTION
## Summary

- Scalpel 0.3.7 activates in the Scalpel shard group but immediately falls back to building all modules because `origin/main` is not available after checkout
- Enable `scalpel.fetchBaseBranch=true` in `.mvn/maven.config` so Scalpel fetches the base branch itself via JGit, using `GITHUB_BASE_REF` from the CI environment
- No workflow changes needed: the `fetch-depth: 0` checkout already provides full history; Scalpel handles the rest

**Evidence from CI logs** (run 29989142524, every Scalpel shard):
```
[INFO] Scalpel 0.3.7 activated (mode=skip-tests)
[WARNING] Cannot resolve base branch: origin/main
[WARNING] Scalpel: Could not find merge base between origin/main and HEAD, building all modules
```

**Impact:** Without this fix, the Scalpel shard group runs identical test counts to the normal group (verified: 271/271 for app-sql, 66/66 for app-kafkasql, 24/24 for app-gitops across multiple runs), making the parallel A/B comparison impossible.

**Why property instead of workflow step:** Scalpel's built-in JGit fetch avoids `--depth=1` shallow grafts that can break merge-base computation, reads `GITHUB_BASE_REF` directly from the environment (matching its own `detectBaseBranch()` logic), and works automatically in any workflow that enables Scalpel without duplicating fetch steps.

## Test plan

- [ ] Verify Scalpel logs show successful base branch resolution instead of the fallback warning
- [ ] Compare test counts between normal and Scalpel shards on a PR that touches a single module
- [ ] Confirm normal (non-Scalpel) shards are unaffected (`scalpel.enabled=false` in maven.config means `fetchBaseBranch` is a no-op)
- [ ] Verify local builds are unaffected (Scalpel disabled by default)