### PR TITLE
fix(auth): require Admin or current owner for ownership transfers

### DIFF
--- a/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
@@ -237,6 +237,15 @@ public class AuthConfig {
         return this.proxyHeaderAuthEnabled;
     }
 
+    /**
+     * True when any authentication backend is enabled. Canonical check used by
+     * {@link AuthorizedInterceptor} and ownership-transfer authorization — keep those
+     * call sites on this method so a new backend cannot silently bypass authz.
+     */
+    public boolean isAuthenticationEnabled() {
+        return oidcAuthEnabled || basicAuthEnabled || proxyHeaderAuthEnabled || kubernetesAuthEnabled;
+    }
+
     public boolean isRbacEnabled() {
         return this.roleBasedAuthorizationEnabled;
     }

--- a/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
@@ -233,6 +233,10 @@ public class AuthConfig {
         return this.basicAuthEnabled;
     }
 
+    public boolean isProxyHeaderAuthEnabled() {
+        return this.proxyHeaderAuthEnabled;
+    }
+
     public boolean isRbacEnabled() {
         return this.roleBasedAuthorizationEnabled;
     }

--- a/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
@@ -74,8 +74,7 @@ public class AuthorizedInterceptor {
         }
 
         // If authentication is not enabled, just do it.
-        if (!authConfig.oidcAuthEnabled && !authConfig.basicAuthEnabled
-                && !authConfig.proxyHeaderAuthEnabled && !authConfig.kubernetesAuthEnabled) {
+        if (!authConfig.isAuthenticationEnabled()) {
             return context.proceed();
         }
 

--- a/app/src/main/java/io/apicurio/registry/auth/OwnershipTransferAuthorizer.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OwnershipTransferAuthorizer.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.auth;
+
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.security.Principal;
+import java.util.Objects;
+
+/**
+ * Authorizes ownership transfers for artifacts and groups.
+ *
+ * <p>Metadata update endpoints use {@link AuthorizedLevel#Write} so non-owners can still
+ * change name/description/labels. Ownership changes require Admin or the current owner
+ * (mirrors V2 {@code updateArtifactOwner} / {@link AuthorizedLevel#AdminOrOwner}).
+ *
+ * <p>Cannot be expressed solely via {@code @Authorized(level = AdminOrOwner)} because that
+ * would block non-owners from updating non-owner metadata fields on the same endpoint.
+ */
+@ApplicationScoped
+public class OwnershipTransferAuthorizer {
+
+    private static final String TRANSFER_FORBIDDEN =
+            "Only the current owner or an admin can transfer ownership.";
+
+    @Inject
+    AuthConfig authConfig;
+
+    @Inject
+    AdminOverride adminOverride;
+
+    @Inject
+    RoleBasedAccessController rbac;
+
+    @Inject
+    SecurityIdentity securityIdentity;
+
+    /**
+     * Ensures the caller may set ownership to {@code requestedOwner}.
+     *
+     * <ul>
+     *   <li>No-op when authentication is disabled</li>
+     *   <li>No-op when {@code requestedOwner} equals the current owner</li>
+     *   <li>Allowed for admins (admin-override or RBAC admin role)</li>
+     *   <li>Allowed when the resource is unowned ({@code currentOwner == null})</li>
+     *   <li>Allowed when the caller is the current owner</li>
+     *   <li>Otherwise forbidden</li>
+     * </ul>
+     *
+     * @param currentOwner the owner currently stored for the resource (may be null)
+     * @param requestedOwner the non-empty owner value from the request
+     */
+    public void authorizeOwnerChange(String currentOwner, String requestedOwner) {
+        if (!isAuthenticationEnabled()) {
+            return;
+        }
+
+        if (Objects.equals(currentOwner, requestedOwner)) {
+            return;
+        }
+
+        if (isAdmin()) {
+            return;
+        }
+
+        Principal principal = securityIdentity.getPrincipal();
+        String currentUser = principal != null ? principal.getName() : null;
+
+        // Unowned resources may be claimed by any authenticated Write user.
+        if (currentOwner == null || currentOwner.equals(currentUser)) {
+            return;
+        }
+
+        throw new ForbiddenException(TRANSFER_FORBIDDEN);
+    }
+
+    private boolean isAdmin() {
+        return adminOverride.isAdmin() || (authConfig.isRbacEnabled() && rbac.isAdmin());
+    }
+
+    private boolean isAuthenticationEnabled() {
+        return authConfig.isOidcAuthEnabled() || authConfig.isBasicAuthEnabled()
+                || authConfig.isProxyHeaderAuthEnabled() || authConfig.isKubernetesAuthEnabled();
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/auth/OwnershipTransferAuthorizer.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OwnershipTransferAuthorizer.java
@@ -27,6 +27,12 @@ import java.util.Objects;
 /**
  * Authorizes ownership transfers for artifacts and groups.
  *
+ * <p>Wired into the only V3 client-writable owner paths:
+ * {@code GroupsResourceImpl#updateArtifactMetaData} and
+ * {@code GroupsResourceImpl#updateGroupById}. Version metadata has no owner field;
+ * import/bulk paths are Admin-only. V2 uses a dedicated
+ * {@code updateArtifactOwner} with {@link AuthorizedLevel#AdminOrOwner}.
+ *
  * <p>Metadata update endpoints use {@link AuthorizedLevel#Write} so non-owners can still
  * change name/description/labels. Ownership changes require Admin or the current owner
  * (mirrors V2 {@code updateArtifactOwner} / {@link AuthorizedLevel#AdminOrOwner}).
@@ -68,7 +74,7 @@ public class OwnershipTransferAuthorizer {
      * @param requestedOwner the non-empty owner value from the request
      */
     public void authorizeOwnerChange(String currentOwner, String requestedOwner) {
-        if (!isAuthenticationEnabled()) {
+        if (!authConfig.isAuthenticationEnabled()) {
             return;
         }
 
@@ -93,10 +99,5 @@ public class OwnershipTransferAuthorizer {
 
     private boolean isAdmin() {
         return adminOverride.isAdmin() || (authConfig.isRbacEnabled() && rbac.isAdmin());
-    }
-
-    private boolean isAuthenticationEnabled() {
-        return authConfig.isOidcAuthEnabled() || authConfig.isBasicAuthEnabled()
-                || authConfig.isProxyHeaderAuthEnabled() || authConfig.isKubernetesAuthEnabled();
     }
 }

--- a/app/src/main/java/io/apicurio/registry/auth/OwnershipTransferAuthorizer.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OwnershipTransferAuthorizer.java
@@ -29,9 +29,14 @@ import java.util.Objects;
  *
  * <p>Wired into the only V3 client-writable owner paths:
  * {@code GroupsResourceImpl#updateArtifactMetaData} and
- * {@code GroupsResourceImpl#updateGroupById}. Version metadata has no owner field;
- * import/bulk paths are Admin-only. V2 uses a dedicated
- * {@code updateArtifactOwner} with {@link AuthorizedLevel#AdminOrOwner}.
+ * {@code GroupsResourceImpl#updateGroupById}. Confirmed by grepping
+ * {@code rest/v3/impl} for {@code data.getOwner()} / {@code setOwner} and checking
+ * OpenAPI {@code Editable*} schemas in {@code common/.../openapi.json}: only
+ * {@code EditableArtifactMetaData} and {@code EditableGroupMetaData} expose
+ * {@code owner}; {@code EditableVersionMetaData} / {@code CreateArtifact} /
+ * {@code CreateGroup} do not (create stamps owner from the principal); import is
+ * Admin-only. V2 uses dedicated {@code updateArtifactOwner} with
+ * {@link AuthorizedLevel#AdminOrOwner}.
  *
  * <p>Metadata update endpoints use {@link AuthorizedLevel#Write} so non-owners can still
  * change name/description/labels. Ownership changes require Admin or the current owner

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -3,6 +3,7 @@ package io.apicurio.registry.rest.v3.impl;
 import io.apicurio.registry.auth.Authorized;
 import io.apicurio.registry.auth.AuthorizedLevel;
 import io.apicurio.registry.auth.AuthorizedStyle;
+import io.apicurio.registry.auth.OwnershipTransferAuthorizer;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.contracts.ContractLabels;
 import io.apicurio.registry.storage.dto.PromotionStage;
@@ -139,6 +140,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
 
     @Inject
     SecurityIdentity securityIdentity;
+
+    @Inject
+    OwnershipTransferAuthorizer ownershipTransferAuthorizer;
 
     @Inject
     io.apicurio.registry.services.PromptRenderingService promptRenderingService;
@@ -583,21 +587,24 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
+        String rawGroupId = new GroupId(groupId).getRawGroupIdWithNull();
         if (data.getOwner() != null) {
             if (data.getOwner().trim().isEmpty()) {
                 throw new MissingRequiredParameterException("Owner cannot be empty");
-            } else {
-                // TODO extra security check - if the user is trying to change the owner, fail unless they are
-                // an Admin or the current Owner
             }
+            // Cannot use @Authorized(AdminOrOwner) on the method: Write users must still update
+            // non-owner metadata. Ownership changes require Admin or the current owner.
+            ArtifactMetaDataDto currentMetaData = storage.getArtifactMetaData(rawGroupId, artifactId);
+            ownershipTransferAuthorizer.authorizeOwnerChange(currentMetaData.getOwner(),
+                    data.getOwner().trim());
         }
 
         EditableArtifactMetaDataDto dto = new EditableArtifactMetaDataDto();
         dto.setName(data.getName());
         dto.setDescription(data.getDescription());
-        dto.setOwner(data.getOwner());
+        dto.setOwner(data.getOwner() != null ? data.getOwner().trim() : null);
         dto.setLabels(data.getLabels());
-        storage.updateArtifactMetaData(new GroupId(groupId).getRawGroupIdWithNull(), artifactId, dto);
+        storage.updateArtifactMetaData(rawGroupId, artifactId, dto);
     }
 
     @Override
@@ -631,11 +638,23 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     public void updateGroupById(String groupId, EditableGroupMetaData data) {
         ParameterValidationUtils.requireParameter("groupId", groupId);
 
+        String rawGroupId = new GroupId(groupId).getRawGroupIdWithNull();
+        if (data.getOwner() != null) {
+            if (data.getOwner().trim().isEmpty()) {
+                throw new MissingRequiredParameterException("Owner cannot be empty");
+            }
+            // Same rationale as updateArtifactMetaData: Write covers non-owner fields;
+            // ownership transfer is Admin or current owner only.
+            GroupMetaDataDto currentMetaData = storage.getGroupMetaData(rawGroupId);
+            ownershipTransferAuthorizer.authorizeOwnerChange(currentMetaData.getOwner(),
+                    data.getOwner().trim());
+        }
+
         EditableGroupMetaDataDto dto = new EditableGroupMetaDataDto();
         dto.setDescription(data.getDescription());
         dto.setLabels(data.getLabels());
-        dto.setOwner(data.getOwner());
-        storage.updateGroupMetaData(new GroupId(groupId).getRawGroupIdWithNull(), dto);
+        dto.setOwner(data.getOwner() != null ? data.getOwner().trim() : null);
+        storage.updateGroupMetaData(rawGroupId, dto);
     }
 
     @Override

--- a/app/src/test/java/io/apicurio/registry/auth/BasicAuthWithPropertiesTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/BasicAuthWithPropertiesTest.java
@@ -7,8 +7,11 @@ import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.rest.client.RegistryClient;
 import io.apicurio.registry.rest.client.models.ArtifactMetaData;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateGroup;
 import io.apicurio.registry.rest.client.models.CreateRule;
 import io.apicurio.registry.rest.client.models.EditableArtifactMetaData;
+import io.apicurio.registry.rest.client.models.EditableGroupMetaData;
+import io.apicurio.registry.rest.client.models.GroupMetaData;
 import io.apicurio.registry.rest.client.models.RuleType;
 import io.apicurio.registry.rest.client.models.UserInfo;
 import io.apicurio.registry.rest.client.models.VersionMetaData;
@@ -535,6 +538,81 @@ public class BasicAuthWithPropertiesTest extends AbstractResourceTestBase {
             client_dev1.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).get();
         });
         assertNotFound(exception2);
+    }
+
+    @Test
+    public void testUpdateGroupOwnerByOwner() throws Exception {
+        var client = RegistryClientFactory.create(RegistryClientOptions.create(registryV3ApiUrl, vertx)
+                .basicAuth(DEVELOPER_USERNAME, DEVELOPER_PASSWORD));
+
+        final String groupId = "testUpdateGroupOwnerByOwner-" + UUID.randomUUID();
+        CreateGroup createGroup = new CreateGroup();
+        createGroup.setGroupId(groupId);
+        createGroup.setDescription("owned by bob1");
+        GroupMetaData created = client.groups().post(createGroup);
+        assertEquals(DEVELOPER_USERNAME, created.getOwner());
+
+        EditableGroupMetaData update = new EditableGroupMetaData();
+        update.setOwner(DEVELOPER_2_USERNAME);
+        client.groups().byGroupId(groupId).put(update);
+
+        GroupMetaData updated = client.groups().byGroupId(groupId).get();
+        assertEquals(DEVELOPER_2_USERNAME, updated.getOwner());
+    }
+
+    @Test
+    public void testUpdateGroupOwnerDeniedForNonOwner() throws Exception {
+        var client_dev1 = RegistryClientFactory.create(
+                RegistryClientOptions.create(registryV3ApiUrl, vertx)
+                .basicAuth(DEVELOPER_USERNAME, DEVELOPER_PASSWORD));
+        var client_dev2 = RegistryClientFactory.create(
+                RegistryClientOptions.create(registryV3ApiUrl, vertx)
+                .basicAuth(DEVELOPER_2_USERNAME, DEVELOPER_2_PASSWORD));
+
+        final String groupId = "testUpdateGroupOwnerDenied-" + UUID.randomUUID();
+        CreateGroup createGroup = new CreateGroup();
+        createGroup.setGroupId(groupId);
+        createGroup.setDescription("owned by bob1");
+        GroupMetaData created = client_dev1.groups().post(createGroup);
+        assertEquals(DEVELOPER_USERNAME, created.getOwner());
+
+        // Non-owner may still update non-owner metadata (OBAC group limit is off by default).
+        EditableGroupMetaData descriptionUpdate = new EditableGroupMetaData();
+        descriptionUpdate.setDescription("updated by bob2");
+        client_dev2.groups().byGroupId(groupId).put(descriptionUpdate);
+        assertEquals("updated by bob2", client_dev1.groups().byGroupId(groupId).get().getDescription());
+        assertEquals(DEVELOPER_USERNAME, client_dev1.groups().byGroupId(groupId).get().getOwner());
+
+        // Non-owner must not transfer ownership.
+        var exception = assertThrows(Exception.class, () -> {
+            EditableGroupMetaData ownerUpdate = new EditableGroupMetaData();
+            ownerUpdate.setOwner(DEVELOPER_2_USERNAME);
+            client_dev2.groups().byGroupId(groupId).put(ownerUpdate);
+        });
+        assertForbidden(exception);
+        assertEquals(DEVELOPER_USERNAME, client_dev1.groups().byGroupId(groupId).get().getOwner());
+    }
+
+    @Test
+    public void testUpdateGroupOwnerByAdmin() throws Exception {
+        var client_dev1 = RegistryClientFactory.create(
+                RegistryClientOptions.create(registryV3ApiUrl, vertx)
+                .basicAuth(DEVELOPER_USERNAME, DEVELOPER_PASSWORD));
+        var client_admin = RegistryClientFactory.create(
+                RegistryClientOptions.create(registryV3ApiUrl, vertx)
+                .basicAuth(ADMIN_USERNAME, ADMIN_PASSWORD));
+
+        final String groupId = "testUpdateGroupOwnerByAdmin-" + UUID.randomUUID();
+        CreateGroup createGroup = new CreateGroup();
+        createGroup.setGroupId(groupId);
+        GroupMetaData created = client_dev1.groups().post(createGroup);
+        assertEquals(DEVELOPER_USERNAME, created.getOwner());
+
+        EditableGroupMetaData ownerUpdate = new EditableGroupMetaData();
+        ownerUpdate.setOwner(DEVELOPER_2_USERNAME);
+        client_admin.groups().byGroupId(groupId).put(ownerUpdate);
+
+        assertEquals(DEVELOPER_2_USERNAME, client_dev1.groups().byGroupId(groupId).get().getOwner());
     }
 
 }

--- a/app/src/test/java/io/apicurio/registry/auth/OwnershipTransferAuthorizerTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/OwnershipTransferAuthorizerTest.java
@@ -35,49 +35,52 @@ public class OwnershipTransferAuthorizerTest {
 
     @Test
     public void ownerCanTransfer() {
-        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob1", false, true);
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob1", false, false, true);
         assertDoesNotThrow(() -> authorizer.authorizeOwnerChange("bob1", "bob2"));
     }
 
     @Test
     public void nonOwnerCannotTransfer() {
-        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, true);
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, false, true);
         assertThrows(ForbiddenException.class, () -> authorizer.authorizeOwnerChange("bob1", "bob2"));
     }
 
     @Test
-    public void adminCanTransfer() {
-        OwnershipTransferAuthorizer authorizer = newAuthorizer("alice", true, true);
+    public void adminOverrideCanTransfer() {
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("alice", true, false, true);
+        assertDoesNotThrow(() -> authorizer.authorizeOwnerChange("bob1", "bob2"));
+    }
+
+    @Test
+    public void rbacAdminCanTransfer() {
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("alice", false, true, true);
         assertDoesNotThrow(() -> authorizer.authorizeOwnerChange("bob1", "bob2"));
     }
 
     @Test
     public void unownedCanBeClaimed() {
-        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, true);
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, false, true);
         assertDoesNotThrow(() -> authorizer.authorizeOwnerChange(null, "bob2"));
     }
 
     @Test
     public void noopSameOwnerAllowed() {
-        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, true);
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, false, true);
         assertDoesNotThrow(() -> authorizer.authorizeOwnerChange("bob1", "bob1"));
     }
 
     @Test
     public void skippedWhenAuthDisabled() {
-        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, false);
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, false, false);
         assertDoesNotThrow(() -> authorizer.authorizeOwnerChange("bob1", "bob2"));
     }
 
     private OwnershipTransferAuthorizer newAuthorizer(String username, boolean adminOverrideActive,
-            boolean authEnabled) {
+            boolean rbacAdmin, boolean authEnabled) {
         OwnershipTransferAuthorizer authorizer = new OwnershipTransferAuthorizer();
 
         AuthConfig authConfig = mock(AuthConfig.class);
-        when(authConfig.isOidcAuthEnabled()).thenReturn(false);
-        when(authConfig.isBasicAuthEnabled()).thenReturn(authEnabled);
-        when(authConfig.isProxyHeaderAuthEnabled()).thenReturn(false);
-        when(authConfig.isKubernetesAuthEnabled()).thenReturn(false);
+        when(authConfig.isAuthenticationEnabled()).thenReturn(authEnabled);
         when(authConfig.isRbacEnabled()).thenReturn(true);
         authorizer.authConfig = authConfig;
 
@@ -86,7 +89,7 @@ public class OwnershipTransferAuthorizerTest {
         authorizer.adminOverride = adminOverride;
 
         RoleBasedAccessController rbac = mock(RoleBasedAccessController.class);
-        when(rbac.isAdmin()).thenReturn(false);
+        when(rbac.isAdmin()).thenReturn(rbacAdmin);
         authorizer.rbac = rbac;
 
         Principal principal = mock(Principal.class);

--- a/app/src/test/java/io/apicurio/registry/auth/OwnershipTransferAuthorizerTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/OwnershipTransferAuthorizerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.auth;
+
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Decision-matrix coverage for {@link OwnershipTransferAuthorizer}.
+ * HTTP end-to-end coverage lives in {@link BasicAuthWithPropertiesTest}.
+ */
+public class OwnershipTransferAuthorizerTest {
+
+    @Test
+    public void ownerCanTransfer() {
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob1", false, true);
+        assertDoesNotThrow(() -> authorizer.authorizeOwnerChange("bob1", "bob2"));
+    }
+
+    @Test
+    public void nonOwnerCannotTransfer() {
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, true);
+        assertThrows(ForbiddenException.class, () -> authorizer.authorizeOwnerChange("bob1", "bob2"));
+    }
+
+    @Test
+    public void adminCanTransfer() {
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("alice", true, true);
+        assertDoesNotThrow(() -> authorizer.authorizeOwnerChange("bob1", "bob2"));
+    }
+
+    @Test
+    public void unownedCanBeClaimed() {
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, true);
+        assertDoesNotThrow(() -> authorizer.authorizeOwnerChange(null, "bob2"));
+    }
+
+    @Test
+    public void noopSameOwnerAllowed() {
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, true);
+        assertDoesNotThrow(() -> authorizer.authorizeOwnerChange("bob1", "bob1"));
+    }
+
+    @Test
+    public void skippedWhenAuthDisabled() {
+        OwnershipTransferAuthorizer authorizer = newAuthorizer("bob2", false, false);
+        assertDoesNotThrow(() -> authorizer.authorizeOwnerChange("bob1", "bob2"));
+    }
+
+    private OwnershipTransferAuthorizer newAuthorizer(String username, boolean adminOverrideActive,
+            boolean authEnabled) {
+        OwnershipTransferAuthorizer authorizer = new OwnershipTransferAuthorizer();
+
+        AuthConfig authConfig = mock(AuthConfig.class);
+        when(authConfig.isOidcAuthEnabled()).thenReturn(false);
+        when(authConfig.isBasicAuthEnabled()).thenReturn(authEnabled);
+        when(authConfig.isProxyHeaderAuthEnabled()).thenReturn(false);
+        when(authConfig.isKubernetesAuthEnabled()).thenReturn(false);
+        when(authConfig.isRbacEnabled()).thenReturn(true);
+        authorizer.authConfig = authConfig;
+
+        AdminOverride adminOverride = mock(AdminOverride.class);
+        when(adminOverride.isAdmin()).thenReturn(adminOverrideActive);
+        authorizer.adminOverride = adminOverride;
+
+        RoleBasedAccessController rbac = mock(RoleBasedAccessController.class);
+        when(rbac.isAdmin()).thenReturn(false);
+        authorizer.rbac = rbac;
+
+        Principal principal = mock(Principal.class);
+        when(principal.getName()).thenReturn(username);
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        when(identity.getPrincipal()).thenReturn(principal);
+        authorizer.securityIdentity = identity;
+
+        return authorizer;
+    }
+}


### PR DESCRIPTION
## Summary
- Restrict changing the `owner` field on artifact and group metadata updates to the current owner or an admin
- Keep other metadata fields (name, description, labels) writable for users with Write access
- Add `OwnershipTransferAuthorizer` plus unit and basic-auth integration tests for positive and negative (403) cases

Fixes #8596

## Test plan
- [x] `OwnershipTransferAuthorizerTest` (decision matrix)
- [x] `BasicAuthWithPropertiesTest#testUpdateGroupOwner*` (owner / non-owner 403 / admin)
- [x] Regression: existing artifact-owner auth tests and `GroupMetaDataTest` (auth disabled)
- [x] `./mvnw checkstyle:check -pl app` on touched files
- [ ] CI auth/security suite on this PR