### PR TITLE
fix(ui): show enum allowed values in prompt template variables table

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
@@ -188,6 +188,7 @@ export const PromptTemplateViewer: FunctionComponent<PromptTemplateViewerProps> 
                                         <th>Type</th>
                                         <th>Required</th>
                                         <th>Default</th>
+                                        <th>Allowed Values</th>
                                         <th>Description</th>
                                     </tr>
                                 </thead>
@@ -207,6 +208,13 @@ export const PromptTemplateViewer: FunctionComponent<PromptTemplateViewerProps> 
                                             </td>
                                             <td>{variable.default !== undefined ? (
                                                 <code>{formatDefault(variable.default)}</code>
+                                            ) : "-"}</td>
+                                            <td>{variable.enum && variable.enum.length > 0 ? (
+                                                <LabelGroup numLabels={variable.enum.length}>
+                                                    {variable.enum.map((value, i) => (
+                                                        <Label key={i} color="grey" isCompact>{value}</Label>
+                                                    ))}
+                                                </LabelGroup>
                                             ) : "-"}</td>
                                             <td>{variable.description || "-"}</td>
                                         </tr>


### PR DESCRIPTION
Fixes #9103

The Variables table on the Documentation tab didn't show enum-constrained values, even though the Test Panel already reads and renders them. So a user reading the docs had no way to see which values were valid for an enum variable.

This adds an "Allowed Values" column to the table. When a variable has an enum, the values render as PatternFly `Label` chips (matching how Tags and other lists are shown in this component); otherwise the cell shows `-`.

**How I tested:** typecheck, lint, production build, and the existing test suite all pass. Verified the rendering logic against the enum example from the issue.
