### PR TITLE
fix(ui): include falsy query parameters in createEndpoint helper

### DIFF
--- a/ui/ui-app/src/utils/rest.utils.test.ts
+++ b/ui/ui-app/src/utils/rest.utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { createEndpoint } from "./rest.utils";
+
+describe("createEndpoint", () => {
+    const baseHref = "http://localhost:8080/apis/registry/v3";
+
+    it("should correctly substitute path parameters", () => {
+        const url = createEndpoint(baseHref, "/groups/:groupId/artifacts/:artifactId", {
+            groupId: "my-group",
+            artifactId: "my-artifact"
+        });
+        expect(url).toBe(`${baseHref}/groups/my-group/artifacts/my-artifact`);
+    });
+
+    it("should handle paths without query parameters or path parameters", () => {
+        const url = createEndpoint(baseHref, "/system/info");
+        expect(url).toBe(`${baseHref}/system/info`);
+    });
+
+    it("should append query parameters correctly, including falsy boolean and numeric values", () => {
+        const url = createEndpoint(
+            baseHref,
+            "/search",
+            {},
+            {
+                isActive: true,
+                isDeprecated: false,
+                limit: 10,
+                offset: 0,
+                negative: -1
+            }
+        );
+        expect(url).toBe(`${baseHref}/search?isActive=true&isDeprecated=false&limit=10&offset=0&negative=-1`);
+    });
+
+    it("should omit null, undefined, and empty string query parameters", () => {
+        const url = createEndpoint(
+            baseHref,
+            "/search",
+            {},
+            {
+                query: "",
+                filter: null,
+                sort: undefined,
+                validParam: "value"
+            }
+        );
+        expect(url).toBe(`${baseHref}/search?validParam=value`);
+    });
+
+    it("should correctly handle path and query parameters combined", () => {
+        const url = createEndpoint(
+            baseHref,
+            "/groups/:groupId/artifacts",
+            { groupId: "group-1" },
+            { limit: 5, offset: 0 }
+        );
+        expect(url).toBe(`${baseHref}/groups/group-1/artifacts?limit=5&offset=0`);
+    });
+});

--- a/ui/ui-app/src/utils/rest.utils.ts
+++ b/ui/ui-app/src/utils/rest.utils.ts
@@ -261,16 +261,15 @@ export function createEndpoint(baseHref: string, path: string, params?: any, que
     if (queryParams) {
         let first: boolean = true;
         for (const key in queryParams) {
-            if (queryParams[key]) {
-                const value: string = encodeURIComponent(queryParams[key]);
+            const rawValue: any = queryParams[key];
+            if (rawValue !== null && rawValue !== undefined && rawValue !== "") {
+                const value: string = encodeURIComponent(rawValue);
                 if (first) {
                     rval = rval + "?" + key;
                 } else {
                     rval = rval + "&" + key;
                 }
-                if (value !== null && value !== undefined) {
-                    rval = rval + "=" + value;
-                }
+                rval = rval + "=" + value;
                 first = false;
             }
         }


### PR DESCRIPTION
## Summary

This PR fixes an issue in the `createEndpoint` utility where valid falsy query parameter values were omitted when constructing request URLs.

The previous implementation filtered query parameters using a truthiness check, causing values such as `false` and `0` to be excluded from the generated URL. As a result, callers could not explicitly send these values to the backend and requests could unintentionally fall back to server defaults.

This change replaces the truthiness check with explicit `null`/`undefined` handling so that valid falsy values are preserved while continuing to omit `null`, `undefined`, and empty-string (`""`) values. The exclusion of empty strings is intentional to preserve the existing behavior and keep the change narrowly scoped to the reported issue.

## Changes

* Preserve valid falsy query parameter values (`false` and `0`) during URL construction.
* Continue ignoring `null`, `undefined`, and empty-string (`""`) query parameters.
* Add regression tests covering:

  * Boolean query parameters (`true` and `false`)
  * Numeric query parameters (including `0`)
  * Ignoring `null`, `undefined`, and empty-string query parameters
  * Existing path parameter substitution behavior

## Testing

* Added unit tests for `createEndpoint`.
* Verified that generated URLs correctly serialize `false` and `0`.
* Confirmed that `null`, `undefined`, and empty-string query parameters continue to be omitted as intended.

## Related Issue

Fixes #9129
