### PR TITLE
test(cli): split mislabeled GroupCommandTest failure cases

### DIFF
--- a/cli/src/test/java/io/apicurio/registry/cli/GroupCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/GroupCommandTest.java
@@ -133,10 +133,24 @@ public class GroupCommandTest extends AbstractCLITest {
 
     @Test
     public void testGroupGetCommandFails() {
+        // Assert on the error message so these cases cannot pass merely because the
+        // command failed for some other reason.
+
         // Required groupId parameter is missing
+        err.getBuffer().setLength(0);
         executeAndAssertFailure("group", "get");
+        assertThat(err.toString())
+                .as(withCliOutput("Missing groupId parameter must be reported"))
+                .contains("Missing required parameter")
+                .contains("groupId");
+
         // Unknown output type (rejected while parsing, so the group need not exist)
+        err.getBuffer().setLength(0);
         executeAndAssertFailure("group", "get", "some-group", "--output-type", "foo");
+        assertThat(err.toString())
+                .as(withCliOutput("Invalid --output-type value must be reported"))
+                .contains("--output-type")
+                .contains("foo");
     }
 
     @Test

--- a/cli/src/test/java/io/apicurio/registry/cli/GroupCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/GroupCommandTest.java
@@ -111,13 +111,32 @@ public class GroupCommandTest extends AbstractCLITest {
     }
 
     @Test
-    public void testGroupGetCommandFails() {
-        // Unknown output type
-        executeAndAssertFailure("group", "create", "--output-type", "foo");
+    public void testGroupListCommandFails() {
+        // Pagination options belong to the `group` list command, not to `group create`.
+        // Assert on the error message so these cases cannot pass merely because the
+        // option is unrecognized by the command under test.
+
         // Page must be greater than 0
-        executeAndAssertFailure("group", "create", "-p", "-1");
+        err.getBuffer().setLength(0);
+        executeAndAssertFailure("group", "-p", "-1");
+        assertThat(err.toString())
+                .as(withCliOutput("Page must be rejected as not greater than 0"))
+                .contains("must be greater than 0");
+
         // Size must be greater than 0
-        executeAndAssertFailure("group", "create", "-s", "0");
+        err.getBuffer().setLength(0);
+        executeAndAssertFailure("group", "-s", "0");
+        assertThat(err.toString())
+                .as(withCliOutput("Size must be rejected as not greater than 0"))
+                .contains("must be greater than 0");
+    }
+
+    @Test
+    public void testGroupGetCommandFails() {
+        // Required groupId parameter is missing
+        executeAndAssertFailure("group", "get");
+        // Unknown output type (rejected while parsing, so the group need not exist)
+        executeAndAssertFailure("group", "get", "some-group", "--output-type", "foo");
     }
 
     @Test


### PR DESCRIPTION
Fixes #9274

## What

`testGroupGetCommandFails` in `GroupCommandTest` covered three unrelated things, none of them `group get`:

```java
executeAndAssertFailure("group", "create", "-p", "-1");
executeAndAssertFailure("group", "create", "-s", "0");
executeAndAssertFailure("group", "create", "--output-type", "json");
```

This splits it into `testGroupListCommandFails` (pagination) and a `testGroupGetCommandFails` that actually exercises `group get`.

## Why

Three separate problems in nine lines:

1. **Wrong command under test.** `-p/--page` and `-s/--size` come from `PaginationMixin`, which `GroupCommand` (the list command) uses and `GroupGetCommand` does not. Pagination validation belongs on the list command.

2. **The pagination cases passed for the wrong reason.** `group create -p -1` fails because picocli does not recognize `-p` on that command — not because `PositiveIntegerValidator` rejected the value. The test would still pass if the validator were deleted. These now run against `group` and assert on the error message, so they fail if the validator stops working:
   ```java
   executeAndAssertFailure("group", "-p", "-1");
   assertThat(err.toString()).contains("must be greater than 0");
   ```

3. **A duplicated assertion.** The third line was byte-identical to one already in `testGroupCreateCommandFails` (line 79). Dropped rather than moved.

## Note on the issue's suggested fix

The issue proposes renaming the method to `testGroupCreateCommandFails`. That name is already taken by an existing test in the same class, so a straight rename would not compile. Splitting by the command each case actually targets keeps both names meaningful.

## Testing

`GroupCommandTest` run locally against the containerized registry — 9 tests, 0 failures:

```
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0 -- in io.apicurio.registry.cli.GroupCommandTest
```

Also verified: `./mvnw checkstyle:check -pl cli` and `./mvnw test-compile -pl cli -am` both pass. Test-only change, no production code touched.
