### PR TITLE
fix(search): use Locale.ROOT for state filter uppercasing in Elasticsearch query

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -212,7 +213,7 @@ public class ElasticsearchSearchService {
 
         case state:
             return Query.of(q -> q.term(t -> t
-                    .field("state").value(filter.getStringValue().toUpperCase())));
+                    .field("state").value(filter.getStringValue().toUpperCase(Locale.ROOT))));
 
         case globalId:
             return Query.of(q -> q.term(t -> t

--- a/app/src/test/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchServiceTest.java
@@ -4,6 +4,8 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import io.apicurio.registry.storage.dto.SearchFilter;
 import io.apicurio.registry.storage.dto.SearchFilterType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.util.Locale;
 import java.util.Set;
@@ -13,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ElasticsearchSearchServiceTest {
 
     @Test
+    @ResourceLock(value = "jvm.defaultLocale", mode = ResourceAccessMode.READ_WRITE)
     void stateFilterUppercasesUnderTurkishDefaultLocale() {
         Locale originalLocale = Locale.getDefault();
         Locale.setDefault(Locale.forLanguageTag("tr-TR"));

--- a/app/src/test/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchServiceTest.java
@@ -1,0 +1,34 @@
+package io.apicurio.registry.storage.impl.search;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.apicurio.registry.storage.dto.SearchFilter;
+import io.apicurio.registry.storage.dto.SearchFilterType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ElasticsearchSearchServiceTest {
+
+    @Test
+    void stateFilterUppercasesUnderTurkishDefaultLocale() {
+        Locale originalLocale = Locale.getDefault();
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+        try {
+            ElasticsearchSearchService service = new ElasticsearchSearchService();
+
+            SearchFilter filter = new SearchFilter();
+            filter.setType(SearchFilterType.state);
+            filter.setStringValue("disabled");
+
+            Query query = service.buildEsQuery(Set.of(filter));
+
+            String termValue = query.bool().must().get(0).term().value().stringValue();
+            assertEquals("DISABLED", termValue);
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+    }
+}


### PR DESCRIPTION
## What

`ElasticsearchSearchService.buildFilterQuery()` calls `toUpperCase()` on the `state` filter's string value without a `Locale` argument, relying on the JVM default locale for case conversion. This violates the project's convention that all case conversions go through `Locale.ROOT`.

## Why

The only current caller (`SearchFilter.ofState(VersionState)`) always passes an already-uppercase ASCII value (`ENABLED`, `DISABLED`, `DEPRECATED`, `DRAFT`), so there's no observable failure today. But under a Turkish-family default locale (`tr`/`tr-TR`), an uppercase conversion on a lowercase `i` produces the dotted `İ` instead of plain `I`. If any future or alternate code path ever passes a value that isn't already uppercase, the resulting term query would silently fail to match the `state` keyword field and return zero results, with no exception or log line to point at the cause.

Fixes #9073

## Changes

- `ElasticsearchSearchService.buildFilterQuery()`: `filter.getStringValue().toUpperCase()` → `filter.getStringValue().toUpperCase(Locale.ROOT)`
- Added `ElasticsearchSearchServiceTest`, which sets the default locale to `tr-TR`, builds a state filter from a lowercase value, and asserts the resulting term query value is `DISABLED` (not the Turkish dotted variant).

## Test plan

- `./mvnw test -pl app -Dtest=ElasticsearchSearchServiceTest` — passes
- `./mvnw checkstyle:check -pl app` — 0 violations
- `./mvnw install -pl app -am -DskipTests` — builds clean