### PR TITLE
fix: route well-known discovery endpoints through configured Registry…

### DIFF
--- a/mcp/src/main/java/io/apicurio/registry/mcp/RegistryService.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/RegistryService.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -465,65 +466,51 @@ public class RegistryService {
         return client.admin().config().properties().byPropertyName(propertyName).get();
     }
 
-    // ---- Well-known agent/MCP tool endpoints (no SDK support, use raw HTTP) ----
-
-    private static final java.net.http.HttpClient wellKnownHttpClient = java.net.http.HttpClient.newBuilder()
-            .connectTimeout(java.time.Duration.ofSeconds(10))
-            .build();
-
     public String searchAgentCards(String name, String skill, String capability) throws Exception {
-        StringBuilder url = new StringBuilder(rawBaseUrl).append("/.well-known/agents?limit=50");
-        if (name != null && !name.isBlank()) {
-            url.append("&name=").append(java.net.URLEncoder.encode(name, StandardCharsets.UTF_8));
-        }
-        if (skill != null && !skill.isBlank()) {
-            url.append("&skill=").append(java.net.URLEncoder.encode(skill, StandardCharsets.UTF_8));
-        }
-        if (capability != null && !capability.isBlank()) {
-            url.append("&capability=").append(java.net.URLEncoder.encode(capability, StandardCharsets.UTF_8));
-        }
-        return fetchWellKnownEndpoint(url.toString());
+        var results = client.wellKnown().agents().get(config -> {
+            config.queryParameters.limit = 50;
+            if (name != null && !name.isBlank()) {
+                config.queryParameters.name = name;
+            }
+            if (skill != null && !skill.isBlank()) {
+                config.queryParameters.skill = new String[]{ skill };
+            }
+            if (capability != null && !capability.isBlank()) {
+                config.queryParameters.capability = new String[]{ capability };
+            }
+        });
+        return utils.toPrettyJson(results);
     }
 
     public String getAgentCard(String groupId, String artifactId) throws Exception {
-        String url = rawBaseUrl + "/.well-known/agents/"
-                + java.net.URLEncoder.encode(groupId, StandardCharsets.UTF_8) + "/"
-                + java.net.URLEncoder.encode(artifactId, StandardCharsets.UTF_8);
-        return fetchWellKnownEndpoint(url);
+        try (InputStream is = client.wellKnown().agents().byGroupId(groupId).byArtifactId(artifactId).get()) {
+            if (is == null) {
+                throw new ToolCallException("Unable to retrieve Agent Card.");
+            }
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 
     public String searchMcpTools(String name, String parameter) throws Exception {
-        StringBuilder url = new StringBuilder(rawBaseUrl).append("/.well-known/mcp-tools?limit=50");
-        if (name != null && !name.isBlank()) {
-            url.append("&name=").append(java.net.URLEncoder.encode(name, StandardCharsets.UTF_8));
-        }
-        if (parameter != null && !parameter.isBlank()) {
-            url.append("&parameter=").append(java.net.URLEncoder.encode(parameter, StandardCharsets.UTF_8));
-        }
-        return fetchWellKnownEndpoint(url.toString());
+        var results = client.wellKnown().mcpTools().get(config -> {
+            config.queryParameters.limit = 50;
+            if (name != null && !name.isBlank()) {
+                config.queryParameters.name = name;
+            }
+            if (parameter != null && !parameter.isBlank()) {
+                config.queryParameters.parameter = new String[]{ parameter };
+            }
+        });
+        return utils.toPrettyJson(results);
     }
 
     public String getMcpTool(String groupId, String artifactId) throws Exception {
-        String url = rawBaseUrl + "/.well-known/mcp-tools/"
-                + java.net.URLEncoder.encode(groupId, StandardCharsets.UTF_8) + "/"
-                + java.net.URLEncoder.encode(artifactId, StandardCharsets.UTF_8);
-        return fetchWellKnownEndpoint(url);
-    }
-
-    private String fetchWellKnownEndpoint(String url) throws Exception {
-        var request = java.net.http.HttpRequest.newBuilder()
-                .uri(java.net.URI.create(url))
-                .header("Accept", "application/json")
-                .timeout(java.time.Duration.ofSeconds(30))
-                .GET()
-                .build();
-        var response = wellKnownHttpClient.send(request,
-                java.net.http.HttpResponse.BodyHandlers.ofString());
-        if (response.statusCode() >= 400) {
-            throw new ToolCallException("Registry returned HTTP " + response.statusCode()
-                    + " for " + url);
+        try (InputStream is = client.wellKnown().mcpTools().byGroupId(groupId).byArtifactId(artifactId).get()) {
+            if (is == null) {
+                throw new ToolCallException("Unable to retrieve MCP tool.");
+            }
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
         }
-        return response.body();
     }
 
     public void updateConfigurationProperty(String propertyName, String propertyValue) {

--- a/mcp/src/test/java/io/apicurio/registry/mcp/RegistryServiceTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/RegistryServiceTest.java
@@ -1,0 +1,275 @@
+package io.apicurio.registry.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RegistryServiceTest {
+
+    private HttpServer server;
+    private int port;
+    private final Map<String, String> lastHeaders = new ConcurrentHashMap<>();
+    private volatile String lastUri;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        port = server.getAddress().getPort();
+
+        server.createContext("/", exchange -> {
+            lastUri = exchange.getRequestURI().toString();
+            exchange.getRequestHeaders().forEach((k, v) -> {
+                if (!v.isEmpty()) {
+                    lastHeaders.put(k.toLowerCase(), v.get(0));
+                }
+            });
+
+            String path = exchange.getRequestURI().getPath();
+
+            // Mock OAuth2 token endpoint
+            if (path.equals("/oauth/token")) {
+                String response = "{\"access_token\":\"mock-token-123\",\"token_type\":\"Bearer\",\"expires_in\":3600}";
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes(StandardCharsets.UTF_8));
+                }
+                return;
+            }
+
+            // System info GET endpoint (called in init)
+            if (path.endsWith("/system/info")) {
+                String response = "{\"version\":\"3.0.0\"}";
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes(StandardCharsets.UTF_8));
+                }
+                return;
+            }
+
+            if (path.endsWith("/well-known/agents") || path.contains("/well-known/agents?")) {
+                String response = "{\"agents\":[{\"name\":\"test-agent\"}],\"count\":1}";
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes(StandardCharsets.UTF_8));
+                }
+                return;
+            }
+
+            if (path.matches(".*/well-known/agents/g1/a1.*")) {
+                String response = "{\"id\":\"a1\",\"name\":\"card-a1\"}";
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes(StandardCharsets.UTF_8));
+                }
+                return;
+            }
+
+            if (path.endsWith("/well-known/mcp-tools") || path.contains("/well-known/mcp-tools?")) {
+                String response = "{\"tools\":[{\"name\":\"test-tool\"}],\"count\":1}";
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes(StandardCharsets.UTF_8));
+                }
+                return;
+            }
+
+            if (path.matches(".*/well-known/mcp-tools/g1/m1.*")) {
+                String response = "{\"id\":\"m1\",\"name\":\"tool-m1\"}";
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes(StandardCharsets.UTF_8));
+                }
+                return;
+            }
+
+            if (path.matches(".*/well-known/(agents|mcp-tools)/err/404.*")) {
+                String response = "{\"error_code\":404,\"message\":\"Not Found\"}";
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(404, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes(StandardCharsets.UTF_8));
+                }
+                return;
+            }
+
+            String response = "{}";
+            exchange.sendResponseHeaders(200, response.length());
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response.getBytes(StandardCharsets.UTF_8));
+            }
+        });
+
+        server.start();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    private RegistryService createService(String rawUrl, boolean authEnabled) {
+        RegistryService service = new RegistryService();
+        service.rawBaseUrl = rawUrl;
+        Utils utils = new Utils();
+        utils.mapper = new ObjectMapper();
+        service.utils = utils;
+        service.config = new McpConfig() {
+            @Override
+            public boolean safeMode() {
+                return false;
+            }
+
+            @Override
+            public Paging paging() {
+                return new Paging() {
+                    @Override
+                    public int limit() {
+                        return 200;
+                    }
+
+                    @Override
+                    public boolean limitError() {
+                        return false;
+                    }
+                };
+            }
+
+            @Override
+            public Auth auth() {
+                return new Auth() {
+                    @Override
+                    public boolean enabled() {
+                        return authEnabled;
+                    }
+
+                    @Override
+                    public Optional<String> tokenEndpoint() {
+                        return Optional.of("http://localhost:" + port + "/oauth/token");
+                    }
+
+                    @Override
+                    public Optional<String> clientId() {
+                        return Optional.of("test-client");
+                    }
+
+                    @Override
+                    public Optional<String> clientSecret() {
+                        return Optional.of("test-secret");
+                    }
+
+                    @Override
+                    public Optional<String> scope() {
+                        return Optional.empty();
+                    }
+                };
+            }
+
+            @Override
+            public Tls tls() {
+                return new Tls() {
+                    @Override
+                    public boolean trustAll() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean verifyHost() {
+                        return false;
+                    }
+
+                    @Override
+                    public Truststore truststore() {
+                        return new Truststore() {
+                            @Override
+                            public Optional<String> type() { return Optional.empty(); }
+                            @Override
+                            public Optional<String> path() { return Optional.empty(); }
+                            @Override
+                            public Optional<String> password() { return Optional.empty(); }
+                        };
+                    }
+
+                    @Override
+                    public Keystore keystore() {
+                        return new Keystore() {
+                            @Override
+                            public Optional<String> type() { return Optional.empty(); }
+                            @Override
+                            public Optional<String> path() { return Optional.empty(); }
+                            @Override
+                            public Optional<String> password() { return Optional.empty(); }
+                        };
+                    }
+                };
+            }
+        };
+
+        service.init();
+        return service;
+    }
+
+    @Test
+    public void testOAuth2HeaderAttachment() throws Exception {
+        RegistryService service = createService("http://localhost:" + port, true);
+        service.searchAgentCards("abc", null, null);
+        assertTrue(lastHeaders.containsKey("authorization"));
+        assertEquals("Bearer mock-token-123", lastHeaders.get("authorization"));
+    }
+
+    @Test
+    public void testQueryParameterPropagation() throws Exception {
+        RegistryService service = createService("http://localhost:" + port, false);
+        service.searchAgentCards("abc", "java", "streaming");
+        assertTrue(lastUri.contains("limit=50"));
+        assertTrue(lastUri.contains("name=abc"));
+        assertTrue(lastUri.contains("skill=java"));
+        assertTrue(lastUri.contains("capability=streaming"));
+
+        service.searchMcpTools("mytool", "param1");
+        assertTrue(lastUri.contains("limit=50"));
+        assertTrue(lastUri.contains("name=mytool"));
+        assertTrue(lastUri.contains("parameter=param1"));
+    }
+
+    @Test
+    public void testIndividualArtifactRetrieval() throws Exception {
+        RegistryService service = createService("http://localhost:" + port, false);
+        String card = service.getAgentCard("g1", "a1");
+        assertNotNull(card);
+        assertTrue(card.contains("card-a1"));
+
+        String tool = service.getMcpTool("g1", "m1");
+        assertNotNull(tool);
+        assertTrue(tool.contains("tool-m1"));
+    }
+
+    @Test
+    public void testErrorHandlingOn404() {
+        RegistryService service = createService("http://localhost:" + port, false);
+        assertThrows(Exception.class, () -> service.getAgentCard("err", "404"));
+        assertThrows(Exception.class, () -> service.getMcpTool("err", "404"));
+    }
+}


### PR DESCRIPTION
## Summary

Replace the raw `java.net.http.HttpClient` implementation for well-known
discovery endpoints with the generated Kiota RegistryClient SDK builders.

Previously, `searchAgentCards`, `getAgentCard`, `searchMcpTools`, and `getMcpTool`
bypassed the configured client using a separate `HttpClient` that did not
inherit OAuth2 authentication, TLS trust-store/mTLS, hostname verification,
retries, or URL normalization settings.

## Changes

- Route all four well-known methods through `client.wellKnown().agents()`
  and `client.wellKnown().mcpTools()` builders off the already-configured
  `RegistryClient` instance
- Serialize search results via `utils.toPrettyJson()`
- Read artifact `InputStream` responses with try-with-resources and `StandardCharsets.UTF_8`
- Remove `wellKnownHttpClient`, `fetchWellKnownEndpoint()`, manual URL concatenation,
  `URLEncoder` calls, and stale comments

## Tests

- OAuth2 bearer token header propagation
- Query parameter and `limit=50` propagation for both search endpoints
- Artifact card/tool retrieval (`getAgentCard`, `getMcpTool`)
- Error handling on non-2xx responses (HTTP 404)

Fixes #9098
