### PR TITLE
fix(ci): skip checkstyle in console-plugin Docker build

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -176,6 +176,9 @@ jobs:
           if ! grep -q 'root-pom.xml' registry/console-plugin/Dockerfile; then
             sed -i '/^COPY backend\/pom.xml pom.xml/i COPY root-pom.xml /opt/pom.xml' registry/console-plugin/Dockerfile
           fi
+          if ! grep -q 'checkstyle.skip' registry/console-plugin/Dockerfile; then
+            sed -i 's/mvn package -DskipTests -Dmaven.javadoc.skip/mvn package -DskipTests -Dmaven.javadoc.skip -Dcheckstyle.skip/' registry/console-plugin/Dockerfile
+          fi
           cd registry/console-plugin
           TAGS="-t quay.io/apicurio/apicurio-registry-console-plugin:$RELEASE_VERSION"
           TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-console-plugin:$MINOR_TAG"

--- a/console-plugin/Dockerfile
+++ b/console-plugin/Dockerfile
@@ -26,7 +26,7 @@ COPY backend/src/ src/
 COPY --from=web-builder /opt/app-root/src/dist/ src/main/resources/META-INF/resources/
 
 # Build Quarkus app (fast-jar packaging)
-RUN mvn package -DskipTests -Dmaven.javadoc.skip
+RUN mvn package -DskipTests -Dmaven.javadoc.skip -Dcheckstyle.skip
 
 # Stage 3: Final image
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest


### PR DESCRIPTION
## Summary

- Follow-up to #8945. The parent POM fix worked, but the Maven build inside Docker now fails on checkstyle because `suppressions.xml` is referenced via a relative path (`../../.checkstyle/`) that doesn't exist in the Docker context.
- Fix: add `-Dcheckstyle.skip` to `mvn package` in the Dockerfile. Checkstyle has already passed in CI before the release.
- The workflow also patches older Dockerfiles at runtime with `sed` for re-runs on tags that predate this fix (3.3.1).

## Test plan

- [ ] Merge this PR
- [ ] Re-run `Release Images` workflow via `workflow_dispatch` with tag `3.3.1`
- [ ] Verify `apicurio-registry-console-plugin:3.3.1` and `apicurio-registry-ui:3.3.1` are published to quay.io