### PR TITLE
feat(ui): auto-detect version from artifact content (#1788)

### DIFF
--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -118,6 +118,10 @@ jobs:
         working-directory: ui
         run: npm run lint
 
+      - name: Test
+        working-directory: ui
+        run: npm run test
+
       - name: Build
         working-directory: ui
         run: npm run build

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,6 +19,8 @@
         "lint-docs": "cd ui-docs && npm run lint",
         "lint-editors": "cd ui-editors && npm run lint",
         "lint": "npm run lint-sdk && npm run lint-app && npm run lint-docs && npm run lint-editors",
+        "test-app": "cd ui-app && npm run test",
+        "test": "npm run test-app",
         "build-sdk": "cd ../typescript-sdk && npm run generate-sources && npm run build",
         "build-app": "cd ui-app && npm run build",
         "build-docs": "cd ui-docs && npm run build",

--- a/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
+++ b/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, MouseEvent, Ref, useEffect, useState } from "react";
+import { FunctionComponent, MouseEvent, Ref, useEffect, useRef, useState } from "react";
 import "./CreateArtifactModal.css";
 import {
     FileUpload,
@@ -35,7 +35,7 @@ import { ArtifactTypesService, useArtifactTypesService } from "@services/useArti
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
 import { ArtifactLabel, LabelsFormGroup, ArtifactReferenceFormItem, ReferencesFormGroup, formItemsToReferences, isReferencesValid } from "@app/components";
 import { listToLabels } from "@utils/labels.utils.ts";
-import { detectContentType } from "@utils/content.utils.ts";
+import { detectContentType, detectVersionInContent } from "@utils/content.utils.ts";
 
 
 export type ValidType = "default" | "success" | "error";
@@ -127,6 +127,10 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
     const [versionLabels, setVersionLabels] = useState<ArtifactLabel[]>([]);
     const [versionReferences, setVersionReferences] = useState<ArtifactReferenceFormItem[]>([]);
     const [isDetectingRefs, setIsDetectingRefs] = useState(false);
+    const [autoDetectedVersion, setAutoDetectedVersion] = useState<string | undefined>();
+    // Ref rather than state: content change handlers can fire asynchronously (e.g. when
+    // a URL fetch resolves) and must see the current value, not a stale closure.
+    const versionIsDirty = useRef(false);
 
     const urlService: UrlService = useUrlService();
     const atService: ArtifactTypesService = useArtifactTypesService();
@@ -195,16 +199,26 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
     };
 
     const onFileTextChange = (_event: any, value: string | undefined): void => {
-        setData({
-            ...data,
+        // Auto-detect the version from the content (e.g. "info.version" in an OpenAPI or
+        // AsyncAPI spec), but only while the user has not edited the version themselves.
+        // The functional update matters: this handler can be called asynchronously (URL
+        // fetch, file read), so spreading a captured `data` could clobber newer state.
+        const detectedVersion: string | undefined = detectVersionInContent(value);
+        const applyDetectedVersion: boolean = !versionIsDirty.current;
+        setData(prevData => ({
+            ...prevData,
             firstVersion: {
-                ...data.firstVersion,
+                ...prevData.firstVersion,
+                version: applyDetectedVersion ? detectedVersion : prevData.firstVersion?.version,
                 content: {
                     content: value,
-                    contentType: detectContentType(data.artifactType, value)
+                    contentType: detectContentType(prevData.artifactType, value)
                 }
             }
-        });
+        }));
+        if (applyDetectedVersion) {
+            setAutoDetectedVersion(detectedVersion);
+        }
     };
 
     const onFileClear = (): void => {
@@ -220,6 +234,9 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
     };
 
     const setVersionNumber = (newVersion: string): void => {
+        // The user edited the version (including clearing it): stop auto-detecting.
+        versionIsDirty.current = true;
+        setAutoDetectedVersion(undefined);
         setData({
             ...data,
             firstVersion: {
@@ -313,6 +330,8 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
         if (props.isOpen) {
             setData(EMPTY_FORM_DATA);
             setVersionReferences([]);
+            setAutoDetectedVersion(undefined);
+            versionIsDirty.current = false;
             if (props.groupId) {
                 setGroupId(props.groupId);
             } else {
@@ -549,6 +568,13 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
                                 onChange={(_evt, value) => setVersionNumber(value)}
                                 // validated={groupValidated()}
                             />
+                            <If condition={autoDetectedVersion !== undefined && data.firstVersion?.version === autoDetectedVersion}>
+                                <FormHelperText>
+                                    <HelperText>
+                                        <HelperTextItem>Version detected from the content.</HelperTextItem>
+                                    </HelperText>
+                                </FormHelperText>
+                            </If>
                         </FormGroup>
                         <FormGroup label="Content" isRequired={false} fieldId="form-content">
                             <Tabs

--- a/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
+++ b/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
@@ -201,10 +201,12 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
     const onFileTextChange = (_event: any, value: string | undefined): void => {
         // Auto-detect the version from the content (e.g. "info.version" in an OpenAPI or
         // AsyncAPI spec), but only while the user has not edited the version themselves.
+        // When nothing is detected (non-spec content, or content that is transiently
+        // unparseable mid-edit) the previous value is preserved rather than cleared.
         // The functional update matters: this handler can be called asynchronously (URL
         // fetch, file read), so spreading a captured `data` could clobber newer state.
         const detectedVersion: string | undefined = detectVersionInContent(value);
-        const applyDetectedVersion: boolean = !versionIsDirty.current;
+        const applyDetectedVersion: boolean = !versionIsDirty.current && detectedVersion !== undefined;
         setData(prevData => ({
             ...prevData,
             firstVersion: {
@@ -237,13 +239,13 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
         // The user edited the version (including clearing it): stop auto-detecting.
         versionIsDirty.current = true;
         setAutoDetectedVersion(undefined);
-        setData({
-            ...data,
+        setData(prevData => ({
+            ...prevData,
             firstVersion: {
-                ...data.firstVersion,
+                ...prevData.firstVersion,
                 version: newVersion
             }
-        });
+        }));
     };
 
     const setVersionName = (newName: string): void => {

--- a/ui/ui-app/src/app/components/modals/CreateVersionModal.tsx
+++ b/ui/ui-app/src/app/components/modals/CreateVersionModal.tsx
@@ -1,16 +1,20 @@
-import { FunctionComponent, useEffect, useState } from "react";
+import { FunctionComponent, useEffect, useRef, useState } from "react";
 import {
     Button,
     FileUpload,
     Form,
     FormGroup,
+    FormHelperText,
+    HelperText,
+    HelperTextItem,
     TextInput
 } from "@patternfly/react-core";
 import {
     Modal
 } from "@patternfly/react-core/deprecated";
+import { If } from "@apicurio/common-ui-components";
 import { isStringEmptyOrUndefined } from "@utils/string.utils.ts";
-import { detectContentType } from "@utils/content.utils.ts";
+import { detectContentType, detectVersionInContent } from "@utils/content.utils.ts";
 import { CreateVersion } from "@sdk/lib/generated-client/models";
 import { ArtifactReferenceFormItem, ReferencesFormGroup, formItemsToReferences, isReferencesValid } from "@app/components";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
@@ -37,10 +41,21 @@ export const CreateVersionModal: FunctionComponent<CreateVersionModalProps> = (p
     const [isFormValid, setFormValid] = useState(false);
     const [references, setReferences] = useState<ArtifactReferenceFormItem[]>([]);
     const [isDetectingRefs, setIsDetectingRefs] = useState(false);
+    const [autoDetectedVersion, setAutoDetectedVersion] = useState<string | undefined>();
+    // Ref rather than state: content change handlers can fire asynchronously (e.g. when
+    // a file read finishes) and must see the current value, not a stale closure.
+    const versionIsDirty = useRef(false);
 
     const groupsService: GroupsService = useGroupsService();
 
     const onContentChange = (_event: any, value: any): void => {
+        // Auto-detect the version from the content (e.g. "info.version" in an OpenAPI or
+        // AsyncAPI spec), but only while the user has not edited the version themselves.
+        const detectedVersion: string | undefined = detectVersionInContent(value);
+        if (!versionIsDirty.current) {
+            setVersion(detectedVersion || "");
+            setAutoDetectedVersion(detectedVersion);
+        }
         setContent(value);
     };
 
@@ -96,6 +111,8 @@ export const CreateVersionModal: FunctionComponent<CreateVersionModalProps> = (p
             setVersion("");
             setContent("");
             setReferences([]);
+            setAutoDetectedVersion(undefined);
+            versionIsDirty.current = false;
         }
     }, [props.isOpen]);
 
@@ -140,9 +157,20 @@ export const CreateVersionModal: FunctionComponent<CreateVersionModalProps> = (p
                         value={version}
                         placeholder="Version (optional)"
                         onChange={(_evt, value) => {
+                            // The user edited the version (including clearing it): stop
+                            // auto-detecting.
+                            versionIsDirty.current = true;
+                            setAutoDetectedVersion(undefined);
                             setVersion(value);
                         }}
                     />
+                    <If condition={autoDetectedVersion !== undefined && version === autoDetectedVersion}>
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem>Version detected from the content.</HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
+                    </If>
                 </FormGroup>
                 <FormGroup
                     label="Content"

--- a/ui/ui-app/src/app/components/modals/CreateVersionModal.tsx
+++ b/ui/ui-app/src/app/components/modals/CreateVersionModal.tsx
@@ -51,9 +51,11 @@ export const CreateVersionModal: FunctionComponent<CreateVersionModalProps> = (p
     const onContentChange = (_event: any, value: any): void => {
         // Auto-detect the version from the content (e.g. "info.version" in an OpenAPI or
         // AsyncAPI spec), but only while the user has not edited the version themselves.
+        // When nothing is detected (non-spec content, or content that is transiently
+        // unparseable mid-edit) the previous value is preserved rather than cleared.
         const detectedVersion: string | undefined = detectVersionInContent(value);
-        if (!versionIsDirty.current) {
-            setVersion(detectedVersion || "");
+        if (!versionIsDirty.current && detectedVersion !== undefined) {
+            setVersion(detectedVersion);
             setAutoDetectedVersion(detectedVersion);
         }
         setContent(value);

--- a/ui/ui-app/src/utils/content.utils.test.ts
+++ b/ui/ui-app/src/utils/content.utils.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the artifact types service module: content.utils imports it only for the
+// ArtifactTypes constants, but loading the real module pulls the full service (and
+// PatternFly CSS) into the test runner, which node cannot parse.
+vi.mock("@services/useArtifactTypesService.ts", () => ({
+    ArtifactTypes: {
+        PROTOBUF: "PROTOBUF"
+    }
+}));
+
+import { detectVersionInContent } from "./content.utils";
+
+const OPENAPI_JSON: string = `{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Hello World API",
+        "version": "1.0.0"
+    }
+}`;
+
+const OPENAPI_YAML: string = `
+openapi: 3.0.2
+info:
+    title: Hello World API
+    version: 1.0.0
+`;
+
+const ASYNCAPI_YAML: string = `
+asyncapi: 2.1.0
+info:
+    title: Hello world application
+    version: '0.1.0'
+`;
+
+const SWAGGER_JSON: string = `{
+    "swagger": "2.0",
+    "info": {
+        "title": "Legacy API",
+        "version": "2.5"
+    }
+}`;
+
+const OPENAPI_NO_VERSION: string = `{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Hello World API"
+    }
+}`;
+
+const NON_SPEC_JSON: string = `{
+    "info": {
+        "version": "1.0.0"
+    },
+    "something": "else"
+}`;
+
+describe("detectVersionInContent", () => {
+    it("detects the version in an OpenAPI (JSON) spec", () => {
+        expect(detectVersionInContent(OPENAPI_JSON)).toBe("1.0.0");
+    });
+
+    it("detects the version in an OpenAPI (YAML) spec", () => {
+        expect(detectVersionInContent(OPENAPI_YAML)).toBe("1.0.0");
+    });
+
+    it("detects the version in an AsyncAPI (YAML) spec", () => {
+        expect(detectVersionInContent(ASYNCAPI_YAML)).toBe("0.1.0");
+    });
+
+    it("detects the version in a Swagger 2.0 spec", () => {
+        expect(detectVersionInContent(SWAGGER_JSON)).toBe("2.5");
+    });
+
+    it("returns undefined when the spec has no info.version", () => {
+        expect(detectVersionInContent(OPENAPI_NO_VERSION)).toBeUndefined();
+    });
+
+    it("returns undefined for content that is not an API spec", () => {
+        expect(detectVersionInContent(NON_SPEC_JSON)).toBeUndefined();
+    });
+
+    it("returns undefined for empty or undefined content", () => {
+        expect(detectVersionInContent(undefined)).toBeUndefined();
+        expect(detectVersionInContent("")).toBeUndefined();
+    });
+
+    it("returns undefined for content that cannot be parsed", () => {
+        expect(detectVersionInContent("this is just some text")).toBeUndefined();
+        expect(detectVersionInContent("syntax = \"proto3\";")).toBeUndefined();
+    });
+
+    it("returns undefined for a non-string version (unquoted YAML number is lossy)", () => {
+        expect(detectVersionInContent("openapi: 3.0.2\ninfo:\n    version: 1.0\n")).toBeUndefined();
+        expect(detectVersionInContent("{\"openapi\": \"3.0.2\", \"info\": {\"version\": {\"major\": 1}}}")).toBeUndefined();
+    });
+
+    it("returns undefined for multi-document YAML", () => {
+        expect(detectVersionInContent("openapi: 3.0.2\ninfo:\n    version: '1.0.0'\n---\nsecond: doc\n")).toBeUndefined();
+    });
+});

--- a/ui/ui-app/src/utils/content.utils.ts
+++ b/ui/ui-app/src/utils/content.utils.ts
@@ -132,6 +132,47 @@ export function detectContentType(artifactType: string | undefined | null, conte
 }
 
 
+/**
+ * Detects the version of an API specification from its content.  Supports JSON or YAML
+ * content that declares a top level "openapi", "asyncapi", or "swagger" property (so that
+ * arbitrary content with an unrelated "info" section is not matched).  Returns the value
+ * of the "info.version" property, or undefined if it is not present.
+ * @param content the content to inspect
+ */
+export function detectVersionInContent(content: string | undefined): string | undefined {
+    if (isStringEmptyOrUndefined(content)) {
+        return undefined;
+    }
+    // Parse the content only once (this runs on every content change): try JSON first,
+    // then fall back to YAML.
+    let parsed: any;
+    try {
+        parsed = JSON.parse(content as string);
+    } catch {
+        try {
+            parsed = YAML.parse(content as string);
+        } catch {
+            return undefined;
+        }
+    }
+    if (parsed === null || typeof parsed !== "object") {
+        return undefined;
+    }
+    const isApiSpec: boolean = parsed.openapi !== undefined || parsed.asyncapi !== undefined || parsed.swagger !== undefined;
+    if (!isApiSpec) {
+        return undefined;
+    }
+    // Both OpenAPI and AsyncAPI require "info.version" to be a string.  Anything else is
+    // ignored - e.g. an unquoted YAML number like "version: 1.0" parses (lossily) to the
+    // number 1, so prefilling from it would be misleading.
+    const version: any = parsed.info?.version;
+    if (typeof version === "string" && version.trim().length > 0) {
+        return version.trim();
+    }
+    return undefined;
+}
+
+
 export function contentTypeForDraft(draft: Draft, content: DraftContent): string {
     if (content.contentType) {
         return content.contentType;


### PR DESCRIPTION
Implements #1788: when the content added in the Create Artifact wizard or the Create Version modal is an OpenAPI, AsyncAPI, or Swagger document, the Version field is prefilled from the spec's `info.version`. The field stays fully editable, and a helper text ("Version detected from the content.") indicates when the current value came from the content.

Behavior details:

- The detected version is only applied while the user hasn't edited the Version field themselves. Any manual edit, including clearing the field to fall back to a server-generated version, turns auto-detection off for that dialog session. This is tracked with a ref (not state) so the async content paths (URL fetch or file read resolving after the user typed) can't overwrite a manually entered version with a stale value.
- Only a string `info.version` is used. OpenAPI and AsyncAPI both define it as a string, and unquoted YAML numbers parse lossily (`version: 1.0` becomes the number 1), which would prefill a misleading value.
- Content is only treated as an API spec if it has a top-level `openapi`, `asyncapi`, or `swagger` property, so unrelated JSON/YAML that happens to contain an `info.version` field is ignored.

Scope notes:

- The Create Draft modal was deliberately left out: its version field is on the Coordinates step, before any content exists, and back-filling it would re-trigger the coordinate-availability validation on a step the user already left. I think that needs its own UX discussion; happy to follow up if there's interest.
- The earlier discussion in this issue about failing a create when the content changed but the version didn't is server-side behavior and out of scope for this UI change (the server already rejects duplicate versions with a 409).

Testing: unit tests added for the new detection helper (`content.utils.test.ts`), covering OpenAPI/AsyncAPI/Swagger in JSON and YAML, missing and non-string versions, multi-document YAML, and non-spec content. Also verified manually against a local registry: both create flows, the manual-override case, and the cleared-field case. One observation from setting that up: CI currently doesn't run the ui-app vitest suite (the build-ui job runs lint and build only) — I can add a test step in a follow-up PR if that's welcome.

Screenshots:

Version auto-detected from pasted OpenAPI content (Create Artifact wizard):
<img width="1280" height="720" alt="2-after-autodetect" src="https://github.com/user-attachments/assets/50d077af-8a38-412a-a193-6e17248d9a3f" />

A manually entered version is never overwritten by content changes:
<img width="1280" height="720" alt="3-user-version-preserved" src="https://github.com/user-attachments/assets/846b29b1-5408-4059-ac6d-1b2a289d3a49" />

Same behavior in the Create Version modal:
<img width="1280" height="720" alt="5-create-version-autodetect" src="https://github.com/user-attachments/assets/e3171b04-c8d7-4ce1-ba9e-e256c9dd374e" />

Closes #1788

Note: this replaces #9080, which was auto-closed by the PR limit check while my previous PR (#9058, now closed) was still open.