### PR TITLE
fix(ci): pass ROLLING_CHANNEL to catalog build in operator release

### DIFF
--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -135,7 +135,11 @@ jobs:
       - name: Build operator catalog
         working-directory: registry/operator
         run: |
-          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_CATALOG_IMAGE_TAG=latest catalog
+          ROLLING_CHANNEL_ARG=""
+          if [ "$BRANCH" = "main" ]; then
+            ROLLING_CHANNEL_ARG="ROLLING_CHANNEL=3.x"
+          fi
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_CATALOG_IMAGE_TAG=latest $ROLLING_CHANNEL_ARG catalog
 
       - name: Generate install file for tests
         working-directory: registry/operator


### PR DESCRIPTION
## Summary

The bundle build passes `ROLLING_CHANNEL=3.x` for main releases, but the catalog build step does not. The catalog's `defaultChannel` in the `olm.package` entry was set to `3.3.x` instead of `3.x`, causing `testDefaultChannel` to fail.

One-line fix: pass `ROLLING_CHANNEL` to the `make catalog` command too.

## Test plan

- [ ] Merge, re-trigger `Release Operator` with tag `3.3.1`
- [ ] OLM channel validation test should pass