### PR TITLE
ci: split the app-other unit test shard to fix heap exhaustion

### DIFF
--- a/.github/scripts/verify-test-shards.py
+++ b/.github/scripts/verify-test-shards.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Verify the app-module unit-test shards in verify-unit-tests.yaml partition the
+test set exactly once.
+
+Every surefire-eligible test class in app/ must be claimed by exactly one app-*
+shard. A class claimed by none never runs in CI and fails silently, because the
+workflow passes -Dsurefire.failIfNoSpecifiedTests=false. A class claimed by two
+wastes a shard's budget.
+
+Implements surefire's -Dtest= semantics: comma-separated fully-qualified-name
+patterns, '!' prefix excludes, '**' matches across package separators, '*'
+matches within one segment. A filter of exclusions only includes everything not
+excluded.
+
+Usage:  python3 .github/scripts/verify-test-shards.py
+Exits non-zero when the partition is broken.
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+APP_TESTS = REPO / "app/src/test/java"
+WORKFLOW = REPO / ".github/workflows/verify-unit-tests.yaml"
+
+# The 'non-app' shard selects by Maven -pl, not by -Dtest, so it is not part of
+# the app-module partition.
+NON_APP_SHARD = "non-app"
+
+
+def is_surefire_name(stem):
+    """Match surefire's default includes."""
+    return (
+        stem.startswith("Test")
+        or stem.endswith("Test")
+        or stem.endswith("Tests")
+        or stem.endswith("TestCase")
+    )
+
+
+def enumerate_classes():
+    """Fully-qualified names of app/ test classes surefire would actually run."""
+    found = []
+    for path in APP_TESTS.rglob("*.java"):
+        stem = path.stem
+        if not is_surefire_name(stem):
+            continue
+        source = path.read_text(encoding="utf-8", errors="replace")
+        # Abstract classes are bases for other tests; surefire never runs them.
+        if re.search(r"\babstract\s+class\s+" + re.escape(stem) + r"\b", source):
+            continue
+        found.append(str(path.relative_to(APP_TESTS)).replace("/", ".")[:-len(".java")])
+    return sorted(found)
+
+
+def pattern_to_regex(pattern):
+    regex, i = "", 0
+    while i < len(pattern):
+        if pattern.startswith("**", i):
+            regex += ".*"
+            i += 2
+        elif pattern[i] == "*":
+            regex += "[^.]*"
+            i += 1
+        else:
+            regex += re.escape(pattern[i])
+            i += 1
+    return re.compile("^" + regex + "$")
+
+
+def matches(fqn, test_filter):
+    if not test_filter:
+        return True
+    patterns = [p.strip() for p in test_filter.split(",") if p.strip()]
+    includes = [pattern_to_regex(p) for p in patterns if not p.startswith("!")]
+    excludes = [pattern_to_regex(p[1:]) for p in patterns if p.startswith("!")]
+    if includes and not any(r.match(fqn) for r in includes):
+        return False
+    return not any(r.match(fqn) for r in excludes)
+
+
+def parse_shards():
+    """Read (name, test-filter) pairs straight from the workflow matrix."""
+    shards, name = [], None
+    for line in WORKFLOW.read_text(encoding="utf-8").splitlines():
+        matched = re.match(r"\s*- name:\s*(\S+)", line)
+        if matched:
+            name = matched.group(1)
+            continue
+        matched = re.match(r'\s*test-filter:\s*"(.*)"\s*$', line)
+        if matched and name:
+            value = matched.group(1)
+            if value.startswith("-Dtest="):
+                value = value[len("-Dtest="):]
+            shards.append((name, value))
+            name = None
+    return [s for s in shards if s[0] != NON_APP_SHARD]
+
+
+def main():
+    classes = enumerate_classes()
+    shards = parse_shards()
+    if not shards:
+        print("ERROR: no shards parsed from", WORKFLOW)
+        return 2
+
+    print(f"app test classes (surefire-eligible, non-abstract): {len(classes)}")
+    print(f"app shards: {', '.join(n for n, _ in shards)}\n")
+
+    print(f"{'SHARD':<20} {'CLASSES':>8}")
+    for name, test_filter in shards:
+        print(f"{name:<20} {sum(1 for c in classes if matches(c, test_filter)):>8}")
+
+    claims = {c: [n for n, f in shards if matches(c, f)] for c in classes}
+    orphans = sorted(c for c, hits in claims.items() if not hits)
+    duplicates = {c: h for c, h in sorted(claims.items()) if len(h) > 1}
+
+    print(f"\nrun exactly once  : {sum(1 for h in claims.values() if len(h) == 1)}")
+    print(f"run ZERO times    : {len(orphans)}")
+    print(f"run MORE than once: {len(duplicates)}")
+
+    if orphans:
+        print("\n!! ORPHANS - these run in no shard and fail silently:")
+        for c in orphans:
+            print("    ", c)
+    if duplicates:
+        print("\n!! DUPLICATES - these run in several shards:")
+        for c, hits in duplicates.items():
+            print(f"     {c} -> {', '.join(hits)}")
+
+    ok = not orphans and not duplicates
+    print("\nRESULT:", "PARTITION OK" if ok else "PARTITION BROKEN")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -117,6 +117,17 @@ does so silently: `verify-unit-tests.yaml` sets
 happens. Any new storage or event subpackage **must** be added to an include
 shard in `verify-unit-tests.yaml`, or its tests will never run in CI.
 
+This is enforced, not left to reviewers. The **Lint and Validate** job runs:
+
+```bash
+python3 .github/scripts/verify-test-shards.py
+```
+
+which reads the shard matrix out of `verify-unit-tests.yaml`, applies
+surefire's `-Dtest=` matching rules, and fails the build if any `app/` test
+class is claimed by zero shards or by more than one. Run it locally before
+changing any shard boundary — it is much faster than waiting for CI.
+
 ### Rebalancing shards
 
 If one shard grows significantly slower than the others, rebalance by moving

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -63,8 +63,7 @@ are control-group measurements as of 2026-08-01 from
 [Discussion #8364](https://github.com/Apicurio/apicurio-registry/discussions/8364).
 They are illustrative, not guaranteed: actual times vary with runner load and
 cache state. The only CI-enforced budget is the 600 s per-shard warning
-threshold in `verify-unit-tests.yaml`; `app-other` currently exceeds it by
-design (a known gap, tracked separately).
+threshold in `verify-unit-tests.yaml`.
 
 | Shard | Intent | Typical duration |
 |-------|--------|-----------------|
@@ -73,17 +72,25 @@ design (a known gap, tracked separately).
 | `app-kafkasql` | KafkaSQL storage variant | ~6 min |
 | `app-gitops` | GitOps storage variant | ~4 min |
 | `app-kubernetesops` | Kubernetes ConfigMaps storage variant | ~3 min |
-| `app-other` | Catch-all for everything else in `app/`: auth, tls, metrics, rbac, cors, limits, rules, search, ui, and most of `noprofile/*` (compatibility, resolver, serde, proxy, etc.), excluding `noprofile.rest`/`noprofile.ccompat` and all `storage.**`/`event.**` | ~14 min |
+| `app-auth` | Authentication, authorization and rate-limit tests (`auth`, `rbac`, `limits`) | ~4 min |
+| `app-transport` | TLS/mTLS, HTTP security headers and CORS (`tls`, `headers`, `cors`) | ~2.5 min |
+| `app-metrics` | Metrics, tracing and search-index tests (`metrics`, `search`) | ~2 min |
+| `app-other` | Catch-all for everything else in `app/`: rules, ui, services, contracts, customTypes and most of `noprofile/*` (compatibility, resolver, serde, proxy, etc.), excluding the packages claimed by every other `app-*` shard | ~9 min |
 | `non-app` | All modules except `app/`, `distro/docker`, `docs`, `docs/config-generator`, `docs/rest-api` (schema-util, serdes, java-sdk, cli, mcp, etc.) | ~5 min |
 
 ### How sharding works
 
-- **app-rest**, **app-sql**, **app-kafkasql**, **app-gitops**, and
-  **app-kubernetesops** each use surefire's `-Dtest=` to *include* a specific
-  set of packages.
-- **app-other** uses `-Dtest=!...` to *exclude* the packages claimed by the
-  `noprofile.rest`, `noprofile.ccompat`, `storage.**`, and `event.**` filters,
-  catching everything else in `app/`.
+- **app-rest**, **app-sql**, **app-kafkasql**, **app-gitops**,
+  **app-kubernetesops**, **app-auth**, **app-transport**, and **app-metrics**
+  each use surefire's `-Dtest=` to *include* a specific set of packages.
+- **app-other** uses `-Dtest=!...` to *exclude* every package claimed by those
+  include shards, catching everything else in `app/`. Each exclusion in its
+  filter must pair with an inclusion in another shard, or tests go missing.
+- Shard boundaries are chosen by `@TestProfile` density, not just class count.
+  Surefire runs a shard in one forked JVM (`forkCount=1`, `reuseForks=true`
+  by default), and each distinct profile makes Quarkus tear down and rebuild
+  the application in that JVM. Concentrating many profiles in one shard is what
+  exhausted its heap in issue #9265.
 - **non-app** uses Maven's `-pl` to run all modules except `app` and modules that
   depend on the `app` JAR (`distro/docker`, `docs`, `docs/config-generator`, `docs/rest-api`).
 
@@ -96,6 +103,8 @@ subpackages are an exception. Read this before adding one:
   it runs in `app-rest`. A `storage.impl.*` / `event.*` subpackage that is
   already covered by one of the storage-variant include filters
   (`app-sql`, `app-kafkasql`, `app-gitops`, `app-kubernetesops`) runs there.
+  `auth`/`rbac`/`limits`, `tls`/`headers`/`cors`, and `metrics`/`search` run in
+  `app-auth`, `app-transport`, and `app-metrics` respectively.
   Everything else lands in `app-other` (the exclusion-based shard).
 - **In any other module**: runs in `non-app`.
 

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -42,9 +42,29 @@ jobs:
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=io.apicurio.registry.storage.impl.kubernetesops.**"
             maven-opts: "-Xmx4g -Dassembly.skipAssembly=true"
+          # app-auth / app-transport / app-metrics are carved out of app-other. Each @TestProfile in a
+          # shard forces Quarkus to tear down and rebuild the application in the single forked JVM
+          # (forkCount=1 with the default reuseForks=true), and app-other had accumulated 42 distinct
+          # profiles across 148 classes -- four times the next-densest shard. That is what exhausted the
+          # heap and pushed the shard past an hour. These three groups are the profile-dense clusters.
+          # See issue #9265.
+          - name: app-auth
+            modules: "-pl app -am -Dfull -DcliSkipNative"
+            test-filter: "-Dtest=io.apicurio.registry.auth.**,io.apicurio.registry.rbac.**,io.apicurio.registry.limits.**"
+            maven-opts: "-Xmx4g -Dassembly.skipAssembly=true"
+          - name: app-transport
+            modules: "-pl app -am -Dfull -DcliSkipNative"
+            test-filter: "-Dtest=io.apicurio.registry.tls.**,io.apicurio.registry.headers.**,io.apicurio.registry.cors.**"
+            maven-opts: "-Xmx4g -Dassembly.skipAssembly=true"
+          - name: app-metrics
+            modules: "-pl app -am -Dfull -DcliSkipNative"
+            test-filter: "-Dtest=io.apicurio.registry.metrics.**,io.apicurio.registry.search.**"
+            maven-opts: "-Xmx4g -Dassembly.skipAssembly=true"
+          # Catch-all: stays an exclusion filter so a newly added package lands here rather than in no
+          # shard at all. Every exclusion below must correspond to another shard's inclusion.
           - name: app-other
             modules: "-pl app -am -Dfull -DcliSkipNative"
-            test-filter: "-Dtest=!io.apicurio.registry.noprofile.rest.**,!io.apicurio.registry.noprofile.ccompat.**,!io.apicurio.registry.storage.**,!io.apicurio.registry.event.**"
+            test-filter: "-Dtest=!io.apicurio.registry.noprofile.rest.**,!io.apicurio.registry.noprofile.ccompat.**,!io.apicurio.registry.storage.**,!io.apicurio.registry.event.**,!io.apicurio.registry.auth.**,!io.apicurio.registry.rbac.**,!io.apicurio.registry.limits.**,!io.apicurio.registry.tls.**,!io.apicurio.registry.headers.**,!io.apicurio.registry.cors.**,!io.apicurio.registry.metrics.**,!io.apicurio.registry.search.**"
             maven-opts: "-Xmx4g -Dassembly.skipAssembly=true"
           - name: non-app
             modules: "-Dfull -DcliSkipNative -pl !app,!distro/docker,!docs,!docs/config-generator,!docs/rest-api"

--- a/.github/workflows/verify-unit-tests.yaml
+++ b/.github/workflows/verify-unit-tests.yaml
@@ -45,9 +45,10 @@ jobs:
           # app-auth / app-transport / app-metrics are carved out of app-other. Each @TestProfile in a
           # shard forces Quarkus to tear down and rebuild the application in the single forked JVM
           # (forkCount=1 with the default reuseForks=true), and app-other had accumulated 42 distinct
-          # profiles across 148 classes -- four times the next-densest shard. That is what exhausted the
+          # profiles across 147 classes -- four times the next-densest shard. That is what exhausted the
           # heap and pushed the shard past an hour. These three groups are the profile-dense clusters.
-          # See issue #9265.
+          # Counts come from .github/scripts/verify-test-shards.py, which is also what enforces that
+          # every class below is claimed by exactly one shard. See issue #9265.
           - name: app-auth
             modules: "-pl app -am -Dfull -DcliSkipNative"
             test-filter: "-Dtest=io.apicurio.registry.auth.**,io.apicurio.registry.rbac.**,io.apicurio.registry.limits.**"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -287,6 +287,13 @@ jobs:
       - name: Run linter
         run: ./scripts/validate-files.sh
 
+      # Fails if any app/ test class is claimed by zero shards (it would never run in CI, and
+      # -Dsurefire.failIfNoSpecifiedTests=false means no shard would complain) or by more than
+      # one (wasted runner time). Runs here rather than in verify-unit-tests.yaml so it is checked
+      # once instead of once per shard, and so it fails fast. See issue #9265.
+      - name: Verify unit test shard partition
+        run: python3 .github/scripts/verify-test-shards.py
+
       - name: Verify docs generation
         run: |
           if [ -n "$(git status --untracked-files=no --porcelain docs)" ]; then

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -21,6 +21,8 @@
          Without this, Java 25+ treats the literal '@{argLine}' as an arg file reference
          and fails with 'could not open {argLine}'. -->
     <argLine/>
+    <!-- Max heap for the forked surefire JVM that runs the tests. -->
+    <surefire.maxHeap>4g</surefire.maxHeap>
   </properties>
 
   <dependencies>
@@ -517,7 +519,10 @@
         <configuration>
           <groups>${groups}</groups>
           <forkCount>1</forkCount>
-          <argLine>@{argLine} -Xmx4g</argLine>
+          <!-- This, not MAVEN_OPTS, is the heap the tests actually run in: surefire forks a JVM and
+               MAVEN_OPTS only sizes the Maven process that spawns it. Override per CI shard with
+               -Dsurefire.maxHeap=<size>. See issue #9265. -->
+          <argLine>@{argLine} -Xmx${surefire.maxHeap}</argLine>
           <forkedProcessExitTimeoutInSeconds>1800</forkedProcessExitTimeoutInSeconds>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>


### PR DESCRIPTION
## Summary

Splits the `app-other` unit test shard, which fails with a `Java heap space` OOM
in the Surefire forked JVM.

Fixes #9265

## Root Cause

Surefire runs a shard in one forked JVM (`forkCount=1`, `reuseForks=true` by
default), and every distinct `@TestProfile` makes Quarkus tear down and rebuild
the whole application inside it. `app-other` had 42 distinct profiles across 147
classes — four times the next-densest shard — which exhausted its 4 GB heap.

Note the heap was not where the issue suggested: `MAVEN_OPTS` sizes the Maven
process, while the test JVM's heap came from a hardcoded `-Xmx4g` in
`app/pom.xml`.

## Changes

- **`verify-unit-tests.yaml`** — carved the profile-dense clusters out of
  `app-other` into `app-auth` (auth, rbac, limits), `app-transport` (tls,
  headers, cors) and `app-metrics` (metrics, search). `app-other` stays an
  exclusion filter so new packages still land somewhere. Worst-shard profile
  count drops 42 → 15.
- **`app/pom.xml`** — forked-JVM heap is now `-Xmx${surefire.maxHeap}`, default
  `4g` (unchanged), overridable per shard.
- **`.github/scripts/verify-test-shards.py`** (new) — implements Surefire's
  `-Dtest=` matching and fails if any test class is claimed by zero or more than
  one shard.
- **`workflows/README.md`** — updated shard table; documented that boundaries
  are set by profile density.

## Test plan

- [x] Partition exact: 253 classes, 0 orphans, 0 duplicates
- [x] Coverage unchanged: new shards match the same 147 classes as the old filter
- [x] Checker catches deliberate orphan and duplicate sabotages (exit 1)
- [x] OOM reproduced before the fix: `BUILD FAILURE`, 2543 s, 20 `Java heap
      space` lines, 390 app tests completed
- [x] Fixed on the same host at the same `-Xmx4g`: `BUILD SUCCESS`, 175 s, 0 heap
      errors, 669 app tests
- [x] New shards pass with their CI filters (`app-auth` 192, `app-transport` 78,
      `app-metrics` 64)
- [x] Heap property verified on the forked command line (`maxHeap=6g` → `-Xmx6g`;
      `MAVEN_OPTS=-Xmx512m` → still `-Xmx4g`)
- [x] CI confirmation — a green `app-other` across a few real runs

**Storage variants:** N/A — CI configuration only, no product code changed.
