### PR TITLE
fix(ci): backport release operator fixes to 3.2.x

### DIFF
--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -50,9 +50,16 @@ jobs:
           cd registry && git checkout "$RELEASE_VERSION"
           # Resolve BRANCH if it's a commit SHA (happens when releasing from non-default branches)
           if [[ "$BRANCH" =~ ^[0-9a-f]{40}$ ]]; then
-            RESOLVED=$(git branch -r --contains "$BRANCH" | grep -v HEAD | sed 's|.*origin/||' | tr -d ' ' | head -1)
+            # Prefer maintenance branches (X.Y.x) over main to avoid resolving
+            # maintenance releases to main (the SHA may exist on both after post-release sync).
+            # Feature branches are ignored — only main and X.Y.x patterns are considered.
+            ALL_BRANCHES=$(git branch -r --contains "$BRANCH" | grep -v HEAD | sed 's|.*origin/||' | tr -d ' ')
+            RESOLVED=$(echo "$ALL_BRANCHES" | grep -E '^[0-9]+\.[0-9]+\.x$' | head -1)
+            if [ -z "$RESOLVED" ]; then
+              RESOLVED="main"
+            fi
             if [ -n "$RESOLVED" ]; then
-              echo "Resolved branch SHA $BRANCH to $RESOLVED"
+              echo "Resolved branch SHA $BRANCH to $RESOLVED (candidates: $(echo $ALL_BRANCHES | tr '\n' ', '))"
               echo "BRANCH=$RESOLVED" >> $GITHUB_ENV
             else
               echo "ERROR: Could not resolve commit $BRANCH to a branch name"
@@ -124,7 +131,11 @@ jobs:
       - name: Build operator catalog
         working-directory: registry/operator
         run: |
-          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_CATALOG_IMAGE_TAG=latest catalog
+          ROLLING_CHANNEL_ARG=""
+          if [ "$BRANCH" = "main" ]; then
+            ROLLING_CHANNEL_ARG="ROLLING_CHANNEL=3.x"
+          fi
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_CATALOG_IMAGE_TAG=latest $ROLLING_CHANNEL_ARG catalog
 
       - name: Generate install file for tests
         working-directory: registry/operator
@@ -329,24 +340,93 @@ jobs:
           git checkout --track origin/main
           git push -f source main
 
-      - name: Create the Openshift Community Operators PR
-        id: openshift-community-operators-pr
+      - name: Create the Openshift Community Operators Bundle PR
+        id: openshift-community-operators-bundle-pr
         continue-on-error: true
         working-directory: openshift-community-operators
         run: |
-          git checkout -b "$RELEASE_BRANCH"
+          git checkout -b "${RELEASE_BRANCH}-bundle"
           TITLE="Release Apicurio Registry Operator $PACKAGE_VERSION"
           BODY="$(curl -s https://raw.githubusercontent.com/redhat-openshift-ecosystem/community-operators-prod/main/docs/pull_request_template.md)"
           cp -r "../registry/operator/target/bundle/apicurio-registry-3/$PACKAGE_VERSION" operators/apicurio-registry-3
           git add .
           git commit -s -m "$TITLE"
-          git push -f source "$RELEASE_BRANCH"
+          git push -f source "${RELEASE_BRANCH}-bundle"
           gh repo set-default redhat-openshift-ecosystem/community-operators-prod
-          gh pr create --title "$TITLE" --body "$BODY" --base main --head "Apicurio:$RELEASE_BRANCH"
+          gh pr create --title "$TITLE" --body "$BODY" --base main --head "Apicurio:${RELEASE_BRANCH}-bundle"
 
-      - name: Warn if Openshift Community Operators PR failed
-        if: steps.openshift-community-operators-pr.outcome == 'failure'
-        run: echo "::warning::Failed to create Openshift Community Operators PR. Please create it manually."
+      - name: Warn if Openshift Community Operators Bundle PR failed
+        if: steps.openshift-community-operators-bundle-pr.outcome == 'failure'
+        run: echo "::warning::Failed to create Openshift Community Operators Bundle PR. Please create it manually."
+
+      - name: Create the Openshift Community Operators Catalog PR
+        id: openshift-community-operators-catalog-pr
+        if: steps.openshift-community-operators-bundle-pr.outcome == 'success'
+        continue-on-error: true
+        working-directory: openshift-community-operators
+        run: |
+          PKG_NAME="apicurio-registry-3"
+          FBC_ENABLED=$(cd "operators/$PKG_NAME" && cat ci.yaml | grep -c "fbc:" || true)
+          if [ "$FBC_ENABLED" -eq 0 ]; then
+            echo "FBC is not enabled — skipping catalog PR"
+            exit 0
+          fi
+
+          git checkout main
+          git checkout -b "${RELEASE_BRANCH}-catalog"
+          TITLE="Update FBC catalogs for Apicurio Registry Operator $PACKAGE_VERSION"
+
+          MINOR_CHANNEL=$(echo "$PACKAGE_VERSION" | sed 's/\([0-9]*\.[0-9]*\)\..*/\1.x/')
+          CSV_NAME="$PKG_NAME.v$PACKAGE_VERSION"
+          BUNDLE_IMG="quay.io/apicurio/apicurio-registry-3-operator-bundle:$PACKAGE_VERSION"
+
+          if [ "$BRANCH" = "main" ]; then
+            CHANNELS="3.x $MINOR_CHANNEL"
+          else
+            CHANNELS="$MINOR_CHANNEL"
+          fi
+
+          cd "operators/$PKG_NAME"
+
+          if [ ! -f ../../bin/yq ]; then
+            mkdir -p ../../bin
+            curl -sLo ../../bin/yq "https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64"
+            chmod +x ../../bin/yq
+          fi
+          YQ="../../bin/yq"
+
+          for tpl in catalog-templates/v4.*.yaml; do
+            echo "  Updating $tpl"
+            for CH in $CHANNELS; do
+              CH_EXISTS=$($YQ ".entries[] | select(.schema == \"olm.channel\") | select(.name == \"$CH\") | .name" "$tpl" 2>/dev/null || true)
+              CH_HEAD=$($YQ ".entries[] | select(.schema == \"olm.channel\") | select(.name == \"$CH\") | .entries[0].name" "$tpl" 2>/dev/null || true)
+
+              if [ -z "$CH_EXISTS" ] || [ "$CH_EXISTS" = "null" ]; then
+                echo "    Creating new channel $CH"
+                $YQ -i ".entries |= . + [{\"schema\": \"olm.channel\", \"package\": \"$PKG_NAME\", \"name\": \"$CH\", \"entries\": [{\"name\": \"$CSV_NAME\"}]}]" "$tpl"
+              elif [ -n "$CH_HEAD" ] && [ "$CH_HEAD" != "null" ]; then
+                $YQ -i "(.entries[] | select(.schema == \"olm.channel\") | select(.name == \"$CH\") | .entries) |= [{\"name\": \"$CSV_NAME\", \"replaces\": \"$CH_HEAD\"}] + ." "$tpl"
+              else
+                $YQ -i "(.entries[] | select(.schema == \"olm.channel\") | select(.name == \"$CH\") | .entries) |= [{\"name\": \"$CSV_NAME\"}]" "$tpl"
+              fi
+            done
+            $YQ -i ".entries |= . + [{\"schema\": \"olm.bundle\", \"image\": \"$BUNDLE_IMG\"}]" "$tpl"
+          done
+
+          make catalogs
+          make validate-catalogs
+          echo "FBC catalog update complete"
+          cd ../..
+
+          git add .
+          git commit -s -m "$TITLE"
+          git push -f source "${RELEASE_BRANCH}-catalog"
+          gh repo set-default redhat-openshift-ecosystem/community-operators-prod
+          gh pr create --title "$TITLE" --body "FBC catalog update for $PACKAGE_VERSION." --base main --head "Apicurio:${RELEASE_BRANCH}-catalog"
+
+      - name: Warn if Openshift Community Operators Catalog PR failed
+        if: steps.openshift-community-operators-catalog-pr.outcome == 'failure'
+        run: echo "::warning::Failed to create Openshift Community Operators Catalog PR. Please create it manually."
 
       - name: Prepare post-release changes
         working-directory: registry/operator


### PR DESCRIPTION
## Summary

Backport of release operator workflow fixes from main to the `3.2.x` maintenance branch, ensuring a 3.2.7 release works correctly.

Fixes applied:
- **Branch resolution**: prefer `X.Y.x` maintenance branches, fall back to `main` explicitly (instead of picking random feature branches)
- **Split community-operators-prod PRs**: bundle and catalog in separate PRs (pipeline rejects combined PRs)
- **Pass ROLLING_CHANNEL to catalog build**: ensures `defaultChannel` is set correctly
- **Gate catalog PR on bundle PR success**: avoids orphan catalog PRs

## Test plan

- [ ] Release 3.2.7 and verify two separate PRs are created on community-operators-prod
- [ ] Verify k8s community-operators PR has correct `replaces` and channel annotations