### PR TITLE
fix(ui): handle 404 gracefully on Global Contract Rules page (#9106)

### DIFF
--- a/ui/ui-app/src/app/pages/contractRules/GlobalContractRulesPage.tsx
+++ b/ui/ui-app/src/app/pages/contractRules/GlobalContractRulesPage.tsx
@@ -57,7 +57,9 @@ export const GlobalContractRulesPage: FunctionComponent<PageProperties> = () => 
 
     const createLoaders = (): Promise<any> => {
         return contracts.getGlobalContractRuleset().then(setRuleset).catch(error => {
-            setPageError(toPageError(error, "Error loading global contract rules."));
+            if (error?.status !== 404) {
+                setPageError(toPageError(error, "Error loading global contract rules."));
+            }
         });
     };
 


### PR DESCRIPTION
This PR handles the unhandled 404 error when navigating to the global contract rules page on a fresh setup. Instead of crashing the UI with a fatal error, it now gracefully renders the empty state.

Fixes #9106