### PR TITLE
fix(import): set import status to SKIPPED when startup import is skipped

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
+++ b/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
@@ -60,7 +60,7 @@ public class ImportLifecycleBean {
                     importStatus = ImportStatus.ERROR;
                 } catch (ConflictException ce) {
                     log.info("Import skipped, registry not empty.");
-                    importStatus = ImportStatus.ERROR;
+                    importStatus = ImportStatus.SKIPPED;
                 } catch (Exception e) {
                     log.error("Registry import failed", e);
                     importStatus = ImportStatus.ERROR;

--- a/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
+++ b/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
@@ -38,7 +38,7 @@ public class ImportLifecycleBean {
     @Inject
     AdminResourceImpl v3Admin;
 
-    private ImportStatus importStatus = ImportStatus.UNKNOWN;
+    private volatile ImportStatus importStatus = ImportStatus.UNKNOWN;
 
     void onStorageReady(@ObservesAsync StorageEvent ev) {
         if (StorageEventType.READY.equals(ev.getType())) {

--- a/app/src/test/java/io/apicurio/registry/ImportLifecycleBeanUnitTest.java
+++ b/app/src/test/java/io/apicurio/registry/ImportLifecycleBeanUnitTest.java
@@ -1,0 +1,40 @@
+package io.apicurio.registry;
+
+import io.apicurio.registry.rest.ConflictException;
+import io.apicurio.registry.rest.v3.impl.AdminResourceImpl;
+import io.apicurio.registry.storage.StorageEvent;
+import io.apicurio.registry.storage.StorageEventType;
+import io.apicurio.registry.storage.importing.ImportExportConfigProperties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class ImportLifecycleBeanUnitTest {
+
+    @Test
+    public void testConflictExceptionSetsStatusToSkipped() throws Exception {
+        ImportLifecycleBean bean = new ImportLifecycleBean();
+        bean.log = LoggerFactory.getLogger(ImportLifecycleBean.class);
+
+        // Mock ImportExportConfigProperties with a local temp file URL
+        bean.importExportProps = Mockito.mock(ImportExportConfigProperties.class);
+        java.io.File tempFile = java.io.File.createTempFile("dummy-import", ".zip");
+        tempFile.deleteOnExit();
+        bean.importExportProps.registryImportUrlProp = Optional.of(tempFile.toURI().toURL());
+
+        // Mock AdminResourceImpl to throw ConflictException when importData is called
+        bean.v3Admin = Mockito.mock(AdminResourceImpl.class);
+        Mockito.doThrow(new ConflictException("Registry not empty"))
+               .when(bean.v3Admin).importData(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+
+        // Trigger the onStorageReady event
+        StorageEvent event = StorageEvent.builder().type(StorageEventType.READY).build();
+        bean.onStorageReady(event);
+
+        // Verify bean is ready
+        Assertions.assertTrue(bean.isReady(), "ImportLifecycleBean should be ready when import is skipped due to existing data");
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes the startup import status when the registry already contains data.

When `apicurio.import.url` is configured, Apicurio Registry attempts to import data during startup. If the registry is already populated (for example, after restarting with persistent storage), the import process throws a `ConflictException` and skips the import as expected.

However, `ImportLifecycleBean` currently sets the import status to `ERROR` when handling this exception, causing the readiness probe to report the application as **not ready** even though the registry is fully operational.

This PR updates the import status to `SKIPPED`, ensuring the readiness check correctly reflects the application's state.

## Changes

* Update `ImportLifecycleBean` to set `ImportStatus.SKIPPED` instead of `ImportStatus.ERROR` when a `ConflictException` occurs during startup import.
* Preserve the existing behaviour and log message indicating that the import was intentionally skipped.
* Add a regression test to verify that the registry reports a ready state when startup import is skipped because the registry already contains data.

## Testing

The following scenario was verified:

1. Configure `apicurio.import.url`.
2. Start the registry with an empty database and allow the import to complete.
3. Restart the registry while using the same persistent database.
4. Verify that the startup import is skipped because the registry already contains data.
5. Confirm that the readiness endpoint (`/health/ready`) returns **HTTP 200 OK**.

## Related Issue

Fixes #9030
