### PR TITLE
fix(contracts): emit ruleset events on kafkasql and fix data export

### DIFF
--- a/app/src/main/java/io/apicurio/registry/events/ContractRulesetConfigured.java
+++ b/app/src/main/java/io/apicurio/registry/events/ContractRulesetConfigured.java
@@ -8,6 +8,23 @@ import java.util.UUID;
 import static io.apicurio.registry.storage.StorageEventType.CONTRACT_RULESET_CONFIGURED;
 
 public class ContractRulesetConfigured extends OutboxEvent {
+
+    /**
+     * Sentinel carried as both groupId and artifactId when the event describes the global (not artifact
+     * scoped) contract ruleset. Global events do not use null or empty coordinates, so a consumer that
+     * needs to detect global scope must compare both coordinates against this constant rather than
+     * testing for absence. Every storage variant emits the same value.
+     */
+    public static final String GLOBAL_COORDINATE = "__GLOBAL__";
+
+    /**
+     * The mutation that produced the event. The enum name is what appears in the "action" payload field,
+     * so consumers switching on that field see exactly these values.
+     */
+    public enum Action {
+        SET, DELETE
+    }
+
     private final JSONObject eventPayload;
 
     private ContractRulesetConfigured(String id, String aggregateId, JSONObject eventPayload) {
@@ -16,18 +33,26 @@ public class ContractRulesetConfigured extends OutboxEvent {
     }
 
     public static ContractRulesetConfigured of(String groupId, String artifactId,
-            String version, String action) {
+            String version, Action action) {
         String id = UUID.randomUUID().toString();
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("id", id)
                 .put("groupId", groupId)
                 .put("artifactId", artifactId)
-                .put("action", action)
+                .put("action", action.name())
                 .put("eventType", CONTRACT_RULESET_CONFIGURED.name());
         if (version != null) {
             jsonObject.put("version", version);
         }
         return new ContractRulesetConfigured(id, groupId + "-" + artifactId, jsonObject);
+    }
+
+    /**
+     * Builds an event for the global contract ruleset, using {@link #GLOBAL_COORDINATE} for both
+     * coordinates so no caller has to repeat the sentinel.
+     */
+    public static ContractRulesetConfigured ofGlobal(Action action) {
+        return of(GLOBAL_COORDINATE, GLOBAL_COORDINATE, null, action);
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -10,6 +10,7 @@ import io.apicurio.registry.events.ArtifactVersionCreated;
 import io.apicurio.registry.events.ArtifactVersionDeleted;
 import io.apicurio.registry.events.ArtifactVersionMetadataUpdated;
 import io.apicurio.registry.events.ArtifactVersionStateChanged;
+import io.apicurio.registry.events.ContractRulesetConfigured;
 import io.apicurio.registry.events.GlobalRuleConfigured;
 import io.apicurio.registry.events.GroupCreated;
 import io.apicurio.registry.events.GroupDeleted;
@@ -99,6 +100,9 @@ import static io.apicurio.registry.utils.ConcurrentUtil.blockOnResult;
 @Logged
 @LookupIfProperty(name = "apicurio.storage.kind", stringValue = "kafkasql")
 public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implements RegistryStorage {
+
+    // Coordinates used by contract ruleset events to identify the global (non artifact scoped) ruleset.
+    private static final String GLOBAL_CONTRACT_COORDINATE = "__GLOBAL__";
 
     @Inject
     Logger log;
@@ -691,6 +695,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new SetArtifactContractRuleset3Message(groupId, artifactId, ruleset);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent
+                .of(ContractRulesetConfigured.of(groupId, artifactId, null, "SET")));
     }
 
     @Override
@@ -699,6 +705,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new DeleteArtifactContractRuleset2Message(groupId, artifactId);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent
+                .of(ContractRulesetConfigured.of(groupId, artifactId, null, "DELETE")));
     }
 
     @Override
@@ -713,6 +721,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new SetVersionContractRuleset4Message(groupId, artifactId, version, ruleset);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent
+                .of(ContractRulesetConfigured.of(groupId, artifactId, version, "SET")));
     }
 
     @Override
@@ -721,6 +731,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new DeleteVersionContractRuleset3Message(groupId, artifactId, version);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent
+                .of(ContractRulesetConfigured.of(groupId, artifactId, version, "DELETE")));
     }
 
     @Override
@@ -741,6 +753,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new SetGlobalContractRuleset1Message(ruleset);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent.of(ContractRulesetConfigured
+                .of(GLOBAL_CONTRACT_COORDINATE, GLOBAL_CONTRACT_COORDINATE, null, "SET")));
     }
 
     @Override
@@ -748,6 +762,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new DeleteGlobalContractRuleset0Message();
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
+        outboxEvent.fire(KafkaSqlOutboxEvent.of(ContractRulesetConfigured
+                .of(GLOBAL_CONTRACT_COORDINATE, GLOBAL_CONTRACT_COORDINATE, null, "DELETE")));
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -101,9 +101,6 @@ import static io.apicurio.registry.utils.ConcurrentUtil.blockOnResult;
 @LookupIfProperty(name = "apicurio.storage.kind", stringValue = "kafkasql")
 public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implements RegistryStorage {
 
-    // Coordinates used by contract ruleset events to identify the global (non artifact scoped) ruleset.
-    private static final String GLOBAL_CONTRACT_COORDINATE = "__GLOBAL__";
-
     @Inject
     Logger log;
 
@@ -695,8 +692,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new SetArtifactContractRuleset3Message(groupId, artifactId, ruleset);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
-        outboxEvent.fire(KafkaSqlOutboxEvent
-                .of(ContractRulesetConfigured.of(groupId, artifactId, null, "SET")));
+        outboxEvent.fire(KafkaSqlOutboxEvent.of(ContractRulesetConfigured.of(
+                groupId, artifactId, null, ContractRulesetConfigured.Action.SET)));
     }
 
     @Override
@@ -705,8 +702,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new DeleteArtifactContractRuleset2Message(groupId, artifactId);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
-        outboxEvent.fire(KafkaSqlOutboxEvent
-                .of(ContractRulesetConfigured.of(groupId, artifactId, null, "DELETE")));
+        outboxEvent.fire(KafkaSqlOutboxEvent.of(ContractRulesetConfigured.of(
+                groupId, artifactId, null, ContractRulesetConfigured.Action.DELETE)));
     }
 
     @Override
@@ -721,8 +718,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new SetVersionContractRuleset4Message(groupId, artifactId, version, ruleset);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
-        outboxEvent.fire(KafkaSqlOutboxEvent
-                .of(ContractRulesetConfigured.of(groupId, artifactId, version, "SET")));
+        outboxEvent.fire(KafkaSqlOutboxEvent.of(ContractRulesetConfigured.of(
+                groupId, artifactId, version, ContractRulesetConfigured.Action.SET)));
     }
 
     @Override
@@ -731,8 +728,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new DeleteVersionContractRuleset3Message(groupId, artifactId, version);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
-        outboxEvent.fire(KafkaSqlOutboxEvent
-                .of(ContractRulesetConfigured.of(groupId, artifactId, version, "DELETE")));
+        outboxEvent.fire(KafkaSqlOutboxEvent.of(ContractRulesetConfigured.of(
+                groupId, artifactId, version, ContractRulesetConfigured.Action.DELETE)));
     }
 
     @Override
@@ -753,8 +750,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new SetGlobalContractRuleset1Message(ruleset);
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
-        outboxEvent.fire(KafkaSqlOutboxEvent.of(ContractRulesetConfigured
-                .of(GLOBAL_CONTRACT_COORDINATE, GLOBAL_CONTRACT_COORDINATE, null, "SET")));
+        outboxEvent.fire(KafkaSqlOutboxEvent
+                .of(ContractRulesetConfigured.ofGlobal(ContractRulesetConfigured.Action.SET)));
     }
 
     @Override
@@ -762,8 +759,8 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         var message = new DeleteGlobalContractRuleset0Message();
         var uuid = blockOnResult(submitter.submitMessage(message));
         coordinator.waitForResponse(uuid);
-        outboxEvent.fire(KafkaSqlOutboxEvent.of(ContractRulesetConfigured
-                .of(GLOBAL_CONTRACT_COORDINATE, GLOBAL_CONTRACT_COORDINATE, null, "DELETE")));
+        outboxEvent.fire(KafkaSqlOutboxEvent
+                .of(ContractRulesetConfigured.ofGlobal(ContractRulesetConfigured.Action.DELETE)));
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -7,6 +7,7 @@ import io.apicurio.common.apps.config.Info;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.core.System;
 import io.apicurio.registry.events.ArtifactCreated;
+import io.apicurio.registry.events.ContractRulesetConfigured;
 import io.apicurio.registry.model.BranchId;
 import io.apicurio.registry.model.GA;
 import io.apicurio.registry.model.GAV;
@@ -842,18 +843,16 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     public void setArtifactContractRuleset(String groupId, String artifactId,
             ContractRuleSetDto ruleset) throws RegistryStorageException {
         contractRuleRepository.setArtifactContractRuleset(groupId, artifactId, ruleset);
-        outboxEvent.fire(SqlOutboxEvent.of(
-                io.apicurio.registry.events.ContractRulesetConfigured.of(
-                        groupId, artifactId, null, "SET")));
+        outboxEvent.fire(SqlOutboxEvent.of(ContractRulesetConfigured.of(
+                groupId, artifactId, null, ContractRulesetConfigured.Action.SET)));
     }
 
     @Override
     public void deleteArtifactContractRuleset(String groupId, String artifactId)
             throws RegistryStorageException {
         contractRuleRepository.deleteArtifactContractRuleset(groupId, artifactId);
-        outboxEvent.fire(SqlOutboxEvent.of(
-                io.apicurio.registry.events.ContractRulesetConfigured.of(
-                        groupId, artifactId, null, "DELETE")));
+        outboxEvent.fire(SqlOutboxEvent.of(ContractRulesetConfigured.of(
+                groupId, artifactId, null, ContractRulesetConfigured.Action.DELETE)));
     }
 
     @Override
@@ -866,18 +865,16 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     public void setVersionContractRuleset(String groupId, String artifactId, String version,
             ContractRuleSetDto ruleset) throws VersionNotFoundException, RegistryStorageException {
         contractRuleRepository.setVersionContractRuleset(groupId, artifactId, version, ruleset);
-        outboxEvent.fire(SqlOutboxEvent.of(
-                io.apicurio.registry.events.ContractRulesetConfigured.of(
-                        groupId, artifactId, version, "SET")));
+        outboxEvent.fire(SqlOutboxEvent.of(ContractRulesetConfigured.of(
+                groupId, artifactId, version, ContractRulesetConfigured.Action.SET)));
     }
 
     @Override
     public void deleteVersionContractRuleset(String groupId, String artifactId, String version)
             throws VersionNotFoundException, RegistryStorageException {
         contractRuleRepository.deleteVersionContractRuleset(groupId, artifactId, version);
-        outboxEvent.fire(SqlOutboxEvent.of(
-                io.apicurio.registry.events.ContractRulesetConfigured.of(
-                        groupId, artifactId, version, "DELETE")));
+        outboxEvent.fire(SqlOutboxEvent.of(ContractRulesetConfigured.of(
+                groupId, artifactId, version, ContractRulesetConfigured.Action.DELETE)));
     }
 
     @Override
@@ -888,17 +885,15 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     @Override
     public void setGlobalContractRuleset(ContractRuleSetDto ruleset) throws RegistryStorageException {
         contractRuleRepository.setGlobalContractRuleset(ruleset);
-        outboxEvent.fire(SqlOutboxEvent.of(
-                io.apicurio.registry.events.ContractRulesetConfigured.of(
-                        "__GLOBAL__", "__GLOBAL__", null, "SET")));
+        outboxEvent.fire(SqlOutboxEvent
+                .of(ContractRulesetConfigured.ofGlobal(ContractRulesetConfigured.Action.SET)));
     }
 
     @Override
     public void deleteGlobalContractRuleset() throws RegistryStorageException {
         contractRuleRepository.deleteGlobalContractRuleset();
-        outboxEvent.fire(SqlOutboxEvent.of(
-                io.apicurio.registry.events.ContractRulesetConfigured.of(
-                        "__GLOBAL__", "__GLOBAL__", null, "DELETE")));
+        outboxEvent.fire(SqlOutboxEvent
+                .of(ContractRulesetConfigured.ofGlobal(ContractRulesetConfigured.Action.DELETE)));
     }
 
     @Override

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/ContractRuleImportExportTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/ContractRuleImportExportTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.registry.noprofile.rest.v3;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.cdi.Current;
+import io.apicurio.registry.rest.client.models.DownloadRef;
+import io.apicurio.registry.rest.v3.beans.ContractRule;
+import io.apicurio.registry.rest.v3.beans.ContractRuleSet;
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static io.restassured.RestAssured.given;
+
+/**
+ * Verifies that contract rules survive a full export/import round trip. Contract rules are exported by
+ * SqlExportRepository, so an export of any registry containing them used to fail outright because
+ * EntityWriter had no case for the ContractRule entity type.
+ */
+@QuarkusTest
+public class ContractRuleImportExportTest extends AbstractResourceTestBase {
+
+    private static final String GROUP_ID = "ContractRuleImportExportTestGroup";
+    private static final String ARTIFACT_ID = "ContractRuleImportExportTestArtifact";
+    private static final String ARTIFACT_RULE = "artifactScopedRule";
+    private static final String VERSION_RULE = "versionScopedRule";
+    private static final String GLOBAL_RULE = "globalScopedRule";
+
+    @Inject
+    @Current
+    RegistryStorage storage;
+
+    @Test
+    public void testContractRulesSurviveExportImport() throws Exception {
+        storage.deleteAllUserData();
+
+        createArtifact(GROUP_ID, ARTIFACT_ID, ArtifactType.JSON, "{\"type\":\"object\"}",
+                ContentTypes.APPLICATION_JSON);
+
+        // An artifact scoped ruleset, a version scoped ruleset and the global ruleset, so that all three
+        // shapes of ContractRuleEntity (null globalId, non-null globalId, and __GLOBAL__ coordinates) are
+        // covered by the export.
+        putRuleSet("/registry/v3/groups/" + GROUP_ID + "/artifacts/" + ARTIFACT_ID + "/contract/ruleset",
+                newRuleSet(ARTIFACT_RULE));
+        putRuleSet("/registry/v3/groups/" + GROUP_ID + "/artifacts/" + ARTIFACT_ID
+                + "/versions/1/contract/ruleset", newRuleSet(VERSION_RULE));
+        putRuleSet("/registry/v3/admin/contracts/ruleset", newRuleSet(GLOBAL_RULE));
+
+        // Export. Before the fix this threw "Unhandled entity type: ContractRule" and never produced a zip.
+        File exportFile = exportRegistry();
+
+        List<String> contractRuleEntries = zipEntries(exportFile).stream()
+                .filter(name -> name.endsWith(".ContractRule.json")).toList();
+        Assertions.assertEquals(3, contractRuleEntries.size(),
+                "Expected one entry per exported contract rule, found: " + contractRuleEntries);
+
+        // Wipe and re-import.
+        storage.deleteAllUserData();
+        assertRuleAbsent("/registry/v3/groups/" + GROUP_ID + "/artifacts/" + ARTIFACT_ID
+                + "/contract/ruleset");
+
+        importRegistry(exportFile);
+
+        // The reader had no ContractRule case either, so without that half the rules would be silently
+        // dropped on the way back in.
+        assertSingleRule("/registry/v3/groups/" + GROUP_ID + "/artifacts/" + ARTIFACT_ID
+                + "/contract/ruleset", ARTIFACT_RULE);
+        assertSingleRule("/registry/v3/groups/" + GROUP_ID + "/artifacts/" + ARTIFACT_ID
+                + "/versions/1/contract/ruleset", VERSION_RULE);
+        assertSingleRule("/registry/v3/admin/contracts/ruleset", GLOBAL_RULE);
+
+        Files.deleteIfExists(exportFile.toPath());
+    }
+
+    private void putRuleSet(String path, ContractRuleSet ruleSet) {
+        given().contentType(CT_JSON).body(ruleSet).put(path).then().statusCode(200);
+    }
+
+    private void assertSingleRule(String path, String expectedRuleName) {
+        ContractRuleSet retrieved = given().get(path).then().statusCode(200).extract()
+                .as(ContractRuleSet.class);
+        Assertions.assertNotNull(retrieved.getDomainRules(),
+                "Expected domain rules to be restored at " + path);
+        Assertions.assertEquals(1, retrieved.getDomainRules().size(),
+                "Expected exactly one restored rule at " + path);
+        ContractRule rule = retrieved.getDomainRules().get(0);
+        Assertions.assertEquals(expectedRuleName, rule.getName());
+        Assertions.assertEquals("CEL", rule.getType());
+        Assertions.assertEquals("true", rule.getExpr());
+        Assertions.assertEquals(ContractRule.Kind.CONDITION, rule.getKind());
+        Assertions.assertEquals(ContractRule.Mode.WRITE, rule.getMode());
+    }
+
+    private void assertRuleAbsent(String path) {
+        ContractRuleSet retrieved = given().get(path).then().extract().as(ContractRuleSet.class);
+        Assertions.assertTrue(
+                retrieved.getDomainRules() == null || retrieved.getDomainRules().isEmpty(),
+                "Expected no contract rules after deleting all user data at " + path);
+    }
+
+    private File exportRegistry() throws IOException {
+        DownloadRef downloadRef = clientV3.admin().export().get();
+        URL url = new URL(String.format("http://localhost:%s%s", testPort, downloadRef.getHref()));
+        File tempFile = File.createTempFile(ContractRuleImportExportTest.class.getSimpleName(), ".zip");
+        try (InputStream in = url.openStream()) {
+            Files.deleteIfExists(tempFile.toPath());
+            Files.copy(in, tempFile.toPath());
+        }
+        return tempFile;
+    }
+
+    private void importRegistry(File exportFile) throws IOException {
+        try (FileInputStream fis = new FileInputStream(exportFile)) {
+            clientV3.admin().importEscaped().post(fis, config -> {
+                config.headers.putIfAbsent("Content-Type", Set.of("application/zip"));
+            });
+        }
+    }
+
+    private List<String> zipEntries(File file) throws IOException {
+        List<String> names = new ArrayList<>();
+        try (ZipFile zipFile = new ZipFile(file)) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                names.add(entries.nextElement().getName());
+            }
+        }
+        return names;
+    }
+
+    private ContractRuleSet newRuleSet(String ruleName) {
+        ContractRule rule = new ContractRule();
+        rule.setName(ruleName);
+        rule.setKind(ContractRule.Kind.CONDITION);
+        rule.setType("CEL");
+        rule.setMode(ContractRule.Mode.WRITE);
+        rule.setExpr("true");
+
+        ContractRuleSet ruleSet = new ContractRuleSet();
+        ruleSet.setDomainRules(List.of(rule));
+        ruleSet.setMigrationRules(List.of());
+        return ruleSet;
+    }
+}

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/EntityReader.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/EntityReader.java
@@ -10,6 +10,7 @@ import io.apicurio.registry.utils.impexp.v3.ArtifactVersionEntity;
 import io.apicurio.registry.utils.impexp.v3.BranchEntity;
 import io.apicurio.registry.utils.impexp.v3.CommentEntity;
 import io.apicurio.registry.utils.impexp.v3.ContentEntity;
+import io.apicurio.registry.utils.impexp.v3.ContractRuleEntity;
 import io.apicurio.registry.utils.impexp.v3.GlobalRuleEntity;
 import io.apicurio.registry.utils.impexp.v3.GroupEntity;
 import io.apicurio.registry.utils.impexp.v3.GroupRuleEntity;
@@ -63,6 +64,8 @@ public class EntityReader {
                         return readContent(entityInfo);
                     case GlobalRule:
                         return readGlobalRule(entityInfo);
+                    case ContractRule:
+                        return readContractRule(entityInfo);
                     case Group:
                         return readGroup(entityInfo);
                     case GroupRule:
@@ -104,6 +107,7 @@ public class EntityReader {
      * <li>Group Rules</li>
      * <li>Artifact Rules</li>
      * <li>Artifact Versions</li>
+     * <li>Contract Rules</li>
      * <li>Artifact Branches</li>
      * <li>Comments</li>
      * </ol>
@@ -117,6 +121,7 @@ public class EntityReader {
         List<EntityInfo> artifacts = new LinkedList<>();
         List<EntityInfo> artifactRules = new LinkedList<>();
         List<EntityInfo> versions = new LinkedList<>();
+        List<EntityInfo> contractRules = new LinkedList<>();
         List<EntityInfo> branches = new LinkedList<>();
         List<EntityInfo> comments = new LinkedList<>();
 
@@ -132,6 +137,9 @@ public class EntityReader {
                     break;
                 case ArtifactRule:
                     artifactRules.add(entityInfo);
+                    break;
+                case ContractRule:
+                    contractRules.add(entityInfo);
                     break;
                 case ArtifactVersion:
                     versions.add(entityInfo);
@@ -190,6 +198,9 @@ public class EntityReader {
         entities.addAll(artifacts);
         entities.addAll(versions);
         entities.addAll(artifactRules);
+        // Contract rules must come after versions: a version scoped rule has a foreign key to
+        // versions(globalId).
+        entities.addAll(contractRules);
         entities.addAll(branches);
         entities.addAll(comments);
     }
@@ -264,6 +275,10 @@ public class EntityReader {
 
     private Entity readBranch(EntityInfo entry) throws IOException {
         return readEntry(entry, BranchEntity.class);
+    }
+
+    private Entity readContractRule(EntityInfo entry) throws IOException {
+        return readEntry(entry, ContractRuleEntity.class);
     }
 
     private Entity readGlobalRule(EntityInfo entry) throws IOException {

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/EntityWriter.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/EntityWriter.java
@@ -60,6 +60,9 @@ public class EntityWriter {
             case GlobalRule:
                 writeEntity((GlobalRuleEntity) entity);
                 break;
+            case ContractRule:
+                writeEntity((ContractRuleEntity) entity);
+                break;
             case Comment:
                 writeEntity((CommentEntity) entity);
                 break;
@@ -126,6 +129,17 @@ public class EntityWriter {
         write(mdEntry, entity, GlobalRuleEntity.class);
     }
 
+    private void writeEntity(ContractRuleEntity entity) throws IOException {
+        // The rule name is user supplied, so it is not used in the file name. A contract rule is uniquely
+        // identified within its artifact by the version it applies to (globalId, null for artifact and
+        // global level rules) plus its category and order within that category.
+        String fileName = String.format("%s-%s-%d", entity.globalId == null ? "all" : entity.globalId,
+                entity.ruleCategory, entity.orderIndex);
+        ZipEntry mdEntry = createZipEntry(EntityType.ContractRule, entity.groupId, entity.artifactId,
+                fileName, "json");
+        write(mdEntry, entity, ContractRuleEntity.class);
+    }
+
     private void writeEntity(CommentEntity entity) throws IOException {
         ZipEntry mdEntry = createZipEntry(EntityType.Comment, entity.globalId + '-' + entity.commentId,
                 "json");
@@ -154,6 +168,10 @@ public class EntityWriter {
             case ArtifactRule:
                 path = String.format("groups/%s/artifacts/%s/rules/%s.%s.%s", groupOrDefault(groupId),
                         artifactId, fileName, type.name(), fileExt);
+                break;
+            case ContractRule:
+                path = String.format("groups/%s/artifacts/%s/contract-rules/%s.%s.%s",
+                        groupOrDefault(groupId), artifactId, fileName, type.name(), fileExt);
                 break;
             case Artifact:
                 path = String.format("groups/%s/artifacts/%s/%s.%s.%s", groupOrDefault(groupId), artifactId,

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/EntityWriter.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/EntityWriter.java
@@ -22,6 +22,9 @@ public class EntityWriter {
 
     private final transient ZipOutputStream zip;
 
+    /** Disambiguates contract rule zip entries; see {@link #writeEntity(ContractRuleEntity)}. */
+    private int contractRuleSequence = 0;
+
     /**
      * Constructor.
      * 
@@ -130,11 +133,13 @@ public class EntityWriter {
     }
 
     private void writeEntity(ContractRuleEntity entity) throws IOException {
-        // The rule name is user supplied, so it is not used in the file name. A contract rule is uniquely
-        // identified within its artifact by the version it applies to (globalId, null for artifact and
-        // global level rules) plus its category and order within that category.
-        String fileName = String.format("%s-%s-%d", entity.globalId == null ? "all" : entity.globalId,
-                entity.ruleCategory, entity.orderIndex);
+        // The rule name is user supplied, and contract_rules has no unique constraint beyond its ruleId
+        // primary key, so no combination of the exported columns is guaranteed distinct. Duplicate zip
+        // entry names would silently drop rules from the export, so a per-writer sequence number is
+        // appended. The name is descriptive only: the reader derives the entity type from the
+        // ".ContractRule.json" suffix and reads every field from the file body.
+        String fileName = String.format("%s-%s-%d-%d", entity.globalId == null ? "all" : entity.globalId,
+                entity.ruleCategory, entity.orderIndex, contractRuleSequence++);
         ZipEntry mdEntry = createZipEntry(EntityType.ContractRule, entity.groupId, entity.artifactId,
                 fileName, "json");
         write(mdEntry, entity, ContractRuleEntity.class);


### PR DESCRIPTION
## Summary

Contract ruleset changes emitted no events under `kafkasql` storage, and
contract rules were silently dropped from data exports.

Fixes #9246

## Root Cause

`KafkaSqlRegistryStorage` fires a `KafkaSqlOutboxEvent` after every mutation
except the six contract-ruleset ones, which just submitted the journal message
and returned. Those events existed only on the SQL path, which writes to a DB
outbox table nothing reads under kafkasql — so nothing reached the
`registry-events` topic and the tests timed out at 20s. Deterministic, not
flaky: the `app-sql` shard passes the identical inherited tests in the same run.

Separately, `EntityWriter`/`EntityReader` had no `ContractRule` case, so exports
threw `Unhandled entity type: ContractRule`. `DataExporter` swallows that, so
the export returned 200 with a zip missing every contract rule.

## Changes

- `KafkaSqlRegistryStorage`: fire `ContractRulesetConfigured` in the six
  contract-ruleset methods, after `coordinator.waitForResponse(uuid)`
- `EntityWriter` / `EntityReader`: handle the `ContractRule` entity type;
  indexed after versions due to the FK on `versions(globalId)`
- New `ContractRuleImportExportTest` covering artifact, version and global scope

## Test plan

- [x] `KafkaSqlEventsTest` — 30/30 pass, including the six from #9246
- [x] `ContractRuleImportExportTest` passes; fails with the export fix stashed
- [x] `checkstyle:check -pl app,utils/importexport` clean
- [ ] Full CI (four unrelated shards were already red on the referenced run)
