### PR TITLE
docs: use correct REGISTRY_AUTH_* variable names for UI OIDC config

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ so a single set of credentials works for both. Set the following environment var
 
 | Env. variable                | Description                       |
 |------------------------------|-----------------------------------|
-| `APICURIO_AUTH_TYPE`         | Set to `oidc` (default is `none`) |
-| `APICURIO_AUTH_URL`          | OIDC auth URL                     |
-| `APICURIO_AUTH_REDIRECT_URL` | OIDC redirect URL                 |
-| `APICURIO_AUTH_CLIENT_ID`    | The client for the UI             |
+| `REGISTRY_AUTH_TYPE`         | Set to `oidc` (default is `none`) |
+| `REGISTRY_AUTH_URL`          | OIDC auth URL                     |
+| `REGISTRY_AUTH_REDIRECT_URL` | OIDC redirect URL                 |
+| `REGISTRY_AUTH_CLIENT_ID`    | The client for the UI             |
 
 Everything must be configured in your OIDC provider before starting the application. Registry
 supports a much wider range of authentication and authorization options than shown here — treat


### PR DESCRIPTION
Fixes #8842

The UI OIDC environment variables in the README were listed with an `APICURIO_AUTH_` prefix, but the UI container reads `REGISTRY_AUTH_*` (see `ui/.docker-scripts/create-config.cjs` and `ui/README.md`). Following the README as written leaves authentication disabled, since the variables are simply never read.

The other two problems reported in the issue — the malformed `java Dapicurio.storage.kind=kafkasql` command and the obsolete `jdbc:h2:tcp://localhost:9123/mem:registry` default — are no longer present on `main`. The Runtime Configuration section that contained them was removed in #8972, so only the auth table needed fixing.

Documentation only — no code or build changes.