### PR TITLE
fix(app): declare default for apicurio.storage.kind and align @Info metadata

### DIFF
--- a/app/src/main/java/io/apicurio/registry/core/System.java
+++ b/app/src/main/java/io/apicurio/registry/core/System.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 
+import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_STORAGE;
 import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_SYSTEM;
 
 /**
@@ -64,7 +65,8 @@ public class System {
     String date;
 
     @Inject
-    @ConfigProperty(name = "apicurio.storage.kind")
+    @ConfigProperty(name = "apicurio.storage.kind", defaultValue = "sql")
+    @Info(category = CATEGORY_STORAGE, description = "Application storage variant, for example, sql, kafkasql, gitops, or kubernetesops", availableSince = "3.0.0")
     String storageKind;
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorageProducer.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorageProducer.java
@@ -32,7 +32,7 @@ public class RegistryStorageProducer {
     @Inject
     Instance<RegistryStorageDecorator> decorators;
 
-    @ConfigProperty(name = "apicurio.storage.kind")
+    @ConfigProperty(name = "apicurio.storage.kind", defaultValue = "sql")
     @Info(category = CATEGORY_STORAGE, description = "Application storage variant, for example, sql, kafkasql, gitops, or kubernetesops", availableSince = "3.0.0")
     String registryStorageType;
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsRegistryStorage.java
@@ -22,8 +22,8 @@ import static io.quarkus.scheduler.Scheduled.ConcurrentExecution.SKIP;
 @LookupIfProperty(name = "apicurio.storage.kind", stringValue = "gitops")
 public class GitOpsRegistryStorage extends AbstractPollingRegistryStorage<GitOpsMarker> {
 
-    @ConfigProperty(name = "apicurio.storage.kind")
-    @Info(category = CATEGORY_STORAGE, description = "Application storage variant, for example, sql, kafkasql, or gitops", availableSince = "3.0.0")
+    @ConfigProperty(name = "apicurio.storage.kind", defaultValue = "sql")
+    @Info(category = CATEGORY_STORAGE, description = "Application storage variant, for example, sql, kafkasql, gitops, or kubernetesops", availableSince = "3.0.0")
     String registryStorageType;
 
     @Inject

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlEventsProcessor.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlEventsProcessor.java
@@ -23,7 +23,7 @@ import static io.apicurio.registry.utils.ConcurrentUtil.blockOnResult;
 public class KafkaSqlEventsProcessor {
 
     @ConfigProperty(name = "apicurio.storage.kind", defaultValue = "sql")
-    @Info(category = CATEGORY_STORAGE, description = "The type of storage to use for the registry", availableSince = "3.0.0")
+    @Info(category = CATEGORY_STORAGE, description = "Application storage variant, for example, sql, kafkasql, gitops, or kubernetesops", availableSince = "3.0.0")
     String storageType;
 
     @Inject

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSnapshotScheduler.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSnapshotScheduler.java
@@ -51,7 +51,7 @@ public class KafkaSqlSnapshotScheduler {
     private static final long MIN_INITIAL_DELAY_SECONDS = 60L;
     private static final long MAX_INITIAL_DELAY_JITTER_SECONDS = 30L;
 
-    @ConfigProperty(name = "apicurio.storage.kind")
+    @ConfigProperty(name = "apicurio.storage.kind", defaultValue = "sql")
     @Info(category = CATEGORY_STORAGE, description = "Application storage variant, for example, sql, kafkasql, gitops, or kubernetesops", availableSince = "3.0.0")
     String registryStorageType;
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSubmitter.java
@@ -33,7 +33,7 @@ public class KafkaSqlSubmitter {
     public static final String BOOTSTRAP_MESSAGE_TYPE = "Bootstrap";
 
     @ConfigProperty(name = "apicurio.storage.kind", defaultValue = "sql")
-    @Info(category = CATEGORY_STORAGE, description = "The type of storage to use for the registry", availableSince = "3.0.0")
+    @Info(category = CATEGORY_STORAGE, description = "Application storage variant, for example, sql, kafkasql, gitops, or kubernetesops", availableSince = "3.0.0")
     String storageType;
 
     @Inject

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kubernetesops/KubernetesOpsRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kubernetesops/KubernetesOpsRegistryStorage.java
@@ -42,7 +42,7 @@ public class KubernetesOpsRegistryStorage extends AbstractPollingRegistryStorage
     @Inject
     Event<StorageEvent> storageEvent;
 
-    @ConfigProperty(name = "apicurio.storage.kind")
+    @ConfigProperty(name = "apicurio.storage.kind", defaultValue = "sql")
     @Info(category = CATEGORY_STORAGE, description = "Application storage variant, for example, sql, kafkasql, gitops, or kubernetesops", availableSince = "3.0.0")
     String registryStorageType;
 

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -1425,7 +1425,7 @@ The following {registry} configuration options are available for each component 
 |Enable automatic creation of group when creating an artifact
 |`apicurio.storage.kind`
 |`string`
-|
+|`sql`
 |`3.0.0`
 |Application storage variant, for example, sql, kafkasql, gitops, or kubernetesops
 |`apicurio.storage.read-only.enabled`


### PR DESCRIPTION
apicurio.storage.kind is declared at seven injection points. Five of them omitted defaultValue, and the @Info descriptions disagreed across sites (three distinct strings, one site had no @Info at all).

The config doc generator resolves one declaration per property name, and it picked a site without a defaultValue, so the published configuration reference listed the property with an empty default even though the effective default is sql (application.properties). Which description was published was likewise incidental.

Give every declaration defaultValue = "sql" and the same @Info description, so the generated reference is correct regardless of which site is selected, and regenerate ref-registry-all-configs.adoc.