### PR TITLE
chore(build): include serdes and maven-plugin in local build tier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,60 +2,25 @@
 
 Open-source API and Schema Registry. Apache 2.0 license, DCO sign-off required on all commits.
 
-## Build & Test Commands
+## Build & Test
 
-```bash
-./mvnw clean install -DskipTests        # Full build, skip tests
-./mvnw clean install                     # Full build with unit tests
-./mvnw quarkus:dev                       # Dev mode (run from app/)
-./mvnw test -pl <module>                 # Run tests for a specific module
-./mvnw checkstyle:check -pl <module>     # Run checkstyle for a module
-./mvnw verify -Pintegration-tests -pl integration-tests -am  # Integration tests
-```
-
-UI (separate build system):
-```bash
-cd ui && npm install && npm run build    # Build UI
-cd ui/ui-app && npm run dev              # UI dev server
-```
+See [DEVELOPING.md](DEVELOPING.md) for build tiers, build properties, testing, and IDE setup.
+See [README.md](README.md) for a quick-start guide.
 
 ## Architecture
 
-Multi-module Maven project (~30 modules). Java 17 (source), Java 21 (runtime). Quarkus 3.27.2.
+Multi-module Maven project. Quarkus-based. Storage variants and build configuration are
+documented in [DEVELOPING.md](DEVELOPING.md).
 
-### Key Modules
-
-| Module | Purpose |
-|--------|---------|
-| `app/` | Main Quarkus application (REST API, auth, storage orchestration) |
-| `common/` | Shared models, interfaces, DTOs |
-| `storage/` | Storage layer implementations (under `app/src/.../storage/impl/`) |
-| `ui/` | React + TypeScript frontend (ui-app/, ui-docs/, ui-editors/) |
-| `java-sdk/`, `go-sdk/`, `python-sdk/`, `typescript-sdk/` | Client SDKs |
-| `serdes/` | Kafka/NATS/Pulsar serializers/deserializers |
-| `schema-util/` | Schema type utilities (Avro, Protobuf, JSON Schema, OpenAPI, etc.) |
-| `integration-tests/` | Cross-module integration test suite |
-| `operator/` | Kubernetes operator |
-| `mcp/` | MCP server (Model Context Protocol, uses quarkus-mcp-server-stdio) |
-| `cli/` | Command-line interface |
-
-### Storage Variants
-
-Selected via `APICURIO_STORAGE_KIND` environment variable:
-
-- **sql** (default) — PostgreSQL via JDBC. Canonical implementation.
-- **kafkasql** — Kafka journal + SQL snapshot. State changes replicated via Kafka topics.
-- **gitops** — Git repository as backing store. Read-only mode.
-- **kubernetesops** — Kubernetes ConfigMaps as backing store.
-
-Implementations: `app/src/main/java/io/apicurio/registry/storage/impl/`
+Storage implementations: `app/src/main/java/io/apicurio/registry/storage/impl/`
 
 ## Conventions
 
 ### Commit Messages
-Conventional Commits format: `<type>(<scope>): <description> (#PR)`
 
-Types: `feat`, `fix`, `chore`, `docs`, `ci`, `test`, `refactor`
+Conventional Commits format: `<type>(<scope>): <description> (#PR)`
+Types: `feat`, `fix`, `chore`, `docs`, `ci`, `test`, `refactor`.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full commit and PR guidelines.
 
 ### Code Style
 
@@ -103,15 +68,15 @@ Other conventions:
 - Never expose stack traces or internal errors to API clients
 
 ### Testing
-- Unit tests: `@QuarkusTest` annotation, same module under `src/test/`
-- Integration tests: `integration-tests/` module
-- Profiles: `local-tests`, `remote-mem`, `remote-sql`, `remote-kafka`
-- Storage-touching features must work across all variants
+
+See [DEVELOPING.md](DEVELOPING.md) for test commands and [CONTRIBUTING.md](CONTRIBUTING.md) for
+storage-variant testing requirements. Storage-touching features must work across all variants.
 
 ## Contributor Checklist (external contributors)
 
 Before opening a PR, verify every item. PRs that skip these get sent back.
 Project committers have more latitude but should still follow the Code and Tests sections.
+Full contribution guidelines are in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Before writing code
 - [ ] **One PR at a time.** Do not open a second PR until your first one is merged. Maintainers will close additional PRs with "one PR at a time" — no exceptions, even if the work is ready.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -49,13 +49,13 @@ The project uses a three-tier build system to allow developers to build only wha
 
 | Tier        | Flag      | What's included                                         | Use case                           |
 |-------------|-----------|--------------------------------------------------------|------------------------------------|
-| **Local**   | `-Dlocal` | Core server, Java SDK, schema utilities — skips javadoc, source JARs, checkstyle, assembly | Quick local development iteration |
-| **Default** | *(none)*  | Local + serializers, CLI, docs, distribution            | Normal development                 |
+| **Local**   | `-Dlocal` | Core server, Java SDK, schema utilities, serializers — skips javadoc, source JARs, checkstyle, assembly | Quick local development iteration |
+| **Default** | *(none)*  | Local + CLI, docs, distribution                         | Normal development                 |
 | **Full**    | `-Dfull`  | Default + MCP server, Go SDK, operator, extra utilities | CI builds, releases                |
 
 ```bash
-# Local: core server only, skip non-essential plugins (~3 min)
-./mvnw clean install -Dlocal -Dmaven.test.skip=true
+# Local: core server + serializers, skip non-essential plugins
+./mvnw clean install -Dlocal -DskipTests
 
 # Default: normal development
 ./mvnw clean install -DskipTests
@@ -64,14 +64,10 @@ The project uses a three-tier build system to allow developers to build only wha
 ./mvnw clean install -Dfull -DskipTests
 ```
 
-**Note:** the *local* tier requires `-Dmaven.test.skip=true` rather than `-DskipTests`.
-The local tier excludes the serde and Maven plugin modules, but the `app` module's test
-sources import packages from them, so `-DskipTests` (which still compiles test sources)
-fails at test compilation. `-Dmaven.test.skip=true` skips test compilation entirely.
-The same applies to dev mode, which also compiles test sources:
+Dev mode:
 
 ```bash
-cd app && ../mvnw quarkus:dev -Dlocal -Dmaven.test.skip=true
+cd app && ../mvnw quarkus:dev -Dlocal
 ```
 
 Integration tests and examples are always opt-in via their own profiles:
@@ -83,19 +79,17 @@ Integration tests and examples are always opt-in via their own profiles:
 |-----------------------|------------------------------------------------------------------------------------------|
 | `-Pprod`              | Enables Quarkus *prod* configuration profile (higher logging level, production defaults) |
 | `-DskipTests`         | Skip running tests (test sources are still compiled)                                     |
-| `-Dmaven.test.skip=true` | Skip compiling and running tests (required with `-Dlocal`)                            |
+| `-Dmaven.test.skip=true` | Skip compiling and running tests                                                      |
 | `-DcliSkipNative`     | Skip CLI native image compilation (no executable is produced, but tests can still run)   |
 | `-DskipOperatorTests` | Skip operator tests (default: `true`, requires a running cluster)                        |
 
 ## Dependency Analysis
 
 `dependency:analyze` cannot be run directly over the full reactor: the `app` module
-declares a test dependency of type `maven-plugin` on `apicurio-registry-maven-plugin`
-via its `local-excluded-test-deps` profile (active whenever `-Dlocal` is absent), and
-the `utils/maven-plugin` module that produces that artifact is only present in the
-reactor under `-Dfull`, which is why both documented commands below carry `-Dfull`.
-Maven cannot satisfy `maven-plugin`-typed dependencies from the reactor when
-`dependency:analyze` forks `test-compile`. The
+declares a test dependency of type `maven-plugin` on `apicurio-registry-maven-plugin`,
+and Maven cannot satisfy `maven-plugin`-typed dependencies from the reactor when
+`dependency:analyze` forks `test-compile`. Both commands below carry `-Dfull` to
+ensure full reactor coverage (all modules including CLI, operator, Go SDK, etc.). The
 `dependency-check` Maven profile works around this by using
 [`dependency:analyze-only`](https://maven.apache.org/plugins/maven-dependency-plugin/analyze-only-mojo.html)
 instead, which does not fork the build, binding it to the `package` phase instead of

--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ Build the project and run the registry with the in-memory storage variant:
 **Build requirement:** JDK 21 or newer is required to build the project (the build tooling, e.g. Checkstyle, needs a Java 21+ runtime). The produced artifacts still target Java 17.
 
  ```
- ./mvnw clean install -Dlocal -Dmaven.test.skip=true
+ ./mvnw clean install -Dlocal -DskipTests
  cd app/
- ../mvnw quarkus:dev -Dlocal -Dmaven.test.skip=true
+ ../mvnw quarkus:dev -Dlocal
  ```
 
-(The `-Dlocal` build tier requires `-Dmaven.test.skip=true` — see
-[DEVELOPING.md](DEVELOPING.md#build-tiers) for details and other build options.)
+(See [DEVELOPING.md](DEVELOPING.md#build-tiers) for build tier details and other options.)
 
 This should result in Quarkus and the in-memory registry starting up, with the REST APIs available on localhost port 8080:
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -427,6 +427,58 @@
       <artifactId>quarkus-test-kubernetes-client</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-protobuf-serde-kafka</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-jsonschema-serde-kafka</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-avro-serde-pulsar</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-kafka-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-common-avro</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-serde-common-jsonschema</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-maven-plugin</artifactId>
+      <type>maven-plugin</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>raml-test-micro-service</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 
@@ -752,72 +804,5 @@
     </plugins>
   </build>
 
-  <!-- Test-scoped dependencies on modules excluded from the reactor by the -Dlocal profile
-       (serdes, maven-plugin, raml-test-micro-service). Keep them out of -Dlocal builds so
-       dependency resolution succeeds even with -DskipTests; include them for non-local test runs. -->
-  <profiles>
-    <profile>
-      <id>local-excluded-test-deps</id>
-      <activation>
-        <property>
-          <name>!local</name>
-        </property>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>io.apicurio</groupId>
-          <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.apicurio</groupId>
-          <artifactId>apicurio-registry-protobuf-serde-kafka</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.apicurio</groupId>
-          <artifactId>apicurio-registry-jsonschema-serde-kafka</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.apicurio</groupId>
-          <artifactId>apicurio-registry-avro-serde-pulsar</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.apicurio</groupId>
-          <artifactId>apicurio-registry-serde-common</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.apicurio</groupId>
-          <artifactId>apicurio-registry-serde-kafka-common</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.apicurio</groupId>
-          <artifactId>apicurio-registry-serde-common-avro</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.apicurio</groupId>
-          <artifactId>apicurio-registry-serde-common-jsonschema</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.apicurio</groupId>
-          <artifactId>apicurio-registry-maven-plugin</artifactId>
-          <type>maven-plugin</type>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>raml-test-micro-service</artifactId>
-          <version>${project.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,18 @@
     <module>schema-util/wsdl</module>
     <module>schema-util/xml</module>
     <module>schema-util/xsd</module>
+    <module>serdes/generic/serde-common</module>
+    <module>serdes/generic/serde-common-avro</module>
+    <module>serdes/generic/serde-common-jsonschema</module>
+    <module>serdes/generic/serde-common-protobuf</module>
+    <module>serdes/kafka/avro-serde</module>
+    <module>serdes/kafka/jsonschema-serde</module>
+    <module>serdes/kafka/protobuf-serde</module>
+    <module>serdes/kafka/serde-kafka-common</module>
+    <module>serdes/nats/avro-serde</module>
+    <module>serdes/pulsar/avro-serde</module>
+    <module>utils/maven-plugin</module>
+    <module>utils/raml-test-micro-service</module>
   </modules>
 
   <scm>
@@ -1374,18 +1386,6 @@
         <module>distro</module>
         <module>docs</module>
         <module>utils/converter</module>
-        <module>utils/maven-plugin</module>
-        <module>utils/raml-test-micro-service</module>
-        <module>serdes/generic/serde-common</module>
-        <module>serdes/generic/serde-common-avro</module>
-        <module>serdes/generic/serde-common-jsonschema</module>
-        <module>serdes/generic/serde-common-protobuf</module>
-        <module>serdes/kafka/avro-serde</module>
-        <module>serdes/kafka/jsonschema-serde</module>
-        <module>serdes/kafka/protobuf-serde</module>
-        <module>serdes/kafka/serde-kafka-common</module>
-        <module>serdes/nats/avro-serde</module>
-        <module>serdes/pulsar/avro-serde</module>
       </modules>
     </profile>
     <profile>
@@ -1415,18 +1415,6 @@
         <module>distro</module>
         <module>docs</module>
         <module>utils/converter</module>
-        <module>utils/maven-plugin</module>
-        <module>utils/raml-test-micro-service</module>
-        <module>serdes/generic/serde-common</module>
-        <module>serdes/generic/serde-common-avro</module>
-        <module>serdes/generic/serde-common-jsonschema</module>
-        <module>serdes/generic/serde-common-protobuf</module>
-        <module>serdes/kafka/avro-serde</module>
-        <module>serdes/kafka/jsonschema-serde</module>
-        <module>serdes/kafka/protobuf-serde</module>
-        <module>serdes/kafka/serde-kafka-common</module>
-        <module>serdes/nats/avro-serde</module>
-        <module>serdes/pulsar/avro-serde</module>
         <!-- Full-only modules -->
         <module>go-sdk</module>
         <module>mcp</module>


### PR DESCRIPTION
## Summary

- **Moves serde modules, maven-plugin, and raml-test-micro-service into the base module list** so
  they are always built, including with `-Dlocal`. This adds ~7s to the local build (from ~38s to
  ~45s) but eliminates the `-Dmaven.test.skip=true` requirement — developers can now use
  `-Dlocal -DskipTests` or just `-Dlocal` (with tests) and both work.
- **Removes the `local-excluded-test-deps` profile** from `app/pom.xml` — the serde/plugin test
  dependencies are now unconditional since the modules are always in the reactor.
- **Cleans up the `full` profile** to remove modules that are now in the base list (it retains
  only the truly full-only modules: go-sdk, mcp, operator, etc.).
- **Updates DEVELOPING.md, README.md, and CLAUDE.md** to reflect the simplified build commands
  and removes stale/duplicated documentation.

## Motivation

The previous `-Dlocal` tier excluded serde and maven-plugin modules from the reactor, which meant
`app` test sources (20 files importing from those modules) couldn't compile. This forced developers
to always pass `-Dmaven.test.skip=true` with `-Dlocal`, which was unintuitive and prevented running
any tests in the local tier. The serde modules only add ~7s to the build — a negligible cost for
a much better developer experience.

## Test plan

- [x] `./mvnw clean install -Dlocal -DskipTests` builds successfully (~45s)
- [x] `./mvnw clean install -Dlocal` compiles tests successfully (serde/plugin test sources compile)
- [x] Default build (`./mvnw clean install -DskipTests`) still works
- [ ] CI verification build passes