### PR TITLE
docs: fix contributor build and test commands that no longer work

### DIFF
--- a/.claude/commands/run-tests.md
+++ b/.claude/commands/run-tests.md
@@ -29,7 +29,7 @@ $ARGUMENTS — Optional: module name, test class, or "all"
 
 4. **If storage layer was changed**, suggest integration tests:
    ```bash
-   ./mvnw verify -pl integration-tests -Plocal-tests
+   ./mvnw verify -Pintegration-tests -pl integration-tests -am
    ```
 
 5. **If UI was changed**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Open-source API and Schema Registry. Apache 2.0 license, DCO sign-off required o
 ./mvnw quarkus:dev                       # Dev mode (run from app/)
 ./mvnw test -pl <module>                 # Run tests for a specific module
 ./mvnw checkstyle:check -pl <module>     # Run checkstyle for a module
-./mvnw verify -pl integration-tests -Plocal-tests  # Integration tests
+./mvnw verify -Pintegration-tests -pl integration-tests -am  # Integration tests
 ```
 
 UI (separate build system):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,11 +80,38 @@ Because we are all humans, and to ensure Apicurio Registry is stable for everyon
 Don't forget to include tests in your pull requests.
 Also don't forget the documentation (reference documentation, javadoc...).
 
-Be sure to test your pull request using all storage variants:
+Be sure to test your pull request against the storage variants your change affects.
 
-1. SQL storage (using the `-Psql` profile)
-2. SQL Server storage (using the `-Pmssql` profile)
-3. KafkaSQL storage (using the `-Pkafkasql` profile)
+Since Apicurio Registry 3.0 a single build supports every storage variant, so the
+variant is selected at runtime rather than by a Maven profile
+(see [DEVELOPING.md](DEVELOPING.md#build-configuration)):
+
+| Storage variant                | Selected with                                                            |
+|--------------------------------|--------------------------------------------------------------------------|
+| SQL                            | `-Dapicurio.storage.kind=sql` (default)                                   |
+| KafkaSQL                       | `-Dapicurio.storage.kind=kafkasql`                                        |
+| GitOps (experimental)          | `-Dapicurio.storage.kind=gitops`                                          |
+| Kubernetes ConfigMap (experimental) | `-Dapicurio.storage.kind=kubernetesops`                              |
+
+For the SQL variant, the database flavor is chosen separately with
+`-Dapicurio.storage.sql.kind`, which accepts `h2` (default), `postgresql`, `mssql`,
+and `mysql`.
+
+Storage-specific unit tests live under the matching packages and can be run directly:
+
+```bash
+./mvnw test -pl app -Dtest='io.apicurio.registry.storage.impl.kafkasql.**'
+```
+
+Integration tests are opt-in and are documented in the
+[integration tests module](integration-tests/):
+
+```bash
+./mvnw verify -Pintegration-tests -pl integration-tests -am
+```
+
+CI runs the full storage matrix on every pull request, so running every variant
+locally is not required.
 
 ### Customizing Registry supported ArtifactTypes
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -55,13 +55,23 @@ The project uses a three-tier build system to allow developers to build only wha
 
 ```bash
 # Local: core server only, skip non-essential plugins (~3 min)
-./mvnw clean install -Dlocal -DskipTests
+./mvnw clean install -Dlocal -Dmaven.test.skip=true
 
 # Default: normal development
 ./mvnw clean install -DskipTests
 
 # Full: everything
 ./mvnw clean install -Dfull -DskipTests
+```
+
+**Note:** the *local* tier requires `-Dmaven.test.skip=true` rather than `-DskipTests`.
+The local tier excludes the serde and Maven plugin modules, but the `app` module's test
+sources import packages from them, so `-DskipTests` (which still compiles test sources)
+fails at test compilation. `-Dmaven.test.skip=true` skips test compilation entirely.
+The same applies to dev mode, which also compiles test sources:
+
+```bash
+cd app && ../mvnw quarkus:dev -Dlocal -Dmaven.test.skip=true
 ```
 
 Integration tests and examples are always opt-in via their own profiles:
@@ -72,7 +82,8 @@ Integration tests and examples are always opt-in via their own profiles:
 | Property              | Purpose                                                                                  |
 |-----------------------|------------------------------------------------------------------------------------------|
 | `-Pprod`              | Enables Quarkus *prod* configuration profile (higher logging level, production defaults) |
-| `-DskipTests`         | Skip all tests                                                                           |
+| `-DskipTests`         | Skip running tests (test sources are still compiled)                                     |
+| `-Dmaven.test.skip=true` | Skip compiling and running tests (required with `-Dlocal`)                            |
 | `-DcliSkipNative`     | Skip CLI native image compilation (no executable is produced, but tests can still run)   |
 | `-DskipOperatorTests` | Skip operator tests (default: `true`, requires a running cluster)                        |
 
@@ -132,7 +143,7 @@ are in a separate module and need to be explicitly enabled:
 
 ```bash
 # Run default integration tests (smoke + serdes + acceptance)
-./mvnw verify -Pintegration-tests -Plocal-tests -pl integration-tests -am
+./mvnw verify -Pintegration-tests -pl integration-tests -am
 ```
 
 See the [integration tests module](integration-tests/) for test groups, deployment

--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ Build the project and run the registry with the in-memory storage variant:
 **Build requirement:** JDK 21 or newer is required to build the project (the build tooling, e.g. Checkstyle, needs a Java 21+ runtime). The produced artifacts still target Java 17.
 
  ```
- ./mvnw clean install -Dlocal -DskipTests
+ ./mvnw clean install -Dlocal -Dmaven.test.skip=true
  cd app/
- ../mvnw quarkus:dev
+ ../mvnw quarkus:dev -Dlocal -Dmaven.test.skip=true
  ```
+
+(The `-Dlocal` build tier requires `-Dmaven.test.skip=true` — see
+[DEVELOPING.md](DEVELOPING.md#build-tiers) for details and other build options.)
 
 This should result in Quarkus and the in-memory registry starting up, with the REST APIs available on localhost port 8080:
 


### PR DESCRIPTION
Three sets of commands in the contributor docs fail when run as written.

### 1. The `local` build tier needs `-Dmaven.test.skip=true` (#9018)

`-DskipTests` still compiles test sources. 21 files under `app/src/test` import packages from the serde and Maven plugin modules that the `local` tier excludes, so the build dies at test compilation. Dev mode compiles test sources too, so it needs the same flag.

### 2. CONTRIBUTING.md documents storage profiles that were deleted (#9113)

`-Psql`, `-Pmssql`, and `-Pkafkasql` were removed in #3902 when storage variants were unified. The variant is now selected at runtime via `apicurio.storage.kind`.

### 3. `-Plocal-tests` was removed in #7628

Still referenced in `DEVELOPING.md`, `CLAUDE.md`, and `.claude/commands/run-tests.md`. The latter two were also missing `-Pintegration-tests`, without which the integration-tests module is not built at all.

### How I found #3

While fixing #9113 I swept every `<id>` defined in every `pom.xml` against every `-P` reference in every `.md`. These four are the only phantom profiles left.

Maven does not fail on an unknown profile, it only warns, so these have been silent no-ops:

```
$ ./mvnw validate -Plocal-tests
[WARNING] The requested profile "local-tests" could not be activated because it does not exist.

$ ./mvnw validate -Psql
[WARNING] The requested profile "sql" could not be activated because it does not exist.
```

`-Pintegration-tests` produces no such warning.

The replacement instructions in CONTRIBUTING.md are taken from `DEVELOPING.md` (storage kinds), `RegistryDatabaseKind` (the four SQL flavors), and `integration-tests/README.md` (the working integration-test command).

Fixes #9018
Fixes #9113
