### PR TITLE
fix(ui): display estimated token metadata for prompt templates

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
@@ -146,6 +146,14 @@ export const PromptTemplateViewer: FunctionComponent<PromptTemplateViewerProps> 
                             <DescriptionListDescription>{meta.createdAt}</DescriptionListDescription>
                         </DescriptionListGroup>
                     )}
+                    {meta?.estimatedTokens && (
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Estimated Tokens</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                {meta.estimatedTokens.input ?? 0} (+{meta.estimatedTokens.variableOverhead ?? 0} overhead)
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                    )}
                 </DescriptionList>
 
                 {promptTemplate.template && (


### PR DESCRIPTION
## Description

Fixes #9054.

The Registry API already returns `estimatedTokens` as part of Prompt Template metadata, but the Prompt Template Documentation view did not display this information.

The `PromptTemplateMetadata` interface already defines `estimatedTokens`, including the `input` and `variableOverhead` fields. However, `PromptTemplateViewer` did not render the field in the Basic Information section.

This change adds an `Estimated Tokens` entry to the existing metadata list and displays the input token count together with the variable overhead.

### Before

The API response contains:

```text
estimatedTokens:
  input: 500
  variableOverhead: 2
```

but this metadata was not displayed in the Documentation view.

<img width="1919" height="923" alt="Image" src="https://github.com/user-attachments/assets/4a304fdc-853a-4cbb-8d37-02e29779463a" />

### After

The Documentation view now displays:

```text
Estimated Tokens    500 (+2 overhead)
```

<img width="1919" height="921" alt="Image" src="https://github.com/user-attachments/assets/87f7b488-2b5c-461b-bd1a-2b7aabfbea2d" />

### Testing

* Reproduced the issue locally.
* Verified the API response contains `estimatedTokens`.
* Verified the metadata was missing from the Documentation view before the change.
* Verified the new `Estimated Tokens` row is displayed correctly after the change.
* `npm run lint` — passed.
* `npm test` — passed (4/4 tests).
