### PR TITLE
fix(ui): display enum allowed values in Prompt Template variables table

### DIFF
--- a/ui/tests/specs/promptTemplate.spec.ts
+++ b/ui/tests/specs/promptTemplate.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from "@playwright/test";
+
+const REGISTRY_UI_URL: string = process.env["REGISTRY_UI_URL"] || "http://localhost:8888";
+
+const MOCK_PROMPT_TEMPLATE = {
+    templateId: "test-template",
+    name: "Test Template",
+    template: "Hello {{name}}, choose your {{color}}",
+    variables: {
+        color: {
+            name: "color",
+            type: "string",
+            description: "A color",
+            enum: ["red", "green", "blue"]
+        },
+        name: {
+            name: "name",
+            type: "string",
+            description: "Your name"
+        },
+        emptyEnum: {
+            name: "emptyEnum",
+            type: "string",
+            enum: []
+        }
+    }
+};
+
+const MOCK_VERSION_METADATA = {
+    groupId: "default",
+    artifactId: "test-prompt-template",
+    version: "1",
+    type: "PROMPT_TEMPLATE",
+    artifactType: "PROMPT_TEMPLATE",
+    state: "ENABLED",
+    name: "Test Prompt Template",
+    description: "A test prompt template",
+    createdOn: "2026-08-05T00:00:00Z",
+    createdBy: "test-user",
+    labels: {}
+};
+
+test("Prompt Template - renders enum allowed values correctly", async ({ page }) => {
+    // Mock system config, info, and user endpoints so the UI loads without a backend
+    await page.route("**/apis/registry/v3/system/info", async route => {
+        await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ name: "Apicurio Registry", version: "3.3.2.Final" }) });
+    });
+    await page.route("**/apis/registry/v3/users/me", async route => {
+        await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ username: "test-user", displayName: "Test User", admin: true, developer: true, viewer: true }) });
+    });
+    await page.route("**/apis/registry/v3/config", async route => {
+        await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ features: { readOnly: false } }) });
+    });
+
+    // Mock the artifact metadata response
+    await page.route("**/apis/registry/v3/groups/default/artifacts/test-prompt-template", async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(MOCK_VERSION_METADATA)
+        });
+    });
+
+    // Mock the version metadata response so the UI knows it's a PROMPT_TEMPLATE
+    await page.route("**/apis/registry/v3/groups/default/artifacts/test-prompt-template/versions/1", async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(MOCK_VERSION_METADATA)
+        });
+    });
+
+    // Mock the content response to return our mock Prompt Template
+    await page.route("**/apis/registry/v3/groups/default/artifacts/test-prompt-template/versions/1/content*", async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(MOCK_PROMPT_TEMPLATE)
+        });
+    });
+
+    // Mock the artifact rules response to avoid errors
+    await page.route("**/apis/registry/v3/groups/default/artifacts/test-prompt-template/rules", async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([])
+        });
+    });
+
+    // Mock the branches response
+    await page.route("**/apis/registry/v3/groups/default/artifacts/test-prompt-template/branches", async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([{ branchId: "latest", version: "1" }])
+        });
+    });
+    
+    // Navigate directly to the artifact documentation tab
+    await page.goto(`${REGISTRY_UI_URL}/explore/default/test-prompt-template/versions/1/documentation`);
+
+    // Verify the page title and that the template loaded
+    await expect(page).toHaveTitle(/Apicurio Registry/);
+    await expect(page.getByText("Test Template")).toBeVisible();
+
+    // Verify that the variables table is present
+    const table = page.locator(".variables-table");
+    await expect(table).toBeVisible();
+
+    // Verify the color variable (has enum values)
+    const colorRow = table.locator("tbody tr").filter({ hasText: "color" });
+    await expect(colorRow).toBeVisible();
+    await expect(colorRow.locator("td").nth(4)).toContainText("red");
+    await expect(colorRow.locator("td").nth(4)).toContainText("green");
+    await expect(colorRow.locator("td").nth(4)).toContainText("blue");
+    // Verify it uses the patternfly label component
+    await expect(colorRow.locator("td").nth(4).locator(".pf-v6-c-label").first()).toBeVisible();
+
+    // Verify the name variable (no enum, should render '-')
+    const nameRow = table.locator("tbody tr").filter({ hasText: "name" }).filter({ hasNotText: "emptyEnum" });
+    await expect(nameRow).toBeVisible();
+    await expect(nameRow.locator("td").nth(4)).toHaveText("-");
+
+    // Verify the emptyEnum variable (empty array enum, should render '-')
+    const emptyEnumRow = table.locator("tbody tr").filter({ hasText: "emptyEnum" });
+    await expect(emptyEnumRow).toBeVisible();
+    await expect(emptyEnumRow.locator("td").nth(4)).toHaveText("-");
+});

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.tsx
@@ -170,6 +170,7 @@ export const PromptTemplateViewer: FunctionComponent<PromptTemplateViewerProps> 
                                         <th>Type</th>
                                         <th>Required</th>
                                         <th>Default</th>
+                                        <th>Allowed Values</th>
                                         <th>Description</th>
                                     </tr>
                                 </thead>
@@ -190,6 +191,15 @@ export const PromptTemplateViewer: FunctionComponent<PromptTemplateViewerProps> 
                                             <td>{variable.default !== undefined ? (
                                                 <code>{String(variable.default)}</code>
                                             ) : "-"}</td>
+                                            <td>
+                                                {variable.enum && variable.enum.length > 0 ? (
+                                                    <LabelGroup>
+                                                        {variable.enum.map((val, i) => (
+                                                            <Label key={i} color="grey" isCompact>{String(val)}</Label>
+                                                        ))}
+                                                    </LabelGroup>
+                                                ) : "-"}
+                                            </td>
                                             <td>{variable.description || "-"}</td>
                                         </tr>
                                     ))}


### PR DESCRIPTION
Fixes #9103.

The backend already exposes enum values for Prompt Template variables, and the Playground/Test Panel correctly uses them to render a dropdown for enum-constrained variables. However, the Documentation view did not surface this information, making it difficult for users to discover the valid values for a variable directly from the generated documentation.

This change updates the Prompt Template documentation table by:

- adding an **Allowed Values** column to the Variables table
- rendering enum values using existing PatternFly `LabelGroup` and `Label` components
- displaying `-` when a variable has no enum restriction
- keeping the documentation view consistent with the Playground/Test Panel

## Before

The Variables table displayed:

- Name
- Type
- Required
- Default
- Description

Although the backend returned the enum values and the Playground rendered them correctly, the Documentation view omitted them completely.

**Screenshot:**

<img width="1918" height="925" alt="Screenshot 2026-07-31 205220" src="https://github.com/user-attachments/assets/8ba2d0e5-b709-4870-869d-6c549d23f401" />

---

## After

The Variables table now includes an **Allowed Values** column.

For enum-constrained variables, the allowed values are displayed as PatternFly labels, making the documentation consistent with the Playground while improving discoverability.

**Screenshot:**

<img width="1919" height="924" alt="Screenshot 2026-07-31 212956" src="https://github.com/user-attachments/assets/d9df15ab-8caa-44ca-97ab-9dd647f77103" />

---

## Testing

- Reproduced the issue locally.
- Verified that enum values are present in the backend API response.
- Verified that the Documentation view now displays enum values correctly.
- Verified that variables without enum values continue to display `-`.
- Ran `npm run lint` successfully.
- Ran `npm test` successfully.