### PR TITLE
fix(kafkasql): publish contract ruleset events to the events topic

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -10,6 +10,7 @@ import io.apicurio.registry.events.ArtifactVersionCreated;
 import io.apicurio.registry.events.ArtifactVersionDeleted;
 import io.apicurio.registry.events.ArtifactVersionMetadataUpdated;
 import io.apicurio.registry.events.ArtifactVersionStateChanged;
+import io.apicurio.registry.events.ContractRulesetConfigured;
 import io.apicurio.registry.events.GlobalRuleConfigured;
 import io.apicurio.registry.events.GroupCreated;
 import io.apicurio.registry.events.GroupDeleted;
@@ -99,6 +100,9 @@ import static io.apicurio.registry.utils.ConcurrentUtil.blockOnResult;
 @Logged
 @LookupIfProperty(name = "apicurio.storage.kind", stringValue = "kafkasql")
 public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implements RegistryStorage {
+
+    // Coordinates used by contract ruleset events to identify the global (non artifact scoped) ruleset.
+    private static final String GLOBAL_CONTRACT_COORDINATE = "__GLOBAL__";
 
     @Inject
     Logger log;
@@ -691,6 +695,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new SetArtifactContractRuleset3Message(groupId, artifactId, ruleset);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent
+                .of(ContractRulesetConfigured.of(groupId, artifactId, null, "SET")));
     }
 
     @Override
@@ -699,6 +705,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new DeleteArtifactContractRuleset2Message(groupId, artifactId);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent
+                .of(ContractRulesetConfigured.of(groupId, artifactId, null, "DELETE")));
     }
 
     @Override
@@ -713,6 +721,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new SetVersionContractRuleset4Message(groupId, artifactId, version, ruleset);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent
+                .of(ContractRulesetConfigured.of(groupId, artifactId, version, "SET")));
     }
 
     @Override
@@ -721,6 +731,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new DeleteVersionContractRuleset3Message(groupId, artifactId, version);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent
+                .of(ContractRulesetConfigured.of(groupId, artifactId, version, "DELETE")));
     }
 
     @Override
@@ -741,6 +753,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new SetGlobalContractRuleset1Message(ruleset);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent.of(ContractRulesetConfigured
+                .of(GLOBAL_CONTRACT_COORDINATE, GLOBAL_CONTRACT_COORDINATE, null, "SET")));
     }
 
     @Override
@@ -748,6 +762,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new DeleteGlobalContractRuleset0Message();
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent.of(ContractRulesetConfigured
+                .of(GLOBAL_CONTRACT_COORDINATE, GLOBAL_CONTRACT_COORDINATE, null, "DELETE")));
     }
 
     @Override


### PR DESCRIPTION
Fixes #9246
Contract ruleset changes emitted no events at all under kafkasql storage.

KafkaSqlRegistryStorage fires a KafkaSqlOutboxEvent after every mutation except the six contract-ruleset ones, which submitted the journal message and returned. Those events were only fired on the SQL path in AbstractSqlRegistryStorage, and that path is observed by SqlEventsProcessor, which gates on supportsDatabaseEvents() and writes to a DB outbox table that nothing reads in kafkasql mode. Nothing ever reached the registry-events topic.

Fire the missing events after coordinator.waitForResponse(uuid) so they publish only once the write is applied. Payload coordinates match what the SQL side emits, so both variants produce identical events.

This is what made the six ContractRuleset tests in KafkaSqlEventsTest time out; they were reporting a genuine gap rather than being flaky. No test changes needed -- the existing tests become the regression guard.

