### PR TITLE
fix(limits): reject null label values in RegistryLimitsService.checkLabels

### DIFF
--- a/app/src/main/java/io/apicurio/registry/limits/RegistryLimitsService.java
+++ b/app/src/main/java/io/apicurio/registry/limits/RegistryLimitsService.java
@@ -30,6 +30,7 @@ public class RegistryLimitsService {
     private static final String MAX_LABELS_EXCEEDED_MSG = "Maximum number of labels exceeded for this artifact";
     private static final String MAX_LABEL_KEY_SIZE_EXCEEDED_MSG = "Maximum label key size exceeded";
     private static final String MAX_LABEL_VALUE_SIZE_EXCEEDED_MSG = "Maximum label value size exceeded";
+    private static final String LABEL_VALUE_NULL_MSG = "Label value must not be null";
 
     @Inject
     Logger log;
@@ -248,10 +249,14 @@ public class RegistryLimitsService {
                         errorMessages.add(MAX_LABEL_KEY_SIZE_EXCEEDED_MSG);
                     }
 
-                    if (isLimitEnabled(RegistryLimitsConfiguration::getMaxPropertyValueSizeBytes)
-                            && e.getValue().length() > registryLimitsConfiguration
-                                    .getMaxPropertyValueSizeBytes()) {
-                        errorMessages.add(MAX_LABEL_VALUE_SIZE_EXCEEDED_MSG);
+                    if (isLimitEnabled(RegistryLimitsConfiguration::getMaxPropertyValueSizeBytes)) {
+                        String value = e.getValue();
+                        if (value == null) {
+                            errorMessages.add(LABEL_VALUE_NULL_MSG);
+                        } else if (value.length() > registryLimitsConfiguration
+                                .getMaxPropertyValueSizeBytes()) {
+                            errorMessages.add(MAX_LABEL_VALUE_SIZE_EXCEEDED_MSG);
+                        }
                     }
                 });
             }

--- a/app/src/test/java/io/apicurio/registry/limits/RegistryLimitsNullLabelValueTest.java
+++ b/app/src/test/java/io/apicurio/registry/limits/RegistryLimitsNullLabelValueTest.java
@@ -1,0 +1,45 @@
+package io.apicurio.registry.limits;
+
+import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@QuarkusTest
+@TestProfile(RegistryLimitsNullLabelValueTestProfile.class)
+public class RegistryLimitsNullLabelValueTest {
+
+    @Inject
+    RegistryLimitsService limitsService;
+
+    @Test
+    public void testNullLabelValueIsRejected() {
+        EditableArtifactMetaDataDto meta = new EditableArtifactMetaDataDto();
+        Map<String, String> labels = new HashMap<>();
+        labels.put("mykey", null);
+        meta.setLabels(labels);
+
+        LimitsCheckResult result = limitsService.checkMetaData(meta);
+
+        Assertions.assertFalse(result.isAllowed(),
+                "A null label value must be rejected, not throw NullPointerException");
+        Assertions.assertTrue(result.getMessage().contains("Label value must not be null"),
+                "Error message should indicate the label value must not be null");
+    }
+
+    @Test
+    public void testNonNullLabelValueIsAllowed() {
+        EditableArtifactMetaDataDto meta = new EditableArtifactMetaDataDto();
+        meta.setLabels(Map.of("mykey", "short-value"));
+
+        LimitsCheckResult result = limitsService.checkMetaData(meta);
+
+        Assertions.assertTrue(result.isAllowed(),
+                "A non-null label value within the limit must be allowed");
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/limits/RegistryLimitsNullLabelValueTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/limits/RegistryLimitsNullLabelValueTestProfile.java
@@ -1,0 +1,17 @@
+package io.apicurio.registry.limits;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RegistryLimitsNullLabelValueTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> props = new HashMap<>();
+        props.put("apicurio.limits.config.max-property-value-size.bytes", "100");
+        return props;
+    }
+
+}


### PR DESCRIPTION
## Description

Issue #8835 reported a `NullPointerException` in `RegistryLimitsService.checkLabels()` when a labels map contains a null value (e.g. `{"labels": {"mykey": null}}`).

The value-size check called `e.getValue().length()` directly. Since `Map<String, String>` legally permits null values and no upstream validation prevents them from reaching `checkLabels()`, this threw an unhandled `NullPointerException` that surfaced as a `500 Internal Server Error` instead of a `400 Bad Request`.

### Fix

Guard the value branch in `checkLabels()`:

```java
if (isLimitEnabled(RegistryLimitsConfiguration::getMaxPropertyValueSizeBytes)) {
    String value = e.getValue();
    if (value == null) {
        errorMessages.add(LABEL_VALUE_NULL_MSG);
    } else if (value.length() > registryLimitsConfiguration
            .getMaxPropertyValueSizeBytes()) {
        errorMessages.add(MAX_LABEL_VALUE_SIZE_EXCEEDED_MSG);
    }
}
```

A new constant `LABEL_VALUE_NULL_MSG = "Label value must not be null"` is added, so the request is rejected with a descriptive message rather than crashing.

### Note on "one PR at a time"

This repo's contributor guidelines ask for one PR at a time. #9195 (for #8734) is still open; if maintainers prefer a single PR I can fold this in, otherwise this stands on its own.

## Test Evidence

Added `RegistryLimitsNullLabelValueTest` (with `RegistryLimitsNullLabelValueTestProfile` enabling `apicurio.limits.config.max-property-value-size.bytes=100`):

- `testNullLabelValueIsRejected` — a null label value returns `disallowed` with a message containing "Label value must not be null" (no NPE).
- `testNonNullLabelValueIsAllowed` — a valid value within the limit is allowed.

```
./mvnw test -pl app -am -Dtest='RegistryLimitsNullLabelValueTest' -Dsurefire.failIfNoSpecifiedTests=false
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] DCO sign-off included (`Signed-off-by`)
- [x] Tests added/updated for the changed path
- [x] Commit message follows Conventional Commits

Fixes #8835
