### PR TITLE
fix(ci): make ci-settings.xml optional in release workflows

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -79,10 +79,21 @@ jobs:
           git config --global user.email "apicurio.ci@gmail.com"
           git clone --branch ${{ needs.prepare.outputs.release-version }} --single-branch https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git registry
 
+      # Backward compatibility: ci-settings.xml was added after 3.3.1 (#8556) and may not
+      # exist in older release tags. Remove this guard once all supported tags include the file.
+      - name: Resolve Maven settings
+        run: |
+          SETTINGS_FILE="${{ github.workspace }}/registry/.github/ci-settings.xml"
+          if [ -f "$SETTINGS_FILE" ]; then
+            echo "MVN_SETTINGS=-s $SETTINGS_FILE" >> $GITHUB_ENV
+          else
+            echo "MVN_SETTINGS=" >> $GITHUB_ENV
+          fi
+
       - name: Verify Project Version
         run: |
           cd registry
-          PROJECT_VERSION=$(mvn -s ${{ github.workspace }}/registry/.github/ci-settings.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+          PROJECT_VERSION=$(mvn $MVN_SETTINGS help:evaluate -Dexpression=project.version -q -DforceStdout)
           if [[ $PROJECT_VERSION != ${{ needs.prepare.outputs.release-version }} ]]; then
             echo "ERROR: Project Version '${PROJECT_VERSION}' does not match"
             exit 1
@@ -136,6 +147,17 @@ jobs:
           git config --global user.email "apicurio.ci@gmail.com"
           git clone --branch ${{ needs.prepare.outputs.release-version }} --single-branch https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git registry
 
+      # Backward compatibility: ci-settings.xml was added after 3.3.1 (#8556) and may not
+      # exist in older release tags. Remove this guard once all supported tags include the file.
+      - name: Resolve Maven settings
+        run: |
+          SETTINGS_FILE="${{ github.workspace }}/registry/.github/ci-settings.xml"
+          if [ -f "$SETTINGS_FILE" ]; then
+            echo "MVN_SETTINGS=-s $SETTINGS_FILE" >> $GITHUB_ENV
+          else
+            echo "MVN_SETTINGS=" >> $GITHUB_ENV
+          fi
+
       - name: Checkout SBOMs Repo
         run: |
           git clone --branch main --single-branch https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-sboms.git sboms
@@ -156,13 +178,13 @@ jobs:
       - name: Maven Install
         run: |
           cd registry
-          mvn -s ${{ github.workspace }}/registry/.github/ci-settings.xml install -pl app -am -Pprod -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress
+          mvn $MVN_SETTINGS install -pl app -am -Pprod -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress
 
       - name: Generate Maven SBOMs
         run: |
           mkdir -p $SBOM_OUTPUT_DIR
           cd registry
-          mvn -s ${{ github.workspace }}/registry/.github/ci-settings.xml -f app/pom.xml dependency:tree -DoutputType=dot -Dscope=runtime -DoutputFile=$SBOM_OUTPUT_DIR/apicurio-registry-app-${{ needs.prepare.outputs.release-version }}.runtime.sbom.dot
+          mvn $MVN_SETTINGS -f app/pom.xml dependency:tree -DoutputType=dot -Dscope=runtime -DoutputFile=$SBOM_OUTPUT_DIR/apicurio-registry-app-${{ needs.prepare.outputs.release-version }}.runtime.sbom.dot
 
       - name: Generate npm SBOMs
         run: |
@@ -195,10 +217,21 @@ jobs:
           git config --global user.email "apicurio.ci@gmail.com"
           git clone --branch ${{ needs.prepare.outputs.release-version }} --single-branch https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git registry
 
+      # Backward compatibility: ci-settings.xml was added after 3.3.1 (#8556) and may not
+      # exist in older release tags. Remove this guard once all supported tags include the file.
+      - name: Resolve Maven settings
+        run: |
+          SETTINGS_FILE="${{ github.workspace }}/registry/.github/ci-settings.xml"
+          if [ -f "$SETTINGS_FILE" ]; then
+            echo "MVN_SETTINGS=-s $SETTINGS_FILE" >> $GITHUB_ENV
+          else
+            echo "MVN_SETTINGS=" >> $GITHUB_ENV
+          fi
+
       - name: Verify Project Version
         run: |
           cd registry
-          PROJECT_VERSION=$(mvn -s ${{ github.workspace }}/registry/.github/ci-settings.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+          PROJECT_VERSION=$(mvn $MVN_SETTINGS help:evaluate -Dexpression=project.version -q -DforceStdout)
           if [[ $PROJECT_VERSION != ${{ needs.prepare.outputs.release-version }} ]]; then
             echo "ERROR: Project Version '${PROJECT_VERSION}' does not match"
             exit 1
@@ -213,9 +246,9 @@ jobs:
       - name: Generate Maven Site
         run: |
           cd registry
-          mvn -s ${{ github.workspace }}/registry/.github/ci-settings.xml clean install -pl utils/maven-plugin -am -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress
+          mvn $MVN_SETTINGS clean install -pl utils/maven-plugin -am -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress
           cd utils/maven-plugin
-          mvn -s ${{ github.workspace }}/registry/.github/ci-settings.xml site --no-transfer-progress
+          mvn $MVN_SETTINGS site --no-transfer-progress
 
       - name: Apicurio Website Checkout
         run: |

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -87,12 +87,23 @@ jobs:
       - name: Download Source Code
         run: git clone --branch $RELEASE_VERSION --single-branch ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git registry
 
+      # Backward compatibility: ci-settings.xml was added after 3.3.1 (#8556) and may not
+      # exist in older release tags. Remove this guard once all supported tags include the file.
+      - name: Resolve Maven settings
+        run: |
+          SETTINGS_FILE="${{ github.workspace }}/registry/.github/ci-settings.xml"
+          if [ -f "$SETTINGS_FILE" ]; then
+            echo "MVN_SETTINGS=-s $SETTINGS_FILE" >> $GITHUB_ENV
+          else
+            echo "MVN_SETTINGS=" >> $GITHUB_ENV
+          fi
+
       # We have faced issues in the past where a github release was created from a wrong commit
       # This step will ensure that the release was created from the right commit
       - name: Verify Project Version
         run: |
           cd registry
-          PROJECT_VERSION=$(mvn -s ${{ github.workspace }}/registry/.github/ci-settings.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+          PROJECT_VERSION=$(mvn $MVN_SETTINGS help:evaluate -Dexpression=project.version -q -DforceStdout)
           if [[ $PROJECT_VERSION != $RELEASE_VERSION ]]
           then
               echo "ERROR: Project Version '${PROJECT_VERSION}' does not match with Released Version '${RELEASE_VERSION}'"
@@ -115,7 +126,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For downloading Kiota binary.
         working-directory: registry
         run: |
-          ./mvnw -s ${{ github.workspace }}/registry/.github/ci-settings.xml clean package -am --no-transfer-progress -Pprod -Dfull -DskipTests -DskipCommitIdPlugin=false -DcliSkipNative \
+          ./mvnw $MVN_SETTINGS clean package -am --no-transfer-progress -Pprod -Dfull -DskipTests -DskipCommitIdPlugin=false -DcliSkipNative \
             -Daether.syncContext.named.factory=noop \
             -Dmaven.wagon.httpconnectionManager.maxTotal=30 -Dmaven.wagon.http.retryHandler.count=5
 

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -61,10 +61,21 @@ jobs:
             fi
           fi
 
+      # Backward compatibility: ci-settings.xml was added after 3.3.1 (#8556) and may not
+      # exist in older release tags. Remove this guard once all supported tags include the file.
+      - name: Resolve Maven settings
+        run: |
+          SETTINGS_FILE="${{ github.workspace }}/registry/.github/ci-settings.xml"
+          if [ -f "$SETTINGS_FILE" ]; then
+            echo "MVN_SETTINGS=-s $SETTINGS_FILE" >> $GITHUB_ENV
+          else
+            echo "MVN_SETTINGS=" >> $GITHUB_ENV
+          fi
+
       - name: Verify Project Version
         working-directory: registry
         run: |
-          PROJECT_VERSION="$(mvn -s ${{ github.workspace }}/registry/.github/ci-settings.xml help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          PROJECT_VERSION="$(mvn $MVN_SETTINGS help:evaluate -Dexpression=project.version -q -DforceStdout)"
           if [[ "$PROJECT_VERSION" != "$RELEASE_VERSION" ]]
           then
               echo "ERROR: Project version $PROJECT_VERSION does not match released version $RELEASE_VERSION"

--- a/.github/workflows/release-sdks.yaml
+++ b/.github/workflows/release-sdks.yaml
@@ -77,10 +77,21 @@ jobs:
           git config --global user.email "apicurio.ci@gmail.com"
           git clone --branch ${{ needs.prepare.outputs.release-version }} --single-branch https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git registry
 
+      # Backward compatibility: ci-settings.xml was added after 3.3.1 (#8556) and may not
+      # exist in older release tags. Remove this guard once all supported tags include the file.
+      - name: Resolve Maven settings
+        run: |
+          SETTINGS_FILE="${{ github.workspace }}/registry/.github/ci-settings.xml"
+          if [ -f "$SETTINGS_FILE" ]; then
+            echo "MVN_SETTINGS=-s $SETTINGS_FILE" >> $GITHUB_ENV
+          else
+            echo "MVN_SETTINGS=" >> $GITHUB_ENV
+          fi
+
       - name: Verify Project Version
         run: |
           cd registry
-          PROJECT_VERSION=$(mvn -s ${{ github.workspace }}/registry/.github/ci-settings.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+          PROJECT_VERSION=$(mvn $MVN_SETTINGS help:evaluate -Dexpression=project.version -q -DforceStdout)
           if [[ $PROJECT_VERSION != ${{ needs.prepare.outputs.release-version }} ]]; then
             echo "ERROR: Project Version '${PROJECT_VERSION}' does not match with Released Version '${{ needs.prepare.outputs.release-version }}'"
             exit 1
@@ -124,10 +135,21 @@ jobs:
           git config --global user.email "apicurio.ci@gmail.com"
           git clone --branch ${{ needs.prepare.outputs.release-version }} --single-branch https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git registry
 
+      # Backward compatibility: ci-settings.xml was added after 3.3.1 (#8556) and may not
+      # exist in older release tags. Remove this guard once all supported tags include the file.
+      - name: Resolve Maven settings
+        run: |
+          SETTINGS_FILE="${{ github.workspace }}/registry/.github/ci-settings.xml"
+          if [ -f "$SETTINGS_FILE" ]; then
+            echo "MVN_SETTINGS=-s $SETTINGS_FILE" >> $GITHUB_ENV
+          else
+            echo "MVN_SETTINGS=" >> $GITHUB_ENV
+          fi
+
       - name: Verify Project Version
         run: |
           cd registry
-          PROJECT_VERSION=$(mvn -s ${{ github.workspace }}/registry/.github/ci-settings.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+          PROJECT_VERSION=$(mvn $MVN_SETTINGS help:evaluate -Dexpression=project.version -q -DforceStdout)
           if [[ $PROJECT_VERSION != ${{ needs.prepare.outputs.release-version }} ]]; then
             echo "ERROR: Project Version '${PROJECT_VERSION}' does not match with Released Version '${{ needs.prepare.outputs.release-version }}'"
             exit 1
@@ -193,10 +215,21 @@ jobs:
           git config --global user.email "apicurio.ci@gmail.com"
           git clone --branch ${{ needs.prepare.outputs.release-version }} --single-branch https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio-registry.git registry
 
+      # Backward compatibility: ci-settings.xml was added after 3.3.1 (#8556) and may not
+      # exist in older release tags. Remove this guard once all supported tags include the file.
+      - name: Resolve Maven settings
+        run: |
+          SETTINGS_FILE="${{ github.workspace }}/registry/.github/ci-settings.xml"
+          if [ -f "$SETTINGS_FILE" ]; then
+            echo "MVN_SETTINGS=-s $SETTINGS_FILE" >> $GITHUB_ENV
+          else
+            echo "MVN_SETTINGS=" >> $GITHUB_ENV
+          fi
+
       - name: Verify Project Version
         run: |
           cd registry
-          PROJECT_VERSION=$(mvn -s ${{ github.workspace }}/registry/.github/ci-settings.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+          PROJECT_VERSION=$(mvn $MVN_SETTINGS help:evaluate -Dexpression=project.version -q -DforceStdout)
           if [[ $PROJECT_VERSION != ${{ needs.prepare.outputs.release-version }} ]]; then
             echo "ERROR: Project Version '${PROJECT_VERSION}' does not match with Released Version '${{ needs.prepare.outputs.release-version }}'"
             exit 1


### PR DESCRIPTION
## Summary

- Make `.github/ci-settings.xml` usage optional in all release workflows so re-runs against older tags (before #8556) don't fail
- Adds a "Resolve Maven settings" step that sets `$MVN_SETTINGS` only if the file exists in the cloned source

## Problem

PR #8556 added `-s .../ci-settings.xml` to all `mvn` commands in release workflows. The file exists on `main` but not in older release tags (e.g. `3.3.1`). Since `workflow_dispatch` re-runs use the workflow YAML from `main` but clone source from the release tag, every `mvn` invocation fails because the settings file doesn't exist.

This broke the 3.3.1 Release Images re-run at the "Verify Project Version" step.

## Changes

All 4 release workflows (`release-images`, `release-operator`, `release-artifacts`, `release-sdks`):
- Added a "Resolve Maven settings" step after source code checkout that checks if `ci-settings.xml` exists and sets `MVN_SETTINGS` accordingly
- Replaced all hardcoded `-s .../ci-settings.xml` with `$MVN_SETTINGS` (12 occurrences total)
- Added a comment noting the guard can be removed once all supported release tags include the file

## Test plan

- [ ] Verify workflow YAML syntax is valid (CI will check)
- [ ] Re-run Release Images with tag `3.3.1` — should now pass the "Verify Project Version" step
- [ ] Future releases from `main` will have `ci-settings.xml` present and use it normally