### PR TITLE
fix(ui): highlight handlebars closing tags in prompt template preview 

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
@@ -65,8 +65,10 @@ export type PromptTemplateViewerProps = {
 
 const highlightVariables = (template: string): React.ReactNode[] => {
     const parts: React.ReactNode[] = [];
-    // Match both {{variable}} and {{#if variable}} / {{/if}} handlebars syntax
-    const regex = /\{\{(#?\/?(?:if|unless|each|with)\s+)?(\w+)\}\}/g;
+    // Match {{variable}} and handlebars block tags: {{#if var}}, {{/if}}, {{#each items}}, {{/each}}, etc.
+    // The first alternative catches block open/close tags (closing tags have no variable name).
+    // The second alternative catches plain variable references.
+    const regex = /\{\{([#/](?:if|unless|each|with))(?:\s+\w+)?\}\}|\{\{(\w+)\}\}/g;
     let lastIndex = 0;
     let match;
     let key = 0;


### PR DESCRIPTION
Fixes #8913
The regex in `highlightVariables` (PromptTemplateViewer.tsx) is meant to match both `{{variable}}` and handlebars block tags, per its own comment, but the pattern can't match closing tags like `{{/if}}` or `{{/each}}`: the block-prefix group requires trailing whitespace and a variable name, neither of which exists on a closing tag.
Restructured the regex into two alternatives: one for block open/close tags (variable name optional, so `{{/if}}` matches), one for plain variables. Behavior for opening tags and plain variables is unchanged.
Verified locally with a template containing `{{#if}}...{{/if}}` and `{{#each}}...{{/each}}` blocks. All four closing tag forms (`if`, `unless`, `each`, `with`) now get the `template-block` class.