### PR TITLE
fix(ui): include all artifact types in fallback list to prevent silent drop on API failure

### DIFF
--- a/ui/ui-app/src/services/useArtifactTypesService.ts
+++ b/ui/ui-app/src/services/useArtifactTypesService.ts
@@ -127,6 +127,19 @@ export class ArtifactTypes {
         return title;
     }
 
+    // All artifact types the UI knows about. Used as a fallback when the backend
+    // list of types can't be fetched. Keep in sync with the constants above so that
+    // new types don't silently drop out of the Create Artifact dropdown on API failure.
+    public static all(): string[] {
+        return [
+            ArtifactTypes.AVRO, ArtifactTypes.PROTOBUF, ArtifactTypes.JSON,
+            ArtifactTypes.OPENAPI, ArtifactTypes.ASYNCAPI, ArtifactTypes.GRAPHQL,
+            ArtifactTypes.KCONNECT, ArtifactTypes.WSDL, ArtifactTypes.XSD,
+            ArtifactTypes.XML, ArtifactTypes.THRIFT, ArtifactTypes.AGENT_CARD,
+            ArtifactTypes.MCP_TOOL, ArtifactTypes.MODEL_SCHEMA, ArtifactTypes.PROMPT_TEMPLATE
+        ];
+    }
+
     public static getClassNames(type: string): string {
         let classes: string = "artifact-type-icon";
         switch (type) {
@@ -191,7 +204,7 @@ const allTypes = async (admin: AdminService): Promise<string[]> => {
         try {
             ALL_TYPES = (await admin.getArtifactTypes()).map(t => t.name!);
         } catch {
-            ALL_TYPES = ["AVRO", "PROTOBUF", "JSON", "OPENAPI", "ASYNCAPI", "GRAPHQL", "KCONNECT", "WSDL", "XSD", "XML"];
+            ALL_TYPES = ArtifactTypes.all();
         }
     }
     return Promise.resolve(ALL_TYPES);


### PR DESCRIPTION
Fixes #9225

The hardcoded fallback in `useArtifactTypesService.ts` had drifted from the `ArtifactTypes` constants and was missing THRIFT, AGENT_CARD, MCP_TOOL, MODEL_SCHEMA, and PROMPT_TEMPLATE. When `admin.getArtifactTypes()` fails, those 5 types silently disappeared from the Create Artifact dropdown.

This adds an `ArtifactTypes.all()` method as a single source of truth for the known types, and uses it for the fallback instead of a separate hardcoded array, so new types won't drop out again next time one is added.

**How I tested:** temporarily forced the catch branch (threw before the API call) and confirmed the Create Artifact dropdown then showed all 15 types, including the 5 that were missing before.
