### PR TITLE
fix(ui): align Agent Card creation UI with A2A Protocol v1.0 schema

### DIFF
--- a/ui/ui-app/src/app/components/agentCard/AgentCardEditor.tsx
+++ b/ui/ui-app/src/app/components/agentCard/AgentCardEditor.tsx
@@ -102,7 +102,7 @@ export const AgentCardEditor: FunctionComponent<AgentCardEditorProps> = (props: 
     };
 
     const handleAddInterface = (): void => {
-        const newInterface: AgentInterface = { url: "", protocolBinding: "A2A", protocolVersion: "1.0" };
+        const newInterface: AgentInterface = { id: crypto.randomUUID(), url: "", protocolBinding: "A2A", protocolVersion: "1.0" };
         updateField("supportedInterfaces", [...(agentCard.supportedInterfaces || []), newInterface]);
     };
 
@@ -176,7 +176,7 @@ export const AgentCardEditor: FunctionComponent<AgentCardEditorProps> = (props: 
                     </Title>
 
                     {(agentCard.supportedInterfaces || []).map((iface, index) => (
-                        <Card isPlain key={index} className="interface-entry">
+                        <Card isPlain key={iface.id || index} className="interface-entry">
                             <CardBody>
                                 <FormGroup label="URL" isRequired fieldId={`interface-url-${index}`}>
                                     <InputGroup>

--- a/ui/ui-app/src/app/components/agentCard/AgentCardEditor.tsx
+++ b/ui/ui-app/src/app/components/agentCard/AgentCardEditor.tsx
@@ -1,6 +1,9 @@
 import { FunctionComponent, useState } from "react";
 import "./AgentCardEditor.css";
 import {
+    ActionList,
+    ActionListItem,
+    Button,
     Card,
     CardBody,
     CardHeader,
@@ -20,9 +23,10 @@ import {
     InputGroup,
     InputGroupItem
 } from "@patternfly/react-core";
+import { PlusCircleIcon, TrashIcon } from "@patternfly/react-icons";
 import { CapabilityEditor } from "./CapabilityEditor";
 import { SkillEditor } from "./SkillEditor";
-import { AgentCard } from "./AgentCardViewer";
+import { AgentCard, AgentInterface } from "./AgentCardViewer";
 import { AgentCapabilities } from "./AgentCardCapabilities";
 import { AgentSkill } from "./AgentCardSkills";
 
@@ -97,6 +101,23 @@ export const AgentCardEditor: FunctionComponent<AgentCardEditorProps> = (props: 
         });
     };
 
+    const handleAddInterface = (): void => {
+        const newInterface: AgentInterface = { url: "", protocolBinding: "A2A", protocolVersion: "1.0" };
+        updateField("supportedInterfaces", [...(agentCard.supportedInterfaces || []), newInterface]);
+    };
+
+    const handleRemoveInterface = (index: number): void => {
+        const updated = (agentCard.supportedInterfaces || []).filter((_, i) => i !== index);
+        updateField("supportedInterfaces", updated);
+    };
+
+    const handleUpdateInterface = (index: number, field: keyof AgentInterface, value: string): void => {
+        const updated = (agentCard.supportedInterfaces || []).map((iface, i) =>
+            i === index ? { ...iface, [field]: value } : iface
+        );
+        updateField("supportedInterfaces", updated);
+    };
+
     return (
         <Card className={`agent-card-editor ${className || ""}`}>
             <CardHeader>
@@ -118,7 +139,7 @@ export const AgentCardEditor: FunctionComponent<AgentCardEditorProps> = (props: 
                         />
                     </FormGroup>
 
-                    <FormGroup label="Description" fieldId="agent-description">
+                    <FormGroup label="Description" isRequired fieldId="agent-description">
                         <TextArea
                             id="agent-description"
                             value={agentCard.description || ""}
@@ -128,7 +149,7 @@ export const AgentCardEditor: FunctionComponent<AgentCardEditorProps> = (props: 
                         />
                     </FormGroup>
 
-                    <FormGroup label="Version" fieldId="agent-version">
+                    <FormGroup label="Version" isRequired fieldId="agent-version">
                         <TextInput
                             id="agent-version"
                             value={agentCard.version || ""}
@@ -146,6 +167,67 @@ export const AgentCardEditor: FunctionComponent<AgentCardEditorProps> = (props: 
                             placeholder="https://example.com/agent"
                         />
                     </FormGroup>
+
+                    <Divider className="section-divider" />
+
+                    {/* Supported Interfaces Section (A2A v1.0 required) */}
+                    <Title headingLevel="h3" className="section-header">
+                        Supported Interfaces <span style={{ color: "var(--pf-t--global--color--status--danger--default)" }}>*</span>
+                    </Title>
+
+                    {(agentCard.supportedInterfaces || []).map((iface, index) => (
+                        <Card isPlain key={index} className="interface-entry">
+                            <CardBody>
+                                <FormGroup label="URL" isRequired fieldId={`interface-url-${index}`}>
+                                    <InputGroup>
+                                        <InputGroupItem isFill>
+                                            <TextInput
+                                                id={`interface-url-${index}`}
+                                                type="url"
+                                                value={iface.url}
+                                                onChange={(_event, value) => handleUpdateInterface(index, "url", value)}
+                                                placeholder="https://agent.example.com/a2a"
+                                            />
+                                        </InputGroupItem>
+                                    </InputGroup>
+                                </FormGroup>
+                                <FormGroup label="Protocol Binding" isRequired fieldId={`interface-binding-${index}`}>
+                                    <TextInput
+                                        id={`interface-binding-${index}`}
+                                        value={iface.protocolBinding}
+                                        onChange={(_event, value) => handleUpdateInterface(index, "protocolBinding", value)}
+                                        placeholder="e.g., A2A, JSONRPC"
+                                    />
+                                </FormGroup>
+                                <FormGroup label="Protocol Version" isRequired fieldId={`interface-version-${index}`}>
+                                    <TextInput
+                                        id={`interface-version-${index}`}
+                                        value={iface.protocolVersion}
+                                        onChange={(_event, value) => handleUpdateInterface(index, "protocolVersion", value)}
+                                        placeholder="e.g., 1.0"
+                                    />
+                                </FormGroup>
+                                <ActionList>
+                                    <ActionListItem>
+                                        <Button
+                                            variant="danger"
+                                            icon={<TrashIcon />}
+                                            onClick={() => handleRemoveInterface(index)}
+                                        >
+                                            Remove interface
+                                        </Button>
+                                    </ActionListItem>
+                                </ActionList>
+                            </CardBody>
+                        </Card>
+                    ))}
+                    <Button
+                        variant="link"
+                        icon={<PlusCircleIcon />}
+                        onClick={handleAddInterface}
+                    >
+                        Add interface
+                    </Button>
 
                     <Divider className="section-divider" />
 

--- a/ui/ui-app/src/app/components/agentCard/AgentCardViewer.tsx
+++ b/ui/ui-app/src/app/components/agentCard/AgentCardViewer.tsx
@@ -31,10 +31,14 @@ export interface AgentProvider {
 
 /**
  * A single transport interface through which the agent can be reached.
- * Each entry in supportedInterfaces must supply all three fields to pass
- * the backend's AgentCardContentValidator (A2A Protocol v1.0).
+ * Each entry in supportedInterfaces must supply url, protocolBinding, and
+ * protocolVersion to pass the backend's AgentCardContentValidator (A2A Protocol v1.0).
+ *
+ * `id` is a UI-only stable key used for React list reconciliation and is
+ * never sent to the backend.
  */
 export interface AgentInterface {
+    id?: string;
     url: string;
     protocolBinding: string;
     protocolVersion: string;
@@ -47,13 +51,13 @@ export interface AgentInterface {
 export interface AgentCard {
     /** REQUIRED – human-readable name of the agent. */
     name: string;
-    /** REQUIRED – human-readable description of what the agent does. */
+    /** REQUIRED by A2A v1.0 contract; optional in the TS model to accommodate partial or legacy cards. */
     description?: string;
-    /** REQUIRED – semantic version of the agent card (e.g. "1.0.0"). */
+    /** REQUIRED by A2A v1.0 contract; optional in the TS model to accommodate partial or legacy cards. */
     version?: string;
     /** Optional – version of the A2A protocol implemented by this agent. */
     protocolVersion?: string;
-    /** REQUIRED – at least one transport interface must be present. */
+    /** REQUIRED by A2A v1.0 contract (≥1 entry); optional in the TS model to accommodate partial or legacy cards. */
     supportedInterfaces?: AgentInterface[];
     url?: string;
     provider?: AgentProvider;
@@ -149,7 +153,7 @@ export const AgentCardViewer: FunctionComponent<AgentCardViewerProps> = (props: 
                 <DescriptionListTerm>Supported Interfaces</DescriptionListTerm>
                 <DescriptionListDescription>
                     {agentCard.supportedInterfaces.map((iface, index) => (
-                        <div key={index} className="agent-interface">
+                        <div key={iface.id || iface.url || index} className="agent-interface">
                             <a href={iface.url} target="_blank" rel="noopener noreferrer" className="agent-url">
                                 {iface.url}
                                 <ExternalLinkAltIcon className="external-link-icon" />

--- a/ui/ui-app/src/app/components/agentCard/AgentCardViewer.tsx
+++ b/ui/ui-app/src/app/components/agentCard/AgentCardViewer.tsx
@@ -30,20 +30,44 @@ export interface AgentProvider {
 }
 
 /**
- * Full Agent Card structure
+ * A single transport interface through which the agent can be reached.
+ * Each entry in supportedInterfaces must supply all three fields to pass
+ * the backend's AgentCardContentValidator (A2A Protocol v1.0).
+ */
+export interface AgentInterface {
+    url: string;
+    protocolBinding: string;
+    protocolVersion: string;
+}
+
+/**
+ * Full Agent Card structure aligned with A2A Protocol v1.0.
+ * Fields marked with REQUIRED must be non-empty to pass FULL content validation.
  */
 export interface AgentCard {
+    /** REQUIRED – human-readable name of the agent. */
     name: string;
+    /** REQUIRED – human-readable description of what the agent does. */
     description?: string;
+    /** REQUIRED – semantic version of the agent card (e.g. "1.0.0"). */
     version?: string;
+    /** Optional – version of the A2A protocol implemented by this agent. */
+    protocolVersion?: string;
+    /** REQUIRED – at least one transport interface must be present. */
+    supportedInterfaces?: AgentInterface[];
     url?: string;
     provider?: AgentProvider;
     capabilities?: AgentCapabilities;
     skills?: AgentSkill[];
     defaultInputModes?: string[];
     defaultOutputModes?: string[];
+    /** @deprecated use securitySchemes / securityRequirements instead */
     authentication?: AgentAuthentication;
     supportsExtendedAgentCard?: boolean;
+    iconUrl?: string;
+    documentationUrl?: string;
+    securitySchemes?: Record<string, object>;
+    securityRequirements?: object[];
 }
 
 /**
@@ -116,6 +140,31 @@ export const AgentCardViewer: FunctionComponent<AgentCardViewerProps> = (props: 
         );
     };
 
+    const renderSupportedInterfaces = (): React.ReactElement | null => {
+        if (!agentCard.supportedInterfaces || agentCard.supportedInterfaces.length === 0) {
+            return null;
+        }
+        return (
+            <DescriptionListGroup>
+                <DescriptionListTerm>Supported Interfaces</DescriptionListTerm>
+                <DescriptionListDescription>
+                    {agentCard.supportedInterfaces.map((iface, index) => (
+                        <div key={index} className="agent-interface">
+                            <a href={iface.url} target="_blank" rel="noopener noreferrer" className="agent-url">
+                                {iface.url}
+                                <ExternalLinkAltIcon className="external-link-icon" />
+                            </a>
+                            <LabelGroup className="interface-labels">
+                                <Label color="purple" isCompact>{iface.protocolBinding}</Label>
+                                <Label color="blue" isCompact>v{iface.protocolVersion}</Label>
+                            </LabelGroup>
+                        </div>
+                    ))}
+                </DescriptionListDescription>
+            </DescriptionListGroup>
+        );
+    };
+
     return (
         <Card className={`agent-card-viewer ${className || ""}`}>
             <CardHeader>
@@ -144,6 +193,7 @@ export const AgentCardViewer: FunctionComponent<AgentCardViewerProps> = (props: 
                 <DescriptionList isCompact className="agent-basic-info">
                     {renderUrl()}
                     {renderProvider()}
+                    {renderSupportedInterfaces()}
                     {renderModes(agentCard.defaultInputModes, "Input Modes")}
                     {renderModes(agentCard.defaultOutputModes, "Output Modes")}
                     {agentCard.supportsExtendedAgentCard !== undefined && (

--- a/ui/ui-app/src/app/pages/agents/components/modals/CreateAgentModal.tsx
+++ b/ui/ui-app/src/app/pages/agents/components/modals/CreateAgentModal.tsx
@@ -27,6 +27,9 @@ type Validities = {
 
 const EMPTY_AGENT_CARD: AgentCard = {
     name: "",
+    description: "",
+    version: "",
+    supportedInterfaces: [],
     defaultInputModes: ["text"],
     defaultOutputModes: ["text"]
 };
@@ -84,7 +87,19 @@ export const CreateAgentModal: FunctionComponent<CreateAgentModalProps> = (props
     };
 
     const isContentStepValid = (): boolean => {
-        return !!agentCard.name && agentCard.name.trim().length > 0;
+        return (
+            !!agentCard.name?.trim() &&
+            !!agentCard.description?.trim() &&
+            !!agentCard.version?.trim() &&
+            Array.isArray(agentCard.supportedInterfaces) &&
+            agentCard.supportedInterfaces.length > 0 &&
+            agentCard.supportedInterfaces.every(
+                iface => !!iface.url?.trim() && !!iface.protocolBinding?.trim() && !!iface.protocolVersion?.trim()
+            ) &&
+            agentCard.capabilities !== undefined &&
+            Array.isArray(agentCard.skills) &&
+            agentCard.skills.length > 0
+        );
     };
 
     const coordinatesStepFooter: Partial<WizardFooterProps> = {

--- a/ui/ui-app/src/app/pages/agents/components/modals/CreateAgentModal.tsx
+++ b/ui/ui-app/src/app/pages/agents/components/modals/CreateAgentModal.tsx
@@ -67,7 +67,12 @@ export const CreateAgentModal: FunctionComponent<CreateAgentModalProps> = (props
     const handleCreate = (): void => {
         const sanitizedCard = {
             ...agentCard,
-            supportedInterfaces: agentCard.supportedInterfaces?.map(({ id: _id, ...rest }) => rest)
+            // Strip UI-only `id` keys before JSON serialization to the backend.
+            supportedInterfaces: agentCard.supportedInterfaces?.map((iface) => {
+                const rest = { ...iface };
+                delete rest.id;
+                return rest;
+            })
         };
         const data: CreateArtifact = {
             artifactId: artifactId || undefined,

--- a/ui/ui-app/src/app/pages/agents/components/modals/CreateAgentModal.tsx
+++ b/ui/ui-app/src/app/pages/agents/components/modals/CreateAgentModal.tsx
@@ -65,6 +65,10 @@ export const CreateAgentModal: FunctionComponent<CreateAgentModalProps> = (props
     };
 
     const handleCreate = (): void => {
+        const sanitizedCard = {
+            ...agentCard,
+            supportedInterfaces: agentCard.supportedInterfaces?.map(({ id: _id, ...rest }) => rest)
+        };
         const data: CreateArtifact = {
             artifactId: artifactId || undefined,
             artifactType: "AGENT_CARD",
@@ -73,7 +77,7 @@ export const CreateAgentModal: FunctionComponent<CreateAgentModalProps> = (props
             firstVersion: {
                 version: version || undefined,
                 content: {
-                    content: JSON.stringify(agentCard, null, 2),
+                    content: JSON.stringify(sanitizedCard, null, 2),
                     contentType: "application/json"
                 }
             }


### PR DESCRIPTION
## Summary

Fixes #8991

The Create Agent wizard and the `AgentCard` TypeScript model were built against a pre-v1.0 shape of the A2A spec. Any attempt to create an Agent Card with full content validation enabled fails with a `400 RuleViolationException` because the form never gives the user a way to fill in several required fields (`description`, `version`, `supportedInterfaces`).

Three independent defects are fixed together because they all stem from the same root cause — the TypeScript model and form were never updated after the A2A Protocol advanced to v1.0:

---

## Changes

### 1. `AgentCardViewer.tsx` — update `AgentCard` TypeScript interface

- Add `AgentInterface` type `{ url, protocolBinding, protocolVersion }` matching the backend's `AgentCardContentValidator` validation rules
- Add `supportedInterfaces?: AgentInterface[]` to `AgentCard`
- Add optional `protocolVersion`, `iconUrl`, `documentationUrl`, `securitySchemes`, `securityRequirements` fields
- Mark `description` and `version` with JSDoc REQUIRED annotations
- Add `renderSupportedInterfaces()` so the read-only viewer shows all interface entries

### 2. `AgentCardEditor.tsx` — add Supported Interfaces repeater

- Mark **Description** and **Version** `FormGroup`s as `isRequired`
- Add a **Supported Interfaces** section: users can add/remove interface entries, each with URL, Protocol Binding, and Protocol Version inputs — the three fields `AgentCardContentValidator` enforces per entry

### 3. `CreateAgentModal.tsx` — full content-step validation

- Seed `EMPTY_AGENT_CARD` with `description: ""`, `version: ""`, `supportedInterfaces: []`
- Replace the name-only guard in `isContentStepValid()` with a complete check mirroring the backend validator:
  - `name`, `description`, `version` must be non-empty strings
  - At least one `supportedInterface` must exist and be fully filled (url, protocolBinding, protocolVersion)
  - `capabilities` must be present
  - At least one `skill` must be present
- This prevents the wizard from reaching the **Create** button when the submitted payload would fail server-side validation

---

## Validation

Cross-referenced against `AgentCardContentValidator.java` to ensure every field the backend enforces as required is now either collected by the form or validated in `isContentStepValid()`.

- `npm run lint` — passes (0 errors)
- `tsc --noEmit` — passes (0 errors)