### PR TITLE
fix(kafkasql): publish contract metadata and status events

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -182,9 +182,6 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     io.apicurio.registry.contracts.migration.MigrationRuleService migrationRuleService;
 
     @Inject
-    jakarta.enterprise.event.Event<io.apicurio.registry.storage.impl.sql.SqlOutboxEvent> contractOutboxEvent;
-
-    @Inject
     io.apicurio.registry.contracts.audit.ContractAuditService contractAuditService;
 
     /**
@@ -2013,8 +2010,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         storage.mergeArtifactLabels(rawGroupId, artifactId, prefix, contractLabels);
 
         // Fire metadata updated event
-        contractOutboxEvent.fire(io.apicurio.registry.storage.impl.sql.SqlOutboxEvent.of(
-                io.apicurio.registry.events.ContractMetadataUpdated.of(rawGroupId, artifactId)));
+        storage.createEvent(io.apicurio.registry.events.ContractMetadataUpdated.of(rawGroupId, artifactId));
 
         // Audit log
         contractAuditService.recordAction(rawGroupId, artifactId, null,
@@ -2161,11 +2157,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         }
 
         // Fire status changed event
-        contractOutboxEvent.fire(io.apicurio.registry.storage.impl.sql.SqlOutboxEvent.of(
-                io.apicurio.registry.events.ContractStatusChanged.of(rawGroupId, artifactId,
-                        currentMetadata.getStatus() != null
-                                ? currentMetadata.getStatus().name() : null,
-                        targetStatus.name())));
+        storage.createEvent(io.apicurio.registry.events.ContractStatusChanged.of(rawGroupId, artifactId,
+                currentMetadata.getStatus() != null ? currentMetadata.getStatus().name() : null,
+                targetStatus.name()));
 
         // Audit log
         contractAuditService.recordAction(rawGroupId, artifactId, null,

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -1294,7 +1294,7 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
 
     @Override
     public String createEvent(OutboxEvent event) {
-        // No op, the event is created by the event processor.
+        outboxEvent.fire(KafkaSqlOutboxEvent.of(event));
         return event.getId();
     }
 

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlContractEventsTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlContractEventsTest.java
@@ -1,0 +1,92 @@
+package io.apicurio.registry.storage.impl.kafkasql;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.KafkasqlTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+@TestProfile(KafkasqlTestProfile.class)
+public class KafkaSqlContractEventsTest extends AbstractResourceTestBase {
+
+    private static final String EVENTS_TOPIC = "registry-events";
+    private static final String GROUP = "default";
+
+    @Test
+    public void testContractEventsArePublished() throws Exception {
+        String artifactId = "contract-events-" + UUID.randomUUID();
+
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(
+                Map.of(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                        System.getProperty("bootstrap.servers.external"),
+                        ConsumerConfig.GROUP_ID_CONFIG, "tc-" + UUID.randomUUID(),
+                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
+                new StringDeserializer(), new StringDeserializer());
+        try {
+            consumer.subscribe(List.of(EVENTS_TOPIC));
+
+            createArtifact(GROUP, artifactId, ArtifactType.JSON, "{\"type\":\"object\"}",
+                    ContentTypes.APPLICATION_JSON);
+
+            given().when().contentType("application/json").pathParam("groupId", GROUP)
+                    .pathParam("artifactId", artifactId)
+                    .body("{\"status\": \"STABLE\", \"ownerTeam\": \"events-test\"}")
+                    .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata").then()
+                    .statusCode(200);
+
+            given().when().contentType("application/json").pathParam("groupId", GROUP)
+                    .pathParam("artifactId", artifactId).body("{\"status\": \"DEPRECATED\"}")
+                    .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/status").then()
+                    .statusCode(200);
+
+            List<String> events = consumeEvents(consumer, artifactId);
+
+            Assertions.assertTrue(
+                    events.stream().anyMatch(e -> e.contains("CONTRACT_METADATA_UPDATED")),
+                    "Expected a CONTRACT_METADATA_UPDATED event for artifact " + artifactId
+                            + " on the " + EVENTS_TOPIC + " topic. Events found: " + events);
+            Assertions.assertTrue(events.stream().anyMatch(e -> e.contains("CONTRACT_STATUS_CHANGED")),
+                    "Expected a CONTRACT_STATUS_CHANGED event for artifact " + artifactId + " on the "
+                            + EVENTS_TOPIC + " topic. Events found: " + events);
+        } finally {
+            consumer.close();
+        }
+    }
+
+    /**
+     * Collects the events published for the given artifact, waiting until both contract events have
+     * been seen or the timeout expires.
+     */
+    private List<String> consumeEvents(KafkaConsumer<String, String> consumer, String artifactId) {
+        List<String> events = new ArrayList<>();
+        long deadline = System.currentTimeMillis() + 20000;
+        while (System.currentTimeMillis() < deadline) {
+            for (ConsumerRecord<String, String> consumerRecord : consumer.poll(Duration.ofMillis(500))) {
+                if (consumerRecord.value() != null && consumerRecord.value().contains(artifactId)) {
+                    events.add(consumerRecord.value());
+                }
+            }
+            if (events.stream().anyMatch(e -> e.contains("CONTRACT_METADATA_UPDATED"))
+                    && events.stream().anyMatch(e -> e.contains("CONTRACT_STATUS_CHANGED"))) {
+                break;
+            }
+        }
+        return events;
+    }
+}


### PR DESCRIPTION
Fixes #8928

## Problem

On the KafkaSQL storage variant, updating a contract's metadata or transitioning its contract status does not emit the corresponding CONTRACT_METADATA_UPDATED and CONTRACT_STATUS_CHANGED events to the registry-events topic.

Both operations complete successfully (200 OK) and persist their changes. Other registry events (for example, artifact and version creation) are published as expected, but these two contract events are missing.

The events were fired directly from the REST layer (GroupsResourceImpl) as a SqlOutboxEvent. That event type is only processed by SqlEventsProcessor. On KafkaSQL, it is routed to the embedded SQL store (where database events are not enabled) and is therefore never published. Meanwhile, KafkaSqlEventsProcessor only handles KafkaSqlOutboxEvent, so the events never reach the registry-events topic.

Unlike other registry events, these two contract events bypassed the storage abstraction and were tied directly to the SQL implementation.

## Fix

- Route contract metadata and contract status events through RegistryStorage.createEvent(...) instead of publishing a hardcoded SqlOutboxEvent.

- Implement createEvent(...) in KafkaSqlRegistryStorage so KafkaSQL publishes these events instead of ignoring them.

- Keep the SQL implementation unchanged; it continues to persist outbox events through the existing event repository, guarded by supportsDatabaseEvents().

This removes the storage-specific event publishing logic from the REST layer and allows each storage implementation to publish events using its own mechanism.

## Testing

Added `KafkaSqlContractEventsTest`, which drives the public REST endpoints (create artifact, update contract metadata, transition contract status) and asserts that both `CONTRACT_METADATA_UPDATED` and `CONTRACT_STATUS_CHANGED` are published to the `registry-events` topic. The test fails before this change (neither event is produced) and passes after it.

Verified locally:

    ./mvnw test -pl app -am \
      -Dtest=KafkaSqlContractEventsTest \
      -Dsurefire.failIfNoSpecifiedTests=false
    ./mvnw checkstyle:check -pl app

## Note

The SQL variant continues to write the outbox row via `createEvent` as before. On KafkaSQL, the event is now published to `registry-events` in the same way as the other registry events.