### PR TITLE
fix(ui): add missing aria-labels for screen reader accessibility

### DIFF
--- a/ui/ui-app/src/app/components/agentCard/SkillEditor.tsx
+++ b/ui/ui-app/src/app/components/agentCard/SkillEditor.tsx
@@ -213,6 +213,7 @@ export const SkillEditor: FunctionComponent<SkillEditorProps> = (props: SkillEdi
                                 </Button>
                                 <Button icon={<TrashIcon />}
                                     variant="plain"
+                                    aria-label={`Delete skill ${skill.name}`}
                                     onClick={() => handleDeleteSkill(skill.id)}
                                     className="delete-btn"
                                 />

--- a/ui/ui-app/src/app/components/header/AppHeaderToolbar.tsx
+++ b/ui/ui-app/src/app/components/header/AppHeaderToolbar.tsx
@@ -49,7 +49,7 @@ export const AppHeaderToolbar: FunctionComponent<AppHeaderToolbarProps> = () => 
                 <ToolbarContent>
                     <ToolbarGroup align={{ default: "alignEnd" }}>
                         <ToolbarItem>
-                            <Button icon={<QuestionCircleIcon style={{ fontSize: "16px" }} />} variant="plain" onClick={() => setIsAboutModalOpen(!isAboutModalOpen)} />
+                            <Button icon={<QuestionCircleIcon style={{ fontSize: "16px" }} />} variant="plain" aria-label="About" onClick={() => setIsAboutModalOpen(!isAboutModalOpen)} />
                         </ToolbarItem>
                         <ToolbarItem>
                             <IfAuth enabled={true}>

--- a/ui/ui-app/src/app/components/mcpTool/McpToolViewer.tsx
+++ b/ui/ui-app/src/app/components/mcpTool/McpToolViewer.tsx
@@ -111,7 +111,7 @@ export const McpToolViewer: FunctionComponent<McpToolViewerProps> = (props: McpT
                             </CardTitle>
                         </CardHeader>
                         <CardBody>
-                            <table className="pf-v5-c-table pf-m-compact pf-m-grid-md">
+                            <table className="pf-v5-c-table pf-m-compact pf-m-grid-md" aria-label="Input parameters">
                                 <thead>
                                     <tr>
                                         <th>Parameter</th>
@@ -157,7 +157,7 @@ export const McpToolViewer: FunctionComponent<McpToolViewerProps> = (props: McpT
                             </CardTitle>
                         </CardHeader>
                         <CardBody>
-                            <table className="pf-v5-c-table pf-m-compact pf-m-grid-md">
+                            <table className="pf-v5-c-table pf-m-compact pf-m-grid-md" aria-label="Output schema">
                                 <thead>
                                     <tr>
                                         <th>Field</th>

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
@@ -164,7 +164,7 @@ export const PromptTemplateViewer: FunctionComponent<PromptTemplateViewerProps> 
                         <Divider className="section-divider" />
                         <Title headingLevel="h3" size="md">Variables</Title>
                         <div className="variables-table-wrapper">
-                            <table className="variables-table">
+                            <table className="variables-table" aria-label="Template variables">
                                 <thead>
                                     <tr>
                                         <th>Name</th>

--- a/ui/ui-app/src/app/components/ruleList/RuleList.tsx
+++ b/ui/ui-app/src/app/components/ruleList/RuleList.tsx
@@ -93,7 +93,8 @@ export const RuleList: FunctionComponent<RuleListProps> = (props: RuleListProps)
                 <Button icon={<TrashIcon />} variant="plain"
                     key="delete-action"
                     data-testid="rules-validity-disable"
-                    title="Disable the  validity rule"
+                    title="Disable the validity rule"
+                    aria-label="Disable the validity rule"
                     onClick={doDisableRule("VALIDITY")} />
             </React.Fragment>
         );
@@ -120,6 +121,7 @@ export const RuleList: FunctionComponent<RuleListProps> = (props: RuleListProps)
                     key="delete-action"
                     data-testid="rules-compatibility-disable"
                     title="Disable the compatibility rule"
+                    aria-label="Disable the compatibility rule"
                     onClick={doDisableRule("COMPATIBILITY")} />
             </React.Fragment>
         );
@@ -146,6 +148,7 @@ export const RuleList: FunctionComponent<RuleListProps> = (props: RuleListProps)
                     key="delete-action"
                     data-testid="rules-integrity-disable"
                     title="Disable the integrity rule"
+                    aria-label="Disable the integrity rule"
                     onClick={doDisableRule("INTEGRITY")} />
             </React.Fragment>
         );

--- a/ui/ui-app/src/app/pages/explore/components/toolbar/ExplorePageToolbar.tsx
+++ b/ui/ui-app/src/app/pages/explore/components/toolbar/ExplorePageToolbar.tsx
@@ -134,7 +134,7 @@ export const ExplorePageToolbar: FunctionComponent<ExplorePageToolbarProps> = (p
                 <ToolbarItem className="sort-icon-item">
                     <Button icon={
                         filterAscending ? <SortAlphaDownIcon/> : <SortAlphaDownAltIcon/>
-                    } variant="plain" aria-label="edit" data-testid="artifact-filter-sort"
+                    } variant="plain" aria-label={filterAscending ? "Sort descending" : "Sort ascending"} data-testid="artifact-filter-sort"
                     onClick={onToggleAscending} />
                 </ToolbarItem>
                 <ToolbarItem className="create-artifact-item">

--- a/ui/ui-app/src/app/pages/settings/components/ConfigProperty.tsx
+++ b/ui/ui-app/src/app/pages/settings/components/ConfigProperty.tsx
@@ -95,11 +95,11 @@ export const ConfigProperty: FunctionComponent<ConfigPropertyProps> = ({ propert
                 </FlexItem>
                 <FlexItem className="actions" align={{ default: "alignRight" }}>
                     <If condition={!isEditing}>
-                        <Button icon={<PencilAltIcon />} variant="plain" className="action single" onClick={onStartEditing} />
+                        <Button icon={<PencilAltIcon />} variant="plain" className="action single" aria-label="Edit property" onClick={onStartEditing} />
                     </If>
                     <If condition={isEditing}>
-                        <Button icon={<CheckIcon />} variant="plain" className="action" onClick={onSavePropertyValue} isDisabled={!isValid} />
-                        <Button icon={<CloseIcon />} variant="plain" className="action" onClick={onCancelEdit} />
+                        <Button icon={<CheckIcon />} variant="plain" className="action" aria-label="Save property" onClick={onSavePropertyValue} isDisabled={!isValid} />
+                        <Button icon={<CloseIcon />} variant="plain" className="action" aria-label="Cancel editing" onClick={onCancelEdit} />
                     </If>
                 </FlexItem>
             </Flex>


### PR DESCRIPTION
## Description

Add missing aria-labels to icon-only buttons and raw HTML tables across the UI to improve screen reader accessibility.

## Motivation

Icon-only buttons without aria-labels are invisible to assistive technology -- screen readers announce them as empty buttons. Raw HTML tables without aria-labels have no programmatic identification for table navigation. One button had an incorrect aria-label ("edit" on a sort toggle). This PR fixes 12 accessibility gaps across 7 files.

## Changes

- Added aria-label to the About/help button in AppHeaderToolbar
- Added aria-labels to Edit/Save/Cancel buttons in ConfigProperty
- Added aria-labels to Disable rule buttons (Validity, Compatibility, Integrity) in RuleList
- Fixed incorrect aria-label="edit" on sort toggle in ExplorePageToolbar to show dynamic direction
- Added aria-label to Delete skill button in SkillEditor
- Added aria-label to variables table in PromptTemplateViewer
- Added aria-labels to Input Parameters and Output Schema tables in McpToolViewer
- Fixed double-space typo in validity rule title attribute

## Testing

- [x] Ran npm run lint in ui/ui-app/ - passes (0 errors, only pre-existing warnings)

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
