### PR TITLE
fix(ui): render object and array variable defaults as JSON in the Variables table

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
@@ -97,6 +97,15 @@ const getVariablesList = (variables: Record<string, PromptVariable> | PromptVari
     return Object.entries(variables).map(([name, variable]) => ({ name, variable }));
 };
 
+// Format a variable default for display in the Variables table.
+// Objects and arrays go through JSON.stringify so they don't render as "[object Object]".
+const formatDefault = (value: any): string => {
+    if (typeof value === "object" && value !== null) {
+        return JSON.stringify(value);
+    }
+    return String(value);
+};
+
 export const PromptTemplateViewer: FunctionComponent<PromptTemplateViewerProps> = (props: PromptTemplateViewerProps) => {
     const { promptTemplate, className } = props;
     const variablesList = getVariablesList(promptTemplate.variables);
@@ -189,7 +198,7 @@ export const PromptTemplateViewer: FunctionComponent<PromptTemplateViewerProps> 
                                                 )}
                                             </td>
                                             <td>{variable.default !== undefined ? (
-                                                <code>{String(variable.default)}</code>
+                                                <code>{formatDefault(variable.default)}</code>
                                             ) : "-"}</td>
                                             <td>{variable.description || "-"}</td>
                                         </tr>


### PR DESCRIPTION
Fixes #8941
The Default column in the Variables table (Documentation tab) used `String(variable.default)`, which returns `[object Object]` for any object and comma-joins array items (losing brackets and quotes). Any prompt template with an object or array default rendered incorrectly.
Added a small `formatDefault` helper that runs `JSON.stringify` for objects and arrays, and falls back to `String()` for primitives. Primitives (string, number, boolean) render exactly as before.
Verified locally with a template containing:
- string default (unchanged: `AI`)
- object default (was `[object Object]`, now `{"tone":"formal","length":"short"}`)
- array default (was `ml,ai`, now `["ml","ai"]`)