### PR TITLE
refactor(avro): route Schema.Parser construction through AvroParserAccessor

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemaFormatService.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemaFormatService.java
@@ -4,6 +4,7 @@ import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.avro.content.dereference.AvroDereferencer;
+import io.apicurio.registry.avro.util.AvroParserAccessor;
 import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.protobuf.content.dereference.ProtobufDereferencer;
 import io.apicurio.registry.types.ArtifactType;
@@ -109,7 +110,7 @@ public class SchemaFormatService {
                 return dereferencedContent.getContent();
             } else {
                 // No references to resolve, but still parse and return the canonical form
-                Schema.Parser parser = new Schema.Parser();
+                Schema.Parser parser = AvroParserAccessor.newParser();
                 Schema schema = parser.parse(content.content());
                 return ContentHandle.create(schema.toString());
             }

--- a/app/src/main/java/io/apicurio/registry/contracts/tags/AvroTagExtractor.java
+++ b/app/src/main/java/io/apicurio/registry/contracts/tags/AvroTagExtractor.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.contracts.tags;
 
+import io.apicurio.registry.avro.util.AvroParserAccessor;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.types.ArtifactType;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -30,7 +31,7 @@ public class AvroTagExtractor implements TagExtractor {
     @Override
     public Map<String, Set<String>> extractTags(ContentHandle content) {
         try {
-            Schema schema = new Schema.Parser().parse(content.content());
+            Schema schema = AvroParserAccessor.newParser().parse(content.content());
             Map<String, Set<String>> result = new LinkedHashMap<>();
             Set<String> visited = new HashSet<>();
             extractTagsFromSchema(schema, "", result, visited);

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/AvroContentAccepter.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/AvroContentAccepter.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.avro.content;
 
+import io.apicurio.registry.avro.util.AvroParserAccessor;
 import io.apicurio.registry.content.ContentAccepter;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.util.ContentTypeUtil;
@@ -30,7 +31,9 @@ public class AvroContentAccepter implements ContentAccepter {
                 return false;
             }
             // Avro without quote
-            final Schema.Parser parser = new Schema.Parser();
+            // Seeded inline rather than via AvroParserAccessor#newParser(Map) because this call site also
+            // needs the parsed reference schemas themselves, and skips any reference name already known.
+            final Schema.Parser parser = AvroParserAccessor.newParser();
             final List<Schema> schemaRefs = new ArrayList<>();
             for (Map.Entry<String, TypedContent> referencedContent : resolvedReferences.entrySet()) {
                 if (!parser.getTypes().containsKey(referencedContent.getKey())) {

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/canon/AvroContentCanonicalizer.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/canon/AvroContentCanonicalizer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.registry.avro.util.AvroParserAccessor;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
@@ -57,7 +58,9 @@ public class AvroContentCanonicalizer implements ContentCanonicalizer {
             return TypedContent.create(ContentHandle.create(converted), ContentTypes.APPLICATION_JSON);
         } catch (Throwable t) {
             // best effort
-            final Schema.Parser parser = new Schema.Parser();
+            // Seeded inline rather than via AvroParserAccessor#newParser(Map) because this call site also
+            // needs the parsed reference schemas themselves, to pass to Schema#toString.
+            final Schema.Parser parser = AvroParserAccessor.newParser();
             final List<Schema> schemaRefs = new ArrayList<>();
             for (TypedContent referencedContent : resolvedReferences.values()) {
                 Schema schemaRef = parser.parse(referencedContent.getContent().content());

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/canon/EnhancedAvroContentCanonicalizer.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/canon/EnhancedAvroContentCanonicalizer.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.avro.content.canon;
 
+import io.apicurio.registry.avro.util.AvroParserAccessor;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.canon.ContentCanonicalizer;
@@ -10,7 +11,6 @@ import org.apache.avro.Schema;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -43,32 +43,9 @@ public class EnhancedAvroContentCanonicalizer implements ContentCanonicalizer {
      */
     public static Schema normalizeSchema(String schemaString,
             Map<String, TypedContent> resolvedReferences) {
-        Schema.Parser parser = new Schema.Parser();
-
-        // Seed the parser with the referenced schemas, so that the named types they declare are already
-        // known once the main schema is parsed. Without this, a schema that references another artifact
-        // fails to parse at all. References may depend on each other and the map imposes no ordering, so
-        // re-attempt the ones that fail until a full pass resolves nothing further. Anything still
-        // unresolved is left to the main parse below, which reports the offending type name.
-        List<String> pending = new ArrayList<>(resolvedReferences.size());
-        for (TypedContent referencedContent : resolvedReferences.values()) {
-            pending.add(referencedContent.getContent().content());
-        }
-        boolean progressed = true;
-        while (progressed && !pending.isEmpty()) {
-            progressed = false;
-            Iterator<String> iter = pending.iterator();
-            while (iter.hasNext()) {
-                try {
-                    parser.parse(iter.next());
-                    iter.remove();
-                    progressed = true;
-                } catch (AvroRuntimeException e) {
-                    // Either this reference depends on another one not parsed yet (retried on the next
-                    // pass), or it cannot be parsed on its own. Neither is fatal here.
-                }
-            }
-        }
+        // The parser is seeded with the referenced schemas so that the named types they declare are already
+        // known once the main schema is parsed; see AvroParserAccessor#newParser(Map).
+        Schema.Parser parser = AvroParserAccessor.newParser(resolvedReferences);
 
         return normalizeSchema(parser.parse(schemaString));
     }

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/dereference/AvroDereferencer.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/dereference/AvroDereferencer.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.avro.content.dereference;
 
+import io.apicurio.registry.avro.util.AvroParserAccessor;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.dereference.ContentDereferencer;
@@ -12,10 +13,7 @@ public class AvroDereferencer implements ContentDereferencer {
 
     @Override
     public TypedContent dereference(TypedContent content, Map<String, TypedContent> resolvedReferences) {
-        final Schema.Parser parser = new Schema.Parser();
-        for (TypedContent referencedContent : resolvedReferences.values()) {
-            parser.parse(referencedContent.getContent().content());
-        }
+        final Schema.Parser parser = AvroParserAccessor.newParser(resolvedReferences);
         final Schema schema = parser.parse(content.getContent().content());
         return TypedContent.create(ContentHandle.create(schema.toString()), ContentTypes.APPLICATION_JSON);
     }

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/extract/AvroStructuredContentExtractor.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/extract/AvroStructuredContentExtractor.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.avro.content.extract;
 
+import io.apicurio.registry.avro.util.AvroParserAccessor;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.extract.StructuredContentExtractor;
 import io.apicurio.registry.content.extract.StructuredElement;
@@ -24,7 +25,7 @@ public class AvroStructuredContentExtractor implements StructuredContentExtracto
     @Override
     public List<StructuredElement> extract(ContentHandle content) {
         try {
-            Schema.Parser parser = new Schema.Parser();
+            Schema.Parser parser = AvroParserAccessor.newParser();
             Schema schema = parser.parse(content.content());
             List<StructuredElement> elements = new ArrayList<>();
             Set<String> visited = new HashSet<>();

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/rules/compatibility/AvroCompatibilityChecker.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/rules/compatibility/AvroCompatibilityChecker.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.avro.rules.compatibility;
 
+import io.apicurio.registry.avro.util.AvroParserAccessor;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.rules.compatibility.AbstractCompatibilityChecker;
 import io.apicurio.registry.rules.compatibility.CompatibilityDifference;
@@ -20,17 +21,10 @@ public class AvroCompatibilityChecker extends AbstractCompatibilityChecker<Incom
     protected Set<Incompatibility> isBackwardsCompatibleWith(String existing, String proposed,
             Map<String, TypedContent> resolvedReferences) {
         try {
-            Schema.Parser existingParser = new Schema.Parser();
-            for (TypedContent schema : resolvedReferences.values()) {
-                existingParser.parse(schema.getContent().content());
-            }
-            final Schema existingSchema = existingParser.parse(existing);
-
-            Schema.Parser proposingParser = new Schema.Parser();
-            for (TypedContent schema : resolvedReferences.values()) {
-                proposingParser.parse(schema.getContent().content());
-            }
-            final Schema proposedSchema = proposingParser.parse(proposed);
+            // Two independent parsers: each accumulates the named types it parses, so reusing one would
+            // leak the existing schema's types into the proposed schema's namespace.
+            final Schema existingSchema = AvroParserAccessor.newParser(resolvedReferences).parse(existing);
+            final Schema proposedSchema = AvroParserAccessor.newParser(resolvedReferences).parse(proposed);
 
             var result = SchemaCompatibility.checkReaderWriterCompatibility(proposedSchema, existingSchema)
                     .getResult();

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/rules/validity/AvroContentValidator.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/rules/validity/AvroContentValidator.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.avro.rules.validity;
 
 import io.apicurio.registry.avro.content.refs.AvroReferenceFinder;
+import io.apicurio.registry.avro.util.AvroParserAccessor;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.refs.ExternalReference;
 import io.apicurio.registry.rest.v3.beans.ArtifactReference;
@@ -34,10 +35,7 @@ public class AvroContentValidator extends AbstractContentValidator {
             Map<String, TypedContent> resolvedReferences) throws RuleViolationException {
         if (level == ValidityLevel.SYNTAX_ONLY || level == ValidityLevel.FULL) {
             try {
-                Schema.Parser parser = new Schema.Parser();
-                for (TypedContent schemaTC : resolvedReferences.values()) {
-                    parser.parse(schemaTC.getContent().content());
-                }
+                Schema.Parser parser = AvroParserAccessor.newParser(resolvedReferences);
                 parser.parse(content.getContent().content());
             } catch (Exception e) {
                 throw new RuleViolationException("Syntax violation for Avro artifact.", RuleType.VALIDITY,

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/util/AvroParserAccessor.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/util/AvroParserAccessor.java
@@ -1,0 +1,93 @@
+package io.apicurio.registry.avro.util;
+
+import io.apicurio.registry.content.TypedContent;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Single construction point for {@link Schema.Parser} instances, mirroring the role that
+ * {@code DocumentBuilderAccessor} and {@code SchemaFactoryAccessor} play for the XML and XSD types. Every
+ * Avro parser used by the registry should be obtained here so that parser hardening lives in exactly one
+ * place instead of being duplicated across every call site.
+ * <p>
+ * Unlike the XML and XSD accessors, this class deliberately does <em>not</em> cache the parser in a
+ * {@link ThreadLocal}. {@link Schema.Parser} accumulates the named types it has seen and carries them into
+ * subsequent {@code parse()} calls on the same instance — behaviour that
+ * {@link #newParser(Map)} depends on. A shared or thread-cached parser would therefore leak type
+ * definitions between unrelated schemas, letting a schema that references a type it never declares parse
+ * successfully because an earlier, unrelated parse happened to define that name. Each caller gets a fresh
+ * instance; only the configuration is shared.
+ */
+public final class AvroParserAccessor {
+
+    private AvroParserAccessor() {
+    }
+
+    /**
+     * @return a new, hardened parser with no named types pre-registered.
+     */
+    public static Schema.Parser newParser() {
+        return configure(new Schema.Parser());
+    }
+
+    /**
+     * Returns a new parser seeded with the given referenced schemas, so that the named types they declare are
+     * already known by the time the referring schema is parsed. Without this, a schema that references
+     * another artifact fails to parse at all.
+     * <p>
+     * References may depend on one another and the map imposes no ordering, so the ones that fail are
+     * re-attempted until a full pass resolves nothing further. Anything still unresolved is left to the
+     * caller's own parse, which reports the offending type name.
+     *
+     * @param resolvedReferences the content of the artifacts referenced by the schema, keyed by reference
+     *            name. May be empty or null.
+     * @return a new, hardened parser with the resolvable references already registered.
+     */
+    public static Schema.Parser newParser(Map<String, TypedContent> resolvedReferences) {
+        Schema.Parser parser = newParser();
+        if (resolvedReferences == null || resolvedReferences.isEmpty()) {
+            return parser;
+        }
+
+        List<String> pending = new ArrayList<>(resolvedReferences.size());
+        for (TypedContent referencedContent : resolvedReferences.values()) {
+            pending.add(referencedContent.getContent().content());
+        }
+        boolean progressed = true;
+        while (progressed && !pending.isEmpty()) {
+            progressed = false;
+            Iterator<String> iter = pending.iterator();
+            while (iter.hasNext()) {
+                try {
+                    parser.parse(iter.next());
+                    iter.remove();
+                    progressed = true;
+                } catch (AvroRuntimeException e) {
+                    // Either this reference depends on another one not parsed yet (retried on the next
+                    // pass), or it cannot be parsed on its own. Neither is fatal here.
+                }
+            }
+        }
+        return parser;
+    }
+
+    /**
+     * Applies the registry's parser hardening. This is the single place to add future restrictions, for
+     * example a nesting-depth limit to bound stack usage on deeply nested schemas.
+     * <p>
+     * The settings applied here currently match the Avro library defaults, so this method is behaviour
+     * preserving. They are set explicitly so that the registry's posture is stated at one site and cannot be
+     * loosened by a change of default in a future Avro release. Note that name validation is fixed at
+     * construction time in Avro 1.12 ({@code Schema.Parser} holds it in a final field and exposes no setter),
+     * so the strict default is inherited from the no-argument constructor above.
+     */
+    private static Schema.Parser configure(Schema.Parser parser) {
+        parser.setValidateDefaults(true);
+        return parser;
+    }
+}

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/util/AvroParserAccessor.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/util/AvroParserAccessor.java
@@ -80,11 +80,21 @@ public final class AvroParserAccessor {
      * Applies the registry's parser hardening. This is the single place to add future restrictions, for
      * example a nesting-depth limit to bound stack usage on deeply nested schemas.
      * <p>
-     * The settings applied here currently match the Avro library defaults, so this method is behaviour
-     * preserving. They are set explicitly so that the registry's posture is stated at one site and cannot be
-     * loosened by a change of default in a future Avro release. Note that name validation is fixed at
-     * construction time in Avro 1.12 ({@code Schema.Parser} holds it in a final field and exposes no setter),
-     * so the strict default is inherited from the no-argument constructor above.
+     * The settings applied here match the Avro library defaults, so this method is behaviour preserving. They
+     * are set explicitly so that the registry's posture is stated at one site and cannot be loosened by a
+     * change of default in a future Avro release.
+     * <p>
+     * Do not take Avro's own documentation as the authority on the {@code validateDefaults} default: in the
+     * pinned Avro 1.12.1, {@code Schema.java:1432} initialises the field to {@code true} while the
+     * {@code getValidateDefaults()} javadoc at {@code Schema.java:1480} claims "False by default". The
+     * initialiser is what runs, and it was confirmed against the pinned version rather than the docs, so
+     * passing {@code true} here changes nothing today. {@code AvroParserAccessorTest} pins the expected
+     * value so a future Avro upgrade that really does flip the default fails loudly instead of silently
+     * relaxing validation.
+     * <p>
+     * Name validation is fixed at construction time in Avro 1.12 ({@code Schema.Parser} holds it in a final
+     * field and exposes no setter), so the strict default is inherited from the no-argument constructor
+     * above.
      */
     private static Schema.Parser configure(Schema.Parser parser) {
         parser.setValidateDefaults(true);

--- a/schema-util/avro/src/test/java/io/apicurio/registry/avro/util/AvroParserAccessorTest.java
+++ b/schema-util/avro/src/test/java/io/apicurio/registry/avro/util/AvroParserAccessorTest.java
@@ -49,6 +49,13 @@ class AvroParserAccessorTest {
      * independent sites, so any hardening had to be repeated eight times and one could silently be missed.
      * This asserts the invariant itself: within this module's production sources, AvroParserAccessor is the
      * only class allowed to construct a parser.
+     * <p>
+     * Scope limitation: this walks only the current module, so it does not cover the two call sites that were
+     * also routed through the accessor but live in the app module
+     * ({@code contracts/tags/AvroTagExtractor} and {@code ccompat/rest/v7/impl/SchemaFormatService}, the
+     * latter on the Confluent-compatibility path). A regression there would not fail this test. Extending the
+     * same guard to the app module is worth doing separately; do not read a pass here as repository-wide
+     * coverage.
      */
     @Test
     void noProductionCodeInThisModuleConstructsSchemaParserDirectly() throws IOException {

--- a/schema-util/avro/src/test/java/io/apicurio/registry/avro/util/AvroParserAccessorTest.java
+++ b/schema-util/avro/src/test/java/io/apicurio/registry/avro/util/AvroParserAccessorTest.java
@@ -1,0 +1,160 @@
+package io.apicurio.registry.avro.util;
+
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.types.ContentTypes;
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AvroParserAccessorTest {
+
+    private static final Pattern DIRECT_CONSTRUCTION = Pattern.compile("new\\s+Schema\\.Parser\\s*\\(");
+
+    private static final String ADDRESS = "{\"type\":\"record\",\"name\":\"Address\","
+            + "\"namespace\":\"com.example\",\"fields\":[{\"name\":\"street\",\"type\":\"string\"}]}";
+
+    private static final String CITY = "{\"type\":\"record\",\"name\":\"City\","
+            + "\"namespace\":\"com.example\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}";
+
+    /** Depends on City, so it cannot be parsed before City has been. */
+    private static final String ADDRESS_WITH_CITY = "{\"type\":\"record\",\"name\":\"Address\","
+            + "\"namespace\":\"com.example\",\"fields\":[{\"name\":\"city\",\"type\":\"com.example.City\"}]}";
+
+    private static final String PERSON_REFERENCING_ADDRESS = "{\"type\":\"record\",\"name\":\"Person\","
+            + "\"namespace\":\"com.example\",\"fields\":[{\"name\":\"address\",\"type\":\"com.example.Address\"}]}";
+
+    private static TypedContent content(String schema) {
+        return TypedContent.create(ContentHandle.create(schema), ContentTypes.APPLICATION_JSON);
+    }
+
+    /**
+     * The guard that fails on the buggy code. Before the fix this module constructed Schema.Parser at eight
+     * independent sites, so any hardening had to be repeated eight times and one could silently be missed.
+     * This asserts the invariant itself: within this module's production sources, AvroParserAccessor is the
+     * only class allowed to construct a parser.
+     */
+    @Test
+    void noProductionCodeInThisModuleConstructsSchemaParserDirectly() throws IOException {
+        // Surefire runs with the working directory set to the module base directory.
+        Path mainSources = Paths.get("src", "main", "java");
+        assertTrue(Files.isDirectory(mainSources),
+                "expected to run from the module base directory, but " + mainSources.toAbsolutePath()
+                        + " does not exist");
+
+        List<Path> offenders;
+        try (Stream<Path> sources = Files.walk(mainSources)) {
+            offenders = sources.filter(p -> p.toString().endsWith(".java"))
+                    // The accessor is the one place allowed to construct a parser.
+                    .filter(p -> !p.getFileName().toString().equals("AvroParserAccessor.java"))
+                    .filter(p -> DIRECT_CONSTRUCTION.matcher(readString(p)).find()).toList();
+        }
+
+        assertTrue(offenders.isEmpty(),
+                "Schema.Parser must be obtained from AvroParserAccessor so that parser hardening lives in "
+                        + "one place. Direct construction found in: " + offenders);
+    }
+
+    @Test
+    void newParserAppliesHardening() {
+        // Explicitly pinned rather than inherited, so a change of Avro default cannot loosen validation.
+        assertTrue(AvroParserAccessor.newParser().getValidateDefaults());
+
+        // Strict name validation is inherited from the no-arg constructor and must stay in effect.
+        assertThrows(Exception.class, () -> AvroParserAccessor.newParser()
+                .parse("{\"type\":\"record\",\"name\":\"has-dash\",\"fields\":[]}"));
+
+        // A bad default value must still be rejected.
+        assertThrows(Exception.class, () -> AvroParserAccessor.newParser().parse(
+                "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"f\",\"type\":\"int\",\"default\":\"nope\"}]}"));
+    }
+
+    /**
+     * The reason this accessor must not cache parsers the way DocumentBuilderAccessor does: a parser
+     * accumulates named types, so a reused instance would let a schema reference a type it never declares.
+     */
+    @Test
+    void eachCallReturnsAnIndependentParser() {
+        Schema.Parser first = AvroParserAccessor.newParser();
+        Schema.Parser second = AvroParserAccessor.newParser();
+        assertNotSame(first, second);
+
+        first.parse(ADDRESS);
+        assertTrue(first.getTypes().containsKey("com.example.Address"));
+
+        // The second parser must not have inherited Address from the first.
+        assertFalse(second.getTypes().containsKey("com.example.Address"));
+        assertThrows(Exception.class, () -> second.parse(PERSON_REFERENCING_ADDRESS));
+    }
+
+    @Test
+    void seededParserResolvesReferences() {
+        Map<String, TypedContent> references = Map.of("com.example.Address", content(ADDRESS));
+
+        Schema parsed = AvroParserAccessor.newParser(references).parse(PERSON_REFERENCING_ADDRESS);
+
+        assertEquals("Person", parsed.getName());
+        assertEquals(Schema.Type.RECORD, parsed.getField("address").schema().getType());
+    }
+
+    /**
+     * Interdependent references in an unlucky map order. The retry-to-fixpoint pass in the accessor is what
+     * makes this work regardless of iteration order; a single naive pass would fail here.
+     */
+    @Test
+    void seededParserResolvesInterdependentReferencesInAnyOrder() {
+        // LinkedHashMap so Address (which needs City) is offered before City.
+        Map<String, TypedContent> references = new LinkedHashMap<>();
+        references.put("com.example.Address", content(ADDRESS_WITH_CITY));
+        references.put("com.example.City", content(CITY));
+
+        Schema parsed = AvroParserAccessor.newParser(references).parse(PERSON_REFERENCING_ADDRESS);
+
+        assertEquals("Person", parsed.getName());
+    }
+
+    @Test
+    void seededParserToleratesNullAndEmptyReferences() {
+        assertEquals("Address",
+                AvroParserAccessor.newParser((Map<String, TypedContent>) null).parse(ADDRESS).getName());
+        assertEquals("Address", AvroParserAccessor.newParser(Map.of()).parse(ADDRESS).getName());
+    }
+
+    /**
+     * An unresolvable reference must not mask the real failure: the main parse still reports the type it
+     * cannot find.
+     */
+    @Test
+    void unresolvableReferenceStillFailsTheMainParse() {
+        Map<String, TypedContent> references = Map.of("broken", content("{ not a schema }"));
+
+        Exception ex = assertThrows(Exception.class,
+                () -> AvroParserAccessor.newParser(references).parse(PERSON_REFERENCING_ADDRESS));
+        assertTrue(ex.getMessage().contains("com.example.Address"),
+                "expected the offending type name in the message, got: " + ex.getMessage());
+    }
+
+    private static String readString(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`Schema.Parser` was constructed at ten independent sites in production code, each relying on whatever the Avro defaults happened to be. There was no shared place to configure them, so any future hardening (the obvious candidate being a nesting-depth limit to bound stack usage) would have to be applied ten times and kept in sync, with nothing failing if one was missed.

This adds `AvroParserAccessor` as the single construction point, mirroring the existing `DocumentBuilderAccessor`, `SchemaFactoryAccessor` and `WSDLReaderAccessor`, and routes all ten call sites through it.

Fixes #9027

## Root Cause

Eight sites in `schema-util/avro`, plus two outside it that are easy to miss:

| File | Line |
|---|---|
| `avro/content/AvroContentAccepter.java` | 33 |
| `avro/content/canon/AvroContentCanonicalizer.java` | 60 |
| `avro/content/canon/EnhancedAvroContentCanonicalizer.java` | 46 |
| `avro/content/dereference/AvroDereferencer.java` | 15 |
| `avro/content/extract/AvroStructuredContentExtractor.java` | 27 |
| `avro/rules/validity/AvroContentValidator.java` | 37 |
| `avro/rules/compatibility/AvroCompatibilityChecker.java` | 23, 29 |
| `app/.../contracts/tags/AvroTagExtractor.java` | 33 |
| `app/.../ccompat/rest/v7/impl/SchemaFormatService.java` | 112 |

The last one is on the Confluent-compatibility surface, so a change scoped to `schema-util/avro` alone would have left the ccompat path unhardened. That is the site you would least want to miss.

For contrast, the equivalent grep on the XML side returns exactly one hit, inside `DocumentBuilderAccessor`:

```bash
grep -rn "DocumentBuilderFactory.newInstance()" --include="*.java" schema-util app | grep -v /target/ | grep "/main/"
# -> schema-util/xml/.../util/DocumentBuilderAccessor.java:18
```

## Changes

- New `schema-util/avro/.../avro/util/AvroParserAccessor.java` with `newParser()` and `newParser(Map<String, TypedContent>)`.
- All ten call sites now obtain their parser from it. After this change the only `new Schema.Parser()` in production code is inside the accessor itself.
- `EnhancedAvroContentCanonicalizer` loses 24 lines of inline seeding logic, which moved into the accessor unchanged.

Net: 11 files, +280 / −51. Of the additions, 160 lines are the new test, so this removes more production code than it adds.

### Two design points worth calling out

**No `ThreadLocal` caching, deliberately.** This is where the accessor differs from `DocumentBuilderAccessor`, and the deviation is intentional. `Schema.Parser` accumulates the named types it has parsed and carries them into later `parse()` calls on the same instance, which is exactly what reference seeding relies on. A cached or thread-cached parser would leak type definitions between unrelated schemas, letting a schema reference a type it never declares because an earlier, unrelated parse happened to define that name. Each caller gets a fresh instance and only the configuration is shared. This is stated in the class javadoc and locked in by `eachCallReturnsAnIndependentParser`, so it is not later "fixed" for consistency with the other accessors.

**Behaviour preserving on validation.** `setValidateDefaults(true)` is set explicitly, but that is already the Avro 1.12.1 default, so which schemas are accepted does not change. It is pinned so a future Avro release cannot quietly loosen it. Verified against 1.12.1 directly rather than from the docs:

```
default validateDefaults = true
name "has-dash"                      -> REJECTED (SchemaParseException)
int field with default "nope"        -> REJECTED (AvroTypeException)
named types carry over between parse() calls: YES
```

Note that `Schema.Parser.setValidate(boolean)` does not exist in 1.12 — name validation is constructor-only and the field is `final` — so the strict default is inherited from the no-argument constructor.

## Behaviour change (one, deliberate)

Reference seeding is unified on the retry-to-fixpoint pass that `EnhancedAvroContentCanonicalizer` already used. `AvroDereferencer`, `AvroContentValidator` and `AvroCompatibilityChecker` previously did a single naive pass, so a valid set of interdependent references could fail depending on map iteration order. Those three now cope with any order.

Consequences:

- Valid schemas with interdependent references that previously failed on unlucky iteration order now succeed. Covered by `seededParserResolvesInterdependentReferencesInAnyOrder`.
- An unparseable reference is now swallowed during seeding rather than thrown immediately. If the broken reference was actually needed, the main parse still fails and still names the offending type — locked in by `unresolvableReferenceStillFailsTheMainParse`. Only the case where a broken reference was *unused* changes from failure to success. `AvroDereferencer` is the one site where this is observable as a thrown-exception change, since the other two already wrapped in `try`/`catch`.

`AvroContentAccepter` and `AvroContentCanonicalizer` keep their own seeding loops, because they also need the parsed reference `Schema` objects for `Schema#toString(refs, false)`. They use `newParser()` for construction only, so their behaviour is untouched.

If you would rather this were a pure refactor, dropping the seeding overload from those three call sites leaves the accessor intact and the diff smaller. Happy to do that.

## Upgrade impact

None. No `RegistryStorage` method, SQL statement, DDL, KafkaSQL message type or `db-version` is touched, so there is no migration and no storage-variant parity concern. No OpenAPI change, so no SDK regeneration.

Canonical hashes are unchanged: `SchemaNormalizerTest` (30 cases, covering the canonicalizer's output byte-for-byte) passes untouched.

## Test plan

New `AvroParserAccessorTest`, 7 cases. The load-bearing one is an invariant guard rather than a behaviour test, since the defect *is* the duplication: it walks this module's `src/main/java` and fails if anything other than the accessor constructs a `Schema.Parser`.

Fail→pass confirmed by reintroducing the bug at one site:

```
Tests run: 7, Failures: 1
AssertionFailedError: Schema.Parser must be obtained from AvroParserAccessor so that parser
hardening lives in one place. Direct construction found in:
[src/main/java/io/apicurio/registry/avro/content/extract/AvroStructuredContentExtractor.java]
```

Run with CI's flags (`-Pprod`, and `-Dfull -DcliSkipNative` for `app`):

- [x] `clean test -Pprod -pl schema-util/avro -am` — **44/44** (7 new + `SchemaNormalizerTest` 30 + `AvroCompatibilityTest` 6 + `AvroSchemaSmokeTest` 1)
- [x] `app` downstream — **33/33** (`AvroCanonicalHashUpgraderTest` 4, `ArtifactTypeUtilTest` 12, `AvroTagExtractorTest` 14, `TagExtractorFactoryTest` 3)
- [x] `test-compile -Pprod -pl app -am -Dfull -DcliSkipNative` — clean
- [x] `checkstyle:check -pl schema-util/avro,app` — 0 violations in both
- [x] `./scripts/validate-files.sh` — DB version 108 consistent across all four DDLs
- [x] `git status --porcelain docs` — clean, no docs regeneration needed
- [x] Multi-module reactor from the repo root — the guard test resolves `src/main/java` relative to the module basedir, and the `non-app` unit-test shard runs from the root across many modules, so I verified it there too rather than only under `-pl schema-util/avro`

## Not verified

- `SchemaFormatService` (ccompat v7) has no unit test. The change there is construction-only and behaviour-identical, but it sits on a surface consumed by third-party Confluent clients, so it would be worth someone running `-Pintegration-tests -Premote-sql -Dgroups=default` (which picks up `ConfluentClientTest`). I did not run the integration suite.
- MySQL and MSSQL have no integration coverage in CI. Not relevant here since nothing touches SQL — noted only so the omission is not read as an oversight.

## Notes for reviewers

`AvroContentCanonicalizer` appears to be dead code: its only reference anywhere in the repo is its own declaration. I routed it through the accessor for consistency but deliberately did not delete it, since it is `public` in a published module and removing it is an API change that belongs in its own PR. Same call I made in #8973.
