### PR TITLE
docs(rest-api): fix missing Maven flags in REST API docs build instructions (#8904)

### DIFF
--- a/docs/rest-api/readme.adoc
+++ b/docs/rest-api/readme.adoc
@@ -2,7 +2,7 @@
 
 To build and view the latest Apicurio Registry REST API documentation from the source code:   
 
-1. Build the Apicurio Registry project: `mvn clean install`
+1. Build the Apicurio Registry REST API documentation: `./mvnw clean install -pl docs/rest-api -am -DskipTests` (or `./mvnw clean install -Dfull -DskipTests`)
 2. Change directory to `apicurio-registry/docs/rest-api/target`
 3. Extract `apicurio-registry-docs-rest-api-<version>-static.zip` 
 4. Execute `run.sh`


### PR DESCRIPTION
## Description
Fixes #8904.

In `docs/rest-api/readme.adoc`, the instructions state to run `mvn clean install` to build the static REST API docs zip file. However, standard builds skip generating the zip unless `-pl docs/rest-api -am` or `-Dfull` is supplied.

This PR updates `docs/rest-api/readme.adoc` to specify the exact command required to build the REST API documentation locally.

## Contributor Checklist
- [x] Conventional Commits format (`docs(rest-api): fix missing Maven flags in REST API docs build instructions (#8904)`)
- [x] All commits have DCO sign-off (`Signed-off-by: ...`)
- [x] PR contains no unrelated changes
