### PR TITLE
fix(cli): allow HTTPS registry URLs in native CLI binary (backport #8967)

### DIFF
--- a/cli/src/main/resources/application.properties
+++ b/cli/src/main/resources/application.properties
@@ -21,6 +21,7 @@ quarkus.log.category."io.quarkus.arc".level=ERROR
 # Native image configuration
 quarkus.native.additional-build-args=\
   --initialize-at-run-time=io.vertx.ext.auth.impl.jose.JWT
+quarkus.native.enable-https-url-handler=true
 
 %test.quarkus.log.level=INFO
 %test.quarkus.log.category."io.apicurio.registry.cli".level=DEBUG

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -7,6 +7,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -291,9 +292,17 @@ public class RegistryClientRequestAdapterFactory {
         }
 
         try {
-            var _ignored1 = new URI(url);
-            var _ignored2 = _ignored1.toURL();
-        } catch (Exception ex) {
+            var uri = new URI(url);
+            if (uri.getScheme() == null || uri.getHost() == null) {
+                throw new IllegalArgumentException(
+                        "Registry API URL '" + url + "' is not well-formed: scheme and host are required.");
+            }
+            var scheme = uri.getScheme().toLowerCase(java.util.Locale.ROOT);
+            if (!"http".equals(scheme) && !"https".equals(scheme)) {
+                throw new IllegalArgumentException(
+                        "Registry API URL '" + url + "' is not well-formed: unsupported scheme '" + uri.getScheme() + "'.");
+            }
+        } catch (URISyntaxException ex) {
             throw new IllegalArgumentException("Registry API URL '" + url + "' is not well-formed: " + ex.getMessage());
         }
 

--- a/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RegistryUrlValidationTest.java
+++ b/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RegistryUrlValidationTest.java
@@ -1,0 +1,70 @@
+package io.apicurio.registry.client.common;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RegistryUrlValidationTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://example.com/apis/registry/v3",
+            "https://registry.example.com:8443/apis/registry/v3",
+            "http://localhost:8080/apis/registry/v3",
+            "http://example.com/apis/registry/v3",
+    })
+    void testValidUrlsAreAccepted(String url) {
+        var options = RegistryClientOptions.create().rawRegistryUrl(url);
+        try {
+            RegistryClientRequestAdapterFactory.createRequestAdapter(options, Version.V3);
+        } catch (IllegalArgumentException ex) {
+            throw new AssertionError("URL '" + url + "' should be accepted but was rejected: " + ex.getMessage(), ex);
+        } catch (IllegalStateException ignored) {
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "ftp://example.com/apis/registry/v3",
+            "ws://example.com/apis/registry/v3",
+    })
+    void testUnsupportedSchemesAreRejected(String url) {
+        var options = RegistryClientOptions.create().rawRegistryUrl(url);
+        var ex = assertThrows(IllegalArgumentException.class, () ->
+                RegistryClientRequestAdapterFactory.createRequestAdapter(options, Version.V3));
+        assertTrue(ex.getMessage().contains("unsupported scheme"), ex.getMessage());
+    }
+
+    @Test
+    void testMissingSchemeIsRejected() {
+        var options = RegistryClientOptions.create().rawRegistryUrl("example.com/apis/registry/v3");
+        var ex = assertThrows(IllegalArgumentException.class, () ->
+                RegistryClientRequestAdapterFactory.createRequestAdapter(options, Version.V3));
+        assertTrue(ex.getMessage().contains("not well-formed"), ex.getMessage());
+    }
+
+    @Test
+    void testNullUrlIsRejected() {
+        var options = RegistryClientOptions.create();
+        assertThrows(IllegalArgumentException.class, () ->
+                RegistryClientRequestAdapterFactory.createRequestAdapter(options, Version.V3));
+    }
+
+    @Test
+    void testBlankUrlIsRejected() {
+        var options = RegistryClientOptions.create("   ");
+        assertThrows(IllegalArgumentException.class, () ->
+                RegistryClientRequestAdapterFactory.createRequestAdapter(options, Version.V3));
+    }
+
+    @Test
+    void testInvalidUriSyntaxIsRejected() {
+        var options = RegistryClientOptions.create().rawRegistryUrl("http://exam ple.com/apis/registry/v3");
+        var ex = assertThrows(IllegalArgumentException.class, () ->
+                RegistryClientRequestAdapterFactory.createRequestAdapter(options, Version.V3));
+        assertTrue(ex.getMessage().contains("not well-formed"), ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary

Backport of #8967 to `3.2.x`.

- Replace `URI.toURL()` validation with URI-only checks (scheme + host) in `RegistryClientRequestAdapterFactory` to avoid depending on JDK URL protocol handlers unavailable in GraalVM native images
- Enable `quarkus.native.enable-https-url-handler=true` in the CLI native build as defense-in-depth
- Add `RegistryUrlValidationTest` with 10 parameterized tests

Cherry-picked cleanly from `3d911c2528a7e515f5004f8fa3158d744d4b3e02`.

## Test plan

- [ ] CI passes on `3.2.x`