### PR TITLE
fix(ui): preserve page context on rule action failures

### DIFF
--- a/ui/tests/specs/explore.spec.ts
+++ b/ui/tests/specs/explore.spec.ts
@@ -61,6 +61,37 @@ test("Explore - Group specific rules", async ({ page }) => {
 });
 
 
+test("Explore - Group specific rules, enable failure keeps the page intact", async ({ page }) => {
+    // Force the rule-creation request to fail, simulating a backend/network error.
+    await page.route("**/apis/registry/v3/groups/ExploreTest/rules", async route => {
+        if (route.request().method() === "POST") {
+            await route.fulfill({
+                status: 500,
+                contentType: "application/json",
+                body: JSON.stringify({ message: "Simulated failure" })
+            });
+        } else {
+            await route.continue();
+        }
+    });
+
+    await page.goto(`${REGISTRY_UI_URL}/explore/ExploreTest`);
+    await page.getByTestId("group-rules-tab").click();
+    await expect(page.locator("#compatibility-rule-name")).toContainText("Compatibility rule");
+
+    // Attempt to enable the rule; the mocked request fails.
+    await page.getByTestId("rules-compatibility-enable").click();
+
+    // The page must remain intact - no full-page error, the group header/tabs are still there.
+    await expect(page.getByTestId("group-rules-tab")).toBeVisible();
+    await expect(page.getByTestId("rule-action-error")).toBeVisible();
+
+    // The rule must NOT show as enabled - the failed request must not have been applied optimistically.
+    await expect(page.getByTestId("rules-compatibility-enable")).toBeVisible();
+    await expect(page.getByTestId("rules-compatibility-disable")).toHaveCount(0);
+});
+
+
 test("Explore - Create artifact", async ({ page }) => {
     // Navigate to the group details page
     await page.goto(`${REGISTRY_UI_URL}/explore/ExploreTest`);
@@ -170,6 +201,37 @@ test("Explore - Artifact specific rules", async ({ page }) => {
     // Select "syntax only" config option
     await page.getByTestId("validity-config-syntax").click();
     expect(page.getByTestId("rules-validity-disable")).toBeDefined();
+});
+
+
+test("Explore - Artifact specific rules, enable failure keeps the page intact", async ({ page }) => {
+    // Force the rule-creation request to fail, simulating a backend/network error.
+    await page.route("**/apis/registry/v3/groups/ExploreTest/artifacts/MyArtifact/rules", async route => {
+        if (route.request().method() === "POST") {
+            await route.fulfill({
+                status: 500,
+                contentType: "application/json",
+                body: JSON.stringify({ message: "Simulated failure" })
+            });
+        } else {
+            await route.continue();
+        }
+    });
+
+    await page.goto(`${REGISTRY_UI_URL}/explore/ExploreTest/MyArtifact`);
+    await page.getByTestId("artifact-rules-tab").click();
+    await expect(page.locator("#compatibility-rule-name")).toContainText("Compatibility rule");
+
+    // Attempt to enable the rule; the mocked request fails.
+    await page.getByTestId("rules-compatibility-enable").click();
+
+    // The page must remain intact - no full-page error, the artifact header/tabs are still there.
+    await expect(page.getByTestId("artifact-rules-tab")).toBeVisible();
+    await expect(page.getByTestId("rule-action-error")).toBeVisible();
+
+    // The rule must NOT show as enabled - the failed request must not have been applied optimistically.
+    await expect(page.getByTestId("rules-compatibility-enable")).toBeVisible();
+    await expect(page.getByTestId("rules-compatibility-disable")).toHaveCount(0);
 });
 
 

--- a/ui/tests/specs/globalRules.spec.ts
+++ b/ui/tests/specs/globalRules.spec.ts
@@ -73,3 +73,31 @@ test("Global Rules - Enable Integrity Rule", async ({ page }) => {
     // Disable the rule (back to original state)
     await page.getByTestId("rules-integrity-disable").click();
 });
+
+test("Global Rules - Enable Validity Rule failure keeps the page intact", async ({ page }) => {
+    // Force the rule-creation request to fail, simulating a backend/network error.
+    await page.route("**/apis/registry/v3/admin/rules", async route => {
+        if (route.request().method() === "POST") {
+            await route.fulfill({
+                status: 500,
+                contentType: "application/json",
+                body: JSON.stringify({ message: "Simulated failure" })
+            });
+        } else {
+            await route.continue();
+        }
+    });
+
+    await expect(page.locator("#validity-rule-name")).toContainText("Validity rule");
+
+    // Attempt to enable the rule; the mocked request fails.
+    await page.getByTestId("rules-validity-enable").click();
+
+    // The page must remain intact - no full-page error, the other rules are still there.
+    await expect(page.locator("div.rule")).toHaveCount(3);
+    await expect(page.getByTestId("rule-action-error")).toBeVisible();
+
+    // The rule must NOT show as enabled - the failed request must not have been applied optimistically.
+    await expect(page.getByTestId("rules-validity-enable")).toBeVisible();
+    await expect(page.getByTestId("rules-validity-disable")).toHaveCount(0);
+});

--- a/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
+++ b/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
@@ -59,6 +59,7 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
     const [isPleaseWaitModalOpen, setIsPleaseWaitModalOpen] = useState(false);
     const [pleaseWaitMessage, setPleaseWaitMessage] = useState("");
     const [rules, setRules] = useState<Rule[]>([]);
+    const [ruleActionError, setRuleActionError] = useState<string>();
     const [invalidContentError, setInvalidContentError] = useState<RuleViolationProblemDetails>();
     const [isInvalidContentModalOpen, setIsInvalidContentModalOpen] = useState(false);
     const [versionToDelete, setVersionToDelete] = useState<SearchedVersion>();
@@ -121,36 +122,42 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
 
     const doEnableRule = (ruleType: string): void => {
         logger.debug("[ArtifactPage] Enabling rule:", ruleType);
+        setRuleActionError(undefined);
         let config: string = "FULL";
         if (ruleType === "COMPATIBILITY") {
             config = "BACKWARD";
         }
-        groups.createArtifactRule(groupId as string, artifactId as string, ruleType, config).catch(error => {
-            setPageError(toPageError(error, `Error enabling "${ ruleType }" artifact rule.`));
+        groups.createArtifactRule(groupId as string, artifactId as string, ruleType, config).then(() => {
+            setRules([...rules, { config, ruleType: ruleType as RuleType }]);
+        }).catch(error => {
+            setRuleActionError(error?.message || `Error enabling "${ ruleType }" artifact rule. Please try again.`);
         });
-        setRules([...rules, { config, ruleType: ruleType as RuleType }]);
     };
 
     const doDisableRule = (ruleType: string): void => {
         logger.debug("[ArtifactPage] Disabling rule:", ruleType);
-        groups.deleteArtifactRule(groupId as string, artifactId as string, ruleType).catch(error => {
-            setPageError(toPageError(error, `Error disabling "${ ruleType }" artifact rule.`));
+        setRuleActionError(undefined);
+        groups.deleteArtifactRule(groupId as string, artifactId as string, ruleType).then(() => {
+            setRules(rules.filter(r => r.ruleType !== ruleType));
+        }).catch(error => {
+            setRuleActionError(error?.message || `Error disabling "${ ruleType }" artifact rule. Please try again.`);
         });
-        setRules(rules.filter(r => r.ruleType !== ruleType));
     };
 
     const doConfigureRule = (ruleType: string, config: string): void => {
         logger.debug("[ArtifactPage] Configuring rule:", ruleType, config);
-        groups.updateArtifactRule(groupId as string, artifactId as string, ruleType, config).catch(error => {
-            setPageError(toPageError(error, `Error configuring "${ ruleType }" artifact rule.`));
+        setRuleActionError(undefined);
+        groups.updateArtifactRule(groupId as string, artifactId as string, ruleType, config).then(() => {
+            setRules(rules.map(r => {
+                if (r.ruleType === ruleType) {
+                    return { config, ruleType: r.ruleType };
+                } else {
+                    return r;
+                }
+            }));
+        }).catch(error => {
+            setRuleActionError(error?.message || `Error configuring "${ ruleType }" artifact rule. Please try again.`);
         });
-        setRules(rules.map(r => {
-            if (r.ruleType === ruleType) {
-                return { config, ruleType: r.ruleType };
-            } else {
-                return r;
-            }
-        }));
     };
 
     const onDeleteModalClose = (): void => {
@@ -387,6 +394,8 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
                 onEnableRule={doEnableRule}
                 onDisableRule={doDisableRule}
                 onConfigureRule={doConfigureRule}
+                actionError={ruleActionError}
+                onDismissActionError={() => setRuleActionError(undefined)}
             />
         </Tab>,
         <Tab data-testid="artifact-branches-tab" eventKey="branches" title="Branches" key="branches" tabContentId="tab-branches">

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactRulesTabContent.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactRulesTabContent.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from "react";
 import "./ArtifactRulesTabContent.css";
 import "@app/styles/empty.css";
 import { RuleList, RuleListType } from "@app/components";
-import { Card, CardBody, CardTitle, Divider } from "@patternfly/react-core";
+import { Alert, AlertActionCloseButton, Card, CardBody, CardTitle, Divider } from "@patternfly/react-core";
 import { ArtifactMetaData, Rule } from "@sdk/lib/generated-client/models";
 
 /**
@@ -14,6 +14,8 @@ export type ArtifactRulesTabContentProps = {
     onEnableRule: (ruleType: string) => void;
     onDisableRule: (ruleType: string) => void;
     onConfigureRule: (ruleType: string, config: string) => void;
+    actionError?: string;
+    onDismissActionError: () => void;
 };
 
 /**
@@ -35,6 +37,15 @@ export const ArtifactRulesTabContent: FunctionComponent<ArtifactRulesTabContentP
                             individually enabled, configured, and disabled. Artifact-specific rules override
                             the equivalent global rules.
                         </p>
+                        {props.actionError && (
+                            <Alert
+                                variant="danger"
+                                title={props.actionError}
+                                actionClose={<AlertActionCloseButton onClose={props.onDismissActionError} />}
+                                isInline
+                                style={{ marginBottom: "15px" }}
+                                data-testid="rule-action-error" />
+                        )}
                         <RuleList
                             type={RuleListType.Artifact}
                             resourceOwner={props.artifact.owner}

--- a/ui/ui-app/src/app/pages/group/GroupPage.tsx
+++ b/ui/ui-app/src/app/pages/group/GroupPage.tsx
@@ -55,6 +55,7 @@ export const GroupPage: FunctionComponent<PageProperties> = () => {
     const [artifactToDelete, setArtifactToDelete] = useState<SearchedVersion>();
     const [artifactDeleteSuccessCallback, setArtifactDeleteSuccessCallback] = useState<() => void>();
     const [rules, setRules] = useState<Rule[]>([]);
+    const [ruleActionError, setRuleActionError] = useState<string>();
 
     const appNavigation: AppNavigation = useAppNavigation();
     const logger: LoggerService = useLoggerService();
@@ -156,36 +157,42 @@ export const GroupPage: FunctionComponent<PageProperties> = () => {
 
     const doEnableRule = (ruleType: string): void => {
         logger.debug("[GroupPage] Enabling rule:", ruleType);
+        setRuleActionError(undefined);
         let config: string = "FULL";
         if (ruleType === "COMPATIBILITY") {
             config = "BACKWARD";
         }
-        groups.createGroupRule(groupId as string, ruleType, config).catch(error => {
-            setPageError(toPageError(error, `Error enabling "${ ruleType }" group rule.`));
+        groups.createGroupRule(groupId as string, ruleType, config).then(() => {
+            setRules([...rules, { config, ruleType: ruleType as RuleType }]);
+        }).catch(error => {
+            setRuleActionError(error?.message || `Error enabling "${ ruleType }" group rule. Please try again.`);
         });
-        setRules([...rules, { config, ruleType: ruleType as RuleType }]);
     };
 
     const doDisableRule = (ruleType: string): void => {
         logger.debug("[GroupPage] Disabling rule:", ruleType);
-        groups.deleteGroupRule(groupId as string, ruleType).catch(error => {
-            setPageError(toPageError(error, `Error disabling "${ ruleType }" group rule.`));
+        setRuleActionError(undefined);
+        groups.deleteGroupRule(groupId as string, ruleType).then(() => {
+            setRules(rules.filter(r => r.ruleType !== ruleType));
+        }).catch(error => {
+            setRuleActionError(error?.message || `Error disabling "${ ruleType }" group rule. Please try again.`);
         });
-        setRules(rules.filter(r => r.ruleType !== ruleType));
     };
 
     const doConfigureRule = (ruleType: string, config: string): void => {
         logger.debug("[GroupPage] Configuring rule:", ruleType, config);
-        groups.updateGroupRule(groupId as string, ruleType, config).catch(error => {
-            setPageError(toPageError(error, `Error configuring "${ ruleType }" group rule.`));
+        setRuleActionError(undefined);
+        groups.updateGroupRule(groupId as string, ruleType, config).then(() => {
+            setRules(rules.map(r => {
+                if (r.ruleType === ruleType) {
+                    return { config, ruleType: r.ruleType };
+                } else {
+                    return r;
+                }
+            }));
+        }).catch(error => {
+            setRuleActionError(error?.message || `Error configuring "${ ruleType }" group rule. Please try again.`);
         });
-        setRules(rules.map(r => {
-            if (r.ruleType === ruleType) {
-                return { config, ruleType: r.ruleType };
-            } else {
-                return r;
-            }
-        }));
     };
 
     const closeInvalidContentModal = (): void => {
@@ -275,6 +282,8 @@ export const GroupPage: FunctionComponent<PageProperties> = () => {
                 onEnableRule={doEnableRule}
                 onDisableRule={doDisableRule}
                 onConfigureRule={doConfigureRule}
+                actionError={ruleActionError}
+                onDismissActionError={() => setRuleActionError(undefined)}
             />
         </Tab>
     ];

--- a/ui/ui-app/src/app/pages/group/components/tabs/GroupRulesTabContent.tsx
+++ b/ui/ui-app/src/app/pages/group/components/tabs/GroupRulesTabContent.tsx
@@ -3,6 +3,8 @@ import "./GroupRulesTabContent.css";
 import "@app/styles/empty.css";
 import { RuleList, RuleListType } from "@app/components";
 import {
+    Alert,
+    AlertActionCloseButton,
     Card,
     CardBody,
     CardTitle,
@@ -24,6 +26,8 @@ export type GroupRulesTabContentProps = {
     onEnableRule: (ruleType: string) => void;
     onDisableRule: (ruleType: string) => void;
     onConfigureRule: (ruleType: string, config: string) => void;
+    actionError?: string;
+    onDismissActionError: () => void;
 };
 
 /**
@@ -56,6 +60,15 @@ export const GroupRulesTabContent: FunctionComponent<GroupRulesTabContentProps> 
                                 individually enabled, configured, and disabled. Group-specific rules override
                                 the equivalent global rules.
                             </p>
+                            {props.actionError && (
+                                <Alert
+                                    variant="danger"
+                                    title={props.actionError}
+                                    actionClose={<AlertActionCloseButton onClose={props.onDismissActionError} />}
+                                    isInline
+                                    style={{ marginBottom: "15px" }}
+                                    data-testid="rule-action-error" />
+                            )}
                             <RuleList
                                 type={RuleListType.Group}
                                 rules={props.rules}

--- a/ui/ui-app/src/app/pages/rules/RulesPage.tsx
+++ b/ui/ui-app/src/app/pages/rules/RulesPage.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
 import "./RulesPage.css";
-import { PageSection, PageSectionVariants, Content } from "@patternfly/react-core";
+import { Alert, AlertActionCloseButton, PageSection, PageSectionVariants, Content } from "@patternfly/react-core";
 import { RootPageHeader, RuleList, RuleListType } from "@app/components";
 import { PageDataLoader, PageError, PageErrorHandler, PageProperties, RULES_PAGE_IDX, toPageError } from "@app/pages";
 import { AdminService, useAdminService } from "@services/useAdminService.ts";
@@ -15,6 +15,7 @@ export const RulesPage: FunctionComponent<PageProperties> = () => {
     const [pageError, setPageError] = useState<PageError>();
     const [loaders, setLoaders] = useState<Promise<any> | Promise<any>[] | undefined>();
     const [rules, setRules] = useState<Rule[]>([]);
+    const [ruleActionError, setRuleActionError] = useState<string>();
 
     const admin: AdminService = useAdminService();
     const logger: LoggerService = useLoggerService();
@@ -27,36 +28,42 @@ export const RulesPage: FunctionComponent<PageProperties> = () => {
 
     const doEnableRule = (ruleType: string): void => {
         logger.debug("[RulesPage] Enabling global rule:", ruleType);
+        setRuleActionError(undefined);
         let config: string = "FULL";
         if (ruleType === "COMPATIBILITY") {
             config = "BACKWARD";
         }
-        admin.createRule(ruleType, config).catch(error => {
-            setPageError(toPageError(error, `Error enabling "${ ruleType }" global rule.`));
+        admin.createRule(ruleType, config).then(() => {
+            setRules([...rules, { config, ruleType: ruleType as RuleType }]);
+        }).catch(error => {
+            setRuleActionError(error?.message || `Error enabling "${ ruleType }" global rule. Please try again.`);
         });
-        setRules([...rules, { config, ruleType: ruleType as RuleType }]);
     };
 
     const doDisableRule = (ruleType: string): void => {
         logger.debug("[RulesPage] Disabling global rule:", ruleType);
-        admin.deleteRule(ruleType).catch(error => {
-            setPageError(toPageError(error, `Error disabling "${ ruleType }" global rule.`));
+        setRuleActionError(undefined);
+        admin.deleteRule(ruleType).then(() => {
+            setRules(rules.filter(r => r.ruleType !== ruleType));
+        }).catch(error => {
+            setRuleActionError(error?.message || `Error disabling "${ ruleType }" global rule. Please try again.`);
         });
-        setRules(rules.filter(r => r.ruleType !== ruleType));
     };
 
     const doConfigureRule = (ruleType: string, config: string): void => {
         logger.debug("[RulesPage] Configuring global rule:", ruleType, config);
-        admin.updateRule(ruleType, config).catch(error => {
-            setPageError(toPageError(error, `Error configuring "${ ruleType }" global rule.`));
+        setRuleActionError(undefined);
+        admin.updateRule(ruleType, config).then(() => {
+            setRules(rules.map(r => {
+                if (r.ruleType === ruleType) {
+                    return { config, ruleType: r.ruleType };
+                } else {
+                    return r;
+                }
+            }));
+        }).catch(error => {
+            setRuleActionError(error?.message || `Error configuring "${ ruleType }" global rule. Please try again.`);
         });
-        setRules(rules.map(r => {
-            if (r.ruleType === ruleType) {
-                return { config, ruleType: r.ruleType };
-            } else {
-                return r;
-            }
-        }));
     };
 
     useEffect(() => {
@@ -76,6 +83,15 @@ export const RulesPage: FunctionComponent<PageProperties> = () => {
                 </PageSection>
                 <PageSection hasBodyWrapper={false} variant={PageSectionVariants.default} isFilled={true}>
                     <React.Fragment>
+                        {ruleActionError && (
+                            <Alert
+                                variant="danger"
+                                title={ruleActionError}
+                                actionClose={<AlertActionCloseButton onClose={() => setRuleActionError(undefined)} />}
+                                isInline
+                                style={{ marginBottom: "15px" }}
+                                data-testid="rule-action-error" />
+                        )}
                         <RuleList
                             type={RuleListType.Global}
                             rules={rules}


### PR DESCRIPTION
## Summary

Closes #8984

This PR prevents rule enable/disable/configure failures from replacing the entire page with a generic error screen.!

Instead of updating the UI optimistically before the API request completes, the rule state is now updated only after a successful response. If the request fails, the current page remains visible and a scoped inline error is displayed near the affected rules list!

## Changes

- Delay rule state updates until the corresponding API request succeeds
- Replace full-page error handling with an inline, dismissible error message
- Apply the fix consistently across:
  - Global Rules
  - Artifact Rules
  - Group Rules
- Preserve page navigation, breadcrumbs, tabs, and surrounding context when a rule action fails
- Add Playwright regression tests covering the failure path on all affected rule pages

## Testing

Verified manually by reproducing the failure on:

- Global Rules
- Artifact Rules
- Group Rules

Also verified with:

- [x] Playwright regression tests
- [x] Existing test suite
- [x] TypeScript type checking
- [x] ESLint

## Result

Before:
- Rule action failure replaced the entire page with a generic error screen.
- Navigation context and rules list were lost.

After:
- The page remains visible.
- The rule state is not updated unless the request succeeds.
- A scoped inline error is shown for the failed operation.