### PR TITLE
ci(scalpel): drop scalpel-report job from CI pipeline (#9138)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -128,7 +128,6 @@ non-Java changes (docs, UI).
 | `verify.yaml` | PR, push to main | Main orchestrator: `decide` job determines what to run, `verification-gate` is the single required check | N/A |
 | `verify-build.yaml` | Called by verify | Parallel Java (`mvnw package -T 0.5C`) + UI (`npm build`) builds. Produces Docker images and build artifacts uploaded with 1-day retention | ~6 min |
 | `verify-unit-tests.yaml` | Called by verify | Unit tests in 3 parallel shards (see above) | ~16 min (critical path) |
-| `scalpel-report` (job in `verify.yaml`) | PR with java changes | Scalpel affected-module analysis in report mode; uploads JSON artifact for offline analysis. Not in the Verification Gate. Opt out per PR with the `ci/disable-scalpel` label | ~2 min |
 | `verify-integration-tests.yaml` | Called by verify | 13-job matrix across storage backends, each with Minikube | ~15 min per job |
 | `verify-extras.yaml` | Called by verify | 5 parallel jobs: extra tests, UI Playwright tests, legacy V2 compatibility tests, TypeScript SDK tests, example builds | ~13 min |
 | `verify-sdk.yaml` | Called by verify | Go and Python SDK verification | ~2 min |

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -29,7 +29,6 @@ jobs:
       lifecycle-ready: ${{ steps.decide.outputs.lifecycle-ready }}
       run-build: ${{ steps.decide.outputs.run-build }}
       run-unit-tests: ${{ steps.decide.outputs.run-unit-tests }}
-      run-scalpel-report: ${{ steps.decide.outputs.run-scalpel-report }}
       run-integration: ${{ steps.decide.outputs.run-integration }}
       run-extras: ${{ steps.decide.outputs.run-extras }}
       run-sdk: ${{ steps.decide.outputs.run-sdk }}
@@ -37,7 +36,6 @@ jobs:
       run-go-sdk-freshness: ${{ steps.decide.outputs.run-go-sdk-freshness }}
       run-operator: ${{ steps.decide.outputs.run-operator }}
       run-console-plugin: ${{ steps.decide.outputs.run-console-plugin }}
-      scalpel-enabled: ${{ steps.decide.outputs.scalpel-enabled }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -120,10 +118,9 @@ jobs:
               LABEL='${{ github.event.label.name }}'
               if [[ "$LABEL" != lifecycle/* ]]; then
                 echo "lifecycle-ready=skip" >> "$GITHUB_OUTPUT"
-                for out in run-build run-unit-tests run-scalpel-report run-integration run-extras run-sdk run-cli run-operator run-console-plugin run-go-sdk-freshness; do
+                for out in run-build run-unit-tests run-integration run-extras run-sdk run-cli run-operator run-console-plugin run-go-sdk-freshness; do
                   echo "$out=false" >> "$GITHUB_OUTPUT"
                 done
-                echo "scalpel-enabled=false" >> "$GITHUB_OUTPUT"
                 exit 0
               fi
             fi
@@ -139,10 +136,9 @@ jobs:
             SENDER='${{ github.event.sender.login }}'
             if has_label "orchestrator/merge-rebase" && [ "$SENDER" = "github-actions[bot]" ]; then
               echo "lifecycle-ready=true" >> "$GITHUB_OUTPUT"
-              for out in run-build run-unit-tests run-scalpel-report run-integration run-extras run-sdk run-cli run-operator run-console-plugin run-go-sdk-freshness; do
+              for out in run-build run-unit-tests run-integration run-extras run-sdk run-cli run-operator run-console-plugin run-go-sdk-freshness; do
                 echo "$out=false" >> "$GITHUB_OUTPUT"
               done
-              echo "scalpel-enabled=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
@@ -201,9 +197,6 @@ jobs:
           echo "lifecycle-ready=$run_smoke" >> "$GITHUB_OUTPUT"
           decide run-build       "$run_smoke" "$IS_PUSH" "$JAVA" "$UI" "$SDK" "$CLI" "$CI"
           decide run-unit-tests  "$run_smoke" "$IS_PUSH" "$JAVA" "$CI"
-          # Report only when java sources changed: .github-only PRs trip
-          # scalpel.disableTriggers and would produce an empty report.
-          decide run-scalpel-report "$run_smoke" "$JAVA"
           decide run-integration "$run_full"  "$IS_PUSH" "$INTEGRATION" "$CI"
           decide run-extras      "$run_full"  "$IS_PUSH" "$JAVA" "$UI" "$CI"
           decide run-sdk         "$run_full"  "$IS_PUSH" "$SDK" "$JAVA" "$CI"
@@ -211,13 +204,6 @@ jobs:
           decide run-operator        "$run_full"  "$IS_PUSH" "$OPERATOR" "$CI_OPERATOR"
           decide run-console-plugin  "$run_smoke" "$IS_PUSH" "$CONSOLE_PLUGIN" "$CI"
           decide run-go-sdk-freshness "$run_smoke" "$GO_SDK_GEN" "$CI"
-
-          # Scalpel (affected-module detection) can be disabled via PR label
-          if [ "$EVENT" != "push" ] && has_label "ci/disable-scalpel"; then
-            echo "scalpel-enabled=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "scalpel-enabled=true" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Save decision summary
         if: github.event_name == 'pull_request' && steps.decide.outputs.lifecycle-ready != 'skip'
@@ -227,15 +213,13 @@ jobs:
             "lifecycle-ready": "${{ steps.decide.outputs.lifecycle-ready }}",
             "run-build": "${{ steps.decide.outputs.run-build }}",
             "run-unit-tests": "${{ steps.decide.outputs.run-unit-tests }}",
-            "run-scalpel-report": "${{ steps.decide.outputs.run-scalpel-report }}",
             "run-integration": "${{ steps.decide.outputs.run-integration }}",
             "run-extras": "${{ steps.decide.outputs.run-extras }}",
             "run-sdk": "${{ steps.decide.outputs.run-sdk }}",
             "run-cli": "${{ steps.decide.outputs.run-cli }}",
             "run-operator": "${{ steps.decide.outputs.run-operator }}",
             "run-console-plugin": "${{ steps.decide.outputs.run-console-plugin }}",
-            "run-go-sdk-freshness": "${{ steps.decide.outputs.run-go-sdk-freshness }}",
-            "scalpel-enabled": "${{ steps.decide.outputs.scalpel-enabled }}"
+            "run-go-sdk-freshness": "${{ steps.decide.outputs.run-go-sdk-freshness }}"
           }
           ARTIFACT_EOF
           cat > /tmp/verify-changes.json << 'ARTIFACT_EOF'
@@ -304,68 +288,6 @@ jobs:
     uses: ./.github/workflows/verify-unit-tests.yaml
     with:
       image-tag: ${{ github.sha }}
-
-  # ============================================================================
-  # Scalpel Report (affected-module detection, data collection only)
-  #
-  # Runs Scalpel in mode=report to record which modules it considers affected,
-  # without running any tests. Archives the JSON report as an artifact for
-  # offline analysis. ~2 minutes per run vs ~40 for the full shadow group.
-  # Not in the Verification Gate: a failure here never blocks a PR.
-  #
-  # Runs only when java sources changed (run-scalpel-report): on .github-only
-  # PRs Scalpel disables itself via scalpel.disableTriggers, so a report run
-  # would produce nothing. Mixed PRs (java + .github) still trip that trigger,
-  # which is why a missing report is a warning, not an error.
-  #
-  # See Discussion #8364 for the evaluation results that led to this change.
-  # ============================================================================
-  scalpel-report:
-    name: Scalpel Report
-    needs: [decide]
-    if: >-
-      github.event_name == 'pull_request'
-      && needs.decide.outputs.run-scalpel-report == 'true'
-      && needs.decide.outputs.scalpel-enabled == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          # Full history: Scalpel diffs against the base branch (GITHUB_BASE_REF)
-          fetch-depth: 0
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: Restore Maven cache
-        uses: ./.github/actions/setup-maven-cache
-
-      - name: Generate Scalpel report
-        run: |
-          # CLI flags win over .mvn/maven.config (scalpel.enabled=false there).
-          # reportFile restates the documented default so the upload path
-          # below cannot drift if upstream changes it.
-          # wagon flags: same transient-failure hardening as the other CI jobs.
-          ./mvnw validate --no-transfer-progress \
-            -s ${{ github.workspace }}/.github/ci-settings.xml \
-            -Dscalpel.enabled=true \
-            -Dscalpel.mode=report \
-            -Dscalpel.reportFile=target/scalpel-report.json \
-            -Dmaven.wagon.httpconnectionManager.maxTotal=30 \
-            -Dmaven.wagon.http.retryHandler.count=5
-
-      - name: Upload Scalpel report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: scalpel-report-pr${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
-          path: target/scalpel-report.json
-          retention-days: 30
-          if-no-files-found: warn
 
   # ============================================================================
   # CLI Verification

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Scalpel: affected-module detection for CI. Disabled by default
-     in maven.config; the scalpel-report CI job opts in via -Dscalpel.enabled=true. -->
+<!-- Scalpel: affected-module detection for ad-hoc local analysis. Disabled by
+     default in maven.config; pass -Dscalpel.enabled=true to opt in. -->
 <extensions>
     <extension>
         <groupId>eu.maveniverse.maven.scalpel</groupId>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,9 +1,8 @@
 -T 1C
-# Scalpel (affected-module detection) is disabled by default; no Maven
-# invocation builds with it unless -Dscalpel.enabled=true is passed. The only
-# consumer is the scalpel-report CI job in verify.yaml, which runs mode=report
-# (analysis only, no reactor changes). mode is pinned here too so an ad-hoc
-# -Dscalpel.enabled=true never trims the reactor or skips tests by surprise.
+# Scalpel (affected-module detection) is disabled by default. The extension
+# is available for ad-hoc local analysis; pass -Dscalpel.enabled=true to opt
+# in. mode is pinned to report so an ad-hoc invocation never trims the reactor
+# or skips tests by surprise.
 -Dscalpel.enabled=false
 -Dscalpel.mode=report
 # disableTriggers: changes to CI/build config disable Scalpel entirely (full build).


### PR DESCRIPTION
Remove the scalpel-report CI job and all its decision plumbing from verify.yaml. The job uploaded affected-modules JSON artifacts on every java-touching PR but nothing consumed them and no re-evaluation was scheduled, so the data silently expired after 30 days.

The Scalpel Maven extension remains available (disabled by default in .mvn/maven.config) for ad-hoc local analysis via:
  ./mvnw validate -Dscalpel.enabled=true

Changes:
- Remove scalpel-report job (lines, steps, artifact upload)
- Remove run-scalpel-report and scalpel-enabled decision outputs
- Remove ci/disable-scalpel label check from decide logic
- Update .mvn/maven.config and extensions.xml comments to reflect the extension is now for local use only
- Remove scalpel-report row from .github/workflows/README.md

Closes #9138