### PR TITLE
fix(ui): coerce enum prompt template values to their declared type

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -21,6 +21,7 @@ import {
 import { PromptVariable } from "./PromptTemplateViewer";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
 import { RenderPromptResponse, RenderPromptValidationError } from "@models/RenderPromptResponse.ts";
+import { coerceEnumValue } from "./PromptTemplateTestPanel.utils";
 
 export type PromptTemplateTestPanelProps = {
     groupId: string;
@@ -108,7 +109,7 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
             return (
                 <FormSelect
                     value={values[name] || ""}
-                    onChange={(_event, val) => setValue(name, val)}
+                    onChange={(_event, val) => setValue(name, coerceEnumValue(val, type))}
                     aria-label={name}
                 >
                     <FormSelectOption key="placeholder" value="" label="-- Select --" />

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -108,7 +108,7 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
         if (variable.enum && variable.enum.length > 0) {
             return (
                 <FormSelect
-                    value={values[name] || ""}
+                    value={values[name] ?? ""}
                     onChange={(_event, val) => setValue(name, coerceEnumValue(val, type))}
                     aria-label={name}
                 >

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.test.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { coerceEnumValue } from "./PromptTemplateTestPanel.utils";
+
+describe("coerceEnumValue", () => {
+    it("parses an integer enum selection to a number", () => {
+        expect(coerceEnumValue("443", "integer")).toBe(443);
+    });
+
+    it("parses a number enum selection to a float", () => {
+        expect(coerceEnumValue("3.14", "number")).toBe(3.14);
+    });
+
+    it("parses a boolean enum selection to true", () => {
+        expect(coerceEnumValue("true", "boolean")).toBe(true);
+    });
+
+    it("parses a boolean enum selection to false", () => {
+        expect(coerceEnumValue("false", "boolean")).toBe(false);
+    });
+
+    it("leaves a string enum selection untouched", () => {
+        expect(coerceEnumValue("prod", "string")).toBe("prod");
+    });
+
+    it("keeps the placeholder selection as an empty string for an integer variable", () => {
+        expect(coerceEnumValue("", "integer")).toBe("");
+    });
+
+    it("keeps the placeholder selection as an empty string for a number variable", () => {
+        expect(coerceEnumValue("", "number")).toBe("");
+    });
+
+    it("keeps the placeholder selection as an empty string for a boolean variable", () => {
+        expect(coerceEnumValue("", "boolean")).toBe("");
+    });
+});

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.ts
@@ -1,0 +1,13 @@
+export const coerceEnumValue = (val: string, type: string): any => {
+    if (val === "") return "";
+    switch (type) {
+        case "integer":
+            return parseInt(val, 10);
+        case "number":
+            return parseFloat(val);
+        case "boolean":
+            return val === "true";
+        default:
+            return val;
+    }
+};


### PR DESCRIPTION
Fixes #8997

the enum FormSelect in PromptTemplateTestPanel was just passing the raw
string straight to setValue(), no matter what type the variable actually
was. so any integer, number or boolean variable using enum always failed
on the backend with "type mismatch: expected X but got string" even when
you picked a totally valid option from the dropdown..

root cause is basically that onChange never coerced the value. the
integer/number branch a few lines below already does this with
parseInt/parseFloat but the enum branch never got the same treatment,
guessing it just got missed.

fix: added a small coerceEnumValue helper in a new
PromptTemplateTestPanel.utils.ts (kept it in its own file so it's
actually testable and doesn't trip the react-refresh lint rule for
exporting non-components from a component file). it parses the selected
value based on the declared type before it hits setValue, and also
handles the placeholder option ("-- select --", value "") so it doesn't
turn into NaN for integer/number types.

TESTING:
- added PromptTemplateTestPanel.utils.test.ts, 8 tests covering
  integer/number/boolean/string coercion plus the placeholder case for
  each.. all passing
- tsc --noEmit is clean, no new errors (there's some pre-existing
  unrelated ones from the unbuilt typescript-sdk client but nothing
  touching these files)
- eslint clean on the changed files