### PR TITLE
Fix/content accepters null content type

### DIFF
--- a/schema-util/asyncapi/src/main/java/io/apicurio/registry/asyncapi/content/AsyncApiContentAccepter.java
+++ b/schema-util/asyncapi/src/main/java/io/apicurio/registry/asyncapi/content/AsyncApiContentAccepter.java
@@ -14,11 +14,11 @@ public class AsyncApiContentAccepter implements ContentAccepter {
     public boolean acceptsContent(TypedContent content, Map<String, TypedContent> resolvedReferences) {
         try {
             String contentType = content.getContentType();
+            String lc = contentType != null ? contentType.toLowerCase(Locale.ROOT) : null;
             JsonNode tree = null;
             // If the content is YAML, then convert it to JSON first (the data-models library only accepts
             // JSON).
-            if (contentType != null && (contentType.toLowerCase(Locale.ROOT).contains("yml")
-                    || contentType.toLowerCase(Locale.ROOT).contains("yaml"))) {
+            if (lc != null && (lc.contains("yml") || lc.contains("yaml"))) {
                 tree = ContentTypeUtil.parseYaml(content.getContent());
             } else {
                 tree = ContentTypeUtil.parseJson(content.getContent());

--- a/schema-util/asyncapi/src/main/java/io/apicurio/registry/asyncapi/content/AsyncApiContentAccepter.java
+++ b/schema-util/asyncapi/src/main/java/io/apicurio/registry/asyncapi/content/AsyncApiContentAccepter.java
@@ -5,6 +5,7 @@ import io.apicurio.registry.content.ContentAccepter;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.util.ContentTypeUtil;
 
+import java.util.Locale;
 import java.util.Map;
 
 public class AsyncApiContentAccepter implements ContentAccepter {
@@ -16,12 +17,13 @@ public class AsyncApiContentAccepter implements ContentAccepter {
             JsonNode tree = null;
             // If the content is YAML, then convert it to JSON first (the data-models library only accepts
             // JSON).
-            if (contentType.toLowerCase().contains("yml") || contentType.toLowerCase().contains("yaml")) {
+            if (contentType != null && (contentType.toLowerCase(Locale.ROOT).contains("yml")
+                    || contentType.toLowerCase(Locale.ROOT).contains("yaml"))) {
                 tree = ContentTypeUtil.parseYaml(content.getContent());
             } else {
                 tree = ContentTypeUtil.parseJson(content.getContent());
             }
-            if (tree.has("asyncapi")) {
+            if (tree != null && tree.has("asyncapi")) {
                 return true;
             }
         } catch (Exception e) {

--- a/schema-util/graphql/src/main/java/io/apicurio/registry/graphql/content/GraphQLContentAccepter.java
+++ b/schema-util/graphql/src/main/java/io/apicurio/registry/graphql/content/GraphQLContentAccepter.java
@@ -5,6 +5,7 @@ import graphql.schema.idl.TypeDefinitionRegistry;
 import io.apicurio.registry.content.ContentAccepter;
 import io.apicurio.registry.content.TypedContent;
 
+import java.util.Locale;
 import java.util.Map;
 
 public class GraphQLContentAccepter implements ContentAccepter {
@@ -13,7 +14,7 @@ public class GraphQLContentAccepter implements ContentAccepter {
     public boolean acceptsContent(TypedContent content, Map<String, TypedContent> resolvedReferences) {
         try {
             String contentType = content.getContentType();
-            if (contentType.toLowerCase().contains("graph")) {
+            if (contentType != null && contentType.toLowerCase(Locale.ROOT).contains("graph")) {
                 TypeDefinitionRegistry typeRegistry = new SchemaParser()
                         .parse(content.getContent().content());
                 if (typeRegistry != null) {

--- a/schema-util/openapi/src/main/java/io/apicurio/registry/openapi/content/OpenApiContentAccepter.java
+++ b/schema-util/openapi/src/main/java/io/apicurio/registry/openapi/content/OpenApiContentAccepter.java
@@ -5,6 +5,7 @@ import io.apicurio.registry.content.ContentAccepter;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.util.ContentTypeUtil;
 
+import java.util.Locale;
 import java.util.Map;
 
 public class OpenApiContentAccepter implements ContentAccepter {
@@ -16,12 +17,13 @@ public class OpenApiContentAccepter implements ContentAccepter {
             JsonNode tree = null;
             // If the content is YAML, then convert it to JSON first (the data-models library only accepts
             // JSON).
-            if (contentType.toLowerCase().contains("yml") || contentType.toLowerCase().contains("yaml")) {
+            if (contentType != null && (contentType.toLowerCase(Locale.ROOT).contains("yml")
+                    || contentType.toLowerCase(Locale.ROOT).contains("yaml"))) {
                 tree = ContentTypeUtil.parseYaml(content.getContent());
             } else {
                 tree = ContentTypeUtil.parseJson(content.getContent());
             }
-            if (tree.has("openapi") || tree.has("swagger")) {
+            if (tree != null && (tree.has("openapi") || tree.has("swagger"))) {
                 return true;
             }
         } catch (Exception e) {

--- a/schema-util/openapi/src/main/java/io/apicurio/registry/openapi/content/OpenApiContentAccepter.java
+++ b/schema-util/openapi/src/main/java/io/apicurio/registry/openapi/content/OpenApiContentAccepter.java
@@ -14,11 +14,11 @@ public class OpenApiContentAccepter implements ContentAccepter {
     public boolean acceptsContent(TypedContent content, Map<String, TypedContent> resolvedReferences) {
         try {
             String contentType = content.getContentType();
+            String lc = contentType != null ? contentType.toLowerCase(Locale.ROOT) : null;
             JsonNode tree = null;
             // If the content is YAML, then convert it to JSON first (the data-models library only accepts
             // JSON).
-            if (contentType != null && (contentType.toLowerCase(Locale.ROOT).contains("yml")
-                    || contentType.toLowerCase(Locale.ROOT).contains("yaml"))) {
+            if (lc != null && (lc.contains("yml") || lc.contains("yaml"))) {
                 tree = ContentTypeUtil.parseYaml(content.getContent());
             } else {
                 tree = ContentTypeUtil.parseJson(content.getContent());

--- a/schema-util/openapi/src/main/java/io/apicurio/registry/openapi/content/dereference/ApicurioDataModelsContentDereferencer.java
+++ b/schema-util/openapi/src/main/java/io/apicurio/registry/openapi/content/dereference/ApicurioDataModelsContentDereferencer.java
@@ -13,6 +13,7 @@ import io.apicurio.registry.content.dereference.ContentDereferencer;
 import io.apicurio.registry.content.util.ContentTypeUtil;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Map;
 
 public class ApicurioDataModelsContentDereferencer implements ContentDereferencer {
@@ -85,10 +86,7 @@ public class ApicurioDataModelsContentDereferencer implements ContentDereference
      * @return true if the content type is YAML, false otherwise
      */
     private boolean isYamlContentType(String contentType) {
-        if (contentType == null) {
-            return false;
-        }
-        String lowerContentType = contentType.toLowerCase();
-        return lowerContentType.contains("yaml") || lowerContentType.contains("yml");
+        String lc = contentType != null ? contentType.toLowerCase(Locale.ROOT) : null;
+        return lc != null && (lc.contains("yaml") || lc.contains("yml"));
     }
 }

--- a/schema-util/openrpc/src/main/java/io/apicurio/registry/openrpc/content/OpenRpcContentAccepter.java
+++ b/schema-util/openrpc/src/main/java/io/apicurio/registry/openrpc/content/OpenRpcContentAccepter.java
@@ -14,11 +14,11 @@ public class OpenRpcContentAccepter implements ContentAccepter {
     public boolean acceptsContent(TypedContent content, Map<String, TypedContent> resolvedReferences) {
         try {
             String contentType = content.getContentType();
+            String lc = contentType != null ? contentType.toLowerCase(Locale.ROOT) : null;
             JsonNode tree = null;
             // If the content is YAML, then convert it to JSON first (the data-models library only accepts
             // JSON).
-            if (contentType.toLowerCase(Locale.ROOT).contains("yml")
-                    || contentType.toLowerCase(Locale.ROOT).contains("yaml")) {
+            if (lc != null && (lc.contains("yml") || lc.contains("yaml"))) {
                 tree = ContentTypeUtil.parseYaml(content.getContent());
             } else {
                 tree = ContentTypeUtil.parseJson(content.getContent());

--- a/schema-util/protobuf/src/main/java/io/apicurio/registry/protobuf/content/ProtobufContentAccepter.java
+++ b/schema-util/protobuf/src/main/java/io/apicurio/registry/protobuf/content/ProtobufContentAccepter.java
@@ -7,6 +7,7 @@ import io.apicurio.registry.utils.protobuf.schema.FileDescriptorUtils;
 import io.apicurio.registry.utils.protobuf.schema.ProtobufFile;
 
 import java.util.Base64;
+import java.util.Locale;
 import java.util.Map;
 
 public class ProtobufContentAccepter implements ContentAccepter {
@@ -15,7 +16,7 @@ public class ProtobufContentAccepter implements ContentAccepter {
     public boolean acceptsContent(TypedContent content, Map<String, TypedContent> resolvedReferences) {
         try {
             String contentType = content.getContentType();
-            if (contentType != null && !contentType.toLowerCase().contains("proto")) {
+            if (contentType != null && !contentType.toLowerCase(Locale.ROOT).contains("proto")) {
                 return false;
             }
             ProtobufFile.toProtoFileElement(content.getContent().content());

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/content/accepter/ContentAccepterNullContentTypeTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/content/accepter/ContentAccepterNullContentTypeTest.java
@@ -1,0 +1,80 @@
+package io.apicurio.registry.content.accepter;
+
+import io.apicurio.registry.asyncapi.content.AsyncApiContentAccepter;
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.graphql.content.GraphQLContentAccepter;
+import io.apicurio.registry.openapi.content.OpenApiContentAccepter;
+import io.apicurio.registry.wsdl.content.WsdlContentAccepter;
+import io.apicurio.registry.xml.content.XmlContentAccepter;
+import io.apicurio.registry.xsd.content.XsdContentAccepter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+public class ContentAccepterNullContentTypeTest {
+
+    @Test
+    public void testOpenApiContentAccepter_nullContentType() {
+        String openApiJson = "{\n" +
+                "  \"openapi\": \"3.0.0\",\n" +
+                "  \"info\": {\n" +
+                "    \"title\": \"Sample API\",\n" +
+                "    \"version\": \"0.1.0\"\n" +
+                "  },\n" +
+                "  \"paths\": {}\n" +
+                "}";
+        TypedContent content = TypedContent.create(ContentHandle.create(openApiJson), null);
+        OpenApiContentAccepter accepter = new OpenApiContentAccepter();
+
+        Assertions.assertTrue(accepter.acceptsContent(content, Collections.emptyMap()));
+    }
+
+    @Test
+    public void testAsyncApiContentAccepter_nullContentType() {
+        String asyncApiJson = "{\n" +
+                "  \"asyncapi\": \"2.0.0\",\n" +
+                "  \"info\": {\n" +
+                "    \"title\": \"Sample AsyncAPI\",\n" +
+                "    \"version\": \"0.1.0\"\n" +
+                "  }\n" +
+                "}";
+        TypedContent content = TypedContent.create(ContentHandle.create(asyncApiJson), null);
+        AsyncApiContentAccepter accepter = new AsyncApiContentAccepter();
+
+        Assertions.assertTrue(accepter.acceptsContent(content, Collections.emptyMap()));
+    }
+
+    @Test
+    public void testXmlContentAccepter_nullContentType_noNpe() {
+        TypedContent content = TypedContent.create(ContentHandle.create("<root/>"), null);
+        XmlContentAccepter accepter = new XmlContentAccepter();
+
+        Assertions.assertDoesNotThrow(() -> accepter.acceptsContent(content, Collections.emptyMap()));
+    }
+
+    @Test
+    public void testXsdContentAccepter_nullContentType_noNpe() {
+        TypedContent content = TypedContent.create(ContentHandle.create("<schema xmlns=\"http://www.w3.org/2001/XMLSchema\"/>"), null);
+        XsdContentAccepter accepter = new XsdContentAccepter();
+
+        Assertions.assertDoesNotThrow(() -> accepter.acceptsContent(content, Collections.emptyMap()));
+    }
+
+    @Test
+    public void testWsdlContentAccepter_nullContentType_noNpe() {
+        TypedContent content = TypedContent.create(ContentHandle.create("<definitions xmlns=\"http://schemas.xmlsoap.org/wsdl/\"/>"), null);
+        WsdlContentAccepter accepter = new WsdlContentAccepter();
+
+        Assertions.assertDoesNotThrow(() -> accepter.acceptsContent(content, Collections.emptyMap()));
+    }
+
+    @Test
+    public void testGraphQLContentAccepter_nullContentType_noNpe() {
+        TypedContent content = TypedContent.create(ContentHandle.create("type Query { hello: String }"), null);
+        GraphQLContentAccepter accepter = new GraphQLContentAccepter();
+
+        Assertions.assertDoesNotThrow(() -> accepter.acceptsContent(content, Collections.emptyMap()));
+    }
+}

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/content/accepter/ContentAccepterNullContentTypeTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/content/accepter/ContentAccepterNullContentTypeTest.java
@@ -47,34 +47,34 @@ public class ContentAccepterNullContentTypeTest {
     }
 
     @Test
-    public void testXmlContentAccepter_nullContentType_noNpe() {
+    public void testXmlContentAccepter_nullContentType() {
         TypedContent content = TypedContent.create(ContentHandle.create("<root/>"), null);
         XmlContentAccepter accepter = new XmlContentAccepter();
 
-        Assertions.assertDoesNotThrow(() -> accepter.acceptsContent(content, Collections.emptyMap()));
+        Assertions.assertFalse(accepter.acceptsContent(content, Collections.emptyMap()));
     }
 
     @Test
-    public void testXsdContentAccepter_nullContentType_noNpe() {
+    public void testXsdContentAccepter_nullContentType() {
         TypedContent content = TypedContent.create(ContentHandle.create("<schema xmlns=\"http://www.w3.org/2001/XMLSchema\"/>"), null);
         XsdContentAccepter accepter = new XsdContentAccepter();
 
-        Assertions.assertDoesNotThrow(() -> accepter.acceptsContent(content, Collections.emptyMap()));
+        Assertions.assertFalse(accepter.acceptsContent(content, Collections.emptyMap()));
     }
 
     @Test
-    public void testWsdlContentAccepter_nullContentType_noNpe() {
+    public void testWsdlContentAccepter_nullContentType() {
         TypedContent content = TypedContent.create(ContentHandle.create("<definitions xmlns=\"http://schemas.xmlsoap.org/wsdl/\"/>"), null);
         WsdlContentAccepter accepter = new WsdlContentAccepter();
 
-        Assertions.assertDoesNotThrow(() -> accepter.acceptsContent(content, Collections.emptyMap()));
+        Assertions.assertFalse(accepter.acceptsContent(content, Collections.emptyMap()));
     }
 
     @Test
-    public void testGraphQLContentAccepter_nullContentType_noNpe() {
+    public void testGraphQLContentAccepter_nullContentType() {
         TypedContent content = TypedContent.create(ContentHandle.create("type Query { hello: String }"), null);
         GraphQLContentAccepter accepter = new GraphQLContentAccepter();
 
-        Assertions.assertDoesNotThrow(() -> accepter.acceptsContent(content, Collections.emptyMap()));
+        Assertions.assertFalse(accepter.acceptsContent(content, Collections.emptyMap()));
     }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/content/accepter/ContentAccepterNullContentTypeTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/content/accepter/ContentAccepterNullContentTypeTest.java
@@ -5,6 +5,7 @@ import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.graphql.content.GraphQLContentAccepter;
 import io.apicurio.registry.openapi.content.OpenApiContentAccepter;
+import io.apicurio.registry.openrpc.content.OpenRpcContentAccepter;
 import io.apicurio.registry.wsdl.content.WsdlContentAccepter;
 import io.apicurio.registry.xml.content.XmlContentAccepter;
 import io.apicurio.registry.xsd.content.XsdContentAccepter;
@@ -76,5 +77,20 @@ public class ContentAccepterNullContentTypeTest {
         GraphQLContentAccepter accepter = new GraphQLContentAccepter();
 
         Assertions.assertFalse(accepter.acceptsContent(content, Collections.emptyMap()));
+    }
+
+    @Test
+    public void testOpenRpcContentAccepter_nullContentType() {
+        String openRpcJson = "{\n" +
+                "  \"openrpc\": \"1.2.6\",\n" +
+                "  \"info\": {\n" +
+                "    \"title\": \"Sample OpenRPC\",\n" +
+                "    \"version\": \"1.0.0\"\n" +
+                "  }\n" +
+                "}";
+        TypedContent content = TypedContent.create(ContentHandle.create(openRpcJson), null);
+        OpenRpcContentAccepter accepter = new OpenRpcContentAccepter();
+
+        Assertions.assertTrue(accepter.acceptsContent(content, Collections.emptyMap()));
     }
 }

--- a/schema-util/wsdl/src/main/java/io/apicurio/registry/wsdl/content/WsdlContentAccepter.java
+++ b/schema-util/wsdl/src/main/java/io/apicurio/registry/wsdl/content/WsdlContentAccepter.java
@@ -7,6 +7,7 @@ import io.apicurio.registry.xml.util.DocumentBuilderAccessor;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import java.util.Locale;
 import java.util.Map;
 
 public class WsdlContentAccepter implements ContentAccepter {
@@ -15,7 +16,7 @@ public class WsdlContentAccepter implements ContentAccepter {
     public boolean acceptsContent(TypedContent content, Map<String, TypedContent> resolvedReferences) {
         try {
             String contentType = content.getContentType();
-            if (contentType.toLowerCase().contains("xml")
+            if (contentType != null && contentType.toLowerCase(Locale.ROOT).contains("xml")
                     && ContentTypeUtil.isParsableXml(content.getContent())) {
                 Document xmlDocument = DocumentBuilderAccessor.getDocumentBuilder()
                         .parse(content.getContent().stream());

--- a/schema-util/xml/src/main/java/io/apicurio/registry/xml/content/XmlContentAccepter.java
+++ b/schema-util/xml/src/main/java/io/apicurio/registry/xml/content/XmlContentAccepter.java
@@ -7,6 +7,7 @@ import io.apicurio.registry.xml.util.DocumentBuilderAccessor;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import java.util.Locale;
 import java.util.Map;
 
 public class XmlContentAccepter implements ContentAccepter {
@@ -15,7 +16,7 @@ public class XmlContentAccepter implements ContentAccepter {
     public boolean acceptsContent(TypedContent content, Map<String, TypedContent> resolvedReferences) {
         try {
             String contentType = content.getContentType();
-            if (contentType.toLowerCase().contains("xml")
+            if (contentType != null && contentType.toLowerCase(Locale.ROOT).contains("xml")
                     && ContentTypeUtil.isParsableXml(content.getContent())) {
                 Document xmlDocument = DocumentBuilderAccessor.getDocumentBuilder()
                         .parse(content.getContent().stream());

--- a/schema-util/xsd/src/main/java/io/apicurio/registry/xsd/content/XsdContentAccepter.java
+++ b/schema-util/xsd/src/main/java/io/apicurio/registry/xsd/content/XsdContentAccepter.java
@@ -7,6 +7,7 @@ import io.apicurio.registry.xml.util.DocumentBuilderAccessor;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import java.util.Locale;
 import java.util.Map;
 
 public class XsdContentAccepter implements ContentAccepter {
@@ -15,7 +16,7 @@ public class XsdContentAccepter implements ContentAccepter {
     public boolean acceptsContent(TypedContent content, Map<String, TypedContent> resolvedReferences) {
         try {
             String contentType = content.getContentType();
-            if (contentType.toLowerCase().contains("xml")
+            if (contentType != null && contentType.toLowerCase(Locale.ROOT).contains("xml")
                     && ContentTypeUtil.isParsableXml(content.getContent())) {
                 Document xmlDocument = DocumentBuilderAccessor.getDocumentBuilder()
                         .parse(content.getContent().stream());


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

Several `ContentAccepter` implementations in `schema-util` called `content.getContentType().toLowerCase()` without checking whether `contentType` was `null`.

When `TypedContent` is created without a `Content-Type` header, `getContentType()` returns `null`. Calling `toLowerCase()` on a `null` value results in a `NullPointerException`, which is caught by the surrounding `catch (Exception)` block, causing `acceptsContent()` to incorrectly return `false` instead of falling back to content inspection.

This PR adds null checks before lowercasing the content type in the affected `ContentAccepter` implementations and standardizes all lowercase conversions to use `Locale.ROOT` for locale-independent behavior.

## Which issue(s) this PR fixes

Fixes #9203 

## Special notes for your reviewer

- No behavioral changes when a valid `Content-Type` is present.
- Prevents `NullPointerException` when `contentType` is `null`.
- Preserves the existing fallback content inspection logic.
- Replaces locale-dependent `toLowerCase()` calls with `toLowerCase(Locale.ROOT)` for consistent behavior.
- Added unit tests covering `acceptsContent()` with a `null` content type.
- Verified locally by running the relevant module tests.

## AI assistance disclosure

I consulted ChatGPT and Claude to help analyze the issue and discuss the implementation approach. The implementation, tests, validation, commit message, and final code changes were completed and verified by me. I reviewed all generated suggestions, ran the relevant tests locally, and take full responsibility for the final contribution.

## Does this PR introduce a user-facing change?

```release-note
NONE
```