### PR TITLE
fix(ci): fetch base branch for Scalpel and fix fetch-depth expression

### DIFF
--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -59,7 +59,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Full history only needed when Scalpel is enabled (git diff against base branch)
-          fetch-depth: ${{ inputs.scalpel-enabled == 'true' && 0 || 1 }}
+          fetch-depth: ${{ inputs.scalpel-enabled == 'true' && '0' || 1 }}
+
+      - name: Fetch base branch for Scalpel
+        if: inputs.scalpel-enabled == 'true' && env.GITHUB_BASE_REF != ''
+        continue-on-error: true
+        run: git fetch origin "$GITHUB_BASE_REF" --no-tags
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: ${{ inputs.scalpel-enabled == 'true' && '0' || 1 }}
 
       - name: Fetch base branch for Scalpel
-        if: inputs.scalpel-enabled == 'true' && env.GITHUB_BASE_REF != ''
+        if: inputs.scalpel-enabled == 'true' && github.base_ref != ''
         continue-on-error: true
         run: git fetch origin "$GITHUB_BASE_REF" --no-tags
 

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,6 +5,6 @@
     <extension>
         <groupId>eu.maveniverse.maven.scalpel</groupId>
         <artifactId>extension</artifactId>
-        <version>0.3.7</version>
+        <version>0.3.9</version>
     </extension>
 </extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -11,8 +11,5 @@
 # skipTestsForUpstream: upstream deps of -pl target compile but skip tests.
 # Works because non-app shard always tests upstream modules independently.
 -Dscalpel.skipTestsForUpstream=true
-# fetchBaseBranch: let Scalpel fetch origin/<base> itself via JGit (no shallow grafts).
-# Requires fetch-depth: 0 in the checkout step so full history is available.
--Dscalpel.fetchBaseBranch=true
 # failSafe: on any Scalpel error, fall back to a full build instead of failing
 -Dscalpel.failSafe=true


### PR DESCRIPTION
## Summary

Follow-up to #8903 (merged). Three fixes for Scalpel affected-module detection:

- **fetch-depth expression bug**: `&& 0 || 1` always evaluates to `1` because `0` is falsy in GitHub Actions expressions. Scalpel has never had full git history. Fix: quote as `'0'` (non-empty string, truthy).
- **JGit auth failure**: `scalpel.fetchBaseBranch=true` fails because JGit inside Maven lacks the `GITHUB_TOKEN` credentials. CI logs: `"Scalpel: Failed to fetch origin/main"`. Replace with a workflow-level `git fetch` that inherits the checkout token.
- **Graceful degradation**: `continue-on-error: true` ensures transient fetch failures degrade to a full build (matching Scalpel's `failSafe=true` behavior). `env.GITHUB_BASE_REF != ''` guard prevents failure on non-PR callers.

**Evidence** (run 30387339544, Scalpel shard logs):
```
[INFO] Scalpel 0.3.7 activated (mode=skip-tests)
[INFO] Scalpel: Fetching main from origin
[WARNING] Scalpel: Failed to fetch origin/main, building all modules: Failed to fetch origin/main
```
And `fetch-depth: 1` despite `scalpel-enabled: true` (the expression bug).

## Test plan

- [ ] Verify Scalpel logs show `"Merge base between origin/main and HEAD: <sha>"` instead of the fallback warning
- [ ] Verify `fetch-depth: 0` in the checkout step (not 1)
- [ ] Compare test counts between normal and Scalpel shards on a PR touching a single module
- [ ] Confirm the fetch step is skipped for non-Scalpel shards (check logs for "Fetch base branch" step)
- [ ] Confirm a transient fetch failure doesn't fail the job (continue-on-error)