### PR TITLE
fix(mcp): correct tool descriptions for get_group_metadata and search_artifacts

### DIFF
--- a/mcp/src/main/java/io/apicurio/registry/mcp/servers/ArtifactsMCPServer.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/servers/ArtifactsMCPServer.java
@@ -99,7 +99,7 @@ public class ArtifactsMCPServer {
 
     @Tool(description = """
             Search for artifacts in the Apicurio Registry server. \
-            Returns metadata of the groups that fit the search criteria.""")
+            Returns metadata of the artifacts that fit the search criteria.""")
     List<SearchedArtifact> search_artifacts(
             @ToolArg(description = GROUP_ID) String groupId,
             @ToolArg(description = ARTIFACT_ID, required = false) String artifactId,

--- a/mcp/src/main/java/io/apicurio/registry/mcp/servers/GroupsMCPServer.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/servers/GroupsMCPServer.java
@@ -68,7 +68,7 @@ public class GroupsMCPServer {
     }
 
     @Tool(description = """
-            Update group metadata in the Apicurio Registry server.""")
+            Retrieve metadata of a specific group in the Apicurio Registry server.""")
     GroupMetaData get_group_metadata(
             @ToolArg(description = GROUP_ID) String groupId
     ) {


### PR DESCRIPTION
fixes #8907 
This PR fixes two copy-paste typos in `@Tool(description = ...)` annotations in the `mcp` module:

1. **`GroupsMCPServer.java` (`get_group_metadata`):** Updated tool description from `"Update group metadata in the Apicurio Registry server."` to `"Retrieve metadata of a specific group in the Apicurio Registry server."`. `get_group_metadata` is a read-only GET operation and was incorrectly describing itself as an update tool.
2. **`ArtifactsMCPServer.java` (`search_artifacts`):** Updated tool description from `"Returns metadata of the groups that fit the search criteria."` to `"Returns metadata of the artifacts that fit the search criteria."`.

### Checklist

- [x] Code compiles cleanly
- [x] All commits signed-off (`Signed-off-by`) for DCO compliance
- [x] Follows Conventional Commits standard
