### PR TITLE
fix(rules): flag outputSchema removal in MCP tool compatibility (#9297)

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -18,6 +18,7 @@ import java.util.Set;
  * - Adding required parameters: Backward incompatible
  * - Removing required parameters: Backward incompatible
  * - Changing inputSchema type: Backward incompatible
+ * - Removing outputSchema, or a property of it: Backward incompatible
  * - Changing name, title, description, annotations: Always compatible
  */
 public class McpToolCompatibilityChecker
@@ -45,6 +46,9 @@ public class McpToolCompatibilityChecker
 
             // Check removed required parameters
             checkRequiredParamRemovals(existingNode, proposedNode, differences);
+
+            // Check removed output schema or output properties
+            checkOutputSchemaCompatibility(existingNode, proposedNode, differences);
 
         } catch (Exception e) {
             differences.add(new McpToolCompatibilityDifference(
@@ -106,6 +110,38 @@ public class McpToolCompatibilityChecker
                 differences.add(new McpToolCompatibilityDifference(
                         McpToolCompatibilityDifference.Type.REQUIRED_PARAM_REMOVED,
                         "Required parameter '" + param + "' was removed"));
+            }
+        }
+    }
+
+    private void checkOutputSchemaCompatibility(JsonNode existing, JsonNode proposed,
+            Set<McpToolCompatibilityDifference> differences) {
+        JsonNode existingSchema = existing.get("outputSchema");
+        if (existingSchema == null || !existingSchema.isObject()) {
+            return;
+        }
+
+        JsonNode proposedSchema = proposed.get("outputSchema");
+        if (proposedSchema == null || !proposedSchema.isObject()) {
+            differences.add(new McpToolCompatibilityDifference(
+                    McpToolCompatibilityDifference.Type.OUTPUT_SCHEMA_REMOVED,
+                    "Output schema was removed"));
+            return;
+        }
+
+        JsonNode existingProps = existingSchema.get("properties");
+        if (existingProps == null || !existingProps.isObject()) {
+            return;
+        }
+
+        JsonNode proposedProps = proposedSchema.get("properties");
+        Iterator<String> propNames = existingProps.fieldNames();
+        while (propNames.hasNext()) {
+            String propName = propNames.next();
+            if (proposedProps == null || !proposedProps.has(propName)) {
+                differences.add(new McpToolCompatibilityDifference(
+                        McpToolCompatibilityDifference.Type.OUTPUT_SCHEMA_PROPERTY_REMOVED,
+                        "Output property '" + propName + "' was removed"));
             }
         }
     }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityDifference.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityDifference.java
@@ -14,6 +14,8 @@ public class McpToolCompatibilityDifference implements CompatibilityDifference {
         REQUIRED_PARAM_REMOVED("inputSchema/required"),
         INPUT_SCHEMA_TYPE_CHANGED("inputSchema/type"),
         PROPERTY_REMOVED("inputSchema/properties"),
+        OUTPUT_SCHEMA_REMOVED("outputSchema"),
+        OUTPUT_SCHEMA_PROPERTY_REMOVED("outputSchema/properties"),
         PARSE_ERROR("document");
 
         private final String context;

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -309,6 +309,141 @@ class McpToolCompatibilityCheckerTest {
     }
 
     @Test
+    void testBackwardIncompatibleRemovingOutputSchema() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    },
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "results": { "type": "array" },
+                            "total": { "type": "integer" }
+                        }
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Removing outputSchema should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleRemovingOutputSchemaProperty() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    },
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "results": { "type": "array" },
+                            "total": { "type": "integer" }
+                        }
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    },
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "results": { "type": "array" }
+                        }
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Removing an outputSchema property should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardCompatibleAddingOutputSchemaProperty() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    },
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "results": { "type": "array" }
+                        }
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    },
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "results": { "type": "array" },
+                            "total": { "type": "integer" }
+                        }
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Adding an outputSchema property should be backward compatible");
+    }
+
+    @Test
     void testFullCompatibilityBothDirections() {
         String existing = """
                 {


### PR DESCRIPTION
## What

`McpToolCompatibilityChecker` now checks `outputSchema` when comparing two versions of an MCP tool.
Removing the `outputSchema` object, or removing one of its properties, is reported as backward
incompatible.

## Why

The checker only ever read `inputSchema`, so a tool could delete its whole declared output contract
and the rule still returned compatible. A client depending on that tool's `structuredContent` then
breaks at call time with nothing flagged at registration.

`PROMPT_TEMPLATE` already treats the same change as breaking, in
`PromptTemplateCompatibilityChecker.checkOutputSchemaCompatibility`. Both types extend
`AbstractCompatibilityChecker` and both support an optional `outputSchema`, so the two were
inconsistent for no clear reason.

## How

Added `checkOutputSchemaCompatibility`, following the prompt template implementation so the two
behave the same way, plus two values on `McpToolCompatibilityDifference.Type`,
`OUTPUT_SCHEMA_REMOVED` and `OUTPUT_SCHEMA_PROPERTY_REMOVED`, using the same JSON pointer context
style as the existing input scoped values.

No change to the input side, and no change to how compatibility levels are evaluated.

## Testing

Three cases added to `McpToolCompatibilityCheckerTest`: removing `outputSchema` entirely, removing
a single property from it, and adding a property staying compatible. All 12 tests in the class pass.

Both new incompatibility tests fail against unmodified `main` with `expected: <false> but was:
<true>`, so they cover the reported behaviour rather than restating current behaviour.

`checkstyle:check` passes on `schema-util/common` and `schema-util/util-provider`.

Closes #9297
