### PR TITLE
fix(ui): respect declared default for boolean prompt template variables

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -59,7 +59,7 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
             variablesList.forEach(({ name, variable }) => {
                 if (!(name in next)) {
                     const type = (variable.type || "string").toLowerCase();
-                    next[name] = type === "boolean" ? false : (variable.default ?? "");
+                    next[name] = variable.default ?? (type === "boolean" ? false : "");
                 }
             });
             return next;


### PR DESCRIPTION
Fixes #9015

## What changed
In `PromptTemplateTestPanel`, the `useEffect` that seeds values for newly
appearing prompt variables unconditionally forced `boolean`-typed
variables to `false`, ignoring any declared `default`.

Before:
```js
next[name] = type === "boolean" ? false : (variable.default ?? "");
```

After:
```js
next[name] = variable.default ?? (type === "boolean" ? false : "");
```

This only falls back to `false` when no default is declared, so a
boolean variable with `default: true` is now seeded correctly.

## Why it's reachable
For `PROMPT_TEMPLATE` artifacts, content is dereferenced asynchronously
(`DocumentationTabContent`), so `PromptTemplateTestPanel` mounts once with
`variables={undefined}` and then updates once the async fetch resolves.
That update path runs this `useEffect`, so this triggers on every load of
a Prompt Template artifact's Documentation tab — not an edge case.

## Before

[raw-recording (6).webm](https://github.com/user-attachments/assets/4ee4600b-3372-4ad0-b984-98a8330448cc)


## After

[raw-recording (7).webm](https://github.com/user-attachments/assets/40e36a82-272a-43af-ab82-5b80f44406a2)


## How to test
1. Create a `PROMPT_TEMPLATE` artifact with a boolean variable that has
   `default: true`.
2. Open its version's Documentation tab.
3. Confirm the Variables table shows `Default: true` for that variable,
   and the Test Prompt checkbox now renders checked to match.

