### PR TITLE
fix: use fixed height for error details CodeEditor

### DIFF
--- a/ui/ui-app/src/app/components/errorPage/ErrorPage.tsx
+++ b/ui/ui-app/src/app/components/errorPage/ErrorPage.tsx
@@ -96,7 +96,7 @@ export const ErrorPage: FunctionComponent<ErrorPageProps> = (props: ErrorPagePro
                                     editor.layout();
                                     monaco.editor.getModels()[0].updateOptions({ tabSize: 4 });
                                 }}
-                                height="sizeToFit"
+                                height="300px"
                             />
                             :
                             <div/>


### PR DESCRIPTION
## Description
The CodeEditor component in ErrorPage.tsx used  which fails when the editor is initially hidden and then revealed. The sizeToFit calculation doesn't work correctly because the editor wasn't in the DOM when hidden.

## Changes
- Changed  to  to ensure the editor is always visible when shown

## Related Issue
Fixes #9021