### PR TITLE
fix(ui): use page size for pagination requests

### DIFF
--- a/ui/ui-app/src/services/useAdminService.test.ts
+++ b/ui/ui-app/src/services/useAdminService.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { Paging } from "@models/Paging.ts";
+
+const { getRegistryClientMock } = vi.hoisted(() => {
+    // useConfigService.ts reads this global at module load time (normally injected
+    // by the app's config.js in a real browser); provide a minimal stand-in so the
+    // service modules under test can be imported in a Vitest (node) environment.
+    const registryConfig = { artifacts: { url: "http://localhost:8080/apis/registry/v3/" } };
+    (globalThis as any).ApicurioRegistryConfig = registryConfig;
+    (globalThis as any).window = { ApicurioRegistryConfig: registryConfig };
+    return { getRegistryClientMock: vi.fn() };
+});
+
+vi.mock("@apicurio/common-ui-components", () => ({
+    useAuth: () => ({})
+}));
+
+vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
+    return {
+        ...actual,
+        getRegistryClient: getRegistryClientMock
+    };
+});
+
+import { useAdminService } from "./useAdminService";
+
+// Regression test for issue #9086: the `limit` query param must always equal
+// `pageSize`, regardless of which page is being requested. Previously it was
+// computed as `offset + pageSize`, so it grew on every page past page 1.
+describe("useAdminService pagination", () => {
+    it("sends a constant limit and correct offset across pages for getRoleMappings", async () => {
+        const get = vi.fn().mockResolvedValue({ count: 0, roleMappings: [] });
+        getRegistryClientMock.mockReturnValue({ admin: { roleMappings: { get } } });
+
+        const service = useAdminService();
+        const pagesToCheck: { page: number; expectedOffset: number }[] = [
+            { page: 1, expectedOffset: 0 },
+            { page: 2, expectedOffset: 10 },
+            { page: 3, expectedOffset: 20 }
+        ];
+        for (const { page } of pagesToCheck) {
+            const paging: Paging = { page, pageSize: 10 };
+            await service.getRoleMappings(paging);
+        }
+
+        const queryParams = get.mock.calls.map(call => call[0].queryParameters);
+        queryParams.forEach((params: any, i: number) => {
+            expect(params.limit).toBe(10);
+            expect(params.offset).toBe(pagesToCheck[i].expectedOffset);
+        });
+    });
+});

--- a/ui/ui-app/src/services/useAdminService.test.ts
+++ b/ui/ui-app/src/services/useAdminService.test.ts
@@ -44,6 +44,7 @@ describe("useAdminService pagination", () => {
             await service.getRoleMappings(paging);
         }
 
+        expect(get).toHaveBeenCalledTimes(pagesToCheck.length);
         const queryParams = get.mock.calls.map(call => call[0].queryParameters);
         queryParams.forEach((params: any, i: number) => {
             expect(params.limit).toBe(10);

--- a/ui/ui-app/src/services/useAdminService.ts
+++ b/ui/ui-app/src/services/useAdminService.ts
@@ -58,10 +58,9 @@ const deleteRule = async (config: ConfigService, auth: AuthService, ruleType: st
 const getRoleMappings = async (config: ConfigService, auth: AuthService, paging: Paging): Promise<RoleMappingSearchResults> => {
     console.info("[AdminService] Getting the list of role mappings.");
     const start: number = (paging.page - 1) * paging.pageSize;
-    const end: number = start + paging.pageSize;
     return getRegistryClient(config, auth).admin.roleMappings.get({
         queryParameters: {
-            limit: end,
+            limit: paging.pageSize,
             offset: start
         }
     }).then(v => v!);

--- a/ui/ui-app/src/services/useDraftsService.test.ts
+++ b/ui/ui-app/src/services/useDraftsService.test.ts
@@ -44,6 +44,7 @@ describe("useDraftsService pagination", () => {
             await service.searchDrafts([], "name" as any, "asc" as any, paging);
         }
 
+        expect(get).toHaveBeenCalledTimes(pagesToCheck.length);
         const queryParams = get.mock.calls.map(call => call[0].queryParameters);
         queryParams.forEach((params: any, i: number) => {
             expect(params.limit).toBe(10);

--- a/ui/ui-app/src/services/useDraftsService.test.ts
+++ b/ui/ui-app/src/services/useDraftsService.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { Paging } from "@models/Paging.ts";
+
+const { getRegistryClientMock } = vi.hoisted(() => {
+    // useConfigService.ts reads this global at module load time (normally injected
+    // by the app's config.js in a real browser); provide a minimal stand-in so the
+    // service modules under test can be imported in a Vitest (node) environment.
+    const registryConfig = { artifacts: { url: "http://localhost:8080/apis/registry/v3/" } };
+    (globalThis as any).ApicurioRegistryConfig = registryConfig;
+    (globalThis as any).window = { ApicurioRegistryConfig: registryConfig };
+    return { getRegistryClientMock: vi.fn() };
+});
+
+vi.mock("@apicurio/common-ui-components", () => ({
+    useAuth: () => ({})
+}));
+
+vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
+    return {
+        ...actual,
+        getRegistryClient: getRegistryClientMock
+    };
+});
+
+import { useDraftsService } from "./useDraftsService";
+
+// Regression test for issue #9086: the `limit` query param must always equal
+// `pageSize`, regardless of which page is being requested. Previously it was
+// computed as `offset + pageSize`, so it grew on every page past page 1.
+describe("useDraftsService pagination", () => {
+    it("sends a constant limit and correct offset across pages for searchDrafts", async () => {
+        const get = vi.fn().mockResolvedValue({ count: 0, versions: [] });
+        getRegistryClientMock.mockReturnValue({ search: { versions: { get } } });
+
+        const service = useDraftsService();
+        const pagesToCheck: { page: number; expectedOffset: number }[] = [
+            { page: 1, expectedOffset: 0 },
+            { page: 2, expectedOffset: 10 },
+            { page: 3, expectedOffset: 20 }
+        ];
+        for (const { page } of pagesToCheck) {
+            const paging: Paging = { page, pageSize: 10 };
+            await service.searchDrafts([], "name" as any, "asc" as any, paging);
+        }
+
+        const queryParams = get.mock.calls.map(call => call[0].queryParameters);
+        queryParams.forEach((params: any, i: number) => {
+            expect(params.limit).toBe(10);
+            expect(params.offset).toBe(pagesToCheck[i].expectedOffset);
+        });
+    });
+});

--- a/ui/ui-app/src/services/useDraftsService.ts
+++ b/ui/ui-app/src/services/useDraftsService.ts
@@ -67,10 +67,9 @@ async function searchDrafts(config: ConfigService, auth: AuthService, filters: D
     const client: ApicurioRegistryClient = getRegistryClient(config, auth);
 
     const start: number = (paging.page - 1) * paging.pageSize;
-    const end: number = start + paging.pageSize;
     const queryParams: VersionsRequestBuilderGetQueryParameters = {
         state: "DRAFT",
-        limit: end,
+        limit: paging.pageSize,
         offset: start,
         order: sortOrder,
         orderby: sortBy as any

--- a/ui/ui-app/src/services/useGroupsService.test.ts
+++ b/ui/ui-app/src/services/useGroupsService.test.ts
@@ -32,6 +32,7 @@ const PAGES_TO_CHECK: { page: number; expectedOffset: number }[] = [
 ];
 
 function assertConstantLimit(get: ReturnType<typeof vi.fn>): void {
+    expect(get).toHaveBeenCalledTimes(PAGES_TO_CHECK.length);
     const queryParams = get.mock.calls.map(call => call[0].queryParameters);
     queryParams.forEach((params: any, i: number) => {
         expect(params.limit).toBe(10);

--- a/ui/ui-app/src/services/useGroupsService.test.ts
+++ b/ui/ui-app/src/services/useGroupsService.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { Paging } from "@models/Paging.ts";
+
+const { getRegistryClientMock } = vi.hoisted(() => {
+    // useConfigService.ts reads this global at module load time (normally injected
+    // by the app's config.js in a real browser); provide a minimal stand-in so the
+    // service modules under test can be imported in a Vitest (node) environment.
+    const registryConfig = { artifacts: { url: "http://localhost:8080/apis/registry/v3/" } };
+    (globalThis as any).ApicurioRegistryConfig = registryConfig;
+    (globalThis as any).window = { ApicurioRegistryConfig: registryConfig };
+    return { getRegistryClientMock: vi.fn() };
+});
+
+vi.mock("@apicurio/common-ui-components", () => ({
+    useAuth: () => ({})
+}));
+
+vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
+    return {
+        ...actual,
+        getRegistryClient: getRegistryClientMock
+    };
+});
+
+import { useGroupsService } from "./useGroupsService";
+
+const PAGES_TO_CHECK: { page: number; expectedOffset: number }[] = [
+    { page: 1, expectedOffset: 0 },
+    { page: 2, expectedOffset: 10 },
+    { page: 3, expectedOffset: 20 }
+];
+
+function assertConstantLimit(get: ReturnType<typeof vi.fn>): void {
+    const queryParams = get.mock.calls.map(call => call[0].queryParameters);
+    queryParams.forEach((params: any, i: number) => {
+        expect(params.limit).toBe(10);
+        expect(params.offset).toBe(PAGES_TO_CHECK[i].expectedOffset);
+    });
+}
+
+// Regression test for issue #9086: the `limit` query param must always equal
+// `pageSize`, regardless of which page is being requested. Previously it was
+// computed as `offset + pageSize`, so it grew on every page past page 1.
+describe("useGroupsService pagination", () => {
+    it("sends a constant limit and correct offset across pages for getGroupArtifacts", async () => {
+        const get = vi.fn().mockResolvedValue({ count: 0, artifacts: [] });
+        getRegistryClientMock.mockReturnValue({
+            groups: { byGroupId: () => ({ artifacts: { get } }) }
+        });
+
+        const service = useGroupsService();
+        for (const { page } of PAGES_TO_CHECK) {
+            const paging: Paging = { page, pageSize: 10 };
+            await service.getGroupArtifacts("default", "name" as any, "asc" as any, paging);
+        }
+
+        assertConstantLimit(get);
+    });
+
+    it("sends a constant limit and correct offset across pages for getArtifactVersions", async () => {
+        const get = vi.fn().mockResolvedValue({ count: 0, versions: [] });
+        getRegistryClientMock.mockReturnValue({
+            groups: { byGroupId: () => ({ artifacts: { byArtifactId: () => ({ versions: { get } }) } }) }
+        });
+
+        const service = useGroupsService();
+        for (const { page } of PAGES_TO_CHECK) {
+            const paging: Paging = { page, pageSize: 10 };
+            await service.getArtifactVersions("default", "my-artifact", "version" as any, "asc" as any, paging);
+        }
+
+        assertConstantLimit(get);
+    });
+
+    it("sends a constant limit and correct offset across pages for getArtifactBranches", async () => {
+        const get = vi.fn().mockResolvedValue({ count: 0, branches: [] });
+        getRegistryClientMock.mockReturnValue({
+            groups: { byGroupId: () => ({ artifacts: { byArtifactId: () => ({ branches: { get } }) } }) }
+        });
+
+        const service = useGroupsService();
+        for (const { page } of PAGES_TO_CHECK) {
+            const paging: Paging = { page, pageSize: 10 };
+            await service.getArtifactBranches("default", "my-artifact", paging);
+        }
+
+        assertConstantLimit(get);
+    });
+
+    it("sends a constant limit and correct offset across pages for getArtifactBranchVersions", async () => {
+        const get = vi.fn().mockResolvedValue({ count: 0, versions: [] });
+        getRegistryClientMock.mockReturnValue({
+            groups: {
+                byGroupId: () => ({
+                    artifacts: {
+                        byArtifactId: () => ({
+                            branches: { byBranchId: () => ({ versions: { get } }) }
+                        })
+                    }
+                })
+            }
+        });
+
+        const service = useGroupsService();
+        for (const { page } of PAGES_TO_CHECK) {
+            const paging: Paging = { page, pageSize: 10 };
+            await service.getArtifactBranchVersions("default", "my-artifact", "my-branch", paging);
+        }
+
+        assertConstantLimit(get);
+    });
+});

--- a/ui/ui-app/src/services/useGroupsService.ts
+++ b/ui/ui-app/src/services/useGroupsService.ts
@@ -67,9 +67,8 @@ const getGroupMetaData = async (config: ConfigService, auth: AuthService, groupI
 const getGroupArtifacts = async (config: ConfigService, auth: AuthService, groupId: string, sortBy: ArtifactSortBy, sortOrder: SortOrder, paging: Paging): Promise<ArtifactSearchResults> => {
     groupId = normalizeGroupId(groupId);
     const start: number = (paging.page - 1) * paging.pageSize;
-    const end: number = start + paging.pageSize;
     const queryParams: any = {
-        limit: end,
+        limit: paging.pageSize,
         offset: start,
         order: sortOrder,
         orderby: sortBy
@@ -253,9 +252,8 @@ const getArtifactVersionContentDereferenced = async (config: ConfigService, auth
 const getArtifactVersions = async (config: ConfigService, auth: AuthService, groupId: string|null, artifactId: string, sortBy: VersionSortBy, sortOrder: SortOrder, paging: Paging): Promise<VersionSearchResults> => {
     groupId = normalizeGroupId(groupId);
     const start: number = (paging.page - 1) * paging.pageSize;
-    const end: number = start + paging.pageSize;
     const queryParams: any = {
-        limit: end,
+        limit: paging.pageSize,
         offset: start,
         order: sortOrder,
         orderby: sortBy
@@ -299,9 +297,8 @@ const deleteArtifactVersionComment = async (config: ConfigService, auth: AuthSer
 const getArtifactBranches = async (config: ConfigService, auth: AuthService, groupId: string|null, artifactId: string, paging: Paging): Promise<VersionSearchResults> => {
     groupId = normalizeGroupId(groupId);
     const start: number = (paging.page - 1) * paging.pageSize;
-    const end: number = start + paging.pageSize;
     const queryParams: any = {
-        limit: end,
+        limit: paging.pageSize,
         offset: start
     };
 
@@ -342,9 +339,8 @@ const updateArtifactBranchMetaData = async (config: ConfigService, auth: AuthSer
 const getArtifactBranchVersions = async (config: ConfigService, auth: AuthService, groupId: string|null, artifactId: string, branchId: string, paging: Paging): Promise<VersionSearchResults> => {
     groupId = normalizeGroupId(groupId);
     const start: number = (paging.page - 1) * paging.pageSize;
-    const end: number = start + paging.pageSize;
     const queryParams: any = {
-        limit: end,
+        limit: paging.pageSize,
         offset: start
     };
 

--- a/ui/ui-app/src/services/useSearchService.test.ts
+++ b/ui/ui-app/src/services/useSearchService.test.ts
@@ -45,6 +45,7 @@ describe("useSearchService pagination", () => {
             await service.searchGroups([], "groupId" as any, "asc" as any, paging);
         }
 
+        expect(get).toHaveBeenCalledTimes(pagesToCheck.length);
         const queryParams = get.mock.calls.map(call => call[0].queryParameters);
         queryParams.forEach((params: any, i: number) => {
             expect(params.limit).toBe(10);
@@ -64,6 +65,7 @@ describe("useSearchService pagination", () => {
             );
         }
 
+        expect(get).toHaveBeenCalledTimes(pagesToCheck.length);
         const queryParams = get.mock.calls.map(call => call[0].queryParameters);
         queryParams.forEach((params: any, i: number) => {
             expect(params.limit).toBe(10);
@@ -81,6 +83,7 @@ describe("useSearchService pagination", () => {
             await service.searchVersions([], "version" as any, "asc" as any, paging);
         }
 
+        expect(get).toHaveBeenCalledTimes(pagesToCheck.length);
         const queryParams = get.mock.calls.map(call => call[0].queryParameters);
         queryParams.forEach((params: any, i: number) => {
             expect(params.limit).toBe(10);

--- a/ui/ui-app/src/services/useSearchService.test.ts
+++ b/ui/ui-app/src/services/useSearchService.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { Paging } from "@models/Paging.ts";
+
+const { getRegistryClientMock } = vi.hoisted(() => {
+    // useConfigService.ts reads this global at module load time (normally injected
+    // by the app's config.js in a real browser); provide a minimal stand-in so the
+    // service modules under test can be imported in a Vitest (node) environment.
+    const registryConfig = { artifacts: { url: "http://localhost:8080/apis/registry/v3/" } };
+    (globalThis as any).ApicurioRegistryConfig = registryConfig;
+    (globalThis as any).window = { ApicurioRegistryConfig: registryConfig };
+    return { getRegistryClientMock: vi.fn() };
+});
+
+vi.mock("@apicurio/common-ui-components", () => ({
+    useAuth: () => ({})
+}));
+
+vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
+    return {
+        ...actual,
+        getRegistryClient: getRegistryClientMock
+    };
+});
+
+import { FilterBy, useSearchService } from "./useSearchService";
+
+// Regression test for issue #9086: the `limit` query param must always equal
+// `pageSize`, regardless of which page is being requested. Previously it was
+// computed as `offset + pageSize`, so it grew on every page past page 1.
+describe("useSearchService pagination", () => {
+    const pagesToCheck: { page: number; expectedOffset: number }[] = [
+        { page: 1, expectedOffset: 0 },
+        { page: 2, expectedOffset: 10 },
+        { page: 3, expectedOffset: 20 }
+    ];
+
+    it("sends a constant limit and correct offset across pages for searchGroups", async () => {
+        const get = vi.fn().mockResolvedValue({ count: 0, groups: [] });
+        getRegistryClientMock.mockReturnValue({ search: { groups: { get } } });
+
+        const service = useSearchService();
+        for (const { page } of pagesToCheck) {
+            const paging: Paging = { page, pageSize: 10 };
+            await service.searchGroups([], "groupId" as any, "asc" as any, paging);
+        }
+
+        const queryParams = get.mock.calls.map(call => call[0].queryParameters);
+        queryParams.forEach((params: any, i: number) => {
+            expect(params.limit).toBe(10);
+            expect(params.offset).toBe(pagesToCheck[i].expectedOffset);
+        });
+    });
+
+    it("sends a constant limit and correct offset across pages for searchArtifacts", async () => {
+        const get = vi.fn().mockResolvedValue({ count: 0, artifacts: [] });
+        getRegistryClientMock.mockReturnValue({ search: { artifacts: { get } } });
+
+        const service = useSearchService();
+        for (const { page } of pagesToCheck) {
+            const paging: Paging = { page, pageSize: 10 };
+            await service.searchArtifacts(
+                [{ by: FilterBy.name, value: "" }], "name" as any, "asc" as any, paging
+            );
+        }
+
+        const queryParams = get.mock.calls.map(call => call[0].queryParameters);
+        queryParams.forEach((params: any, i: number) => {
+            expect(params.limit).toBe(10);
+            expect(params.offset).toBe(pagesToCheck[i].expectedOffset);
+        });
+    });
+
+    it("sends a constant limit and correct offset across pages for searchVersions", async () => {
+        const get = vi.fn().mockResolvedValue({ count: 0, versions: [] });
+        getRegistryClientMock.mockReturnValue({ search: { versions: { get } } });
+
+        const service = useSearchService();
+        for (const { page } of pagesToCheck) {
+            const paging: Paging = { page, pageSize: 10 };
+            await service.searchVersions([], "version" as any, "asc" as any, paging);
+        }
+
+        const queryParams = get.mock.calls.map(call => call[0].queryParameters);
+        queryParams.forEach((params: any, i: number) => {
+            expect(params.limit).toBe(10);
+            expect(params.offset).toBe(pagesToCheck[i].expectedOffset);
+        });
+    });
+});

--- a/ui/ui-app/src/services/useSearchService.ts
+++ b/ui/ui-app/src/services/useSearchService.ts
@@ -30,9 +30,8 @@ const VERSION_STATES: string[] = [
 const searchGroups = async (config: ConfigService, auth: AuthService, filters: SearchFilter[], sortBy: GroupSortBy, sortOrder: SortOrder, paging: Paging): Promise<GroupSearchResults> => {
     console.debug("[SearchService] Searching groups: ", filters, paging);
     const start: number = (paging.page - 1) * paging.pageSize;
-    const end: number = start + paging.pageSize;
     const queryParams: any = {
-        limit: end,
+        limit: paging.pageSize,
         offset: start,
         order: sortOrder,
         orderby: sortBy
@@ -51,9 +50,8 @@ const searchGroups = async (config: ConfigService, auth: AuthService, filters: S
 const searchArtifacts = async (config: ConfigService, auth: AuthService, filters: SearchFilter[], sortBy: ArtifactSortBy, sortOrder: SortOrder, paging: Paging): Promise<ArtifactSearchResults> => {
     console.debug("[SearchService] Searching artifacts: ", filters, sortBy, sortOrder, paging);
     const start: number = (paging.page - 1) * paging.pageSize;
-    const end: number = start + paging.pageSize;
     const queryParams: any = {
-        limit: end,
+        limit: paging.pageSize,
         offset: start,
         order: sortOrder,
         orderby: sortBy
@@ -74,9 +72,8 @@ const searchArtifacts = async (config: ConfigService, auth: AuthService, filters
 const searchVersions = async (config: ConfigService, auth: AuthService, filters: SearchFilter[], sortBy: VersionSortBy, sortOrder: SortOrder, paging: Paging): Promise<VersionSearchResults> => {
     console.debug("[SearchService] Searching versions: ", filters, sortBy, sortOrder, paging);
     const start: number = (paging.page - 1) * paging.pageSize;
-    const end: number = start + paging.pageSize;
     const queryParams: any = {
-        limit: end,
+        limit: paging.pageSize,
         offset: start,
         order: sortOrder,
         orderby: sortBy


### PR DESCRIPTION
## Summary

Fixes the pagination request construction used across multiple UI service methods!

Previously, the UI sent the `limit` query parameter as the end index (`start + pageSize`) instead of the requested page size! Since the backend interprets `limit` as the number of items to return, requests after the first page fetched progressively larger result sets, resulting in duplicate rows being rendered across paginated views..!

This change updates all affected service methods to send `limit: paging.pageSize` while keeping `offset` unchanged!

Fixes #9086

## Changes

- Replace `limit: end` with `limit: paging.pageSize` in all affected pagination request builders
- Remove the now-unused `end` variable where applicable
- Add regression tests covering the affected services to verify the generated pagination query parameters across multiple pages

## Testing

- Added regression tests for:
  - `useSearchService`
  - `useAdminService`
  - `useDraftsService`
  - `useGroupsService`
- Verified all existing and new tests pass
- Ran lint successfully
- Reproduced the original issue against a live registry instance and verified that subsequent pages now request only the configured page size with no duplicate rows rendered.