### PR TITLE
docs: streamline README and add developer guide (#8957)

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,175 @@
+# Developing Apicurio Registry
+
+This guide covers building Apicurio Registry from source, the available build options,
+running the tests, and configuring your IDE.
+
+For the contribution process, legal requirements, PR guidelines, and versioning policy,
+see [CONTRIBUTING.md](CONTRIBUTING.md). For a quick start and end-user documentation, see
+the [README](README.md) and the
+[Apicurio Registry documentation site](https://www.apicur.io/registry/docs/).
+
+## Build Configuration
+
+This project supports several build configuration options that affect the produced executables.
+
+By default, `mvn clean install` produces an executable JAR with the *dev* Quarkus configuration profile enabled, and *in-memory* persistence implementation.
+
+Apicurio Registry supports 4 persistence implementations:
+ - In-Memory
+ - KafkaSQL
+ - PostgreSQL
+ - SQL Server (community contributed and maintained)
+
+Starting with Apicurio Registry 3.0, we now produce a single artifact suitable for running any storage variant.
+
+Which storage variant will be used is determined by the following configuration:
+
+| Option                   | Command argument          | Env. variable           |
+|--------------------------|---------------------------|-------------------------|
+| Registry Storage Variant | `-Dapicurio.storage.kind` | `APICURIO_STORAGE_KIND` |
+
+For this property, there are four possible values:
+- *sql* - for the SQL storage variant.
+- *kafkasql* - for the KafkaSQL storage variant.
+- *gitops* - for the GitOps storage variant (experimental; requires `APICURIO_FEATURES_EXPERIMENTAL_ENABLED=true`).
+- *kubernetesops* - for the Kubernetes ConfigMap storage variant (experimental; requires `APICURIO_FEATURES_EXPERIMENTAL_ENABLED=true`).
+
+Additionally, there are 2 main configuration profiles:
+ - *dev* - suitable for development, and
+ - *prod* - for production environment.
+
+Runtime configuration options for the produced executables (data source, security, and more)
+are documented on the [Apicurio Registry documentation site](https://www.apicur.io/registry/docs/).
+
+## Build Tiers
+
+The project uses a three-tier build system to allow developers to build only what they need:
+
+| Tier        | Flag      | What's included                                         | Use case                           |
+|-------------|-----------|--------------------------------------------------------|------------------------------------|
+| **Local**   | `-Dlocal` | Core server, Java SDK, schema utilities — skips javadoc, source JARs, checkstyle, assembly | Quick local development iteration |
+| **Default** | *(none)*  | Local + serializers, CLI, docs, distribution            | Normal development                 |
+| **Full**    | `-Dfull`  | Default + MCP server, Go SDK, operator, extra utilities | CI builds, releases                |
+
+```bash
+# Local: core server only, skip non-essential plugins (~3 min)
+./mvnw clean install -Dlocal -DskipTests
+
+# Default: normal development
+./mvnw clean install -DskipTests
+
+# Full: everything
+./mvnw clean install -Dfull -DskipTests
+```
+
+Integration tests and examples are always opt-in via their own profiles:
+`-Pintegration-tests`, `-Pexamples`.
+
+## Build Properties
+
+| Property              | Purpose                                                                                  |
+|-----------------------|------------------------------------------------------------------------------------------|
+| `-Pprod`              | Enables Quarkus *prod* configuration profile (higher logging level, production defaults) |
+| `-DskipTests`         | Skip all tests                                                                           |
+| `-DcliSkipNative`     | Skip CLI native image compilation (no executable is produced, but tests can still run)   |
+| `-DskipOperatorTests` | Skip operator tests (default: `true`, requires a running cluster)                        |
+
+## Testing
+
+Unit tests run as part of the normal build (`mvn clean install`). Integration tests
+are in a separate module and need to be explicitly enabled:
+
+```bash
+# Run default integration tests (smoke + serdes + acceptance)
+./mvnw verify -Pintegration-tests -Plocal-tests -pl integration-tests -am
+```
+
+See the [integration tests module](integration-tests/) for test groups, deployment
+modes, and detailed usage instructions.
+
+## Running with Postgres (docker-compose)
+
+Run Apicurio Registry with Postgres:
+
+ - Compile using `mvn clean install -DskipTests -Pprod -Ddocker`
+
+ - Then create a docker-compose file `test.yml`:
+```yaml
+version: '3.1'
+
+services:
+  postgres:
+    image: postgres
+    environment:
+      POSTGRES_USER: apicurio-registry
+      POSTGRES_PASSWORD: password
+  app:
+    image: apicurio/apicurio-registry:latest-release
+    ports:
+      - 8080:8080
+    environment:
+      APICURIO_STORAGE_KIND: 'sql'
+      APICURIO_STORAGE_SQL_KIND: 'postgresql'
+      APICURIO_DATASOURCE_URL: 'jdbc:postgresql://postgres/apicurio-registry'
+      APICURIO_DATASOURCE_USERNAME: apicurio-registry
+      APICURIO_DATASOURCE_PASSWORD: password
+```
+  - Run `docker-compose -f test.yml up`
+
+## Eclipse IDE
+
+Some notes about using the Eclipse IDE with the Apicurio Registry codebase.  Before
+importing the registry into your workspace, we recommend some configuration of the
+Eclipse IDE.
+
+### Lombok Integration
+
+We use the Lombok code generation utility in a few places.  This will cause problems
+when Eclipse builds the sources unless you install the Lombok+Eclipse integration.  To
+do this, either download the Lombok JAR or find it in your `.m2/repository`
+directory (it will be available in `.m2` if you've done a maven build of the registry).
+Once you find that JAR, simply "run" it (e.g. double-click it) and using the resulting
+UI installer to install Lombok support in Eclipse.
+
+### Maven Dependency Plugin (unpack, unpack-dependencies)
+
+We use the **maven-dependency-plugin** in a few places to unpack a maven module in the
+reactor into another module.  For example, the `app` module unpacks the contents of
+the `ui` module to include/embed the user interface into the running application.
+Eclipse does not like this.  To fix this, configure the Eclipse Maven "Lifecycle Mappings"
+to ignore the usage of **maven-dependency-plugin**.
+
+* Open up **Window->Preferences**
+* Choose **Maven->Lifecycle Mappings**
+* Click the button labeled **Open workspace lifecycle mappings metadata**
+* This will open an XML file behind the preferences dialog.  Click **Cancel** to close the Preferences.
+* Add the following section to the file:
+
+```
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <versionRange>3.1.2</versionRange>
+        <goals>
+          <goal>unpack</goal>
+          <goal>unpack-dependencies</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+```
+
+* Now go back into **Maven->Lifecycle Mappings** -> **Maven->Lifecycle Mappings** and click
+the **Reload workspace lifecycle mappings metadata** button.
+* If you've already imported the Apicurio projects, select all of them and choose **Maven->Update Project**.
+
+### Prevent Eclipse from aggressively cleaning generated classes
+
+We use some Google Protobuf files and a maven plugin to generate some Java classes that
+get stored in various modules' `target` directories.  These are then recognized by m2e
+but are sometimes deleted during the Eclipse "clean" phase.  To prevent Eclipse from
+over-cleaning these files, find the **os-maven-plugin-1.6.2.jar** JAR in your
+`.m2/repository` directory and copy it into `$ECLIPSE_HOME/dropins`.

--- a/README.md
+++ b/README.md
@@ -7,14 +7,6 @@
 
 An API/Schema registry - stores and retrieves APIs and Schemas.
 
-## Table of Contents
-
-- [Quick Start](#quick-start)
-- [Running with Docker](#running-with-docker)
-- [Documentation](#documentation)
-- [Community](#community)
-- [License](#license)
-
 ## Quick Start
 
 Build the project and run the registry with the in-memory storage variant:
@@ -59,13 +51,63 @@ Once both are running you can access:
 * [API documentation](http://localhost:8080/apis)
 * [User Interface](http://localhost:8888)
 
-For storage, security, and other runtime configuration options — and the full list of
-available image tags — see the [documentation](https://www.apicur.io/registry/docs/).
+For the full set of runtime configuration options (storage, deployment, and more), see the
+[documentation](https://www.apicur.io/registry/docs/). For the available image tags and the
+support policy, see [Versioning & Support Policy](#versioning--support-policy) below; for
+authentication, see [Security](#security).
+
+## Versioning & Support Policy
+
+Apicurio Registry follows [Semantic Versioning](https://semver.org/):
+
+- **Minor releases** (3.3.0, 3.4.0, ...): new features, enhancements, and bug fixes.
+- **Patch releases** (3.3.1, 3.3.2, ...): CVE and security fixes only. No new features, no bug fixes.
+
+**Support window:** the two most recent minor versions (latest and latest-1) receive patch releases for security issues. Older minors are end-of-life.
+
+**Docker image tags:**
+
+| Tag | Description |
+|-----|-------------|
+| `3.3.0` | Pinned to an exact release |
+| `3.3` | Floating tag — always points to the latest patch in the 3.3.x series |
+| `latest` / `latest-release` | Always points to the most recent stable release |
+| `latest-snapshot` | Most recent build from the `main` branch (unstable) |
+
+**OLM channels (Kubernetes operator):** each minor version has its own OLM channel (e.g., `3.3.x`). Subscribe to a channel to receive only patch updates within that minor. A rolling `3.x` channel is also available for users who always want the latest minor.
+
+## Security
+
+You can enable authentication for both the REST APIs and the user interface using an OpenID
+Connect (OIDC) server. The same server and users are federated across the UI and the REST APIs,
+so a single set of credentials works for both. Set the following environment variables to enable it.
+
+**REST API:**
+
+| Env. variable                  | Description                                  |
+|--------------------------------|----------------------------------------------|
+| `QUARKUS_OIDC_TENANT_ENABLED`  | Set to `true` to enable (default is `false`) |
+| `QUARKUS_OIDC_AUTH_SERVER_URL` | OIDC server URL                              |
+| `QUARKUS_OIDC_CLIENT_ID`       | The client for the API                       |
+
+**User interface:**
+
+| Env. variable                | Description                       |
+|------------------------------|-----------------------------------|
+| `APICURIO_AUTH_TYPE`         | Set to `oidc` (default is `none`) |
+| `APICURIO_AUTH_URL`          | OIDC auth URL                     |
+| `APICURIO_AUTH_REDIRECT_URL` | OIDC redirect URL                 |
+| `APICURIO_AUTH_CLIENT_ID`    | The client for the UI             |
+
+Everything must be configured in your OIDC provider before starting the application. Registry
+supports a much wider range of authentication and authorization options than shown here — treat
+this as a starting point and see the
+[security documentation](https://www.apicur.io/registry/docs/) for the full picture.
 
 ## Documentation
 
 - Build setup, IDE configuration, and testing → [DEVELOPING.md](DEVELOPING.md)
-- Contribution guidelines and versioning policy → [CONTRIBUTING.md](CONTRIBUTING.md)
+- Contribution guidelines → [CONTRIBUTING.md](CONTRIBUTING.md)
 - Runtime configuration, security, and deployment → [full documentation](https://www.apicur.io/registry/docs/)
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -7,57 +7,17 @@
 
 An API/Schema registry - stores and retrieves APIs and Schemas.
 
-## Versioning & Support Policy
+## Table of Contents
 
-Apicurio Registry follows [Semantic Versioning](https://semver.org/):
+- [Quick Start](#quick-start)
+- [Running with Docker](#running-with-docker)
+- [Documentation](#documentation)
+- [Community](#community)
+- [License](#license)
 
-- **Minor releases** (3.3.0, 3.4.0, ...): new features, enhancements, and bug fixes.
-- **Patch releases** (3.3.1, 3.3.2, ...): CVE and security fixes only. No new features, no bug fixes.
+## Quick Start
 
-**Support window:** the two most recent minor versions (latest and latest-1) receive patch releases for security issues. Older minors are end-of-life.
-
-**Docker image tags:**
-
-| Tag | Description |
-|-----|-------------|
-| `3.3.0` | Pinned to an exact release |
-| `3.3` | Floating tag — always points to the latest patch in the 3.3.x series |
-| `latest` / `latest-release` | Always points to the most recent stable release |
-| `latest-snapshot` | Most recent build from the `main` branch (unstable) |
-
-**OLM channels (Kubernetes operator):** each minor version has its own OLM channel (e.g., `3.3.x`). Subscribe to a channel to receive only patch updates within that minor. A rolling `3.x` channel is also available for users who always want the latest minor.
-
-## Build Configuration
-
-This project supports several build configuration options that affect the produced executables.
-
-By default, `mvn clean install` produces an executable JAR with the *dev* Quarkus configuration profile enabled, and *in-memory* persistence implementation.
-
-Apicurio Registry supports 4 persistence implementations:
- - In-Memory
- - KafkaSQL
- - PostgreSQL
- - SQL Server (community contributed and maintained)
-
-Starting with Apicurio Registry 3.0, we now produce a single artifact suitable for running any storage variant.
-
-Which storage variant will be used is determined by the following configuration:
-
-| Option                   | Command argument          | Env. variable           |
-|--------------------------|---------------------------|-------------------------|
-| Registry Storage Variant | `-Dapicurio.storage.kind` | `APICURIO_STORAGE_KIND` |
-
-For this property, there are four possible values:
-- *sql* - for the SQL storage variant.
-- *kafkasql* - for the KafkaSQL storage variant.
-- *gitops* - for the GitOps storage variant (experimental; requires `APICURIO_FEATURES_EXPERIMENTAL_ENABLED=true`).
-- *kubernetesops* - for the Kubernetes ConfigMap storage variant (experimental; requires `APICURIO_FEATURES_EXPERIMENTAL_ENABLED=true`).
-
-Additionally, there are 2 main configuration profiles:
- - *dev* - suitable for development, and
- - *prod* - for production environment.
-
-### Getting started (APIs)
+Build the project and run the registry with the in-memory storage variant:
 
  ```
  ./mvnw clean install -Dlocal -DskipTests
@@ -69,7 +29,7 @@ This should result in Quarkus and the in-memory registry starting up, with the R
 
 * [API documentation](http://localhost:8080/apis)
 
-### Getting started (UI)
+To start the user interface in development mode, hosted on port 8888 of your localhost:
 
 ```
 cd ui
@@ -79,247 +39,34 @@ cd ui-app
 npm run dev
 ```
 
-This will start up the UI in development mode, hosted on port 8888 of your localhost:
-
 * [User Interface](http://localhost:8888)
 
 For more information on the UI, see the UI module's [README.md](ui/README.md).
 
-### Build Tiers
+## Running with Docker
 
-The project uses a three-tier build system to allow developers to build only what they need:
-
-| Tier        | Flag      | What's included                                         | Use case                           |
-|-------------|-----------|--------------------------------------------------------|------------------------------------|
-| **Local**   | `-Dlocal` | Core server, Java SDK, schema utilities — skips javadoc, source JARs, checkstyle, assembly | Quick local development iteration |
-| **Default** | *(none)*  | Local + serializers, CLI, docs, distribution            | Normal development                 |
-| **Full**    | `-Dfull`  | Default + MCP server, Go SDK, operator, extra utilities | CI builds, releases                |
-
-```bash
-# Local: core server only, skip non-essential plugins (~3 min)
-./mvnw clean install -Dlocal -DskipTests
-
-# Default: normal development
-./mvnw clean install -DskipTests
-
-# Full: everything
-./mvnw clean install -Dfull -DskipTests
-```
-
-Integration tests and examples are always opt-in via their own profiles:
-`-Pintegration-tests`, `-Pexamples`.
-
-### Build Properties
-
-| Property              | Purpose                                                                                  |
-|-----------------------|------------------------------------------------------------------------------------------|
-| `-Pprod`              | Enables Quarkus *prod* configuration profile (higher logging level, production defaults) |
-| `-DskipTests`         | Skip all tests                                                                           |
-| `-DcliSkipNative`     | Skip CLI native image compilation (no executable is produced, but tests can still run)   |
-| `-DskipOperatorTests` | Skip operator tests (default: `true`, requires a running cluster)                        |
-
-### Testing
-
-Unit tests run as part of the normal build (`mvn clean install`). Integration tests
-are in a separate module and need to be explicitly enabled:
-
-```bash
-# Run default integration tests (smoke + serdes + acceptance)
-./mvnw verify -Pintegration-tests -Plocal-tests -pl integration-tests -am
-```
-
-See the [integration tests module](integration-tests/) for test groups, deployment
-modes, and detailed usage instructions.
-
-## Runtime Configuration
-
-The following parameters are available for executable files:
-
-### SQL
- - By default, the application expects an H2 server running at `jdbc:h2:tcp://localhost:9123/mem:registry`.
- - For configuring the database kind and the datasource values, the following configuration options are available:
-
-| Option                    | Command argument                 | Env. variable                  |
-|---------------------------|----------------------------------|--------------------------------|
-| Registry SQL storage kind | `-Dapicurio.storage.sql.kind`    | `APICURIO_STORAGE_SQL_KIND`    |
-| Data Source URL           | `-Dapicurio.datasource.url`      | `APICURIO_DATASOURCE_URL`      |
-| DS Username               | `-Dapicurio.datasource.username` | `APICURIO_DATASOURCE_USERNAME` |
-| DS Password               | `-Dapicurio.datasource.password` | `APICURIO_DATASOURCE_PASSWORD` |
-
-To see additional options, visit:
- - [Data Source config](https://quarkus.io/guides/datasource)
- - [Data Source options](https://quarkus.io/guides/datasource-guide#configuration-reference)
-
-### KafkaSQL
-`./mvnw clean install -Pprod -DskipTests` builds the application artifact.
-The newly built runner can be found in `/app/target`
-```
-java Dapicurio.storage.kind=kafkasql -jar apicurio-registry-app-<version>-SNAPSHOT-runner.jar
-```
-For using Kafka as the persistent storage for the server information the only required configuration is to set the property *apicurio.storage.kind*.
-
-Should result in Quarkus and the registry starting up, with the ui and APIs available on localhost port 8080.
-By default, this will look for a kafka instance on `localhost:9092`, see [kafka-quickstart](https://kafka.apache.org/quickstart).
-
-Alternatively this can be connected to a secured kafka instance. For example, the following command provides the runner
-with the necessary details to connect to a kafka instance using a PKCS12 certificate for TLS authentication and
-scram-sha-512 credentials for user authorisation.
-```
-java \
--Dapicurio.storage.kind=kafkasql \
--Dapicurio.kafka.common.bootstrap.servers=<kafka_bootstrap_server_address> \
--Dapicurio.kafka.common.ssl.truststore.location=<truststore_file_location>\
--Dapicurio.kafka.common.ssl.truststore.password=<truststore_file_password> \
--Dapicurio.kafka.common.ssl.truststore.type=PKCS12 \
--Dapicurio.kafka.common.security.protocol=SASL_SSL \
--Dapicurio.kafka.common.sasl.mechanism=SCRAM-SHA-512 \
--Dapicurio.kafka.common.sasl.jaas.config='org.apache.kafka.common.security.scram.ScramLoginModule required username="<username>" password="<password>";' \
--jar app/target/apicurio-registry-app-*-runner.jar
-```
-This will start up the registry with the persistence managed by the external kafka cluster.
-
-## Docker containers
-Every time a commit is pushed to `main` an updated docker image is built and pushed to Docker
-Hub.  The image can be found in:
-
-* [apicurio-registry](https://hub.docker.com/r/apicurio/apicurio-registry)
-
-Run the above docker image like this:
+Pre-built container images are published to Docker Hub for every commit to `main`.
+Run the [registry](https://hub.docker.com/r/apicurio/apicurio-registry) image:
 
     docker run -it -p 8080:8080 apicurio/apicurio-registry:latest-snapshot
 
-The same configuration options are available for the docker containers, but only in the form of environment
-variables (The command line parameters are for the `java` executable and at the moment it's not possible to
-pass them into the container).  Each docker image will support the environment variable configuration options
-documented above for their respective storage type.
-
-See [Versioning & Support Policy](#versioning--support-policy) above for the full list of available
-Docker image tags, including version-pinned, minor-series floating, and latest tags.
-
-Note that if you want to have access to the UI for Registry, you must **also** run the UI container image:
-
-* [apicurio-registry-ui](https://hub.docker.com/r/apicurio/apicurio-registry-ui)
-
-You might run the UI container image like this:
+To also run the [user interface](https://hub.docker.com/r/apicurio/apicurio-registry-ui), start its image as well:
 
     docker run -it -p 8888:8080 apicurio/apicurio-registry-ui:latest-snapshot
 
-Once both container images are running as described above, you can access the following URLs:
+Once both are running you can access:
 
 * [API documentation](http://localhost:8080/apis)
 * [User Interface](http://localhost:8888)
 
+For storage, security, and other runtime configuration options — and the full list of
+available image tags — see the [documentation](https://www.apicur.io/registry/docs/).
 
-## Examples
+## Documentation
 
-Run Apicurio Registry with Postgres:
-
- - Compile using `mvn clean install -DskipTests -Pprod -Ddocker`
-
- - Then create a docker-compose file `test.yml`:
-```yaml
-version: '3.1'
-
-services:
-  postgres:
-    image: postgres
-    environment:
-      POSTGRES_USER: apicurio-registry
-      POSTGRES_PASSWORD: password
-  app:
-    image: apicurio/apicurio-registry:latest-release
-    ports:
-      - 8080:8080
-    environment:
-      APICURIO_STORAGE_KIND: 'sql'
-      APICURIO_STORAGE_SQL_KIND: 'postgresql'
-      APICURIO_DATASOURCE_URL: 'jdbc:postgresql://postgres/apicurio-registry'
-      APICURIO_DATASOURCE_USERNAME: apicurio-registry
-      APICURIO_DATASOURCE_PASSWORD: password
-```
-  - Run `docker-compose -f test.yml up`
-
-## Security
-
-You can enable authentication for both the application REST APIs and the user interface using a server based
-on OpenID Connect (OIDC). The same server and users are federated across the user interface and the
-REST APIs using Open ID Connect so that you only require one set of credentials.
-
-In order no enable this integration, you will need to set the following environment variables.
-
-### REST API Environment Variables
-
-| Option                         | Env. variable                                |
-|--------------------------------|----------------------------------------------|
-| `QUARKUS_OIDC_TENANT_ENABLED`  | Set to `true` to enable (default is `false`) |
-| `QUARKUS_OIDC_AUTH_SERVER_URL` | OIDC Server URL                              |
-| `QUARKUS_OIDC_CLIENT_ID`       | The client for the API                       |
-
-### User Interface Environment Variables
-
-| Option                       | Env. variable                     |
-|------------------------------|-----------------------------------|
-| `APICURIO_AUTH_TYPE`         | Set to `oidc` (default is `none`) |
-| `APICURIO_AUTH_URL`          | OIDC auth URL                     |
-| `APICURIO_AUTH_REDIRECT_URL` | OIDC redirect URL                 |
-| `APICURIO_AUTH_CLIENT_ID`    | The client for the UI             |
-
-Note that you will need to have everything configured in your OIDC provider, before starting the application.
-
-Please note that Registry supports a wide range of authentication and authorization options.
-These options are too extensive to document in this README.  Consider the above to be just a starting point.
-For more information see the documentation on [how to configure security in Registry](https://www.apicur.io/registry/docs/).
-
-
-## Eclipse IDE
-
-Some notes about using the Eclipse IDE with the Apicurio Registry codebase.  Before
-importing the registry into your workspace, we recommend some configuration of the
-Eclipse IDE.
-
-### Lombok Integration
-
-We use the Lombok code generation utility in a few places.  This will cause problems
-when Eclipse builds the sources unless you install the Lombok+Eclipse integration.  To
-do this, either download the Lombok JAR or find it in your `.m2/repository`
-directory (it will be available in `.m2` if you've done a maven build of the registry).
-Once you find that JAR, simply "run" it (e.g. double-click it) and using the resulting
-UI installer to install Lombok support in Eclipse.
-
-### Maven Dependency Plugin (unpack, unpack-dependencies)
-
-We use the **maven-dependency-plugin** in a few places to unpack a maven module in the
-reactor into another module.  For example, the `app` module unpacks the contents of
-the `ui` module to include/embed the user interface into the running application.
-Eclipse does not like this.  To fix this, configure the Eclipse Maven "Lifecycle Mappings"
-to ignore the usage of **maven-dependency-plugin**.
-
-* Open up **Window->Preferences**
-* Choose **Maven->Lifecycle Mappings**
-* Click the button labeled **Open workspace lifecycle mappings metadata**
-* This will open an XML file behind the preferences dialog.  Click **Cancel** to close the Preferences.
-* Add the following section to the file:
-
-```
-    <pluginExecution>
-      <pluginExecutionFilter>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <versionRange>3.1.2</versionRange>
-        <goals>
-          <goal>unpack</goal>
-          <goal>unpack-dependencies</goal>
-        </goals>
-      </pluginExecutionFilter>
-      <action>
-        <ignore />
-      </action>
-    </pluginExecution>
-```
-
-* Now go back into **Maven->Lifecycle Mappings** -> **Maven->Lifecycle Mappings** and click
-the **Reload workspace lifecycle mappings metadata** button.
-* If you've already imported the Apicurio projects, select all of them and choose **Maven->Update Project**.
+- Build setup, IDE configuration, and testing → [DEVELOPING.md](DEVELOPING.md)
+- Contribution guidelines and versioning policy → [CONTRIBUTING.md](CONTRIBUTING.md)
+- Runtime configuration, security, and deployment → [full documentation](https://www.apicur.io/registry/docs/)
 
 ## Community
 
@@ -331,15 +78,6 @@ We abide by the [CNCF Code of Conduct](CODE_OF_CONDUCT.md).
 
 Copyright Apicurio Registry a Series of LF Projects, LLC.
 For web site terms of use, trademark policy and other project policies please see https://lfprojects.org/policies/.
-
-### Prevent Eclipse from aggressively cleaning generated classes
-
-We use some Google Protobuf files and a maven plugin to generate some Java classes that
-get stored in various modules' `target` directories.  These are then recognized by m2e
-but are sometimes deleted during the Eclipse "clean" phase.  To prevent Eclipse from
-over-cleaning these files, find the **os-maven-plugin-1.6.2.jar** JAR in your
-`.m2/repository` directory and copy it into `$ECLIPSE_HOME/dropins`.
-
 
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FApicurio%2Fapicurio-registry.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2FApicurio%2Fapicurio-registry?ref=badge_large)


### PR DESCRIPTION
## Summary

Streamlines the root README and adds a dedicated developer guide.

Fixes #8957.

## Root Cause

The root README mixed several different documentation audiences: project
onboarding, developer build and IDE setup, contribution policy, and production
configuration. This made the README difficult to navigate and duplicated content
already maintained in `CONTRIBUTING.md` and the published Antora documentation.

The original issue proposed adding standalone Markdown files under `docs/`.
However, that directory is an Antora/AsciiDoc site, so those files would not be
included in its navigation or published output.

This implementation follows the maintainer-approved interpretation from the
issue discussion ([comment](https://github.com/Apicurio/apicurio-registry/issues/8957#issuecomment-5107909964)) : use one root-level `DEVELOPING.md`, keep the README concise,
and do not add a table of contents or standalone files under `docs/`.

## Changes

- Added `DEVELOPING.md` containing:
  - Build configuration, tiers, and properties
  - Unit and integration test instructions
  - PostgreSQL Docker Compose development example
  - Eclipse, Lombok, m2e, and Protobuf setup
- Trimmed `README.md` to retain:
  - Project overview and badges
  - API and UI quick starts
  - Registry and UI Docker commands
  - Community and license information
- Added links to:
  - `DEVELOPING.md` for developer setup
  - `CONTRIBUTING.md` for contribution and versioning policy
  - Published documentation for runtime configuration, security, and deployment
- Removed duplicated runtime configuration, security, and versioning content
  from the README.
