### PR TITLE
fix(a2a): add missing agent-card JSON schema for well-known endpoint

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -661,6 +661,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
             return "schemas/model-schema-v1.json";
         } else if ("mcp-tool".equals(type) && "v1".equals(version)) {
             return "schemas/mcp-tool-v1.json";
+        } else if ("agent-card".equals(type) && "v1".equals(version)) {
+            return "schemas/agent-card-v1.json";
         }
         return null;
     }

--- a/app/src/main/resources/schemas/agent-card-v1.json
+++ b/app/src/main/resources/schemas/agent-card-v1.json
@@ -1,0 +1,263 @@
+{
+  "description": "Schema for A2A Agent Cards stored as registry artifacts, based on the A2A v1.0 specification.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "protocolVersion": {
+      "type": "string"
+    },
+    "provider": {
+      "$ref": "#/definitions/AgentProvider"
+    },
+    "capabilities": {
+      "$ref": "#/definitions/AgentCapabilities"
+    },
+    "skills": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AgentSkill"
+      }
+    },
+    "defaultInputModes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "defaultOutputModes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "supportedInterfaces": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AgentInterface"
+      }
+    },
+    "securitySchemes": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/AgentSecurityScheme"
+      }
+    },
+    "securityRequirements": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AgentSecurityRequirement"
+      }
+    },
+    "iconUrl": {
+      "type": "string"
+    },
+    "documentationUrl": {
+      "type": "string"
+    },
+    "signatures": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AgentCardSignature"
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://apicurio.io/schemas/agent-card.json",
+  "title": "A2A Agent Card",
+  "required": [
+    "name",
+    "description",
+    "protocolVersion",
+    "capabilities"
+  ],
+  "definitions": {
+    "AgentCardSignature": {
+      "description": "Signature on an agent card.",
+      "type": "object",
+      "properties": {
+        "protected": {
+          "type": "string"
+        },
+        "signature": {
+          "type": "string"
+        },
+        "header": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      }
+    },
+    "AgentSecurityRequirement": {
+      "description": "Security requirement for an A2A agent.",
+      "type": "object",
+      "properties": {
+        "schemes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "AgentSecurityScheme": {
+      "description": "Security scheme for an A2A agent.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "bearerFormat": {
+          "type": "string"
+        },
+        "flows": {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "oauth2MetadataUrl": {
+          "type": "string"
+        },
+        "openIdConnectUrl": {
+          "type": "string"
+        }
+      }
+    },
+    "AgentInterface": {
+      "description": "Interface endpoint for an A2A agent.",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "protocolBinding": {
+          "type": "string"
+        },
+        "protocolVersion": {
+          "type": "string"
+        },
+        "tenant": {
+          "type": "string"
+        }
+      }
+    },
+    "AgentSkill": {
+      "description": "A skill an A2A agent can perform.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "inputModes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "outputModes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "securityRequirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AgentSecurityRequirement"
+          }
+        }
+      }
+    },
+    "AgentCapabilities": {
+      "description": "Capabilities of an A2A agent.",
+      "type": "object",
+      "properties": {
+        "streaming": {
+          "type": "boolean"
+        },
+        "pushNotifications": {
+          "type": "boolean"
+        },
+        "extendedAgentCard": {
+          "type": "boolean"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AgentExtension"
+          }
+        }
+      }
+    },
+    "AgentExtension": {
+      "description": "Extension for an A2A agent.",
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      }
+    },
+    "AgentProvider": {
+      "description": "Provider of an A2A agent.",
+      "type": "object",
+      "properties": {
+        "organization": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview
This PR fixes a bug where the `/.well-known/schemas/agent-card/v1` endpoint returns a `404 Not Found` error. 

While the `mcp-tool` schema was correctly mapped and available in the resources, the `agent-card` JSON schema was missing, which prevented external tools (like IDEs or agents) from retrieving the schema for validation and autocompletion.

## What's Changed
* Extracted the `AgentCard` schema from `openapi.json`, resolved all `$ref` definitions, and added it as a standalone schema file: `app/src/main/resources/schemas/agent-card-v1.json`.
* Updated `WellKnownResourceImpl.java` to handle the `"agent-card"` schemaType and `"v1"` version, routing it to the newly created schema file.

## Issue
Fixes #9161

## Testing
* **Manual Testing:** Started the registry with `-Dapicurio.a2a.enabled=true` and ran `curl -I http://localhost:8080/.well-known/schemas/agent-card/v1`. It now correctly returns a `200 OK` with `application/schema+json`.
* **IDE Testing:** Successfully tested the autocompletion in VS Code by mapping the schema URL in `settings.json`, and it accurately validates `agent-card.json` files.