### PR TITLE
fix(ui): mock TypeScript SDK imports in service tests to fix CI

### DIFF
--- a/ui/ui-app/src/services/useAdminService.test.ts
+++ b/ui/ui-app/src/services/useAdminService.test.ts
@@ -15,6 +15,21 @@ vi.mock("@apicurio/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 
+// The TypeScript SDK generated client (typescript-sdk/lib/generated-client/)
+// is produced by kiota and gitignored — it does not exist in the UI-only CI
+// build. Mock the three @sdk paths that rest.utils.ts imports so that
+// importOriginal can load the real rest.utils module without reaching the
+// missing generated client.
+vi.mock("@sdk/lib/sdk", () => ({
+    RegistryClientFactory: { createRegistryClient: vi.fn() }
+}));
+vi.mock("@sdk/lib/generated-client/apicurioRegistryClient.ts", () => ({
+    ApicurioRegistryClient: class {}
+}));
+vi.mock("@sdk/lib/generated-client/models", () => ({
+    Labels: {}
+}));
+
 vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
     return {

--- a/ui/ui-app/src/services/useDraftsService.test.ts
+++ b/ui/ui-app/src/services/useDraftsService.test.ts
@@ -15,6 +15,16 @@ vi.mock("@apicurio/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 
+vi.mock("@sdk/lib/sdk", () => ({
+    RegistryClientFactory: { createRegistryClient: vi.fn() }
+}));
+vi.mock("@sdk/lib/generated-client/apicurioRegistryClient.ts", () => ({
+    ApicurioRegistryClient: class {}
+}));
+vi.mock("@sdk/lib/generated-client/models", () => ({
+    Labels: {}
+}));
+
 vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
     return {

--- a/ui/ui-app/src/services/useGroupsService.test.ts
+++ b/ui/ui-app/src/services/useGroupsService.test.ts
@@ -15,6 +15,16 @@ vi.mock("@apicurio/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 
+vi.mock("@sdk/lib/sdk", () => ({
+    RegistryClientFactory: { createRegistryClient: vi.fn() }
+}));
+vi.mock("@sdk/lib/generated-client/apicurioRegistryClient.ts", () => ({
+    ApicurioRegistryClient: class {}
+}));
+vi.mock("@sdk/lib/generated-client/models", () => ({
+    Labels: {}
+}));
+
 vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
     return {

--- a/ui/ui-app/src/services/useSearchService.test.ts
+++ b/ui/ui-app/src/services/useSearchService.test.ts
@@ -15,6 +15,16 @@ vi.mock("@apicurio/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 
+vi.mock("@sdk/lib/sdk", () => ({
+    RegistryClientFactory: { createRegistryClient: vi.fn() }
+}));
+vi.mock("@sdk/lib/generated-client/apicurioRegistryClient.ts", () => ({
+    ApicurioRegistryClient: class {}
+}));
+vi.mock("@sdk/lib/generated-client/models", () => ({
+    Labels: {}
+}));
+
 vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
     return {


### PR DESCRIPTION
Closes the CI regression introduced by #9112.

## Summary

The 4 service test files added in #9112 (`useAdminService.test.ts`, `useDraftsService.test.ts`, `useGroupsService.test.ts`, `useSearchService.test.ts`) use `importOriginal` to load the real `rest.utils` module. This triggers the full import chain: `rest.utils.ts` → `@sdk/lib/sdk` → `../generated-client/apicurioRegistryClient.js`. The `generated-client/` directory is produced by `kiota` during the Maven build and is gitignored — it does not exist in the UI-only CI job (`Build UI Application`), causing all 4 tests to fail with `ERR_MODULE_NOT_FOUND`.

This blocks the Verification Gate on every open PR.

## Changes

Add `vi.mock` stubs for the three `@sdk` import paths (`RegistryClientFactory`, `ApicurioRegistryClient`, `Labels`) in each of the 4 failing test files. This breaks the import chain before it reaches the missing generated client, allowing `importOriginal` to load the real `rest.utils` module successfully.

No test logic changes — the mocked SDK modules are never exercised by the tests (they only test pagination via the already-mocked `getRegistryClient`).

## Likely root cause

#9112 added the test files. The tests were likely developed and verified with a full Maven build (where kiota had already generated the client), but the UI-only CI job doesn't run Maven/kiota.

## Test plan

- [x] `cd ui/ui-app && npx vitest run` — all 8 test files pass (35 tests), including the 4 previously failing ones