### PR TITLE
fix(rules): validate MCP tool annotations against the ToolAnnotations schema (#8926)

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
@@ -31,6 +31,11 @@ import java.util.Set;
 public class McpToolContentValidator implements ContentValidator {
 
     /**
+     * Declared by both Tool (via BaseMetadata) and ToolAnnotations, so it is validated in both places.
+     */
+    private static final String TITLE_FIELD = "title";
+
+    /**
      * The optional behavioral hints of the MCP ToolAnnotations schema. All of them are booleans.
      */
     private static final List<String> TOOL_ANNOTATION_HINTS = List.of("readOnlyHint",
@@ -94,7 +99,7 @@ public class McpToolContentValidator implements ContentValidator {
     }
 
     private void validateOptionalStringFields(JsonNode tree, Set<RuleViolation> violations) {
-        JsonValidationUtils.validateOptionalString(tree, "title", violations);
+        JsonValidationUtils.validateOptionalString(tree, TITLE_FIELD, violations);
         JsonValidationUtils.validateOptionalString(tree, "description", violations);
     }
 
@@ -163,7 +168,7 @@ public class McpToolContentValidator implements ContentValidator {
         }
 
         // title: optional string (fallback display name per MCP spec)
-        JsonValidationUtils.validateOptionalString(annotations, "title", violations);
+        JsonValidationUtils.validateOptionalString(annotations, TITLE_FIELD, violations);
 
         // readOnlyHint, destructiveHint, idempotentHint, openWorldHint: optional booleans
         for (String hint : TOOL_ANNOTATION_HINTS) {
@@ -178,7 +183,7 @@ public class McpToolContentValidator implements ContentValidator {
         Iterator<String> fieldNames = annotations.fieldNames();
         while (fieldNames.hasNext()) {
             String field = fieldNames.next();
-            if (!"title".equals(field) && !TOOL_ANNOTATION_HINTS.contains(field)) {
+            if (!TITLE_FIELD.equals(field) && !TOOL_ANNOTATION_HINTS.contains(field)) {
                 violations.add(new RuleViolation("'annotations." + field
                         + "' is not a ToolAnnotations property", "/annotations/" + field));
             }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
@@ -10,6 +10,7 @@ import io.apicurio.registry.types.RuleType;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -22,7 +23,8 @@ import java.util.Set;
  * Validation levels:
  * - NONE: No validation
  * - SYNTAX_ONLY: Validates that the content is valid JSON and is an object
- * - FULL: Full schema validation including required fields, type checking, and structure validation
+ * - FULL: Full schema validation including required fields, type checking, and structure
+ *   validation. The 'annotations' object is validated as a closed ToolAnnotations shape.
  *
  * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/tools">MCP Tools</a>
  */
@@ -168,6 +170,17 @@ public class McpToolContentValidator implements ContentValidator {
             if (annotations.has(hint) && !annotations.get(hint).isBoolean()) {
                 violations.add(new RuleViolation("'annotations." + hint + "' must be a boolean",
                         "/annotations/" + hint));
+            }
+        }
+
+        // ToolAnnotations is a closed shape at FULL, so a typo or a stray field is a violation
+        // rather than a silently ignored no-op.
+        Iterator<String> fieldNames = annotations.fieldNames();
+        while (fieldNames.hasNext()) {
+            String field = fieldNames.next();
+            if (!"title".equals(field) && !TOOL_ANNOTATION_HINTS.contains(field)) {
+                violations.add(new RuleViolation("'annotations." + field
+                        + "' is not a ToolAnnotations property", "/annotations/" + field));
             }
         }
     }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
@@ -28,6 +28,12 @@ import java.util.Set;
  */
 public class McpToolContentValidator implements ContentValidator {
 
+    /**
+     * The optional behavioral hints of the MCP ToolAnnotations schema. All of them are booleans.
+     */
+    private static final List<String> TOOL_ANNOTATION_HINTS = List.of("readOnlyHint",
+            "destructiveHint", "idempotentHint", "openWorldHint");
+
     @Override
     public void validate(ValidityLevel level, TypedContent content,
             Map<String, TypedContent> resolvedReferences) throws RuleViolationException {
@@ -157,31 +163,11 @@ public class McpToolContentValidator implements ContentValidator {
         // title: optional string (fallback display name per MCP spec)
         JsonValidationUtils.validateOptionalString(annotations, "title", violations);
 
-        // audience: optional array of strings ("user", "assistant")
-        if (annotations.has("audience")) {
-            JsonNode audience = annotations.get("audience");
-            if (!audience.isArray()) {
-                violations.add(new RuleViolation("'annotations.audience' must be an array",
-                        "/annotations/audience"));
-            } else {
-                JsonValidationUtils.validateStringArray(audience,
-                        "/annotations/audience", "audience role", violations);
-            }
-        }
-
-        // priority: optional number between 0 and 1
-        if (annotations.has("priority")) {
-            JsonNode priority = annotations.get("priority");
-            if (!priority.isNumber()) {
-                violations.add(new RuleViolation("'annotations.priority' must be a number",
-                        "/annotations/priority"));
-            } else {
-                double value = priority.asDouble();
-                if (value < 0 || value > 1) {
-                    violations.add(new RuleViolation(
-                            "'annotations.priority' must be between 0 and 1",
-                            "/annotations/priority"));
-                }
+        // readOnlyHint, destructiveHint, idempotentHint, openWorldHint: optional booleans
+        for (String hint : TOOL_ANNOTATION_HINTS) {
+            if (annotations.has(hint) && !annotations.get(hint).isBoolean()) {
+                violations.add(new RuleViolation("'annotations." + hint + "' must be a boolean",
+                        "/annotations/" + hint));
             }
         }
     }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
@@ -84,6 +84,8 @@ public class McpToolContentValidatorTest extends ArtifactUtilProviderTestBase {
         // Violations for title (not a string), readOnlyHint and destructiveHint (not booleans)
         Assertions.assertEquals(3, error.getCauses().size());
         Assertions.assertTrue(error.getCauses().stream()
+                .anyMatch(v -> "'title' field must be a string".equals(v.getDescription())));
+        Assertions.assertTrue(error.getCauses().stream()
                 .anyMatch(v -> "'annotations.readOnlyHint' must be a boolean"
                         .equals(v.getDescription())));
         Assertions.assertTrue(error.getCauses().stream()

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
@@ -81,10 +81,24 @@ public class McpToolContentValidatorTest extends ArtifactUtilProviderTestBase {
         RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
             validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
         });
-        Assertions.assertFalse(error.getCauses().isEmpty());
-        // Should have violations for title (not string), audience (not array),
-        // and priority (not number)
-        Assertions.assertTrue(error.getCauses().size() >= 3);
+        // Violations for title (not a string), readOnlyHint and destructiveHint (not booleans)
+        Assertions.assertEquals(3, error.getCauses().size());
+        Assertions.assertTrue(error.getCauses().stream()
+                .anyMatch(v -> "'annotations.readOnlyHint' must be a boolean"
+                        .equals(v.getDescription())));
+        Assertions.assertTrue(error.getCauses().stream()
+                .anyMatch(v -> "'annotations.destructiveHint' must be a boolean"
+                        .equals(v.getDescription())));
+    }
+
+    @Test
+    public void testMcpToolAnnotationsIgnoreContentAnnotationFields() throws Exception {
+        // audience and priority belong to the MCP content annotation schema, not to
+        // ToolAnnotations, so they must not be validated on a tool definition.
+        TypedContent content = resourceToTypedContentHandle(
+                "mcptool-annotations-content-fields.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
     }
 
     @Test

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
@@ -94,13 +94,22 @@ public class McpToolContentValidatorTest extends ArtifactUtilProviderTestBase {
     }
 
     @Test
-    public void testMcpToolAnnotationsIgnoreContentAnnotationFields() throws Exception {
+    public void testMcpToolAnnotationsRejectUnsupportedFields() throws Exception {
         // audience and priority belong to the MCP content annotation schema, not to
-        // ToolAnnotations, so they must not be validated on a tool definition.
+        // ToolAnnotations, so at FULL they are rejected as unsupported rather than range-checked.
         TypedContent content = resourceToTypedContentHandle(
                 "mcptool-annotations-content-fields.json");
         McpToolContentValidator validator = new McpToolContentValidator();
-        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertEquals(2, error.getCauses().size());
+        Assertions.assertTrue(error.getCauses().stream()
+                .anyMatch(v -> "'annotations.audience' is not a ToolAnnotations property"
+                        .equals(v.getDescription())));
+        Assertions.assertTrue(error.getCauses().stream()
+                .anyMatch(v -> "'annotations.priority' is not a ToolAnnotations property"
+                        .equals(v.getDescription())));
     }
 
     @Test

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-annotations-content-fields.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-annotations-content-fields.json
@@ -4,8 +4,8 @@
     "type": "object"
   },
   "annotations": {
-    "title": 123,
-    "readOnlyHint": "not-a-boolean",
-    "destructiveHint": 123
+    "title": "Annotated Tool",
+    "audience": ["user"],
+    "priority": 5
   }
 }

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-valid.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-valid.json
@@ -20,7 +20,9 @@
   },
   "annotations": {
     "title": "DB Search",
-    "audience": ["user", "assistant"],
-    "priority": 0.8
+    "readOnlyHint": true,
+    "destructiveHint": false,
+    "idempotentHint": true,
+    "openWorldHint": false
   }
 }


### PR DESCRIPTION
## What

`McpToolContentValidator` now validates an MCP_TOOL artifact's `annotations` object against the
MCP `ToolAnnotations` schema: the optional `title` string plus the four optional boolean hints
`readOnlyHint`, `destructiveHint`, `idempotentHint` and `openWorldHint`.

## Why

`validateAnnotationsField` was checking `audience` and `priority`, which are MCP *content
annotation* fields, not `ToolAnnotations` fields. Two concrete consequences at VALIDITY FULL:

- `annotations: {"readOnlyHint": "not-a-boolean", "destructiveHint": 123}` passed validation,
  because the real hint fields were never inspected.
- `annotations: {"priority": 5}` was rejected with `'annotations.priority' must be between 0 and 1`,
  even though `priority` is not part of `ToolAnnotations` at all.

Spec: https://modelcontextprotocol.io/specification/2025-11-25/server/tools

## How

Kept the existing `title` check. Replaced the `audience` and `priority` blocks with a loop over a
`TOOL_ANNOTATION_HINTS` constant that reports a violation when a hint field is present but not a
boolean, using the same message and JSON-pointer style as the surrounding validators.

## Testing

`McpToolContentValidatorTest` covers an invalid-hints document producing exactly three violations
(`title` plus two bad hints, asserted by message), and a new
`testMcpToolAnnotationsIgnoreContentAnnotationFields` case proving a tool carrying `audience` and
`priority` is no longer wrongly rejected. `mcptool-valid.json` now exercises all four hints, so the
happy path is real rather than incidental.

`checkstyle:check` passes on `schema-util/common` and `schema-util/util-provider`.

Closes #8926

Part of the MCP spec validation scope in #8427.

