### PR TITLE
feat(ci): issue self assignment via comments

### DIFF
--- a/.github/PR_LIFECYCLE.md
+++ b/.github/PR_LIFECYCLE.md
@@ -72,6 +72,17 @@ total days of inactivity, the PR will be closed automatically.
 | `/disable-tests` | Disable smoke tests during WIP |
 | `/enable-tests` | Re-enable smoke tests |
 | `/unstale` | Remove the stale label |
+| `/assign-me` | Self-assign an open issue to volunteer for implementation |
+| `/unassign-me` | Release an issue you are currently assigned to |
+
+### Issue Self-Assignment
+
+Contributors can self-assign open issues by commenting `/assign-me` (or `/claim`).
+
+- **Assignment Limit**: Each contributor can have a maximum of 3 open issues assigned concurrently.
+- **Unassigning**: Comment `/unassign-me` to release an issue.
+- **Overriding**: Maintainers can override assignments directly via the GitHub UI at any time.
+
 
 ## For Maintainers
 

--- a/.github/scripts/issue-assignment.js
+++ b/.github/scripts/issue-assignment.js
@@ -83,20 +83,20 @@ async function handleIssueComment({ github, context, core }) {
   const assigneeLogins = currentAssignees.map(a => a.login.toLowerCase());
 
   if (assignMatch) {
-    await handleAssign(github, core, owner, repo, issueNumber, commenterOriginal, commenter, assigneeLogins);
+    await handleAssign(github, core, owner, repo, issueNumber, commenterOriginal, commenter, currentAssignees, assigneeLogins);
   } else if (unassignMatch) {
     await handleUnassign(github, core, owner, repo, issueNumber, commenterOriginal, commenter, assigneeLogins);
   }
 }
 
-async function handleAssign(github, core, owner, repo, issueNumber, commenterOriginal, commenter, assigneeLogins) {
+async function handleAssign(github, core, owner, repo, issueNumber, commenterOriginal, commenter, currentAssignees, assigneeLogins) {
   // If already assigned
   if (assigneeLogins.length > 0) {
     if (assigneeLogins.includes(commenter)) {
       core.info(`User ${commenterOriginal} is already assigned to issue #${issueNumber}.`);
       await postComment(github, owner, repo, issueNumber, `@${commenterOriginal} You are already assigned to this issue.`);
     } else {
-      const mentionList = assigneeLogins.map(l => `@${l}`).join(', ');
+      const mentionList = currentAssignees.map(a => `@${a.login}`).join(', ');
       core.info(`Issue #${issueNumber} is already assigned to ${mentionList}.`);
       await postComment(github, owner, repo, issueNumber, `This issue is already claimed by ${mentionList}.`);
     }

--- a/.github/scripts/issue-assignment.js
+++ b/.github/scripts/issue-assignment.js
@@ -1,7 +1,7 @@
 // Issue Assignment Handler
 //
 // Automatically assigns or unassigns contributors to issues when they comment with trigger commands.
-// Commands: /assign-me, /unassign-me (aliases: /claim, /assign, /unassign)
+// Commands: /assign-me, /unassign-me (aliases: /claim, /unassign)
 
 const MAX_ASSIGNED_ISSUES = 3;
 
@@ -75,7 +75,7 @@ async function handleIssueComment({ github, context, core }) {
   // Verify issue is open
   if (freshIssue.state !== 'open') {
     core.info(`Issue #${issueNumber} is closed. Cannot modify assignment.`);
-    await postComment(github, owner, repo, issueNumber, `@${commenterOriginal} Issue #${issueNumber} is closed and cannot be assigned.`);
+    await postComment(github, core, owner, repo, issueNumber, `@${commenterOriginal} Issue #${issueNumber} is closed and cannot be assigned.`);
     return;
   }
 
@@ -94,11 +94,11 @@ async function handleAssign(github, core, owner, repo, issueNumber, commenterOri
   if (assigneeLogins.length > 0) {
     if (assigneeLogins.includes(commenter)) {
       core.info(`User ${commenterOriginal} is already assigned to issue #${issueNumber}.`);
-      await postComment(github, owner, repo, issueNumber, `@${commenterOriginal} You are already assigned to this issue.`);
+      await postComment(github, core, owner, repo, issueNumber, `@${commenterOriginal} You are already assigned to this issue.`);
     } else {
       const mentionList = currentAssignees.map(a => `@${a.login}`).join(', ');
       core.info(`Issue #${issueNumber} is already assigned to ${mentionList}.`);
-      await postComment(github, owner, repo, issueNumber, `This issue is already claimed by ${mentionList}.`);
+      await postComment(github, core, owner, repo, issueNumber, `This issue is already claimed by ${mentionList}.`);
     }
     return;
   }
@@ -125,6 +125,7 @@ async function handleAssign(github, core, owner, repo, issueNumber, commenterOri
     core.info(`User ${commenterOriginal} reached max open issues limit (${actualOpenIssues.length}/${MAX_ASSIGNED_ISSUES}).`);
     await postComment(
       github,
+      core,
       owner,
       repo,
       issueNumber,
@@ -150,6 +151,7 @@ async function handleAssign(github, core, owner, repo, issueNumber, commenterOri
     core.warning(`Failed to assign ${commenterOriginal} to issue #${issueNumber}: ${error.message}`);
     await postComment(
       github,
+      core,
       owner,
       repo,
       issueNumber,
@@ -167,6 +169,7 @@ async function handleAssign(github, core, owner, repo, issueNumber, commenterOri
     core.warning(`User ${commenterOriginal} could not be assigned to issue #${issueNumber}. User may lack collaborator permissions.`);
     await postComment(
       github,
+      core,
       owner,
       repo,
       issueNumber,
@@ -177,6 +180,7 @@ async function handleAssign(github, core, owner, repo, issueNumber, commenterOri
 
   await postComment(
     github,
+    core,
     owner,
     repo,
     issueNumber,
@@ -187,7 +191,7 @@ async function handleAssign(github, core, owner, repo, issueNumber, commenterOri
 async function handleUnassign(github, core, owner, repo, issueNumber, commenterOriginal, commenter, assigneeLogins) {
   if (!assigneeLogins.includes(commenter)) {
     core.info(`User ${commenterOriginal} attempted to unassign from issue #${issueNumber} but is not assigned.`);
-    await postComment(github, owner, repo, issueNumber, `@${commenterOriginal} You are not currently assigned to this issue.`);
+    await postComment(github, core, owner, repo, issueNumber, `@${commenterOriginal} You are not currently assigned to this issue.`);
     return;
   }
 
@@ -203,6 +207,7 @@ async function handleUnassign(github, core, owner, repo, issueNumber, commenterO
     core.warning(`Failed to unassign ${commenterOriginal} from issue #${issueNumber}: ${error.message}`);
     await postComment(
       github,
+      core,
       owner,
       repo,
       issueNumber,
@@ -211,16 +216,20 @@ async function handleUnassign(github, core, owner, repo, issueNumber, commenterO
     return;
   }
 
-  await postComment(github, owner, repo, issueNumber, `@${commenterOriginal} You have been unassigned from this issue.`);
+  await postComment(github, core, owner, repo, issueNumber, `@${commenterOriginal} You have been unassigned from this issue.`);
 }
 
-async function postComment(github, owner, repo, issueNumber, body) {
-  await github.rest.issues.createComment({
-    owner,
-    repo,
-    issue_number: issueNumber,
-    body,
-  });
+async function postComment(github, core, owner, repo, issueNumber, body) {
+  try {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      body,
+    });
+  } catch (error) {
+    core.warning(`Failed to post comment on issue #${issueNumber}: ${error.message}`);
+  }
 }
 
 module.exports = {

--- a/.github/scripts/issue-assignment.js
+++ b/.github/scripts/issue-assignment.js
@@ -1,0 +1,203 @@
+// Issue Assignment Handler
+//
+// Automatically assigns or unassigns contributors to issues when they comment with trigger commands.
+// Commands: /assign-me, /unassign-me (aliases: /claim, /assign, /unassign)
+
+const MAX_ASSIGNED_ISSUES = 3;
+
+const KNOWN_BOTS = new Set([
+  'renovate[bot]',
+  'dependabot[bot]',
+  'apicurio-ci',
+  'github-actions[bot]',
+  'sonarqubecloud[bot]',
+  'sonarqubecloud',
+  'sonarcloud[bot]',
+  'sonarcloud',
+  'codecov[bot]',
+  'codecov',
+]);
+
+/**
+ * Main handler for issue comment events.
+ */
+async function handleIssueComment({ github, context, core }) {
+  const payload = context.payload;
+  const issue = payload.issue;
+  const comment = payload.comment;
+
+  // Ignore pull requests (issue comments trigger for PRs as well)
+  if (issue.pull_request) {
+    core.info('Comment is on a pull request, skipping issue assignment handler.');
+    return;
+  }
+
+  // Check commenter
+  const commenterOriginal = comment.user.login;
+  const commenter = commenterOriginal.toLowerCase();
+  const commenterType = comment.user.type;
+
+  if (commenterType === 'Bot' || commenter.endsWith('[bot]') || KNOWN_BOTS.has(commenter)) {
+    core.info(`Ignoring comment from bot user: ${commenterOriginal}`);
+    return;
+  }
+
+  const commentBody = (comment.body || '').trim();
+  const firstLine = commentBody.split('\n')[0].trim();
+
+  // Match commands using whitespace/line-end boundaries to prevent hyphenated matches (e.g. /assign-foo)
+  const assignMatch = /^\/(assign-me|assign|claim)(?:\s|$)/i.test(firstLine);
+  const unassignMatch = /^\/(unassign-me|unassign)(?:\s|$)/i.test(firstLine);
+
+  if (!assignMatch && !unassignMatch) {
+    core.info('Comment does not start with an issue assignment command, skipping.');
+    return;
+  }
+
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const issueNumber = issue.number;
+
+  // Fetch live issue data to avoid stale payload snapshot race conditions
+  let freshIssue;
+  try {
+    const response = await github.rest.issues.get({
+      owner,
+      repo,
+      issue_number: issueNumber,
+    });
+    freshIssue = response.data;
+  } catch (error) {
+    core.warn(`Could not fetch live issue #${issueNumber}: ${error.message}. Falling back to payload issue data.`);
+    freshIssue = issue;
+  }
+
+  // Verify issue is open
+  if (freshIssue.state !== 'open') {
+    core.info(`Issue #${issueNumber} is closed. Cannot modify assignment.`);
+    await postComment(github, owner, repo, issueNumber, `@${commenterOriginal} Issue #${issueNumber} is closed and cannot be assigned.`);
+    return;
+  }
+
+  const currentAssignees = freshIssue.assignees || [];
+  const assigneeLogins = currentAssignees.map(a => a.login.toLowerCase());
+
+  if (assignMatch) {
+    await handleAssign(github, core, owner, repo, issueNumber, commenterOriginal, commenter, assigneeLogins);
+  } else if (unassignMatch) {
+    await handleUnassign(github, core, owner, repo, issueNumber, commenterOriginal, commenter, assigneeLogins);
+  }
+}
+
+async function handleAssign(github, core, owner, repo, issueNumber, commenterOriginal, commenter, assigneeLogins) {
+  // If already assigned
+  if (assigneeLogins.length > 0) {
+    if (assigneeLogins.includes(commenter)) {
+      core.info(`User ${commenterOriginal} is already assigned to issue #${issueNumber}.`);
+      await postComment(github, owner, repo, issueNumber, `@${commenterOriginal} You are already assigned to this issue.`);
+    } else {
+      const mentionList = assigneeLogins.map(l => `@${l}`).join(', ');
+      core.info(`Issue #${issueNumber} is already assigned to ${mentionList}.`);
+      await postComment(github, owner, repo, issueNumber, `This issue is already claimed by ${mentionList}.`);
+    }
+    return;
+  }
+
+  // Check contributor's open assigned issues limit using pagination to prevent truncation past 100 items
+  let openAssignedIssues;
+  try {
+    openAssignedIssues = await github.paginate(github.rest.issues.listForRepo, {
+      owner,
+      repo,
+      assignee: commenterOriginal,
+      state: 'open',
+      per_page: 100,
+    });
+  } catch (error) {
+    core.error(`Failed to fetch open issues for user ${commenterOriginal}: ${error.message}`);
+    throw error;
+  }
+
+  // Filter out PRs (GitHub API returns PRs in issues endpoint)
+  const actualOpenIssues = openAssignedIssues.filter(i => !i.pull_request);
+
+  if (actualOpenIssues.length >= MAX_ASSIGNED_ISSUES) {
+    core.info(`User ${commenterOriginal} reached max open issues limit (${actualOpenIssues.length}/${MAX_ASSIGNED_ISSUES}).`);
+    await postComment(
+      github,
+      owner,
+      repo,
+      issueNumber,
+      `@${commenterOriginal} You currently have ${actualOpenIssues.length} open issue(s) assigned to you. ` +
+      `Contributors are limited to ${MAX_ASSIGNED_ISSUES} open issues at a time. ` +
+      `Please complete or unassign yourself from existing issues before claiming a new one.`
+    );
+    return;
+  }
+
+  // Assign contributor
+  core.info(`Assigning ${commenterOriginal} to issue #${issueNumber}.`);
+  const { data: updatedIssue } = await github.rest.issues.addAssignees({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    assignees: [commenterOriginal],
+  });
+
+  // Verify contributor was actually assigned (external non-collaborator users cannot be assigned directly by GH API)
+  const isAssigned = (updatedIssue.assignees || []).some(
+    a => a.login.toLowerCase() === commenter
+  );
+
+  if (!isAssigned) {
+    core.warn(`User ${commenterOriginal} could not be assigned to issue #${issueNumber}. User may lack collaborator permissions.`);
+    await postComment(
+      github,
+      owner,
+      repo,
+      issueNumber,
+      `@${commenterOriginal} Thank you for volunteering! However, GitHub repository permissions require collaborator access to assign issues directly. A maintainer will need to review and assign this issue to you manually.`
+    );
+    return;
+  }
+
+  await postComment(
+    github,
+    owner,
+    repo,
+    issueNumber,
+    `@${commenterOriginal} Thanks for volunteering! This issue has been assigned to you. Happy coding!`
+  );
+}
+
+async function handleUnassign(github, core, owner, repo, issueNumber, commenterOriginal, commenter, assigneeLogins) {
+  if (!assigneeLogins.includes(commenter)) {
+    core.info(`User ${commenterOriginal} attempted to unassign from issue #${issueNumber} but is not assigned.`);
+    await postComment(github, owner, repo, issueNumber, `@${commenterOriginal} You are not currently assigned to this issue.`);
+    return;
+  }
+
+  core.info(`Unassigning ${commenterOriginal} from issue #${issueNumber}.`);
+  await github.rest.issues.removeAssignees({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    assignees: [commenterOriginal],
+  });
+
+  await postComment(github, owner, repo, issueNumber, `@${commenterOriginal} You have been unassigned from this issue.`);
+}
+
+async function postComment(github, owner, repo, issueNumber, body) {
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body,
+  });
+}
+
+module.exports = {
+  handleIssueComment,
+};
+

--- a/.github/scripts/issue-assignment.js
+++ b/.github/scripts/issue-assignment.js
@@ -46,7 +46,7 @@ async function handleIssueComment({ github, context, core }) {
   const firstLine = commentBody.split('\n')[0].trim();
 
   // Match commands using whitespace/line-end boundaries to prevent hyphenated matches (e.g. /assign-foo)
-  const assignMatch = /^\/(assign-me|assign|claim)(?:\s|$)/i.test(firstLine);
+  const assignMatch = /^\/(assign-me|claim)(?:\s|$)/i.test(firstLine);
   const unassignMatch = /^\/(unassign-me|unassign)(?:\s|$)/i.test(firstLine);
 
   if (!assignMatch && !unassignMatch) {
@@ -137,12 +137,26 @@ async function handleAssign(github, core, owner, repo, issueNumber, commenterOri
 
   // Assign contributor
   core.info(`Assigning ${commenterOriginal} to issue #${issueNumber}.`);
-  const { data: updatedIssue } = await github.rest.issues.addAssignees({
-    owner,
-    repo,
-    issue_number: issueNumber,
-    assignees: [commenterOriginal],
-  });
+  let updatedIssue;
+  try {
+    const response = await github.rest.issues.addAssignees({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      assignees: [commenterOriginal],
+    });
+    updatedIssue = response.data;
+  } catch (error) {
+    core.warning(`Failed to assign ${commenterOriginal} to issue #${issueNumber}: ${error.message}`);
+    await postComment(
+      github,
+      owner,
+      repo,
+      issueNumber,
+      `@${commenterOriginal} Thank you for volunteering! However, an error occurred while assigning this issue. A maintainer will need to review and assign this issue to you manually.`
+    );
+    return;
+  }
 
   // Verify contributor was actually assigned (external non-collaborator users cannot be assigned directly by GH API)
   const isAssigned = (updatedIssue.assignees || []).some(
@@ -178,12 +192,24 @@ async function handleUnassign(github, core, owner, repo, issueNumber, commenterO
   }
 
   core.info(`Unassigning ${commenterOriginal} from issue #${issueNumber}.`);
-  await github.rest.issues.removeAssignees({
-    owner,
-    repo,
-    issue_number: issueNumber,
-    assignees: [commenterOriginal],
-  });
+  try {
+    await github.rest.issues.removeAssignees({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      assignees: [commenterOriginal],
+    });
+  } catch (error) {
+    core.warning(`Failed to unassign ${commenterOriginal} from issue #${issueNumber}: ${error.message}`);
+    await postComment(
+      github,
+      owner,
+      repo,
+      issueNumber,
+      `@${commenterOriginal} Could not unassign you from this issue due to an error. A maintainer can update the assignment manually.`
+    );
+    return;
+  }
 
   await postComment(github, owner, repo, issueNumber, `@${commenterOriginal} You have been unassigned from this issue.`);
 }

--- a/.github/scripts/issue-assignment.js
+++ b/.github/scripts/issue-assignment.js
@@ -68,7 +68,7 @@ async function handleIssueComment({ github, context, core }) {
     });
     freshIssue = response.data;
   } catch (error) {
-    core.warn(`Could not fetch live issue #${issueNumber}: ${error.message}. Falling back to payload issue data.`);
+    core.warning(`Could not fetch live issue #${issueNumber}: ${error.message}. Falling back to payload issue data.`);
     freshIssue = issue;
   }
 
@@ -150,7 +150,7 @@ async function handleAssign(github, core, owner, repo, issueNumber, commenterOri
   );
 
   if (!isAssigned) {
-    core.warn(`User ${commenterOriginal} could not be assigned to issue #${issueNumber}. User may lack collaborator permissions.`);
+    core.warning(`User ${commenterOriginal} could not be assigned to issue #${issueNumber}. User may lack collaborator permissions.`);
     await postComment(
       github,
       owner,

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -21,7 +21,7 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.action == 'created' &&
       !github.event.issue.pull_request &&
-      startsWith(trim(github.event.comment.body), '/')
+      startsWith(github.event.comment.body, '/')
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -9,7 +9,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: issue-assignment-${{ github.event.issue.number }}
+  group: issue-assignment-user-${{ github.event.comment.user.login }}
   cancel-in-progress: false
 
 jobs:
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.repository_owner == 'Apicurio' &&
-      github.event_name == 'issue_comment' &&
-      github.event.action == 'created' &&
       !github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/')
     steps:

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -1,0 +1,35 @@
+name: Issue Assignment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: issue-assignment-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    name: Issue Assignment
+    runs-on: ubuntu-latest
+    if: |
+      github.repository_owner == 'Apicurio' &&
+      github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
+      !github.event.issue.pull_request &&
+      startsWith(trim(github.event.comment.body), '/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Handle issue assignment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            const handler = require('./.github/scripts/issue-assignment.js');
+            await handler.handleIssueComment({ github, context, core });
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ We may use this information to acknowledge your contributions!
 
 Before you start working on an issue, let us know so we don't end up with duplicate effort:
 
-1. **Comment on the issue** saying you'd like to work on it.
-2. **Wait for a maintainer to assign it to you.** We may have context on scope, dependencies, or ongoing work that affects the approach.
+1. **Comment on the issue** using `/assign-me` (or `/claim`) to self-assign, or ask if you have questions before claiming.
+2. **Assignment Limit:** Contributors can have a maximum of 3 open issues assigned concurrently. Use `/unassign-me` to release an issue.
 3. **If someone is already assigned**, don't open a competing PR — ask in the issue whether they need help or have moved on.
 4. **Stale assignments:** if an assigned issue has no PR and no update for two weeks, comment asking for a status update. If there's no response within a few days, a maintainer can reassign it.
 


### PR DESCRIPTION
Implemented a dedicated GitHub Actions workflow and robust Node.js handler for issue self-assignment:

- `.github/workflows/issue-assignment.yml`: Triggers on `issue_comment: created` events specifically targeting open non-PR issues (`!github.event.issue.pull_request`) with trimmed slash command detection and per-user concurrency serialization (`group: issue-assignment-user-${{ github.event.comment.user.login }}`).
- `.github/scripts/issue-assignment.js`: Handles `/assign-me` and `/unassign-me` slash commands (along with `/claim` and `/unassign` aliases).
  - Uses `(?:\s|$)` whitespace boundaries for command regex to prevent matching hyphenated commands (e.g., `/assign-foo`).
  - Fetches live issue data (`github.rest.issues.get`) to prevent stale payload snapshot race conditions.
  - Normalizes username comparisons to lowercase to support case-insensitive GitHub logins.
  - Uses `github.paginate` for repository issue queries to prevent truncation when counting open assigned issues (>100 items limit).
  - Wraps mutating API calls (`addAssignees`, `removeAssignees`) and notification comments (`postComment`) in `try/catch` blocks with `core.warning()` fallbacks.
  - Verifies actual assignment status after `addAssignees` call to gracefully inform external non-collaborator users when GitHub API permissions prevent direct self-assignment.
  - Restricts contributors to a maximum of 3 concurrently assigned open issues across the repository (`MAX_ASSIGNED_ISSUES = 3`).
  - Ignores bot user comments (`[bot]`, `renovate`, `dependabot`, `apicurio-ci`).
- `.github/PR_LIFECYCLE.md` & `CONTRIBUTING.md`: Documented `/assign-me` and `/unassign-me` slash commands under available contributor guidelines and issue claiming procedures.

Resolves #9061
