### PR TITLE
fix(test): add retry and diagnostics to integration test pod wait

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/deployment/DebeziumDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/DebeziumDeploymentManager.java
@@ -222,8 +222,7 @@ public class DebeziumDeploymentManager {
         kubernetesClient.load(DebeziumDeploymentManager.class.getResourceAsStream(resourcePath))
                 .serverSideApply();
 
-        // Wait for all pods to be ready (6 minute timeout)
-        kubernetesClient.pods().inNamespace(TEST_NAMESPACE).waitUntilReady(360, java.util.concurrent.TimeUnit.SECONDS);
+        RegistryDeploymentManager.waitForAllPodsReady();
     }
 
     /**
@@ -434,9 +433,8 @@ public class DebeziumDeploymentManager {
                     modifiedManifest.getBytes(java.nio.charset.StandardCharsets.UTF_8)
             )).serverSideApply();
 
-            // Wait for all pods to be ready (including initContainer completion)
             LOGGER.info("Waiting for Debezium Connect pod to be ready (including initContainer)...");
-            kubernetesClient.pods().inNamespace(TEST_NAMESPACE).waitUntilReady(360, java.util.concurrent.TimeUnit.SECONDS);
+            RegistryDeploymentManager.waitForAllPodsReady();
 
             LOGGER.info("Debezium Connect with local converters deployed successfully");
 

--- a/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
@@ -4,6 +4,7 @@ import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.api.model.Route;
@@ -190,8 +191,7 @@ public class RegistryDeploymentManager implements TestExecutionListener {
             LOGGER.debug("Error creating registry resources:", ex);
         }
 
-        // Wait for all the pods of the variant to be ready
-        kubernetesClient.pods().inNamespace(TEST_NAMESPACE).waitUntilReady(360, TimeUnit.SECONDS);
+        waitForAllPodsReady();
 
         setupTestNetworking();
 
@@ -229,12 +229,49 @@ public class RegistryDeploymentManager implements TestExecutionListener {
     }
 
     private static void deployResource(String resource) {
-        // Deploy all the resources associated to the external requirements
         kubernetesClient.load(RegistryDeploymentManager.class.getResourceAsStream(resource))
                 .serverSideApply();
 
-        // Wait for all the external resources pods to be ready
-        kubernetesClient.pods().inNamespace(TEST_NAMESPACE).waitUntilReady(360, TimeUnit.SECONDS);
+        waitForAllPodsReady();
+    }
+
+    static final int POD_WAIT_TIMEOUT_SECONDS = 360;
+    static final int POD_WAIT_MAX_ATTEMPTS = 2;
+
+    static void waitForAllPodsReady() {
+        for (int attempt = 1; attempt <= POD_WAIT_MAX_ATTEMPTS; attempt++) {
+            try {
+                kubernetesClient.pods().inNamespace(TEST_NAMESPACE)
+                        .waitUntilReady(POD_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                return;
+            } catch (KubernetesClientTimeoutException e) {
+                logPodStatus();
+                if (attempt == POD_WAIT_MAX_ATTEMPTS) {
+                    throw new RuntimeException(
+                            "Pods not ready after " + POD_WAIT_MAX_ATTEMPTS + " attempts ("
+                                    + POD_WAIT_TIMEOUT_SECONDS + "s each)",
+                            e);
+                }
+                LOGGER.warn("Pod wait attempt {}/{} timed out, retrying: {}",
+                        attempt, POD_WAIT_MAX_ATTEMPTS, e.getMessage());
+            }
+        }
+    }
+
+    static void logPodStatus() {
+        try {
+            PodList pods = kubernetesClient.pods().inNamespace(TEST_NAMESPACE).list();
+            pods.getItems().forEach(pod -> {
+                String name = pod.getMetadata().getName();
+                String phase = pod.getStatus() != null ? pod.getStatus().getPhase() : "unknown";
+                boolean ready = pod.getStatus() != null && pod.getStatus().getConditions() != null
+                        && pod.getStatus().getConditions().stream()
+                                .anyMatch(c -> "Ready".equals(c.getType()) && "True".equals(c.getStatus()));
+                LOGGER.info("Pod {}: phase={}, ready={}", name, phase, ready);
+            });
+        } catch (Exception e) {
+            LOGGER.warn("Could not list pods for diagnostics: {}", e.getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Extract shared `waitForAllPodsReady()` in `RegistryDeploymentManager` with retry (2 attempts, 360s each) and per-pod diagnostic logging on failure
- Replace all 4 bare `waitUntilReady(360, TimeUnit.SECONDS)` calls across `RegistryDeploymentManager` (2) and `DebeziumDeploymentManager` (2)
- Catch `KubernetesClientTimeoutException` specifically (not bare `Exception`) to let auth/API errors propagate immediately
- Null-safe pod status inspection for newly created pods that don't have status yet

**Root cause:** The postgresql-auth integration test deploys 3 pods (Keycloak + PostgreSQL + Registry). On CI runners with cold image caches, the namespace-wide `waitUntilReady` can time out at 360s. With no retry and no diagnostics, the failure message is `"Timed out waiting for [Pod] with name:[null]"` which gives no indication of which pod is stuck.

**Evidence:** Run [30721224433](https://github.com/Apicurio/apicurio-registry/actions/runs/30721224433), postgresql-auth shard.

## Test plan

- [ ] Integration tests compile: `./mvnw test-compile -pl integration-tests -am -DskipTests -Pintegration-tests`
- [ ] On timeout, logs show per-pod status (name, phase, ready) before retry
- [ ] On transient failure, retry succeeds and tests continue
- [ ] Non-timeout exceptions (auth, API errors) propagate immediately without retry