### PR TITLE
fix(ui): render recommended models as read-only labels

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.css
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.css
@@ -94,12 +94,3 @@
     background-color: var(--pf-t--global--background--color--secondary--default);
     border-radius: 3px;
 }
-
-.prompt-template-viewer .model-link {
-    color: inherit;
-    text-decoration: none;
-}
-
-.prompt-template-viewer .model-link:hover {
-    text-decoration: underline;
-}

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
@@ -216,8 +216,8 @@ export const PromptTemplateViewer: FunctionComponent<PromptTemplateViewerProps> 
                         <Divider className="section-divider" />
                         <Title headingLevel="h3" size="md">Recommended Models</Title>
                         <LabelGroup className="section-content">
-                            {meta.recommendedModels.map((model, index) => (
-                                <Label key={index} color="purple" isCompact>
+                            {meta.recommendedModels.map((model) => (
+                                <Label key={model} color="purple" isCompact>
                                     {model}
                                 </Label>
                             ))}

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent } from "react";
-import { Link } from "react-router";
 import "./PromptTemplateViewer.css";
 import {
     Card,
@@ -219,9 +218,7 @@ export const PromptTemplateViewer: FunctionComponent<PromptTemplateViewerProps> 
                         <LabelGroup className="section-content">
                             {meta.recommendedModels.map((model, index) => (
                                 <Label key={index} color="purple" isCompact>
-                                    <Link to={`/explore/default/${encodeURIComponent(model)}`} className="model-link">
-                                        {model}
-                                    </Link>
+                                    {model}
                                 </Label>
                             ))}
                         </LabelGroup>


### PR DESCRIPTION
metadata.recommendedModels holds AI model identifiers (e.g. gpt-4o, claude-3-5-sonnet), not artifact IDs in the default group. Linking each one to /explore/default/<model> therefore navigated to a non-existent artifact and rendered a 404 page.

Render the models as plain PatternFly labels instead, since they are informational metadata rather than artifact references. Also drops the now-unused Link import and the dead .model-link styles.

Fixes #8873

## What
`metadata.recommendedModels` on a PROMPT_TEMPLATE artifact was rendered as React
Router links pointing at `/explore/default/<model>`.
## Why
That field holds AI model identifiers (`gpt-4o`, `claude-3-5-sonnet`), not artifact
IDs in the `default` group — so every click resolved to a non-existent artifact and
landed the user on a 404 page.
Recommended models are informational metadata rather than artifact references, so
they are now plain PatternFly labels with no navigation. The unused `Link` import
and the dead `.model-link` styles are removed along with it.
## Verification
- `npx tsc --noEmit` — no new errors in the changed file
- `npx eslint` on the changed file — clean
- No behavioural change outside the Recommended Models section