### PR TITLE
fix(test): retry Kafka container startup in KafkaFacade (#8990)

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/tests/utils/KafkaFacade.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/utils/KafkaFacade.java
@@ -61,20 +61,42 @@ public class KafkaFacade implements AutoCloseable {
         }
     }
 
+    private static final int MAX_START_ATTEMPTS = 2;
+
     public void start() {
         if (isRunning()) {
             throw new IllegalStateException("Kafka cluster is already running");
         }
 
-        LOGGER.info("Starting kafka container");
-        this.kafkaContainer = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
-                .withNumberOfBrokers(1)
-                .withAdditionalKafkaConfiguration(Map.of(
-                        "transaction.state.log.replication.factor", "1",
-                        "transaction.state.log.min.isr", "1"))
-                .build();
-        kafkaContainer.start();
-
+        for (int attempt = 1; attempt <= MAX_START_ATTEMPTS; attempt++) {
+            LOGGER.info("Starting kafka container (attempt {}/{})", attempt, MAX_START_ATTEMPTS);
+            this.kafkaContainer = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                    .withNumberOfBrokers(1)
+                    .withAdditionalKafkaConfiguration(Map.of(
+                            "transaction.state.log.replication.factor", "1",
+                            "transaction.state.log.min.isr", "1"))
+                    .build();
+            try {
+                kafkaContainer.start();
+                return;
+            } catch (Exception e) {
+                if (e instanceof InterruptedException
+                        || e.getCause() instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+                LOGGER.warn("Kafka container start attempt {} failed: {}", attempt, e.getMessage());
+                try {
+                    kafkaContainer.stop();
+                } catch (Exception stopEx) {
+                    LOGGER.debug("Error stopping failed container", stopEx);
+                }
+                kafkaContainer = null;
+                if (attempt == MAX_START_ATTEMPTS) {
+                    throw new RuntimeException("Failed to start Kafka container after " + MAX_START_ATTEMPTS + " attempts", e);
+                }
+            }
+        }
     }
 
     public void stopIfPossible() throws Exception {


### PR DESCRIPTION
## Summary

- `KafkaFacade.start()` creates a `StrimziKafkaCluster` without startup resilience
- In CI environments with cold Docker caches or resource contention, the default Testcontainers timeout causes `AvroSerdeIT` to fail with "Timed out while starting Kafka containers"
- Add a retry loop (max 2 attempts) with proper container cleanup between attempts
- `InterruptedException` is detected (direct or wrapped in `RuntimeException`) and re-thrown immediately without retrying

**Evidence:** main branch run [30303558199](https://github.com/Apicurio/apicurio-registry/actions/runs/30303558199) (Jul 27), `AvroSerdeIT` failed with 60s container startup timeout.

Fixes #8990

## Test plan

- [ ] `./mvnw test-compile -pl integration-tests -am -DskipTests -Pintegration-tests` compiles cleanly
- [ ] Existing integration tests pass (the retry is transparent on success, adds ~0ms overhead)
- [ ] On startup failure, logs show `"Kafka container start attempt 1 failed"` followed by a retry