### PR TITLE
fix(references): extract embedded schemas on every artifact version, not just the first

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/EmbeddedSchemaService.java
+++ b/app/src/main/java/io/apicurio/registry/services/EmbeddedSchemaService.java
@@ -238,6 +238,8 @@ public class EmbeddedSchemaService {
                     return existing.getVersion();
                 } catch (ArtifactNotFoundException nfe) {
                     // No version with matching content - create a new one.
+                    log.debug("No existing version with matching content for {}/{}, creating new version",
+                            groupId, schemaArtifactId);
                 }
                 ArtifactVersionMetaDataDto vmd = storage.createArtifactVersion(groupId, schemaArtifactId,
                         null, "JSON", contentWrapper, versionMeta, Collections.emptyList(),

--- a/app/src/main/java/io/apicurio/registry/services/EmbeddedSchemaService.java
+++ b/app/src/main/java/io/apicurio/registry/services/EmbeddedSchemaService.java
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
+import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.dto.ContentWrapperDto;
 import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.EditableVersionMetaDataDto;
 import io.apicurio.registry.storage.error.ArtifactAlreadyExistsException;
+import io.apicurio.registry.storage.error.ArtifactNotFoundException;
 import io.apicurio.registry.types.ContentTypes;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -95,12 +98,12 @@ public class EmbeddedSchemaService {
             // Extract "input" schema
             if (rootObj.has("input") && rootObj.get("input").isObject() && hasSchemaProperties(rootObj.get("input"))) {
                 String schemaArtifactId = artifactId + "-input-schema";
-                String version = "1";
-                String refName = buildReferenceName(groupId, schemaArtifactId, version);
                 JsonNode inputSchema = rootObj.get("input");
 
-                if (autoRegisterSchema(storage, groupId, schemaArtifactId, inputSchema,
-                        "Input schema for " + artifactId, owner)) {
+                String version = autoRegisterSchema(storage, groupId, schemaArtifactId, inputSchema,
+                        "Input schema for " + artifactId, owner);
+                if (version != null) {
+                    String refName = buildReferenceName(groupId, schemaArtifactId, version);
                     rootObj.set("input", createRefNode(refName));
                     references.add(ArtifactReferenceDto.builder()
                             .groupId(groupId).artifactId(schemaArtifactId).version(version).name(refName)
@@ -112,12 +115,12 @@ public class EmbeddedSchemaService {
             // Extract "output" schema
             if (rootObj.has("output") && rootObj.get("output").isObject() && hasSchemaProperties(rootObj.get("output"))) {
                 String schemaArtifactId = artifactId + "-output-schema";
-                String version = "1";
-                String refName = buildReferenceName(groupId, schemaArtifactId, version);
                 JsonNode outputSchema = rootObj.get("output");
 
-                if (autoRegisterSchema(storage, groupId, schemaArtifactId, outputSchema,
-                        "Output schema for " + artifactId, owner)) {
+                String version = autoRegisterSchema(storage, groupId, schemaArtifactId, outputSchema,
+                        "Output schema for " + artifactId, owner);
+                if (version != null) {
+                    String refName = buildReferenceName(groupId, schemaArtifactId, version);
                     rootObj.set("output", createRefNode(refName));
                     references.add(ArtifactReferenceDto.builder()
                             .groupId(groupId).artifactId(schemaArtifactId).version(version).name(refName)
@@ -162,12 +165,12 @@ public class EmbeddedSchemaService {
             // Extract "outputSchema"
             if (rootObj.has("outputSchema") && rootObj.get("outputSchema").isObject() && hasSchemaProperties(rootObj.get("outputSchema"))) {
                 String schemaArtifactId = artifactId + "-output-schema";
-                String version = "1";
-                String refName = buildReferenceName(groupId, schemaArtifactId, version);
                 JsonNode outputSchema = rootObj.get("outputSchema");
 
-                if (autoRegisterSchema(storage, groupId, schemaArtifactId, outputSchema,
-                        "Output schema for prompt template " + artifactId, owner)) {
+                String version = autoRegisterSchema(storage, groupId, schemaArtifactId, outputSchema,
+                        "Output schema for prompt template " + artifactId, owner);
+                if (version != null) {
+                    String refName = buildReferenceName(groupId, schemaArtifactId, version);
                     rootObj.set("outputSchema", createRefNode(refName));
                     references.add(ArtifactReferenceDto.builder()
                             .groupId(groupId).artifactId(schemaArtifactId).version(version).name(refName)
@@ -193,11 +196,13 @@ public class EmbeddedSchemaService {
     }
 
     /**
-     * Auto-register a JSON Schema as a separate JSON artifact.
+     * Auto-register a JSON Schema as a separate JSON artifact. If the schema artifact already
+     * exists, an existing version with identical content is reused, otherwise a new version
+     * is created.
      *
-     * @return true if the schema was successfully registered, false otherwise
+     * @return the version of the registered schema, or null if registration failed
      */
-    private boolean autoRegisterSchema(RegistryStorage storage, String groupId, String schemaArtifactId,
+    private String autoRegisterSchema(RegistryStorage storage, String groupId, String schemaArtifactId,
             JsonNode schema, String description, String owner) {
         try {
             String schemaContent = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(schema);
@@ -217,19 +222,33 @@ public class EmbeddedSchemaService {
                     .references(Collections.emptyList())
                     .build();
 
-            storage.createArtifact(groupId, schemaArtifactId, "JSON", artifactMeta,
-                    "1", contentWrapper, versionMeta, Collections.emptyList(),
-                    false, false, owner);
-
-            log.info("Auto-registered embedded schema as artifact: {}/{}", groupId, schemaArtifactId);
-            return true;
-        } catch (ArtifactAlreadyExistsException e) {
-            log.info("Embedded schema artifact already exists: {}/{}, skipping auto-registration",
-                    groupId, schemaArtifactId);
-            return false;
+            try {
+                storage.createArtifact(groupId, schemaArtifactId, "JSON", artifactMeta,
+                        "1", contentWrapper, versionMeta, Collections.emptyList(),
+                        false, false, owner);
+                log.info("Auto-registered embedded schema as artifact: {}/{}", groupId, schemaArtifactId);
+                return "1";
+            } catch (ArtifactAlreadyExistsException e) {
+                // The schema artifact already exists. Reuse an existing version with identical content
+                // if there is one, otherwise register the updated schema as a new version.
+                TypedContent typedContent = TypedContent.create(contentHandle, ContentTypes.APPLICATION_JSON);
+                try {
+                    ArtifactVersionMetaDataDto existing = storage.getArtifactVersionMetaDataByContent(
+                            groupId, schemaArtifactId, false, typedContent, Collections.emptyList());
+                    return existing.getVersion();
+                } catch (ArtifactNotFoundException nfe) {
+                    // No version with matching content - create a new one.
+                }
+                ArtifactVersionMetaDataDto vmd = storage.createArtifactVersion(groupId, schemaArtifactId,
+                        null, "JSON", contentWrapper, versionMeta, Collections.emptyList(),
+                        false, false, owner);
+                log.info("Auto-registered updated embedded schema as new version: {}/{} v{}",
+                        groupId, schemaArtifactId, vmd.getVersion());
+                return vmd.getVersion();
+            }
         } catch (Exception e) {
             log.warn("Failed to auto-register embedded schema {}/{}: {}", groupId, schemaArtifactId, e.getMessage());
-            return false;
+            return null;
         }
     }
 

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/EmbeddedSchemaExtractionTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/EmbeddedSchemaExtractionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.apicurio.registry.noprofile.rest.v3;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/EmbeddedSchemaExtractionTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/EmbeddedSchemaExtractionTest.java
@@ -1,0 +1,163 @@
+package io.apicurio.registry.noprofile.rest.v3;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.client.models.ArtifactReference;
+import io.apicurio.registry.rest.client.models.VersionSearchResults;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static io.apicurio.registry.util.JsonObjectMapper.MAPPER;
+
+/**
+ * Tests that embedded schemas in PROMPT_TEMPLATE and MODEL_SCHEMA artifacts are extracted and
+ * auto-registered for every artifact version, not just the first one.
+ */
+@QuarkusTest
+public class EmbeddedSchemaExtractionTest extends AbstractResourceTestBase {
+
+    private static final String PROMPT_TEMPLATE = "PROMPT_TEMPLATE";
+    private static final String MODEL_SCHEMA = "MODEL_SCHEMA";
+
+    private static final String PROMPT_V1 = """
+            {
+              "templateId": "test",
+              "name": "Test",
+              "template": "Hello {{user}}",
+              "outputSchema": {
+                "type": "object",
+                "properties": {
+                  "greeting": { "type": "string" }
+                }
+              }
+            }
+            """;
+
+    private static final String PROMPT_V2 = """
+            {
+              "templateId": "test",
+              "name": "Test",
+              "template": "Hello {{user}}",
+              "outputSchema": {
+                "type": "object",
+                "properties": {
+                  "greeting": { "type": "string" },
+                  "sessionId": { "type": "string" }
+                }
+              }
+            }
+            """;
+
+    private String getVersionContent(String groupId, String artifactId, String version) throws Exception {
+        try (InputStream stream = clientV3.groups().byGroupId(groupId).artifacts()
+                .byArtifactId(artifactId).versions().byVersionExpression(version).content().get()) {
+            return IOUtils.toString(stream, StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    public void testPromptTemplateOutputSchemaExtractedOnNewVersion() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = "prompt-with-schema";
+        String schemaArtifactId = artifactId + "-output-schema";
+
+        createArtifact(groupId, artifactId, PROMPT_TEMPLATE, PROMPT_V1, ContentTypes.APPLICATION_JSON);
+        createArtifactVersion(groupId, artifactId, PROMPT_V2, ContentTypes.APPLICATION_JSON);
+
+        // Both versions must reference the extracted schema rather than embedding it inline.
+        JsonNode v1 = MAPPER.readTree(getVersionContent(groupId, artifactId, "1"));
+        JsonNode v2 = MAPPER.readTree(getVersionContent(groupId, artifactId, "2"));
+
+        Assertions.assertEquals(groupId + ":" + schemaArtifactId + ":1",
+                v1.path("outputSchema").path("$ref").asText());
+        Assertions.assertEquals(groupId + ":" + schemaArtifactId + ":2",
+                v2.path("outputSchema").path("$ref").asText());
+
+        // Each version must record an outbound reference to the schema version it uses.
+        List<ArtifactReference> v1Refs = clientV3.groups().byGroupId(groupId).artifacts()
+                .byArtifactId(artifactId).versions().byVersionExpression("1").references().get();
+        List<ArtifactReference> v2Refs = clientV3.groups().byGroupId(groupId).artifacts()
+                .byArtifactId(artifactId).versions().byVersionExpression("2").references().get();
+
+        Assertions.assertEquals(1, v1Refs.size());
+        Assertions.assertEquals("1", v1Refs.get(0).getVersion());
+        Assertions.assertEquals(1, v2Refs.size());
+        Assertions.assertEquals("2", v2Refs.get(0).getVersion());
+
+        // The schema artifact must have a second version holding the updated schema.
+        VersionSearchResults versions = clientV3.groups().byGroupId(groupId).artifacts()
+                .byArtifactId(schemaArtifactId).versions().get();
+        Assertions.assertEquals(2, versions.getCount());
+
+        JsonNode schemaV1 = MAPPER.readTree(getVersionContent(groupId, schemaArtifactId, "1"));
+        JsonNode schemaV2 = MAPPER.readTree(getVersionContent(groupId, schemaArtifactId, "2"));
+
+        Assertions.assertTrue(schemaV1.path("properties").has("greeting"));
+        Assertions.assertFalse(schemaV1.path("properties").has("sessionId"));
+        Assertions.assertTrue(schemaV2.path("properties").has("greeting"));
+        Assertions.assertTrue(schemaV2.path("properties").has("sessionId"));
+    }
+
+    @Test
+    public void testPromptTemplateOutputSchemaReusedWhenUnchanged() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = "prompt-stable-schema";
+        String schemaArtifactId = artifactId + "-output-schema";
+
+        createArtifact(groupId, artifactId, PROMPT_TEMPLATE, PROMPT_V1, ContentTypes.APPLICATION_JSON);
+        createArtifactVersion(groupId, artifactId, PROMPT_V1, ContentTypes.APPLICATION_JSON);
+
+        // An unchanged schema must be reused instead of producing a redundant version.
+        JsonNode v2 = MAPPER.readTree(getVersionContent(groupId, artifactId, "2"));
+        Assertions.assertEquals(groupId + ":" + schemaArtifactId + ":1",
+                v2.path("outputSchema").path("$ref").asText());
+
+        VersionSearchResults versions = clientV3.groups().byGroupId(groupId).artifacts()
+                .byArtifactId(schemaArtifactId).versions().get();
+        Assertions.assertEquals(1, versions.getCount());
+    }
+
+    @Test
+    public void testModelSchemaEmbeddedSchemasExtractedOnNewVersion() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = "model-with-schemas";
+        String outputSchemaArtifactId = artifactId + "-output-schema";
+
+        String modelV1 = """
+                {
+                  "name": "Test Model",
+                  "input": { "type": "object", "properties": { "prompt": { "type": "string" } } },
+                  "output": { "type": "object", "properties": { "text": { "type": "string" } } }
+                }
+                """;
+        String modelV2 = """
+                {
+                  "name": "Test Model",
+                  "input": { "type": "object", "properties": { "prompt": { "type": "string" } } },
+                  "output": { "type": "object", "properties": { "text": { "type": "string" }, "tokens": { "type": "integer" } } }
+                }
+                """;
+
+        createArtifact(groupId, artifactId, MODEL_SCHEMA, modelV1, ContentTypes.APPLICATION_JSON);
+        createArtifactVersion(groupId, artifactId, modelV2, ContentTypes.APPLICATION_JSON);
+
+        JsonNode v2 = MAPPER.readTree(getVersionContent(groupId, artifactId, "2"));
+
+        // The unchanged input schema is reused; the changed output schema gets a new version.
+        Assertions.assertEquals(groupId + ":" + artifactId + "-input-schema:1",
+                v2.path("input").path("$ref").asText());
+        Assertions.assertEquals(groupId + ":" + outputSchemaArtifactId + ":2",
+                v2.path("output").path("$ref").asText());
+
+        JsonNode outputSchemaV2 = MAPPER.readTree(getVersionContent(groupId, outputSchemaArtifactId, "2"));
+        Assertions.assertTrue(outputSchemaV2.path("properties").has("tokens"));
+    }
+}


### PR DESCRIPTION
Fixes #9053

## Root cause

`EmbeddedSchemaService.autoRegisterSchema()` only ever *created* the generated schema artifact. It called `storage.createArtifact()` with a hardcoded version `"1"` and had no path for handling an artifact that already existed.

On the first version of a `PROMPT_TEMPLATE` this worked: the embedded `outputSchema` was registered as a separate JSON artifact and replaced with a `$ref`. On every subsequent version the call hit `ArtifactAlreadyExistsException`, which was caught and turned into `return false`. That return value signaled that extraction had failed, so the remainder of the extraction process was skipped.

As a result:

- the new artifact version kept its **raw embedded schema** instead of a `$ref`, leaving the same artifact with two different content shapes across versions
- the generated schema artifact was **never updated**, remaining frozen at the first version's schema
- **no outbound reference** was recorded for the new artifact version

The request still completed successfully, so the only visible indication was an INFO log entry.

## The fix

`autoRegisterSchema()` now returns the version it registered (or `null` on failure) instead of a boolean.

When the generated schema artifact already exists, it first looks for an existing version with identical content using `storage.getArtifactVersionMetaDataByContent()`. If one exists, that version is reused; otherwise a new schema artifact version is created.

The callers now use the returned version when constructing both the `$ref` and the `ArtifactReferenceDto`, replacing the previously hardcoded `"1"`.

This lookup-then-create flow follows the existing content-deduplication pattern already used in `handleIfExistsReturnOrUpdate` (v2 and v3) and the ccompat `registerSchemaUnderSubject` implementation. Reusing identical schema versions also avoids creating redundant schema versions when the embedded schema is unchanged across parent artifact versions.

Existing references remain unaffected because reference resolution is version-pinned. A `$ref` pointing to version `1` continues to resolve to version `1` even after newer schema versions are created.

## MODEL_SCHEMA

`autoRegisterSchema()` is shared by both `PROMPT_TEMPLATE` and `MODEL_SCHEMA`, so this change also fixes embedded `input` and `output` schema extraction for `MODEL_SCHEMA`.

Although the reported issue focused on `PROMPT_TEMPLATE`, both artifact types shared the same implementation and therefore the same defect. Test coverage has been added for both.

## Testing

Added a new `EmbeddedSchemaExtractionTest` covering:

- a changed `outputSchema` on a new artifact version creates a new generated schema version, replaces the embedded schema with a `$ref`, and records the correct outbound reference
- an unchanged `outputSchema` reuses the existing generated schema version instead of creating a redundant one
- `MODEL_SCHEMA` embedded `input` and `output` schema extraction, verifying reuse for unchanged schemas and version creation for changed schemas

Existing `PromptRenderTest` continues to pass, and `./mvnw checkstyle:check -pl app` completes successfully.