### PR TITLE
Fix OIDC token endpoint trailing slash handling

### DIFF
--- a/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
@@ -92,9 +92,9 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
             tokenUrl = authConfig.oidcTokenPath;
         } else {
             tokenUrl = authConfig.authServerUrl + authConfig.oidcTokenPath;
-        }
-        while (tokenUrl.endsWith("/")) {
-            tokenUrl = tokenUrl.substring(0, tokenUrl.length() - 1);
+            while (tokenUrl.endsWith("/")) {
+                tokenUrl = tokenUrl.substring(0, tokenUrl.length() - 1);
+            }
         }
         this.oidcTokenUrl = tokenUrl;
     }

--- a/app/src/test/java/io/apicurio/registry/auth/OidcAuthenticationStrategyTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/OidcAuthenticationStrategyTest.java
@@ -1,0 +1,45 @@
+package io.apicurio.registry.auth;
+
+import org.junit.jupiter.api.Test;
+import java.lang.reflect.Field;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OidcAuthenticationStrategyTest {
+
+    @Test
+    void testOidcTokenUrlConstruction() throws Exception {
+        // Case 1: Relative Path
+        AuthConfig config1 = new AuthConfig();
+        config1.authServerUrl = "http://keycloak/auth";
+        config1.oidcTokenPath = "/token";
+        OidcAuthenticationStrategy strategy1 = new OidcAuthenticationStrategy(null, config1, null, null, null, null);
+        assertEquals("http://keycloak/auth/token", getOidcTokenUrl(strategy1));
+
+        // Case 2: Relative Path with Trailing Slash
+        AuthConfig config2 = new AuthConfig();
+        config2.authServerUrl = "http://keycloak/auth";
+        config2.oidcTokenPath = "/token/";
+        OidcAuthenticationStrategy strategy2 = new OidcAuthenticationStrategy(null, config2, null, null, null, null);
+        assertEquals("http://keycloak/auth/token", getOidcTokenUrl(strategy2));
+
+        // Case 3: Absolute URL
+        AuthConfig config3 = new AuthConfig();
+        config3.authServerUrl = "http://keycloak/auth"; // Should be ignored
+        config3.oidcTokenPath = "http://authentik/token";
+        OidcAuthenticationStrategy strategy3 = new OidcAuthenticationStrategy(null, config3, null, null, null, null);
+        assertEquals("http://authentik/token", getOidcTokenUrl(strategy3));
+
+        // Case 4: Absolute URL with Trailing Slash
+        AuthConfig config4 = new AuthConfig();
+        config4.authServerUrl = "http://keycloak/auth"; // Should be ignored
+        config4.oidcTokenPath = "http://authentik/token/";
+        OidcAuthenticationStrategy strategy4 = new OidcAuthenticationStrategy(null, config4, null, null, null, null);
+        assertEquals("http://authentik/token/", getOidcTokenUrl(strategy4));
+    }
+
+    private String getOidcTokenUrl(OidcAuthenticationStrategy strategy) throws Exception {
+        Field field = OidcAuthenticationStrategy.class.getDeclaredField("oidcTokenUrl");
+        field.setAccessible(true);
+        return (String) field.get(strategy);
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses #8939 by preserving explicitly configured absolute OIDC token endpoint URLs exactly as provided, while retaining the existing trailing-slash normalization for URLs constructed from `authServerUrl + oidcTokenPath`.

The current implementation strips trailing slashes unconditionally, which causes providers such as Authentik to reject client credential requests when the configured token endpoint requires the trailing slash.

## Changes

- Preserve absolute `quarkus.oidc.token-path` values exactly as configured.
- Continue applying trailing-slash normalization only for constructed relative URLs.
- Added a regression test covering both absolute and relative URL handling.

## Why this approach?

The existing normalization remains unchanged for the common relative-path configuration, preserving current behavior.

For users who explicitly configure an absolute token endpoint URL, the configuration is now respected exactly as provided, which restores compatibility with providers such as Authentik that require the trailing slash.

This follows one of the approaches suggested in the original issue while keeping the change minimal and localized.

Fixes #8939.

---

This is my first contribution to Apicurio Registry, so if there's a project-specific convention or a different approach you'd prefer, I'd be happy to update the implementation. Thanks for taking the time to review it!