### PR TITLE
docs: fix local-tier build and dev-mode commands (#9018)

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -55,13 +55,23 @@ The project uses a three-tier build system to allow developers to build only wha
 
 ```bash
 # Local: core server only, skip non-essential plugins (~3 min)
-./mvnw clean install -Dlocal -DskipTests
+./mvnw clean install -Dlocal -Dmaven.test.skip=true
 
 # Default: normal development
 ./mvnw clean install -DskipTests
 
 # Full: everything
 ./mvnw clean install -Dfull -DskipTests
+```
+
+**Note:** the *local* tier requires `-Dmaven.test.skip=true` rather than `-DskipTests`.
+The local tier excludes the serde and Maven plugin modules, but the `app` module's test
+sources import packages from them, so `-DskipTests` (which still compiles test sources)
+fails at test compilation. `-Dmaven.test.skip=true` skips test compilation entirely.
+The same applies to dev mode, which also compiles test sources:
+
+```bash
+cd app && ../mvnw quarkus:dev -Dlocal -Dmaven.test.skip=true
 ```
 
 Integration tests and examples are always opt-in via their own profiles:
@@ -72,7 +82,8 @@ Integration tests and examples are always opt-in via their own profiles:
 | Property              | Purpose                                                                                  |
 |-----------------------|------------------------------------------------------------------------------------------|
 | `-Pprod`              | Enables Quarkus *prod* configuration profile (higher logging level, production defaults) |
-| `-DskipTests`         | Skip all tests                                                                           |
+| `-DskipTests`         | Skip running tests (test sources are still compiled)                                     |
+| `-Dmaven.test.skip=true` | Skip compiling and running tests (required with `-Dlocal`)                            |
 | `-DcliSkipNative`     | Skip CLI native image compilation (no executable is produced, but tests can still run)   |
 | `-DskipOperatorTests` | Skip operator tests (default: `true`, requires a running cluster)                        |
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ Build the project and run the registry with the in-memory storage variant:
 **Build requirement:** JDK 21 or newer is required to build the project (the build tooling, e.g. Checkstyle, needs a Java 21+ runtime). The produced artifacts still target Java 17.
 
  ```
- ./mvnw clean install -Dlocal -DskipTests
+ ./mvnw clean install -Dlocal -Dmaven.test.skip=true
  cd app/
- ../mvnw quarkus:dev
+ ../mvnw quarkus:dev -Dlocal -Dmaven.test.skip=true
  ```
+
+(The `-Dlocal` build tier requires `-Dmaven.test.skip=true` — see
+[DEVELOPING.md](DEVELOPING.md#build-tiers) for details and other build options.)
 
 This should result in Quarkus and the in-memory registry starting up, with the REST APIs available on localhost port 8080:
 


### PR DESCRIPTION
Relates to #9018.

The documented local-tier flow fails on a fresh clone: `./mvnw clean install -Dlocal -DskipTests` dies at app test compilation (the local tier excludes the serde/Maven-plugin modules, but the `app` module's test sources import their packages, and `-DskipTests` still compiles test sources). The README quick start then runs `../mvnw quarkus:dev` without `-Dlocal`, which tries to resolve the excluded test-scoped artifacts and fails on a fresh `.m2`.

This PR documents the verified working flow (`-Dmaven.test.skip=true` for both the build and dev mode) and explains the `-DskipTests` vs `-Dmaven.test.skip=true` distinction in DEVELOPING.md. Verified against a fresh checkout of main (05667bff).

The docs fix keeps the current behavior; if the team would rather make `-DskipTests` work under `-Dlocal` (e.g. via test-compile excludes in the local profile, per the options in #9018), I'm happy to follow up with that PR instead or in addition.
