### PR TITLE
fix(ui): add Windows PowerShell equivalent for init-dev.sh (#8535)Add PowerShell equivalent of init-dev.sh for Windows users (#8535)

### DIFF
--- a/ui/ui-app/init-dev.ps1
+++ b/ui/ui-app/init-dev.ps1
@@ -1,0 +1,13 @@
+Write-Host "----"
+Write-Host "Initializing development environment for UI-only development."
+Write-Host "----"
+
+$ConfigType = $args[0]
+if ([string]::IsNullOrEmpty($ConfigType)) {
+    $ConfigType = "local"
+}
+
+Copy-Item "configs\version.js" "version.js" -Force
+Copy-Item "configs\config-$ConfigType.js" "config.js" -Force
+
+Write-Host "Done.  Try:  'npm run dev'"


### PR DESCRIPTION
## Summary
Adds `init-dev.ps1` as a PowerShell equivalent of `init-dev.sh` for Windows users setting up the UI dev environment, as described in #8535.

## Problem
The `ui/ui-app/README.md` only documents `./init-dev.sh`, which doesn't run natively in Windows Command Prompt. Windows users have to install/use Git Bash to run it, which isn't documented anywhere.

## Change
- Added `ui/ui-app/init-dev.ps1`, a PowerShell script that replicates the same behavior (copies `version.js` and the appropriate `config-<type>.js` file).
- Tested locally on Windows — confirmed it correctly generates `config.js` and `version.js`.

## Testing
Ran `powershell -ExecutionPolicy Bypass -File init-dev.ps1` and confirmed it produced the same output/files as the original `.sh` script.

Fixes #8535