### PR TITLE
fix(ui): add path="*" to Not Found route so unknown URLs render 404 page

### DIFF
--- a/ui/ui-app/src/app/MainPageWithAuth.tsx
+++ b/ui/ui-app/src/app/MainPageWithAuth.tsx
@@ -134,7 +134,7 @@ export const MainPageWithAuth: FunctionComponent<MainPageWithAuthProps> = () => 
                         />
 
 
-                        <Route element={ <NotFoundPage /> } />
+                        <Route path="*" element={ <NotFoundPage /> } />
                     </Routes>
                 </Page>
             </ApplicationAuth>


### PR DESCRIPTION
Fixes #8931

## Root cause

In react-router v7, a `<Route>` with no `path` and no `index` is a pathless
layout route that only renders when one of its child routes matches. The
`NotFoundPage` route had no children, so it never matched anything.

Navigating to any unknown URL left the content area blank — the masthead
rendered but nothing else did.

## Fix

Add `path="*"` to the fallback route, making it a standard catch-all.
`NotFoundPage` renders inside the existing `<ApplicationAuth>` and
`<Page masthead={<AppHeader />}>` wrappers, so the full app shell stays intact.

## Testing

- ESLint: clean (0 errors, 0 warnings)
- No UI unit tests exist in this repo for this component
- Manually verified: navigating to `/does-not-exist` now renders the 404 page
  with the "Show all artifacts" button