### PR TITLE
docs(ui-app): fix config directory reference (config -> configs)

### DIFF
--- a/ui/ui-app/README.md
+++ b/ui/ui-app/README.md
@@ -17,7 +17,7 @@ Run a full build
 Initialize config.js
 `./init-dev.sh`
 
-Note: the init-dev.sh script just copies an appropriate file from config/config-*.js to the right place.  You can 
+Note: the init-dev.sh script just copies an appropriate file from configs/config-*.js to the right place.  You can 
 either specify `local` or `3scale` (for example) as the argument to the script.  The choice depends on how you are 
 running the back-end component.
 


### PR DESCRIPTION
Fixes #8535
   
   Corrected the README to reference the `configs/` directory instead of the incorrect `config/` path.