### PR TITLE
fix(schema-util): remove unchecked generic varargs warning in unionOf

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AbstractCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AbstractCompatibilityChecker.java
@@ -95,11 +95,9 @@ public abstract class AbstractCompatibilityChecker<D> implements CompatibilityCh
 
     protected abstract CompatibilityDifference transform(D original);
 
-    private Set<D> unionOf(Set<D>... from) {
-        Set<D> rval = new HashSet<>();
-        for (Set<D> f : from) {
-            rval.addAll(f);
-        }
+    private Set<D> unionOf(Set<D> first, Set<D> second) {
+        Set<D> rval = new HashSet<>(first);
+        rval.addAll(second);
         return rval;
     }
 


### PR DESCRIPTION
## What

`AbstractCompatibilityChecker.unionOf` took a generic varargs parameter (`Set<D>... from`). Because `Set<D>` isn't reifiable, the compiler creates a generic array for the varargs, which emits unchecked warnings on a normal build.

Both call sites — the `FULL` and `FULL_TRANSITIVE` branches of `testCompatibility` — only ever pass exactly two sets, so the varargs wasn't buying anything. This replaces it with two explicit parameters, which removes the generic array creation entirely rather than papering over it with `@SafeVarargs`.

Fixes #8905

## Why this shape

`@SafeVarargs` would silence the warnings (the method is `private`, so it's allowed), but it keeps an unnecessary array allocation on every call and leaves the API looking more general than it is. Since both callers pass a fixed pair, a two-argument signature is the simpler and more honest fix — and it needs no suppression annotation.

## Before / After

Compiling the file with `-Xlint:unchecked` on `main` produces three warnings:

```
AbstractCompatibilityChecker.java:52: warning: [unchecked] unchecked generic array creation
                                     for varargs parameter of type Set<D>[]      (FULL)
AbstractCompatibilityChecker.java:59: warning: [unchecked] unchecked generic array creation
                                     for varargs parameter of type Set<D>[]      (FULL_TRANSITIVE)
AbstractCompatibilityChecker.java:98: warning: [unchecked] Possible heap pollution from
                                     parameterized vararg type Set<D>            (declaration)
```

After the change, the same compile is clean — no warnings from this file.

(The issue mentions the two call-site warnings; the declaration also emits a heap-pollution warning, so this clears all three.)

## Testing

- Compiled the file with `javac -Xlint:unchecked` before and after: 3 warnings → 0.
- Verified the union semantics are unchanged with a side-by-side comparison of the old varargs
  implementation and the new two-argument one across disjoint, overlapping, identical,
  first-empty, second-empty and both-empty set pairs — results identical in every case, and
  neither input set is mutated (the new version copies `first` rather than adding into it).
- No behavioural change is intended or expected: `new HashSet<>(first)` + `addAll(second)` is
  equivalent to the previous empty-set-plus-two-`addAll` loop.
