### PR TITLE
fix(ui): handle plain-text error responses in unwrapErrorData

### DIFF
--- a/ui/ui-app/src/utils/rest.utils.test.ts
+++ b/ui/ui-app/src/utils/rest.utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { unwrapErrorData } from "./rest.utils";
+
+describe("unwrapErrorData", () => {
+    it("should correctly unwrap and spread JSON object response data", () => {
+        const error = {
+            message: "Request failed with status code 409",
+            response: {
+                status: 409,
+                data: {
+                    message: "Artifact already exists",
+                    errorCode: 409
+                }
+            }
+        };
+        const result = unwrapErrorData(error);
+        expect(result).toEqual({
+            message: "Artifact already exists",
+            errorCode: 409,
+            status: 409
+        });
+    });
+
+    it("should correctly handle and wrap plain-text/HTML string response data", () => {
+        const error = {
+            message: "Request failed with status code 504",
+            response: {
+                status: 504,
+                data: "504 Gateway Time-out"
+            }
+        };
+        const result = unwrapErrorData(error);
+        expect(result).toEqual({
+            message: "504 Gateway Time-out",
+            status: 504
+        });
+    });
+
+    it("should handle response with null/undefined data by falling back to error message", () => {
+        const error = {
+            message: "Request failed with status code 500",
+            response: {
+                status: 500,
+                data: null
+            }
+        };
+        const result = unwrapErrorData(error);
+        expect(result).toEqual({
+            message: "Request failed with status code 500",
+            status: 500
+        });
+    });
+
+    it("should handle errors without response object by returning status 500", () => {
+        const error = new Error("Connection failed");
+        const result = unwrapErrorData(error);
+        expect(result).toEqual({
+            message: "Connection failed",
+            status: 500
+        });
+    });
+
+    it("should handle unknown/falsy errors gracefully", () => {
+        const result = unwrapErrorData(undefined);
+        expect(result).toEqual({
+            message: "Unknown error",
+            status: 500
+        });
+    });
+});

--- a/ui/ui-app/src/utils/rest.utils.ts
+++ b/ui/ui-app/src/utils/rest.utils.ts
@@ -215,12 +215,15 @@ function createAxiosConfig(method: string, url: string, options: any, data?: any
 }
 
 
-function unwrapErrorData(error: any): any {
+export function unwrapErrorData(error: any): any {
     console.debug("Error detected, unwrapping...");
     if (error && error.response && error.response.data) {
+        const errorData = (typeof error.response.data === "object" && error.response.data !== null)
+            ? error.response.data
+            : { message: error.response.data };
         return {
             message: error.message,
-            ...error.response.data,
+            ...errorData,
             status: error.response.status
         };
     } else if (error && error.response) {


### PR DESCRIPTION
## Summary

This PR fixes an issue in the UI error handler where plain-text or HTML error responses were incorrectly spread into character-indexed properties.

Previously, `unwrapErrorData` assumed `error.response.data` was always an object. When the response body was a string (for example, from a `504 Gateway Timeout` or `413 Payload Too Large` response), using the spread operator (`...error.response.data`) produced an object with numeric keys instead of preserving the original message.

This change updates `unwrapErrorData` to:

* Detect whether `error.response.data` is a non-null object before spreading it.
* Wrap non-object values (such as strings) as `{ message: error.response.data }`.
* Preserve the existing behavior for JSON error responses.

Additionally, unit tests have been added to cover:

* JSON object error responses.
* Plain-text/HTML error responses.
* `null` and `undefined` response data.
* Errors without a response object.
* Unknown or falsy errors.

## Testing

* Added unit tests for all supported error response scenarios.
* Verified all tests pass with `npm run test`.
* Verified linting passes with `npm run lint`.

## Related Issue

Closes #9169
