### PR TITLE
fix(cli): encrypt OAuth client secret in file-based credential fallback

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialEncryption.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialEncryption.java
@@ -1,0 +1,109 @@
+package io.apicurio.registry.cli.auth;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.EnumSet;
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Encrypts and decrypts secrets stored by {@link FileCredentialProvider} using an
+ * AES-256-GCM key kept in a separate, permission-restricted file next to credentials.json.
+ * This keeps a leaked or backed-up credentials.json from exposing secrets on its own.
+ */
+class CredentialEncryption {
+
+    static final String ENCRYPTED_PREFIX = "enc:v1:";
+
+    private static final String KEY_ALGORITHM = "AES";
+    private static final String CIPHER_TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int KEY_SIZE_BITS = 256;
+    private static final int GCM_IV_LENGTH_BYTES = 12;
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+
+    private final Path keyPath;
+    private SecretKey key;
+
+    CredentialEncryption(final Path keyPath) {
+        this.keyPath = keyPath;
+    }
+
+    static boolean isEncrypted(final String value) {
+        return value != null && value.startsWith(ENCRYPTED_PREFIX);
+    }
+
+    String encrypt(final String plaintext) {
+        try {
+            final var iv = new byte[GCM_IV_LENGTH_BYTES];
+            new SecureRandom().nextBytes(iv);
+            final var cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, loadOrCreateKey(), new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            final var ciphertext = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+            return ENCRYPTED_PREFIX
+                    + Base64.getEncoder().encodeToString(iv)
+                    + ":"
+                    + Base64.getEncoder().encodeToString(ciphertext);
+        } catch (GeneralSecurityException | IOException ex) {
+            throw new CredentialStoreException("Failed to encrypt credential: " + ex.getMessage(), ex);
+        }
+    }
+
+    String decrypt(final String encoded) {
+        try {
+            final var parts = encoded.substring(ENCRYPTED_PREFIX.length()).split(":", 2);
+            final var iv = Base64.getDecoder().decode(parts[0]);
+            final var ciphertext = Base64.getDecoder().decode(parts[1]);
+            final var cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, loadOrCreateKey(), new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
+        } catch (GeneralSecurityException | IOException ex) {
+            throw new CredentialStoreException("Failed to decrypt credential: " + ex.getMessage(), ex);
+        }
+    }
+
+    private synchronized SecretKey loadOrCreateKey() throws IOException, GeneralSecurityException {
+        if (key != null) {
+            return key;
+        }
+        if (!Files.exists(keyPath)) {
+            generateKeyFile();
+        }
+        key = new SecretKeySpec(Files.readAllBytes(keyPath), KEY_ALGORITHM);
+        return key;
+    }
+
+    private void generateKeyFile() throws IOException, GeneralSecurityException {
+        final KeyGenerator generator = KeyGenerator.getInstance(KEY_ALGORITHM);
+        generator.init(KEY_SIZE_BITS);
+        final var temp = Files.createTempFile(keyPath.getParent(), "credentials-key", ".tmp");
+        try {
+            Files.write(temp, generator.generateKey().getEncoded());
+            restrictFilePermissions(temp);
+            Files.move(temp, keyPath, StandardCopyOption.ATOMIC_MOVE);
+        } catch (FileAlreadyExistsException ex) {
+            // Another process created the key file concurrently — use it instead.
+        } finally {
+            Files.deleteIfExists(temp);
+        }
+    }
+
+    private static void restrictFilePermissions(final Path path) throws IOException {
+        try {
+            Files.setPosixFilePermissions(path, EnumSet.of(
+                    PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+        } catch (UnsupportedOperationException ex) {
+            // Non-POSIX filesystem — best effort only.
+        }
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialEncryption.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialEncryption.java
@@ -37,7 +37,12 @@ class CredentialEncryption {
     private static final int KEY_SIZE_BITS = 256;
     private static final int GCM_IV_LENGTH_BYTES = 12;
     private static final int GCM_TAG_LENGTH_BITS = 128;
-    private static final SecureRandom RANDOM = new SecureRandom();
+
+    // Deliberately an instance field, not a static final constant: a static SecureRandom is
+    // initialized during native-image class-init (build time), which GraalVM rejects — building
+    // it in the image heap would bake in a fixed/cached seed. Constructing it per-instance keeps
+    // initialization at runtime, after the image has started.
+    private final SecureRandom random = new SecureRandom();
 
     private final Path keyPath;
     private SecretKey key;
@@ -53,7 +58,7 @@ class CredentialEncryption {
     String encrypt(final String plaintext) {
         try {
             final var iv = new byte[GCM_IV_LENGTH_BYTES];
-            RANDOM.nextBytes(iv);
+            random.nextBytes(iv);
             final var cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
             cipher.init(Cipher.ENCRYPT_MODE, loadOrCreateKey(), new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
             final var ciphertext = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
@@ -62,20 +67,29 @@ class CredentialEncryption {
                     + ":"
                     + Base64.getEncoder().encodeToString(ciphertext);
         } catch (GeneralSecurityException | IOException ex) {
-            throw new CredentialStoreException("Failed to encrypt credential: " + ex.getMessage(), ex);
+            throw new CredentialStoreException("Failed to encrypt credential", ex);
         }
     }
 
     String decrypt(final String encoded) {
+        final byte[] iv;
+        final byte[] ciphertext;
         try {
             final var parts = encoded.substring(ENCRYPTED_PREFIX.length()).split(":", 2);
-            final var iv = Base64.getDecoder().decode(parts[0]);
-            final var ciphertext = Base64.getDecoder().decode(parts[1]);
+            if (parts.length != 2) {
+                throw new CredentialStoreException("Corrupted encrypted credential — re-run login");
+            }
+            iv = Base64.getDecoder().decode(parts[0]);
+            ciphertext = Base64.getDecoder().decode(parts[1]);
+        } catch (IllegalArgumentException ex) {
+            throw new CredentialStoreException("Corrupted encrypted credential — re-run login", ex);
+        }
+        try {
             final var cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
             cipher.init(Cipher.DECRYPT_MODE, loadOrCreateKey(), new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
             return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
         } catch (GeneralSecurityException | IOException ex) {
-            throw new CredentialStoreException("Failed to decrypt credential: " + ex.getMessage(), ex);
+            throw new CredentialStoreException("Failed to decrypt credential", ex);
         }
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialEncryption.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialEncryption.java
@@ -21,6 +21,12 @@ import javax.crypto.spec.SecretKeySpec;
  * Encrypts and decrypts secrets stored by {@link FileCredentialProvider} using an
  * AES-256-GCM key kept in a separate, permission-restricted file next to credentials.json.
  * This keeps a leaked or backed-up credentials.json from exposing secrets on its own.
+ *
+ * <p>Threat model: since {@code credentials.key} is stored unencrypted in the same directory
+ * as {@code credentials.json}, this only defends against a single-file leak or backup of
+ * credentials.json — it does not protect against compromise of the whole config directory,
+ * which exposes both the key and the ciphertext. This is not a keychain-equivalent; it exists
+ * only for the fallback path used when no OS keychain is available.
  */
 class CredentialEncryption {
 
@@ -89,8 +95,8 @@ class CredentialEncryption {
         generator.init(KEY_SIZE_BITS);
         final var temp = Files.createTempFile(keyPath.getParent(), "credentials-key", ".tmp");
         try {
-            Files.write(temp, generator.generateKey().getEncoded());
             restrictFilePermissions(temp);
+            Files.write(temp, generator.generateKey().getEncoded());
             Files.move(temp, keyPath, StandardCopyOption.ATOMIC_MOVE);
         } catch (FileAlreadyExistsException ex) {
             // Another process created the key file concurrently — use it instead.

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialEncryption.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialEncryption.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.cli.auth;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,6 +17,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import org.jboss.logging.Logger;
 
 /**
  * Encrypts and decrypts secrets stored by {@link FileCredentialProvider} using an
@@ -30,11 +32,14 @@ import javax.crypto.spec.SecretKeySpec;
  */
 class CredentialEncryption {
 
+    private static final Logger log = Logger.getLogger(CredentialEncryption.class);
+
     static final String ENCRYPTED_PREFIX = "enc:v1:";
 
     private static final String KEY_ALGORITHM = "AES";
     private static final String CIPHER_TRANSFORMATION = "AES/GCM/NoPadding";
     private static final int KEY_SIZE_BITS = 256;
+    private static final int KEY_SIZE_BYTES = KEY_SIZE_BITS / 8;
     private static final int GCM_IV_LENGTH_BYTES = 12;
     private static final int GCM_TAG_LENGTH_BITS = 128;
 
@@ -100,7 +105,15 @@ class CredentialEncryption {
         if (!Files.exists(keyPath)) {
             generateKeyFile();
         }
-        key = new SecretKeySpec(Files.readAllBytes(keyPath), KEY_ALGORITHM);
+        var keyBytes = Files.readAllBytes(keyPath);
+        if (keyBytes.length != KEY_SIZE_BYTES) {
+            log.warnf("Encryption key file (%s) has an unexpected length — regenerating it."
+                    + " Credentials encrypted with the old key will need to be re-entered.", keyPath);
+            Files.delete(keyPath);
+            generateKeyFile();
+            keyBytes = Files.readAllBytes(keyPath);
+        }
+        key = new SecretKeySpec(keyBytes, KEY_ALGORITHM);
         return key;
     }
 
@@ -111,7 +124,14 @@ class CredentialEncryption {
         try {
             restrictFilePermissions(temp);
             Files.write(temp, generator.generateKey().getEncoded());
-            Files.move(temp, keyPath, StandardCopyOption.ATOMIC_MOVE);
+            try {
+                Files.move(temp, keyPath, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException ex) {
+                // Filesystem doesn't support atomic moves (e.g. NFS, some cloud mounts) —
+                // fall back to a plain move, which still fails with FileAlreadyExistsException
+                // if the target was created concurrently.
+                Files.move(temp, keyPath);
+            }
         } catch (FileAlreadyExistsException ex) {
             // Another process created the key file concurrently — use it instead.
         } finally {

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialEncryption.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/CredentialEncryption.java
@@ -31,6 +31,7 @@ class CredentialEncryption {
     private static final int KEY_SIZE_BITS = 256;
     private static final int GCM_IV_LENGTH_BYTES = 12;
     private static final int GCM_TAG_LENGTH_BITS = 128;
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     private final Path keyPath;
     private SecretKey key;
@@ -46,7 +47,7 @@ class CredentialEncryption {
     String encrypt(final String plaintext) {
         try {
             final var iv = new byte[GCM_IV_LENGTH_BYTES];
-            new SecureRandom().nextBytes(iv);
+            RANDOM.nextBytes(iv);
             final var cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
             cipher.init(Cipher.ENCRYPT_MODE, loadOrCreateKey(), new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
             final var ciphertext = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
@@ -77,8 +77,13 @@ class FileCredentialProvider implements CredentialProvider {
         if (credentials.isEmpty()) {
             try {
                 Files.deleteIfExists(credentialsPath());
+                Files.deleteIfExists(keyPath());
+                // Drop the cached key so a subsequent store() in this same process
+                // regenerates it on disk instead of encrypting with an in-memory key
+                // that no longer has a backing file.
+                resetEncryption();
             } catch (IOException ex) {
-                // Non-critical — empty file is harmless
+                // Non-critical — leftover files are harmless
             }
         } else {
             writeCredentials(credentials);
@@ -144,10 +149,18 @@ class FileCredentialProvider implements CredentialProvider {
         return config.getAcrCurrentHomePath().resolve(CREDENTIALS_FILE);
     }
 
+    private Path keyPath() {
+        return config.getAcrCurrentHomePath().resolve(KEY_FILE);
+    }
+
     private synchronized CredentialEncryption encryption() {
         if (encryption == null) {
-            encryption = new CredentialEncryption(config.getAcrCurrentHomePath().resolve(KEY_FILE));
+            encryption = new CredentialEncryption(keyPath());
         }
         return encryption;
+    }
+
+    private synchronized void resetEncryption() {
+        encryption = null;
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
@@ -16,15 +16,17 @@ import org.jboss.logging.Logger;
 
 /**
  * File-based credential provider for environments without an OS keychain.
- * Stores credentials in a separate JSON file alongside config.json.
+ * Stores credentials, encrypted at rest, in a separate JSON file alongside config.json.
  */
 class FileCredentialProvider implements CredentialProvider {
 
     private static final Logger log = Logger.getLogger(FileCredentialProvider.class);
 
     private static final String CREDENTIALS_FILE = "credentials.json";
+    private static final String KEY_FILE = "credentials.key";
 
     private final Config config;
+    private CredentialEncryption encryption;
 
     FileCredentialProvider(final Config config) {
         this.config = config;
@@ -33,13 +35,24 @@ class FileCredentialProvider implements CredentialProvider {
     @Override
     public void store(final String account, final String secret) {
         final var credentials = readCredentials();
-        credentials.put(account, secret);
+        credentials.put(account, encryption().encrypt(secret));
         writeCredentials(credentials);
     }
 
     @Override
     public String retrieve(final String account) {
-        return readCredentials().get(account);
+        final var credentials = readCredentials();
+        final var stored = credentials.get(account);
+        if (stored == null) {
+            return null;
+        }
+        if (CredentialEncryption.isEncrypted(stored)) {
+            return encryption().decrypt(stored);
+        }
+        // Legacy plain text entry — migrate it to encrypted storage before returning it.
+        credentials.put(account, encryption().encrypt(stored));
+        writeCredentials(credentials);
+        return stored;
     }
 
     @Override
@@ -114,5 +127,12 @@ class FileCredentialProvider implements CredentialProvider {
 
     private Path credentialsPath() {
         return config.getAcrCurrentHomePath().resolve(CREDENTIALS_FILE);
+    }
+
+    private CredentialEncryption encryption() {
+        if (encryption == null) {
+            encryption = new CredentialEncryption(config.getAcrCurrentHomePath().resolve(KEY_FILE));
+        }
+        return encryption;
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
@@ -50,8 +50,16 @@ class FileCredentialProvider implements CredentialProvider {
             return encryption().decrypt(stored);
         }
         // Legacy plain text entry — migrate it to encrypted storage before returning it.
-        credentials.put(account, encryption().encrypt(stored));
-        writeCredentials(credentials);
+        // Migration is best-effort: if the config directory can't be written to (read-only
+        // filesystem, full disk, permission regression), the caller still gets a valid
+        // credential and migration is retried on the next retrieve() call.
+        try {
+            credentials.put(account, encryption().encrypt(stored));
+            writeCredentials(credentials);
+        } catch (CredentialStoreException ex) {
+            log.warnf("Could not migrate legacy plain text credential for '%s' to encrypted"
+                    + " storage (%s). Will retry on next use.", account, ex.getMessage());
+        }
         return stored;
     }
 
@@ -129,7 +137,7 @@ class FileCredentialProvider implements CredentialProvider {
         return config.getAcrCurrentHomePath().resolve(CREDENTIALS_FILE);
     }
 
-    private CredentialEncryption encryption() {
+    private synchronized CredentialEncryption encryption() {
         if (encryption == null) {
             encryption = new CredentialEncryption(config.getAcrCurrentHomePath().resolve(KEY_FILE));
         }

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
@@ -47,7 +47,14 @@ class FileCredentialProvider implements CredentialProvider {
             return null;
         }
         if (CredentialEncryption.isEncrypted(stored)) {
-            return encryption().decrypt(stored);
+            try {
+                return encryption().decrypt(stored);
+            } catch (CredentialStoreException ex) {
+                log.warnf("Could not decrypt stored credential for '%s' (%s)."
+                        + " The stored value may be corrupted — please log in again.",
+                        account, ex.getMessage());
+                return null;
+            }
         }
         // Legacy plain text entry — migrate it to encrypted storage before returning it.
         // Migration is best-effort: if the config directory can't be written to (read-only

--- a/cli/src/test/java/io/apicurio/registry/cli/auth/CredentialEncryptionTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/auth/CredentialEncryptionTest.java
@@ -1,0 +1,72 @@
+package io.apicurio.registry.cli.auth;
+
+import java.nio.file.Path;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CredentialEncryptionTest {
+
+    private static final String SECRET = "s3cr3t-value";
+
+    @TempDir
+    Path home;
+
+    private CredentialEncryption newEncryption() {
+        return new CredentialEncryption(home.resolve("credentials.key"));
+    }
+
+    @Test
+    public void testEncryptDecryptRoundTrip() {
+        var encryption = newEncryption();
+
+        var encrypted = encryption.encrypt(SECRET);
+
+        assertThat(CredentialEncryption.isEncrypted(encrypted)).isTrue();
+        assertThat(encryption.decrypt(encrypted)).isEqualTo(SECRET);
+    }
+
+    @Test
+    public void testDecryptRejectsTamperedCiphertext() {
+        var encryption = newEncryption();
+        var encrypted = encryption.encrypt(SECRET);
+
+        var prefixEnd = CredentialEncryption.ENCRYPTED_PREFIX.length();
+        var separator = encrypted.indexOf(':', prefixEnd);
+        var iv = encrypted.substring(prefixEnd, separator);
+        var ciphertext = encrypted.substring(separator + 1);
+        // Flip a byte inside the ciphertext (keeping base64 length/padding intact) so
+        // GCM tag verification fails on decrypt rather than base64 decoding.
+        var decoded = Base64.getDecoder().decode(ciphertext);
+        decoded[0] ^= 0x01;
+        var tamperedCiphertext = Base64.getEncoder().encodeToString(decoded);
+        var tampered = CredentialEncryption.ENCRYPTED_PREFIX + iv + ":" + tamperedCiphertext;
+
+        assertThatThrownBy(() -> encryption.decrypt(tampered))
+                .isInstanceOf(CredentialStoreException.class)
+                .hasMessage("Failed to decrypt credential");
+    }
+
+    @Test
+    public void testDecryptRejectsMalformedValueMissingSeparator() {
+        var encryption = newEncryption();
+        var malformed = CredentialEncryption.ENCRYPTED_PREFIX + "not-a-valid-payload";
+
+        assertThatThrownBy(() -> encryption.decrypt(malformed))
+                .isInstanceOf(CredentialStoreException.class)
+                .hasMessage("Corrupted encrypted credential — re-run login");
+    }
+
+    @Test
+    public void testDecryptRejectsMalformedValueInvalidBase64() {
+        var encryption = newEncryption();
+        var malformed = CredentialEncryption.ENCRYPTED_PREFIX + "not-base64!!:also-not-base64!!";
+
+        assertThatThrownBy(() -> encryption.decrypt(malformed))
+                .isInstanceOf(CredentialStoreException.class)
+                .hasMessage("Corrupted encrypted credential — re-run login");
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/auth/FileCredentialProviderTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/auth/FileCredentialProviderTest.java
@@ -1,0 +1,103 @@
+package io.apicurio.registry.cli.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.cli.config.Config;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FileCredentialProviderTest {
+
+    private static final String ACCOUNT = "test/client-secret";
+    private static final String SECRET = "s3cr3t-value";
+
+    @TempDir
+    Path home;
+
+    private FileCredentialProvider newProvider() {
+        var config = new Config();
+        config.setAcrCurrentHomePath(home);
+        return new FileCredentialProvider(config);
+    }
+
+    @Test
+    public void testStoredSecretIsEncryptedOnDisk() throws Exception {
+        newProvider().store(ACCOUNT, SECRET);
+
+        var raw = Files.readString(home.resolve("credentials.json"));
+        assertThat(raw)
+                .as("Secret must not appear in plain text on disk")
+                .doesNotContain(SECRET);
+        assertThat(raw)
+                .as("Stored value should use the encrypted format")
+                .contains(CredentialEncryption.ENCRYPTED_PREFIX);
+    }
+
+    @Test
+    public void testRetrieveDecryptsTransparently() {
+        var provider = newProvider();
+        provider.store(ACCOUNT, SECRET);
+
+        assertThat(provider.retrieve(ACCOUNT)).isEqualTo(SECRET);
+    }
+
+    @Test
+    public void testKeyFileHasRestrictedPermissions() throws Exception {
+        newProvider().store(ACCOUNT, SECRET);
+
+        var keyFile = home.resolve("credentials.key");
+        assertThat(Files.exists(keyFile)).isTrue();
+        var view = Files.getFileAttributeView(keyFile, PosixFileAttributeView.class);
+        if (view != null) {
+            var permissions = Files.getPosixFilePermissions(keyFile);
+            assertThat(permissions)
+                    .as("Key file should only be readable/writable by the owner")
+                    .containsExactlyInAnyOrder(
+                            PosixFilePermission.OWNER_READ,
+                            PosixFilePermission.OWNER_WRITE);
+        }
+    }
+
+    @Test
+    public void testLegacyPlainTextSecretIsMigratedOnRetrieve() throws Exception {
+        // Simulate an existing credentials.json from before encryption was introduced.
+        Map<String, String> legacy = new HashMap<>();
+        legacy.put(ACCOUNT, SECRET);
+        Files.writeString(home.resolve("credentials.json"), new ObjectMapper().writeValueAsString(legacy));
+
+        var provider = newProvider();
+
+        // Reading it transparently returns the original secret...
+        assertThat(provider.retrieve(ACCOUNT)).isEqualTo(SECRET);
+
+        // ...and migrates the on-disk value to the encrypted format.
+        var raw = Files.readString(home.resolve("credentials.json"));
+        assertThat(raw).doesNotContain(SECRET);
+        assertThat(raw).contains(CredentialEncryption.ENCRYPTED_PREFIX);
+
+        // A second read (fresh provider instance, same key file) still resolves correctly.
+        assertThat(newProvider().retrieve(ACCOUNT)).isEqualTo(SECRET);
+    }
+
+    @Test
+    public void testRetrieveMissingAccountReturnsNull() {
+        assertThat(newProvider().retrieve("does/not-exist")).isNull();
+    }
+
+    @Test
+    public void testDeleteRemovesSecret() {
+        var provider = newProvider();
+        provider.store(ACCOUNT, SECRET);
+
+        provider.delete(ACCOUNT);
+
+        assertThat(provider.retrieve(ACCOUNT)).isNull();
+    }
+}

--- a/cli/src/test/java/io/apicurio/registry/cli/auth/FileCredentialProviderTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/auth/FileCredentialProviderTest.java
@@ -1,11 +1,13 @@
 package io.apicurio.registry.cli.auth;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apicurio.registry.cli.config.Config;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -99,5 +101,47 @@ public class FileCredentialProviderTest {
         provider.delete(ACCOUNT);
 
         assertThat(provider.retrieve(ACCOUNT)).isNull();
+    }
+
+    @Test
+    public void testRetrieveReturnsNullForTamperedCiphertext() throws Exception {
+        newProvider().store(ACCOUNT, SECRET);
+
+        var path = home.resolve("credentials.json");
+        Map<String, String> credentials = new ObjectMapper().readValue(path.toFile(), new TypeReference<>() {});
+        var encrypted = credentials.get(ACCOUNT);
+        var prefixEnd = CredentialEncryption.ENCRYPTED_PREFIX.length();
+        var separator = encrypted.indexOf(':', prefixEnd);
+        var iv = encrypted.substring(prefixEnd, separator);
+        var ciphertext = encrypted.substring(separator + 1);
+        // Flip a byte inside the ciphertext (keeping base64 length/padding intact) so
+        // GCM tag verification fails on decrypt rather than base64 decoding.
+        var decoded = Base64.getDecoder().decode(ciphertext);
+        decoded[0] ^= 0x01;
+        var tamperedCiphertext = Base64.getEncoder().encodeToString(decoded);
+        credentials.put(ACCOUNT, CredentialEncryption.ENCRYPTED_PREFIX + iv + ":" + tamperedCiphertext);
+        Files.writeString(path, new ObjectMapper().writeValueAsString(credentials));
+
+        // A corrupted/tampered credential must not surface a stack trace to the caller —
+        // retrieve() reports it as absent so the CLI can prompt the user to log in again.
+        assertThat(newProvider().retrieve(ACCOUNT)).isNull();
+    }
+
+    @Test
+    public void testRetrieveReturnsNullForMalformedEncryptedValueMissingSeparator() throws Exception {
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put(ACCOUNT, CredentialEncryption.ENCRYPTED_PREFIX + "not-a-valid-payload");
+        Files.writeString(home.resolve("credentials.json"), new ObjectMapper().writeValueAsString(credentials));
+
+        assertThat(newProvider().retrieve(ACCOUNT)).isNull();
+    }
+
+    @Test
+    public void testRetrieveReturnsNullForMalformedEncryptedValueInvalidBase64() throws Exception {
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put(ACCOUNT, CredentialEncryption.ENCRYPTED_PREFIX + "not-base64!!:also-not-base64!!");
+        Files.writeString(home.resolve("credentials.json"), new ObjectMapper().writeValueAsString(credentials));
+
+        assertThat(newProvider().retrieve(ACCOUNT)).isNull();
     }
 }

--- a/cli/src/test/java/io/apicurio/registry/cli/auth/FileCredentialProviderTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/auth/FileCredentialProviderTest.java
@@ -144,4 +144,50 @@ public class FileCredentialProviderTest {
 
         assertThat(newProvider().retrieve(ACCOUNT)).isNull();
     }
+
+    @Test
+    public void testCorruptedKeyFileIsRegeneratedRatherThanBreakingPermanently() throws Exception {
+        newProvider().store(ACCOUNT, SECRET);
+
+        // Simulate a truncated/corrupted key file (e.g. disk error, partial backup restore).
+        var keyFile = home.resolve("credentials.key");
+        Files.write(keyFile, new byte[] {1, 2, 3});
+
+        // The old stored value can no longer be decrypted with a fresh key, but the
+        // provider must recover instead of failing every call forever.
+        var provider = newProvider();
+        assertThat(provider.retrieve(ACCOUNT)).isNull();
+
+        // A regenerated, correctly sized key must now be usable for new credentials.
+        provider.store(ACCOUNT, SECRET);
+        assertThat(provider.retrieve(ACCOUNT)).isEqualTo(SECRET);
+        assertThat(Files.readAllBytes(keyFile)).hasSize(32);
+    }
+
+    @Test
+    public void testDeleteRemovesKeyFileWhenLastCredentialIsDeleted() {
+        var provider = newProvider();
+        provider.store(ACCOUNT, SECRET);
+        assertThat(Files.exists(home.resolve("credentials.key"))).isTrue();
+
+        provider.delete(ACCOUNT);
+
+        assertThat(Files.exists(home.resolve("credentials.json"))).isFalse();
+        assertThat(Files.exists(home.resolve("credentials.key"))).isFalse();
+    }
+
+    @Test
+    public void testStoreAfterDeleteRegeneratesKeyFileAndRoundTrips() {
+        var provider = newProvider();
+        provider.store(ACCOUNT, SECRET);
+        provider.delete(ACCOUNT);
+
+        // Storing again in the same provider instance (same process) must not silently
+        // encrypt with a stale in-memory key that no longer has a file on disk.
+        provider.store(ACCOUNT, SECRET);
+
+        assertThat(Files.exists(home.resolve("credentials.key"))).isTrue();
+        assertThat(provider.retrieve(ACCOUNT)).isEqualTo(SECRET);
+        assertThat(newProvider().retrieve(ACCOUNT)).isEqualTo(SECRET);
+    }
 }


### PR DESCRIPTION



## Summary

When the OS keychain isn't available, the CLI falls back to storing login credentials (OAuth2 client secret, Basic auth password) in a plain text `credentials.json` file. This encrypts those values at rest.

Fixes #8380.

## Changes

### Encryption at rest (`CredentialEncryption`, new)
- Encrypts/decrypts secrets with AES-256-GCM (random 96-bit IV per value, 128-bit auth tag).
- The key is generated on first use and stored in a separate `credentials.key` file with owner-only permissions, alongside `credentials.json`.

### Transparent encrypt/decrypt (`FileCredentialProvider`)
- `store()` encrypts the secret before writing it to `credentials.json`.
- `retrieve()` decrypts an already-encrypted value and returns it unchanged to the caller  (`Client.configureAuth`), so every existing CLI command that authenticates works exactly
  as before.

### Migration of existing plain text secrets (`FileCredentialProvider.retrieve`)
- If a stored value isn't in the encrypted format (i.e. it was written before this change),  it's treated as legacy plain text: the original value is still returned, and the entry is  encrypted and rewritten to `credentials.json` before the call returns. No user action or extra command is needed — migration happens the next time the credential is used.

## Testing

- `FileCredentialProviderTest` (new): secret is never stored as plain text on disk, round-trip encrypt/decrypt returns the original value, the key file gets owner-only permissions, a pre-existing plain text entry is migrated on `retrieve()` and stays readable afterwards  (including across a fresh provider instance), a missing account returns `null`, and `delete()`
  removes the secret.
- `./mvnw test -pl cli`
- `./mvnw checkstyle:check -pl cli`
- `./scripts/validate-files.sh`
- `./mvnw clean package -Pprod -Dfull -DskipTests -DcliSkipNative`

## Notes

- The OAuth client secret and Basic auth password were never stored in `config.json` itself — only in the OS keychain or, as a fallback, `credentials.json`. The keychain path was already encrypted at the OS level; this change closes the gap in the file-based fallback, which is  the path the CLI explicitly warns about as "not recommended for production use".
- Native-image (GraalVM) build/runtime behavior for the new `javax.crypto` usage was not  independently verified in this environment — worth a manual check with
  `./mvnw verify -pl cli -Dquarkus.native.container-build=false` before merging if that hasn't run in CI yet.
