### PR TITLE
fix(ui): use applied filters for agents page paging and empty state

### DIFF
--- a/ui/ui-app/src/app/pages/agents/AgentsPage.tsx
+++ b/ui/ui-app/src/app/pages/agents/AgentsPage.tsx
@@ -68,6 +68,7 @@ export const AgentsPage: FunctionComponent<PageProperties> = () => {
     const [isSearching, setSearching] = useState<boolean>(false);
     const [results, setResults] = useState<AgentSearchResults>(EMPTY_RESULTS);
     const [paging, setPaging] = useState<Paging>(DEFAULT_PAGING);
+    const [appliedFilters, setAppliedFilters] = useState<AgentSearchFilters>({});
     const [nameFilter, setNameFilter] = useState<string>("");
     const [capabilityFilter, setCapabilityFilter] = useState<string>("");
     const [skillFilter, setSkillFilter] = useState<string>("");
@@ -91,6 +92,7 @@ export const AgentsPage: FunctionComponent<PageProperties> = () => {
     };
 
     const search = async (filters: AgentSearchFilters, paging: Paging): Promise<void> => {
+        setAppliedFilters(filters);
         setSearching(true);
         try {
             const results = await agentSvc.searchAgents(filters, paging);
@@ -102,14 +104,18 @@ export const AgentsPage: FunctionComponent<PageProperties> = () => {
         }
     };
 
+    const applyFilters = (newFilters: AgentSearchFilters): void => {
+        const newPaging = { ...DEFAULT_PAGING };
+        setPaging(newPaging);
+        search(newFilters, newPaging);
+    };
+
     const createLoaders = (): Promise<any> => {
         return search(createFilters(), paging);
     };
 
     const handleSearch = (): void => {
-        const newPaging = { ...DEFAULT_PAGING };
-        setPaging(newPaging);
-        search(createFilters(), newPaging);
+        applyFilters(createFilters());
     };
 
     const handleKeyPress = (event: React.KeyboardEvent): void => {
@@ -121,26 +127,23 @@ export const AgentsPage: FunctionComponent<PageProperties> = () => {
     const handlePageChange = (_event: any, page: number): void => {
         const newPaging = { ...paging, page };
         setPaging(newPaging);
-        search(createFilters(), newPaging);
+        search(appliedFilters, newPaging);
     };
 
     const handlePerPageChange = (_event: any, perPage: number): void => {
         const newPaging = { page: 1, pageSize: perPage };
         setPaging(newPaging);
-        search(createFilters(), newPaging);
+        search(appliedFilters, newPaging);
     };
 
     const handleCapabilitySelect = (_event: React.MouseEvent | undefined, value: string | number | undefined): void => {
         const selectedValue = value as string || "";
         setCapabilityFilter(selectedValue);
         setCapabilitySelectOpen(false);
-        const filters: AgentSearchFilters = {
-            name: nameFilter || undefined,
-            capability: selectedValue || undefined,
-            skill: skillFilter || undefined
-        };
-        search(filters, { ...DEFAULT_PAGING });
-        setPaging({ ...DEFAULT_PAGING });
+        applyFilters({
+            ...appliedFilters,
+            capability: selectedValue || undefined
+        });
     };
 
     const navigateToAgent = (agent: AgentSearchResult): void => {
@@ -249,7 +252,7 @@ export const AgentsPage: FunctionComponent<PageProperties> = () => {
     };
 
     const renderEmptyState = (): React.ReactElement => {
-        const isFiltered = !!(nameFilter || capabilityFilter || skillFilter);
+        const isFiltered = !!(appliedFilters.name || appliedFilters.capability || appliedFilters.skill);
         return (
             <EmptyState
                 headingLevel="h4"
@@ -276,12 +279,10 @@ export const AgentsPage: FunctionComponent<PageProperties> = () => {
                             onSearch={handleSearch}
                             onClear={() => {
                                 setNameFilter("");
-                                const filters: AgentSearchFilters = {
-                                    capability: capabilityFilter || undefined,
-                                    skill: skillFilter || undefined
-                                };
-                                search(filters, { ...DEFAULT_PAGING });
-                                setPaging({ ...DEFAULT_PAGING });
+                                applyFilters({
+                                    ...appliedFilters,
+                                    name: undefined
+                                });
                             }}
                             onKeyDown={handleKeyPress}
                         />
@@ -294,12 +295,10 @@ export const AgentsPage: FunctionComponent<PageProperties> = () => {
                             onSearch={handleSearch}
                             onClear={() => {
                                 setSkillFilter("");
-                                const filters: AgentSearchFilters = {
-                                    name: nameFilter || undefined,
-                                    capability: capabilityFilter || undefined
-                                };
-                                search(filters, { ...DEFAULT_PAGING });
-                                setPaging({ ...DEFAULT_PAGING });
+                                applyFilters({
+                                    ...appliedFilters,
+                                    skill: undefined
+                                });
                             }}
                             onKeyDown={handleKeyPress}
                         />


### PR DESCRIPTION
## Description

Fixes #8708

On the Agents page, pagination and per-page changes used the live toolbar input instead of the last applied search criteria. Typing into a search box without submitting, then clicking a page number, silently filtered the results by the unsubmitted text. The empty state's "filtered" message also triggered on unsubmitted input.

## Changes

- Track applied filters separately from the live toolbar input
- Use the applied filters for page change, per-page change, and the empty state
- Capability select and search box clear actions update the applied filters

## Testing

- [x] Ran `npm run lint` in `ui/ui-app/` - passes (0 errors)
- [x] Typecheck passes for the modified file (only pre-existing missing SDK module errors remain)

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
