### PR TITLE
docs(gitops): fix broken relative links in gitops storage README

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/README.md
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/README.md
@@ -175,7 +175,7 @@ code review. The registry handles conflict detection if two repos define the sam
 
 In environments where outbound network access is restricted, an external process pushes changes to a
 Git repository hosted inside the cluster. The sidecar exposes an SSH endpoint for receiving pushes.
-See [`distro/gitops/README.md`](../../../../distro/gitops/README.md) for push mode configuration.
+See [`distro/gitops/README.md`](../../../../../../../../../../distro/gitops/README.md) for push mode configuration.
 
 ### PR Verification with CI/CD
 
@@ -389,7 +389,7 @@ Error categories:
 
 A pre-built container image (`quay.io/apicurio/apicurio-registry-gitops-sync`) is available
 for pulling from remote Git repositories. It runs as a sidecar alongside the registry,
-managing a shared volume. See [`distro/gitops/README.md`](../../../../distro/gitops/README.md)
+managing a shared volume. See [`distro/gitops/README.md`](../../../../../../../../../../distro/gitops/README.md)
 for configuration, security levels, and deployment details.
 
 ## Future Work
@@ -407,7 +407,7 @@ For the full design document and implementation plan, see the
 
 ### Docker Compose
 
-For complete working examples with Docker Compose, see [`examples/gitops/`](../../../../examples/gitops/).
+For complete working examples with Docker Compose, see [`examples/gitops/`](../../../../../../../../../../examples/gitops/).
 
 ### Kubernetes / OpenShift (Operator)
 
@@ -447,7 +447,7 @@ gitops:
 
 Additional configuration (custom sidecar image, extra env vars) is done via `podTemplateSpec`
 overrides. See the operator example CRs for all supported scenarios:
-[`operator/controller/src/test/resources/k8s/examples/gitops/`](../../../../operator/controller/src/test/resources/k8s/examples/gitops/).
+[`operator/controller/src/test/resources/k8s/examples/gitops/`](../../../../../../../../../../operator/controller/src/test/resources/k8s/examples/gitops/).
 
 <!--
 

--- a/ui/ui-app/README.md
+++ b/ui/ui-app/README.md
@@ -17,7 +17,7 @@ Run a full build
 Initialize config.js
 `./init-dev.sh`
 
-Note: the init-dev.sh script just copies an appropriate file from config/config-*.js to the right place.  You can 
+Note: the init-dev.sh script just copies an appropriate file from configs/config-*.js to the right place.  You can 
 either specify `local` or `3scale` (for example) as the argument to the script.  The choice depends on how you are 
 running the back-end component.
 


### PR DESCRIPTION
Fixes #9087

Corrected 4 relative markdown links in the GitOps storage README that used only `../../../../` (4 levels up) when the file is actually 10 directories deep from repo root (`app/src/main/java/io/apicurio/registry/storage/impl/gitops/`). Verified `../../../../distro/gitops/README.md` was resolving to a 404'd path; all links now correctly use `../../../../../../../../../../` to reach repo root.