### PR TITLE
ci: replace Scalpel shadow group with lightweight report-only job

### DIFF
--- a/.github/PR_LIFECYCLE.md
+++ b/.github/PR_LIFECYCLE.md
@@ -30,6 +30,7 @@ Opened --> new --> wip --> ready-for-review --> ready-to-merge --> merged
 | `lifecycle/waiting-on-author` | PR needs action from the author (failed tests or changes requested). |
 | `lifecycle/waiting-on-maintainer` | PR needs maintainer attention (ready to review or merge). |
 | `lifecycle/stale` | No activity for 7 days. PR will be closed after 7 more days of inactivity. |
+| `ci/disable-scalpel` | Skips the non-blocking `scalpel-report` data-collection job for this PR. |
 
 ## For Contributors
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -128,6 +128,7 @@ non-Java changes (docs, UI).
 | `verify.yaml` | PR, push to main | Main orchestrator: `decide` job determines what to run, `verification-gate` is the single required check | N/A |
 | `verify-build.yaml` | Called by verify | Parallel Java (`mvnw package -T 0.5C`) + UI (`npm build`) builds. Produces Docker images and build artifacts uploaded with 1-day retention | ~6 min |
 | `verify-unit-tests.yaml` | Called by verify | Unit tests in 3 parallel shards (see above) | ~16 min (critical path) |
+| `scalpel-report` (job in `verify.yaml`) | PR with java changes | Scalpel affected-module analysis in report mode; uploads JSON artifact for offline analysis. Not in the Verification Gate. Opt out per PR with the `ci/disable-scalpel` label | ~2 min |
 | `verify-integration-tests.yaml` | Called by verify | 13-job matrix across storage backends, each with Minikube | ~15 min per job |
 | `verify-extras.yaml` | Called by verify | 5 parallel jobs: extra tests, UI Playwright tests, legacy V2 compatibility tests, TypeScript SDK tests, example builds | ~13 min |
 | `verify-sdk.yaml` | Called by verify | Go and Python SDK verification | ~2 min |

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -10,10 +10,6 @@ on:
         type: string
         required: true
         description: 'Build artifact identifier (commit SHA)'
-      scalpel-enabled:
-        type: string
-        default: 'false'
-        description: 'Set to true to enable Scalpel affected-module detection'
 
 permissions:
   contents: read
@@ -58,13 +54,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # Full history only needed when Scalpel is enabled (git diff against base branch)
-          fetch-depth: ${{ inputs.scalpel-enabled == 'true' && '0' || 1 }}
-
-      - name: Fetch base branch for Scalpel
-        if: inputs.scalpel-enabled == 'true' && github.base_ref != ''
-        continue-on-error: true
-        run: git fetch origin "$GITHUB_BASE_REF" --no-tags
+          fetch-depth: 1
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
@@ -102,7 +92,6 @@ jobs:
           # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
           ./mvnw verify \
             --no-transfer-progress -s ${{ github.workspace }}/.github/ci-settings.xml \
-            ${{ inputs.scalpel-enabled == 'true' && '-Dscalpel.enabled=true' || '' }} \
             -Pprod ${{ matrix.shard.modules }} \
             ${{ matrix.shard.test-filter }} \
             -Dsurefire.failIfNoSpecifiedTests=false \

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -29,6 +29,7 @@ jobs:
       lifecycle-ready: ${{ steps.decide.outputs.lifecycle-ready }}
       run-build: ${{ steps.decide.outputs.run-build }}
       run-unit-tests: ${{ steps.decide.outputs.run-unit-tests }}
+      run-scalpel-report: ${{ steps.decide.outputs.run-scalpel-report }}
       run-integration: ${{ steps.decide.outputs.run-integration }}
       run-extras: ${{ steps.decide.outputs.run-extras }}
       run-sdk: ${{ steps.decide.outputs.run-sdk }}
@@ -119,7 +120,7 @@ jobs:
               LABEL='${{ github.event.label.name }}'
               if [[ "$LABEL" != lifecycle/* ]]; then
                 echo "lifecycle-ready=skip" >> "$GITHUB_OUTPUT"
-                for out in run-build run-unit-tests run-integration run-extras run-sdk run-cli run-operator run-console-plugin run-go-sdk-freshness; do
+                for out in run-build run-unit-tests run-scalpel-report run-integration run-extras run-sdk run-cli run-operator run-console-plugin run-go-sdk-freshness; do
                   echo "$out=false" >> "$GITHUB_OUTPUT"
                 done
                 echo "scalpel-enabled=false" >> "$GITHUB_OUTPUT"
@@ -138,7 +139,7 @@ jobs:
             SENDER='${{ github.event.sender.login }}'
             if has_label "orchestrator/merge-rebase" && [ "$SENDER" = "github-actions[bot]" ]; then
               echo "lifecycle-ready=true" >> "$GITHUB_OUTPUT"
-              for out in run-build run-unit-tests run-integration run-extras run-sdk run-cli run-operator run-console-plugin run-go-sdk-freshness; do
+              for out in run-build run-unit-tests run-scalpel-report run-integration run-extras run-sdk run-cli run-operator run-console-plugin run-go-sdk-freshness; do
                 echo "$out=false" >> "$GITHUB_OUTPUT"
               done
               echo "scalpel-enabled=false" >> "$GITHUB_OUTPUT"
@@ -200,6 +201,9 @@ jobs:
           echo "lifecycle-ready=$run_smoke" >> "$GITHUB_OUTPUT"
           decide run-build       "$run_smoke" "$IS_PUSH" "$JAVA" "$UI" "$SDK" "$CLI" "$CI"
           decide run-unit-tests  "$run_smoke" "$IS_PUSH" "$JAVA" "$CI"
+          # Report only when java sources changed: .github-only PRs trip
+          # scalpel.disableTriggers and would produce an empty report.
+          decide run-scalpel-report "$run_smoke" "$JAVA"
           decide run-integration "$run_full"  "$IS_PUSH" "$INTEGRATION" "$CI"
           decide run-extras      "$run_full"  "$IS_PUSH" "$JAVA" "$UI" "$CI"
           decide run-sdk         "$run_full"  "$IS_PUSH" "$SDK" "$JAVA" "$CI"
@@ -223,6 +227,7 @@ jobs:
             "lifecycle-ready": "${{ steps.decide.outputs.lifecycle-ready }}",
             "run-build": "${{ steps.decide.outputs.run-build }}",
             "run-unit-tests": "${{ steps.decide.outputs.run-unit-tests }}",
+            "run-scalpel-report": "${{ steps.decide.outputs.run-scalpel-report }}",
             "run-integration": "${{ steps.decide.outputs.run-integration }}",
             "run-extras": "${{ steps.decide.outputs.run-extras }}",
             "run-sdk": "${{ steps.decide.outputs.run-sdk }}",
@@ -299,26 +304,68 @@ jobs:
     uses: ./.github/workflows/verify-unit-tests.yaml
     with:
       image-tag: ${{ github.sha }}
-      scalpel-enabled: 'false'
 
   # ============================================================================
-  # Unit Tests — Scalpel Shadow (evaluation mode)
+  # Scalpel Report (affected-module detection, data collection only)
   #
-  # Runs the same unit test shards with Scalpel ENABLED to compare results
-  # against the control group (unit-tests). Not in the Verification Gate —
-  # failures here don't block PRs. Remove this once the team is confident
-  # in Scalpel's accuracy and switches over.
-  # PR-only: on push-to-main Scalpel is a no-op (no GITHUB_BASE_REF), so
-  # running both groups would just double CI cost with identical results.
+  # Runs Scalpel in mode=report to record which modules it considers affected,
+  # without running any tests. Archives the JSON report as an artifact for
+  # offline analysis. ~2 minutes per run vs ~40 for the full shadow group.
+  # Not in the Verification Gate: a failure here never blocks a PR.
+  #
+  # Runs only when java sources changed (run-scalpel-report): on .github-only
+  # PRs Scalpel disables itself via scalpel.disableTriggers, so a report run
+  # would produce nothing. Mixed PRs (java + .github) still trip that trigger,
+  # which is why a missing report is a warning, not an error.
+  #
+  # See Discussion #8364 for the evaluation results that led to this change.
   # ============================================================================
-  unit-tests-scalpel:
-    name: Unit Tests (Scalpel)
-    needs: [decide, build]
-    if: needs.decide.outputs.run-unit-tests == 'true' && github.event_name == 'pull_request'
-    uses: ./.github/workflows/verify-unit-tests.yaml
-    with:
-      image-tag: ${{ github.sha }}
-      scalpel-enabled: ${{ needs.decide.outputs.scalpel-enabled }}
+  scalpel-report:
+    name: Scalpel Report
+    needs: [decide]
+    if: >-
+      github.event_name == 'pull_request'
+      && needs.decide.outputs.run-scalpel-report == 'true'
+      && needs.decide.outputs.scalpel-enabled == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Full history: Scalpel diffs against the base branch (GITHUB_BASE_REF)
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Restore Maven cache
+        uses: ./.github/actions/setup-maven-cache
+
+      - name: Generate Scalpel report
+        run: |
+          # CLI flags win over .mvn/maven.config (scalpel.enabled=false there).
+          # reportFile restates the documented default so the upload path
+          # below cannot drift if upstream changes it.
+          # wagon flags: same transient-failure hardening as the other CI jobs.
+          ./mvnw validate --no-transfer-progress \
+            -s ${{ github.workspace }}/.github/ci-settings.xml \
+            -Dscalpel.enabled=true \
+            -Dscalpel.mode=report \
+            -Dscalpel.reportFile=target/scalpel-report.json \
+            -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
+            -Dmaven.wagon.http.retryHandler.count=5
+
+      - name: Upload Scalpel report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scalpel-report-pr${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: target/scalpel-report.json
+          retention-days: 30
+          if-no-files-found: warn
 
   # ============================================================================
   # CLI Verification

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Scalpel: affected-module detection for CI. Disabled by default
-     in maven.config; CI unit test shards opt in via -Dscalpel.enabled=true. -->
+     in maven.config; the scalpel-report CI job opts in via -Dscalpel.enabled=true. -->
 <extensions>
     <extension>
         <groupId>eu.maveniverse.maven.scalpel</groupId>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,15 +1,14 @@
 -T 1C
-# Scalpel (affected-module detection) is disabled by default. Only unit test
-# shards opt in via -Dscalpel.enabled=true. Do not change this default without
-# also updating verify-build.yaml and other workflows that must compile all modules.
+# Scalpel (affected-module detection) is disabled by default; no Maven
+# invocation builds with it unless -Dscalpel.enabled=true is passed. The only
+# consumer is the scalpel-report CI job in verify.yaml, which runs mode=report
+# (analysis only, no reactor changes). mode is pinned here too so an ad-hoc
+# -Dscalpel.enabled=true never trims the reactor or skips tests by surprise.
 -Dscalpel.enabled=false
--Dscalpel.mode=skip-tests
+-Dscalpel.mode=report
 # disableTriggers: changes to CI/build config disable Scalpel entirely (full build).
 # excludePaths: non-build files ignored in change detection (add new non-Maven dirs here).
 -Dscalpel.disableTriggers=.github/**,.mvn/**,mvnw*
 -Dscalpel.excludePaths=*.md,LICENSE,docs/**,ui/**
-# skipTestsForUpstream: upstream deps of -pl target compile but skip tests.
-# Works because non-app shard always tests upstream modules independently.
--Dscalpel.skipTestsForUpstream=true
 # failSafe: on any Scalpel error, fall back to a full build instead of failing
 -Dscalpel.failSafe=true


### PR DESCRIPTION
## Summary

- Replace the 7-shard Scalpel shadow group with a single job running `mvnw validate -Dscalpel.mode=report`
- Uploads the affected-modules JSON as a build artifact (~2 min/run vs ~40 min for the full shadow group)
- New `run-scalpel-report` decide output: the job runs only when java sources change (`.github`-only PRs trip `scalpel.disableTriggers` and would produce an empty report)
- Remove all Scalpel infrastructure from `verify-unit-tests.yaml` (input, fetch-depth, fetch step, Maven flag)
- `maven.config`: pin `scalpel.mode=report` and drop the now-orphaned `skipTestsForUpstream`, so an ad-hoc `-Dscalpel.enabled=true` can never trim the reactor or skip tests
- Document the `ci/disable-scalpel` label (PR_LIFECYCLE.md) and the new job (workflows README)

**Evaluation results** (full write-up in Discussion #8364):

| Metric | Value |
|---|---|
| Timing delta (N=2 clean runs) | mean -45s, within runner noise |
| PRs touching app closure | 52.5% (all modules affected, Scalpel can't help) |
| Genuine Scalpel beneficiaries | 0% of sample (all non-closure PRs were CI/deps, not source) |
| False negatives | 0 (Scalpel never missed a real failure) |
| Noise rate | 25% (Scalpel-specific failures in 2/8 runs) |
| Actual compute cost | ~99.8h/week measured over the full shadow lifetime (254.9h across 351 triggered runs in 2.55 weeks; the original ~84h estimate was roughly right) |
| Dependency graph | Clean (maven-dependency-plugin:analyze confirms no bloat) |

**What stays:** Scalpel 0.3.9 in `.mvn/extensions.xml` (disabled by default), report-only CI job for ongoing data collection. The evaluation helper scripts are attached to Discussion #8364 rather than committed here, to keep this PR CI-only.

## Test plan

- [ ] `scalpel-report` job runs and uploads JSON artifact on a PR that triggers unit tests via java changes
- [x] `scalpel-report` job is skipped on `.github`-only PRs (verified on this PR's own run) and when the `ci/disable-scalpel` label is set
- [x] Unit test shards no longer pass `-Dscalpel.enabled=true`
- [x] Verification Gate is unaffected (was never gated on the shadow group)



> **Correction (2026-08-02):** an earlier revision of this table claimed ~4.5h/week (calling the 84h estimate an 18x overestimate). A full-lifetime enumeration of all 1526 PR-triggered Verify runs refutes that figure: it conflated the wall-clock critical-path delta (near zero, since shadow shards run in parallel with the control group) with runner-minutes, on an N=2 sample. Full write-up in the Discussion #8364 correction comment.
