### PR TITLE
fix(ui): highlight handlebars closing tags in the prompt template preview

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
@@ -65,8 +65,9 @@ export type PromptTemplateViewerProps = {
 
 const highlightVariables = (template: string): React.ReactNode[] => {
     const parts: React.ReactNode[] = [];
-    // Match both {{variable}} and {{#if variable}} / {{/if}} handlebars syntax
-    const regex = /\{\{(#?\/?(?:if|unless|each|with)\s+)?(\w+)\}\}/g;
+    // Match both {{variable}} and {{#if variable}} / {{/if}} handlebars syntax.
+    // Closing tags carry no variable name, so they need their own alternative.
+    const regex = /\{\{(#(?:if|unless|each|with)\s+\w+|\/(?:if|unless|each|with)|\w+)\}\}/g;
     let lastIndex = 0;
     let match;
     let key = 0;
@@ -75,7 +76,7 @@ const highlightVariables = (template: string): React.ReactNode[] => {
         if (match.index > lastIndex) {
             parts.push(template.substring(lastIndex, match.index));
         }
-        const isBlock = !!match[1];
+        const isBlock = match[1].startsWith("#") || match[1].startsWith("/");
         parts.push(
             <span key={key++} className={isBlock ? "template-block" : "template-variable"}>
                 {match[0]}


### PR DESCRIPTION
## What

In the Documentation tab's template preview, handlebars **closing** tags were rendered as plain text. `{{#if detailed}}` got a block highlight but the matching `{{/if}}` did not, so a conditional block looked like it opened and never closed. Same for `{{/each}}`, `{{/unless}}` and `{{/with}}`.

## Why it happened

`highlightVariables()` used:

```ts
// Match both {{variable}} and {{#if variable}} / {{/if}} handlebars syntax
const regex = /\{\{(#?\/?(?:if|unless|each|with)\s+)?(\w+)\}\}/g;
```

The comment states `{{/if}}` should match, but the pattern cannot match it: the block-prefix group ends in `\s+` and is followed by a mandatory `(\w+)`, and a closing tag has neither a space nor a name. Without the prefix group, `(\w+)` would have to start on `/`, which isn't a word character — so no alternative matches and the tag falls through to plain text. Opening tags were fine because they do have a space and a name.

## The change

Closing tags get their own alternative, since they carry no variable name:

```ts
const regex = /\{\{(#(?:if|unless|each|with)\s+\w+|\/(?:if|unless|each|with)|\w+)\}\}/g;
```

`isBlock` is now derived from the matched text (`#`/`/` prefix) instead of from the presence of the old prefix group. The second capture group was unused, so collapsing to a single group is safe.

No CSS change is needed — `.template-block` already exists in `PromptTemplateViewer.css`; closing tags simply never received the class.

Fixes #8913

## Before / After

For this template:

```
Summarize {{topic}}.
{{#if detailed}}Be thorough about {{topic}}.{{/if}}
Done.
```

the emitted parts change from

```
"Summarize "  [VAR {{topic}}]  ".\n"  [BLOCK {{#if detailed}}]  "Be thorough about "  [VAR {{topic}}]  ".{{/if}}\nDone."
                                                                                                        ^^^^^^^^ swallowed into plain text
```

to

```
"Summarize "  [VAR {{topic}}]  ".\n"  [BLOCK {{#if detailed}}]  "Be thorough about "  [VAR {{topic}}]  "."  [BLOCK {{/if}}]  "\nDone."
```

## Testing

`ui-app` has no unit-test harness (no `test` script), so I verified by porting `highlightVariables()` verbatim and running it with the old and new patterns side by side:

- `{{/if}}`, `{{/each}}`, `{{/unless}}`, `{{/with}}` now match and are classed `template-block`; previously none of them matched.
- Every span the old pattern produced is still produced, with the same CSS class — the new output is a strict superset, so plain variables and opening block tags are unaffected.
- A bare `{{if}}` (a variable that happens to be named after a keyword) is still treated as a plain variable, not a block.
- `{{}}` still doesn't match.
- The concatenation of all emitted parts reproduces the input template exactly, so no text is dropped or duplicated.
- `npm run build` (tsc + vite) and `npm run lint` pass.

Whitespace-padded tags such as `{{ topic }}` and dotted paths like `{{user.name}}` are still unmatched — that is pre-existing behaviour and out of scope here; happy to open a separate issue if you'd like those handled too.
