### PR TITLE
fix(kafkasql): journal contract audit entries so they replicate across nodes

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -748,7 +748,9 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
     @Override
     public void insertContractAuditEntry(io.apicurio.registry.storage.dto.ContractAuditEntryDto entry)
             throws RegistryStorageException {
-        sqlStore.insertContractAuditEntry(entry);
+        var message = new InsertContractAuditEntry1Message(entry);
+        var uuid = blockOnResult(submitter.submitMessage(message));
+        coordinator.waitForResponse(uuid);
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/InsertContractAuditEntry1Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/InsertContractAuditEntry1Message.java
@@ -1,0 +1,33 @@
+package io.apicurio.registry.storage.impl.kafkasql.messages;
+
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.dto.ContractAuditEntryDto;
+import io.apicurio.registry.storage.impl.kafkasql.AbstractMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class InsertContractAuditEntry1Message extends AbstractMessage {
+
+    private ContractAuditEntryDto entry;
+
+    /**
+     * @see io.apicurio.registry.storage.impl.kafkasql.KafkaSqlMessage#dispatchTo(io.apicurio.registry.storage.RegistryStorage)
+     */
+    @Override
+    public Object dispatchTo(RegistryStorage storage) {
+        storage.insertContractAuditEntry(entry);
+        return null;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/serde/KafkaSqlMessageIndex.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/serde/KafkaSqlMessageIndex.java
@@ -62,6 +62,7 @@ public class KafkaSqlMessageIndex {
                 DeleteVersionContractRuleset3Message.class,
                 SetGlobalContractRuleset1Message.class,
                 DeleteGlobalContractRuleset0Message.class,
+                InsertContractAuditEntry1Message.class,
                 MergeArtifactLabels4Message.class,
                 MergeVersionLabels5Message.class);
     }

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlContractAuditJournalTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlContractAuditJournalTest.java
@@ -1,0 +1,72 @@
+package io.apicurio.registry.storage.impl.kafkasql;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.storage.dto.ContractAuditEntryDto;
+import io.apicurio.registry.storage.impl.kafkasql.messages.InsertContractAuditEntry1Message;
+import io.apicurio.registry.utils.tests.KafkasqlTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@QuarkusTest
+@TestProfile(KafkasqlTestProfile.class)
+public class KafkaSqlContractAuditJournalTest extends AbstractResourceTestBase {
+
+    private static final String JOURNAL_TOPIC = "kafkasql-journal";
+
+    @Inject
+    KafkaSqlRegistryStorage kafkaSqlRegistryStorage;
+
+    @Test
+    public void testInsertContractAuditEntryIsJournaled() {
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(
+                Map.of(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                        System.getProperty("bootstrap.servers.external"),
+                        ConsumerConfig.GROUP_ID_CONFIG, "tc-" + UUID.randomUUID(),
+                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
+                new StringDeserializer(), new StringDeserializer());
+        try {
+            consumer.subscribe(List.of(JOURNAL_TOPIC));
+
+            ContractAuditEntryDto entry = ContractAuditEntryDto.builder().groupId("audit-group")
+                    .artifactId("audit-artifact").action("METADATA_UPDATED").principal("test-principal")
+                    .createdOn(new Date()).build();
+            kafkaSqlRegistryStorage.insertContractAuditEntry(entry);
+
+            String expectedType = InsertContractAuditEntry1Message.class.getSimpleName();
+            long deadline = System.currentTimeMillis() + 15000;
+            boolean found = false;
+            while (System.currentTimeMillis() < deadline && !found) {
+                for (ConsumerRecord<String, String> consumerRecord : consumer.poll(Duration.ofMillis(500))) {
+                    Header header = consumerRecord.headers().lastHeader(KafkaSqlSubmitter.MESSAGE_TYPE_HEADER);
+                    if (header != null
+                            && expectedType.equals(new String(header.value(), StandardCharsets.UTF_8))) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            Assertions.assertTrue(found, "Expected an " + expectedType
+                    + " message to be produced to the KafkaSQL journal topic, but none was found. "
+                    + "This means the contract audit entry bypassed the journal and would not be "
+                    + "replicated across nodes (issue #8878).");
+        } finally {
+            consumer.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Route `insertContractAuditEntry` in the KafkaSQL storage implementation through the KafkaSQL journal instead of writing directly to the node-local SQL store.

Fixes #8878.

## Root cause

Contract audit entries are recorded when a contract's metadata is updated or its status is changed. On the KafkaSQL variant, `insertContractAuditEntry` in `KafkaSqlRegistryStorage` wrote directly to the node-local SQL store rather than submitting a message to the journal, unlike the other contract operations.

Since each KafkaSQL node derives its state from the journal, these writes were neither replicated to other nodes nor restored on restart. As a result, the contract audit log returned different entries depending on which node served the request, and entries were lost when the node that handled the write was restarted.

## Implementation

- Add `InsertContractAuditEntry1Message`, following the existing KafkaSQL message pattern.
- Route `insertContractAuditEntry` through the KafkaSQL submitter/coordinator workflow.
- Register the new message type in `KafkaSqlMessageIndex`.

## Testing

Added `KafkaSqlContractAuditJournalTest`, which verifies that inserting a contract audit entry produces the expected `InsertContractAuditEntry1Message` on the KafkaSQL journal topic.

Verified locally:

```bash
./mvnw test -pl app -am \
  -Dtest=KafkaSqlContractAuditJournalTest \
  -Dsurefire.failIfNoSpecifiedTests=false

./mvnw checkstyle:check -pl app
```