### PR TITLE
build(deps): declare direct inter-module dependencies used via transitive resolution

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -67,6 +67,23 @@
       <artifactId>apicurio-registry-protobuf-schema-utilities</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-protobuf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-avro</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-json</artifactId>
+    </dependency>
+
     <!-- Quarkus Dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -280,6 +297,51 @@
     <dependency>
       <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-v2-java-sdk</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-java-sdk-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-resolver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-asyncapi</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-openapi</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-graphql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-xml</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-xsd</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-wsdl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-iceberg</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -715,6 +777,26 @@
         <dependency>
           <groupId>io.apicurio</groupId>
           <artifactId>apicurio-registry-avro-serde-pulsar</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.apicurio</groupId>
+          <artifactId>apicurio-registry-serde-common</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.apicurio</groupId>
+          <artifactId>apicurio-registry-serde-kafka-common</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.apicurio</groupId>
+          <artifactId>apicurio-registry-serde-common-avro</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.apicurio</groupId>
+          <artifactId>apicurio-registry-serde-common-jsonschema</artifactId>
           <scope>test</scope>
         </dependency>
         <dependency>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -80,6 +80,11 @@
 
         <dependency>
             <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-java-sdk-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-schema-util-common</artifactId>
         </dependency>
 

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -64,6 +64,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-java-sdk-common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>

--- a/operator/olm-tests/pom.xml
+++ b/operator/olm-tests/pom.xml
@@ -32,6 +32,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-operator-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.quarkiverse.operatorsdk</groupId>
       <artifactId>quarkus-operator-sdk</artifactId>
       <scope>test</scope>

--- a/schema-resolver/pom.xml
+++ b/schema-resolver/pom.xml
@@ -28,6 +28,10 @@
     </dependency>
     <dependency>
       <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-java-sdk-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-common</artifactId>
     </dependency>
 

--- a/schema-util/avro/pom.xml
+++ b/schema-util/avro/pom.xml
@@ -32,6 +32,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/schema-util/graphql/pom.xml
+++ b/schema-util/graphql/pom.xml
@@ -23,6 +23,11 @@
       <artifactId>apicurio-registry-schema-util-common</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
     <!-- GraphQL -->
     <dependency>
       <groupId>com.graphql-java</groupId>

--- a/schema-util/iceberg/pom.xml
+++ b/schema-util/iceberg/pom.xml
@@ -25,6 +25,11 @@
 
     <dependency>
       <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-schema-util-common</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/schema-util/json/pom.xml
+++ b/schema-util/json/pom.xml
@@ -24,6 +24,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.apitomy</groupId>
       <artifactId>apitomy-data-models</artifactId>
     </dependency>

--- a/schema-util/kconnect/pom.xml
+++ b/schema-util/kconnect/pom.xml
@@ -29,6 +29,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-json</artifactId>
     </dependency>

--- a/schema-util/openapi/pom.xml
+++ b/schema-util/openapi/pom.xml
@@ -24,6 +24,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.apitomy</groupId>
       <artifactId>apitomy-data-models</artifactId>
     </dependency>

--- a/schema-util/protobuf/pom.xml
+++ b/schema-util/protobuf/pom.xml
@@ -29,6 +29,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
     </dependency>

--- a/schema-util/thrift/pom.xml
+++ b/schema-util/thrift/pom.xml
@@ -24,6 +24,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/schema-util/util-provider/pom.xml
+++ b/schema-util/util-provider/pom.xml
@@ -24,6 +24,10 @@
     </dependency>
     <dependency>
       <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-schema-util-json</artifactId>
     </dependency>
     <dependency>

--- a/schema-util/wsdl/pom.xml
+++ b/schema-util/wsdl/pom.xml
@@ -29,6 +29,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>wsdl4j</groupId>
       <artifactId>wsdl4j</artifactId>
     </dependency>

--- a/schema-util/xml/pom.xml
+++ b/schema-util/xml/pom.xml
@@ -24,6 +24,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.santuario</groupId>
       <artifactId>xmlsec</artifactId>
     </dependency>

--- a/schema-util/xsd/pom.xml
+++ b/schema-util/xsd/pom.xml
@@ -29,6 +29,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/schema-validation/avro/pom.xml
+++ b/schema-validation/avro/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>apicurio-registry-schema-resolver</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>

--- a/schema-validation/common/pom.xml
+++ b/schema-validation/common/pom.xml
@@ -20,6 +20,10 @@
       <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-schema-resolver</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-java-sdk</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/schema-validation/jsonschema/pom.xml
+++ b/schema-validation/jsonschema/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>apicurio-registry-schema-resolver</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.networknt</groupId>
       <artifactId>json-schema-validator</artifactId>
     </dependency>

--- a/schema-validation/protobuf/pom.xml
+++ b/schema-validation/protobuf/pom.xml
@@ -32,6 +32,10 @@
       <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-schema-util-protobuf</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/serdes/generic/serde-common-avro/pom.xml
+++ b/serdes/generic/serde-common-avro/pom.xml
@@ -23,6 +23,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-resolver</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>

--- a/serdes/generic/serde-common-jsonschema/pom.xml
+++ b/serdes/generic/serde-common-jsonschema/pom.xml
@@ -23,6 +23,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-resolver</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/serdes/generic/serde-common-protobuf/pom.xml
+++ b/serdes/generic/serde-common-protobuf/pom.xml
@@ -29,6 +29,21 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-protobuf-schema-utilities</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-resolver</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>

--- a/serdes/generic/serde-common/pom.xml
+++ b/serdes/generic/serde-common/pom.xml
@@ -25,6 +25,10 @@
       <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-contracts-rules</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-java-sdk</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/serdes/kafka/avro-serde/pom.xml
+++ b/serdes/kafka/avro-serde/pom.xml
@@ -27,6 +27,21 @@
       <artifactId>apicurio-registry-serde-common-avro</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-resolver</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/serdes/kafka/jsonschema-serde/pom.xml
+++ b/serdes/kafka/jsonschema-serde/pom.xml
@@ -27,6 +27,16 @@
       <artifactId>apicurio-registry-serde-common-jsonschema</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-resolver</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/serdes/kafka/protobuf-serde/pom.xml
+++ b/serdes/kafka/protobuf-serde/pom.xml
@@ -26,6 +26,26 @@
       <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-serde-common-protobuf</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-resolver</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-protobuf-schema-utilities</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/serdes/kafka/serde-kafka-common/pom.xml
+++ b/serdes/kafka/serde-kafka-common/pom.xml
@@ -24,6 +24,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-resolver</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/serdes/nats/avro-serde/pom.xml
+++ b/serdes/nats/avro-serde/pom.xml
@@ -24,6 +24,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.nats</groupId>
       <artifactId>jnats</artifactId>
     </dependency>

--- a/serdes/pulsar/avro-serde/pom.xml
+++ b/serdes/pulsar/avro-serde/pom.xml
@@ -30,6 +30,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-pulsar</artifactId>
       <version>${pulsar.testcontainers.version}</version>

--- a/utils/converter/pom.xml
+++ b/utils/converter/pom.xml
@@ -34,6 +34,26 @@
     </dependency>
 
     <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-kafka-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-common-avro</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-api</artifactId>
       <scope>provided</scope>

--- a/utils/exportConfluent/pom.xml
+++ b/utils/exportConfluent/pom.xml
@@ -70,6 +70,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-java-sdk-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Confluent schema providers for tests -->
     <dependency>
       <groupId>io.confluent</groupId>

--- a/utils/maven-plugin/pom.xml
+++ b/utils/maven-plugin/pom.xml
@@ -96,6 +96,18 @@
       <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-schema-util-provider</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-protobuf-schema-utilities</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-java-sdk-common</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
## Summary

- Declare the direct `io.apicurio` inter-module dependencies that 34 modules were consuming via transitive resolution only (66 added `<dependency>` entries, zero deletions, no versions: all covered by the root `dependencyManagement`)
- Evidence-based, not blanket: entries and scopes come from serial (`-T1`) `dependency:analyze` runs over the full 67-module reactor; the per-module extraction plan was cross-checked entry-by-entry against the final diff
- **Scope rule applied:** scopes follow where references actually live, not what `analyze` prints (it reports the resolved scope). Concretely: seven of `app`'s schema-util additions (asyncapi, openapi, graphql, xml, xsd, wsdl, iceberg) are referenced only from test code and are declared `test`; iceberg looks main-referenced at first glance but those are `app`'s own same-prefix REST packages, and the full reactor compiling with it at `test` scope is the mechanical proof
- **`-Dlocal` tier preserved:** four serde test dependencies live in `app`'s existing `local-excluded-test-deps` profile (their modules are absent from the `-Dlocal` reactor); verified with `./mvnw -T1 validate -Dlocal` (37 modules, all green)

## Why

Issue #9134: a future pom refactor of any intermediate module could silently break up to 34 modules that currently compile by accident. Declaring the direct edges is additive robustness; the resolved dependency set of this build does not change.

One framing caveat for reviewers: consumer-visible poms do gain direct entries, which in mixed-version downstream graphs can change nearest-wins mediation depth and exclusion reach. Within this reactor nothing changes; external consumers pinning older Apicurio artifacts should be aware. Also worth a note: `serde-common` now declares its real (pre-existing) compile edge on `apicurio-registry-java-sdk`, previously hidden behind `schema-resolver`.

Follow-ups deliberately not in this PR: a CI gate to prevent drift recurrence belongs to the `dependency-check` profile work (#9136 / PR #9152); the unused-declared cleanup is #9135.

Closes #9134.

## Test plan

- [x] Full reactor `./mvnw -T1 install -DskipTests -Dfull -DcliSkipNative`: green (proves no cycles)
- [x] `./mvnw -T1 validate -Dlocal`: green (local tier resolution intact)
- [x] `dependency:analyze` re-run: `io.apicurio` used-undeclared warnings 66 -> 0 (verified with two independent parsers)
- [x] All 66 entry scopes cross-checked against the analyze logs; `app`'s seven test-only entries additionally re-derived from source references
- [x] `checkstyle:check -pl app` and `./scripts/validate-files.sh` pass
