### PR TITLE
[WIP] feat(ui): prompt template playground prototype for #8425

### DIFF
--- a/ui/ui-app/src/app/MainPageWithAuth.tsx
+++ b/ui/ui-app/src/app/MainPageWithAuth.tsx
@@ -12,6 +12,7 @@ import {
     ExplorePage,
     GroupPage,
     NotFoundPage,
+    PromptPlaygroundPage,
     RootRedirectPage,
     GlobalContractRulesPage,
     RulesPage,
@@ -133,6 +134,12 @@ export const MainPageWithAuth: FunctionComponent<MainPageWithAuthProps> = () => 
                             element={ <BranchPage /> }
                         />
 
+
+                        {/* Prototype route for LFX proposal (issue #8425) — prompt template playground */}
+                        <Route
+                            path="/playground/:groupId/:artifactId/:version"
+                            element={ <PromptPlaygroundPage /> }
+                        />
 
                         <Route path="*" element={ <NotFoundPage /> } />
                     </Routes>

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateEditor.css
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateEditor.css
@@ -1,0 +1,32 @@
+.prompt-template-editor {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.prompt-template-editor .editor-wrapper {
+    flex: 1;
+    min-height: 300px;
+    border: 1px solid var(--pf-t--global--border--color--default);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.prompt-template-editor .extracted-variables {
+    margin-top: 12px;
+}
+
+.prompt-template-editor .extracted-variables-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--pf-t--global--text--color--subtle);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+}
+
+.prompt-template-editor .no-variables-text {
+    font-size: 13px;
+    color: var(--pf-t--global--text--color--subtle);
+    font-style: italic;
+}

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateEditor.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateEditor.tsx
@@ -1,0 +1,99 @@
+import { FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import "./PromptTemplateEditor.css";
+import { Label, LabelGroup } from "@patternfly/react-core";
+import Editor from "@monaco-editor/react";
+import { extractVariables } from "./extractVariables";
+
+export type PromptTemplateEditorProps = {
+    /** Initial template content to display in the editor */
+    value: string;
+    /** Called when the template content changes */
+    onChange?: (value: string) => void;
+    /** Called when extracted variables change */
+    onVariablesChange?: (variables: string[]) => void;
+    className?: string;
+};
+
+/**
+ * Monaco-based editor for prompt template strings with live variable extraction.
+ * Debounces variable extraction to avoid performance issues on rapid typing.
+ *
+ * Prototype component for LFX proposal evaluation (issue #8425).
+ */
+export const PromptTemplateEditor: FunctionComponent<PromptTemplateEditorProps> = (props: PromptTemplateEditorProps) => {
+    const { value, onChange, onVariablesChange, className } = props;
+    const [variables, setVariables] = useState<string[]>(() => extractVariables(value));
+    const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Extract variables from the initial value
+    useEffect(() => {
+        const vars = extractVariables(value);
+        setVariables(vars);
+        onVariablesChange?.(vars);
+    }, []); // Only on mount — subsequent updates come from handleEditorChange
+
+    const handleEditorChange = useCallback((newValue: string | undefined) => {
+        const text = newValue ?? "";
+        onChange?.(text);
+
+        // Debounce variable extraction (300ms)
+        if (debounceTimerRef.current !== null) {
+            clearTimeout(debounceTimerRef.current);
+        }
+        debounceTimerRef.current = setTimeout(() => {
+            const vars = extractVariables(text);
+            setVariables(vars);
+            onVariablesChange?.(vars);
+        }, 300);
+    }, [onChange, onVariablesChange]);
+
+    // Cleanup debounce timer on unmount
+    useEffect(() => {
+        return () => {
+            if (debounceTimerRef.current !== null) {
+                clearTimeout(debounceTimerRef.current);
+            }
+        };
+    }, []);
+
+    const variableLabels = useMemo(() => {
+        if (variables.length === 0) {
+            return <span className="no-variables-text">No variables detected</span>;
+        }
+        return (
+            <LabelGroup>
+                {variables.map((varName) => (
+                    <Label key={varName} color="blue" isCompact>
+                        {"{{" + varName + "}}"}
+                    </Label>
+                ))}
+            </LabelGroup>
+        );
+    }, [variables]);
+
+    return (
+        <div className={`prompt-template-editor ${className || ""}`}>
+            <div className="editor-wrapper">
+                <Editor
+                    language="handlebars"
+                    value={value}
+                    onChange={handleEditorChange}
+                    options={{
+                        automaticLayout: true,
+                        wordWrap: "on",
+                        minimap: { enabled: false },
+                        fontSize: 14,
+                        lineNumbers: "on",
+                        scrollBeyondLastLine: false,
+                        renderWhitespace: "selection",
+                        padding: { top: 8, bottom: 8 },
+                    }}
+                />
+            </div>
+            <div className="extracted-variables">
+                <div className="extracted-variables-title">Extracted Variables</div>
+                {variableLabels}
+            </div>
+        </div>
+    );
+};

--- a/ui/ui-app/src/app/components/promptTemplate/extractVariables.test.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/extractVariables.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { extractVariables } from "./extractVariables";
+
+describe("extractVariables", () => {
+    it("extracts a single variable", () => {
+        expect(extractVariables("Hello, {{name}}!")).toEqual(["name"]);
+    });
+
+    it("extracts multiple distinct variables", () => {
+        expect(extractVariables("{{greeting}}, {{name}}! Welcome to {{place}}."))
+            .toEqual(["greeting", "name", "place"]);
+    });
+
+    it("deduplicates repeated variables", () => {
+        expect(extractVariables("{{name}} said hello to {{name}} and {{other}}"))
+            .toEqual(["name", "other"]);
+    });
+
+    it("trims whitespace inside braces", () => {
+        expect(extractVariables("{{ name }} and {{  place  }}"))
+            .toEqual(["name", "place"]);
+    });
+
+    it("returns empty array for template with no variables", () => {
+        expect(extractVariables("This is plain text with no variables."))
+            .toEqual([]);
+    });
+
+    it("returns empty array for empty string", () => {
+        expect(extractVariables("")).toEqual([]);
+    });
+
+    it("returns empty array for null/undefined input", () => {
+        expect(extractVariables(null as unknown as string)).toEqual([]);
+        expect(extractVariables(undefined as unknown as string)).toEqual([]);
+    });
+
+    it("skips malformed empty braces {{ }}", () => {
+        expect(extractVariables("before {{ }} after {{valid}}"))
+            .toEqual(["valid"]);
+    });
+
+    it("skips Handlebars block helpers like {{#if}} and {{/if}}", () => {
+        expect(extractVariables("{{#if show}}Hello {{name}}{{/if}}"))
+            .toEqual(["name"]);
+    });
+
+    it("skips {{#each}}, {{#unless}}, {{#with}} block helpers", () => {
+        const template = "{{#each items}}{{value}}{{/each}} {{#unless hidden}}{{label}}{{/unless}}";
+        expect(extractVariables(template)).toEqual(["value", "label"]);
+    });
+
+    it("handles variables adjacent to text without spaces", () => {
+        expect(extractVariables("prefix{{a}}middle{{b}}suffix"))
+            .toEqual(["a", "b"]);
+    });
+
+    it("preserves order of first appearance", () => {
+        expect(extractVariables("{{z}} {{a}} {{m}} {{z}}"))
+            .toEqual(["z", "a", "m"]);
+    });
+});

--- a/ui/ui-app/src/app/components/promptTemplate/extractVariables.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/extractVariables.ts
@@ -1,0 +1,50 @@
+/**
+ * Extracts {{variable}} names from a prompt template string.
+ *
+ * Handles:
+ * - Standard syntax: {{name}}
+ * - Whitespace: {{ name }}
+ * - Deduplication: {{name}} ... {{name}} → ["name"]
+ * - Handlebars block helpers: {{#if x}}, {{/if}} are excluded (not variables)
+ * - Malformed/empty: {{ }} → skipped
+ *
+ * @param template - The template string to extract variables from
+ * @returns Deduplicated array of variable names, in order of first appearance
+ */
+export const extractVariables = (template: string): string[] => {
+    if (!template) {
+        return [];
+    }
+
+    const variablePattern = /\{\{([^}]+)\}\}/g;
+    const seen = new Set<string>();
+    const result: string[] = [];
+    let match: RegExpExecArray | null;
+
+    while ((match = variablePattern.exec(template)) !== null) {
+        const raw = match[1].trim();
+
+        // Skip empty matches (e.g. {{ }})
+        if (!raw) {
+            continue;
+        }
+
+        // Skip Handlebars block syntax: {{#if ...}}, {{/if}}, {{#each ...}}, etc.
+        if (/^[#/]/.test(raw)) {
+            continue;
+        }
+
+        // Skip if it contains spaces (likely a block expression, not a variable)
+        // e.g. "if condition" from {{#if condition}} that somehow lost the #
+        if (/\s/.test(raw)) {
+            continue;
+        }
+
+        if (!seen.has(raw)) {
+            seen.add(raw);
+            result.push(raw);
+        }
+    }
+
+    return result;
+};

--- a/ui/ui-app/src/app/components/promptTemplate/index.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/index.ts
@@ -1,2 +1,4 @@
 export * from "./PromptTemplateViewer";
 export * from "./PromptTemplateTestPanel";
+export * from "./PromptTemplateEditor";
+export * from "./extractVariables";

--- a/ui/ui-app/src/app/pages/index.ts
+++ b/ui/ui-app/src/app/pages/index.ts
@@ -14,6 +14,7 @@ export * from "./roles";
 export * from "./root";
 export * from "./rules";
 export * from "./contractRules";
+export * from "./playground";
 export * from "./PageDataLoader";
 export * from "./PageError";
 export * from "./PageErrorHandler";

--- a/ui/ui-app/src/app/pages/playground/PromptPlaygroundPage.css
+++ b/ui/ui-app/src/app/pages/playground/PromptPlaygroundPage.css
@@ -1,0 +1,87 @@
+.prompt-playground-page {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 24px;
+}
+
+.prompt-playground-page .playground-header {
+    margin-bottom: 16px;
+}
+
+.prompt-playground-page .playground-header .playground-title {
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.prompt-playground-page .playground-header .playground-subtitle {
+    color: var(--pf-t--global--text--color--subtle);
+    font-size: 13px;
+    margin-top: 4px;
+}
+
+.prompt-playground-page .playground-header .playground-artifact-info {
+    margin-top: 8px;
+}
+
+.prompt-playground-page .playground-layout {
+    display: flex;
+    flex: 1;
+    gap: 16px;
+    min-height: 0;
+}
+
+.prompt-playground-page .playground-editor-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.prompt-playground-page .playground-test-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow-y: auto;
+}
+
+.prompt-playground-page .playground-test-panel .test-panel-form {
+    margin-bottom: 16px;
+}
+
+.prompt-playground-page .rendered-section {
+    margin-top: 16px;
+}
+
+.prompt-playground-page .rendered-output {
+    background-color: var(--pf-t--global--background--color--secondary--default);
+    padding: 16px;
+    border-radius: 4px;
+    font-family: var(--pf-t--global--font--family--mono);
+    font-size: 13px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    min-height: 60px;
+    margin-top: 8px;
+}
+
+.prompt-playground-page .render-source-label {
+    margin-top: 4px;
+    font-size: 12px;
+}
+
+.prompt-playground-page .validation-errors {
+    margin-top: 8px;
+}
+
+.prompt-playground-page .template-modified-alert {
+    margin-bottom: 12px;
+}
+
+.prompt-playground-page .loading-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 200px;
+}

--- a/ui/ui-app/src/app/pages/playground/PromptPlaygroundPage.tsx
+++ b/ui/ui-app/src/app/pages/playground/PromptPlaygroundPage.tsx
@@ -1,0 +1,348 @@
+import { FunctionComponent, useCallback, useEffect, useState } from "react";
+import "./PromptPlaygroundPage.css";
+import { useParams } from "react-router";
+import {
+    ActionGroup,
+    Alert,
+    Button,
+    Card,
+    CardBody,
+    CardHeader,
+    CardTitle,
+    Form,
+    FormGroup,
+    Label,
+    Spinner,
+    TextInput,
+    Title,
+} from "@patternfly/react-core";
+import { PromptTemplateEditor } from "@app/components/promptTemplate/PromptTemplateEditor";
+import { extractVariables } from "@app/components/promptTemplate/extractVariables";
+import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
+import { RenderPromptResponse } from "@models/RenderPromptResponse.ts";
+
+/**
+ * Performs simple client-side {{variable}} substitution.
+ * This is a LOCAL preview only — no schema validation is applied.
+ */
+const localSubstitute = (template: string, variables: Record<string, string>): string => {
+    return template.replace(/\{\{([^}]+)\}\}/g, (_match, rawName: string) => {
+        const name = rawName.trim();
+        if (name in variables && variables[name] !== "") {
+            return variables[name];
+        }
+        return `{{${name}}}`;
+    });
+};
+
+/**
+ * Prototype Prompt Template Playground page.
+ *
+ * Loads a PROMPT_TEMPLATE artifact from the registry, provides a Monaco editor
+ * for viewing/editing the template string with live variable extraction, and a
+ * test panel for filling in variable values and rendering via the real backend
+ * endpoint. When the template has been locally modified, a client-side preview
+ * is shown alongside the server-rendered result.
+ *
+ * This is a prototype page for LFX Mentorship proposal evaluation (issue #8425).
+ * It does NOT modify the stored artifact — the editor is for local experimentation only.
+ *
+ * Known limitation: The /render endpoint reads template content from storage, not
+ * from the request body. Therefore, server-rendered output always uses the stored
+ * template version. Client-side preview fills this gap for local edits but does not
+ * apply schema validation (type checking, enum constraints, range checks).
+ */
+export const PromptPlaygroundPage: FunctionComponent = () => {
+    const { groupId, artifactId, version } = useParams<{
+        groupId: string;
+        artifactId: string;
+        version: string;
+    }>();
+
+    const groups: GroupsService = useGroupsService();
+
+    // Content state
+    const [originalTemplate, setOriginalTemplate] = useState<string>("");
+    const [currentTemplate, setCurrentTemplate] = useState<string>("");
+    const [variables, setVariables] = useState<string[]>([]);
+    const [values, setValues] = useState<Record<string, string>>({});
+
+    // Loading / error state
+    const [isLoadingContent, setIsLoadingContent] = useState<boolean>(true);
+    const [loadError, setLoadError] = useState<string>("");
+
+    // Render state
+    const [isRendering, setIsRendering] = useState<boolean>(false);
+    const [serverRendered, setServerRendered] = useState<string>("");
+    const [localPreview, setLocalPreview] = useState<string>("");
+    const [renderError, setRenderError] = useState<string>("");
+    const [validationErrors, setValidationErrors] = useState<{ path?: string; message: string }[]>([]);
+
+    const isModified = currentTemplate !== originalTemplate;
+
+    // Load artifact content on mount
+    useEffect(() => {
+        if (!groupId || !artifactId || !version) {
+            setLoadError("Missing route parameters: groupId, artifactId, and version are required.");
+            setIsLoadingContent(false);
+            return;
+        }
+
+        setIsLoadingContent(true);
+        setLoadError("");
+
+        groups.getArtifactVersionContent(groupId === "default" ? null : groupId, artifactId, version)
+            .then((content: string) => {
+                // Parse the content to extract the template field
+                let parsed: { template?: string };
+                try {
+                    parsed = JSON.parse(content);
+                } catch {
+                    // Try YAML-like parsing — the content might be YAML
+                    // For this prototype, we handle JSON; YAML would need the yaml package
+                    setLoadError("Failed to parse artifact content as JSON.");
+                    return;
+                }
+
+                const templateText = parsed.template || "";
+                setOriginalTemplate(templateText);
+                setCurrentTemplate(templateText);
+
+                const vars = extractVariables(templateText);
+                setVariables(vars);
+
+                // Initialize empty values for each variable
+                const initialValues: Record<string, string> = {};
+                vars.forEach((v) => {
+                    initialValues[v] = "";
+                });
+                setValues(initialValues);
+            })
+            .catch((err: unknown) => {
+                const message = err instanceof Error ? err.message : "Failed to load artifact content";
+                setLoadError(message);
+            })
+            .finally(() => {
+                setIsLoadingContent(false);
+            });
+    }, [groupId, artifactId, version]);
+
+    const handleEditorChange = useCallback((newValue: string) => {
+        setCurrentTemplate(newValue);
+    }, []);
+
+    const handleVariablesChange = useCallback((newVars: string[]) => {
+        setVariables(newVars);
+        setValues((prev) => {
+            const next: Record<string, string> = {};
+            newVars.forEach((v) => {
+                next[v] = prev[v] ?? "";
+            });
+            return next;
+        });
+    }, []);
+
+    const handleValueChange = useCallback((varName: string, newValue: string) => {
+        setValues((prev) => ({ ...prev, [varName]: newValue }));
+    }, []);
+
+    const handleRender = useCallback(() => {
+        if (!groupId || !artifactId || !version) {
+            return;
+        }
+
+        setIsRendering(true);
+        setRenderError("");
+        setValidationErrors([]);
+        setServerRendered("");
+        setLocalPreview("");
+
+        // Always call the real backend (uses stored template)
+        const gid = groupId === "default" ? null : groupId;
+        groups.renderPromptTemplate(gid, artifactId, version, values)
+            .then((response: RenderPromptResponse) => {
+                setServerRendered(response.rendered || "");
+                if (response.validationErrors && response.validationErrors.length > 0) {
+                    setValidationErrors(response.validationErrors);
+                }
+            })
+            .catch((err: unknown) => {
+                const message = (err && typeof err === "object" && "message" in err)
+                    ? (err as { message: string }).message
+                    : "Error rendering prompt template";
+                setRenderError(message);
+            })
+            .finally(() => {
+                setIsRendering(false);
+            });
+
+        // If template was modified, also compute client-side preview
+        if (isModified) {
+            const preview = localSubstitute(currentTemplate, values);
+            setLocalPreview(preview);
+        }
+    }, [groupId, artifactId, version, values, isModified, currentTemplate, groups]);
+
+    // ---- Render ----
+
+    if (isLoadingContent) {
+        return (
+            <div className="prompt-playground-page">
+                <div className="loading-container">
+                    <Spinner size="xl" />
+                </div>
+            </div>
+        );
+    }
+
+    if (loadError) {
+        return (
+            <div className="prompt-playground-page">
+                <Alert variant="danger" title="Failed to load artifact">
+                    {loadError}
+                </Alert>
+            </div>
+        );
+    }
+
+    return (
+        <div className="prompt-playground-page">
+            {/* Header */}
+            <div className="playground-header">
+                <Title headingLevel="h1" className="playground-title">
+                    Prompt Template Playground
+                </Title>
+                <div className="playground-subtitle">
+                    Prototype for LFX Mentorship proposal — issue #8425.
+                    Edit the template, fill in variables, and render via the real backend.
+                </div>
+                <div className="playground-artifact-info">
+                    <Label color="blue" isCompact>{groupId || "default"}</Label>{" "}
+                    <Label color="purple" isCompact>{artifactId}</Label>{" "}
+                    <Label color="grey" isCompact>v{version}</Label>
+                </div>
+            </div>
+
+            {/* Split layout */}
+            <div className="playground-layout">
+                {/* Left: Editor */}
+                <div className="playground-editor-panel">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>
+                                <Title headingLevel="h2" size="md">Template Editor</Title>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardBody>
+                            {isModified && (
+                                <Alert
+                                    variant="info"
+                                    isInline
+                                    isPlain
+                                    title="Template modified locally"
+                                    className="template-modified-alert"
+                                >
+                                    Server render uses the stored version. A client-side preview
+                                    of your edits will also be shown.
+                                </Alert>
+                            )}
+                            <PromptTemplateEditor
+                                value={currentTemplate}
+                                onChange={handleEditorChange}
+                                onVariablesChange={handleVariablesChange}
+                            />
+                        </CardBody>
+                    </Card>
+                </div>
+
+                {/* Right: Test Panel */}
+                <div className="playground-test-panel">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>
+                                <Title headingLevel="h2" size="md">Test Variables</Title>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardBody>
+                            <Form className="test-panel-form">
+                                {variables.length === 0 && (
+                                    <span style={{ color: "var(--pf-t--global--text--color--subtle)", fontStyle: "italic" }}>
+                                        No variables detected in template.
+                                    </span>
+                                )}
+                                {variables.map((varName) => (
+                                    <FormGroup
+                                        key={varName}
+                                        label={varName}
+                                        fieldId={`playground-var-${varName}`}
+                                    >
+                                        <TextInput
+                                            type="text"
+                                            id={`playground-var-${varName}`}
+                                            value={values[varName] || ""}
+                                            onChange={(_event, val) => handleValueChange(varName, val)}
+                                            aria-label={varName}
+                                            placeholder={`Enter value for {{${varName}}}`}
+                                        />
+                                    </FormGroup>
+                                ))}
+                                <ActionGroup>
+                                    <Button
+                                        variant="primary"
+                                        onClick={handleRender}
+                                        isDisabled={isRendering || variables.length === 0}
+                                        isLoading={isRendering}
+                                    >
+                                        Render
+                                    </Button>
+                                </ActionGroup>
+                            </Form>
+
+                            {isRendering && <Spinner size="md" />}
+
+                            {renderError && (
+                                <Alert variant="danger" title="Render Error" className="validation-errors">
+                                    {renderError}
+                                </Alert>
+                            )}
+
+                            {validationErrors.length > 0 && (
+                                <Alert variant="warning" title="Validation Errors" className="validation-errors">
+                                    <ul>
+                                        {validationErrors.map((ve, i) => (
+                                            <li key={i}>{ve.path ? `${ve.path}: ` : ""}{ve.message}</li>
+                                        ))}
+                                    </ul>
+                                </Alert>
+                            )}
+
+                            {/* Server-rendered output */}
+                            {serverRendered && (
+                                <div className="rendered-section">
+                                    <Title headingLevel="h3" size="md">Server-Rendered (validated)</Title>
+                                    <div className="render-source-label">
+                                        <Label color="green" isCompact>Server</Label>{" "}
+                                        Uses stored template with backend validation
+                                    </div>
+                                    <div className="rendered-output">{serverRendered}</div>
+                                </div>
+                            )}
+
+                            {/* Client-side preview (only when template is modified) */}
+                            {localPreview && isModified && (
+                                <div className="rendered-section">
+                                    <Title headingLevel="h3" size="md">Local Preview (unvalidated)</Title>
+                                    <div className="render-source-label">
+                                        <Label color="orange" isCompact>Local</Label>{" "}
+                                        Client-side substitution — no schema validation applied
+                                    </div>
+                                    <div className="rendered-output">{localPreview}</div>
+                                </div>
+                            )}
+                        </CardBody>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/ui/ui-app/src/app/pages/playground/index.ts
+++ b/ui/ui-app/src/app/pages/playground/index.ts
@@ -1,0 +1,1 @@
+export * from "./PromptPlaygroundPage";


### PR DESCRIPTION
<html><head></head><body><h2>What does this PR do?</h2><p>This is a <strong>draft/WIP prototype</strong> for issue #8425 (Prompt Template Playground), built as evidence for an LFX Mentorship 2026 Term 3 application. It is <strong>not intended for merge as-is</strong> — it's a scoped-down proof of concept covering the first two items in the issue's scope list, opened early so maintainers can see the approach before I submit my mentee application.</p><p>It adds a standalone playground page where a stored <code inline="">PROMPT_TEMPLATE</code> artifact's content can be edited in a Monaco editor, with live variable extraction and two rendering modes: the real server-side render (validated, using the existing <code inline="">/render</code> endpoint) and a clearly-labeled client-side preview for edits that haven't been saved as a new version yet.</p><h2>Why is this necessary?</h2><p>Issue #8425 asks for an editable playground with live variable extraction and a real-time test panel. Before writing any code, I went through the existing codebase and found that a significant part of the groundwork already exists — <code inline="">PromptTemplateViewer</code>, a working <code inline="">PromptTemplateTestPanel</code> wired to the real backend render endpoint via <code inline="">useGroupsService().renderPromptTemplate()</code>, and full validation/error-state handling. Given that, the actual gap is narrower than the issue's full scope suggests: there was no editable template surface and no standalone <code inline="">extractVariables</code> utility (the existing viewer only uses a regex inline for highlighting, not as a reusable function). This PR closes that specific gap.</p><h2>Scope of this prototype (and what's intentionally left out)</h2><p><strong>In scope here:</strong></p><ul><li><p>Interactive, editable prompt editor with live variable extraction</p></li><li><p>A test panel that renders via the real backend, plus a labeled local preview for unsaved edits</p></li></ul><p><strong>Explicitly out of scope for this PR</strong> (belongs in the full 12-week mentorship plan, not a pre-application prototype):</p><ul><li><p>Side-by-side version diff</p></li><li><p>Version tagging via labels</p></li><li><p>Full E2E test suite</p></li></ul><p>I also considered adding a stateless render endpoint on the backend (to properly render in-progress edits without requiring a saved version first), but decided against including it here — it would expand the public API surface without rate-limiting/size-limiting/auth scoping already thought through, and that's a design decision that deserves maintainer input rather than landing as a drive-by addition in a UI prototype PR. Happy to discuss this as a possible stretch goal if there's interest.</p><h2>Changes</h2><ul><li><p><strong>[NEW]</strong> <code inline="">extractVariables.ts</code> — pure function that extracts deduplicated <code inline="">{{variable}}</code> names from a template string. Handles whitespace inside braces, malformed empty braces, and filters out Handlebars block helpers (<code inline="">{{#if}}</code>, <code inline="">{{/if}}</code>, <code inline="">{{#each}}</code>, <code inline="">{{#unless}}</code>, <code inline="">{{#with}}</code>) so they aren't mistaken for data variables.</p></li><li><p><strong>[NEW]</strong> <code inline="">extractVariables.test.ts</code> — 12 unit tests covering the above, plus dedup, ordering, and null/undefined/empty-string safety.</p></li><li><p><strong>[NEW]</strong> <code inline="">PromptTemplateEditor.tsx</code> / <code inline="">.css</code> — Monaco-based editor (<code inline="">language="handlebars"</code>) with 300ms-debounced live variable extraction, displayed as PatternFly <code inline="">LabelGroup</code> chips. Debounce timers are cleaned up on unmount.</p></li><li><p><strong>[NEW]</strong> <code inline="">PromptPlaygroundPage.tsx</code> / <code inline="">.css</code> — standalone page at <code inline="">/playground/:groupId/:artifactId/:version</code>. Loads the stored artifact on mount, renders the editor alongside a dynamically generated form (one field per extracted variable), and exposes two render actions:</p><ul><li><p><strong>Server-Rendered (validated)</strong> — calls the existing <code inline="">renderPromptTemplate()</code> service method against the real backend; shows backend validation errors as-is.</p></li><li><p><strong>Local Preview (unvalidated)</strong> — only shown once the editor content diverges from the stored version; does a plain client-side substitution and is explicitly labeled as unvalidated so it's never confused with the server-validated result.</p></li></ul></li><li><p><strong>[MODIFY]</strong> <code inline="">MainPageWithAuth.tsx</code> — added the playground route, following the same static top-level import pattern used by every other page in this file (see bundle-size note below).</p></li><li><p><strong>[MODIFY]</strong> <code inline="">pages/index.ts</code>, <code inline="">components/promptTemplate/index.ts</code> — barrel exports for the new components.</p></li></ul><p>No backend files were touched.</p><h2>Testing</h2><pre><code class="language-text">npx vitest run src/app/components/promptTemplate/extractVariables.test.ts
✓ 12 tests passed

npm run lint
✖ 2 warnings, 0 errors (both pre-existing, in ReferencesFormGroup.tsx — a file this PR does
  not touch)

npm run build
✓ built in 52.14s
</code></pre><p>Manually verified: created a <code inline="">PROMPT_TEMPLATE</code> artifact locally, navigated to the playground route, confirmed the editor loads the stored content, variable chips update live as the template is edited, and both the server-rendered and local-preview paths return the expected output (including backend validation errors surfacing correctly for missing required variables).</p><h3>Bundle size check</h3><p>Ran a baseline build against <code inline="">main</code> before these changes and compared:</p>
  | index-*.js (uncompressed) | gzip
-- | -- | --
Baseline (main) | 5,668.43 kB | 1,528.50 kB
With this PR | 5,674.58 kB | 1,530.23 kB
Delta | +6.15 kB | +1.73 kB

<p>The ~5.6 MB chunk is pre-existing — <code inline="">MainPageWithAuth.tsx</code> statically imports every page (including <code inline="">EditorPage.tsx</code>, which already pulls in <code inline="">@monaco-editor/react</code>), so Vite bundles all routes into one chunk regardless of this PR. Since Monaco was already in that bundle, this PR's own use of it added no duplicate Monaco payload — the +6.15 kB is just the new components/utility themselves. I kept the new route consistent with the existing static-import convention used by every other page here rather than introducing lazy-loading unilaterally, since that's a bundle-wide architectural change that would affect every route, not just this one — worth a separate discussion/PR if maintainers want it.</p><h2>Related Issue</h2><p>Prototype for #8425 (not closing it — this covers a subset of the issue's scope, opened ahead of an LFX Mentorship application for discussion/visibility).</p></body></html>