### PR TITLE
fix(ui): use route matching for active tab selection

### DIFF
--- a/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
+++ b/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useEffect, useState } from "react";
 import "./ArtifactPage.css";
 import { LoaderGuard, newLoaderGuard } from "@utils/loader.utils.ts";
 import { Breadcrumb, BreadcrumbItem, PageSection, Tab, Tabs } from "@patternfly/react-core";
-import { Link, useLocation, useParams } from "react-router";
+import { Link, useMatch, useParams } from "react-router";
 import { EXPLORE_PAGE_IDX, PageDataLoader, PageError, PageErrorHandler, PageProperties, toPageError } from "@app/pages";
 import {
     ChangeOwnerModal,
@@ -71,16 +71,19 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
     const logger: LoggerService = useLoggerService();
     const groups: GroupsService = useGroupsService();
     const { groupId, artifactId }= useParams();
-    const location = useLocation();
+    const rulesMatch = useMatch("/explore/:groupId/:artifactId/rules");
+    const branchesMatch = useMatch("/explore/:groupId/:artifactId/branches");
+    const contractMatch = useMatch("/explore/:groupId/:artifactId/contract");
+    const usageMatch = useMatch("/explore/:groupId/:artifactId/usage");
 
     let activeTabKey: string = "overview";
-    if (location.pathname.indexOf("/rules") !== -1) {
+    if (rulesMatch) {
         activeTabKey = "rules";
-    } else if (location.pathname.indexOf("/branches") !== -1) {
+    } else if (branchesMatch) {
         activeTabKey = "branches";
-    } else if (location.pathname.indexOf("/contract") !== -1) {
+    } else if (contractMatch) {
         activeTabKey = "contract";
-    } else if (location.pathname.indexOf("/usage") !== -1) {
+    } else if (usageMatch) {
         activeTabKey = "usage";
     }
 

--- a/ui/ui-app/src/app/pages/group/GroupPage.tsx
+++ b/ui/ui-app/src/app/pages/group/GroupPage.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useEffect, useState } from "react";
 import "./GroupPage.css";
 import { LoaderGuard, newLoaderGuard } from "@utils/loader.utils.ts";
 import { Breadcrumb, BreadcrumbItem, PageSection, PageSectionVariants, Tab, Tabs } from "@patternfly/react-core";
-import { Link, useLocation, useParams } from "react-router";
+import { Link, useLocation, useMatch, useParams } from "react-router";
 import {
     EXPLORE_PAGE_IDX,
     GroupOverviewTabContent,
@@ -61,12 +61,13 @@ export const GroupPage: FunctionComponent<PageProperties> = () => {
     const groups: GroupsService = useGroupsService();
     const { groupId }= useParams();
     const location = useLocation();
+    const rulesMatch = useMatch("/explore/:groupId/rules");
 
     let activeTabKey: string = "overview";
     if (location.pathname.indexOf("/artifacts") !== -1) {
         activeTabKey = "artifacts";
     }
-    if (location.pathname.indexOf("/rules") !== -1) {
+    if (rulesMatch) {
         activeTabKey = "rules";
     }
 

--- a/ui/ui-app/src/app/pages/version/VersionPage.tsx
+++ b/ui/ui-app/src/app/pages/version/VersionPage.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import "./VersionPage.css";
 import { LoaderGuard, newLoaderGuard } from "@utils/loader.utils.ts";
 import { Breadcrumb, BreadcrumbItem, PageSection, Tab, Tabs } from "@patternfly/react-core";
-import { Link, useLocation, useParams } from "react-router";
+import { Link, useMatch, useParams } from "react-router";
 import {
     ContentTabContent,
     DocumentationTabContent,
@@ -81,14 +81,16 @@ export const VersionPage: FunctionComponent<PageProperties> = () => {
     const draftsService: DraftsService = useDraftsService();
     const download: DownloadService = useDownloadService();
     const { groupId, artifactId, version }= useParams();
-    const location = useLocation();
+    const contentMatch = useMatch("/explore/:groupId/:artifactId/versions/:version/content");
+    const referencesMatch = useMatch("/explore/:groupId/:artifactId/versions/:version/references");
+    const documentationMatch = useMatch("/explore/:groupId/:artifactId/versions/:version/documentation");
 
     let activeTabKey: string = "overview";
-    if (location.pathname.indexOf("/content") !== -1) {
+    if (contentMatch) {
         activeTabKey = "content";
-    } else if (location.pathname.indexOf("/references") !== -1) {
+    } else if (referencesMatch) {
         activeTabKey = "references";
-    } else if (location.pathname.indexOf("/documentation") !== -1) {
+    } else if (documentationMatch) {
         activeTabKey = "documentation";
     }
 


### PR DESCRIPTION
## Summary

Fixes #8935

The Artifact, Group, and Version detail pages derived the active tab by searching for reserved tab names (`rules`, `branches`, `contract`, `usage`, `content`, `references`, `documentation`) anywhere in the current pathname using substring matching!

This caused incorrect tab selection when an artifact, group, or version identifier itself started with one of those reserved names (for example, `rules-schema` or `content-v1`), even though the URL was still pointing to the Overview route!

This PR replaces substring matching with route-aware matching using `useMatch`, ensuring that the active tab is determined by the actual matched route rather than arbitrary identifier prefixes!

## Changes

- Replace `pathname.indexOf(...)` active-tab detection with `useMatch(...)` in:
  - `ArtifactPage.tsx`
  - `GroupPage.tsx`
  - `VersionPage.tsx`
- Preserve the existing routing and navigation behaviour.
- Keep the change scoped only to active tab selection.

## Verification

Tested by:

- Opening Overview pages whose identifiers begin with reserved tab names
- Verifying that the correct Overview tab remains selected
- Verifying tab navigation still works correctly
- Running TypeScript and lint checks with no errors introduced by this change

## Notes

This PR intentionally leaves the existing `artifacts` branch in `GroupPage` unchanged, since it is unrelated to the reported bug and keeping the fix narrowly scoped reduces review risk..!