### PR TITLE
test(app): fix compilation errors in DataContractsResourceTest

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/DataContractsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/DataContractsResourceTest.java
@@ -1,11 +1,27 @@
 package io.apicurio.registry.noprofile.rest.v3;
 
+import static io.apicurio.registry.rest.v3.beans.ContractRule.Kind.CONDITION;
+import static io.apicurio.registry.rest.v3.beans.ContractRule.Kind.TRANSFORM;
+import static io.apicurio.registry.rest.v3.beans.ContractRule.Mode.READ;
+import static io.apicurio.registry.rest.v3.beans.ContractRule.Mode.UPGRADE;
+import static io.apicurio.registry.rest.v3.beans.ContractRule.Mode.WRITE;
+import static io.apicurio.registry.rest.v3.beans.ContractRule.Mode.WRITEREAD;
+import static io.apicurio.registry.rest.v3.beans.EditableContractMetadata.Classification.CONFIDENTIAL;
+import static io.apicurio.registry.rest.v3.beans.EditableContractMetadata.Classification.INTERNAL;
+import static io.apicurio.registry.rest.v3.beans.EditableContractMetadata.Stage.DEV;
+
 import io.apicurio.registry.AbstractResourceTestBase;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.rest.v3.beans.ContractRule;
+import io.apicurio.registry.rest.v3.beans.ContractRuleSet;
+import io.apicurio.registry.rest.v3.beans.Params;
+import io.apicurio.registry.rest.v3.beans.ContractStatusTransition;
+import io.apicurio.registry.rest.v3.beans.EditableContractMetadata;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
@@ -53,16 +69,14 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
-                .body("""
-                        {
-                            "status": "DRAFT",
-                            "ownerTeam": "platform-team",
-                            "ownerDomain": "payments",
-                            "supportContact": "platform@example.com",
-                            "classification": "INTERNAL",
-                            "stage": "DEV"
-                        }
-                        """)
+                .body(EditableContractMetadata.builder()
+                        .status(EditableContractMetadata.Status.DRAFT)
+                        .ownerTeam("platform-team")
+                        .ownerDomain("payments")
+                        .supportContact("platform@example.com")
+                        .classification(INTERNAL)
+                        .stage(DEV)
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then()
                 .statusCode(200)
@@ -98,12 +112,10 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
-                .body("""
-                        {
-                            "status": "DRAFT",
-                            "ownerTeam": "team-alpha"
-                        }
-                        """)
+                .body(EditableContractMetadata.builder()
+                        .status(EditableContractMetadata.Status.DRAFT)
+                        .ownerTeam("team-alpha")
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then()
                 .statusCode(200);
@@ -114,13 +126,11 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
-                .body("""
-                        {
-                            "status": "STABLE",
-                            "ownerTeam": "team-beta",
-                            "classification": "CONFIDENTIAL"
-                        }
-                        """)
+                .body(EditableContractMetadata.builder()
+                        .status(EditableContractMetadata.Status.STABLE)
+                        .ownerTeam("team-beta")
+                        .classification(CONFIDENTIAL)
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then()
                 .statusCode(200)
@@ -154,39 +164,40 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
         String content = resourceToString("openapi-empty.json");
         createArtifact(GROUP, artifactId, ArtifactType.OPENAPI, content, ContentTypes.APPLICATION_JSON);
 
+        Params migrationParams = new Params();
+        migrationParams.setAdditionalProperty("targetField", "newField");
+
         // Set ruleset
         given()
                 .when()
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
-                .body("""
-                        {
-                            "domainRules": [
-                                {
-                                    "name": "validate-email",
-                                    "kind": "CONDITION",
-                                    "type": "CEL",
-                                    "mode": "WRITE",
-                                    "expr": "message.email.matches('^[a-zA-Z0-9+_.-]+@[a-zA-Z0-9.-]+$')",
-                                    "tags": ["email", "validation"],
-                                    "onFailure": "ERROR"
-                                }
-                            ],
-                            "migrationRules": [
-                                {
-                                    "name": "add-default-field",
-                                    "kind": "TRANSFORM",
-                                    "type": "CEL_FIELD",
-                                    "mode": "UPGRADE",
-                                    "expr": "has(message.newField) ? message.newField : 'default'",
-                                    "params": {"targetField": "newField"},
-                                    "onSuccess": "NONE",
-                                    "onFailure": "DLQ"
-                                }
-                            ]
-                        }
-                        """)
+                .body(ContractRuleSet.builder()
+                        .domainRules(List.of(
+                                ContractRule.builder()
+                                        .name("validate-email")
+                                        .kind(CONDITION)
+                                        .type("CEL")
+                                        .mode(WRITE)
+                                        .expr("message.email.matches('^[a-zA-Z0-9+_.-]+@[a-zA-Z0-9.-]+$')")
+                                        .tags(List.of("email", "validation"))
+                                        .onFailure(ContractRule.OnFailure.ERROR)
+                                        .build()
+                        ))
+                        .migrationRules(List.of(
+                                ContractRule.builder()
+                                        .name("add-default-field")
+                                        .kind(TRANSFORM)
+                                        .type("CEL_FIELD")
+                                        .mode(UPGRADE)
+                                        .expr("has(message.newField) ? message.newField : 'default'")
+                                        .params(migrationParams)
+                                        .onSuccess(ContractRule.OnSuccess.NONE)
+                                        .onFailure(ContractRule.OnFailure.DLQ)
+                                        .build()
+                        ))
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
                 .then()
                 .statusCode(200)
@@ -225,19 +236,17 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
-                .body("""
-                        {
-                            "domainRules": [
-                                {
-                                    "name": "rule1",
-                                    "kind": "CONDITION",
-                                    "type": "CEL",
-                                    "mode": "WRITE"
-                                }
-                            ],
-                            "migrationRules": []
-                        }
-                        """)
+                .body(ContractRuleSet.builder()
+                        .domainRules(List.of(
+                                ContractRule.builder()
+                                        .name("rule1")
+                                        .kind(CONDITION)
+                                        .type("CEL")
+                                        .mode(WRITE)
+                                        .build()
+                        ))
+                        .migrationRules(List.of())
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
                 .then()
                 .statusCode(200);
@@ -280,20 +289,18 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .pathParam("version", version)
-                .body("""
-                        {
-                            "domainRules": [
-                                {
-                                    "name": "version-rule",
-                                    "kind": "CONDITION",
-                                    "type": "CEL",
-                                    "mode": "READ",
-                                    "disabled": true
-                                }
-                            ],
-                            "migrationRules": []
-                        }
-                        """)
+                .body(ContractRuleSet.builder()
+                        .domainRules(List.of(
+                                ContractRule.builder()
+                                        .name("version-rule")
+                                        .kind(CONDITION)
+                                        .type("CEL")
+                                        .mode(READ)
+                                        .disabled(true)
+                                        .build()
+                        ))
+                        .migrationRules(List.of())
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{version}/contract/ruleset")
                 .then()
                 .statusCode(200)
@@ -329,19 +336,17 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .pathParam("version", version)
-                .body("""
-                        {
-                            "domainRules": [
-                                {
-                                    "name": "temp-rule",
-                                    "kind": "TRANSFORM",
-                                    "type": "CEL_FIELD",
-                                    "mode": "WRITEREAD"
-                                }
-                            ],
-                            "migrationRules": []
-                        }
-                        """)
+                .body(ContractRuleSet.builder()
+                        .domainRules(List.of(
+                                ContractRule.builder()
+                                        .name("temp-rule")
+                                        .kind(TRANSFORM)
+                                        .type("CEL_FIELD")
+                                        .mode(WRITEREAD)
+                                        .build()
+                        ))
+                        .migrationRules(List.of())
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{version}/contract/ruleset")
                 .then()
                 .statusCode(200);
@@ -383,14 +388,17 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
-                .body("""
-                        {
-                            "domainRules": [
-                                {"name": "artifact-rule", "kind": "CONDITION", "type": "CEL", "mode": "WRITE"}
-                            ],
-                            "migrationRules": []
-                        }
-                        """)
+                .body(ContractRuleSet.builder()
+                        .domainRules(List.of(
+                                ContractRule.builder()
+                                        .name("artifact-rule")
+                                        .kind(CONDITION)
+                                        .type("CEL")
+                                        .mode(WRITE)
+                                        .build()
+                        ))
+                        .migrationRules(List.of())
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
                 .then()
                 .statusCode(200);
@@ -402,14 +410,17 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
                 .pathParam("version", version)
-                .body("""
-                        {
-                            "domainRules": [
-                                {"name": "version-rule", "kind": "TRANSFORM", "type": "CEL_FIELD", "mode": "READ"}
-                            ],
-                            "migrationRules": []
-                        }
-                        """)
+                .body(ContractRuleSet.builder()
+                        .domainRules(List.of(
+                                ContractRule.builder()
+                                        .name("version-rule")
+                                        .kind(TRANSFORM)
+                                        .type("CEL_FIELD")
+                                        .mode(READ)
+                                        .build()
+                        ))
+                        .migrationRules(List.of())
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{version}/contract/ruleset")
                 .then()
                 .statusCode(200);
@@ -470,15 +481,23 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
-                .body("""
-                        {
-                            "domainRules": [
-                                {"name": "rule-1", "kind": "CONDITION", "type": "CEL", "mode": "WRITE"},
-                                {"name": "rule-2", "kind": "CONDITION", "type": "CEL", "mode": "READ"}
-                            ],
-                            "migrationRules": []
-                        }
-                        """)
+                .body(ContractRuleSet.builder()
+                        .domainRules(List.of(
+                                ContractRule.builder()
+                                        .name("rule-1")
+                                        .kind(CONDITION)
+                                        .type("CEL")
+                                        .mode(WRITE)
+                                        .build(),
+                                ContractRule.builder()
+                                        .name("rule-2")
+                                        .kind(CONDITION)
+                                        .type("CEL")
+                                        .mode(READ)
+                                        .build()
+                        ))
+                        .migrationRules(List.of())
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
                 .then()
                 .statusCode(200)
@@ -490,14 +509,17 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
                 .contentType(CT_JSON)
                 .pathParam("groupId", GROUP)
                 .pathParam("artifactId", artifactId)
-                .body("""
-                        {
-                            "domainRules": [],
-                            "migrationRules": [
-                                {"name": "migration-1", "kind": "TRANSFORM", "type": "CEL_FIELD", "mode": "UPGRADE"}
-                            ]
-                        }
-                        """)
+                .body(ContractRuleSet.builder()
+                        .domainRules(List.of())
+                        .migrationRules(List.of(
+                                ContractRule.builder()
+                                        .name("migration-1")
+                                        .kind(TRANSFORM)
+                                        .type("CEL_FIELD")
+                                        .mode(UPGRADE)
+                                        .build()
+                        ))
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset")
                 .then()
                 .statusCode(200);
@@ -525,13 +547,13 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
 
         given().when().contentType(CT_JSON)
                 .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
-                .body("{\"status\":\"DRAFT\"}")
+                .body(EditableContractMetadata.builder().status(EditableContractMetadata.Status.DRAFT).build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then().statusCode(200);
 
         given().when().contentType(CT_JSON)
                 .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
-                .body("{\"status\":\"STABLE\"}")
+                .body(ContractStatusTransition.builder().status(ContractStatusTransition.Status.STABLE).build())
                 .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/status")
                 .then().statusCode(200)
                 .body("status", equalTo("STABLE"));
@@ -551,19 +573,19 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
 
         given().when().contentType(CT_JSON)
                 .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
-                .body("{\"status\":\"DRAFT\"}")
+                .body(EditableContractMetadata.builder().status(EditableContractMetadata.Status.DRAFT).build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then().statusCode(200);
 
         given().when().contentType(CT_JSON)
                 .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
-                .body("{\"status\":\"STABLE\"}")
+                .body(ContractStatusTransition.builder().status(ContractStatusTransition.Status.STABLE).build())
                 .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/status")
                 .then().statusCode(200);
 
         given().when().contentType(CT_JSON)
                 .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
-                .body("{\"status\":\"DEPRECATED\"}")
+                .body(ContractStatusTransition.builder().status(ContractStatusTransition.Status.DEPRECATED).build())
                 .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/status")
                 .then().statusCode(200)
                 .body("status", equalTo("DEPRECATED"));
@@ -577,13 +599,17 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
 
         given().when().contentType(CT_JSON)
                 .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
-                .body("{\"status\":\"DRAFT\",\"ownerTeam\":\"my-team\",\"classification\":\"INTERNAL\"}")
+                .body(EditableContractMetadata.builder()
+                        .status(EditableContractMetadata.Status.DRAFT)
+                        .ownerTeam("my-team")
+                        .classification(INTERNAL)
+                        .build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then().statusCode(200);
 
         given().when().contentType(CT_JSON)
                 .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
-                .body("{\"status\":\"STABLE\"}")
+                .body(ContractStatusTransition.builder().status(ContractStatusTransition.Status.STABLE).build())
                 .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/status")
                 .then().statusCode(200);
 
@@ -606,7 +632,7 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
 
         given().when().contentType(CT_JSON)
                 .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
-                .body("{\"status\":\"DRAFT\"}")
+                .body(EditableContractMetadata.builder().status(EditableContractMetadata.Status.DRAFT).build())
                 .put("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/metadata")
                 .then().statusCode(200);
 


### PR DESCRIPTION
### Description

This PR fixes the compilation errors and Checkstyle issues in `DataContractsResourceTest` that were preventing the app module from building successfully.

Closes: #8863 

### Changes

* Removed the wildcard imports for `ContractRule.OnFailure` and `ContractRule.OnSuccess`, and replaced ambiguous enum references with fully qualified enum values.
* Updated the `.params()` builder call to use a `Params` object instead of a `Map`, matching the expected type.
* Removed the unused `Map` import to resolve the remaining Checkstyle warning.

### Why

While building the project locally, the test module failed due to ambiguous enum references, a type mismatch in the builder, and a Checkstyle violation. These issues prevented the module from compiling successfully.

### Testing

I verified the changes locally using the following commands:

```bash
./mvnw test-compile -pl app -am -DskipTests
./mvnw checkstyle:check -pl app
./mvnw test -pl app -Dtest=DataContractsResourceTest
```

All commands completed successfully without compilation or Checkstyle errors.
