### PR TITLE
fix(schema-util): parse {{variable}} with one canonical pattern

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
+++ b/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.services;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.content.util.PromptTemplateVariableUtil;
 import io.apicurio.registry.rest.v3.beans.RenderPromptResponse;
 import io.apicurio.registry.rest.v3.beans.RenderValidationError;
 import io.apicurio.registry.storage.error.InvalidContentException;
@@ -11,8 +12,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static io.apicurio.registry.util.JsonObjectMapper.MAPPER;
 import static io.apicurio.registry.util.YAMLObjectMapper.YAML_MAPPER;
@@ -22,8 +21,6 @@ import static io.apicurio.registry.util.YAMLObjectMapper.YAML_MAPPER;
  */
 @ApplicationScoped
 public class PromptRenderingService {
-
-    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{\\{([^}]+)\\}\\}");
 
     /**
      * Renders a prompt template by substituting variables.
@@ -256,27 +253,11 @@ public class PromptRenderingService {
      * Substitute variables in the template text using {{variable}} syntax.
      */
     private String substituteVariables(String template, Map<String, Object> variables) {
-        StringBuffer result = new StringBuffer();
-        Matcher matcher = VARIABLE_PATTERN.matcher(template);
-
-        while (matcher.find()) {
-            String varName = matcher.group(1).trim();
+        return PromptTemplateVariableUtil.substituteVariables(template, varName -> {
             Object value = variables.get(varName);
-
-            String replacement;
-            if (value == null) {
-                // Keep the original placeholder if variable is not provided
-                replacement = matcher.group(0);
-            } else {
-                replacement = formatValue(value);
-            }
-
-            // Escape special characters for replacement
-            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
-        }
-        matcher.appendTail(result);
-
-        return result.toString();
+            // Returning null keeps the original placeholder if the variable is not provided.
+            return value == null ? null : formatValue(value);
+        });
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
@@ -478,6 +478,76 @@ public class PromptRenderingServiceTest {
     }
 
     @Test
+    public void testWhitespaceInVariableNameWithPadding() {
+        // Both spellings of the same variable must resolve to the same value.
+        String yamlContent = """
+            templateId: whitespace
+            template: "{{name}} / {{ name }} / {{   name   }}"
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of("name", "World");
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "whitespace", "1.0");
+
+        Assertions.assertEquals("World / World / World", response.getRendered());
+    }
+
+    @Test
+    public void testMissingVariableWithWhitespacePreservedAsPlaceholder() {
+        String yamlContent = """
+            templateId: partial
+            template: "Hello, {{ name }}! Your role is {{ role }}."
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of("name", "Bob");
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "partial", "1.0");
+
+        // The unresolved placeholder is written back exactly as the author spelled it.
+        Assertions.assertEquals("Hello, Bob! Your role is {{ role }}.", response.getRendered());
+    }
+
+    @Test
+    public void testDottedNameIsNotAVariable() {
+        // Deliberate behaviour change: the canonical grammar is \\w+, so a dotted placeholder is
+        // literal text here, exactly as it already was for the validator and the MCP converter.
+        String yamlContent = """
+            templateId: dotted
+            template: "Hello, {{user.name}}!"
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of("user.name", "Alice");
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "dotted", "1.0");
+
+        Assertions.assertEquals("Hello, {{user.name}}!", response.getRendered());
+    }
+
+    @Test
+    public void testConditionalBlockMarkersAreNotSubstituted() {
+        String yamlContent = """
+            templateId: conditional
+            template: "{{#if premium}}Hello {{ name }}{{/if}}"
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of("name", "Alice", "premium", true);
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "conditional", "1.0");
+
+        // The render endpoint does not process {{#if}} blocks (see #8728); it must at least leave
+        // the markers alone rather than mangling them while substituting the variable inside.
+        Assertions.assertEquals("{{#if premium}}Hello Alice{{/if}}", response.getRendered());
+    }
+
+    @Test
     public void testMultilineTemplate() {
         String yamlContent = """
             templateId: multiline

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -63,6 +63,15 @@
             <artifactId>apicurio-registry-java-sdk</artifactId>
         </dependency>
 
+        <!--
+        Provides PromptTemplateVariableUtil, the canonical {{variable}} parser shared with the
+        validity rule and the REST render endpoint, so the three do not drift apart again.
+        -->
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-schema-util-common</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>

--- a/mcp/src/main/java/io/apicurio/registry/mcp/PromptTemplateConverter.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/PromptTemplateConverter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.apicurio.registry.content.util.PromptTemplateVariableUtil;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -22,7 +23,6 @@ import java.util.regex.Pattern;
 @ApplicationScoped
 public class PromptTemplateConverter {
 
-    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{\\{(\\w+)\\}\\}");
     private static final Pattern IF_BLOCK_PATTERN = Pattern.compile("\\{\\{#if\\s+(\\w+)\\}\\}([\\s\\S]*?)\\{\\{/if\\}\\}");
 
     @Inject
@@ -434,14 +434,16 @@ public class PromptTemplateConverter {
             return template;
         }
 
-        String rendered = template;
-
-        // Simple {{variable}} substitution
-        for (Map.Entry<String, Object> entry : args.entrySet()) {
-            String placeholder = "\\{\\{" + entry.getKey() + "\\}\\}";
-            String value = entry.getValue() != null ? String.valueOf(entry.getValue()) : "";
-            rendered = rendered.replaceAll(placeholder, Matcher.quoteReplacement(value));
-        }
+        // Simple {{variable}} substitution, using the canonical pattern shared with the validity
+        // rule and the REST render endpoint so that {{name}} and {{ name }} resolve the same way.
+        String rendered = PromptTemplateVariableUtil.substituteVariables(template, varName -> {
+            if (!args.containsKey(varName)) {
+                // Returning null leaves the placeholder in the output, as before.
+                return null;
+            }
+            Object value = args.get(varName);
+            return value != null ? String.valueOf(value) : "";
+        });
 
         // Handle {{#if variable}} ... {{/if}} blocks
         rendered = processConditionalBlocks(rendered, args);

--- a/mcp/src/test/java/io/apicurio/registry/mcp/PromptTemplateConverterTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/PromptTemplateConverterTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests for the {{variable}} substitution done by the MCP prompt converter. These do not need a
+ * Quarkus context - the converter only needs its ObjectMapper, which is set directly here.
+ */
+class PromptTemplateConverterTest {
+
+    private PromptTemplateConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new PromptTemplateConverter();
+        converter.jsonMapper = new ObjectMapper();
+    }
+
+    @Test
+    void testRenderPlainVariable() {
+        Assertions.assertEquals("Hello Alice",
+                converter.renderTemplate("Hello {{name}}", Map.of("name", "Alice")));
+    }
+
+    @Test
+    void testRenderVariableWithWhitespace() {
+        // Previously the converter substituted the literal string "{{" + key + "}}", so a
+        // space-padded placeholder was left in the output as dead text.
+        Assertions.assertEquals("Hello Alice",
+                converter.renderTemplate("Hello {{ name }}", Map.of("name", "Alice")));
+        Assertions.assertEquals("Hello Alice",
+                converter.renderTemplate("Hello {{   name   }}", Map.of("name", "Alice")));
+    }
+
+    @Test
+    void testRenderMixedSpellingsOfSameVariable() {
+        Assertions.assertEquals("Alice / Alice",
+                converter.renderTemplate("{{name}} / {{ name }}", Map.of("name", "Alice")));
+    }
+
+    @Test
+    void testUnknownVariableKeepsPlaceholder() {
+        Assertions.assertEquals("Hello {{name}}",
+                converter.renderTemplate("Hello {{name}}", Map.of()));
+    }
+
+    @Test
+    void testNullValueRendersAsEmptyString() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("name", null);
+        Assertions.assertEquals("Hello !", converter.renderTemplate("Hello {{name}}!", args));
+    }
+
+    @Test
+    void testNullArgsReturnsTemplateUnchanged() {
+        Assertions.assertEquals("Hello {{name}}", converter.renderTemplate("Hello {{name}}", null));
+    }
+
+    @Test
+    void testValueWithRegexReplacementCharacters() {
+        Assertions.assertEquals("Cost: $1,000",
+                converter.renderTemplate("Cost: {{amount}}", Map.of("amount", "$1,000")));
+    }
+
+    @Test
+    void testVariableNameWithRegexMetacharacterDoesNotMatchWildly() {
+        // The old code built a regex from the argument name, so a '.' in the key matched any
+        // character. "a.b" must not substitute the unrelated placeholder "{{axb}}".
+        Assertions.assertEquals("{{axb}}",
+                converter.renderTemplate("{{axb}}", Map.of("a.b", "boom")));
+    }
+
+    @Test
+    void testConditionalBlockStillWorks() {
+        Assertions.assertEquals("Hello Alice",
+                converter.renderTemplate("{{#if premium}}Hello {{ name }}{{/if}}",
+                        Map.of("premium", true, "name", "Alice")));
+    }
+
+    @Test
+    void testConditionalBlockDroppedWhenFalsy() {
+        Assertions.assertEquals("",
+                converter.renderTemplate("{{#if premium}}Hello {{ name }}{{/if}}",
+                        Map.of("premium", false, "name", "Alice")));
+    }
+
+    @Test
+    void testParseAndRenderAutoDetectJsonWithWhitespaceVariable() {
+        String json = """
+                {
+                    "templateId": "greeting",
+                    "template": "Hello {{ name }}!",
+                    "variables": { "name": { "type": "string" } }
+                }
+                """;
+        Assertions.assertEquals("Hello Alice!",
+                converter.parseAndRenderAutoDetect(json, Map.of("name", "Alice")));
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/content/util/PromptTemplateVariableUtil.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/util/PromptTemplateVariableUtil.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.content.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Canonical handling of the <code>{{variable}}</code> placeholder syntax used by Prompt Template
+ * artifacts.
+ *
+ * The validity rule, the REST render endpoint and the MCP prompt converter all have to answer the
+ * same question - "which variables does this template use?" - and each used to answer it with its
+ * own regular expression. Because the expressions disagreed, a placeholder such as
+ * <code>{{ name }}</code> was a variable to one component and literal text to another. Everything
+ * that parses the syntax should go through this class so that the answer stays the same everywhere.
+ *
+ * The grammar is a word-character name with optional whitespace inside the braces, so both
+ * <code>{{name}}</code> and <code>{{ name }}</code> resolve to <code>name</code>. Handlebars-style
+ * control blocks such as <code>{{#if x}}</code> and <code>{{/if}}</code> are deliberately not
+ * matched, because <code>#</code> and <code>/</code> are not word characters.
+ */
+public final class PromptTemplateVariableUtil {
+
+    /**
+     * The single pattern that defines what a prompt template variable placeholder looks like.
+     * Group 1 is the variable name, with any surrounding whitespace already stripped.
+     */
+    public static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{\\{\\s*(\\w+)\\s*\\}\\}");
+
+    private PromptTemplateVariableUtil() {
+    }
+
+    /**
+     * Returns the names of the variables used by the given template, in the order they first
+     * appear and without duplicates. A null template yields an empty list.
+     */
+    public static List<String> extractVariableNames(String template) {
+        if (template == null) {
+            return Collections.emptyList();
+        }
+
+        List<String> variables = new ArrayList<>();
+        Matcher matcher = VARIABLE_PATTERN.matcher(template);
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            if (!variables.contains(name)) {
+                variables.add(name);
+            }
+        }
+        return variables;
+    }
+
+    /**
+     * Replaces every variable placeholder in the template with the value returned by the given
+     * resolver. A resolver that returns null leaves the placeholder exactly as it was written,
+     * which lets each caller decide for itself whether an unresolved variable is an error or is
+     * simply passed through to the output.
+     */
+    public static String substituteVariables(String template, Function<String, String> resolver) {
+        if (template == null) {
+            return null;
+        }
+
+        Matcher matcher = VARIABLE_PATTERN.matcher(template);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String replacement = resolver.apply(matcher.group(1));
+            if (replacement == null) {
+                replacement = matcher.group(0);
+            }
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/PromptTemplateContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/PromptTemplateContentValidator.java
@@ -3,12 +3,12 @@ package io.apicurio.registry.rules.validity;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.util.ContentTypeUtil;
+import io.apicurio.registry.content.util.PromptTemplateVariableUtil;
 import io.apicurio.registry.rest.v3.beans.ArtifactReference;
 import io.apicurio.registry.rules.violation.RuleViolation;
 import io.apicurio.registry.rules.violation.RuleViolationException;
 import io.apicurio.registry.types.RuleType;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -16,8 +16,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Content validator for Prompt Template artifacts.
@@ -27,7 +25,6 @@ import java.util.regex.Pattern;
  */
 public class PromptTemplateContentValidator extends AbstractContentValidator {
 
-    private static final Pattern TEMPLATE_VARIABLE_PATTERN = Pattern.compile("\\{\\{(\\w+)\\}\\}");
     private static final List<String> VALID_VARIABLE_TYPES = Arrays.asList(
             "string", "integer", "number", "boolean", "array", "object");
 
@@ -171,15 +168,7 @@ public class PromptTemplateContentValidator extends AbstractContentValidator {
     }
 
     public static List<String> extractTemplateVariables(String template) {
-        List<String> variables = new ArrayList<>();
-        Matcher matcher = TEMPLATE_VARIABLE_PATTERN.matcher(template);
-        while (matcher.find()) {
-            String varName = matcher.group(1);
-            if (!variables.contains(varName)) {
-                variables.add(varName);
-            }
-        }
-        return variables;
+        return PromptTemplateVariableUtil.extractVariableNames(template);
     }
 
     @Override

--- a/schema-util/common/src/test/java/io/apicurio/registry/content/util/PromptTemplateVariableUtilTest.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/content/util/PromptTemplateVariableUtilTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.content.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+class PromptTemplateVariableUtilTest {
+
+    @Test
+    void testExtractPlainVariable() {
+        Assertions.assertEquals(List.of("name"),
+                PromptTemplateVariableUtil.extractVariableNames("Hello {{name}}"));
+    }
+
+    @Test
+    void testExtractVariableWithSurroundingWhitespace() {
+        // The whole point of the shared pattern: spaces inside the braces are still a variable.
+        Assertions.assertEquals(List.of("name"),
+                PromptTemplateVariableUtil.extractVariableNames("Hello {{ name }}"));
+        Assertions.assertEquals(List.of("name"),
+                PromptTemplateVariableUtil.extractVariableNames("Hello {{   name}}"));
+        Assertions.assertEquals(List.of("name"),
+                PromptTemplateVariableUtil.extractVariableNames("Hello {{name   }}"));
+    }
+
+    @Test
+    void testExtractPreservesOrderAndDeduplicates() {
+        Assertions.assertEquals(List.of("language", "code"),
+                PromptTemplateVariableUtil.extractVariableNames(
+                        "Review this {{language}} code: {{code}} (in {{ language }})"));
+    }
+
+    @Test
+    void testExtractIgnoresConditionalBlockMarkers() {
+        // '#' and '/' are not word characters, so neither {{#if plan}} nor {{/if}} is read as a
+        // variable - not the control keyword, and not the condition subject either. Only the
+        // real placeholder inside the block is returned.
+        Assertions.assertEquals(List.of("name"),
+                PromptTemplateVariableUtil.extractVariableNames(
+                        "{{#if plan}}Hi {{ name }}{{/if}}"));
+    }
+
+    @Test
+    void testExtractFromNullTemplate() {
+        Assertions.assertEquals(List.of(), PromptTemplateVariableUtil.extractVariableNames(null));
+    }
+
+    @Test
+    void testExtractFromTemplateWithNoVariables() {
+        Assertions.assertEquals(List.of(),
+                PromptTemplateVariableUtil.extractVariableNames("A static prompt."));
+    }
+
+    @Test
+    void testSubstituteWithAndWithoutWhitespace() {
+        Map<String, String> values = Map.of("name", "Alice");
+        Assertions.assertEquals("Hello Alice and Alice",
+                PromptTemplateVariableUtil.substituteVariables("Hello {{name}} and {{ name }}",
+                        values::get));
+    }
+
+    @Test
+    void testSubstituteLeavesUnresolvedPlaceholderUntouched() {
+        // A null from the resolver means "no value" - the placeholder is written back verbatim,
+        // including whatever whitespace the author used.
+        Assertions.assertEquals("Hello {{ name }}",
+                PromptTemplateVariableUtil.substituteVariables("Hello {{ name }}", varName -> null));
+    }
+
+    @Test
+    void testSubstituteEscapesRegexReplacementCharacters() {
+        // A '$' or '\' in the value must not be interpreted as a replacement group reference.
+        Assertions.assertEquals("Cost: $1,000 \\ net",
+                PromptTemplateVariableUtil.substituteVariables("Cost: {{amount}}",
+                        varName -> "$1,000 \\ net"));
+    }
+
+    @Test
+    void testSubstituteWithEmptyValue() {
+        Assertions.assertEquals("Hello !",
+                PromptTemplateVariableUtil.substituteVariables("Hello {{name}}!", varName -> ""));
+    }
+
+    @Test
+    void testSubstituteOnNullTemplate() {
+        Assertions.assertNull(PromptTemplateVariableUtil.substituteVariables(null, varName -> "x"));
+    }
+
+    @Test
+    void testSubstituteDoesNotTouchConditionalBlockMarkers() {
+        Assertions.assertEquals("{{#if plan}}Hi Alice{{/if}}",
+                PromptTemplateVariableUtil.substituteVariables("{{#if plan}}Hi {{ name }}{{/if}}",
+                        varName -> "name".equals(varName) ? "Alice" : null));
+    }
+}

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/PromptTemplateContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/PromptTemplateContentValidatorTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Tests for PromptTemplateContentValidator, PromptTemplateContentAccepter, and PromptTemplateContentExtractor.
@@ -153,6 +154,74 @@ class PromptTemplateContentValidatorTest {
         });
         Assertions.assertTrue(
                 error.getCauses().stream().anyMatch(v -> v.getDescription().contains("quality")));
+    }
+
+    @Test
+    void testUndefinedVariableWithWhitespace() {
+        // Same as UNDEFINED_VARIABLE, but the undefined placeholder is written with spaces inside
+        // the braces. Before the shared pattern, the validator's \w+ regex could not see it, so
+        // the "used but not defined" rule silently never fired.
+        String undefinedVariableWithWhitespace = """
+                {
+                    "templateId": "test",
+                    "template": "Hello {{name}}, your code is {{ quality }}",
+                    "variables": {
+                        "name": { "type": "string" }
+                    }
+                }
+                """;
+        PromptTemplateContentValidator validator = new PromptTemplateContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, create(undefinedVariableWithWhitespace),
+                    Collections.emptyMap());
+        });
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getDescription().contains("quality")));
+    }
+
+    @Test
+    void testDefinedVariableWithWhitespaceIsAccepted() {
+        // The flip side: a space-padded placeholder that *is* defined must not be reported.
+        String definedVariableWithWhitespace = """
+                {
+                    "templateId": "test",
+                    "template": "Hello {{ name }}, welcome to {{  place  }}.",
+                    "variables": {
+                        "name": { "type": "string" },
+                        "place": { "type": "string" }
+                    }
+                }
+                """;
+        PromptTemplateContentValidator validator = new PromptTemplateContentValidator();
+        validator.validate(ValidityLevel.FULL, create(definedVariableWithWhitespace),
+                Collections.emptyMap());
+    }
+
+    @Test
+    void testConditionalBlockMarkersAreNotVariables() {
+        // {{#if ...}} and {{/if}} are control syntax, not variables, and must not be reported as
+        // undefined. Only the real {{ name }} placeholder inside the block counts.
+        String withConditionalBlock = """
+                {
+                    "templateId": "test",
+                    "template": "{{#if premium}}Hello {{ name }}{{/if}}",
+                    "variables": {
+                        "name": { "type": "string" },
+                        "premium": { "type": "boolean" }
+                    }
+                }
+                """;
+        PromptTemplateContentValidator validator = new PromptTemplateContentValidator();
+        validator.validate(ValidityLevel.FULL, create(withConditionalBlock), Collections.emptyMap());
+    }
+
+    @Test
+    void testExtractTemplateVariablesNormalisesWhitespace() {
+        // The extraction helper is also used by PromptTemplateCompatibilityChecker, so pin the
+        // exact names it returns: whitespace stripped, first-seen order, no duplicates.
+        Assertions.assertEquals(List.of("language", "code"),
+                PromptTemplateContentValidator.extractTemplateVariables(
+                        "Review this {{language}} code: {{ code }} (in {{  language  }})"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #8877.

The `{{variable}}` placeholder syntax of Prompt Template artifacts was parsed by three
separate components, each with its own regular expression. They disagreed, so the same
template could mean three different things depending on which path it went through.

The most visible consequence is a validation hole: the validity rule's "template variable
used but not defined in `variables`" check silently never fired for a placeholder written
with spaces inside the braces. A template referencing an undefined `{{ quality }}` passed
`FULL` validation, then rendered with the literal `{{ quality }}` still in the output.

This PR pins one canonical pattern in `schema-util/common` and routes all three components
through it, so they cannot drift apart again.

## Root Cause

Three components, three answers to "what is a variable here":

| Component | Pattern | `{{ name }}` resolves to |
|---|---|---|
| `PromptTemplateContentValidator` (`schema-util/common`) | `\{\{(\w+)\}\}` | nothing — not a variable |
| `PromptRenderingService` (`app`, REST `/render`) | `\{\{([^}]+)\}\}` then `.trim()` | `name` |
| `PromptTemplateConverter` (`mcp`) | see below | nothing — left as literal text |

The validator's `\w+` cannot match across the spaces, so `extractTemplateVariables` returns
an empty list for `"Hello {{ quality }}"`. `validateTemplateVariables` then has nothing to
cross-check against the `variables` object, and the rule passes. The same template without
spaces is correctly rejected — that case is already covered by the existing
`testUndefinedVariable`.

Worth flagging one thing I found while fixing the MCP side: `PromptTemplateConverter`
declared a `VARIABLE_PATTERN` field, but nothing ever used it. The actual substitution was
a loop over the supplied arguments doing

```java
String placeholder = "\\{\\{" + entry.getKey() + "\\}\\}";
rendered = rendered.replaceAll(placeholder, Matcher.quoteReplacement(value));
```

The observable behaviour matches what the issue describes — `{{ name }}` is not substituted
— but the mechanism is a literal `{{key}}` match, not the declared regex. It also builds a
regex out of the argument name, so a `.` in a key matched any character: an argument named
`a.b` would substitute an unrelated `{{axb}}` placeholder. Both go away with this change.

## The canonical grammar

Following the direction @paoloantinori gave on the issue thread: one pattern, in the shared
layer, used by everyone.

```java
Pattern.compile("\\{\\{\\s*(\\w+)\\s*\\}\\}");
```

A word-character name with optional surrounding whitespace, so `{{name}}` and `{{ name }}`
both resolve to `name`. Handlebars-style control blocks (`{{#if x}}`, `{{/if}}`) are not
matched, because `#` and `/` are not word characters — so this change does not disturb
conditional blocks, which are a separate concern (#8728).

## Changes

- **New** `schema-util/common/.../content/util/PromptTemplateVariableUtil.java`
  - `VARIABLE_PATTERN` — the single definition of the placeholder syntax.
  - `extractVariableNames(String)` — variable names in first-seen order, deduplicated,
    empty list for a null template.
  - `substituteVariables(String, Function<String, String>)` — replaces placeholders with
    whatever the resolver returns. A resolver returning `null` means "no value", and the
    placeholder is written back verbatim. That hook is what lets both call sites keep their
    own (differing) idea of what an unresolved variable means, while sharing the parsing.

- `schema-util/common/.../rules/validity/PromptTemplateContentValidator.java`
  - Dropped the local `TEMPLATE_VARIABLE_PATTERN`; `extractTemplateVariables` now delegates
    to the shared helper. The method stays `public static` — `PromptTemplateCompatibilityChecker`
    calls it.

- `app/.../services/PromptRenderingService.java`
  - Dropped the local `VARIABLE_PATTERN`; `substituteVariables` now delegates. Unresolved
    variables still keep their placeholder, exactly as before.

- `mcp/.../PromptTemplateConverter.java`
  - Removed the unused `VARIABLE_PATTERN` and replaced the per-argument `replaceAll` loop
    with a single pass through the shared helper. `{{#if}}` handling is untouched and still
    runs after substitution, as it did before.

- `mcp/pom.xml`
  - Added `apicurio-registry-schema-util-common`. See the note below.

## Behaviour changes worth reviewing

1. **`/render` no longer substitutes dotted or hyphenated names.** Tightening the endpoint
   from `[^}]+` to `\w+` is the part of this change that removes a capability: `{{user.name}}`
   and `{{first-name}}` were substituted by `/render` and are now literal text. That was
   already true for the validator and the MCP converter, so this makes `/render` consistent
   with the other two rather than the other way around — but it is the direction choice the
   issue asked about, so it deserves a look. Widening everything to accept dotted names
   instead is a one-line change to the shared pattern if you would rather go that way.

2. **The compatibility checker gets stricter, in the same direction as the fix.**
   `PromptTemplateCompatibilityChecker` uses `extractTemplateVariables` to detect
   `VARIABLE_REMOVED_BUT_USED`. It now also catches the case where the removed variable is
   still referenced as `{{ varName }}`, which it previously missed.

3. **A new module dependency: `mcp` → `schema-util-common`.** This is the one debatable bit.
   The MCP module previously depended only on the Java SDK, so sharing the pattern with it
   means adding a dependency. `schema-util-common` is fairly light (its heavier transitives
   in `apicurio-registry-common` are `provided`-scoped), and duplicating the constant would
   defeat the point of the issue — but if you would rather not grow the MCP server's
   classpath, say so and I will drop the MCP half into a follow-up.

## Test plan

Splitting these honestly into the ones that actually reproduce the bug and the ones that
are there to stop it coming back.

**Reproduce the bug — these fail on `main`:**

- `PromptTemplateContentValidatorTest.testUndefinedVariableWithWhitespace` — the case from
  the issue. `{{ quality }}` is used but not defined, and `FULL` validation now rejects it.
  On `main` the validator extracts nothing from that placeholder, raises no violation, and
  the `assertThrows` fails.
- `PromptTemplateContentValidatorTest.testExtractTemplateVariablesNormalisesWhitespace` —
  pins the exact list the extraction helper returns, since `PromptTemplateCompatibilityChecker`
  depends on it. On `main` the padded spellings are missing from the result.
- `PromptTemplateConverterTest.testRenderVariableWithWhitespace` — `{{ name }}` is now
  substituted by the MCP path instead of surviving into the output as literal text.
- `PromptTemplateConverterTest.testVariableNameWithRegexMetacharacterDoesNotMatchWildly` —
  an argument named `a.b` no longer substitutes an unrelated `{{axb}}` placeholder.
- `PromptRenderingServiceTest.testDottedNameIsNotAVariable` — this one fails on `main`
  because `main` is the more permissive side. It documents behaviour change (1) above.

**Guard the behaviour that must not change — these already pass on `main`:**

- `PromptRenderingServiceTest` — padded spellings resolving identically, unresolved padded
  placeholders preserved verbatim, `{{#if}}` markers left alone by substitution.
- `PromptTemplateContentValidatorTest.testDefinedVariableWithWhitespaceIsAccepted` and
  `testConditionalBlockMarkersAreNotVariables` — no new false positives, and control syntax
  is not mistaken for a variable.
- The existing `testWhitespaceInVariableName` and `testUndefinedVariable` still pass; the
  canonical pattern preserves everything that already worked on both sides.

**New test classes:**

- `PromptTemplateVariableUtilTest` (`schema-util/common`, 12 cases) — direct coverage of the
  shared helper: whitespace variants, first-seen ordering and deduplication, null template,
  control markers, `$` and `\` in substituted values, and the null-resolver contract.
- `PromptTemplateConverterTest` (`mcp`, 11 cases) — the converter had no test coverage at
  all. Covers substitution with and without whitespace, unknown variables, null values,
  null args, regex metacharacters in both values and argument names, and the existing
  `{{#if}}` truthy/falsy behaviour.

Checks run locally:

- [x] `./mvnw -pl schema-util/common,schema-util/util-provider test` — 32 tests, all pass
      (`PromptTemplateVariableUtilTest` 12, `PromptTemplateContentValidatorTest` 22,
      `PromptTemplateCompatibilityCheckerTest` 10, the last unchanged by this PR).
- [x] `./mvnw -Dfull -pl mcp test -Dtest=PromptTemplateConverterTest` — 11 tests, all pass.
      This also confirms the new `mcp` → `schema-util-common` dependency resolves.
- [x] `./mvnw checkstyle:check` clean on `schema-util/common`, `schema-util/util-provider`
      and `mcp`.
- [ ] `app` — `PromptRenderingServiceTest` is a `@QuarkusTest` and I could not get the `app`
      module to build to completion locally. Please let CI run it.
- [ ] Storage variants: not applicable. Nothing here touches `storage/impl/`; the change is
      confined to template-string parsing.

## Notes

- Related but separate: #8728 (`/render` does not process `{{#if}}` blocks) and #8669 (null
  `template` field). This PR deliberately leaves both alone — it only makes the three
  components agree on what a variable *is*.
- PR #8690 is open against `PromptRenderingService.java` and its test, but it changes
  `extractTemplateText` (null/non-string `template` field), not `substituteVariables`, so
  there is no functional overlap. Whichever merges second may need a trivial rebase in the
  test file.
- There is actually a fourth parser I did not touch:
  `ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx` highlights
  placeholders with `/\{\{(#?\/?(?:if|unless|each|with)\s+)?(\w+)\}\}/g`, which is also
  whitespace-intolerant, so `{{ name }}` is not highlighted as a variable in the preview.
  I left it out of scope: it is a separate build system, it is presentation rather than the
  parser of record, and PR #8917 is already open against that component. Happy to follow up
  there once the direction here is settled.
- The class javadoc on `PromptTemplateConverter` calls it "the Java equivalent of
  mcp-converter.ts", but there is no `mcp-converter.ts` in the tree any more. Left as-is
  rather than widening the diff.
