### PR TITLE
fix(http): accept all 2xx responses and restore interrupt flag in HttpClientService

### DIFF
--- a/app/src/main/java/io/apicurio/registry/http/HttpClientContentException.java
+++ b/app/src/main/java/io/apicurio/registry/http/HttpClientContentException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.http;
+
+@SuppressWarnings("java:S110") // Inheritance depth of 6 is necessary to extend HttpClientException
+public class HttpClientContentException extends HttpClientException {
+
+    private static final long serialVersionUID = 1L;
+
+    public HttpClientContentException(String message) {
+        super(message);
+    }
+
+    public HttpClientContentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/http/HttpClientErrorException.java
+++ b/app/src/main/java/io/apicurio/registry/http/HttpClientErrorException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.http;
+
+@SuppressWarnings("java:S110") // Inheritance depth of 6 is necessary to extend HttpClientException
+public class HttpClientErrorException extends HttpClientException {
+
+    private static final long serialVersionUID = 1L;
+
+    public HttpClientErrorException(String message) {
+        super(message);
+    }
+
+    public HttpClientErrorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/http/HttpClientInterruptedException.java
+++ b/app/src/main/java/io/apicurio/registry/http/HttpClientInterruptedException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.http;
+
+@SuppressWarnings("java:S110") // Inheritance depth of 6 is necessary to extend HttpClientException
+public class HttpClientInterruptedException extends HttpClientException {
+    
+    private static final long serialVersionUID = 1L;
+
+    public HttpClientInterruptedException(InterruptedException cause) {
+        super(cause);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/http/HttpClientService.java
+++ b/app/src/main/java/io/apicurio/registry/http/HttpClientService.java
@@ -21,7 +21,28 @@ public class HttpClientService {
     @Inject
     WebClient webClient;
 
-    @Retry(maxRetries = 8, delay = 100, jitter = 50)
+    /**
+     * Sends an HTTP POST request to the given URL and deserializes the response body.
+     *
+     * <p>Any HTTP 2xx status code is treated as success. If {@code outputClass} is {@code Void.class},
+     * this method always returns {@code null} without deserializing the response. For other return types,
+     * an empty response body (such as {@code 204 No Content}) or malformed JSON results in
+     * {@link HttpClientContentException} (which is not retried). HTTP 4xx client errors throw
+     * {@link HttpClientErrorException} (which is also not retried). Only transient 5xx/transport
+     * errors are retried.
+     *
+     * @throws HttpClientContentException if an empty body or malformed JSON is returned when a
+     *                                    non-{@code Void} return type was expected
+     * @throws HttpClientErrorException   if the server returns a 4xx client error status
+     * @throws HttpClientInterruptedException if the request is interrupted
+     * @throws HttpClientException        if the server returns a 5xx status or any other I/O error occurs
+     */
+    @Retry(maxRetries = 8, delay = 100, jitter = 50, abortOn = {
+            HttpClientInterruptedException.class,
+            HttpClientContentException.class,
+            HttpClientErrorException.class,
+            InterruptedException.class
+    })
     @ExponentialBackoff
     @Timeout(value = 10, unit = ChronoUnit.SECONDS)
     public <I, O> O post(String url, I body, Class<O> outputClass) throws HttpClientException {
@@ -33,15 +54,62 @@ public class HttpClientService {
 
             // Wait for the response (vert.x is async).
             HttpResponse<Buffer> httpResponse = future.toCompletionStage().toCompletableFuture().get();
-            if (httpResponse.statusCode() == 200) {
-                return (O) httpResponse.bodyAsJson(outputClass);
-            } else {
-                throw new HttpClientException("Webhook request failed (" + httpResponse.statusCode() + "): " + httpResponse.statusMessage());
-            }
+            return processResponse(httpResponse, outputClass);
         } catch (ExecutionException e) {
             throw new HttpClientException(e);
         } catch (InterruptedException e) {
-            throw new HttpClientException(e);
+            // Restore the interrupt flag before rethrowing so callers and
+            // fault-tolerance retry machinery (@Retry) can observe the interruption.
+            // abortOn = HttpClientInterruptedException.class prevents retrying an interrupted call,
+            // while allowing 5xx server errors to still be retried.
+            Thread.currentThread().interrupt();
+            throw new HttpClientInterruptedException(e);
+        }
+    }
+
+    private <O> O processResponse(HttpResponse<Buffer> httpResponse, Class<O> outputClass) throws HttpClientException {
+        int statusCode = httpResponse.statusCode();
+        if (statusCode >= 200 && statusCode < 300) {
+            return handleSuccess(httpResponse, outputClass, statusCode);
+        }
+        handleFailure(httpResponse, statusCode);
+        return null;
+    }
+
+    private <O> O handleSuccess(HttpResponse<Buffer> httpResponse, Class<O> outputClass, int statusCode) throws HttpClientException {
+        // If Void is expected, return null directly without attempting deserialization.
+        if (outputClass == Void.class) {
+            return null;
+        }
+        Buffer bodyBuffer = httpResponse.body();
+        if (bodyBuffer == null || bodyBuffer.length() == 0) {
+            throw new HttpClientContentException("Webhook returned " + statusCode + " with empty body, expected " + outputClass.getSimpleName());
+        }
+        return decodeResponse(httpResponse, outputClass, statusCode);
+    }
+
+    private void handleFailure(HttpResponse<Buffer> httpResponse, int statusCode) throws HttpClientException {
+        String msg = extractStatusMessage(httpResponse, statusCode);
+        if (statusCode >= 400 && statusCode < 500) {
+            throw new HttpClientErrorException("Webhook request failed (" + statusCode + "): " + msg);
+        }
+        throw new HttpClientException("Webhook request failed (" + statusCode + "): " + msg);
+    }
+
+    private String extractStatusMessage(HttpResponse<Buffer> httpResponse, int statusCode) {
+        String statusMessage = httpResponse.statusMessage();
+        if (statusMessage != null && !statusMessage.isBlank()) {
+            return statusMessage;
+        }
+        return "HTTP status " + statusCode;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <O> O decodeResponse(HttpResponse<Buffer> httpResponse, Class<O> outputClass, int statusCode) throws HttpClientException {
+        try {
+            return (O) httpResponse.bodyAsJson(outputClass);
+        } catch (io.vertx.core.json.DecodeException e) {
+            throw new HttpClientContentException("Failed to decode JSON response from " + statusCode, e);
         }
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/http/HttpClientServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/http/HttpClientServiceTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.noprofile.http;
+
+import io.apicurio.registry.http.HttpClientContentException;
+import io.apicurio.registry.http.HttpClientErrorException;
+import io.apicurio.registry.http.HttpClientException;
+import io.apicurio.registry.http.HttpClientInterruptedException;
+import io.apicurio.registry.http.HttpClientService;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.web.client.WebClient;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link HttpClientService} covering HTTP 2xx handling, non-retriable content
+ * failure discrimination (empty body / malformed JSON), 4xx client error aborts, fault
+ * tolerance retries, and interrupt handling through FT interceptors.
+ */
+@QuarkusTest
+class HttpClientServiceTest {
+
+    private static String baseUrl;
+
+    private static Vertx vertx;
+    private static HttpServer stubServer;
+    private static final ConcurrentHashMap<String, AtomicInteger> requestCounts = new ConcurrentHashMap<>();
+    private static volatile CountDownLatch delayedInterruptLatch;
+
+    /** CDI-managed bean — carries {@code @Retry} + {@code @Timeout} interceptors. */
+    @Inject
+    HttpClientService httpClientService;
+
+    /**
+     * Plain, non-intercepted instance — bypasses {@code @Retry}/{@code @Timeout} so that
+     * status-branching (500) and interrupt tests complete in a single attempt without backoff.
+     */
+    private static HttpClientService rawService;
+
+    @BeforeAll
+    static void startStubServer() throws Exception {
+        vertx = Vertx.vertx();
+        CompletableFuture<Void> ready = new CompletableFuture<>();
+
+        vertx.createHttpServer().requestHandler(req -> {
+            String path = req.path();
+            int attempt = requestCounts.computeIfAbsent(path, p -> new AtomicInteger()).incrementAndGet();
+
+            switch (path) {
+                case "/ok200":
+                    req.response().setStatusCode(200)
+                            .putHeader("content-type", "application/json")
+                            .end("{\"result\":\"ok\"}");
+                    break;
+                case "/created201":
+                    req.response().setStatusCode(201)
+                            .putHeader("content-type", "application/json")
+                            .end("{\"result\":\"created\"}");
+                    break;
+                case "/accepted202":
+                    req.response().setStatusCode(202)
+                            .putHeader("content-type", "application/json")
+                            .end("{\"result\":\"accepted\"}");
+                    break;
+                case "/noContent204":
+                    req.response().setStatusCode(204).end();
+                    break;
+                case "/malformedJson":
+                    req.response().setStatusCode(200)
+                            .putHeader("content-type", "application/json")
+                            .end("not-valid-json");
+                    break;
+                case "/clientError400":
+                    req.response().setStatusCode(400)
+                            .putHeader("content-type", "application/json")
+                            .end("{\"error\":\"bad_request\"}");
+                    break;
+                case "/clientError404":
+                    req.response().setStatusCode(404)
+                            .putHeader("content-type", "application/json")
+                            .end("{\"error\":\"not_found\"}");
+                    break;
+                case "/retryThenSuccess":
+                    if (attempt <= 2) {
+                        req.response().setStatusCode(500)
+                                .putHeader("content-type", "text/plain")
+                                .end("Transient Error");
+                    } else {
+                        req.response().setStatusCode(200)
+                                .putHeader("content-type", "application/json")
+                                .end("{\"result\":\"ok\"}");
+                    }
+                    break;
+                case "/serverError500":
+                    req.response().setStatusCode(500)
+                            .putHeader("content-type", "text/plain")
+                            .end("Internal Server Error");
+                    break;
+                case "/delayed":
+                    vertx.setTimer(2000, id -> {
+                        req.response().setStatusCode(200)
+                                .putHeader("content-type", "application/json")
+                                .end("{\"result\":\"ok\"}");
+                    });
+                    break;
+                case "/delayedInterrupt":
+                    if (delayedInterruptLatch != null) {
+                        delayedInterruptLatch.countDown();
+                    }
+                    vertx.setTimer(5000, id -> {
+                        req.response().setStatusCode(200)
+                                .putHeader("content-type", "application/json")
+                                .end("{\"result\":\"ok\"}");
+                    });
+                    break;
+                default:
+                    req.response().setStatusCode(404).end();
+            }
+        }).listen(0, result -> {
+            if (result.succeeded()) {
+                stubServer = result.result();
+                baseUrl = "http://localhost:" + stubServer.actualPort();
+                try {
+                    // Build a non-intercepted HttpClientService directly so that
+                    // status-branching and interrupt tests bypass the full retry chain.
+                    rawService = new HttpClientService();
+                    Field webClientField = HttpClientService.class.getDeclaredField("webClient");
+                    webClientField.setAccessible(true);
+                    webClientField.set(rawService, WebClient.create(vertx));
+                } catch (Exception e) {
+                    ready.completeExceptionally(e);
+                    return;
+                }
+                ready.complete(null);
+            } else {
+                ready.completeExceptionally(result.cause());
+            }
+        });
+
+        ready.get(10, TimeUnit.SECONDS);
+    }
+
+    @AfterAll
+    static void stopStubServer() throws Exception {
+        if (stubServer != null) {
+            stubServer.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        }
+        if (vertx != null) {
+            vertx.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    // --- 2xx success-path tests (injected bean, FT interceptors active) ---
+
+    @Test
+    void testHttp200DoesNotThrow() {
+        httpClientService.post(baseUrl + "/ok200", "{}", Object.class);
+    }
+
+    @Test
+    void testHttp201DoesNotThrow() {
+        // 201 Created is a valid success code — must not trigger retries or throw.
+        httpClientService.post(baseUrl + "/created201", "{}", Object.class);
+    }
+
+    @Test
+    void testHttp202DoesNotThrow() {
+        // 202 Accepted is the standard CloudEvents webhook acknowledgment.
+        httpClientService.post(baseUrl + "/accepted202", "{}", Object.class);
+    }
+
+    @Test
+    void testHttp204WithVoidClassReturnsNull() {
+        // 204 No Content with Void.class must return null without deserialization attempt.
+        Object result = httpClientService.post(baseUrl + "/noContent204", "{}", Void.class);
+        assertNull(result);
+    }
+
+    @Test
+    void testVoidClassWithBodyReturnsNull() {
+        // A response with a body must return null without deserializing when Void.class is expected.
+        Object result = httpClientService.post(baseUrl + "/ok200", "{}", Void.class);
+        assertNull(result);
+    }
+
+    // --- Behavioral abortOn and retry tests (injected bean, FT interceptors active) ---
+
+    @Test
+    void testHttp204WithNonVoidClassAbortsWithoutRetries() {
+        // Empty body when non-Void is expected throws HttpClientContentException and must abort on attempt 1.
+        int countBefore = requestCounts.getOrDefault("/noContent204", new AtomicInteger()).get();
+        assertThrows(HttpClientContentException.class, () ->
+                httpClientService.post(baseUrl + "/noContent204", "{}", Object.class));
+        int countAfter = requestCounts.get("/noContent204").get();
+        assertEquals(countBefore + 1, countAfter, "Content error must abort immediately without retries");
+    }
+
+    @Test
+    void testMalformedJsonAbortsWithoutRetries() {
+        // Malformed JSON throws HttpClientContentException and must abort on attempt 1 without retries.
+        assertThrows(HttpClientContentException.class, () ->
+                httpClientService.post(baseUrl + "/malformedJson", "{}", Object.class));
+        assertEquals(1, requestCounts.get("/malformedJson").get(),
+                "Malformed JSON response must abort immediately without retries");
+    }
+
+    @Test
+    void testHttp400BadRequestAbortsWithoutRetries() {
+        // 400 Bad Request throws HttpClientErrorException and must abort on attempt 1 without retries.
+        assertThrows(HttpClientErrorException.class, () ->
+                httpClientService.post(baseUrl + "/clientError400", "{}", Object.class));
+        assertEquals(1, requestCounts.get("/clientError400").get(),
+                "400 Bad Request must abort immediately without retries");
+    }
+
+    @Test
+    void testHttp404NotFoundAbortsWithoutRetries() {
+        // 404 Not Found throws HttpClientErrorException and must abort on attempt 1 without retries.
+        assertThrows(HttpClientErrorException.class, () ->
+                httpClientService.post(baseUrl + "/clientError404", "{}", Object.class));
+        assertEquals(1, requestCounts.get("/clientError404").get(),
+                "404 Not Found must abort immediately without retries");
+    }
+
+    @Test
+    void testServerError5xxIsRetried() {
+        // Transient 5xx server errors must be retried with backoff until success.
+        httpClientService.post(baseUrl + "/retryThenSuccess", "{}", Object.class);
+        assertEquals(3, requestCounts.get("/retryThenSuccess").get(),
+                "Transient 5xx error should be retried until success");
+    }
+
+    @Test
+    void testInterruptAbortsRetriesOnInjectedBean() throws Exception {
+        // Asserts that when a thread executing the CDI-managed (FT-intercepted) bean is interrupted,
+        // the call fails with an interrupt exception and @Retry aborts immediately without executing retries.
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        delayedInterruptLatch = new CountDownLatch(1);
+
+        Thread worker = new Thread(() -> {
+            try {
+                httpClientService.post(baseUrl + "/delayedInterrupt", "{}", Object.class);
+            } catch (Throwable t) {
+                thrown.set(t);
+            }
+        });
+
+        worker.start();
+        assertTrue(delayedInterruptLatch.await(5, TimeUnit.SECONDS),
+                "Server should receive the delayedInterrupt request before worker thread is interrupted");
+
+        worker.interrupt();
+        worker.join(5000);
+
+        Throwable ex = thrown.get();
+        if (ex instanceof io.quarkus.arc.ArcUndeclaredThrowableException && ex.getCause() != null) {
+            ex = ex.getCause();
+        }
+        assertTrue(ex instanceof HttpClientInterruptedException || ex instanceof InterruptedException,
+                "Expected HttpClientInterruptedException or InterruptedException from FT-intercepted bean, got: " + ex);
+        assertEquals(1, requestCounts.get("/delayedInterrupt").get(),
+                "Interrupted call must abort immediately on attempt 1 without retrying");
+    }
+
+    // --- Status-branching and interrupt tests (non-intercepted rawService) ---
+
+    @Test
+    void testNon2xxThrowsHttpClientException() {
+        // Uses rawService to skip the 8-retry/exponential-backoff chain — resolves in one attempt.
+        assertThrows(HttpClientException.class, () ->
+                rawService.post(baseUrl + "/serverError500", "{}", Object.class));
+    }
+
+    @Test
+    void testInterruptRestoresFlag() {
+        // Uses rawService (no @Timeout interceptor) so the method runs on the calling thread.
+        // Pre-interrupting the thread causes future.get() to throw InterruptedException,
+        // which our catch block wraps in HttpClientInterruptedException and restores the flag.
+        Thread.currentThread().interrupt();
+        try {
+            HttpClientException ex = assertThrows(HttpClientException.class, () ->
+                    rawService.post(baseUrl + "/delayed", "{}", Object.class));
+            // The exception must be the interrupt-specific subtype so @Retry abortOn works.
+            assertInstanceOf(HttpClientInterruptedException.class, ex,
+                    "Expected HttpClientInterruptedException for interrupt path");
+            // Interrupt flag must be restored so callers can observe the interruption.
+            assertTrue(Thread.currentThread().isInterrupted(),
+                    "Interrupt flag must be restored after InterruptedException is caught");
+        } finally {
+            // Clear the flag so subsequent tests are not affected.
+            Thread.interrupted();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #8691

## What this PR does

Fixes improper retry loops and bugged webhook delivery in `HttpClientService.post()`:

---

### 1. Accept all HTTP 2xx status codes & handle non-transient content errors

- **2xx Success Handling:** Any status code in `[200, 299]` is treated as success. This resolves issues where standard webhook responses like `202 Accepted` (CloudEvents acknowledgment) or `201 Created` incorrectly triggered 8 retries and failed.
- **`Void.class` Safety:** When `Void.class` is requested, `null` is returned directly without attempting deserialization (handling `204 No Content` and 2xx responses with ignored payloads).
- **Non-Retriable Content Errors:** If an empty body is returned when a non-`Void` type is expected, or if JSON deserialization fails (`DecodeException`), `HttpClientContentException` is thrown.
- **Non-Retriable 4xx Client Errors:** HTTP 4xx responses (400, 401, 403, 404, 410, etc.) throw `HttpClientErrorException`.
- **Abort on Non-Transient Failures:** `HttpClientContentException` and `HttpClientErrorException` are added to `@Retry(abortOn = ...)` so permanent errors abort immediately on attempt 1 instead of spinning through 8 exponential-backoff retries (~25s delay and 9× load), while transient 5xx server errors continue to be retried.

```java
int statusCode = httpResponse.statusCode();
if (statusCode >= 200 && statusCode < 300) {
    if (outputClass == Void.class) {
        return null;
    }
    Buffer bodyBuffer = httpResponse.body();
    if (bodyBuffer == null || bodyBuffer.length() == 0) {
        throw new HttpClientContentException("Webhook returned " + statusCode + " with empty body, expected " + outputClass.getSimpleName());
    }
    return decodeResponse(httpResponse, outputClass, statusCode);
} else if (statusCode >= 400 && statusCode < 500) {
    throw new HttpClientErrorException("Webhook request failed (" + statusCode + "): " + httpResponse.statusMessage());
} else {
    throw new HttpClientException("Webhook request failed (" + statusCode + "): " + httpResponse.statusMessage());
}
```

---

### 2. Restore interrupt flag & abort `@Retry` on `InterruptedException`

- Restores `Thread.currentThread().interrupt()` upon catching `InterruptedException`.
- Wraps in `HttpClientInterruptedException` and adds `HttpClientInterruptedException.class` to `@Retry(abortOn = ...)` so interrupted operations abort immediately without retrying.

```java
@Retry(maxRetries = 8, delay = 100, jitter = 50, abortOn = {
        HttpClientInterruptedException.class,
        HttpClientContentException.class,
        HttpClientErrorException.class
})
```

---

## Files changed

- `app/src/main/java/io/apicurio/registry/http/HttpClientService.java`
- `app/src/main/java/io/apicurio/registry/http/HttpClientContentException.java` *(new)*
- `app/src/main/java/io/apicurio/registry/http/HttpClientErrorException.java` *(new)*
- `app/src/main/java/io/apicurio/registry/http/HttpClientInterruptedException.java` *(new)*
- `app/src/test/java/io/apicurio/registry/noprofile/http/HttpClientServiceTest.java` *(new)*

---

## Tests

Added `HttpClientServiceTest` (13 tests) using an embedded Vert.x stub server:

| Scenario | Expected behaviour |
|---|---|
| Server returns `200 OK` | Does not throw, succeeds on attempt 1 |
| Server returns `201 Created` | Does not throw, succeeds on attempt 1 |
| Server returns `202 Accepted` | Does not throw, succeeds on attempt 1 |
| Server returns `204 No Content` with `Void.class` | Returns `null`, 0 retries |
| Server returns `200 OK` with `Void.class` | Returns `null` without deserializing |
| Server returns `204 No Content` with non-`Void` | Throws `HttpClientContentException`, aborts on attempt 1 |
| Server returns `200 OK` with malformed JSON | Throws `HttpClientContentException`, aborts on attempt 1 |
| Server returns `400 Bad Request` | Throws `HttpClientErrorException`, aborts on attempt 1 |
| Server returns `404 Not Found` | Throws `HttpClientErrorException`, aborts on attempt 1 |
| Server returns `500` twice then `200` | Retries 5xx with backoff, succeeds on attempt 3 |
| Injected bean call interrupted | Throws `HttpClientInterruptedException`, aborts on attempt 1, preserves interrupt flag |
| Server returns `500` | Throws `HttpClientException` |
| Thread interrupted before call | Throws `HttpClientInterruptedException`; restores interrupt flag |
