### PR TITLE
feat(mcp): add Compatible Tools API endpoint and UI compatibility view

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
@@ -170,6 +170,46 @@ public interface WellKnownResource {
             @QueryParam("limit") @DefaultValue("20") String limit);
 
     /**
+     * Search for registered MCP tools compatible with a specific target tool by group and artifact ID.
+     * Tool chaining compatibility is evaluated by matching the target tool's outputSchema guaranteed
+     * (required) output properties against candidate tools' inputSchema required input parameters.
+     *
+     * @param groupId the group ID of the target MCP tool
+     * @param artifactId the artifact ID of the target MCP tool
+     * @param version optional version (defaults to latest)
+     * @param offset pagination offset
+     * @param limit pagination limit
+     * @return search results containing matching compatible MCP tools
+     */
+    @GET
+    @Path("/mcp-tools/{groupId}/{artifactId}/compatible")
+    @Produces(MediaType.APPLICATION_JSON)
+    McpToolSearchResults getCompatibleMcpTools(
+            @PathParam("groupId") String groupId,
+            @PathParam("artifactId") String artifactId,
+            @QueryParam("version") String version,
+            @QueryParam("offset") @DefaultValue("0") String offset,
+            @QueryParam("limit") @DefaultValue("20") String limit);
+
+    /**
+     * Search for registered MCP tools compatible with a given MCP tool definition content.
+     *
+     * @param mcpToolContent raw MCP tool JSON definition
+     * @param offset pagination offset
+     * @param limit pagination limit
+     * @return search results containing matching compatible MCP tools
+     */
+    @POST
+    @Path("/mcp-tools/compatible")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    McpToolSearchResults findCompatibleMcpTools(
+            String mcpToolContent,
+            @QueryParam("offset") @DefaultValue("0") String offset,
+            @QueryParam("limit") @DefaultValue("20") String limit);
+
+
+    /**
      * Returns the JSON Schema for a specific LLM artifact type.
      * This enables IDE autocompletion and validation for PROMPT_TEMPLATE, MODEL_SCHEMA,
      * and MCP_TOOL artifacts.

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -558,6 +558,197 @@ public class WellKnownResourceImpl implements WellKnownResource {
         return McpToolSearchResults.builder().count(results.getCount()).tools(tools).build();
     }
 
+    @Override
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
+    public McpToolSearchResults getCompatibleMcpTools(String groupId, String artifactId,
+            String version, String offset, String limit) {
+        if (!mcpToolsConfig.isEnabled()) {
+            throw new NotFoundException("MCP tools support is disabled");
+        }
+
+        int safeOffset = Math.max(0, parsePaginationParam(offset, "offset", 0));
+        int safeLimit = Math.max(1, Math.min(parsePaginationParam(limit, "limit", 20), 500));
+
+        GroupId gid = new GroupId(groupId);
+        String rawGroupId = gid.getRawGroupIdWithNull();
+        GA ga = new GA(rawGroupId, artifactId);
+
+        StoredArtifactVersionDto targetArtifact;
+        try {
+            String versionExpression = StringUtil.isEmpty(version) ? "branch=latest" : version;
+            GAV gav = VersionExpressionParser.parse(ga, versionExpression,
+                    (g, branchId) -> storage.getBranchTip(g, branchId,
+                            RetrievalBehavior.SKIP_DISABLED_LATEST));
+
+            targetArtifact = storage.getArtifactVersionContent(
+                    gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
+
+            ArtifactVersionMetaDataDto metadata = storage.getArtifactVersionMetaData(
+                    gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
+
+            if (!ArtifactType.MCP_TOOL.equals(metadata.getArtifactType())) {
+                throw new NotFoundException("Artifact is not an MCP tool definition");
+            }
+        } catch (ArtifactNotFoundException | VersionNotFoundException e) {
+            throw new NotFoundException("MCP tool not found: " + groupId + "/" + artifactId);
+        }
+
+        String targetContentStr = targetArtifact.getContent().content();
+        return findCompatibleToolsForContent(targetContentStr, ga, safeOffset, safeLimit);
+    }
+
+    @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
+    public McpToolSearchResults findCompatibleMcpTools(String mcpToolContent, String offset, String limit) {
+        if (!mcpToolsConfig.isEnabled()) {
+            throw new NotFoundException("MCP tools support is disabled");
+        }
+
+        if (StringUtil.isEmpty(mcpToolContent)) {
+            throw new BadRequestException("MCP tool content must not be empty");
+        }
+
+        int safeOffset = Math.max(0, parsePaginationParam(offset, "offset", 0));
+        int safeLimit = Math.max(1, Math.min(parsePaginationParam(limit, "limit", 20), 500));
+
+        return findCompatibleToolsForContent(mcpToolContent, null, safeOffset, safeLimit);
+    }
+
+    private McpToolSearchResults findCompatibleToolsForContent(String targetContentStr, GA targetGa,
+            int safeOffset, int safeLimit) {
+        Set<SearchFilter> filters = new HashSet<>();
+        filters.add(SearchFilter.ofArtifactType(ArtifactType.MCP_TOOL));
+
+        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, OrderBy.createdOn,
+                OrderDirection.desc, 0, MAX_VISIBILITY_FILTER_RESULTS, false);
+
+        JsonNode targetOutputSchema = null;
+        try {
+            JsonNode targetRoot = mapper.readTree(targetContentStr);
+            targetOutputSchema = targetRoot.get("outputSchema");
+        } catch (Exception e) {
+            log.warn("Failed to parse target MCP tool content: {}", e.getMessage());
+        }
+
+        List<McpToolSearchResult> compatibleTools = new ArrayList<>();
+
+        for (SearchedArtifactDto artifact : results.getArtifacts()) {
+            // Exclude the target artifact itself if targetGa is specified
+            if (targetGa != null
+                    && java.util.Objects.equals(artifact.getGroupId(), targetGa.getRawGroupIdWithNull())
+                    && java.util.Objects.equals(artifact.getArtifactId(), targetGa.getRawArtifactId())) {
+                continue;
+            }
+
+            try {
+                GA ga = new GA(artifact.getGroupId(), artifact.getArtifactId());
+                GAV gav = VersionExpressionParser.parse(ga, "branch=latest",
+                        (g, branchId) -> storage.getBranchTip(g, branchId,
+                                RetrievalBehavior.SKIP_DISABLED_LATEST));
+                StoredArtifactVersionDto candidateStored = storage.getArtifactVersionContent(
+                        gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
+
+                JsonNode candidateRoot = mapper.readTree(candidateStored.getContent().content());
+                JsonNode candidateInputSchema = candidateRoot.get("inputSchema");
+
+                if (isOutputCompatibleWithInput(targetOutputSchema, candidateInputSchema)) {
+                    compatibleTools.add(convertToMcpToolSearchResult(artifact));
+                }
+            } catch (Exception e) {
+                log.warn("Failed to check output->input compatibility for MCP tool {}/{}: {}",
+                        artifact.getGroupId(), artifact.getArtifactId(), e.getMessage());
+            }
+        }
+
+        int total = compatibleTools.size();
+        int fromIndex = Math.min(safeOffset, total);
+        int toIndex = Math.min(fromIndex + safeLimit, total);
+        List<McpToolSearchResult> page = compatibleTools.subList(fromIndex, toIndex);
+
+        return McpToolSearchResults.builder()
+                .count((long) total)
+                .tools(page)
+                .build();
+    }
+
+    private boolean isOutputCompatibleWithInput(JsonNode targetOutputSchema, JsonNode candidateInputSchema) {
+        if (candidateInputSchema == null || candidateInputSchema.isMissingNode() || !candidateInputSchema.isObject()) {
+            return true;
+        }
+
+        JsonNode candidateRequiredNode = candidateInputSchema.get("required");
+        Set<String> candidateRequiredParams = new HashSet<>();
+        if (candidateRequiredNode != null && candidateRequiredNode.isArray()) {
+            for (JsonNode item : candidateRequiredNode) {
+                if (item.isTextual()) {
+                    candidateRequiredParams.add(item.asText());
+                }
+            }
+        }
+
+        if (candidateRequiredParams.isEmpty()) {
+            return true;
+        }
+
+        if (targetOutputSchema == null || targetOutputSchema.isMissingNode() || !targetOutputSchema.isObject()) {
+            return false;
+        }
+
+        JsonNode targetRequiredNode = targetOutputSchema.get("required");
+        Set<String> targetRequiredOutputs = new HashSet<>();
+        if (targetRequiredNode != null && targetRequiredNode.isArray()) {
+            for (JsonNode item : targetRequiredNode) {
+                if (item.isTextual()) {
+                    targetRequiredOutputs.add(item.asText());
+                }
+            }
+        }
+
+        if (targetRequiredOutputs.isEmpty()) {
+            return false;
+        }
+
+        JsonNode targetProps = targetOutputSchema.get("properties");
+        if (targetProps == null || !targetProps.isObject()) {
+            return false;
+        }
+
+        JsonNode candidateProps = candidateInputSchema.get("properties");
+
+        for (String reqParam : candidateRequiredParams) {
+            if (!targetRequiredOutputs.contains(reqParam) || !targetProps.has(reqParam)) {
+                return false;
+            }
+
+            if (candidateProps != null && candidateProps.isObject()) {
+                JsonNode targetProp = targetProps.get(reqParam);
+                JsonNode candidateProp = candidateProps.get(reqParam);
+
+                if (targetProp != null && candidateProp != null) {
+                    JsonNode targetType = targetProp.get("type");
+                    JsonNode candidateType = candidateProp.get("type");
+
+                    if (targetType != null && candidateType != null
+                            && targetType.isTextual() && candidateType.isTextual()) {
+                        String tType = targetType.asText();
+                        String cType = candidateType.asText();
+
+                        if (!tType.equals(cType)) {
+                            // integer output is compatible with number input
+                            if (!("integer".equals(tType) && "number".equals(cType))) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+
+
     private int parsePaginationParam(String value, String name, int defaultValue) {
         if (StringUtil.isEmpty(value)) {
             return defaultValue;

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
@@ -328,6 +328,194 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
                 .statusCode(404);
     }
 
+    @Test
+    public void testGetCompatibleMcpTools() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String targetId = "target-tool-" + unique;
+        String compatId = "compat-tool-" + unique;
+        String incompatId = "incompat-tool-" + unique;
+
+        // Target tool: outputSchema defines { "result": string, "count": integer }
+        String baseTargetTool = """
+                {
+                    "name": "base_search",
+                    "title": "Base Search",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    },
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "result": { "type": "string" },
+                            "count": { "type": "integer" }
+                        },
+                        "required": ["result"]
+                    }
+                }
+                """;
+
+        // Compatible candidate: requires input { "result": string }, which target produces
+        String compatibleTool = """
+                {
+                    "name": "result_formatter",
+                    "title": "Result Formatter",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "result": { "type": "string" }
+                        },
+                        "required": ["result"]
+                    }
+                }
+                """;
+
+        // Incompatible candidate: requires input { "result": string, "missing_field": string }, where missing_field is not in target output
+        String incompatibleTool = """
+                {
+                    "name": "strict_consumer",
+                    "title": "Strict Consumer",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "result": { "type": "string" },
+                            "missing_field": { "type": "string" }
+                        },
+                        "required": ["result", "missing_field"]
+                    }
+                }
+                """;
+
+        createMcpTool(groupId, targetId, baseTargetTool);
+        createMcpTool(groupId, compatId, compatibleTool);
+        createMcpTool(groupId, incompatId, incompatibleTool);
+
+        givenAtRoot()
+                .when()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", targetId)
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("tools", hasSize(1))
+                .body("tools[0].artifactId", equalTo(compatId));
+    }
+
+    @Test
+    public void testGetCompatibleMcpToolsNotFound() {
+        givenAtRoot()
+                .when()
+                .pathParam("groupId", "nonexistent-group")
+                .pathParam("artifactId", "nonexistent-tool")
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testFindCompatibleMcpToolsPost() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String compatId = "post-compat-" + unique;
+
+        // Raw target content: produces output { "payload": string }
+        String rawContent = """
+                {
+                    "name": "raw_tool",
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "payload": { "type": "string" }
+                        },
+                        "required": ["payload"]
+                    }
+                }
+                """;
+
+        // Candidate tool: requires input { "payload": string }
+        String compatContent = """
+                {
+                    "name": "payload_processor",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "payload": { "type": "string" }
+                        },
+                        "required": ["payload"]
+                    }
+                }
+                """;
+
+        createMcpTool(groupId, compatId, compatContent);
+
+        givenAtRoot()
+                .when()
+                .contentType("application/json")
+                .body(rawContent)
+                .post("/.well-known/mcp-tools/compatible")
+                .then()
+                .statusCode(200)
+                .body("tools.artifactId", hasItem(compatId));
+    }
+
+    @Test
+    public void testOptionalOutputFieldNotSatisfyingRequiredInput() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String targetId = "opt-target-" + unique;
+        String candidateId = "opt-consumer-" + unique;
+
+        // Target tool: outputSchema has "count" in properties, but NOT in required list (only "result" is required)
+        String targetTool = """
+                {
+                    "name": "optional_output_tool",
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "result": { "type": "string" },
+                            "count": { "type": "integer" }
+                        },
+                        "required": ["result"]
+                    }
+                }
+                """;
+
+        // Candidate tool: requires "count" as input
+        String candidateTool = """
+                {
+                    "name": "requires_count_consumer",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "count": { "type": "integer" }
+                        },
+                        "required": ["count"]
+                    }
+                }
+                """;
+
+        createMcpTool(groupId, targetId, targetTool);
+        createMcpTool(groupId, candidateId, candidateTool);
+
+        givenAtRoot()
+                .when()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", targetId)
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(0))
+                .body("tools", hasSize(0));
+    }
+
+
+
+
     private void createMcpTool(String groupId, String artifactId, String content) throws Exception {
         CreateArtifact createArtifact = new CreateArtifact();
         createArtifact.setArtifactId(artifactId);

--- a/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.css
+++ b/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.css
@@ -1,0 +1,27 @@
+.compatible-mcp-tools-viewer {
+    padding: 1rem 0;
+}
+
+.compatible-mcp-tools-subtitle {
+    color: var(--pf-v5-global--Color--200, #6a6e73);
+    font-size: 0.875rem;
+    margin-top: -0.5rem;
+}
+
+.compatible-mcp-tools-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+}
+
+.compatible-mcp-tools-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.compatible-tool-card {
+    border: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+}

--- a/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.test.tsx
+++ b/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { CompatibleMcpToolsViewer } from "./CompatibleMcpToolsViewer";
+import { McpToolSearchResults } from "../../../services/useMcpToolsService";
+
+const mockGetCompatibleMcpTools = vi.fn();
+vi.mock("../../../services/useMcpToolsService", () => ({
+    useMcpToolsService: () => ({
+        getCompatibleMcpTools: mockGetCompatibleMcpTools
+    })
+}));
+
+describe("CompatibleMcpToolsViewer", () => {
+    it("renders loading state initially and empty state when 0 compatible tools are returned", async () => {
+        const emptyResult: McpToolSearchResults = {
+            count: 0,
+            tools: []
+        };
+        mockGetCompatibleMcpTools.mockResolvedValueOnce(emptyResult);
+
+        render(<CompatibleMcpToolsViewer groupId="test-group" artifactId="test-tool" />);
+
+        expect(screen.getByTestId("loading-state")).toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("No Compatible Tools Found")).toBeInTheDocument();
+        expect(mockGetCompatibleMcpTools).toHaveBeenCalledWith("test-group", "test-tool", undefined);
+    });
+
+    it("renders list of compatible tools when non-empty results are returned", async () => {
+        const nonEmptyResult: McpToolSearchResults = {
+            count: 1,
+            tools: [
+                {
+                    groupId: "test-group",
+                    artifactId: "compat-tool-1",
+                    name: "result_formatter",
+                    title: "Result Formatter Tool",
+                    description: "Formats output results into text",
+                    parameters: ["result"]
+                }
+            ]
+        };
+        mockGetCompatibleMcpTools.mockResolvedValueOnce(nonEmptyResult);
+
+        render(<CompatibleMcpToolsViewer groupId="test-group" artifactId="test-tool" />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("tools-list")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("Result Formatter Tool")).toBeInTheDocument();
+        expect(screen.getByText("test-group / compat-tool-1")).toBeInTheDocument();
+        expect(screen.getByText("Formats output results into text")).toBeInTheDocument();
+        expect(screen.getByText("result")).toBeInTheDocument();
+    });
+});

--- a/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.tsx
+++ b/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.tsx
@@ -1,0 +1,170 @@
+import { FunctionComponent, useEffect, useState } from "react";
+import "./CompatibleMcpToolsViewer.css";
+import {
+    Badge,
+    Card,
+    CardBody,
+    CardHeader,
+    CardTitle,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Divider,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateHeader,
+    EmptyStateIcon,
+    Label,
+    LabelGroup,
+    Spinner,
+    Title
+} from "@patternfly/react-core";
+import { PlugIcon } from "@patternfly/react-icons";
+import { McpToolSearchResult, useMcpToolsService } from "../../../services/useMcpToolsService";
+
+export type CompatibleMcpToolsViewerProps = {
+    groupId: string;
+    artifactId: string;
+    version?: string;
+    className?: string;
+};
+
+/**
+ * Component to display MCP tools compatible with a target tool's output schema (Output -> Input tool chaining).
+ * Fetches real compatibility data from /.well-known/mcp-tools/{groupId}/{artifactId}/compatible.
+ */
+export const CompatibleMcpToolsViewer: FunctionComponent<CompatibleMcpToolsViewerProps> = (
+    props: CompatibleMcpToolsViewerProps
+) => {
+    const { groupId, artifactId, version } = props;
+    const mcpToolsService = useMcpToolsService();
+
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+    const [tools, setTools] = useState<McpToolSearchResult[]>([]);
+
+    useEffect(() => {
+        let isMounted = true;
+        setIsLoading(true);
+        setError(null);
+
+        mcpToolsService
+            .getCompatibleMcpTools(groupId, artifactId, version)
+            .then((results) => {
+                if (isMounted) {
+                    setTools(results.tools || []);
+                    setIsLoading(false);
+                }
+            })
+            .catch((err) => {
+                if (isMounted) {
+                    console.error("Failed to load compatible MCP tools:", err);
+                    setError(err.message || "Failed to load compatible MCP tools");
+                    setIsLoading(false);
+                }
+            });
+
+        return () => {
+            isMounted = false;
+        };
+    }, [groupId, artifactId, version]);
+
+    return (
+        <div className={`compatible-mcp-tools-viewer ${props.className || ""}`}>
+            <Card isPlain>
+                <CardHeader>
+                    <CardTitle>
+                        <Title headingLevel="h2">
+                            Compatible Chained Tools <Badge isRead>{tools.length}</Badge>
+                        </Title>
+                    </CardTitle>
+                </CardHeader>
+                <CardBody>
+                    <p className="compatible-mcp-tools-subtitle">
+                        Tools in the registry whose required input parameters are guaranteed by this tool&apos;s output schema (Output &rarr; Input Chaining).
+                    </p>
+                </CardBody>
+            </Card>
+
+            <Divider className="mcp-tool-divider" />
+
+            {isLoading && (
+                <div className="compatible-mcp-tools-loading" data-testid="loading-state">
+                    <Spinner size="lg" aria-label="Loading compatible tools" />
+                    <span className="pf-v5-u-ml-sm">Checking tool compatibility...</span>
+                </div>
+            )}
+
+            {!isLoading && error && (
+                <EmptyState data-testid="error-state">
+                    <EmptyStateHeader
+                        titleText="Error Loading Compatible Tools"
+                        headingLevel="h4"
+                    />
+                    <EmptyStateBody>{error}</EmptyStateBody>
+                </EmptyState>
+            )}
+
+            {!isLoading && !error && tools.length === 0 && (
+                <EmptyState data-testid="empty-state">
+                    <EmptyStateHeader
+                        titleText="No Compatible Tools Found"
+                        icon={<EmptyStateIcon icon={PlugIcon} />}
+                        headingLevel="h4"
+                    />
+                    <EmptyStateBody>
+                        No registered MCP tools in the registry can accept this tool&apos;s guaranteed output as input.
+                    </EmptyStateBody>
+                </EmptyState>
+            )}
+
+            {!isLoading && !error && tools.length > 0 && (
+                <div className="compatible-mcp-tools-list" data-testid="tools-list">
+                    {tools.map((tool) => (
+                        <Card key={`${tool.groupId}/${tool.artifactId}`} className="compatible-tool-card" isCompact>
+                            <CardHeader>
+                                <CardTitle>
+                                    <Title headingLevel="h3">{tool.title || tool.name}</Title>
+                                </CardTitle>
+                                <Label color="green" icon={<PlugIcon />}>
+                                    Output &rarr; Input Compatible
+                                </Label>
+                            </CardHeader>
+                            <CardBody>
+                                <DescriptionList isHorizontal>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Artifact</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <code>{tool.groupId} / {tool.artifactId}</code>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    {tool.description && (
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Description</DescriptionListTerm>
+                                            <DescriptionListDescription>{tool.description}</DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                    )}
+                                    {tool.parameters && tool.parameters.length > 0 && (
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Input Parameters</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                <LabelGroup>
+                                                    {tool.parameters.map((param) => (
+                                                        <Label key={param} color="blue" isCompact>
+                                                            {param}
+                                                        </Label>
+                                                    ))}
+                                                </LabelGroup>
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                    )}
+                                </DescriptionList>
+                            </CardBody>
+                        </Card>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/ui/ui-app/src/app/components/mcpTool/index.ts
+++ b/ui/ui-app/src/app/components/mcpTool/index.ts
@@ -1,1 +1,3 @@
 export * from "./McpToolViewer";
+export * from "./CompatibleMcpToolsViewer";
+

--- a/ui/ui-app/src/app/pages/version/components/tabs/DocumentationTabContent.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/DocumentationTabContent.tsx
@@ -140,7 +140,12 @@ export const DocumentationTabContent: FunctionComponent<DocumentationTabContentP
                 <AgentCardVisualizer spec={parsedContent} />
             </If>
             <If condition={visualizerType === VisualizerType.MCP_TOOL}>
-                <McpToolVisualizer spec={parsedContent} />
+                <McpToolVisualizer
+                    spec={parsedContent}
+                    groupId={props.groupId}
+                    artifactId={props.artifactId}
+                    version={props.version}
+                />
             </If>
             <If condition={visualizerType === VisualizerType.JSON_SCHEMA}>
                 <JsonSchemaVisualizer spec={parsedContent} />

--- a/ui/ui-app/src/app/pages/version/components/tabs/visualizers/McpToolVisualizer.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/visualizers/McpToolVisualizer.tsx
@@ -1,9 +1,12 @@
 import { FunctionComponent } from "react";
 import "./McpToolVisualizer.css";
-import { McpToolViewer } from "@app/components/mcpTool";
+import { McpToolViewer, CompatibleMcpToolsViewer } from "@app/components/mcpTool";
 
 export type McpToolVisualizerProps = {
     spec: any;
+    groupId?: string;
+    artifactId?: string;
+    version?: string;
     className?: string;
 };
 
@@ -14,6 +17,14 @@ export const McpToolVisualizer: FunctionComponent<McpToolVisualizerProps> = (pro
     return (
         <div className={`mcp-tool-visualizer ${props.className || ""}`}>
             <McpToolViewer spec={props.spec} />
+            {props.groupId && props.artifactId && (
+                <CompatibleMcpToolsViewer
+                    groupId={props.groupId}
+                    artifactId={props.artifactId}
+                    version={props.version}
+                />
+            )}
         </div>
     );
 };
+

--- a/ui/ui-app/src/services/index.ts
+++ b/ui/ui-app/src/services/index.ts
@@ -15,3 +15,5 @@ export * from "./useUrlService";
 export * from "./useUserService";
 export * from "./useVersionService";
 export * from "./useSearchService";
+export * from "./useMcpToolsService";
+

--- a/ui/ui-app/src/services/useMcpToolsService.test.ts
+++ b/ui/ui-app/src/services/useMcpToolsService.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getBaseUrl } from "./useMcpToolsService";
+import { ConfigService } from "./useConfigService";
+
+describe("useMcpToolsService getBaseUrl", () => {
+    it("strips /apis/registry/v3 suffix correctly", () => {
+        const mockConfig = {
+            artifactsUrl: () => "http://localhost:8080/apis/registry/v3"
+        } as ConfigService;
+
+        expect(getBaseUrl(mockConfig)).toBe("http://localhost:8080");
+    });
+
+    it("handles trailing slash before suffix removal", () => {
+        const mockConfig = {
+            artifactsUrl: () => "http://localhost:8080/apis/registry/v3/"
+        } as ConfigService;
+
+        expect(getBaseUrl(mockConfig)).toBe("http://localhost:8080");
+    });
+
+    it("falls back to origin for non-standard path", () => {
+        const mockConfig = {
+            artifactsUrl: () => "http://myregistry.example.com:9090/custom/api/path"
+        } as ConfigService;
+
+        expect(getBaseUrl(mockConfig)).toBe("http://myregistry.example.com:9090");
+    });
+});

--- a/ui/ui-app/src/services/useMcpToolsService.ts
+++ b/ui/ui-app/src/services/useMcpToolsService.ts
@@ -1,0 +1,90 @@
+import { ConfigService, useConfigService } from "./useConfigService";
+import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { createAuthOptions } from "../utils/rest.utils";
+
+export interface McpToolSearchResult {
+    groupId: string;
+    artifactId: string;
+    name: string;
+    title?: string;
+    description?: string;
+    owner?: string;
+    createdOn?: number;
+    parameters?: string[];
+}
+
+export interface McpToolSearchResults {
+    count: number;
+    tools: McpToolSearchResult[];
+}
+
+/**
+ * Gets the base URL for well-known endpoints.
+ * Extracts the base URL from the artifacts URL by removing the /apis/registry/v3 suffix.
+ */
+export const getBaseUrl = (config: ConfigService): string => {
+    const artifactsUrl = config.artifactsUrl();
+    const url = artifactsUrl.endsWith("/") ? artifactsUrl.slice(0, -1) : artifactsUrl;
+    const suffix = "/apis/registry/v3";
+    if (url.endsWith(suffix)) {
+        return url.slice(0, -suffix.length);
+    }
+    try {
+        const parsed = new URL(url);
+        return parsed.origin;
+    } catch {
+        return window.location.origin;
+    }
+};
+
+const getCompatibleMcpTools = async (
+    config: ConfigService,
+    auth: AuthService,
+    groupId: string,
+    artifactId: string,
+    version?: string
+): Promise<McpToolSearchResults> => {
+    console.debug("[McpToolsService] Fetching compatible MCP tools for: ", groupId, artifactId, version);
+
+    const baseUrl = getBaseUrl(config);
+    const versionQuery = version ? `?version=${encodeURIComponent(version)}` : "";
+    const url = `${baseUrl}/.well-known/mcp-tools/${encodeURIComponent(groupId)}/${encodeURIComponent(artifactId)}/compatible${versionQuery}`;
+
+    const authOptions = await createAuthOptions(auth);
+    const headers: Record<string, string> = {
+        "Accept": "application/json"
+    };
+    if (authOptions.headers) {
+        Object.entries(authOptions.headers).forEach(([key, value]) => {
+            if (typeof value === "string") {
+                headers[key] = value;
+            }
+        });
+    }
+
+    const response = await fetch(url, {
+        method: "GET",
+        headers
+    });
+
+    if (!response.ok) {
+        throw new Error(`Failed to get compatible MCP tools: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+};
+
+export interface McpToolsService {
+    getCompatibleMcpTools(groupId: string, artifactId: string, version?: string): Promise<McpToolSearchResults>;
+}
+
+export const useMcpToolsService: () => McpToolsService = (): McpToolsService => {
+    const config: ConfigService = useConfigService();
+    const auth = useAuth();
+
+    return {
+        getCompatibleMcpTools(groupId: string, artifactId: string, version?: string): Promise<McpToolSearchResults> {
+            return getCompatibleMcpTools(config, auth, groupId, artifactId, version);
+        }
+    };
+};


### PR DESCRIPTION
Part of #8427

## Summary
Adds output→input compatibility checking between MCP tools: given a tool, 
find other registered tools whose required input parameters are 
guaranteed by this tool's required output schema fields (i.e. "can Tool 
A's output feed Tool B's input").

## What's included
- **Backend**: two new endpoints on the well-known MCP tools resource
  - `GET /.well-known/mcp-tools/{groupId}/{artifactId}/compatible` — 
    by artifact reference
  - `POST /.well-known/mcp-tools/compatible` — by raw tool content
  - Compatibility logic (`isOutputCompatibleWithInput`) checks each 
    candidate's required input fields against the target's required 
    output fields (name + type match, with integer→number widening 
    allowed)
  - Integration tests covering: compatible match, incompatible (missing 
    required field), and the edge case where a target's output field 
    exists in `properties` but isn't listed in `required` (should not 
    count as satisfying a candidate's required input)

- **UI**: `CompatibleMcpToolsViewer` component, mounted in the MCP tool 
  documentation tab (`McpToolVisualizer`) alongside the existing tool 
  viewer. Shows loading, empty, and populated states; wired to the real 
  endpoint above, not mocked data.

## Design notes
- This does **not** reuse `McpToolCompatibilityChecker` (from #8662) — 
  that checker compares the same schema field across two versions of 
  one tool (version-evolution compatibility). This feature compares a 
  different field across two different tools at a single point in time 
  (cross-tool chaining compatibility). Different problem shape, so a 
  separate, purpose-built comparison was needed.
- Known scope boundary: type compatibility is currently name + top-level 
  type match only (with integer→number widening), not full nested/
  structural JSON Schema comparison. Flagging as a deliberate v1 
  boundary, open to feedback on whether deeper structural comparison is 
  expected for this issue.
- Known follow-up: the endpoint currently does a sequential per-candidate 
  storage fetch + compatibility check across all registered MCP_TOOL 
  artifacts (bounded by `MAX_VISIBILITY_FILTER_RESULTS`). Fine at current 
  scale; flagging as a known O(N) characteristic if this becomes a 
  concern at higher artifact counts.

## Test plan
- `./mvnw -pl app -am test -Dtest=WellKnownMcpToolsTest` — 17/17 passing
- `npx vitest run` (ui-app) — all passing
- `npx tsc --noEmit` (ui-app) — clean, exit code 0