### PR TITLE
fix(ui): reset reauthentication state when interceptor is unregistered

### DIFF
--- a/ui/ui-app/src/services/useReauthenticationService.test.ts
+++ b/ui/ui-app/src/services/useReauthenticationService.test.ts
@@ -47,20 +47,35 @@ describe("useReauthenticationService", () => {
     });
 
     it("should cancel pending state when interceptor is unregistered while pending", async () => {
-        const interceptor = vi.fn().mockResolvedValue(true);
-        const unregister = registerInterceptor(interceptor);
+        // 1. Return a never-resolving promise to simulate a truly in-flight re-authentication flow
+        const pendingPromise = new Promise<boolean>(() => {});
+        const firstInterceptor = vi.fn().mockReturnValue(pendingPromise);
+        const unregisterFirst = registerInterceptor(firstInterceptor);
 
-        const promise = service.requestReauthentication(mockAuth);
+        // 2. Trigger requestReauthentication
+        service.requestReauthentication(mockAuth);
         expect(service.isReauthenticationPending()).toBe(true);
+        expect(firstInterceptor).toHaveBeenCalledTimes(1);
 
-        // Unregister the interceptor while re-auth is pending
-        unregister();
+        // 3. Unregister the interceptor while the promise is still pending
+        unregisterFirst();
 
+        // Verify the pending state is cleaned up as expected
         expect(service.isReauthenticationPending()).toBe(false);
-        await promise;
 
-        // Post-await assertion to ensure it remains false
-        expect(service.isReauthenticationPending()).toBe(false);
+        // 4. Register a new interceptor
+        const secondInterceptor = vi.fn().mockResolvedValue(true);
+        registerInterceptor(secondInterceptor);
+
+        // 5. Trigger a second requestReauthentication and assert a fresh flow starts
+        const promise2 = service.requestReauthentication(mockAuth);
+        expect(service.isReauthenticationPending()).toBe(true);
+        expect(secondInterceptor).toHaveBeenCalledTimes(1);
+
+        await expect(promise2).resolves.toBe(true);
+
+        // Ensure the first interceptor was not invoked again
+        expect(firstInterceptor).toHaveBeenCalledTimes(1);
     });
 
     it("should trigger redirect if no interceptor is registered", async () => {

--- a/ui/ui-app/src/services/useReauthenticationService.test.ts
+++ b/ui/ui-app/src/services/useReauthenticationService.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { getReauthenticationService } from "./useReauthenticationService";
+import { AuthService } from "@apicurio/common-ui-components";
+
+describe("useReauthenticationService", () => {
+    const service = getReauthenticationService();
+
+    // Helper mock for AuthService
+    const mockAuth = {
+        isOidcAuthEnabled: () => true,
+        login: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AuthService;
+
+    beforeEach(() => {
+        service.cancelReauthentication();
+    });
+
+    it("should initially not be pending", () => {
+        expect(service.isReauthenticationPending()).toBe(false);
+    });
+
+    it("should become pending when requesting re-authentication and invoke the interceptor", async () => {
+        const interceptor = vi.fn().mockResolvedValue(true);
+        const unregister = service.registerReauthenticationInterceptor(interceptor);
+
+        const promise = service.requestReauthentication(mockAuth);
+        expect(service.isReauthenticationPending()).toBe(true);
+
+        const result = await promise;
+        expect(result).toBe(true);
+        expect(interceptor).toHaveBeenCalledTimes(1);
+        expect(service.isReauthenticationPending()).toBe(true); // remains pending until explicitly dismissed
+
+        unregister();
+    });
+
+    it("should cancel pending state when interceptor is unregistered while pending", async () => {
+        const interceptor = vi.fn().mockResolvedValue(true);
+        const unregister = service.registerReauthenticationInterceptor(interceptor);
+
+        const promise = service.requestReauthentication(mockAuth);
+        expect(service.isReauthenticationPending()).toBe(true);
+
+        // Unregister the interceptor while re-auth is pending
+        unregister();
+
+        expect(service.isReauthenticationPending()).toBe(false);
+        await promise;
+    });
+
+    it("should trigger redirect if no interceptor is registered", async () => {
+        const redirectMockAuth = {
+            isOidcAuthEnabled: () => true,
+            login: vi.fn().mockResolvedValue(undefined),
+        } as unknown as AuthService;
+
+        const promise = service.requestReauthentication(redirectMockAuth);
+        expect(service.isReauthenticationPending()).toBe(true);
+
+        await promise;
+        expect(redirectMockAuth.login).toHaveBeenCalledTimes(1);
+    });
+});

--- a/ui/ui-app/src/services/useReauthenticationService.test.ts
+++ b/ui/ui-app/src/services/useReauthenticationService.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { getReauthenticationService } from "./useReauthenticationService";
 import { AuthService } from "@apicurio/common-ui-components";
 
 describe("useReauthenticationService", () => {
     const service = getReauthenticationService();
+    let cleanups: Array<() => void> = [];
 
     // Helper mock for AuthService
     const mockAuth = {
@@ -13,7 +14,20 @@ describe("useReauthenticationService", () => {
 
     beforeEach(() => {
         service.cancelReauthentication();
+        cleanups = [];
     });
+
+    afterEach(() => {
+        cleanups.forEach(fn => fn());
+        cleanups = [];
+        service.cancelReauthentication();
+    });
+
+    const registerInterceptor = (interceptor: any) => {
+        const unregister = service.registerReauthenticationInterceptor(interceptor);
+        cleanups.push(unregister);
+        return unregister;
+    };
 
     it("should initially not be pending", () => {
         expect(service.isReauthenticationPending()).toBe(false);
@@ -21,7 +35,7 @@ describe("useReauthenticationService", () => {
 
     it("should become pending when requesting re-authentication and invoke the interceptor", async () => {
         const interceptor = vi.fn().mockResolvedValue(true);
-        const unregister = service.registerReauthenticationInterceptor(interceptor);
+        registerInterceptor(interceptor);
 
         const promise = service.requestReauthentication(mockAuth);
         expect(service.isReauthenticationPending()).toBe(true);
@@ -30,13 +44,11 @@ describe("useReauthenticationService", () => {
         expect(result).toBe(true);
         expect(interceptor).toHaveBeenCalledTimes(1);
         expect(service.isReauthenticationPending()).toBe(true); // remains pending until explicitly dismissed
-
-        unregister();
     });
 
     it("should cancel pending state when interceptor is unregistered while pending", async () => {
         const interceptor = vi.fn().mockResolvedValue(true);
-        const unregister = service.registerReauthenticationInterceptor(interceptor);
+        const unregister = registerInterceptor(interceptor);
 
         const promise = service.requestReauthentication(mockAuth);
         expect(service.isReauthenticationPending()).toBe(true);
@@ -46,6 +58,9 @@ describe("useReauthenticationService", () => {
 
         expect(service.isReauthenticationPending()).toBe(false);
         await promise;
+
+        // Post-await assertion to ensure it remains false
+        expect(service.isReauthenticationPending()).toBe(false);
     });
 
     it("should trigger redirect if no interceptor is registered", async () => {

--- a/ui/ui-app/src/services/useReauthenticationService.ts
+++ b/ui/ui-app/src/services/useReauthenticationService.ts
@@ -108,6 +108,9 @@ function createReauthenticationService(): ReauthenticationService {
             return () => {
                 if (interceptor === nextInterceptor) {
                     interceptor = undefined;
+                    if (isPending) {
+                        cancelReauthentication();
+                    }
                 }
             };
         },


### PR DESCRIPTION
## Summary

This PR fixes a UI issue where the global re-authentication service could remain in a pending state after the active re-authentication interceptor is unregistered.

If a component that registers a custom interceptor (such as the Editor page) is unmounted while a re-authentication flow is pending, the interceptor is removed but the pending state is not cleared. As a result, subsequent `401 Unauthorized` responses may not trigger a new re-authentication flow.

## Changes

* Clear the pending re-authentication state when the active interceptor is unregistered.
* Preserve the existing re-authentication flow when the interceptor remains registered.
* Add unit tests covering:

  * Initial service state.
  * Custom interceptor flow.
  * Cleanup of pending state when the active interceptor is unregistered.
  * Default OIDC redirect behavior when no interceptor is registered.

## Testing

* Added regression tests for the re-authentication service.
* Verified all unit tests pass.
* Verified lint checks pass.

## Related Issue

Fixes #9096
