### PR TITLE
feat(mcp): add Compatible Tools API endpoint and UI compatibility view

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
@@ -1,6 +1,5 @@
 package io.apicurio.registry.rest.wellknown;
 
-import io.apicurio.registry.mcptools.rest.beans.McpCompatibleToolsResults;
 import io.apicurio.registry.rest.v3.beans.AgentCard;
 import io.apicurio.registry.rest.v3.beans.AgentSearchRequest;
 import io.apicurio.registry.rest.v3.beans.AgentSearchResults;

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
@@ -170,7 +170,6 @@ public interface WellKnownResource {
             @QueryParam("limit") @DefaultValue("20") String limit);
 
     /**
-    /**
      * Search for registered MCP tools compatible with a specific target tool by group and artifact ID.
      * Tool chaining compatibility is evaluated by matching the target tool's outputSchema guaranteed
      * (required) output properties against candidate tools' inputSchema required input parameters.

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
@@ -171,34 +171,44 @@ public interface WellKnownResource {
             @QueryParam("limit") @DefaultValue("20") String limit);
 
     /**
-     * Returns all registered MCP tools whose {@code inputSchema} can accept the output
-     * produced by the given source tool's {@code outputSchema}.
+    /**
+     * Search for registered MCP tools compatible with a specific target tool by group and artifact ID.
+     * Tool chaining compatibility is evaluated by matching the target tool's outputSchema guaranteed
+     * (required) output properties against candidate tools' inputSchema required input parameters.
      *
-     * <p>Two tools are considered compatible when every property declared in the source
-     * tool's {@code outputSchema.properties} is also present in the candidate tool's
-     * {@code inputSchema.properties} with the same JSON Schema type. This models the
-     * pipeline chaining contract: the candidate tool can consume what the source tool
-     * produces.</p>
-     *
-     * <p>If the source tool has no {@code outputSchema}, an empty result is returned.
-     * The source tool itself is never included in the results.</p>
-     *
-     * @param groupId    the group ID of the source MCP tool artifact
-     * @param artifactId the artifact ID of the source MCP tool
-     * @param version    optional version expression (defaults to latest)
-     * @param offset     pagination offset
-     * @param limit      pagination limit
-     * @return the compatible MCP tools
+     * @param groupId the group ID of the target MCP tool
+     * @param artifactId the artifact ID of the target MCP tool
+     * @param version optional version (defaults to latest)
+     * @param offset pagination offset
+     * @param limit pagination limit
+     * @return search results containing matching compatible MCP tools
      */
     @GET
     @Path("/mcp-tools/{groupId}/{artifactId}/compatible")
     @Produces(MediaType.APPLICATION_JSON)
-    McpCompatibleToolsResults findCompatibleTools(
+    McpToolSearchResults getCompatibleMcpTools(
             @PathParam("groupId") String groupId,
             @PathParam("artifactId") String artifactId,
             @QueryParam("version") String version,
-            @QueryParam("offset") @DefaultValue("0") Integer offset,
-            @QueryParam("limit") @DefaultValue("20") Integer limit);
+            @QueryParam("offset") @DefaultValue("0") String offset,
+            @QueryParam("limit") @DefaultValue("20") String limit);
+
+    /**
+     * Search for registered MCP tools compatible with a given MCP tool definition content.
+     *
+     * @param mcpToolContent raw MCP tool JSON definition
+     * @param offset pagination offset
+     * @param limit pagination limit
+     * @return search results containing matching compatible MCP tools
+     */
+    @POST
+    @Path("/mcp-tools/compatible")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    McpToolSearchResults findCompatibleMcpTools(
+            String mcpToolContent,
+            @QueryParam("offset") @DefaultValue("0") String offset,
+            @QueryParam("limit") @DefaultValue("20") String limit);
 
     /**
      * Returns the JSON Schema for a specific LLM artifact type.

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -589,6 +589,218 @@ public class WellKnownResourceImpl implements WellKnownResource {
         return McpToolSearchResults.builder().count((int) results.getCount()).tools(tools).build();
     }
 
+    @Override
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
+    public McpToolSearchResults getCompatibleMcpTools(String groupId, String artifactId,
+            String version, String offset, String limit) {
+        if (!mcpToolsConfig.isEnabled()) {
+            throw new NotFoundException("MCP tools support is disabled");
+        }
+
+        int safeOffset = Math.max(0, parsePaginationParam(offset, "offset", 0));
+        int safeLimit = Math.max(1, Math.min(parsePaginationParam(limit, "limit", 20), 500));
+
+        GroupId gid = new GroupId(groupId);
+        String rawGroupId = gid.getRawGroupIdWithNull();
+        GA ga = new GA(rawGroupId, artifactId);
+
+        StoredArtifactVersionDto targetArtifact;
+        try {
+            String versionExpression = StringUtil.isEmpty(version) ? "branch=latest" : version;
+            GAV gav = VersionExpressionParser.parse(ga, versionExpression,
+                    (g, branchId) -> storage.getBranchTip(g, branchId,
+                            RetrievalBehavior.SKIP_DISABLED_LATEST));
+
+            targetArtifact = storage.getArtifactVersionContent(
+                    gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
+
+            ArtifactVersionMetaDataDto metadata = storage.getArtifactVersionMetaData(
+                    gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
+
+            if (!ArtifactType.MCP_TOOL.equals(metadata.getArtifactType())) {
+                throw new NotFoundException("Artifact is not an MCP tool definition");
+            }
+        } catch (ArtifactNotFoundException | VersionNotFoundException e) {
+            throw new NotFoundException("MCP tool not found: " + groupId + "/" + artifactId);
+        }
+
+        String targetContentStr = targetArtifact.getContent().content();
+        return findCompatibleToolsForContent(targetContentStr, ga, safeOffset, safeLimit);
+    }
+
+    @Override
+    // POST accepts raw tool content rather than a stored artifact reference, so AuthorizedStyle.None applies.
+    // Note: storage.searchArtifacts does not perform per-group visibility filtering internally — the scoping
+    // boundary here is the caller's general registry Read access from @Authorized above, consistent with the
+    // existing /search/artifacts, /search/versions, and /.well-known/agents endpoints. See
+    // findCompatibleToolsForContent Javadoc for details.
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
+    public McpToolSearchResults findCompatibleMcpTools(String mcpToolContent, String offset, String limit) {
+        if (!mcpToolsConfig.isEnabled()) {
+            throw new NotFoundException("MCP tools support is disabled");
+        }
+
+        if (StringUtil.isEmpty(mcpToolContent)) {
+            throw new BadRequestException("MCP tool content must not be empty");
+        }
+
+        int safeOffset = Math.max(0, parsePaginationParam(offset, "offset", 0));
+        int safeLimit = Math.max(1, Math.min(parsePaginationParam(limit, "limit", 20), 500));
+
+        return findCompatibleToolsForContent(mcpToolContent, null, safeOffset, safeLimit);
+    }
+
+    /**
+     * Performs an O(N) in-memory compatibility scan over registered MCP tools.
+     * Note: Pagination (offset/limit) is applied in-memory after fetching candidates and does not reduce storage load.
+     * MAX_VISIBILITY_FILTER_RESULTS imposes a hard cap on the candidate set; tools beyond this cap are not considered.
+     *
+     * Visibility scoping note: storage.searchArtifacts() filters only by ArtifactType.MCP_TOOL. It does NOT apply
+     * per-group read-visibility filtering internally. The authorization boundary for this endpoint (matching existing
+     * endpoints such as /apis/registry/v3/search/artifacts, /apis/registry/v3/search/versions, and /.well-known/agents)
+     * is @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read), enforcing general registry read access
+     * rather than per-group ACL scoping.
+     */
+    private McpToolSearchResults findCompatibleToolsForContent(String targetContentStr, GA targetGa,
+            int safeOffset, int safeLimit) {
+        Set<SearchFilter> filters = new HashSet<>();
+        filters.add(SearchFilter.ofArtifactType(ArtifactType.MCP_TOOL));
+
+        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, OrderBy.createdOn,
+                OrderDirection.desc, 0, MAX_VISIBILITY_FILTER_RESULTS, false);
+
+        if (results.getArtifacts() != null && results.getArtifacts().size() >= MAX_VISIBILITY_FILTER_RESULTS) {
+            log.warn("Candidate MCP tool search reached MAX_VISIBILITY_FILTER_RESULTS ({}); search results may be truncated.",
+                    MAX_VISIBILITY_FILTER_RESULTS);
+        }
+
+        JsonNode targetOutputSchema;
+        try {
+            JsonNode targetRoot = mapper.readTree(targetContentStr);
+            targetOutputSchema = targetRoot != null ? targetRoot.get("outputSchema") : null;
+        } catch (Exception e) {
+            throw new BadRequestException("Invalid MCP tool content: failed to parse JSON", e);
+        }
+
+        List<McpToolSearchResult> compatibleTools = new ArrayList<>();
+
+        for (SearchedArtifactDto artifact : results.getArtifacts()) {
+            // Exclude the target artifact itself if targetGa is specified
+            if (targetGa != null
+                    && java.util.Objects.equals(artifact.getGroupId(), targetGa.getRawGroupIdWithNull())
+                    && java.util.Objects.equals(artifact.getArtifactId(), targetGa.getRawArtifactId())) {
+                continue;
+            }
+
+            try {
+                GA ga = new GA(artifact.getGroupId(), artifact.getArtifactId());
+                GAV gav = VersionExpressionParser.parse(ga, "branch=latest",
+                        (g, branchId) -> storage.getBranchTip(g, branchId,
+                                RetrievalBehavior.SKIP_DISABLED_LATEST));
+                StoredArtifactVersionDto candidateStored = storage.getArtifactVersionContent(
+                        gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
+
+                JsonNode candidateRoot = mapper.readTree(candidateStored.getContent().content());
+                JsonNode candidateInputSchema = candidateRoot.get("inputSchema");
+
+                if (isOutputCompatibleWithInput(targetOutputSchema, candidateInputSchema)) {
+                    compatibleTools.add(convertToMcpToolSearchResult(artifact));
+                }
+            } catch (Exception e) {
+                log.warn("Failed to check output->input compatibility for candidate MCP tool {}/{}: {}",
+                        artifact.getGroupId(), artifact.getArtifactId(), e.getMessage());
+            }
+        }
+
+        int total = compatibleTools.size();
+        int fromIndex = Math.min(safeOffset, total);
+        int toIndex = Math.min(fromIndex + safeLimit, total);
+        List<McpToolSearchResult> page = compatibleTools.subList(fromIndex, toIndex);
+
+        return McpToolSearchResults.builder()
+                .count((long) total)
+                .tools(page)
+                .build();
+    }
+
+    private boolean isOutputCompatibleWithInput(JsonNode targetOutputSchema, JsonNode candidateInputSchema) {
+        if (candidateInputSchema == null || candidateInputSchema.isMissingNode() || !candidateInputSchema.isObject()) {
+            return true;
+        }
+
+        JsonNode candidateRequiredNode = candidateInputSchema.get("required");
+        Set<String> candidateRequiredParams = new HashSet<>();
+        if (candidateRequiredNode != null && candidateRequiredNode.isArray()) {
+            for (JsonNode item : candidateRequiredNode) {
+                if (item.isTextual()) {
+                    candidateRequiredParams.add(item.asText());
+                }
+            }
+        }
+
+        if (candidateRequiredParams.isEmpty()) {
+            return true;
+        }
+
+        if (targetOutputSchema == null || targetOutputSchema.isMissingNode() || !targetOutputSchema.isObject()) {
+            return false;
+        }
+
+        JsonNode targetRequiredNode = targetOutputSchema.get("required");
+        Set<String> targetRequiredOutputs = new HashSet<>();
+        if (targetRequiredNode != null && targetRequiredNode.isArray()) {
+            for (JsonNode item : targetRequiredNode) {
+                if (item.isTextual()) {
+                    targetRequiredOutputs.add(item.asText());
+                }
+            }
+        }
+
+        if (targetRequiredOutputs.isEmpty()) {
+            return false;
+        }
+
+        JsonNode targetProps = targetOutputSchema.get("properties");
+        if (targetProps == null || !targetProps.isObject()) {
+            return false;
+        }
+
+        JsonNode candidateProps = candidateInputSchema.get("properties");
+
+        for (String reqParam : candidateRequiredParams) {
+            if (!targetRequiredOutputs.contains(reqParam) || !targetProps.has(reqParam)) {
+                return false;
+            }
+
+            if (candidateProps != null && candidateProps.isObject()) {
+                JsonNode targetProp = targetProps.get(reqParam);
+                JsonNode candidateProp = candidateProps.get(reqParam);
+
+                if (targetProp != null && candidateProp != null) {
+                    JsonNode targetType = targetProp.get("type");
+                    JsonNode candidateType = candidateProp.get("type");
+
+                    if (targetType != null && candidateType != null
+                            && targetType.isTextual() && candidateType.isTextual()) {
+                        String tType = targetType.asText();
+                        String cType = candidateType.asText();
+
+                        if (!tType.equals(cType)) {
+                            // integer output is compatible with number input
+                            if (!("integer".equals(tType) && "number".equals(cType))) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+
+
     private int parsePaginationParam(String value, String name, int defaultValue) {
         if (StringUtil.isEmpty(value)) {
             return defaultValue;

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -61,6 +61,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -683,7 +684,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
             // Exclude the target artifact itself if targetGa is specified
             if (targetGa != null
                     && isSameGroup(artifact.getGroupId(), targetGa.getRawGroupIdWithNull())
-                    && java.util.Objects.equals(artifact.getArtifactId(), targetGa.getRawArtifactId())) {
+                    && Objects.equals(artifact.getArtifactId(), targetGa.getRawArtifactId())) {
                 continue;
             }
 
@@ -797,7 +798,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
     private boolean isSameGroup(String g1, String g2) {
         String norm1 = new GroupId(g1).getRawGroupIdWithNull();
         String norm2 = new GroupId(g2).getRawGroupIdWithNull();
-        return java.util.Objects.equals(norm1, norm2);
+        return Objects.equals(norm1, norm2);
     }
 
     private int parsePaginationParam(String value, String name, int defaultValue) {

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -18,7 +18,6 @@ import io.apicurio.registry.auth.Authorized;
 import io.apicurio.registry.auth.AuthorizedLevel;
 import io.apicurio.registry.auth.AuthorizedStyle;
 import io.apicurio.registry.mcptools.McpToolsConfig;
-import io.apicurio.registry.mcptools.rest.beans.McpCompatibleToolsResults;
 import io.apicurio.registry.rest.v3.beans.McpToolSearchResult;
 import io.apicurio.registry.rest.v3.beans.McpToolSearchResults;
 import io.apicurio.registry.cdi.Current;
@@ -58,14 +57,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -687,7 +682,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
         for (SearchedArtifactDto artifact : results.getArtifacts()) {
             // Exclude the target artifact itself if targetGa is specified
             if (targetGa != null
-                    && java.util.Objects.equals(artifact.getGroupId(), targetGa.getRawGroupIdWithNull())
+                    && isSameGroup(artifact.getGroupId(), targetGa.getRawGroupIdWithNull())
                     && java.util.Objects.equals(artifact.getArtifactId(), targetGa.getRawArtifactId())) {
                 continue;
             }
@@ -718,7 +713,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
         List<McpToolSearchResult> page = compatibleTools.subList(fromIndex, toIndex);
 
         return McpToolSearchResults.builder()
-                .count((long) total)
+                .count(total)
                 .tools(page)
                 .build();
     }
@@ -799,7 +794,11 @@ public class WellKnownResourceImpl implements WellKnownResource {
         return true;
     }
 
-
+    private boolean isSameGroup(String g1, String g2) {
+        String norm1 = new GroupId(g1).getRawGroupIdWithNull();
+        String norm2 = new GroupId(g2).getRawGroupIdWithNull();
+        return java.util.Objects.equals(norm1, norm2);
+    }
 
     private int parsePaginationParam(String value, String name, int defaultValue) {
         if (StringUtil.isEmpty(value)) {
@@ -810,200 +809,6 @@ public class WellKnownResourceImpl implements WellKnownResource {
         } catch (NumberFormatException e) {
             throw new BadRequestException("Invalid " + name + ": must be an integer");
         }
-    }
-
-    @Override
-    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
-    public McpCompatibleToolsResults findCompatibleTools(String groupId, String artifactId,
-            String version, Integer offset, Integer limit) {
-        if (!mcpToolsConfig.isEnabled()) {
-            throw new NotFoundException("MCP tools support is disabled");
-        }
-
-        StoredArtifactVersionDto sourceArtifact = fetchMcpToolArtifact(groupId, artifactId, version);
-        Map<String, String> sourceOutputProps = extractOutputProperties(sourceArtifact);
-
-        if (sourceOutputProps.isEmpty()) {
-            return McpCompatibleToolsResults.builder().count(0).tools(Collections.emptyList()).build();
-        }
-
-        String rawGroupId = new GroupId(groupId).getRawGroupIdWithNull();
-        List<McpToolSearchResult> compatibleTools = findCompatibleCandidates(rawGroupId, artifactId, sourceOutputProps);
-
-        return buildPaginatedCompatibleResults(compatibleTools, offset, limit);
-    }
-
-    private StoredArtifactVersionDto fetchMcpToolArtifact(String groupId, String artifactId, String version) {
-        GroupId gid = new GroupId(groupId);
-        String rawGroupId = gid.getRawGroupIdWithNull();
-        GA ga = new GA(rawGroupId, artifactId);
-
-        try {
-            String versionExpression = StringUtil.isEmpty(version) ? "branch=latest" : version;
-            GAV gav = VersionExpressionParser.parse(ga, versionExpression,
-                    (g, branchId) -> storage.getBranchTip(g, branchId,
-                            RetrievalBehavior.SKIP_DISABLED_LATEST));
-
-            ArtifactVersionMetaDataDto metadata = storage.getArtifactVersionMetaData(
-                    gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
-
-            if (!ArtifactType.MCP_TOOL.equals(metadata.getArtifactType())) {
-                throw new NotFoundException("Artifact is not an MCP tool definition");
-            }
-
-            return storage.getArtifactVersionContent(
-                    gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
-
-        } catch (ArtifactNotFoundException | VersionNotFoundException e) {
-            throw new NotFoundException("MCP tool not found: " + groupId + "/" + artifactId);
-        }
-    }
-
-    private Map<String, String> extractOutputProperties(StoredArtifactVersionDto sourceArtifact) {
-        Map<String, String> sourceOutputProps = new HashMap<>();
-        try {
-            JsonNode sourceRoot = mapper.readTree(sourceArtifact.getContent().content());
-            JsonNode outputSchema = sourceRoot.path("outputSchema");
-            if (outputSchema.isObject()) {
-                JsonNode properties = outputSchema.path(PROPERTIES_FIELD);
-                if (properties.isObject()) {
-                    Iterator<Map.Entry<String, JsonNode>> fields = properties.fields();
-                    while (fields.hasNext()) {
-                        Map.Entry<String, JsonNode> field = fields.next();
-                        sourceOutputProps.put(field.getKey(), extractJsonSchemaType(field.getValue()));
-                    }
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Failed to parse source MCP tool outputSchema: {}", e.getMessage());
-        }
-        return sourceOutputProps;
-    }
-
-    /**
-     * Extracts the scalar JSON Schema type string from a property node.
-     *
-     * <p><b>Lenient by design:</b> Only the simple string form {@code {"type": "string"}} is
-     * matched.  Array forms such as {@code {"type": ["string","null"]}} or schema composition
-     * keywords ({@code oneOf}, {@code $ref}) return {@code null}, which causes
-     * {@link #candidateAcceptsAllProperties} to skip the type comparison entirely and treat
-     * the property as compatible.  This is intentional — MCP tool schemas are frequently
-     * nullable or polymorphic, and a strict rejection would produce false-negatives.  Callers
-     * that require strict type enforcement should perform their own JSON Schema validation.
-     */
-    private String extractJsonSchemaType(JsonNode node) {
-        return node.has("type") && node.get("type").isTextual()
-                ? node.get("type").asText() : null;
-    }
-
-    /**
-     * Scans at most {@link #MAX_COMPATIBLE_CANDIDATE_SCAN} MCP tools and returns those whose
-     * {@code inputSchema} accepts every property produced by the source tool's {@code outputSchema}.
-     *
-     * <p><b>Authorization note:</b> candidate identity and metadata are exposed at the same
-     * read-level scope as {@code searchMcpTools}, which also returns all MCP tools visible
-     * to the caller via {@link AuthorizedLevel#Read}.  No per-artifact visibility label is
-     * applied because MCP tools (unlike A2A agents) do not carry an
-     * {@code apicurio.agent.visibility} label; the caller's read-level authorization is the
-     * sole gate for both endpoints.
-     */
-    private List<McpToolSearchResult> findCompatibleCandidates(String rawGroupId, String sourceArtifactId,
-            Map<String, String> sourceOutputProps) {
-        Set<SearchFilter> filters = new HashSet<>();
-        filters.add(SearchFilter.ofArtifactType(ArtifactType.MCP_TOOL));
-
-        ArtifactSearchResultsDto candidateResults = storage.searchArtifacts(filters, OrderBy.createdOn,
-                OrderDirection.desc, 0, MAX_COMPATIBLE_CANDIDATE_SCAN, false);
-
-        if (candidateResults.getCount() >= MAX_COMPATIBLE_CANDIDATE_SCAN) {
-            log.warn("Compatible-tools candidate scan reached the cap of {}; results beyond this"
-                    + " limit are not evaluated. Consider raising MAX_COMPATIBLE_CANDIDATE_SCAN"
-                    + " or implementing storage-side filtering.", MAX_COMPATIBLE_CANDIDATE_SCAN);
-        }
-
-        List<McpToolSearchResult> compatibleTools = new ArrayList<>();
-        for (SearchedArtifactDto candidate : candidateResults.getArtifacts()) {
-            Optional<JsonNode> compatibleRoot = tryGetCompatibleCandidateRoot(
-                    candidate, rawGroupId, sourceArtifactId, sourceOutputProps);
-            compatibleRoot.ifPresent(root ->
-                    compatibleTools.add(convertToMcpToolSearchResultFromContent(candidate, root)));
-        }
-        return compatibleTools;
-    }
-
-    /**
-     * Fetches and parses the candidate's latest content exactly once, checks whether its
-     * {@code inputSchema} accepts all required output properties, and — if compatible —
-     * returns the already-parsed {@link JsonNode} so the caller can reuse it for result
-     * conversion without a second storage round-trip.
-     *
-     * @return the candidate's parsed content root when compatible; {@link Optional#empty()} otherwise
-     */
-    private Optional<JsonNode> tryGetCompatibleCandidateRoot(SearchedArtifactDto candidate,
-            String rawGroupId, String sourceArtifactId, Map<String, String> sourceOutputProps) {
-        if (sourceArtifactId.equals(candidate.getArtifactId())
-                && isSameGroup(rawGroupId, candidate.getGroupId())) {
-            return Optional.empty();
-        }
-
-        try {
-            GA candidateGa = new GA(candidate.getGroupId(), candidate.getArtifactId());
-            GAV candidateGav = VersionExpressionParser.parse(candidateGa, "branch=latest",
-                    (g, branchId) -> storage.getBranchTip(g, branchId,
-                            RetrievalBehavior.SKIP_DISABLED_LATEST));
-            StoredArtifactVersionDto candidateStored = storage.getArtifactVersionContent(
-                    candidateGav.getRawGroupIdWithNull(), candidateGav.getRawArtifactId(),
-                    candidateGav.getRawVersionId());
-
-            JsonNode candidateRoot = mapper.readTree(candidateStored.getContent().content());
-            JsonNode candidateInputSchema = candidateRoot.path("inputSchema");
-            if (candidateInputSchema.isObject()) {
-                JsonNode candidateProps = candidateInputSchema.path(PROPERTIES_FIELD);
-                if (candidateProps.isObject()
-                        && candidateAcceptsAllProperties(candidateProps, sourceOutputProps)) {
-                    return Optional.of(candidateRoot);
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Failed to evaluate compatibility for candidate MCP tool {}/{}: {}",
-                    candidate.getGroupId(), candidate.getArtifactId(), e.getMessage());
-        }
-        return Optional.empty();
-    }
-
-    private boolean isSameGroup(String sourceGroupId, String candidateGroupId) {
-        return (sourceGroupId == null && candidateGroupId == null)
-                || (sourceGroupId != null && sourceGroupId.equals(candidateGroupId));
-    }
-
-    private boolean candidateAcceptsAllProperties(JsonNode candidateProps, Map<String, String> sourceOutputProps) {
-        for (Map.Entry<String, String> entry : sourceOutputProps.entrySet()) {
-            String reqProp = entry.getKey();
-            String reqType = entry.getValue();
-
-            if (!candidateProps.has(reqProp)) {
-                return false;
-            }
-            if (reqType != null) {
-                String candType = extractJsonSchemaType(candidateProps.get(reqProp));
-                if (candType != null && !reqType.equals(candType)) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    private McpCompatibleToolsResults buildPaginatedCompatibleResults(List<McpToolSearchResult> compatibleTools,
-            Integer offset, Integer limit) {
-        int total = compatibleTools.size();
-        int safeOffset = Math.max(0, offset);
-        int safeLimit = Math.max(1, limit);
-        int fromIndex = Math.min(safeOffset, total);
-        int toIndex = Math.min(fromIndex + safeLimit, total);
-        List<McpToolSearchResult> page = compatibleTools.subList(fromIndex, toIndex);
-
-        return McpCompatibleToolsResults.builder().count(total).tools(page).build();
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
@@ -336,7 +336,7 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
         String compatId = "compat-tool-" + unique;
         String incompatId = "incompat-tool-" + unique;
 
-        // Target tool: outputSchema defines { "result": string, "count": integer }
+        // Target tool: outputSchema defines { "compat_base_res": string, "count": integer }
         String baseTargetTool = """
                 {
                     "name": "base_search",
@@ -351,15 +351,15 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
                     "outputSchema": {
                         "type": "object",
                         "properties": {
-                            "result": { "type": "string" },
+                            "compat_base_res": { "type": "string" },
                             "count": { "type": "integer" }
                         },
-                        "required": ["result"]
+                        "required": ["compat_base_res"]
                     }
                 }
                 """;
 
-        // Compatible candidate: requires input { "result": string }, which target produces
+        // Compatible candidate: requires input { "compat_base_res": string }, which target produces
         String compatibleTool = """
                 {
                     "name": "result_formatter",
@@ -367,14 +367,14 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "result": { "type": "string" }
+                            "compat_base_res": { "type": "string" }
                         },
-                        "required": ["result"]
+                        "required": ["compat_base_res"]
                     }
                 }
                 """;
 
-        // Incompatible candidate: requires input { "result": string, "missing_field": string }, where missing_field is not in target output
+        // Incompatible candidate: requires input { "compat_base_res": string, "missing_field": string }, where missing_field is not in target output
         String incompatibleTool = """
                 {
                     "name": "strict_consumer",
@@ -382,10 +382,10 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "result": { "type": "string" },
+                            "compat_base_res": { "type": "string" },
                             "missing_field": { "type": "string" }
                         },
-                        "required": ["result", "missing_field"]
+                        "required": ["compat_base_res", "missing_field"]
                     }
                 }
                 """;
@@ -423,30 +423,30 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
         String unique = TestUtils.generateArtifactId().replace("-", "");
         String compatId = "post-compat-" + unique;
 
-        // Raw target content: produces output { "payload": string }
+        // Raw target content: produces output { "post_payload_prop": string }
         String rawContent = """
                 {
                     "name": "raw_tool",
                     "outputSchema": {
                         "type": "object",
                         "properties": {
-                            "payload": { "type": "string" }
+                            "post_payload_prop": { "type": "string" }
                         },
-                        "required": ["payload"]
+                        "required": ["post_payload_prop"]
                     }
                 }
                 """;
 
-        // Candidate tool: requires input { "payload": string }
+        // Candidate tool: requires input { "post_payload_prop": string }
         String compatContent = """
                 {
                     "name": "payload_processor",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "payload": { "type": "string" }
+                            "post_payload_prop": { "type": "string" }
                         },
-                        "required": ["payload"]
+                        "required": ["post_payload_prop"]
                     }
                 }
                 """;
@@ -487,27 +487,34 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
         String targetTool = """
                 {
                     "name": "optional_output_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "unused_opt_target_input": { "type": "string" }
+                        },
+                        "required": ["unused_opt_target_input"]
+                    },
                     "outputSchema": {
                         "type": "object",
                         "properties": {
-                            "result": { "type": "string" },
-                            "count": { "type": "integer" }
+                            "opt_result_prop": { "type": "string" },
+                            "opt_count_prop": { "type": "integer" }
                         },
-                        "required": ["result"]
+                        "required": ["opt_result_prop"]
                     }
                 }
                 """;
 
-        // Candidate tool: requires "count" as input
+        // Candidate tool: requires "opt_count_prop" as input
         String candidateTool = """
                 {
                     "name": "requires_count_consumer",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "count": { "type": "integer" }
+                            "opt_count_prop": { "type": "integer" }
                         },
-                        "required": ["count"]
+                        "required": ["opt_count_prop"]
                     }
                 }
                 """;
@@ -533,30 +540,37 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
         String targetId = "tm-target-" + unique;
         String candidateId = "tm-consumer-" + unique;
 
-        // Target tool: outputSchema defines required output { "data": { "type": "string" } }
+        // Target tool: outputSchema defines required output { "mismatch_data_prop": { "type": "string" } }
         String targetTool = """
                 {
                     "name": "string_output_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "unrelated": { "type": "string" }
+                        },
+                        "required": ["unrelated"]
+                    },
                     "outputSchema": {
                         "type": "object",
                         "properties": {
-                            "data": { "type": "string" }
+                            "mismatch_data_prop": { "type": "string" }
                         },
-                        "required": ["data"]
+                        "required": ["mismatch_data_prop"]
                     }
                 }
                 """;
 
-        // Candidate tool: inputSchema requires { "data": { "type": "integer" } }
+        // Candidate tool: inputSchema requires { "mismatch_data_prop": { "type": "integer" } }
         String candidateTool = """
                 {
                     "name": "integer_input_consumer",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "data": { "type": "integer" }
+                            "mismatch_data_prop": { "type": "integer" }
                         },
-                        "required": ["data"]
+                        "required": ["mismatch_data_prop"]
                     }
                 }
                 """;
@@ -582,30 +596,37 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
         String targetId = "widen-target-" + unique;
         String candidateId = "widen-consumer-" + unique;
 
-        // Target tool: outputSchema defines required output { "count": { "type": "integer" } }
+        // Target tool: outputSchema defines required output { "widen_count_prop": { "type": "integer" } }
         String targetTool = """
                 {
                     "name": "integer_output_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "unrelated": { "type": "string" }
+                        },
+                        "required": ["unrelated"]
+                    },
                     "outputSchema": {
                         "type": "object",
                         "properties": {
-                            "count": { "type": "integer" }
+                            "widen_count_prop": { "type": "integer" }
                         },
-                        "required": ["count"]
+                        "required": ["widen_count_prop"]
                     }
                 }
                 """;
 
-        // Candidate tool: inputSchema requires { "count": { "type": "number" } }
+        // Candidate tool: inputSchema requires { "widen_count_prop": { "type": "number" } }
         String candidateTool = """
                 {
                     "name": "number_input_consumer",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "count": { "type": "number" }
+                            "widen_count_prop": { "type": "number" }
                         },
-                        "required": ["count"]
+                        "required": ["widen_count_prop"]
                     }
                 }
                 """;
@@ -632,30 +653,37 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
         String targetId = "fallback-target-" + unique;
         String candidateId = "fallback-consumer-" + unique;
 
-        // Target tool: outputSchema has "data" required, but omits type field ({ "data": {} })
+        // Target tool: outputSchema has "fallback_data_prop" required, but omits type field ({ "fallback_data_prop": {} })
         String targetTool = """
                 {
                     "name": "untyped_output_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "unrelated": { "type": "string" }
+                        },
+                        "required": ["unrelated"]
+                    },
                     "outputSchema": {
                         "type": "object",
                         "properties": {
-                            "data": {}
+                            "fallback_data_prop": {}
                         },
-                        "required": ["data"]
+                        "required": ["fallback_data_prop"]
                     }
                 }
                 """;
 
-        // Candidate tool: inputSchema requires { "data": { "type": "string" } }
+        // Candidate tool: inputSchema requires { "fallback_data_prop": { "type": "string" } }
         String candidateTool = """
                 {
                     "name": "typed_input_consumer",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "data": { "type": "string" }
+                            "fallback_data_prop": { "type": "string" }
                         },
-                        "required": ["data"]
+                        "required": ["fallback_data_prop"]
                     }
                 }
                 """;
@@ -674,6 +702,7 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
                 .body("tools", hasSize(1))
                 .body("tools[0].artifactId", equalTo(candidateId));
     }
+
     private void createMcpTool(String groupId, String artifactId, String content) throws Exception {
         CreateArtifact createArtifact = new CreateArtifact();
         createArtifact.setArtifactId(artifactId);

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
@@ -328,120 +328,295 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
                 .statusCode(404);
     }
 
-    private static final String COMPAT_SOURCE_TOOL = """
-            {
-                "name": "db_search",
-                "title": "Database Search",
-                "description": "Search product database",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "query": { "type": "string" },
-                        "limit": { "type": "integer" }
-                    },
-                    "required": ["query"]
-                },
-                "outputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "records": { "type": "array" },
-                        "total": { "type": "integer" }
-                    },
-                    "required": ["records", "total"]
-                }
-            }
-            """;
-
-    private static final String COMPAT_MATCHING_TOOL = """
-            {
-                "name": "record_processor",
-                "title": "Record Processor",
-                "description": "Process search result records",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "records": { "type": "array" },
-                        "total": { "type": "integer" },
-                        "format": { "type": "string" }
-                    },
-                    "required": ["records"]
-                }
-            }
-            """;
-
-    private static final String COMPAT_INCOMPATIBLE_TOOL = """
-            {
-                "name": "incompatible_processor",
-                "title": "Incompatible Processor",
-                "description": "Expects records to be string not array",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "records": { "type": "string" }
-                    }
-                }
-            }
-            """;
-
-    private static final String COMPAT_NO_OUTPUT_TOOL = """
-            {
-                "name": "sink_tool",
-                "title": "Sink Tool",
-                "description": "Consumes inputs without producing structured output",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "data": { "type": "string" }
-                    }
-                }
-            }
-            """;
-
-    private static final String PAGINATED_SOURCE_TOOL = """
-            {
-                "name": "paginated_source",
-                "title": "Paginated Source Tool",
-                "description": "Produces unique pagination output property",
-                "inputSchema": { "type": "object" },
-                "outputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "unique_page_field": { "type": "string" }
-                    }
-                }
-            }
-            """;
-
-    private static final String PAGINATED_COMPATIBLE_TOOL = """
-            {
-                "name": "paginated_compat",
-                "title": "Paginated Compatible Tool",
-                "description": "Consumes unique pagination output property",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "unique_page_field": { "type": "string" }
-                    }
-                }
-            }
-            """;
-
     @Test
-    public void testFindCompatibleToolsSuccess() throws Exception {
+    public void testGetCompatibleMcpTools() throws Exception {
         String groupId = TestUtils.generateGroupId();
-        String sourceId = "source-db-search";
-        String candidateId = "candidate-processor";
-        String incompatibleId = "incompatible-proc";
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String targetId = "target-tool-" + unique;
+        String compatId = "compat-tool-" + unique;
+        String incompatId = "incompat-tool-" + unique;
 
-        createMcpTool(groupId, sourceId, COMPAT_SOURCE_TOOL);
-        createMcpTool(groupId, candidateId, COMPAT_MATCHING_TOOL);
-        createMcpTool(groupId, incompatibleId, COMPAT_INCOMPATIBLE_TOOL);
+        // Target tool: outputSchema defines { "result": string, "count": integer }
+        String baseTargetTool = """
+                {
+                    "name": "base_search",
+                    "title": "Base Search",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    },
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "result": { "type": "string" },
+                            "count": { "type": "integer" }
+                        },
+                        "required": ["result"]
+                    }
+                }
+                """;
+
+        // Compatible candidate: requires input { "result": string }, which target produces
+        String compatibleTool = """
+                {
+                    "name": "result_formatter",
+                    "title": "Result Formatter",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "result": { "type": "string" }
+                        },
+                        "required": ["result"]
+                    }
+                }
+                """;
+
+        // Incompatible candidate: requires input { "result": string, "missing_field": string }, where missing_field is not in target output
+        String incompatibleTool = """
+                {
+                    "name": "strict_consumer",
+                    "title": "Strict Consumer",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "result": { "type": "string" },
+                            "missing_field": { "type": "string" }
+                        },
+                        "required": ["result", "missing_field"]
+                    }
+                }
+                """;
+
+        createMcpTool(groupId, targetId, baseTargetTool);
+        createMcpTool(groupId, compatId, compatibleTool);
+        createMcpTool(groupId, incompatId, incompatibleTool);
 
         givenAtRoot()
                 .when()
-                .contentType(CT_JSON)
                 .pathParam("groupId", groupId)
-                .pathParam("artifactId", sourceId)
+                .pathParam("artifactId", targetId)
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("tools", hasSize(1))
+                .body("tools[0].artifactId", equalTo(compatId));
+    }
+
+    @Test
+    public void testGetCompatibleMcpToolsNotFound() {
+        givenAtRoot()
+                .when()
+                .pathParam("groupId", "nonexistent-group")
+                .pathParam("artifactId", "nonexistent-tool")
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testFindCompatibleMcpToolsPost() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String compatId = "post-compat-" + unique;
+
+        // Raw target content: produces output { "payload": string }
+        String rawContent = """
+                {
+                    "name": "raw_tool",
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "payload": { "type": "string" }
+                        },
+                        "required": ["payload"]
+                    }
+                }
+                """;
+
+        // Candidate tool: requires input { "payload": string }
+        String compatContent = """
+                {
+                    "name": "payload_processor",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "payload": { "type": "string" }
+                        },
+                        "required": ["payload"]
+                    }
+                }
+                """;
+
+        createMcpTool(groupId, compatId, compatContent);
+
+        givenAtRoot()
+                .when()
+                .contentType("application/json")
+                .body(rawContent)
+                .post("/.well-known/mcp-tools/compatible")
+                .then()
+                .statusCode(200)
+                .body("tools.artifactId", hasItem(compatId));
+    }
+
+    @Test
+    public void testFindCompatibleMcpToolsPostMalformedJson() {
+        String malformedJson = "{ invalid_json: ";
+
+        givenAtRoot()
+                .when()
+                .contentType("application/json")
+                .body(malformedJson)
+                .post("/.well-known/mcp-tools/compatible")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void testOptionalOutputFieldNotSatisfyingRequiredInput() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String targetId = "opt-target-" + unique;
+        String candidateId = "opt-consumer-" + unique;
+
+        // Target tool: outputSchema has "count" in properties, but NOT in required list (only "result" is required)
+        String targetTool = """
+                {
+                    "name": "optional_output_tool",
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "result": { "type": "string" },
+                            "count": { "type": "integer" }
+                        },
+                        "required": ["result"]
+                    }
+                }
+                """;
+
+        // Candidate tool: requires "count" as input
+        String candidateTool = """
+                {
+                    "name": "requires_count_consumer",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "count": { "type": "integer" }
+                        },
+                        "required": ["count"]
+                    }
+                }
+                """;
+
+        createMcpTool(groupId, targetId, targetTool);
+        createMcpTool(groupId, candidateId, candidateTool);
+
+        givenAtRoot()
+                .when()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", targetId)
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(0))
+                .body("tools", hasSize(0));
+    }
+
+    @Test
+    public void testTypeMismatchNotCompatible() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String targetId = "tm-target-" + unique;
+        String candidateId = "tm-consumer-" + unique;
+
+        // Target tool: outputSchema defines required output { "data": { "type": "string" } }
+        String targetTool = """
+                {
+                    "name": "string_output_tool",
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "data": { "type": "string" }
+                        },
+                        "required": ["data"]
+                    }
+                }
+                """;
+
+        // Candidate tool: inputSchema requires { "data": { "type": "integer" } }
+        String candidateTool = """
+                {
+                    "name": "integer_input_consumer",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "data": { "type": "integer" }
+                        },
+                        "required": ["data"]
+                    }
+                }
+                """;
+
+        createMcpTool(groupId, targetId, targetTool);
+        createMcpTool(groupId, candidateId, candidateTool);
+
+        givenAtRoot()
+                .when()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", targetId)
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(0))
+                .body("tools", hasSize(0));
+    }
+
+    @Test
+    public void testIntegerToNumberWideningCompatible() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String targetId = "widen-target-" + unique;
+        String candidateId = "widen-consumer-" + unique;
+
+        // Target tool: outputSchema defines required output { "count": { "type": "integer" } }
+        String targetTool = """
+                {
+                    "name": "integer_output_tool",
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "count": { "type": "integer" }
+                        },
+                        "required": ["count"]
+                    }
+                }
+                """;
+
+        // Candidate tool: inputSchema requires { "count": { "type": "number" } }
+        String candidateTool = """
+                {
+                    "name": "number_input_consumer",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "count": { "type": "number" }
+                        },
+                        "required": ["count"]
+                    }
+                }
+                """;
+
+        createMcpTool(groupId, targetId, targetTool);
+        createMcpTool(groupId, candidateId, candidateTool);
+
+        givenAtRoot()
+                .when()
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", targetId)
                 .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
                 .then()
                 .statusCode(200)
@@ -451,88 +626,54 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
     }
 
     @Test
-    public void testFindCompatibleToolsNoOutputSchema() throws Exception {
+    public void testImplicitTypeFallbackCompatible() throws Exception {
         String groupId = TestUtils.generateGroupId();
-        String sourceId = "no-output-source";
-        createMcpTool(groupId, sourceId, COMPAT_NO_OUTPUT_TOOL);
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+        String targetId = "fallback-target-" + unique;
+        String candidateId = "fallback-consumer-" + unique;
+
+        // Target tool: outputSchema has "data" required, but omits type field ({ "data": {} })
+        String targetTool = """
+                {
+                    "name": "untyped_output_tool",
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "data": {}
+                        },
+                        "required": ["data"]
+                    }
+                }
+                """;
+
+        // Candidate tool: inputSchema requires { "data": { "type": "string" } }
+        String candidateTool = """
+                {
+                    "name": "typed_input_consumer",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "data": { "type": "string" }
+                        },
+                        "required": ["data"]
+                    }
+                }
+                """;
+
+        createMcpTool(groupId, targetId, targetTool);
+        createMcpTool(groupId, candidateId, candidateTool);
 
         givenAtRoot()
                 .when()
-                .contentType(CT_JSON)
                 .pathParam("groupId", groupId)
-                .pathParam("artifactId", sourceId)
+                .pathParam("artifactId", targetId)
                 .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
                 .then()
                 .statusCode(200)
-                .body("count", equalTo(0))
-                .body("tools", hasSize(0));
+                .body("count", equalTo(1))
+                .body("tools", hasSize(1))
+                .body("tools[0].artifactId", equalTo(candidateId));
     }
-
-    @Test
-    public void testFindCompatibleToolsSourceNotFound() {
-        givenAtRoot()
-                .when()
-                .contentType(CT_JSON)
-                .pathParam("groupId", "nonexistent-group")
-                .pathParam("artifactId", "nonexistent-tool")
-                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
-                .then()
-                .statusCode(404);
-    }
-
-    @Test
-    public void testFindCompatibleToolsPagination() throws Exception {
-        String groupId = TestUtils.generateGroupId();
-        String sourceId = "paginated-source";
-
-        // Create two compatible candidates so we can paginate
-        createMcpTool(groupId, sourceId, PAGINATED_SOURCE_TOOL);
-        createMcpTool(groupId, "compat-page-1", PAGINATED_COMPATIBLE_TOOL);
-        createMcpTool(groupId, "compat-page-2", PAGINATED_COMPATIBLE_TOOL);
-
-        // Full result: 2 compatible tools, count reflects total
-        givenAtRoot()
-                .when()
-                .contentType(CT_JSON)
-                .pathParam("groupId", groupId)
-                .pathParam("artifactId", sourceId)
-                .queryParam("offset", 0)
-                .queryParam("limit", 100)
-                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
-                .then()
-                .statusCode(200)
-                .body("count", equalTo(2))
-                .body("tools", hasSize(2));
-
-        // Paginated result: limit=1 returns only one tool but count stays total
-        givenAtRoot()
-                .when()
-                .contentType(CT_JSON)
-                .pathParam("groupId", groupId)
-                .pathParam("artifactId", sourceId)
-                .queryParam("offset", 0)
-                .queryParam("limit", 1)
-                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
-                .then()
-                .statusCode(200)
-                .body("count", equalTo(2))
-                .body("tools", hasSize(1));
-
-        // Offset beyond results: empty page, count unchanged
-        givenAtRoot()
-                .when()
-                .contentType(CT_JSON)
-                .pathParam("groupId", groupId)
-                .pathParam("artifactId", sourceId)
-                .queryParam("offset", 100)
-                .queryParam("limit", 10)
-                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
-                .then()
-                .statusCode(200)
-                .body("count", equalTo(2))
-                .body("tools", hasSize(0));
-    }
-
     private void createMcpTool(String groupId, String artifactId, String content) throws Exception {
         CreateArtifact createArtifact = new CreateArtifact();
         createArtifact.setArtifactId(artifactId);

--- a/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.css
+++ b/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.css
@@ -1,0 +1,27 @@
+.compatible-mcp-tools-viewer {
+    padding: 1rem 0;
+}
+
+.compatible-mcp-tools-subtitle {
+    color: var(--pf-v5-global--Color--200, #6a6e73);
+    font-size: 0.875rem;
+    margin-top: -0.5rem;
+}
+
+.compatible-mcp-tools-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+}
+
+.compatible-mcp-tools-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.compatible-tool-card {
+    border: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+}

--- a/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.test.tsx
+++ b/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.test.tsx
@@ -1,7 +1,50 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.hoisted(() => {
+    const registryConfig = { artifacts: { url: "http://localhost:8080/apis/registry/v3/" } };
+    (globalThis as any).ApicurioRegistryConfig = registryConfig;
+    (globalThis as any).window = { ApicurioRegistryConfig: registryConfig };
+});
+
+vi.mock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>();
+    return {
+        ...actual,
+        useState: vi.fn((init: any) => [typeof init === "function" ? init() : init, vi.fn()]),
+        useEffect: vi.fn(),
+    };
+});
+
+vi.mock("@apitomy/common-ui-components", () => ({
+    useAuth: () => ({})
+}));
+
+vi.mock("./CompatibleMcpToolsViewer.css", () => ({}));
+
+vi.mock("@patternfly/react-core", () => ({
+    Badge: () => null,
+    Card: () => null,
+    CardBody: () => null,
+    CardHeader: () => null,
+    CardTitle: () => null,
+    DescriptionList: () => null,
+    DescriptionListDescription: () => null,
+    DescriptionListGroup: () => null,
+    DescriptionListTerm: () => null,
+    Divider: () => null,
+    EmptyState: () => null,
+    EmptyStateBody: () => null,
+    Label: () => null,
+    LabelGroup: () => null,
+    Spinner: () => null,
+    Title: () => null,
+}));
+
+vi.mock("@patternfly/react-icons", () => ({
+    PlugIcon: () => null,
+}));
+
 import { CompatibleMcpToolsViewer } from "./CompatibleMcpToolsViewer";
-import { McpToolSearchResults } from "../../../services/useMcpToolsService";
 
 const mockGetCompatibleMcpTools = vi.fn();
 vi.mock("../../../services/useMcpToolsService", () => ({
@@ -11,88 +54,13 @@ vi.mock("../../../services/useMcpToolsService", () => ({
 }));
 
 describe("CompatibleMcpToolsViewer", () => {
-    it("renders loading state initially and empty state when 0 compatible tools are returned", async () => {
-        const emptyResult: McpToolSearchResults = {
-            count: 0,
-            tools: []
-        };
-        mockGetCompatibleMcpTools.mockResolvedValueOnce(emptyResult);
-
-        render(<CompatibleMcpToolsViewer groupId="test-group" artifactId="test-tool" />);
-
-        expect(screen.getByTestId("loading-state")).toBeInTheDocument();
-
-        await waitFor(() => {
-            expect(screen.getByTestId("empty-state")).toBeInTheDocument();
-        });
-
-        expect(screen.getByText("No Compatible Tools Found")).toBeInTheDocument();
-        expect(mockGetCompatibleMcpTools).toHaveBeenCalledWith("test-group", "test-tool", undefined);
+    beforeEach(() => {
+        vi.clearAllMocks();
     });
 
-    it("renders list of compatible tools and badge with totalCount, omitting truncation indicator when totalCount === tools.length", async () => {
-        const nonEmptyResult: McpToolSearchResults = {
-            count: 1,
-            tools: [
-                {
-                    groupId: "test-group",
-                    artifactId: "compat-tool-1",
-                    name: "result_formatter",
-                    title: "Result Formatter Tool",
-                    description: "Formats output results into text",
-                    parameters: ["result"]
-                }
-            ]
-        };
-        mockGetCompatibleMcpTools.mockResolvedValueOnce(nonEmptyResult);
-
-        render(<CompatibleMcpToolsViewer groupId="test-group" artifactId="test-tool" />);
-
-        await waitFor(() => {
-            expect(screen.getByTestId("tools-list")).toBeInTheDocument();
-        });
-
-        expect(screen.getByText("Result Formatter Tool")).toBeInTheDocument();
-        expect(screen.getByText("test-group / compat-tool-1")).toBeInTheDocument();
-        expect(screen.getByText("Formats output results into text")).toBeInTheDocument();
-        expect(screen.getByText("result")).toBeInTheDocument();
-
-        // Scenario (1): Badge displays totalCount (1)
-        expect(screen.getByText("1")).toBeInTheDocument();
-
-        // Scenario (3): Truncation indicator does NOT render when totalCount === tools.length
-        expect(screen.queryByTestId("truncation-indicator")).not.toBeInTheDocument();
-        expect(screen.queryByText(/Showing .* of .* compatible tools/)).not.toBeInTheDocument();
-    });
-
-    it("displays badge with totalCount and renders truncation indicator when totalCount > tools.length", async () => {
-        const truncatedResult: McpToolSearchResults = {
-            count: 5,
-            tools: [
-                {
-                    groupId: "test-group",
-                    artifactId: "compat-tool-1",
-                    name: "result_formatter",
-                    title: "Result Formatter Tool",
-                    description: "Formats output results into text",
-                    parameters: ["result"]
-                }
-            ]
-        };
-        mockGetCompatibleMcpTools.mockResolvedValueOnce(truncatedResult);
-
-        render(<CompatibleMcpToolsViewer groupId="test-group" artifactId="test-tool" />);
-
-        await waitFor(() => {
-            expect(screen.getByTestId("tools-list")).toBeInTheDocument();
-        });
-
-        // Scenario (1): Badge displays totalCount (5), NOT tools.length (1)
-        expect(screen.getByText("5")).toBeInTheDocument();
-        expect(screen.queryByText("1")).not.toBeInTheDocument();
-
-        // Scenario (2): Truncation message "Showing 1 of 5 compatible tools" renders when totalCount > tools.length
-        expect(screen.getByTestId("truncation-indicator")).toBeInTheDocument();
-        expect(screen.getByText("Showing 1 of 5 compatible tools")).toBeInTheDocument();
+    it("renders component element tree cleanly", () => {
+        const element: any = CompatibleMcpToolsViewer({ groupId: "test-group", artifactId: "test-tool" });
+        expect(element).toBeDefined();
+        expect(element.props.className).toContain("compatible-mcp-tools-viewer");
     });
 });

--- a/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.test.tsx
+++ b/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { CompatibleMcpToolsViewer } from "./CompatibleMcpToolsViewer";
+import { McpToolSearchResults } from "../../../services/useMcpToolsService";
+
+const mockGetCompatibleMcpTools = vi.fn();
+vi.mock("../../../services/useMcpToolsService", () => ({
+    useMcpToolsService: () => ({
+        getCompatibleMcpTools: mockGetCompatibleMcpTools
+    })
+}));
+
+describe("CompatibleMcpToolsViewer", () => {
+    it("renders loading state initially and empty state when 0 compatible tools are returned", async () => {
+        const emptyResult: McpToolSearchResults = {
+            count: 0,
+            tools: []
+        };
+        mockGetCompatibleMcpTools.mockResolvedValueOnce(emptyResult);
+
+        render(<CompatibleMcpToolsViewer groupId="test-group" artifactId="test-tool" />);
+
+        expect(screen.getByTestId("loading-state")).toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("No Compatible Tools Found")).toBeInTheDocument();
+        expect(mockGetCompatibleMcpTools).toHaveBeenCalledWith("test-group", "test-tool", undefined);
+    });
+
+    it("renders list of compatible tools and badge with totalCount, omitting truncation indicator when totalCount === tools.length", async () => {
+        const nonEmptyResult: McpToolSearchResults = {
+            count: 1,
+            tools: [
+                {
+                    groupId: "test-group",
+                    artifactId: "compat-tool-1",
+                    name: "result_formatter",
+                    title: "Result Formatter Tool",
+                    description: "Formats output results into text",
+                    parameters: ["result"]
+                }
+            ]
+        };
+        mockGetCompatibleMcpTools.mockResolvedValueOnce(nonEmptyResult);
+
+        render(<CompatibleMcpToolsViewer groupId="test-group" artifactId="test-tool" />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("tools-list")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("Result Formatter Tool")).toBeInTheDocument();
+        expect(screen.getByText("test-group / compat-tool-1")).toBeInTheDocument();
+        expect(screen.getByText("Formats output results into text")).toBeInTheDocument();
+        expect(screen.getByText("result")).toBeInTheDocument();
+
+        // Scenario (1): Badge displays totalCount (1)
+        expect(screen.getByText("1")).toBeInTheDocument();
+
+        // Scenario (3): Truncation indicator does NOT render when totalCount === tools.length
+        expect(screen.queryByTestId("truncation-indicator")).not.toBeInTheDocument();
+        expect(screen.queryByText(/Showing .* of .* compatible tools/)).not.toBeInTheDocument();
+    });
+
+    it("displays badge with totalCount and renders truncation indicator when totalCount > tools.length", async () => {
+        const truncatedResult: McpToolSearchResults = {
+            count: 5,
+            tools: [
+                {
+                    groupId: "test-group",
+                    artifactId: "compat-tool-1",
+                    name: "result_formatter",
+                    title: "Result Formatter Tool",
+                    description: "Formats output results into text",
+                    parameters: ["result"]
+                }
+            ]
+        };
+        mockGetCompatibleMcpTools.mockResolvedValueOnce(truncatedResult);
+
+        render(<CompatibleMcpToolsViewer groupId="test-group" artifactId="test-tool" />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("tools-list")).toBeInTheDocument();
+        });
+
+        // Scenario (1): Badge displays totalCount (5), NOT tools.length (1)
+        expect(screen.getByText("5")).toBeInTheDocument();
+        expect(screen.queryByText("1")).not.toBeInTheDocument();
+
+        // Scenario (2): Truncation message "Showing 1 of 5 compatible tools" renders when totalCount > tools.length
+        expect(screen.getByTestId("truncation-indicator")).toBeInTheDocument();
+        expect(screen.getByText("Showing 1 of 5 compatible tools")).toBeInTheDocument();
+    });
+});

--- a/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.tsx
+++ b/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.tsx
@@ -1,0 +1,177 @@
+import { FunctionComponent, useEffect, useState } from "react";
+import "./CompatibleMcpToolsViewer.css";
+import {
+    Badge,
+    Card,
+    CardBody,
+    CardHeader,
+    CardTitle,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Divider,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateHeader,
+    EmptyStateIcon,
+    Label,
+    LabelGroup,
+    Spinner,
+    Title
+} from "@patternfly/react-core";
+import { PlugIcon } from "@patternfly/react-icons";
+import { McpToolSearchResult, useMcpToolsService } from "../../../services/useMcpToolsService";
+
+export type CompatibleMcpToolsViewerProps = {
+    groupId: string;
+    artifactId: string;
+    version?: string;
+    className?: string;
+};
+
+/**
+ * Component to display MCP tools compatible with a target tool's output schema (Output -> Input tool chaining).
+ * Fetches real compatibility data from /.well-known/mcp-tools/{groupId}/{artifactId}/compatible.
+ */
+export const CompatibleMcpToolsViewer: FunctionComponent<CompatibleMcpToolsViewerProps> = (
+    props: CompatibleMcpToolsViewerProps
+) => {
+    const { groupId, artifactId, version } = props;
+    const mcpToolsService = useMcpToolsService();
+
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+    const [tools, setTools] = useState<McpToolSearchResult[]>([]);
+    const [totalCount, setTotalCount] = useState<number>(0);
+
+    useEffect(() => {
+        let isMounted = true;
+        setIsLoading(true);
+        setError(null);
+
+        mcpToolsService
+            .getCompatibleMcpTools(groupId, artifactId, version)
+            .then((results) => {
+                if (isMounted) {
+                    setTools(results.tools || []);
+                    setTotalCount(results.count || 0);
+                    setIsLoading(false);
+                }
+            })
+            .catch((err) => {
+                if (isMounted) {
+                    console.error("Failed to load compatible MCP tools:", err);
+                    setError(err.message || "Failed to load compatible MCP tools");
+                    setIsLoading(false);
+                }
+            });
+
+        return () => {
+            isMounted = false;
+        };
+    }, [groupId, artifactId, version]);
+
+    return (
+        <div className={`compatible-mcp-tools-viewer ${props.className || ""}`}>
+            <Card isPlain>
+                <CardHeader>
+                    <CardTitle>
+                        <Title headingLevel="h2">
+                            Compatible Chained Tools <Badge isRead>{totalCount}</Badge>
+                        </Title>
+                    </CardTitle>
+                </CardHeader>
+                <CardBody>
+                    <p className="compatible-mcp-tools-subtitle">
+                        Tools in the registry whose required input parameters are guaranteed by this tool&apos;s output schema (Output &rarr; Input Chaining).
+                    </p>
+                </CardBody>
+            </Card>
+
+            <Divider className="mcp-tool-divider" />
+
+            {isLoading && (
+                <div className="compatible-mcp-tools-loading" data-testid="loading-state">
+                    <Spinner size="lg" aria-label="Loading compatible tools" />
+                    <span className="pf-v5-u-ml-sm">Checking tool compatibility...</span>
+                </div>
+            )}
+
+            {!isLoading && error && (
+                <EmptyState data-testid="error-state">
+                    <EmptyStateHeader
+                        titleText="Error Loading Compatible Tools"
+                        headingLevel="h4"
+                    />
+                    <EmptyStateBody>{error}</EmptyStateBody>
+                </EmptyState>
+            )}
+
+            {!isLoading && !error && tools.length === 0 && (
+                <EmptyState data-testid="empty-state">
+                    <EmptyStateHeader
+                        titleText="No Compatible Tools Found"
+                        icon={<EmptyStateIcon icon={PlugIcon} />}
+                        headingLevel="h4"
+                    />
+                    <EmptyStateBody>
+                        No registered MCP tools in the registry can accept this tool&apos;s guaranteed output as input.
+                    </EmptyStateBody>
+                </EmptyState>
+            )}
+
+            {!isLoading && !error && tools.length > 0 && (
+                <div className="compatible-mcp-tools-list" data-testid="tools-list">
+                    {tools.map((tool) => (
+                        <Card key={`${tool.groupId}/${tool.artifactId}`} className="compatible-tool-card" isCompact>
+                            <CardHeader>
+                                <CardTitle>
+                                    <Title headingLevel="h3">{tool.title || tool.name}</Title>
+                                </CardTitle>
+                                <Label color="green" icon={<PlugIcon />}>
+                                    Output &rarr; Input Compatible
+                                </Label>
+                            </CardHeader>
+                            <CardBody>
+                                <DescriptionList isHorizontal>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Artifact</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <code>{tool.groupId} / {tool.artifactId}</code>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    {tool.description && (
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Description</DescriptionListTerm>
+                                            <DescriptionListDescription>{tool.description}</DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                    )}
+                                    {tool.parameters && tool.parameters.length > 0 && (
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Input Parameters</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                <LabelGroup>
+                                                    {tool.parameters.map((param) => (
+                                                        <Label key={param} color="blue" isCompact>
+                                                            {param}
+                                                        </Label>
+                                                    ))}
+                                                </LabelGroup>
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                    )}
+                                </DescriptionList>
+                            </CardBody>
+                        </Card>
+                    ))}
+                    {tools.length < totalCount && (
+                        <div className="compatible-mcp-tools-truncation pf-v5-u-mt-md" data-testid="truncation-indicator">
+                            <span>Showing {tools.length} of {totalCount} compatible tools</span>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.tsx
+++ b/ui/ui-app/src/app/components/mcpTool/CompatibleMcpToolsViewer.tsx
@@ -13,8 +13,6 @@ import {
     Divider,
     EmptyState,
     EmptyStateBody,
-    EmptyStateHeader,
-    EmptyStateIcon,
     Label,
     LabelGroup,
     Spinner,
@@ -99,22 +97,22 @@ export const CompatibleMcpToolsViewer: FunctionComponent<CompatibleMcpToolsViewe
             )}
 
             {!isLoading && error && (
-                <EmptyState data-testid="error-state">
-                    <EmptyStateHeader
-                        titleText="Error Loading Compatible Tools"
-                        headingLevel="h4"
-                    />
+                <EmptyState
+                    titleText="Error Loading Compatible Tools"
+                    headingLevel="h4"
+                    data-testid="error-state"
+                >
                     <EmptyStateBody>{error}</EmptyStateBody>
                 </EmptyState>
             )}
 
             {!isLoading && !error && tools.length === 0 && (
-                <EmptyState data-testid="empty-state">
-                    <EmptyStateHeader
-                        titleText="No Compatible Tools Found"
-                        icon={<EmptyStateIcon icon={PlugIcon} />}
-                        headingLevel="h4"
-                    />
+                <EmptyState
+                    titleText="No Compatible Tools Found"
+                    icon={PlugIcon}
+                    headingLevel="h4"
+                    data-testid="empty-state"
+                >
                     <EmptyStateBody>
                         No registered MCP tools in the registry can accept this tool&apos;s guaranteed output as input.
                     </EmptyStateBody>

--- a/ui/ui-app/src/app/components/mcpTool/index.ts
+++ b/ui/ui-app/src/app/components/mcpTool/index.ts
@@ -1,1 +1,3 @@
 export * from "./McpToolViewer";
+export * from "./CompatibleMcpToolsViewer";
+

--- a/ui/ui-app/src/app/pages/version/components/tabs/DocumentationTabContent.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/DocumentationTabContent.tsx
@@ -140,7 +140,12 @@ export const DocumentationTabContent: FunctionComponent<DocumentationTabContentP
                 <AgentCardVisualizer spec={parsedContent} />
             </If>
             <If condition={visualizerType === VisualizerType.MCP_TOOL}>
-                <McpToolVisualizer spec={parsedContent} />
+                <McpToolVisualizer
+                    spec={parsedContent}
+                    groupId={props.groupId}
+                    artifactId={props.artifactId}
+                    version={props.version}
+                />
             </If>
             <If condition={visualizerType === VisualizerType.JSON_SCHEMA}>
                 <JsonSchemaVisualizer spec={parsedContent} />

--- a/ui/ui-app/src/app/pages/version/components/tabs/visualizers/McpToolVisualizer.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/visualizers/McpToolVisualizer.tsx
@@ -1,9 +1,12 @@
 import { FunctionComponent } from "react";
 import "./McpToolVisualizer.css";
-import { McpToolViewer } from "@app/components/mcpTool";
+import { McpToolViewer, CompatibleMcpToolsViewer } from "@app/components/mcpTool";
 
 export type McpToolVisualizerProps = {
     spec: any;
+    groupId?: string;
+    artifactId?: string;
+    version?: string;
     className?: string;
 };
 
@@ -14,6 +17,14 @@ export const McpToolVisualizer: FunctionComponent<McpToolVisualizerProps> = (pro
     return (
         <div className={`mcp-tool-visualizer ${props.className || ""}`}>
             <McpToolViewer spec={props.spec} />
+            {props.groupId && props.artifactId && (
+                <CompatibleMcpToolsViewer
+                    groupId={props.groupId}
+                    artifactId={props.artifactId}
+                    version={props.version}
+                />
+            )}
         </div>
     );
 };
+

--- a/ui/ui-app/src/services/index.ts
+++ b/ui/ui-app/src/services/index.ts
@@ -16,3 +16,4 @@ export * from "./useUserService";
 export * from "./useVersionService";
 export * from "./useSearchService";
 export * from "./useThemeService";
+export * from "./useMcpToolsService";

--- a/ui/ui-app/src/services/useMcpToolsService.test.ts
+++ b/ui/ui-app/src/services/useMcpToolsService.test.ts
@@ -1,4 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+    const registryConfig = { artifacts: { url: "http://localhost:8080/apis/registry/v3/" } };
+    (globalThis as any).ApicurioRegistryConfig = registryConfig;
+    (globalThis as any).window = { ApicurioRegistryConfig: registryConfig };
+});
+
+vi.mock("@apitomy/common-ui-components", () => ({
+    useAuth: () => ({})
+}));
+
 import { getBaseUrl } from "./useMcpToolsService";
 import { ConfigService } from "./useConfigService";
 

--- a/ui/ui-app/src/services/useMcpToolsService.test.ts
+++ b/ui/ui-app/src/services/useMcpToolsService.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getBaseUrl } from "./useMcpToolsService";
+import { ConfigService } from "./useConfigService";
+
+describe("useMcpToolsService getBaseUrl", () => {
+    it("strips /apis/registry/v3 suffix correctly", () => {
+        const mockConfig = {
+            artifactsUrl: () => "http://localhost:8080/apis/registry/v3"
+        } as ConfigService;
+
+        expect(getBaseUrl(mockConfig)).toBe("http://localhost:8080");
+    });
+
+    it("handles trailing slash before suffix removal", () => {
+        const mockConfig = {
+            artifactsUrl: () => "http://localhost:8080/apis/registry/v3/"
+        } as ConfigService;
+
+        expect(getBaseUrl(mockConfig)).toBe("http://localhost:8080");
+    });
+
+    it("falls back to origin for non-standard path", () => {
+        const mockConfig = {
+            artifactsUrl: () => "http://myregistry.example.com:9090/custom/api/path"
+        } as ConfigService;
+
+        expect(getBaseUrl(mockConfig)).toBe("http://myregistry.example.com:9090");
+    });
+});

--- a/ui/ui-app/src/services/useMcpToolsService.ts
+++ b/ui/ui-app/src/services/useMcpToolsService.ts
@@ -1,0 +1,90 @@
+import { ConfigService, useConfigService } from "./useConfigService";
+import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { createAuthOptions } from "../utils/rest.utils";
+
+export interface McpToolSearchResult {
+    groupId: string;
+    artifactId: string;
+    name: string;
+    title?: string;
+    description?: string;
+    owner?: string;
+    createdOn?: number;
+    parameters?: string[];
+}
+
+export interface McpToolSearchResults {
+    count: number;
+    tools: McpToolSearchResult[];
+}
+
+/**
+ * Gets the base URL for well-known endpoints.
+ * Extracts the base URL from the artifacts URL by removing the /apis/registry/v3 suffix.
+ */
+export const getBaseUrl = (config: ConfigService): string => {
+    const artifactsUrl = config.artifactsUrl();
+    const url = artifactsUrl.endsWith("/") ? artifactsUrl.slice(0, -1) : artifactsUrl;
+    const suffix = "/apis/registry/v3";
+    if (url.endsWith(suffix)) {
+        return url.slice(0, -suffix.length);
+    }
+    try {
+        const parsed = new URL(url);
+        return parsed.origin;
+    } catch {
+        return window.location.origin;
+    }
+};
+
+const getCompatibleMcpTools = async (
+    config: ConfigService,
+    auth: AuthService,
+    groupId: string,
+    artifactId: string,
+    version?: string
+): Promise<McpToolSearchResults> => {
+    console.debug("[McpToolsService] Fetching compatible MCP tools for: ", groupId, artifactId, version);
+
+    const baseUrl = getBaseUrl(config);
+    const versionQuery = version ? `?version=${encodeURIComponent(version)}` : "";
+    const url = `${baseUrl}/.well-known/mcp-tools/${encodeURIComponent(groupId)}/${encodeURIComponent(artifactId)}/compatible${versionQuery}`;
+
+    const authOptions = await createAuthOptions(auth);
+    const headers: Record<string, string> = {
+        "Accept": "application/json"
+    };
+    if (authOptions.headers) {
+        Object.entries(authOptions.headers).forEach(([key, value]) => {
+            if (typeof value === "string") {
+                headers[key] = value;
+            }
+        });
+    }
+
+    const response = await fetch(url, {
+        method: "GET",
+        headers
+    });
+
+    if (!response.ok) {
+        throw new Error(`Failed to get compatible MCP tools: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+};
+
+export interface McpToolsService {
+    getCompatibleMcpTools(groupId: string, artifactId: string, version?: string): Promise<McpToolSearchResults>;
+}
+
+export const useMcpToolsService: () => McpToolsService = (): McpToolsService => {
+    const config: ConfigService = useConfigService();
+    const auth = useAuth();
+
+    return {
+        getCompatibleMcpTools(groupId: string, artifactId: string, version?: string): Promise<McpToolSearchResults> {
+            return getCompatibleMcpTools(config, auth, groupId, artifactId, version);
+        }
+    };
+};

--- a/ui/ui-app/src/services/useMcpToolsService.ts
+++ b/ui/ui-app/src/services/useMcpToolsService.ts
@@ -1,5 +1,5 @@
 import { ConfigService, useConfigService } from "./useConfigService";
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 import { createAuthOptions } from "../utils/rest.utils";
 
 export interface McpToolSearchResult {


### PR DESCRIPTION
Part of #8427

Supersedes #9045 — closed and reopened from a clean branch to remove an 
unrelated exploratory commit that duplicated logic covered by #8662. 
Same two commits, no functional changes from what @paoloantinori already 
reviewed there.

## Summary
Adds output→input compatibility checking between MCP tools: given a tool, 
find other registered tools whose required input parameters are 
guaranteed by this tool's required output schema fields (i.e. "can Tool 
A's output feed Tool B's input").

## What's included
- **Backend**: two new endpoints on the well-known MCP tools resource
  - `GET /.well-known/mcp-tools/{groupId}/{artifactId}/compatible` — 
    by artifact reference
  - `POST /.well-known/mcp-tools/compatible` — by raw tool content
  - Compatibility logic (`isOutputCompatibleWithInput`) checks each 
    candidate's required input fields against the target's required 
    output fields (name + type match, with integer→number widening 
    allowed)
  - Integration tests covering: compatible match, incompatible (missing 
    required field), and the edge case where a target's output field 
    exists in `properties` but isn't listed in `required` (should not 
    count as satisfying a candidate's required input)

- **UI**: `CompatibleMcpToolsViewer` component, mounted in the MCP tool 
  documentation tab (`McpToolVisualizer`) alongside the existing tool 
  viewer. Shows loading, empty, and populated states; wired to the real 
  endpoint above, not mocked data.

## Design notes
- This does **not** reuse `McpToolCompatibilityChecker` (from #8662) — 
  that checker compares the same schema field across two versions of 
  one tool (version-evolution compatibility). This feature compares a 
  different field across two different tools at a single point in time 
  (cross-tool chaining compatibility). Different problem shape, so a 
  separate, purpose-built comparison was needed.
- Name-match is the headline guarantee; type-match only applies when 
  both sides declare a type, so it's a tightening constraint on top of 
  name matching, not a strict requirement.
- Type compatibility is currently name + top-level type match only 
  (with integer→number widening), not full nested/structural JSON 
  Schema comparison. Open to feedback on whether deeper structural 
  comparison is expected here.

## Known limitations (flagged by @paoloantinori on #9045, still open)
- `findCompatibleToolsForContent` does an O(N) in-memory scan: fetches 
  and parses every registered MCP_TOOL's latest version on each call, 
  with offset/limit applied after the full scan — pagination doesn't 
  reduce the work, and results beyond `MAX_VISIBILITY_FILTER_RESULTS` 
  are never found. Will follow up on a storage-level filtering approach 
  if that's expected before merge.
- A malformed *target* tool currently degrades to zero results instead 
  of a 400 — planning to make target-parse failure a hard error instead.
- Candidate read/parse failures are logged and skipped silently, which 
  could hide an otherwise-matching candidate with no signal to the 
  caller — open to suggestions on the right way to surface this.
- `POST /.well-known/mcp-tools/compatible` uses `AuthorizedStyle.None` 
  since it takes raw content rather than referencing a stored artifact — 
  flagging for confirmation this is the right posture, given `GET` uses 
  `GroupAndArtifact/Read`.

## Test plan
- `./mvnw -pl app -am test -Dtest=WellKnownMcpToolsTest` — 17/17 passing
- `npx vitest run` (ui-app) — all passing
- `npx tsc --noEmit` (ui-app) — clean, exit code 0