### PR TITLE
fix(ui): redirect to artifact root after deleting a version

### DIFF
--- a/ui/ui-app/src/app/pages/version/VersionPage.tsx
+++ b/ui/ui-app/src/app/pages/version/VersionPage.tsx
@@ -275,7 +275,7 @@ export const VersionPage: FunctionComponent<PageProperties> = () => {
             pleaseWait(false);
             const gid: string = encodeURIComponent(groupId || "default");
             const aid: string = encodeURIComponent(artifactId as string);
-            appNavigation.navigateTo(`/explore/${gid}/${aid}/versions`);
+            appNavigation.navigateTo(`/explore/${gid}/${aid}`);
         }).catch(error => {
             setPageError(toPageError(error, "Error deleting a version."));
         });


### PR DESCRIPTION
## Summary

Fixes #9115

Deleting a version via the kebab menu's "Delete version" action, while 
on that version's Overview page, redirected to a malformed URL 
(`/explore/{groupId}/{artifactId}/versions`) that isn't a registered 
route, resulting in a 404 error instead of returning the user to the 
artifact's overview page.

## Root Cause

The delete-success handler in `VersionPage.tsx` navigated to 
`/explore/${groupId}/${artifactId}/versions` after a successful 
delete. That path has no trailing version segment and was never a 
registered route — only `/explore/{groupId}/{artifactId}` (artifact 
root) and `/explore/{groupId}/{artifactId}/versions/{version}` (a 
specific version) exist as valid routes in this app.

## Fix

Changed the post-delete redirect target to 
`/explore/${groupId}/${artifactId}` — the artifact root page, which 
correctly reflects the state after a version no longer exists.

## Testing

Verified both delete entry points:
- **Version Overview page kebab** (previously broken) → now correctly 
  redirects to the artifact page.
- **Artifact's version list page** (was already working) → confirmed 
  unaffected, still stays on the same page and refreshes the list.

## Video

**Before (bug):**

[raw-recording.webm](https://github.com/user-attachments/assets/a7bbe71a-193d-435d-8a9e-a438e2a4bc7a)

**After (fix applied):**

[raw-recording (1).webm](https://github.com/user-attachments/assets/67ebb0da-7a66-4b83-81e9-dad1f9f8f553)
