### PR TITLE
fix(import-export): preserve contract rules in registry backups (#8980)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/shared/DataExporter.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/shared/DataExporter.java
@@ -7,11 +7,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
-import org.slf4j.Logger;
-
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.ZipOutputStream;
 
 /**
@@ -19,9 +17,6 @@ import java.util.zip.ZipOutputStream;
  */
 @ApplicationScoped
 public class DataExporter {
-
-    @Inject
-    Logger log;
 
     @Inject
     @Current
@@ -41,24 +36,17 @@ public class DataExporter {
      */
     public Response exportData(String groupId) {
         StreamingOutput stream = os -> {
-            try {
-                ZipOutputStream zip = new ZipOutputStream(os, StandardCharsets.UTF_8);
+            try (ZipOutputStream zip = new ZipOutputStream(os, StandardCharsets.UTF_8)) {
                 EntityWriter writer = new EntityWriter(zip);
-                AtomicInteger errorCounter = new AtomicInteger(0);
                 storage.exportData(groupId, entity -> {
                     try {
                         writer.writeEntity(entity);
-                    } catch (Exception e) {
-                        log.error("Error writing entity", e);
-                        errorCounter.incrementAndGet();
+                    } catch (IOException e) {
+                        throw new UncheckedIOException("Error writing entity", e);
                     }
                     return null;
                 });
-
-                // TODO if the errorCounter > 0, then what?
-
                 zip.flush();
-                zip.close();
             } catch (IOException e) {
                 throw e;
             } catch (Exception e) {

--- a/app/src/main/java/io/apicurio/registry/storage/importing/v3/SqlDataImporter.java
+++ b/app/src/main/java/io/apicurio/registry/storage/importing/v3/SqlDataImporter.java
@@ -190,6 +190,14 @@ public class SqlDataImporter extends AbstractDataImporter {
     @Override
     protected void importContractRule(ContractRuleEntity entity) {
         try {
+            if (!preserveGlobalId && entity.globalId != null) {
+                Long mappedGlobalId = globalIdMapping.get(entity.globalId);
+                if (mappedGlobalId == null) {
+                    throw new RegistryException(
+                            "Could not remap contract rule globalId: " + entity.globalId);
+                }
+                entity.globalId = mappedGlobalId;
+            }
             storage.importContractRule(entity);
             log.debug("Contract rule imported successfully: {}", entity);
         } catch (Exception ex) {

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/ImportExportTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/ImportExportTest.java
@@ -1,6 +1,10 @@
 package io.apicurio.registry.noprofile.rest.v3;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.v3.beans.ContractRule;
+import io.apicurio.registry.rest.v3.beans.ContractRuleSet;
+import io.apicurio.registry.rest.v3.impl.shared.DataExporter;
 import io.apicurio.registry.rest.client.models.ArtifactMetaData;
 import io.apicurio.registry.rest.client.models.ArtifactSearchResults;
 import io.apicurio.registry.rest.client.models.ArtifactSortBy;
@@ -26,8 +30,10 @@ import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.cdi.Current;
+import io.apicurio.registry.utils.impexp.v3.ContractRuleEntity;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.StreamingOutput;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -37,14 +43,19 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
 public class ImportExportTest extends AbstractResourceTestBase {
@@ -54,6 +65,9 @@ public class ImportExportTest extends AbstractResourceTestBase {
     @Inject
     @Current
     RegistryStorage storage;
+
+    @Inject
+    DataExporter exporter;
 
     @Test
     public void testExportImport() throws Exception {
@@ -84,6 +98,8 @@ public class ImportExportTest extends AbstractResourceTestBase {
         createGroup.getLabels().setAdditionalData(Map.of("isPrimary", "false"));
         clientV3.groups().post(createGroup);
 
+        String secondaryGroupId = "SecondaryTestGroup";
+
         // Configure a group rule
         CreateRule createRule = new CreateRule();
         createRule.setRuleType(RuleType.INTEGRITY);
@@ -103,6 +119,10 @@ public class ImportExportTest extends AbstractResourceTestBase {
             String artifactId = "TestArtifact-" + idx;
             createArtifact(groupId, artifactId, ArtifactType.JSON, "{}", ContentTypes.APPLICATION_JSON);
         }
+
+        String secondaryArtifactId = "SecondaryArtifact";
+        createArtifact(secondaryGroupId, secondaryArtifactId, ArtifactType.JSON, "{}",
+                ContentTypes.APPLICATION_JSON);
 
         // Set artifact metadata
         for (int idx = 1; idx <= 10; idx++) {
@@ -176,6 +196,38 @@ public class ImportExportTest extends AbstractResourceTestBase {
         clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactIdWithRules).rules()
                 .post(createRule);
 
+        String artifactIdWithContractRules = "TestArtifact-8";
+        setContractRules("/registry/v3/admin/contracts/ruleset", "global-contract-rule");
+        setContractRules(
+                "/registry/v3/groups/" + groupId + "/artifacts/" + artifactIdWithContractRules
+                        + "/contract/ruleset",
+                "artifact-contract-rule");
+        setContractRules(
+                "/registry/v3/groups/" + groupId + "/artifacts/" + artifactIdWithContractRules
+                        + "/versions/1/contract/ruleset",
+                "version-contract-rule");
+        setContractRules(
+                "/registry/v3/groups/" + secondaryGroupId + "/artifacts/" + secondaryArtifactId
+                        + "/contract/ruleset",
+                "secondary-contract-rule");
+
+        Long originalVersionGlobalId = clientV3.groups().byGroupId(groupId).artifacts()
+                .byArtifactId(artifactIdWithContractRules).versions().byVersionExpression("1").get()
+                .getGlobalId();
+
+        DownloadRef groupDownloadRef = clientV3.admin().export().get(config -> {
+            config.queryParameters.groupId = groupId;
+        });
+        File groupExport = File.createTempFile(ImportExportTest.class.getSimpleName(), ".zip");
+        downloadTo(new URL(String.format("http://localhost:%s%s", testPort, groupDownloadRef.getHref())),
+                groupExport);
+        List<ContractRuleEntity> groupContractRules = readContractRules(groupExport);
+        Assertions.assertEquals(2, groupContractRules.size());
+        Assertions.assertEquals(Set.of("artifact-contract-rule", "version-contract-rule"),
+                groupContractRules.stream().map(ruleEntity -> ruleEntity.ruleName)
+                        .collect(Collectors.toSet()));
+        Files.delete(groupExport.toPath());
+
         // Add some comments
         // TODO add comments
 
@@ -192,6 +244,7 @@ public class ImportExportTest extends AbstractResourceTestBase {
         System.out.println("Temp export file: " + tempFile.toPath());
         downloadTo(url, tempFile);
         listFiles(tempFile);
+        assertContractRuleEntries(tempFile, 4);
 
         /**
          * Delete all the data.
@@ -201,13 +254,7 @@ public class ImportExportTest extends AbstractResourceTestBase {
         /**
          * Import the data back into the (now empty) registry
          */
-        try (FileInputStream fis = new FileInputStream(tempFile)) {
-            clientV3.admin().importEscaped().post(fis, config -> {
-                config.headers.putIfAbsent("Content-Type", Set.of("application/zip"));
-            });
-            // Clean up the temp file
-            Files.delete(tempFile.toPath());
-        }
+        importData(tempFile, true);
 
         /**
          * Assertions!
@@ -323,9 +370,103 @@ public class ImportExportTest extends AbstractResourceTestBase {
                 .byRuleType(RuleType.INTEGRITY.name()).get();
         Assertions.assertEquals(IntegrityLevel.FULL.name(), rule.getConfig());
 
+        assertContractRules(groupId, artifactIdWithContractRules);
+        Long preservedVersionGlobalId = clientV3.groups().byGroupId(groupId).artifacts()
+                .byArtifactId(artifactIdWithContractRules).versions().byVersionExpression("1").get()
+                .getGlobalId();
+        Assertions.assertEquals(originalVersionGlobalId, preservedVersionGlobalId);
+
+        storage.deleteAllUserData();
+        storage.nextGlobalId();
+        importData(tempFile, false);
+
+        Long remappedVersionGlobalId = clientV3.groups().byGroupId(groupId).artifacts()
+                .byArtifactId(artifactIdWithContractRules).versions().byVersionExpression("1").get()
+                .getGlobalId();
+        Assertions.assertNotEquals(originalVersionGlobalId, remappedVersionGlobalId);
+        assertContractRules(groupId, artifactIdWithContractRules);
+
+        Files.delete(tempFile.toPath());
+
         // Assert artifact comments
         // TODO add comments
 
+    }
+
+    @Test
+    public void testExportFailsWhenAnEntityCannotBeWritten() {
+        StreamingOutput stream = (StreamingOutput) exporter.exportData().getEntity();
+
+        IOException exception = Assertions.assertThrows(IOException.class,
+                () -> stream.write(new OutputStream() {
+                    @Override
+                    public void write(int value) throws IOException {
+                        throw new IOException("Output stream failure");
+                    }
+                }));
+
+        Assertions.assertEquals("Error writing entity", exception.getCause().getMessage());
+    }
+
+    private static void setContractRules(String path, String ruleName) {
+        ContractRule contractRule = new ContractRule();
+        contractRule.setName(ruleName);
+        contractRule.setKind(ContractRule.Kind.CONDITION);
+        contractRule.setType("CEL");
+        contractRule.setMode(ContractRule.Mode.WRITE);
+        contractRule.setExpr("true");
+        contractRule.setOnFailure(ContractRule.OnFailure.ERROR);
+
+        ContractRuleSet ruleset = new ContractRuleSet();
+        ruleset.setDomainRules(List.of(contractRule));
+        ruleset.setMigrationRules(List.of());
+
+        given().contentType("application/json").body(ruleset).put(path).then().statusCode(200);
+    }
+
+    private static void assertContractRules(String groupId, String artifactId) {
+        given().get("/registry/v3/admin/contracts/ruleset").then().statusCode(200)
+                .body("domainRules[0].name", equalTo("global-contract-rule"));
+        given().pathParam("groupId", groupId).pathParam("artifactId", artifactId)
+                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/ruleset").then()
+                .statusCode(200).body("domainRules[0].name", equalTo("artifact-contract-rule"));
+        given().pathParam("groupId", groupId).pathParam("artifactId", artifactId)
+                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/1/contract/ruleset")
+                .then().statusCode(200).body("domainRules[0].name", equalTo("version-contract-rule"));
+    }
+
+    private void importData(File export, boolean preserveGlobalId) throws IOException {
+        try (FileInputStream fis = new FileInputStream(export)) {
+            clientV3.admin().importEscaped().post(fis, config -> {
+                config.headers.putIfAbsent("Content-Type", Set.of("application/zip"));
+                config.headers.putIfAbsent("X-Registry-Preserve-GlobalId",
+                        Set.of(Boolean.toString(preserveGlobalId)));
+            });
+        }
+    }
+
+    private static void assertContractRuleEntries(File export, int expectedCount) throws IOException {
+        try (ZipFile zipFile = new ZipFile(export)) {
+            List<String> entryNames = zipFile.stream().map(ZipEntry::getName)
+                    .filter(name -> name.endsWith(".ContractRule.json")).toList();
+            Assertions.assertEquals(expectedCount, entryNames.size());
+            Assertions.assertTrue(entryNames.stream()
+                    .allMatch(name -> name.matches("contractRules/\\d+\\.ContractRule\\.json")));
+        }
+    }
+
+    private static List<ContractRuleEntity> readContractRules(File export) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        try (ZipFile zipFile = new ZipFile(export)) {
+            return zipFile.stream().filter(entry -> entry.getName().endsWith(".ContractRule.json"))
+                    .map(entry -> {
+                        try (InputStream input = zipFile.getInputStream(entry)) {
+                            return mapper.readValue(input, ContractRuleEntity.class);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }).toList();
+        }
     }
 
     private static void downloadTo(URL url, File tempFile) {

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/EntityReader.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/EntityReader.java
@@ -10,6 +10,7 @@ import io.apicurio.registry.utils.impexp.v3.ArtifactVersionEntity;
 import io.apicurio.registry.utils.impexp.v3.BranchEntity;
 import io.apicurio.registry.utils.impexp.v3.CommentEntity;
 import io.apicurio.registry.utils.impexp.v3.ContentEntity;
+import io.apicurio.registry.utils.impexp.v3.ContractRuleEntity;
 import io.apicurio.registry.utils.impexp.v3.GlobalRuleEntity;
 import io.apicurio.registry.utils.impexp.v3.GroupEntity;
 import io.apicurio.registry.utils.impexp.v3.GroupRuleEntity;
@@ -71,6 +72,8 @@ public class EntityReader {
                         return readComment(entityInfo);
                     case Branch:
                         return readBranch(entityInfo);
+                    case ContractRule:
+                        return readContractRule(entityInfo);
                     case Manifest:
                         return readManifest(entityInfo);
                 }
@@ -104,6 +107,7 @@ public class EntityReader {
      * <li>Group Rules</li>
      * <li>Artifact Rules</li>
      * <li>Artifact Versions</li>
+     * <li>Contract Rules</li>
      * <li>Artifact Branches</li>
      * <li>Comments</li>
      * </ol>
@@ -117,6 +121,7 @@ public class EntityReader {
         List<EntityInfo> artifacts = new LinkedList<>();
         List<EntityInfo> artifactRules = new LinkedList<>();
         List<EntityInfo> versions = new LinkedList<>();
+        List<EntityInfo> contractRules = new LinkedList<>();
         List<EntityInfo> branches = new LinkedList<>();
         List<EntityInfo> comments = new LinkedList<>();
 
@@ -154,6 +159,9 @@ public class EntityReader {
                 case Branch:
                     branches.add(entityInfo);
                     break;
+                case ContractRule:
+                    contractRules.add(entityInfo);
+                    break;
                 case Manifest:
                     manifest = entityInfo;
             }
@@ -190,6 +198,7 @@ public class EntityReader {
         entities.addAll(artifacts);
         entities.addAll(versions);
         entities.addAll(artifactRules);
+        entities.addAll(contractRules);
         entities.addAll(branches);
         entities.addAll(comments);
     }
@@ -264,6 +273,10 @@ public class EntityReader {
 
     private Entity readBranch(EntityInfo entry) throws IOException {
         return readEntry(entry, BranchEntity.class);
+    }
+
+    private Entity readContractRule(EntityInfo entry) throws IOException {
+        return readEntry(entry, ContractRuleEntity.class);
     }
 
     private Entity readGlobalRule(EntityInfo entry) throws IOException {

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/EntityWriter.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/EntityWriter.java
@@ -21,6 +21,7 @@ public class EntityWriter {
     }
 
     private final transient ZipOutputStream zip;
+    private int contractRuleIndex = 0;
 
     /**
      * Constructor.
@@ -65,6 +66,9 @@ public class EntityWriter {
                 break;
             case Branch:
                 writeEntity((BranchEntity) entity);
+                break;
+            case ContractRule:
+                writeEntity((ContractRuleEntity) entity);
                 break;
             case Manifest:
                 writeEntity((ManifestEntity) entity);
@@ -138,6 +142,12 @@ public class EntityWriter {
         write(mdEntry, entity, BranchEntity.class);
     }
 
+    private void writeEntity(ContractRuleEntity entity) throws IOException {
+        ZipEntry mdEntry = createZipEntry(EntityType.ContractRule,
+                Integer.toString(contractRuleIndex++), "json");
+        write(mdEntry, entity, ContractRuleEntity.class);
+    }
+
     private ZipEntry createZipEntry(EntityType type, String fileName, String fileExt) {
         return createZipEntry(type, null, null, fileName, fileExt);
     }
@@ -182,6 +192,9 @@ public class EntityWriter {
                 break;
             case Comment:
                 path = String.format("comments/%s.%s.%s", fileName, type.name(), fileExt);
+                break;
+            case ContractRule:
+                path = String.format("contractRules/%s.%s.%s", fileName, type.name(), fileExt);
                 break;
             case Manifest:
                 path = String.format("%s.%s.%s", fileName, type.name(), fileExt);


### PR DESCRIPTION
## What

Preserve contract rules in Registry export/import backups.

Contract rules are now written as dedicated, collision-safe ZIP entries and restored during import. Version-scoped rules correctly remap their `globalId` when imports do not preserve IDs. Export errors now fail the request instead of silently producing a partial backup.

## Why

Contract rules were already included by SQL/KafkaSQL storage export, but the import/export archive layer did not serialize or read them. As a result, global, artifact, and version contract rules were silently lost after a backup and restore.

Fixes #8980.

## Validation

- Verified global, artifact, and version-scoped contract-rule round trips.
- Verified full and group-filtered exports.
- Verified imports with `X-Registry-Preserve-GlobalId` enabled and disabled.
- Verified existing archives without contract rules still import successfully.
- `./mvnw -T1 test-compile -pl app -am -DskipTests -Dkiota.skip=true`
- Focused `ImportExportTest` and `MigrationTest` passed.