### PR TITLE
build(deps): rename relocated quarkus-junit5 artifacts to quarkus-junit

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -244,7 +244,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -254,7 +254,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -90,7 +90,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/config-index/deployment/pom.xml
+++ b/config-index/deployment/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/console-plugin/backend/pom.xml
+++ b/console-plugin/backend/pom.xml
@@ -35,7 +35,7 @@
         <!-- Test -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,7 +20,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -75,7 +75,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/operator/controller/pom.xml
+++ b/operator/controller/pom.xml
@@ -49,7 +49,7 @@
     <!-- Test -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/operator/model/pom.xml
+++ b/operator/model/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/operator/olm-tests/pom.xml
+++ b/operator/olm-tests/pom.xml
@@ -45,7 +45,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/utils/exportConfluent/pom.xml
+++ b/utils/exportConfluent/pom.xml
@@ -48,7 +48,7 @@
     <!-- Test dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/utils/tests/pom.xml
+++ b/utils/tests/pom.xml
@@ -46,7 +46,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
## Summary

- Rename the relocated Quarkus test artifacts per the Quarkus 3.31 migration: `quarkus-junit5` -> `quarkus-junit`, `quarkus-junit5-mockito` -> `quarkus-junit-mockito`, and `quarkus-junit5-internal` -> `quarkus-junit-internal` (the third one was not in the issue but emits the same relocation warning; confirmed against the relocation pom in the local repo)
- 11 poms changed, artifactId lines only

**Deliberately left on the legacy names:** the four examples under `examples/debezium-otel-tracing` and `examples/otel-tracing`, plus `support-chat`, pin their own pre-3.31 Quarkus BOMs (3.27.0/3.27.2) where the renamed artifacts do not exist; renaming them would break their builds. They keep `quarkus-junit5` until their Quarkus versions are bumped (verified against the cached `quarkus-bom` 3.27.x: no `quarkus-junit` entry).

Closes #9139.

## Test plan

- [x] `./mvnw test-compile -pl app -DskipTests`: clean, zero relocation warnings (previously two)
- [x] Same for `cli`, `config-index/deployment` (covers `quarkus-junit-internal`), `mcp` (`-Dfull`), `utils/tests`
- [x] `grep -rn "quarkus-junit5" --include=pom.xml .` lists exactly the five deliberately-kept poms
- [x] `./mvnw checkstyle:check -pl app` and `./scripts/validate-files.sh` pass
