### PR TITLE
fix(build): fail fast with a clear message when building on JDK < 21

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -10,6 +10,8 @@ the [README](README.md) and the
 
 ## Build Configuration
 
+**Build requirement:** JDK 21 or newer is required to build the project (the build tooling, e.g. Checkstyle, needs a Java 21+ runtime). The produced artifacts still target Java 17.
+
 This project supports several build configuration options that affect the produced executables.
 
 By default, `mvn clean install` produces an executable JAR with the *dev* Quarkus configuration profile enabled, and *in-memory* persistence implementation.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ An API/Schema registry - stores and retrieves APIs and Schemas.
 
 Build the project and run the registry with the in-memory storage variant:
 
+**Build requirement:** JDK 21 or newer is required to build the project (the build tooling, e.g. Checkstyle, needs a Java 21+ runtime). The produced artifacts still target Java 17.
+
  ```
  ./mvnw clean install -Dlocal -DskipTests
  cd app/

--- a/pom.xml
+++ b/pom.xml
@@ -1240,6 +1240,31 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.9.8,)</version>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[21,)</version>
+                  <message>Building Apicurio Registry requires JDK 21 or newer to run the build tooling (e.g. Checkstyle). The produced artifacts still target Java ${maven.compiler.release}.</message>
+                </requireJavaVersion>
+                <banDuplicatePomDependencyVersions/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <dependencies>
           <dependency>
@@ -1263,27 +1288,6 @@
               <goal>check</goal>
             </goals>
             <phase>validate</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <phase>validate</phase>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>[3.9.8,)</version>
-                </requireMavenVersion>
-                <banDuplicatePomDependencyVersions/>
-              </rules>
-            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -1379,7 +1383,6 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.source.skip>true</maven.source.skip>
         <checkstyle.skip>true</checkstyle.skip>
-        <enforcer.skip>true</enforcer.skip>
         <assembly.skipAssembly>true</assembly.skipAssembly>
       </properties>
     </profile>


### PR DESCRIPTION
Fixes #8966

## Problem

Building on JDK 17 fails with a cryptic `UnsupportedClassVersionError` from Checkstyle's classes (compiled for a Java 21+ runtime). The error happens while class-loading the plugin's dependencies — *before* `checkstyle.skip` is evaluated — so neither `-Dlocal` nor `-Dcheckstyle.skip=true` can prevent it, and nothing tells the user what's actually wrong. The minimum build JDK also isn't documented.

## Changes

1. **Add a `requireJavaVersion [21,)` enforcer rule** with a message explaining that the build tooling needs a Java 21+ runtime while the produced artifacts still target Java `${maven.compiler.release}` (interpolated, so the message stays correct if the target is ever bumped).
2. **Move the enforcer plugin declaration above checkstyle** in the root pom. Both bind to the `validate` phase, and same-phase executions run in declaration order — without this move, checkstyle would still crash before the new rule ever runs.
3. **Stop skipping the enforcer in the `-Dlocal` profile** (drop `enforcer.skip=true`), so the guard also covers the README quick-start command. The enforcer adds roughly a second to the build.
4. **Document the JDK 21+ build requirement in the README**, right above the quick-start command.

## Before / after (JDK 17, `./mvnw validate -Dlocal`)

Before:

```
UnsupportedClassVersionError: com/puppycrawl/tools/checkstyle/api/CheckstyleException
has been compiled by a more recent version of the Java Runtime (class file version 65.0),
this version of the Java Runtime only recognizes class file versions up to 61.0
```

After (~5s):

```
[ERROR] Rule 1: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
[ERROR] Building Apicurio Registry requires JDK 21 or newer to run the build tooling (e.g. Checkstyle). The produced artifacts still target Java 17.
```

## Verification

- JDK 17 (Temurin 17.0.19) + `-Dlocal`: fails fast with the message above
- JDK 21 (Temurin 21.0.11): `./mvnw validate` passes both with and without `-Dlocal`
