### PR TITLE
test(operator): use MEDIUM_DURATION for ingress creation waits

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/IngressITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/IngressITTest.java
@@ -45,12 +45,17 @@ public class IngressITTest extends ITBase {
         final var appIngress = k8sCell(client, () -> client.network().v1().ingresses().withName(primary.getCached().getMetadata().getName() + "-app-ingress").get());
         final var uiIngress = k8sCell(client, () -> client.network().v1().ingresses().withName(primary.getCached().getMetadata().getName() + "-ui-ingress").get());
 
-        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
-            assertThat(appIngress.get()).isNotNull();
+        // Creating the Ingress requires a full reconciliation of the freshly created CR, which can
+        // take considerably longer than a subsequent update to an already existing resource. Use
+        // MEDIUM_DURATION here, consistent with the other resource-creation waits such as
+        // ITBase.checkDeploymentExists(). getOptional() is used instead of get() so that a timeout
+        // reports the resource as missing rather than surfacing an IllegalStateException.
+        await().atMost(MEDIUM_DURATION).ignoreExceptions().untilAsserted(() -> {
+            assertThat(appIngress.getOptional()).isPresent();
         });
 
-        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
-            assertThat(uiIngress.get()).isNotNull();
+        await().atMost(MEDIUM_DURATION).ignoreExceptions().untilAsserted(() -> {
+            assertThat(uiIngress.getOptional()).isPresent();
         });
 
         await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {


### PR DESCRIPTION
## What

`IngressITTest.ingressAnnotations` waits for the operator to create the app and UI
Ingress resources. Both waits used `SHORT_DURATION` (30s); this changes them to
`MEDIUM_DURATION` (120s), and switches `get()` to `getOptional()` in those two
assertions.

Only the two initial creation waits change. Every subsequent wait in the test — the
annotation update/removal assertions — still uses `SHORT_DURATION`, since those
operate on an already-reconciled resource.

## Why

Creating an Ingress requires a full reconciliation of a freshly created CR, which
takes considerably longer than a subsequent update to an existing resource. The rest
of the operator suite already reflects this: resource-creation waits use
`MEDIUM_DURATION` in `ITBase.checkDeploymentExists()`, `PodDisruptionBudgetITTest`,
`LeaderElectionITTest`, `MultiNamespaceSmokeITTest`, `HorizontalPodAutoscalerITTest`
and `GitOpsITTest`. The two ingress creation waits were the outliers at 30s, which is
only ~10 polls against `POLL_INTERVAL_DURATION` (3s).

Secondly, the assertion could not fail as written:

```java
assertThat(appIngress.get()).isNotNull();
```

`K8sCell.get()` throws `IllegalStateException` when the resource is absent
(`K8sCell.java:63`), so `isNotNull()` was unreachable and `ignoreExceptions()`
swallowed the exception until the timeout — which is why #9276 surfaces as a bare
`IllegalStateException` with no assertion message. `getOptional()` makes a timeout
report the resource as missing.

## Alternative considered

The timeouts are already tunable, so the OCP 4.16 job could instead pass
`-Dtest.operator.timeout.short=90` (there's precedent — `operator.yaml:286` passes
`-Dtest.operator.timeout.long=600`). I didn't go that route because it raises *every*
`SHORT_DURATION` wait, including the negative checks that use
`await().during(ofSeconds(10)).atMost(SHORT_DURATION)` to assert a resource stays
absent, which would slow the suite for no benefit. Happy to switch if you'd prefer the
pipeline-config approach. Both knobs remain available either way.

## Testing

- `./mvnw checkstyle:check -pl operator/controller -Dfull -Pintegration-tests -Pexamples` — passes
- `./mvnw test-compile -pl operator/controller -am -DskipTests -Dfull -Pintegration-tests -Pexamples` — BUILD SUCCESS

**I have not run `IngressITTest` itself** — it needs a Kubernetes/OpenShift cluster I
don't have available. So I can't demonstrate the flake is gone; the reasoning is based
on the timeout being the reported failure mode and on aligning with the suite's
existing convention for creation waits. The `getOptional()` change is behaviour-neutral
apart from the error message.

One caveat worth flagging from the issue's own logs: the operator pod hit a startup
probe failure on that run. `ITBase` waits for pod readiness once at class setup, so if
the operator restarted mid-run its informer caches would need to resync, and a longer
timeout would only mask that. If the pod restart count from that run is available it
would confirm whether this is sufficient or whether a readiness re-check between tests
is also wanted.

Fixes #9276
