### PR TITLE
fix(ci): resolve console-plugin parent POM in release image build

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -172,6 +172,10 @@ jobs:
 
       - name: Build and Push Multi-arch Console Plugin Images
         run: |
+          cp registry/pom.xml registry/console-plugin/root-pom.xml
+          if ! grep -q 'root-pom.xml' registry/console-plugin/Dockerfile; then
+            sed -i '/^COPY backend\/pom.xml pom.xml/i COPY root-pom.xml /opt/pom.xml' registry/console-plugin/Dockerfile
+          fi
           cd registry/console-plugin
           TAGS="-t quay.io/apicurio/apicurio-registry-console-plugin:$RELEASE_VERSION"
           TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-console-plugin:$MINOR_TAG"

--- a/console-plugin/.gitignore
+++ b/console-plugin/.gitignore
@@ -3,3 +3,4 @@ dist/
 .yarn/
 *.tgz
 package-lock.json
+root-pom.xml

--- a/console-plugin/Dockerfile
+++ b/console-plugin/Dockerfile
@@ -18,6 +18,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS java-builder
 USER 0
 WORKDIR /opt/app-root/src
 
+COPY root-pom.xml /opt/pom.xml
 COPY backend/pom.xml pom.xml
 COPY backend/src/ src/
 


### PR DESCRIPTION
## Summary

- The 3.3.1 `Release Images` workflow failed because the console-plugin Dockerfile builds the backend from source inside Docker, but the parent POM (`io.apicurio:apicurio-registry`) is not published to Maven Central and the `relativePath` (`../../pom.xml`) doesn't exist in the Docker context.
- Fix: copy the root `pom.xml` into the Docker context as `root-pom.xml` and place it at `/opt/pom.xml` inside the container, where the `relativePath` resolves to.
- The workflow also patches older Dockerfiles at runtime with `sed` so re-runs on tags that predate this fix (like 3.3.1) still work.

## Test plan

- [ ] Merge this PR
- [ ] Re-run `Release Images` workflow via `workflow_dispatch` with tag `3.3.1`
- [ ] Verify `apicurio-registry-console-plugin:3.3.1` and `apicurio-registry-ui:3.3.1` are published to quay.io