### PR TITLE
fix(ui): use variableName in validation error display (fixes #8729)

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -228,7 +228,15 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
                     <Alert variant="warning" title="Validation Errors" className="validation-errors">
                         <ul>
                             {validationErrors.map((ve, i) => (
-                                <li key={i}>{ve.path ? `${ve.path}: ` : ""}{ve.message}</li>
+                                <li key={i}>
+                                {ve.variableName ? `${ve.variableName}: ` : ""}
+                                {ve.message}
+                                {ve.expectedType && ve.actualType && (
+                                    <span style={{ color: "var(--pf-t--global--color--600)", marginLeft: "0.5rem" }}>
+                                        (Expected: {ve.expectedType}, Actual: {ve.actualType})
+                                    </span>
+                                )}
+                            </li>
                             ))}
                         </ul>
                     </Alert>

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -229,14 +229,14 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
                         <ul>
                             {validationErrors.map((ve, i) => (
                                 <li key={i}>
-                                {ve.variableName ? `${ve.variableName}: ` : ""}
-                                {ve.message}
-                                {ve.expectedType && ve.actualType && (
-                                    <span style={{ color: "var(--pf-t--global--color--600)", marginLeft: "0.5rem" }}>
-                                        (Expected: {ve.expectedType}, Actual: {ve.actualType})
-                                    </span>
-                                )}
-                            </li>
+                                    {ve.variableName ? `${ve.variableName}: ` : ""}
+                                    {ve.message}
+                                    {ve.expectedType && ve.actualType && (
+                                        <span style={{ color: "var(--pf-t--global--color--600)", marginLeft: "0.5rem" }}>
+                                            (Expected: {ve.expectedType}, Actual: {ve.actualType})
+                                        </span>
+                                    )}
+                                </li>
                             ))}
                         </ul>
                     </Alert>

--- a/ui/ui-app/src/models/RenderPromptResponse.ts
+++ b/ui/ui-app/src/models/RenderPromptResponse.ts
@@ -1,6 +1,8 @@
 export interface RenderPromptValidationError {
-    path?: string;
+    variableName?: string;
     message: string;
+    expectedType?: string;
+    actualType?: string;
 }
 
 export interface RenderPromptResponse {


### PR DESCRIPTION
## Description

Fixes the validation error display in PromptTemplateTestPanel.

The render endpoint returns validation errors with a `variableName` field, but the UI was using `path` (which doesn't exist in the API response).

### Changes
1. **`ui/ui-app/src/models/RenderPromptResponse.ts`** - Updated `RenderPromptValidationError` interface:
   - Changed `path?: string` to `variableName?: string`
   - Added `expectedType?: string` and `actualType?: string` to match API response

2. **`ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx`** - Updated validation error display:
   - Changed `ve.path` to `ve.variableName` in the alert rendering

### Related
- Fixes #8729
- This fix was originally part of PR #9126 which was closed because the other 2 fixes (boolean defaults, number input zero value) were already merged via other PRs.