### PR TITLE
fix(common): specify Locale.ROOT in StringUtil.asLowerCase()

### DIFF
--- a/common/src/main/java/io/apicurio/registry/utils/StringUtil.java
+++ b/common/src/main/java/io/apicurio/registry/utils/StringUtil.java
@@ -1,5 +1,7 @@
 package io.apicurio.registry.utils;
 
+import java.util.Locale;
+
 import static java.util.Objects.requireNonNull;
 
 public class StringUtil {
@@ -16,7 +18,7 @@ public class StringUtil {
         if (value == null) {
             return null;
         }
-        return value.toLowerCase();
+        return value.toLowerCase(Locale.ROOT);
     }
 
     public static String limitStr(String value, int limit, boolean withEllipsis) {

--- a/common/src/test/java/io/apicurio/registry/utils/StringUtilTest.java
+++ b/common/src/test/java/io/apicurio/registry/utils/StringUtilTest.java
@@ -1,0 +1,14 @@
+package io.apicurio.registry.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StringUtilTest {
+
+    @Test
+    public void testAsLowerCase() {
+        Assertions.assertNull(StringUtil.asLowerCase(null));
+        Assertions.assertEquals("hello", StringUtil.asLowerCase("HELLO"));
+        Assertions.assertEquals("test", StringUtil.asLowerCase("Test"));
+    }
+}


### PR DESCRIPTION
## Description

In `common/src/main/java/io/apicurio/registry/utils/StringUtil.java`, `asLowerCase()` called `value.toLowerCase()` without `Locale.ROOT`. 

This PR updates `StringUtil.asLowerCase()` to pass `Locale.ROOT` in accordance with the project code style conventions and adds a unit test in `StringUtilTest`.

## Contributor Checklist
- [x] Conventional Commits format (`fix(common): specify Locale.ROOT in StringUtil.asLowerCase()`)
- [x] All commits have DCO sign-off (`Signed-off-by: Labreo <74888611+Labreo@users.noreply.github.com>`)
- [x] Unit test added (`StringUtilTest.java`)
- [x] `./mvnw checkstyle:check -pl common` passes
- [x] PR contains no unrelated changes

Fixes #9220 