### PR TITLE
build: add dependency-check profile for reactor-wide dependency analysis

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -76,6 +76,55 @@ Integration tests and examples are always opt-in via their own profiles:
 | `-DcliSkipNative`     | Skip CLI native image compilation (no executable is produced, but tests can still run)   |
 | `-DskipOperatorTests` | Skip operator tests (default: `true`, requires a running cluster)                        |
 
+## Dependency Analysis
+
+`dependency:analyze` cannot be run directly over the full reactor: the `app` module
+declares a test dependency of type `maven-plugin` on `apicurio-registry-maven-plugin`
+via its `local-excluded-test-deps` profile (active whenever `-Dlocal` is absent), and
+the `utils/maven-plugin` module that produces that artifact is only present in the
+reactor under `-Dfull`, which is why both documented commands below carry `-Dfull`.
+Maven cannot satisfy `maven-plugin`-typed dependencies from the reactor when
+`dependency:analyze` forks `test-compile`. The
+`dependency-check` Maven profile works around this by using
+[`dependency:analyze-only`](https://maven.apache.org/plugins/maven-dependency-plugin/analyze-only-mojo.html)
+instead, which does not fork the build, binding it to the `package` phase instead of
+running it as a standalone goal. `analyze-only` requires the classes it inspects to
+already be compiled. Binding it to `package` guarantees that, because Maven runs the
+normal (non-forked) `compile`, `test-compile`, and `package` phases for every module,
+in reactor order, before `analyze-only` runs for that module. This is what actually
+gives full reactor coverage. Binding it to an earlier phase such as `validate` was
+tried first and failed partway through the reactor (`BUILD FAILURE` at module 46/67),
+because sibling modules outside `app`'s own dependency closure hadn't been
+compiled/packaged yet and Maven couldn't resolve them as dependencies. The check is
+still a two-step procedure:
+
+```bash
+# Step 1: build app and its dependency closure so apicurio-registry-maven-plugin
+# (and everything else app needs) is installed to the local repository.
+./mvnw -T1 install -pl app -am -DskipTests -Dfull -DcliSkipNative -q
+
+# Step 2: run the report-only dependency analysis over the full reactor.
+./mvnw -T1 -Pdependency-check package -DskipTests -Dfull -DcliSkipNative
+```
+
+The profile configures `analyze-only` with `ignoreNonCompile=true` (ignore
+runtime/provided/test/system scopes when flagging unused dependencies) and
+`failOnWarning=false` (report only, never breaks the build).
+
+**`-T1` is required**, not optional: `.mvn/maven.config` sets `-T 1C` globally, and a
+parallel build interleaves per-module log output, which silently misattributes
+warnings to the wrong module. Always pass `-T1` explicitly for both steps when reading
+the analyze output.
+
+**Results on the `app` module are false-positive-heavy.** `app` is a Quarkus
+application, and Quarkus extensions inject capabilities (e.g. CDI beans, config) at
+build time in ways a bytecode-based analyzer cannot see, so `analyze-only` routinely
+flags used Quarkus extensions (e.g. `io.quarkus:quarkus-core`, `io.quarkus:quarkus-arc`)
+as "used undeclared" or unused. Treat `app` warnings with skepticism and cross-check
+before acting on them. See [issue #9136](https://github.com/Apicurio/apicurio-registry/issues/9136)
+for background, and [quarkus-extension-analyzer](https://github.com/paoloantinori/quarkus-extension-analyzer)
+for a Quarkus-aware alternative that is being explored separately.
+
 ## Testing
 
 Unit tests run as part of the normal build (`mvn clean install`). Integration tests

--- a/pom.xml
+++ b/pom.xml
@@ -1538,5 +1538,31 @@
         </repository>
       </repositories>
     </profile>
+    <!-- Report-only reactor-wide dependency analysis, see DEVELOPING.md for the required
+         two-step procedure (https://github.com/Apicurio/apicurio-registry/issues/9136). -->
+    <profile>
+      <id>dependency-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>analyze-dependencies</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>analyze-only</goal>
+                </goals>
+                <configuration>
+                  <ignoreNonCompile>true</ignoreNonCompile>
+                  <failOnWarning>false</failOnWarning>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
## Summary

- New manual-only `dependency-check` Maven profile: binds `maven-dependency-plugin:analyze-only` (report-only, `failOnWarning=false`, `ignoreNonCompile=true`, plugin version from the existing pinned property) to the `package` phase
- New "Dependency Analysis" section in `DEVELOPING.md` documenting the verified two-step procedure and its two non-obvious constraints:
  - `-T1` is required for readable per-module attribution (the global `-T 1C` in `.mvn/maven.config` interleaves module logs, which silently corrupts any per-module reading of the warnings)
  - the `app` closure must be installed first: `app` declares a `maven-plugin`-typed test dependency (via its `local-excluded-test-deps` profile) that Maven cannot satisfy from the reactor
- The doc also warns that results on the Quarkus `app` module are false-positive-heavy (extensions have no bytecode references) and links the Quarkus-aware analyzer being explored separately

**Why `analyze-only` and `package`, not `analyze` and `validate`:** `analyze` forks `test-compile` and fails on the `maven-plugin`-typed dependency; binding to `validate` was tested and fails at module 46/67 because reactor siblings aren't compiled yet. The committed combination was tested end-to-end on the full reactor: BUILD SUCCESS, 67/67 modules analyzed, 22:26 min.

No default build behavior changes: the profile activates only with `-Pdependency-check`.

Closes #9136. Enables the cleanup work in #9134 and #9135, and the DepClean comparison noted in the issue comments.

## Test plan

- [x] Full-reactor run with the profile: BUILD SUCCESS, `analyze-only` executed 67 times (once per module)
- [x] `./mvnw checkstyle:check -pl .` and `./scripts/validate-files.sh` pass
- [x] Profile has no `activeByDefault` and no property activation
