### PR TITLE
fix(ci): generate TypeScript SDK before running UI tests

### DIFF
--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -118,6 +118,12 @@ jobs:
         working-directory: ui
         run: npm run lint
 
+      - name: Generate TypeScript SDK
+        working-directory: typescript-sdk
+        run: |
+          npm install
+          npm run generate-sources
+
       - name: Test
         working-directory: ui
         run: npm run test

--- a/ui/ui-app/src/services/useAdminService.test.ts
+++ b/ui/ui-app/src/services/useAdminService.test.ts
@@ -15,21 +15,6 @@ vi.mock("@apicurio/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 
-// The TypeScript SDK generated client (typescript-sdk/lib/generated-client/)
-// is produced by kiota and gitignored — it does not exist in the UI-only CI
-// build. Mock the three @sdk paths that rest.utils.ts imports so that
-// importOriginal can load the real rest.utils module without reaching the
-// missing generated client.
-vi.mock("@sdk/lib/sdk", () => ({
-    RegistryClientFactory: { createRegistryClient: vi.fn() }
-}));
-vi.mock("@sdk/lib/generated-client/apicurioRegistryClient.ts", () => ({
-    ApicurioRegistryClient: class {}
-}));
-vi.mock("@sdk/lib/generated-client/models", () => ({
-    Labels: {}
-}));
-
 vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
     return {

--- a/ui/ui-app/src/services/useDraftsService.test.ts
+++ b/ui/ui-app/src/services/useDraftsService.test.ts
@@ -15,16 +15,6 @@ vi.mock("@apicurio/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 
-vi.mock("@sdk/lib/sdk", () => ({
-    RegistryClientFactory: { createRegistryClient: vi.fn() }
-}));
-vi.mock("@sdk/lib/generated-client/apicurioRegistryClient.ts", () => ({
-    ApicurioRegistryClient: class {}
-}));
-vi.mock("@sdk/lib/generated-client/models", () => ({
-    Labels: {}
-}));
-
 vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
     return {

--- a/ui/ui-app/src/services/useGroupsService.test.ts
+++ b/ui/ui-app/src/services/useGroupsService.test.ts
@@ -15,16 +15,6 @@ vi.mock("@apicurio/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 
-vi.mock("@sdk/lib/sdk", () => ({
-    RegistryClientFactory: { createRegistryClient: vi.fn() }
-}));
-vi.mock("@sdk/lib/generated-client/apicurioRegistryClient.ts", () => ({
-    ApicurioRegistryClient: class {}
-}));
-vi.mock("@sdk/lib/generated-client/models", () => ({
-    Labels: {}
-}));
-
 vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
     return {

--- a/ui/ui-app/src/services/useSearchService.test.ts
+++ b/ui/ui-app/src/services/useSearchService.test.ts
@@ -15,16 +15,6 @@ vi.mock("@apicurio/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 
-vi.mock("@sdk/lib/sdk", () => ({
-    RegistryClientFactory: { createRegistryClient: vi.fn() }
-}));
-vi.mock("@sdk/lib/generated-client/apicurioRegistryClient.ts", () => ({
-    ApicurioRegistryClient: class {}
-}));
-vi.mock("@sdk/lib/generated-client/models", () => ({
-    Labels: {}
-}));
-
 vi.mock("@utils/rest.utils.ts", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@utils/rest.utils.ts")>();
     return {


### PR DESCRIPTION
## Summary
The Build UI Application CI job fails because the UI service tests (added in #9112) import from
the TypeScript SDK generated client, which is produced by Kiota during the Maven build and is
gitignored. The UI-only CI job never generated it, causing `ERR_MODULE_NOT_FOUND` failures.

## Changes
- Add a "Generate TypeScript SDK" step (`npm install` + `npm run generate-sources`) to the
  Build UI Application job in `verify-build.yaml`, between Lint and Test
- Remove the SDK mock workarounds from the 4 service test files that were added in 10d01646
  as a temporary fix — the real generated client is now available

## Why this approach
Generating the real SDK is better than mocking it: the tests run against real imports, so if the
SDK's API surface changes, the tests catch it instead of silently passing against stale mocks.