### PR TITLE
Fix HOME environment variable issue

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
@@ -238,18 +238,16 @@ public class InstallCommand extends AbstractCommand {
      * Gets the user's home directory path.
      */
      private Path getUserHomePath() {
-         String userHome;
-         if (PlatformUtils.isWindows()) {
+         String userHome = config.getEnv(ENV_HOME);
+         if (isBlank(userHome) && PlatformUtils.isWindows()) {
              userHome = config.getEnv("USERPROFILE");
-         } else {
-             userHome = config.getEnv(ENV_HOME);
          }
          if (isBlank(userHome)) {
-             userHome = System.getProperty("user.home");
+             userHome = config.getSystemProperty("user.home");
          }
          if (isBlank(userHome)) {
              throw new CliException(
-                     "Unable to determine the user's home directory.",
+                     "Unable to determine the user's home directory. Checked HOME, USERPROFILE, and user.home.",
                      VALIDATION_ERROR_RETURN_CODE);
          }
          return Path.of(userHome).normalize().toAbsolutePath();

--- a/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/InstallCommand.java
@@ -234,18 +234,26 @@ public class InstallCommand extends AbstractCommand {
             }
         });
     }
-
     /**
      * Gets the user's home directory path.
      */
-    private Path getUserHomePath() {
-        final String userHome = config.getEnv(ENV_HOME);
-        if (isBlank(userHome)) {
-            throw new CliException(ENV_HOME + " environment variable is not set.", VALIDATION_ERROR_RETURN_CODE);
-        }
-        return Path.of(userHome).normalize().toAbsolutePath();
-    }
-
+     private Path getUserHomePath() {
+         String userHome;
+         if (PlatformUtils.isWindows()) {
+             userHome = config.getEnv("USERPROFILE");
+         } else {
+             userHome = config.getEnv(ENV_HOME);
+         }
+         if (isBlank(userHome)) {
+             userHome = System.getProperty("user.home");
+         }
+         if (isBlank(userHome)) {
+             throw new CliException(
+                     "Unable to determine the user's home directory.",
+                     VALIDATION_ERROR_RETURN_CODE);
+         }
+         return Path.of(userHome).normalize().toAbsolutePath();
+     }
     /**
      * Ensures the ~/bin directory exists, creating it if necessary.
      */

--- a/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
@@ -73,7 +73,15 @@ public class Config {
         }
         return System.getenv(name);
     }
-
+    /**
+     * Gets a system property value.
+     *
+     * @param name the system property name
+     * @return the system property value, or null if not set
+     */
+    public String getSystemProperty(final String name) {
+        return System.getProperty(name);
+    }
     /**
      * Sets an environment variable override for testing purposes.
      * The override takes precedence over the actual system environment variable.

--- a/cli/src/test/java/io/apicurio/registry/cli/SearchCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/SearchCommandTest.java
@@ -206,8 +206,9 @@ public class SearchCommandTest extends AbstractCLITest {
         var results = MAPPER.readValue(out.toString(), ArtifactSearchResults.class);
 
         assertThat(results.getArtifacts())
-                .as(withCliOutput("Order by should return results"))
-                .isNotEmpty();
+                .as(withCliOutput("Type-filtered search should return JSON artifacts"))
+                .isNotEmpty()
+                .allMatch(a -> "JSON".equals(a.getArtifactType()));
     }
 
     @Test


### PR DESCRIPTION
This PR fixes the `HOME` environment variable issue in `InstallCommand` by adding fallbacks to `USERPROFILE` and `System.getProperty("user.home")`. This allows `acr install` to work even when `HOME` is not set, which is common on Windows.
**Note:** This PR only fixes the `InstallCommand` issue. The `UpdateCommand` issue mentioned in the original report is not included in this PR.