### PR TITLE
fix(rest): make compression kill switch dynamically configurable (#9245)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/RestConfig.java
+++ b/app/src/main/java/io/apicurio/registry/rest/RestConfig.java
@@ -50,9 +50,10 @@ public class RestConfig {
     @Info(category = CATEGORY_REST, description = "When enabled, legacy HTTP error codes are used (e.g. 409 instead of 400 for rule violations)", availableSince = "3.3.0")
     boolean legacyErrorCodesEnabled;
 
+    @Dynamic(label = "Compression", description = "When selected, gzip compression is applied to REST API responses.")
     @ConfigProperty(name = "apicurio.rest.compression.enabled", defaultValue = "true")
     @Info(category = CATEGORY_REST, description = "Enable gzip compression of REST API responses", availableSince = "3.3.2")
-    boolean compressionEnabled;
+    Supplier<Boolean> compressionEnabled;
 
     public int getLabelsInSearchResultsMaxSize() {
         return this.labelsInSearchResultsMaxSize;
@@ -87,7 +88,7 @@ public class RestConfig {
     }
 
     public boolean isCompressionEnabled() {
-        return compressionEnabled;
+        return compressionEnabled.get();
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/rest/RestConfig.java
+++ b/app/src/main/java/io/apicurio/registry/rest/RestConfig.java
@@ -52,7 +52,7 @@ public class RestConfig {
 
     @Dynamic(label = "Compression", description = "When selected, gzip compression is applied to REST API responses.")
     @ConfigProperty(name = "apicurio.rest.compression.enabled", defaultValue = "true")
-    @Info(category = CATEGORY_REST, description = "Enable gzip compression of REST API responses", availableSince = "3.3.2")
+    @Info(category = CATEGORY_REST, description = "Enable gzip compression of REST API responses. This is a dynamic property and can be changed at runtime without restarting the server.", availableSince = "3.3.2")
     Supplier<Boolean> compressionEnabled;
 
     public int getLabelsInSearchResultsMaxSize() {

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -202,6 +202,7 @@ apicurio.ccompat.legacy-id-mode.enabled.dynamic.allow=${apicurio.config.dynamic.
 apicurio.ccompat.use-canonical-hash.dynamic.allow=${apicurio.config.dynamic.allow-all}
 apicurio.ccompat.max-subjects.dynamic.allow=${apicurio.config.dynamic.allow-all}
 apicurio.download.href.ttl.seconds.dynamic.allow=${apicurio.config.dynamic.allow-all}
+apicurio.rest.compression.enabled.dynamic.allow=${apicurio.config.dynamic.allow-all}
 apicurio.rest.deletion.group.enabled.dynamic.allow=${apicurio.config.dynamic.allow-all}
 apicurio.rest.deletion.artifact.enabled.dynamic.allow=${apicurio.config.dynamic.allow-all}
 apicurio.rest.deletion.artifact-version.enabled.dynamic.allow=${apicurio.config.dynamic.allow-all}

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -996,7 +996,7 @@ The following {registry} configuration options are available for each component 
 |`3.1.0`
 |Optional configuration to override default reference handling behavior. When not set, uses API defaults (PRESERVE for v3, false for v2, none for ccompat).
 |`apicurio.rest.compression.enabled`
-|`boolean`
+|`boolean [dynamic]`
 |`true`
 |`3.3.2`
 |Enable gzip compression of REST API responses
@@ -1720,6 +1720,11 @@ The following {registry} configuration options are available for each component 
 |`apicurio.rest.artifact.deletion.enabled`
 |`unknown`
 |`false`
+|
+|
+|`apicurio.rest.compression.enabled.dynamic.allow`
+|`unknown`
+|`${apicurio.config.dynamic.allow-all}`
 |
 |
 |`apicurio.rest.deletion.artifact-version.enabled.dynamic.allow`

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -999,7 +999,7 @@ The following {registry} configuration options are available for each component 
 |`boolean [dynamic]`
 |`true`
 |`3.3.2`
-|Enable gzip compression of REST API responses
+|Enable gzip compression of REST API responses. This is a dynamic property and can be changed at runtime without restarting the server.
 |`apicurio.rest.deletion.artifact-version.enabled`
 |`boolean [dynamic]`
 |`false`


### PR DESCRIPTION
## What
Fixes the flaky `HttpCompressionDisabledTest.testResponseNotCompressedWhenKillSwitchDisabled`.

`apicurio.rest.compression.enabled` was a plain `boolean` injected into the `RestConfig` singleton **once at application startup**. Quarkus applies `@TestProfile` config overrides as system properties and **reuses** the running application instance across `@QuarkusTest` classes when a profile only changes runtime config (the restart decision is based on classloader identity, not the profile). As a result, the profile's `apicurio.rest.compression.enabled=false` was ignored on reused instances: the stale startup value (`true`) won and responses were still gzip-compressed, so the disabled test failed intermittently (CI run 30942716482, job 92115140512).

## Why
A runtime kill switch should be re-read from the live config, not captured at startup. Every other runtime-toggleable property in `RestConfig` (`groupDeletionEnabled`, `artifactDeletionEnabled`, `draftProductionModeEnabled`, ...) already uses the `@Dynamic Supplier<T>` pattern.

## Changes
- `RestConfig.java`: `compressionEnabled` is now `@Dynamic Supplier<Boolean>`; `isCompressionEnabled()` calls `.get()`, re-reading the current config value on every request.
- `application.properties`: added the required `apicurio.rest.compression.enabled.dynamic.allow` entry.
- `ref-registry-all-configs.adoc`: regenerated (type now `boolean [dynamic]` + new `.dynamic.allow` row).

## Verification
- Empirically confirmed the mechanism: with `@Dynamic`, `System.setProperty("apicurio.rest.compression.enabled","false")` after app start is reflected by `isCompressionEnabled()`; the plain `boolean` never could be.
- Full `noprofile.rest` shard: 339 tests, 0 failures.
- `HttpCompressionTest` (7) + `HttpCompressionDisabledTest` (1) pass.
- `checkstyle:check -pl app` passes.