### PR TITLE
fix(ui): hide version kebab menu when no actions are visible

### DIFF
--- a/ui/ui-app/src/app/pages/version/components/pageheader/VersionPageHeader.tsx
+++ b/ui/ui-app/src/app/pages/version/components/pageheader/VersionPageHeader.tsx
@@ -98,7 +98,7 @@ export const VersionPageHeader: FunctionComponent<VersionPageHeaderProps> = (pro
             }
         }
     ];
-    const visibleActions: any[] = actions.filter(action => action.isVisible());
+    const visibleActions = actions.filter(action => action.isVisible());
 
     return (
         <Flex className="example-border">

--- a/ui/ui-app/src/app/pages/version/components/pageheader/VersionPageHeader.tsx
+++ b/ui/ui-app/src/app/pages/version/components/pageheader/VersionPageHeader.tsx
@@ -98,6 +98,7 @@ export const VersionPageHeader: FunctionComponent<VersionPageHeaderProps> = (pro
             }
         }
     ];
+    const visibleActions: any[] = actions.filter(action => action.isVisible());
 
     return (
         <Flex className="example-border">
@@ -128,21 +129,22 @@ export const VersionPageHeader: FunctionComponent<VersionPageHeaderProps> = (pro
                             </IfFeature>
                         </IfFeature>
                     </ActionListItem>
-                    <ActionListItem key="actions">
-                        <ObjectDropdown
-                            label=""
-                            items={actions}
-                            onSelect={item => item.onSelect()}
-                            itemToString={item => item.label}
-                            itemToTestId={item => item.testId}
-                            itemIsVisible={item => item.isVisible()}
-                            itemIsDivider={item => item.divider}
-                            popperProps={{
-                                position: "right"
-                            }}
-                            isKebab={true}
-                        />
-                    </ActionListItem>
+                    <If condition={visibleActions.length > 0}>
+                        <ActionListItem key="actions">
+                            <ObjectDropdown
+                                label=""
+                                items={visibleActions}
+                                onSelect={item => item.onSelect()}
+                                itemToString={item => item.label}
+                                itemToTestId={item => item.testId}
+                                itemIsDivider={item => item.divider}
+                                popperProps={{
+                                    position: "right"
+                                }}
+                                isKebab={true}
+                            />
+                        </ActionListItem>
+                    </If>
                 </ActionList>
             </FlexItem>
         </Flex>


### PR DESCRIPTION
## Summary

Fixes #9076

On the artifact **Version > Overview** page, the kebab ("more actions") 
button was always rendered, even when every action's `isVisible()` 
check evaluated to false. For most artifact types, this meant clicking 
the kebab opened an empty popover — indistinguishable from a dead/
broken button.

## Root Cause

`VersionPageHeader.tsx` always rendered the kebab `ObjectDropdown` and 
passed it the full `actions` array, relying on `itemIsVisible` to 
filter items internally. Only two actions have type-specific visibility:

- **Generate client SDK** — visible only for `artifactType === "OPENAPI"`
- **Edit Agent Card** — visible only for `artifactType === "AGENT_CARD"`

For every other supported artifact type (Avro, JSON, AsyncAPI, 
Protobuf, GraphQL, XSD, WSDL, Kafka Connect, Prompt Template, Model 
Schema, and others), all actions evaluate to invisible simultaneously 
in typical setups, so the kebab opened to nothing.

## Fix

Compute `visibleActions` up front by filtering `actions` on 
`isVisible()`, and only render the kebab `ActionListItem`/
`ObjectDropdown` when `visibleActions.length > 0`. `items={actions}` 
is replaced with `items={visibleActions}`, and the now-redundant 
`itemIsVisible` prop on `ObjectDropdown` is removed.

This fix is condition-agnostic — it doesn't special-case any artifact 
type. If a future action's `isVisible()` condition becomes true for 
any type (new feature flags, new type-specific actions, ownership 
changes), the kebab will automatically appear with the correct items, 
with no further changes needed here.

## Testing

Verified no regression for the two types that currently have working 
actions, and confirmed the fix resolves the empty-menu issue for all 
other tested types:

| Type | Before | After |
|---|---|---|
| OPENAPI | ✅ Generate client SDK | ✅ Generate client SDK (unchanged) |
| AGENT_CARD | ✅ Edit Agent Card | ✅ Edit Agent Card (unchanged) |
| PROMPT_TEMPLATE | ❌ Empty popover | ✅ Kebab hidden |
| ASYNCAPI | ❌ Empty popover | ✅ Kebab hidden |
| AVRO, JSON, PROTOBUF, GRAPHQL, XSD, WSDL, KCONNECT, MODEL_SCHEMA | ❌ Empty popover | ✅ Kebab hidden |

## Video

**Before (bug):**

[raw-recording (9).webm](https://github.com/user-attachments/assets/2ccc9701-f3fb-46fa-9ac8-448a8f6c2455)


**After (fix applied):**

[raw-recording (10).webm](https://github.com/user-attachments/assets/877d689b-d941-467c-8f11-300b24913464)
