### PR TITLE
test(search): use wildcard name search in testSearchVersionsByMetadata

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/tests/search/SearchIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/search/SearchIT.java
@@ -115,11 +115,13 @@ public class SearchIT extends ApicurioRegistryBaseIT {
                     results.getVersions().get(0).getArtifactId());
         });
 
-        // Search by name
+        // Search by name. Name matching is exact unless the value carries explicit '*'
+        // wildcards (see SqlSearchRepository.buildNameClause(), #8002), so a partial
+        // value needs a trailing wildcard to match "Search Smoke Test API".
         retry(() -> {
             VersionSearchResults results = registryClient.search().versions().get(config -> {
                 config.queryParameters.groupId = GROUP;
-                config.queryParameters.name = "Search Smoke Test";
+                config.queryParameters.name = "Search Smoke Test*";
             });
             Assertions.assertTrue(results.getCount() >= 1,
                     "Expected at least 1 result when searching by name");


### PR DESCRIPTION
## What

One-line fix in `SearchIT.testSearchVersionsByMetadata`: search with `name = "Search Smoke Test*"` (explicit trailing wildcard) instead of the partial value `"Search Smoke Test"`, plus a comment documenting why.

## Why

The failure in #9277 is deterministic and isn't an Elasticsearch problem. The name search never reaches ES:

- A `name` filter doesn't route through the search index. `ElasticsearchSearchDecorator.searchVersions()` only diverts to ES for `content`/`structure` filters (`INDEX_ONLY_FILTER_TYPES` in `ElasticsearchSearchService`), everything else falls through to the SQL storage.
- SQL name matching is exact unless the value carries explicit `*` wildcards, documented on `SqlSearchRepository.buildNameClause()` and deliberate behavior from #6298 / #8002.
- The test stores the version name "Search Smoke Test API" but searched the partial value "Search Smoke Test", so the query is `(v.name = 'Search Smoke Test' OR v.artifactId = 'Search Smoke Test')` and returns 0 rows, on every backend, every retry.
- It only surfaced on ES deployments because the `search` test group doesn't run in the other profiles, so the test was never exercised anywhere else.

I'm reproducing the identical scenario on the in-memory profile locally (no ES in the stack) to confirm the mechanism, and will post the results on the issue.

SQL search semantics are left untouched (deliberate design per #8002; the partial-vs-exact question for the well-known endpoints is tracked separately in #8703).

Fixes #9277

## Testing

- `./mvnw checkstyle:check -pl integration-tests -P integration-tests`: 0 violations
- The change is a string literal plus a comment inside an existing test method, so compile risk is minimal; CI compiles the module on the smoke run
- The `search`-profile pipeline exercises the changed test end-to-end with real Elasticsearch
