### PR TITLE
fix(ui): render MCP tool tables with PatternFly Table components

### DIFF
--- a/ui/ui-app/src/app/components/mcpTool/McpToolViewer.tsx
+++ b/ui/ui-app/src/app/components/mcpTool/McpToolViewer.tsx
@@ -14,6 +14,7 @@ import {
     LabelGroup,
     Title
 } from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 /**
  * Properties for the MCP tool viewer.
@@ -111,36 +112,36 @@ export const McpToolViewer: FunctionComponent<McpToolViewerProps> = (props: McpT
                             </CardTitle>
                         </CardHeader>
                         <CardBody>
-                            <table className="pf-v5-c-table pf-m-compact pf-m-grid-md" aria-label="Input parameters">
-                                <thead>
-                                    <tr>
-                                        <th>Parameter</th>
-                                        <th>Type</th>
-                                        <th>Required</th>
-                                        <th>Description</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
+                            <Table aria-label="Input parameters" variant="compact">
+                                <Thead>
+                                    <Tr>
+                                        <Th>Parameter</Th>
+                                        <Th>Type</Th>
+                                        <Th>Required</Th>
+                                        <Th>Description</Th>
+                                    </Tr>
+                                </Thead>
+                                <Tbody>
                                     {paramNames.map((paramName) => {
                                         const param = properties[paramName] || {};
                                         const isRequired = required.includes(paramName);
                                         return (
-                                            <tr key={paramName}>
-                                                <td><strong>{paramName}</strong></td>
-                                                <td>{param.type || "any"}</td>
-                                                <td>
+                                            <Tr key={paramName}>
+                                                <Td dataLabel="Parameter"><strong>{paramName}</strong></Td>
+                                                <Td dataLabel="Type">{param.type || "any"}</Td>
+                                                <Td dataLabel="Required">
                                                     {isRequired ? (
                                                         <Label color="red" isCompact>required</Label>
                                                     ) : (
                                                         <Label color="grey" isCompact>optional</Label>
                                                     )}
-                                                </td>
-                                                <td>{param.description || "-"}</td>
-                                            </tr>
+                                                </Td>
+                                                <Td dataLabel="Description">{param.description || "-"}</Td>
+                                            </Tr>
                                         );
                                     })}
-                                </tbody>
-                            </table>
+                                </Tbody>
+                            </Table>
                         </CardBody>
                     </Card>
                 </>
@@ -157,36 +158,36 @@ export const McpToolViewer: FunctionComponent<McpToolViewerProps> = (props: McpT
                             </CardTitle>
                         </CardHeader>
                         <CardBody>
-                            <table className="pf-v5-c-table pf-m-compact pf-m-grid-md" aria-label="Output schema">
-                                <thead>
-                                    <tr>
-                                        <th>Field</th>
-                                        <th>Type</th>
-                                        <th>Required</th>
-                                        <th>Description</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
+                            <Table aria-label="Output schema" variant="compact">
+                                <Thead>
+                                    <Tr>
+                                        <Th>Field</Th>
+                                        <Th>Type</Th>
+                                        <Th>Required</Th>
+                                        <Th>Description</Th>
+                                    </Tr>
+                                </Thead>
+                                <Tbody>
                                     {Object.keys(outputSchema.properties).map((fieldName) => {
                                         const field = outputSchema.properties[fieldName] || {};
                                         const isRequired = (outputSchema.required || []).includes(fieldName);
                                         return (
-                                            <tr key={fieldName}>
-                                                <td><strong>{fieldName}</strong></td>
-                                                <td>{field.type || "any"}</td>
-                                                <td>
+                                            <Tr key={fieldName}>
+                                                <Td dataLabel="Field"><strong>{fieldName}</strong></Td>
+                                                <Td dataLabel="Type">{field.type || "any"}</Td>
+                                                <Td dataLabel="Required">
                                                     {isRequired ? (
                                                         <Label color="red" isCompact>required</Label>
                                                     ) : (
                                                         <Label color="grey" isCompact>optional</Label>
                                                     )}
-                                                </td>
-                                                <td>{field.description || "-"}</td>
-                                            </tr>
+                                                </Td>
+                                                <Td dataLabel="Description">{field.description || "-"}</Td>
+                                            </Tr>
                                         );
                                     })}
-                                </tbody>
-                            </table>
+                                </Tbody>
+                            </Table>
                         </CardBody>
                     </Card>
                 </>


### PR DESCRIPTION
Fixes #9319

The MCP tool viewer built its Input Parameters and Output Schema tables as raw `<table>` elements with `pf-v5-c-table` classes. The UI is on PatternFly 6, so those v5 classes don't apply and both tables rendered unstyled (no cell padding, no header border, not full width).

This converts both tables to the PatternFly `Table`/`Thead`/`Tbody`/`Tr`/`Th`/`Td` components (`variant="compact"`), matching how every other table in the app is built. Added `dataLabel` on the cells for responsive/stacked display.

**How I tested:** typecheck, lint, production build, and the existing test suite (35 tests) all pass. Verified live in the browser against a real MCP_TOOL artifact, the tables now get proper PatternFly 6 styling (cell padding and full width) where before they had zero cell padding and shrank to content width. Table content is unchanged.
