### PR TITLE
fix(ci): use pre-built artifacts for console-plugin release image

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -121,6 +121,14 @@ jobs:
         with:
           node-version: 24.18.0
 
+      - name: Build Console Plugin frontend
+        working-directory: registry/console-plugin
+        run: |
+          npm install --legacy-peer-deps
+          npm run build
+          mkdir -p backend/src/main/resources/META-INF/resources
+          cp -r dist/* backend/src/main/resources/META-INF/resources/
+
       - name: Build Registry
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For downloading Kiota binary.
@@ -182,23 +190,16 @@ jobs:
               --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le ./distro/docker/target/docker
 
       - name: Build and Push Multi-arch Console Plugin Images
+        working-directory: registry/console-plugin
         run: |
-          cp registry/pom.xml registry/console-plugin/root-pom.xml
-          if ! grep -q 'root-pom.xml' registry/console-plugin/Dockerfile; then
-            sed -i '/^COPY backend\/pom.xml pom.xml/i COPY root-pom.xml /opt/pom.xml' registry/console-plugin/Dockerfile
-          fi
-          if ! grep -q 'checkstyle.skip' registry/console-plugin/Dockerfile; then
-            sed -i 's/mvn package -DskipTests -Dmaven.javadoc.skip/mvn package -DskipTests -Dmaven.javadoc.skip -Dcheckstyle.skip/' registry/console-plugin/Dockerfile
-          fi
-          cd registry/console-plugin
           TAGS="-t quay.io/apicurio/apicurio-registry-console-plugin:$RELEASE_VERSION"
           TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-console-plugin:$MINOR_TAG"
           if [ "$IS_LATEST_RELEASE" = "true" ]; then
             TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-console-plugin:latest"
           fi
-          docker buildx build --push -f ./Dockerfile \
+          docker buildx build --push -f ./Dockerfile.jvm \
               $TAGS \
-              --platform linux/amd64,linux/arm64 .
+              --platform linux/amd64,linux/arm64 ./backend
 
       - name: Build and Push Multi-arch UI Images
         run: |

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -45,10 +45,11 @@ jobs:
           cd registry && git checkout "$RELEASE_VERSION"
           # Resolve BRANCH if it's a commit SHA (happens when releasing from non-default branches)
           if [[ "$BRANCH" =~ ^[0-9a-f]{40}$ ]]; then
-            # Prefer non-main branches to avoid resolving maintenance releases to main
-            # (the SHA may exist on both after post-release sync)
+            # Prefer maintenance branches (X.Y.x) over main to avoid resolving
+            # maintenance releases to main (the SHA may exist on both after post-release sync).
+            # Feature branches are ignored — only main and X.Y.x patterns are considered.
             ALL_BRANCHES=$(git branch -r --contains "$BRANCH" | grep -v HEAD | sed 's|.*origin/||' | tr -d ' ')
-            RESOLVED=$(echo "$ALL_BRANCHES" | grep -v '^main$' | head -1)
+            RESOLVED=$(echo "$ALL_BRANCHES" | grep -E '^[0-9]+\.[0-9]+\.x$' | head -1)
             if [ -z "$RESOLVED" ]; then
               RESOLVED=$(echo "$ALL_BRANCHES" | head -1)
             fi

--- a/console-plugin/Dockerfile.jvm
+++ b/console-plugin/Dockerfile.jvm
@@ -1,0 +1,11 @@
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
+
+USER 185
+
+COPY --chown=185 target/quarkus-app/ /deployments/
+
+EXPOSE 9443
+
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0"
+
+ENTRYPOINT ["java", "-jar", "/deployments/quarkus-run.jar"]


### PR DESCRIPTION
## Summary

- The console-plugin Dockerfile was rebuilding backend + frontend from source inside Docker during `release-images`. Every other image in the workflow uses pre-built artifacts.
- This caused failures: parent POM not on Maven Central (#8945), checkstyle config missing (#8947), and a 401 push error likely caused by the multi-stage build's layer composition.
- Fix: build the console-plugin frontend **before** the Maven build so assets get embedded in the Quarkus JAR, then use a simple `Dockerfile.jvm` that just copies `target/quarkus-app/` — same pattern as the app and MCP server images.
- Tested locally: frontend built, Maven packages with embedded assets, Docker image starts, health check passes, plugin manifest served correctly.

## Test plan

- [ ] Merge this PR
- [ ] Re-run `Release Images` workflow via `workflow_dispatch` with tag `3.3.1`
- [ ] Verify `apicurio-registry-console-plugin:3.3.1` and `apicurio-registry-ui:3.3.1` are published to quay.io