### PR TITLE
fix(ui): correct Error Details CodeEditor height

### DIFF
--- a/ui/ui-app/src/app/components/errorPage/ErrorPage.tsx
+++ b/ui/ui-app/src/app/components/errorPage/ErrorPage.tsx
@@ -96,7 +96,7 @@ export const ErrorPage: FunctionComponent<ErrorPageProps> = (props: ErrorPagePro
                                     editor.layout();
                                     monaco.editor.getModels()[0].updateOptions({ tabSize: 4 });
                                 }}
-                                height="sizeToFit"
+                                height="300px"
                             />
                             :
                             <div/>


### PR DESCRIPTION
## Description

Fixes #9021.

The `CodeEditor` used to display backend error details on the error page was configured with `height="sizeToFit"`, which caused the editor to collapse and clip the displayed error details.

This change replaces the invalid height configuration with a fixed `300px` height so the error details remain readable.

### Testing

- Reproduced the issue locally before the change.
- Verified the error details were vertically clipped.
- Changed the `CodeEditor` height to `300px`.
- Reproduced the same error flow after the change and confirmed the error details are fully readable.
- `npm run lint` — passed with 0 errors (2 existing warnings in an unrelated file).
- `npm test` — passed (4/4 tests).
- Full Maven local build — passed with `-Dlocal -Dmaven.test.skip=true -DcliSkipNative`.