### PR TITLE
feat(cli): auto-save group and artifact IDs to context

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -207,11 +207,12 @@ acr config delete <property-name>
 
 #### Configuration Properties
 
-| Property                             | Default | Description                                                                                  |
-|---------------------------------------|---------|-----------------------------------------------------------------------------------------------|
-| `update.check-enabled`               | `true`  | Enable automatic update checks                                                               |
-| `update.timeout-seconds`             | `60`    | Timeout for update network requests                                                          |
-| `update.skip-checksum-verification`  | `false` | Skip SHA-256 verification of downloaded archives (for custom repos without `.sha256` files)  |
+| Property                             | Default | Description                                                                                                             |
+|---------------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------|
+| `update.check-enabled`               | `true`  | Enable automatic update checks                                                                                          |
+| `update.timeout-seconds`             | `60`    | Timeout for update network requests                                                                                     |
+| `update.skip-checksum-verification`  | `false` | Skip SHA-256 verification of downloaded archives (for custom repos without `.sha256` files)                             |
+| `context.auto-update`                | `false` | Automatically save the group/artifact ID to the current context after `group create`/`get` and `artifact create`/`get` |
 
 #### Logging
 
@@ -271,6 +272,15 @@ acr context delete --all
 ```
 
 Use `--no-switch-current` when creating a context to add it without switching to it.
+
+**Auto context update:**
+```bash
+acr config set context.auto-update=true
+```
+When enabled, `group create`/`get` and `artifact create`/`get` automatically save the resolved group and/or
+artifact ID to the current context, so subsequent commands don't need repeated `-g`/`-a` flags. Switching to a
+different group clears the artifact ID from the context, since the previous artifact no longer applies; re-getting
+the same group leaves it untouched. Disabled by default.
 
 ### Authentication
 

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCreateCommand.java
@@ -132,6 +132,7 @@ public class ArtifactCreateCommand extends AbstractCommand {
                 .groups().byGroupId(resolvedGroupId).artifacts().post(newArtifact);
         //noinspection ConstantConditions
         final var artifact = convert(result.getArtifact());
+        IdUtil.updateArtifactContext(resolvedGroupId, artifact.getArtifactId(), config, output);
         switch (outputType.getOutputType()) {
             case json -> output.writeStdErrChunk(out -> successMessage(out, resolvedGroupId, artifact.getArtifactId()));
             case table -> output.writeStdOutChunk(out -> successMessage(out, resolvedGroupId, artifact.getArtifactId()));

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactGetCommand.java
@@ -80,6 +80,7 @@ public class ArtifactGetCommand extends AbstractCommand {
         } else {
             fetchMetadata(registryClient, resolvedGroupId, output);
         }
+        IdUtil.updateArtifactContext(resolvedGroupId, artifactId, config, output);
     }
 
     // Fetches the raw content of the latest version of the artifact.

--- a/cli/src/main/java/io/apicurio/registry/cli/common/IdUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/IdUtil.java
@@ -1,7 +1,11 @@
 package io.apicurio.registry.cli.common;
 
 import io.apicurio.registry.cli.config.Config;
+import io.apicurio.registry.cli.config.ConfigModel;
+import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.RegistryClient;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 import io.apicurio.registry.rest.v3.beans.GroupSearchResults;
 import io.apicurio.registry.rest.v3.beans.SearchedGroup;
@@ -17,6 +21,8 @@ import static io.apicurio.registry.cli.utils.Utils.isBlank;
 public final class IdUtil {
 
     public static final String DEFAULT_GROUP = "default";
+
+    private static final String AUTO_CONTEXT_UPDATE_PROPERTY = "context.auto-update";
 
     private IdUtil() {
     }
@@ -54,6 +60,61 @@ public final class IdUtil {
         }
         throw new CliException("Artifact ID is required. Provide it via --artifact or set it in the context.",
                 VALIDATION_ERROR_RETURN_CODE);
+    }
+
+    /**
+     * Saves the given group ID to the current context, if the {@code context.auto-update} property is enabled.
+     * Clears the context's artifact ID when the group actually changes, since an artifact from a
+     * different group no longer applies.
+     */
+    public static void updateGroupContext(final String groupId, final Config config, final OutputBuffer output) {
+        Objects.requireNonNull(groupId);
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(output);
+        updateContext(config, output, context -> {
+            if (!groupId.equals(context.getGroupId())) {
+                context.setArtifactId(null);
+            }
+            context.setGroupId(groupId);
+        });
+    }
+
+    /**
+     * Saves the given group and artifact IDs to the current context, if the {@code context.auto-update}
+     * property is enabled.
+     */
+    public static void updateArtifactContext(final String groupId, final String artifactId, final Config config,
+                                              final OutputBuffer output) {
+        Objects.requireNonNull(groupId);
+        Objects.requireNonNull(artifactId);
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(output);
+        updateContext(config, output, context -> {
+            context.setGroupId(groupId);
+            context.setArtifactId(artifactId);
+        });
+    }
+
+    private static void updateContext(final Config config, final OutputBuffer output,
+                                       final Consumer<ConfigModel.Context> mutator) {
+        if (!"true".equalsIgnoreCase(config.read().getConfig().get(AUTO_CONTEXT_UPDATE_PROPERTY))) {
+            return;
+        }
+        final var configModel = config.read();
+        final var contextName = configModel.getCurrentContext();
+        if (isBlank(contextName)) {
+            return;
+        }
+        final var context = configModel.getContext().get(contextName);
+        if (context == null) {
+            return;
+        }
+        mutator.accept(context);
+        try {
+            config.write(configModel);
+        } catch (Exception ex) {
+            output.writeStdErrChunk(out -> out.append("Warning: Could not update context: ").append(ex.getMessage()).append("\n"));
+        }
     }
 
     // Validates the group exists. Skips validation for the "default" group as it is implicit.

--- a/cli/src/main/java/io/apicurio/registry/cli/common/IdUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/IdUtil.java
@@ -1,11 +1,9 @@
 package io.apicurio.registry.cli.common;
 
 import io.apicurio.registry.cli.config.Config;
-import io.apicurio.registry.cli.config.ConfigModel;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.rest.client.RegistryClient;
 import java.util.Objects;
-import java.util.function.Consumer;
 
 import io.apicurio.registry.rest.v3.beans.GroupSearchResults;
 import io.apicurio.registry.rest.v3.beans.SearchedGroup;
@@ -21,8 +19,6 @@ import static io.apicurio.registry.cli.utils.Utils.isBlank;
 public final class IdUtil {
 
     public static final String DEFAULT_GROUP = "default";
-
-    private static final String AUTO_CONTEXT_UPDATE_PROPERTY = "context.auto-update";
 
     private IdUtil() {
     }
@@ -71,12 +67,19 @@ public final class IdUtil {
         Objects.requireNonNull(groupId);
         Objects.requireNonNull(config);
         Objects.requireNonNull(output);
-        updateContext(config, output, context -> {
-            if (!groupId.equals(context.getGroupId())) {
-                context.setArtifactId(null);
-            }
-            context.setGroupId(groupId);
-        });
+        if (!config.isAutoUpdateEnabled()) {
+            return;
+        }
+        try {
+            config.updateCurrentContext(context -> {
+                if (!groupId.equals(context.getGroupId())) {
+                    context.setArtifactId(null);
+                }
+                context.setGroupId(groupId);
+            });
+        } catch (Exception ex) {
+            output.writeStdErrChunk(out -> out.append("Warning: Could not update context: ").append(ex.getMessage()).append("\n"));
+        }
     }
 
     /**
@@ -89,29 +92,14 @@ public final class IdUtil {
         Objects.requireNonNull(artifactId);
         Objects.requireNonNull(config);
         Objects.requireNonNull(output);
-        updateContext(config, output, context -> {
-            context.setGroupId(groupId);
-            context.setArtifactId(artifactId);
-        });
-    }
-
-    private static void updateContext(final Config config, final OutputBuffer output,
-                                       final Consumer<ConfigModel.Context> mutator) {
-        if (!"true".equalsIgnoreCase(config.read().getConfig().get(AUTO_CONTEXT_UPDATE_PROPERTY))) {
+        if (!config.isAutoUpdateEnabled()) {
             return;
         }
-        final var configModel = config.read();
-        final var contextName = configModel.getCurrentContext();
-        if (isBlank(contextName)) {
-            return;
-        }
-        final var context = configModel.getContext().get(contextName);
-        if (context == null) {
-            return;
-        }
-        mutator.accept(context);
         try {
-            config.write(configModel);
+            config.updateCurrentContext(context -> {
+                context.setGroupId(groupId);
+                context.setArtifactId(artifactId);
+            });
         } catch (Exception ex) {
             output.writeStdErrChunk(out -> out.append("Warning: Could not update context: ").append(ex.getMessage()).append("\n"));
         }

--- a/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/config/Config.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.Setter;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -26,6 +27,8 @@ import static java.lang.System.out;
 
 @ApplicationScoped
 public class Config {
+
+    private static final String CONTEXT_AUTO_UPDATE_PROPERTY = "context.auto-update";
 
     /**
      * Static reference for use by {@link AcrHomeConfigSource}, which is loaded via SPI
@@ -197,6 +200,31 @@ public class Config {
         } catch (RuntimeException ex) {
             return false;
         }
+    }
+
+    /**
+     * Whether the {@code context.auto-update} property is enabled.
+     */
+    public boolean isAutoUpdateEnabled() {
+        return Boolean.parseBoolean(read().getConfig().get(CONTEXT_AUTO_UPDATE_PROPERTY));
+    }
+
+    /**
+     * Applies {@code mutator} to the current context and persists the result. No-op if there is no
+     * current context set, or if the current context does not exist.
+     */
+    public void updateCurrentContext(final Consumer<ConfigModel.Context> mutator) {
+        final var model = read();
+        final var contextName = model.getCurrentContext();
+        if (isBlank(contextName)) {
+            return;
+        }
+        final var context = model.getContext().get(contextName);
+        if (context == null) {
+            return;
+        }
+        mutator.accept(context);
+        write(model);
     }
 
     /**

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupCreateCommand.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.cli.group;
 
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.Conversions;
 import io.apicurio.registry.cli.utils.OutputBuffer;
@@ -64,6 +65,7 @@ public class GroupCreateCommand extends AbstractCommand {
             newGroup.setLabels(newLabels);
         }
         var group = convert(client.getRegistryClient().groups().post(newGroup));
+        IdUtil.updateGroupContext(group.getGroupId(), config, output);
         switch (outputType.getOutputType()) {
             case json -> output.writeStdErrChunk(out -> successMessage(out, group.getGroupId()));
             case table -> output.writeStdOutChunk(out -> successMessage(out, group.getGroupId()));

--- a/cli/src/main/java/io/apicurio/registry/cli/group/GroupGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/group/GroupGetCommand.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.cli.group;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
@@ -57,6 +58,7 @@ public class GroupGetCommand extends AbstractCommand {
             //noinspection ConstantConditions
             group = convert(client.getRegistryClient().groups().byGroupId(groupId).get());
         }
+        IdUtil.updateGroupContext(group.getGroupId(), config, output);
         // TODO: Should we include the `default` group in the list?
         printGroup(output, group, outputType);
     }

--- a/cli/src/test/java/io/apicurio/registry/cli/AutoContextUpdateTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/AutoContextUpdateTest.java
@@ -1,0 +1,154 @@
+package io.apicurio.registry.cli;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the {@code context.auto-update} configuration property, which automatically saves
+ * the group/artifact ID to the current context after group and artifact create/get commands.
+ */
+@QuarkusTest
+public class AutoContextUpdateTest extends AbstractCLITest {
+
+    @AfterEach
+    public void disableAutoContextUpdate() {
+        executeAndAssertSuccess("config", "set", "context.auto-update=false");
+    }
+
+    @Test
+    public void testDisabledByDefaultOnGroupCreate() {
+        executeAndAssertSuccess("group", "create", "actx-disabled-group");
+
+        var context = config.read().getContext().get("test");
+        assertThat(context.getGroupId())
+                .as(withCliOutput("Context should not be updated when auto-update is disabled"))
+                .isNull();
+    }
+
+    @Test
+    public void testDisabledByDefaultOnArtifactCreate() throws Exception {
+        var tempFile = writeTempSchema("actx-disabled-schema");
+        try {
+            executeAndAssertSuccess("artifact", "create", "--group", "default", "--type", "JSON",
+                    "--file", tempFile.toString(), "actx-disabled-artifact");
+
+            var context = config.read().getContext().get("test");
+            assertThat(context.getArtifactId())
+                    .as(withCliOutput("Context should not be updated when auto-update is disabled"))
+                    .isNull();
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    public void testGroupCreateUpdatesContext() {
+        executeAndAssertSuccess("config", "set", "context.auto-update=true");
+
+        executeAndAssertSuccess("group", "create", "actx-group-create");
+
+        var context = config.read().getContext().get("test");
+        assertThat(context.getGroupId())
+                .as(withCliOutput("Context group ID should be updated after group create"))
+                .isEqualTo("actx-group-create");
+    }
+
+    @Test
+    public void testGroupGetUpdatesContext() {
+        executeAndAssertSuccess("group", "create", "actx-group-get");
+        executeAndAssertSuccess("config", "set", "context.auto-update=true");
+
+        executeAndAssertSuccess("group", "get", "actx-group-get");
+
+        var context = config.read().getContext().get("test");
+        assertThat(context.getGroupId())
+                .as(withCliOutput("Context group ID should be updated after group get"))
+                .isEqualTo("actx-group-get");
+    }
+
+    @Test
+    public void testArtifactCreateUpdatesContext() throws Exception {
+        executeAndAssertSuccess("config", "set", "context.auto-update=true");
+        var tempFile = writeTempSchema("actx-create-schema");
+        try {
+            executeAndAssertSuccess("artifact", "create", "--group", "default", "--type", "JSON",
+                    "--file", tempFile.toString(), "actx-artifact-create");
+
+            var context = config.read().getContext().get("test");
+            assertThat(context.getGroupId())
+                    .as(withCliOutput("Context group ID should be updated after artifact create"))
+                    .isEqualTo("default");
+            assertThat(context.getArtifactId())
+                    .as(withCliOutput("Context artifact ID should be updated after artifact create"))
+                    .isEqualTo("actx-artifact-create");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    public void testArtifactGetUpdatesContext() throws Exception {
+        var tempFile = writeTempSchema("actx-get-schema");
+        try {
+            executeAndAssertSuccess("artifact", "create", "--group", "default", "--type", "JSON",
+                    "--file", tempFile.toString(), "actx-artifact-get");
+            executeAndAssertSuccess("config", "set", "context.auto-update=true");
+
+            executeAndAssertSuccess("artifact", "get", "--group", "default", "actx-artifact-get");
+
+            var context = config.read().getContext().get("test");
+            assertThat(context.getGroupId())
+                    .as(withCliOutput("Context group ID should be updated after artifact get"))
+                    .isEqualTo("default");
+            assertThat(context.getArtifactId())
+                    .as(withCliOutput("Context artifact ID should be updated after artifact get"))
+                    .isEqualTo("actx-artifact-get");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    public void testGroupChangeClearsArtifactFromContext() {
+        executeAndAssertSuccess("group", "create", "actx-group-a");
+        executeAndAssertSuccess("group", "create", "actx-group-b");
+        executeAndAssertSuccess("context", "update", "--group", "actx-group-a", "--artifact", "stale-artifact");
+        executeAndAssertSuccess("config", "set", "context.auto-update=true");
+
+        executeAndAssertSuccess("group", "get", "actx-group-b");
+
+        var context = config.read().getContext().get("test");
+        assertThat(context.getGroupId())
+                .as(withCliOutput("Context group ID should reflect the newly retrieved group"))
+                .isEqualTo("actx-group-b");
+        assertThat(context.getArtifactId())
+                .as(withCliOutput("Switching to a different group should clear the stale artifact ID"))
+                .isNull();
+    }
+
+    @Test
+    public void testSameGroupGetPreservesArtifactInContext() {
+        executeAndAssertSuccess("group", "create", "actx-group-same");
+        executeAndAssertSuccess("context", "update", "--group", "actx-group-same", "--artifact", "kept-artifact");
+        executeAndAssertSuccess("config", "set", "context.auto-update=true");
+
+        executeAndAssertSuccess("group", "get", "actx-group-same");
+
+        var context = config.read().getContext().get("test");
+        assertThat(context.getArtifactId())
+                .as(withCliOutput("Re-getting the same group should not clear the artifact ID"))
+                .isEqualTo("kept-artifact");
+    }
+
+    private Path writeTempSchema(String prefix) throws Exception {
+        var tempFile = Files.createTempFile(prefix, ".json");
+        Files.writeString(tempFile, "{\"type\": \"string\"}");
+        return tempFile;
+    }
+}


### PR DESCRIPTION


## Summary

Adds an opt-in `context.auto-update` configuration property. When enabled, `group create`/`get` and `artifact create`/`get` automatically save the resolved group and/or artifact ID to the current context, so subsequent commands don't need repeated `-g`/`-a` flags.

Fixes #8022.

## Changes

### Context auto-update (`IdUtil`)
- Added `updateGroupContext(groupId, config, output)` and  `updateArtifactContext(groupId, artifactId, config, output)`, both gated by the  `context.auto-update` property (default: disabled).
- `updateGroupContext` only clears the context's `artifactId` when the group actually
  changes — re-inspecting the group you're already working in (e.g. `group get` on the current group) leaves the artifact untouched.
- A failure while writing the context is caught and reported as a stderr warning rather than failing the command, since the primary group/artifact operation already succeeded.

### Wiring (`GroupCreateCommand`, `GroupGetCommand`, `ArtifactCreateCommand`, `ArtifactGetCommand`)
- Each command calls the corresponding `IdUtil` method after a successful create/get, using the resolved (not raw user-supplied) group ID so context stays accurate whether the user passed `-g` explicitly, relied on the existing context, or fell back to  `default`.

### Documentation (`cli/README.md`)
- Documented `context.auto-update` in the configuration properties table and added a  short note under Context Management explaining the enable command and the  group-change/artifact-clear behavior.

## Testing

- `AutoContextUpdateTest` (new): disabled-by-default for both group and artifact  create, context updates after group/artifact create and get, group-change clears the  stale artifact ID, and re-getting the same group preserves it.
- `./mvnw checkstyle:check -pl cli` — 0 violations.
- `./mvnw test -pl cli` — 293 passed, 0 failed.
- Manual end-to-end verification against a live registry container using the exact
  `acr group add` / `acr artifact add` / `acr artifact version add` sequence from the  issue, with no `-g`/`-a` flags — confirmed the context populates correctly and downstream commands resolve group/artifact from it.

## Notes

- Only `group`/`artifact` `create` and `get` update the context, matching the issue's acceptance criteria. `artifact version add` and other subcommands already resolve  group/artifact from context via the pre-existing `IdUtil.resolveGroupId` /
  `resolveArtifactId` — no changes were needed there.
