### PR TITLE
refactor(core): replace ArtifactType string constants with a sealed hierarchy 

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/AbstractResource.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/AbstractResource.java
@@ -111,7 +111,7 @@ public abstract class AbstractResource {
     }
 
     protected ArtifactVersionMetaDataDto createOrUpdateArtifact(String artifactId, String schema,
-                                                                String artifactType, List<SchemaReference> references, String groupId, boolean normalize) {
+                                                                ArtifactType artifactType, List<SchemaReference> references, String groupId, boolean normalize) {
         ArtifactVersionMetaDataDto res;
         final List<ArtifactReferenceDto> parsedReferences = parseReferences(references, groupId);
         final List<ArtifactReference> artifactReferences = parsedReferences.stream()
@@ -197,7 +197,7 @@ public abstract class AbstractResource {
                 : ContentTypes.APPLICATION_JSON;
             TypedContent typedSchemaContent = TypedContent.create(ContentHandle.create(schema), contentType);
             final List<ArtifactReferenceDto> artifactReferences = parseReferences(schemaReferences, groupId);
-            ArtifactTypeUtilProvider artifactTypeProvider = factory.getArtifactTypeProvider(type);
+            ArtifactTypeUtilProvider artifactTypeProvider = factory.getArtifactTypeProvider(ArtifactType.fromValue(type));
             ArtifactVersionMetaDataDto amd;
 
             if (cconfig.canonicalHashModeEnabled.get() || normalize) {
@@ -380,7 +380,7 @@ public abstract class AbstractResource {
         }
     }
 
-    protected boolean isCcompatManagedType(String artifactType) {
+    protected boolean isCcompatManagedType(ArtifactType artifactType) {
         return artifactType.equals(ArtifactType.AVRO) || artifactType.equals(ArtifactType.PROTOBUF)
                 || artifactType.equals(ArtifactType.JSON);
     }

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/CompatibilityResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/CompatibilityResourceImpl.java
@@ -61,11 +61,11 @@ public class CompatibilityResourceImpl extends AbstractResource implements Compa
         return rulesProperties.isDefaultGlobalRuleConfigured(RuleType.COMPATIBILITY);
     }
 
-    private void validateSchemaContent(String schema, String artifactType) {
+    private void validateSchemaContent(String schema, ArtifactType artifactType) {
         if (schema == null || artifactType == null) {
             throw new UnprocessableEntityException("Schema and artifact type must not be null");
         }
-        String contentType = artifactType.equals(ArtifactType.PROTOBUF)
+        String contentType = artifactType.equals(ArtifactType.BuiltIn.PROTOBUF)
                 ? ContentTypes.APPLICATION_PROTOBUF : ContentTypes.APPLICATION_JSON;
         TypedContent typedContent = TypedContent.create(ContentHandle.create(schema), contentType);
         try {
@@ -89,7 +89,7 @@ public class CompatibilityResourceImpl extends AbstractResource implements Compa
                 final ArtifactVersionMetaDataDto artifactVersionMetaData = storage.getArtifactVersionMetaData(
                         ga.getRawGroupIdWithNull(), ga.getRawArtifactId(), version);
                 String contentType = ContentTypes.APPLICATION_JSON;
-                if (artifactVersionMetaData.getArtifactType().equals(ArtifactType.PROTOBUF)) {
+                if (artifactVersionMetaData.getArtifactType().equals(ArtifactType.BuiltIn.PROTOBUF)) {
                     contentType = ContentTypes.APPLICATION_PROTOBUF;
                 }
 
@@ -136,7 +136,7 @@ public class CompatibilityResourceImpl extends AbstractResource implements Compa
                             final ArtifactVersionMetaDataDto artifact = storage.getArtifactVersionMetaData(
                                     ga.getRawGroupIdWithNull(), ga.getRawArtifactId(), version);
                             String contentType = ContentTypes.APPLICATION_JSON;
-                            if (artifact.getArtifactType().equals(ArtifactType.PROTOBUF)) {
+                            if (artifact.getArtifactType().equals(ArtifactType.BuiltIn.PROTOBUF)) {
                                 contentType = ContentTypes.APPLICATION_PROTOBUF;
                             }
 

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemaFormatService.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemaFormatService.java
@@ -56,16 +56,15 @@ public class SchemaFormatService {
 
         validateFormat(artifactType, format);
 
-        switch (artifactType) {
-            case ArtifactType.AVRO:
-                return applyAvroFormat(content, format, resolvedReferences);
-            case ArtifactType.PROTOBUF:
-                return applyProtobufFormat(content, format, resolvedReferences);
-            case ArtifactType.JSON:
-                // JSON schemas don't support format transformations
-                return content;
-            default:
-                return content;
+        if (ArtifactType.BuiltIn.AVRO.value().equals(artifactType)) {
+            return applyAvroFormat(content, format, resolvedReferences);
+        } else if (ArtifactType.BuiltIn.PROTOBUF.value().equals(artifactType)) {
+            return applyProtobufFormat(content, format, resolvedReferences);
+        } else if (ArtifactType.BuiltIn.JSON.value().equals(artifactType)) {
+            // JSON schemas don't support format transformations
+            return content;
+        } else {
+            return content;
         }
     }
 

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
@@ -55,7 +55,7 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
             contentHandle = artifactVersion.getContent();
             references = artifactVersion.getReferences();
             ArtifactVersionMetaDataDto vmd = storage.getArtifactVersionMetaData(id.longValue());
-            artifactType = vmd.getArtifactType();
+            artifactType = vmd.getArtifactType().value();
         } else {
             ContentWrapperDto contentWrapper = storage.getContentById(id.longValue());
             contentHandle = contentWrapper.getContent();
@@ -65,7 +65,7 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
                 //the contentId points to an orphaned content
                 throw new ArtifactNotFoundException("ContentId: " + id);
             }
-            artifactType = versions.get(0).getArtifactType();
+            artifactType = versions.get(0).getArtifactType().value();
         }
 
         // Apply default format if configured and no format was explicitly provided
@@ -100,7 +100,7 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
             contentHandle = artifactVersion.getContent();
             references = artifactVersion.getReferences();
             ArtifactVersionMetaDataDto vmd = storage.getArtifactVersionMetaData(id.longValue());
-            artifactType = vmd.getArtifactType();
+            artifactType = vmd.getArtifactType().value();
         } else {
             ContentWrapperDto contentWrapper = storage.getContentById(id.longValue());
             contentHandle = contentWrapper.getContent();
@@ -110,7 +110,7 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
                 //the contentId points to an orphaned content
                 throw new ArtifactNotFoundException("ContentId: " + id);
             }
-            artifactType = versions.get(0).getArtifactType();
+            artifactType = versions.get(0).getArtifactType().value();
         }
 
         // Apply default format if configured and no format was explicitly provided
@@ -138,7 +138,7 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
     @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
     public List<String> getSchemaTypes() {
-        return Arrays.asList(ArtifactType.JSON, ArtifactType.PROTOBUF, ArtifactType.AVRO);
+        return Arrays.asList(ArtifactType.BuiltIn.JSON.value(), ArtifactType.BuiltIn.PROTOBUF.value(), ArtifactType.BuiltIn.AVRO.value());
     }
 
     @Override
@@ -183,7 +183,7 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
             try {
                 ContentWrapperDto contentWrapper = storage.getContentById(contentId);
                 Schema schema = converter.convert(contentWrapper.getContent(),
-                        version.getArtifactType(), contentWrapper.getReferences());
+                        version.getArtifactType().value(), contentWrapper.getReferences());
                 schemas.add(schema);
             } catch (Exception e) {
                 // Skip schemas that can't be loaded

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -147,7 +147,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
                         Map<String, TypedContent> resolvedReferences = resolveReferenceDtos(
                                 storedArtifact.getReferences());
                         ContentHandle formattedContent = formatService.applyFormat(
-                                storedArtifact.getContent(), amd.getArtifactType(), effectiveFormat,
+                                storedArtifact.getContent(), amd.getArtifactType().value(), effectiveFormat,
                                 resolvedReferences);
 
                         StoredArtifactVersionDto formattedArtifact = StoredArtifactVersionDto.builder()
@@ -321,9 +321,9 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
             TypedContent typedSchemaContent = TypedContent.create(schemaContent, contentType);
 
             // We validate the schema at creation time by inferring the type from the content
-            final String artifactType = ArtifactTypeUtil.determineArtifactType(typedSchemaContent, null,
+            final ArtifactType artifactType = ArtifactTypeUtil.determineArtifactType(typedSchemaContent, null,
                     resolvedReferences, factory);
-            if (request.getSchemaType() != null && !artifactType.equals(request.getSchemaType())) {
+            if (request.getSchemaType() != null && !artifactType.value().equals(request.getSchemaType())) {
                 throw new UnprocessableEntityException(
                         String.format("Given schema is not from type: %s", request.getSchemaType()));
             }
@@ -468,7 +468,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
 
                     StoredArtifactVersionDto storedArtifact = storage.getArtifactVersionContent(
                             ga.getRawGroupIdWithNull(), ga.getRawArtifactId(), amd.getVersion());
-                    return converter.convert(ga.getRawArtifactId(), storedArtifact, amd.getArtifactType());
+                    return converter.convert(ga.getRawArtifactId(), storedArtifact, amd.getArtifactType().value());
                 });
     }
 
@@ -521,7 +521,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
                         Map<String, TypedContent> resolvedReferences = resolveReferenceDtos(
                                 storedArtifact.getReferences());
                         ContentHandle formattedContent = formatService.applyFormat(
-                                storedArtifact.getContent(), amd.getArtifactType(), effectiveFormat,
+                                storedArtifact.getContent(), amd.getArtifactType().value(), effectiveFormat,
                                 resolvedReferences);
 
                         // Create a new StoredArtifactVersionDto with the formatted content
@@ -530,10 +530,10 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
                                 .versionOrder(storedArtifact.getVersionOrder())
                                 .contentId(storedArtifact.getContentId()).content(formattedContent)
                                 .references(storedArtifact.getReferences()).build();
-                        return converter.convert(artifactId, formattedArtifact, amd.getArtifactType());
+                        return converter.convert(artifactId, formattedArtifact, amd.getArtifactType().value());
                     }
 
-                    return converter.convert(artifactId, storedArtifact, amd.getArtifactType());
+                    return converter.convert(artifactId, storedArtifact, amd.getArtifactType().value());
                 } else {
                     throw new VersionNotFoundException(groupId, artifactId, version);
                 }

--- a/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsExporter.java
+++ b/app/src/main/java/io/apicurio/registry/contracts/odcs/OdcsExporter.java
@@ -208,7 +208,7 @@ public class OdcsExporter {
                 : artifactId + ":" + latest;
         return List.of(OdcsSchema.builder()
                 .name(meta.getName())
-                .type(lowerOrNull(meta.getArtifactType()))
+                .type(lowerOrNull(meta.getArtifactType().value()))
                 .location(location)
                 .fields(fields)
                 .build());

--- a/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/IcebergApiResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/iceberg/rest/v1/impl/IcebergApiResourceImpl.java
@@ -336,7 +336,7 @@ public class IcebergApiResourceImpl implements ApisResource {
 
         Set<SearchFilter> filters = new HashSet<>();
         filters.add(SearchFilter.ofGroupId(groupId));
-        filters.add(SearchFilter.ofArtifactType(ArtifactType.ICEBERG_TABLE));
+        filters.add(SearchFilter.ofArtifactType(ArtifactType.BuiltIn.ICEBERG_TABLE.value()));
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(filters, OrderBy.artifactId,
                 OrderDirection.asc, offset, limit, false);
@@ -440,7 +440,7 @@ public class IcebergApiResourceImpl implements ApisResource {
                 .references(Collections.emptyList())
                 .build();
 
-        storage.createArtifact(groupId, tableName, ArtifactType.ICEBERG_TABLE, artifactMetaData, null,
+        storage.createArtifact(groupId, tableName, ArtifactType.BuiltIn.ICEBERG_TABLE, artifactMetaData, null,
                 content, versionMetaData, null, false, false, getCurrentUser());
         metricsService.recordTableCreated();
 
@@ -574,7 +574,7 @@ public class IcebergApiResourceImpl implements ApisResource {
                 currentMetadata, newMetadata);
 
         storage.createArtifactVersionIfLatest(groupId, table,
-                null, ArtifactType.ICEBERG_TABLE, content, EditableVersionMetaDataDto.builder().build(),
+                null, ArtifactType.BuiltIn.ICEBERG_TABLE, content, EditableVersionMetaDataDto.builder().build(),
                 null, false, getCurrentUser(), baseVersionOrder, artifactMetaData);
 
         metricsService.recordTableCommitted();
@@ -694,7 +694,7 @@ public class IcebergApiResourceImpl implements ApisResource {
                 .references(Collections.emptyList())
                 .build();
 
-        storage.createArtifact(destGroupId, destTable, ArtifactType.ICEBERG_TABLE,
+        storage.createArtifact(destGroupId, destTable, ArtifactType.BuiltIn.ICEBERG_TABLE,
                 EditableArtifactMetaDataDto.builder().build(), null, content,
                 EditableVersionMetaDataDto.builder().build(), null, false, false, getCurrentUser());
 
@@ -729,7 +729,7 @@ public class IcebergApiResourceImpl implements ApisResource {
 
         Set<SearchFilter> filters = new HashSet<>();
         filters.add(SearchFilter.ofGroupId(groupId));
-        filters.add(SearchFilter.ofArtifactType(ArtifactType.ICEBERG_VIEW));
+        filters.add(SearchFilter.ofArtifactType(ArtifactType.BuiltIn.ICEBERG_VIEW.value()));
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(filters, OrderBy.artifactId,
                 OrderDirection.asc, offset, limit, false);
@@ -839,7 +839,7 @@ public class IcebergApiResourceImpl implements ApisResource {
                 .references(Collections.emptyList())
                 .build();
 
-        storage.createArtifact(groupId, viewName, ArtifactType.ICEBERG_VIEW, artifactMetaData, null,
+        storage.createArtifact(groupId, viewName, ArtifactType.BuiltIn.ICEBERG_VIEW, artifactMetaData, null,
                 content, versionMetaData, null, false, false, getCurrentUser());
         metricsService.recordViewCreated();
 
@@ -959,7 +959,7 @@ public class IcebergApiResourceImpl implements ApisResource {
                 currentMetadata, newMetadata);
 
         storage.createArtifactVersionIfLatest(groupId, view,
-                null, ArtifactType.ICEBERG_VIEW, content, EditableVersionMetaDataDto.builder().build(),
+                null, ArtifactType.BuiltIn.ICEBERG_VIEW, content, EditableVersionMetaDataDto.builder().build(),
                 null, false, getCurrentUser(), baseVersionOrder, artifactMetaData);
 
         metricsService.recordViewReplaced();
@@ -1012,7 +1012,7 @@ public class IcebergApiResourceImpl implements ApisResource {
                 .references(Collections.emptyList())
                 .build();
 
-        storage.createArtifact(destGroupId, destView, ArtifactType.ICEBERG_VIEW,
+        storage.createArtifact(destGroupId, destView, ArtifactType.BuiltIn.ICEBERG_VIEW,
                 EditableArtifactMetaDataDto.builder().build(), null, content,
                 EditableVersionMetaDataDto.builder().build(), null, false, false, getCurrentUser());
 

--- a/app/src/main/java/io/apicurio/registry/limits/RegistryStorageLimitsEnforcer.java
+++ b/app/src/main/java/io/apicurio/registry/limits/RegistryStorageLimitsEnforcer.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.limits;
 
 import io.apicurio.registry.storage.decorator.RegistryStorageDecorator;
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.storage.decorator.RegistryStorageDecoratorBase;
 import io.apicurio.registry.storage.decorator.RegistryStorageDecoratorOrderConstants;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
@@ -56,7 +57,7 @@ public class RegistryStorageLimitsEnforcer extends RegistryStorageDecoratorBase
     }
 
     public Pair<ArtifactMetaDataDto, ArtifactVersionMetaDataDto> createArtifact(String groupId,
-            String artifactId, String artifactType, EditableArtifactMetaDataDto artifactMetaData,
+            String artifactId, ArtifactType artifactType, EditableArtifactMetaDataDto artifactMetaData,
             String version, ContentWrapperDto versionContent, EditableVersionMetaDataDto versionMetaData,
             List<String> versionBranches, boolean versionIsDraft, boolean dryRun, String owner)
             throws RegistryStorageException {
@@ -70,7 +71,7 @@ public class RegistryStorageLimitsEnforcer extends RegistryStorageDecoratorBase
     }
 
     public ArtifactVersionMetaDataDto createArtifactVersion(String groupId, String artifactId, String version,
-            String artifactType, ContentWrapperDto content, EditableVersionMetaDataDto metaData,
+            ArtifactType artifactType, ContentWrapperDto content, EditableVersionMetaDataDto metaData,
             List<String> branches, boolean isDraft, boolean dryRun, String owner)
             throws RegistryStorageException {
         ArtifactVersionMetaDataDto dto = withLimitsCheck(

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/AdminResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/AdminResourceImpl.java
@@ -97,7 +97,7 @@ public class AdminResourceImpl implements AdminResource {
     public List<ArtifactTypeInfo> listArtifactTypes() {
         return factory.getAllArtifactTypes().stream().map(t -> {
             ArtifactTypeInfo ati = new ArtifactTypeInfo();
-            ati.setName(t);
+            ati.setName(t.value());
             return ati;
         }).collect(Collectors.toList());
     }

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
@@ -155,7 +155,7 @@ public class GroupsResourceImpl implements GroupsResource {
                 if (artifactTypeProvider.supportsReferencesWithContext()) {
                     RegistryContentUtils.RewrittenContentHolder rewrittenContent = RegistryContentUtils
                             .recursivelyResolveReferencesWithContext(factory, contentToReturn,
-                                    metaData.getArtifactType(), artifact.getReferences(),
+                                    metaData.getArtifactType().value(), artifact.getReferences(),
                                     storage::getContentByReference);
 
                     contentToReturn = artifactTypeProvider.getContentDereferencer().dereference(
@@ -295,7 +295,7 @@ public class GroupsResourceImpl implements GroupsResource {
                 latestGAV.getRawGroupIdWithNull(), latestGAV.getRawArtifactId(), latestGAV.getRawVersionId());
 
         ArtifactMetaData amd = V2ApiUtil.dtoToMetaData(defaultGroupIdToNull(groupId), artifactId,
-                dto.getArtifactType(), dto);
+                dto.getArtifactType().value(), dto);
         amd.setContentId(vdto.getContentId());
         amd.setGlobalId(vdto.getGlobalId());
         amd.setVersion(vdto.getVersion());
@@ -470,7 +470,7 @@ public class GroupsResourceImpl implements GroupsResource {
         ArtifactVersionMetaDataDto dto = storage.getArtifactVersionMetaDataByContent(
                 defaultGroupIdToNull(groupId), artifactId, canonical, typedContent, artifactReferenceDtos);
         return V2ApiUtil.dtoToVersionMetaData(defaultGroupIdToNull(groupId), artifactId,
-                dto.getArtifactType(), dto);
+                dto.getArtifactType().value(), dto);
     }
 
     /**
@@ -624,7 +624,7 @@ public class GroupsResourceImpl implements GroupsResource {
             ct = ContentTypes.APPLICATION_JSON;
         }
 
-        String artifactType = lookupArtifactType(groupId, artifactId);
+        ArtifactType artifactType = lookupArtifactType(groupId, artifactId);
         TypedContent typedContent = TypedContent.create(content, ct);
         rulesService.applyRules(defaultGroupIdToNull(groupId), artifactId, artifactType, typedContent,
                 RuleApplicationType.UPDATE, Collections.emptyList(), Collections.emptyMap()); // TODO:references
@@ -678,7 +678,7 @@ public class GroupsResourceImpl implements GroupsResource {
         if (dereference && !artifact.getReferences().isEmpty()) {
             if (artifactTypeProvider.supportsReferencesWithContext()) {
                 RegistryContentUtils.RewrittenContentHolder rewrittenContent = RegistryContentUtils
-                        .recursivelyResolveReferencesWithContext(factory, contentToReturn, metaData.getArtifactType(),
+                        .recursivelyResolveReferencesWithContext(factory, contentToReturn, metaData.getArtifactType().value(),
                                 artifact.getReferences(), storage::getContentByReference);
 
                 contentToReturn = artifactTypeProvider.getContentDereferencer().dereference(
@@ -735,7 +735,7 @@ public class GroupsResourceImpl implements GroupsResource {
         ArtifactVersionMetaDataDto dto = storage.getArtifactVersionMetaData(defaultGroupIdToNull(groupId),
                 artifactId, version);
         return V2ApiUtil.dtoToVersionMetaData(defaultGroupIdToNull(groupId), artifactId,
-                dto.getArtifactType(), dto);
+                dto.getArtifactType().value(), dto);
     }
 
     /**
@@ -1070,9 +1070,9 @@ public class GroupsResourceImpl implements GroupsResource {
             }
 
             TypedContent typedContent = TypedContent.create(content, ct);
-            String artifactType = ArtifactType.AVRO;
+            ArtifactType artifactType = ArtifactType.BuiltIn.AVRO;
             try {
-                artifactType = ArtifactTypeUtil.determineArtifactType(typedContent, xRegistryArtifactType,
+                artifactType = ArtifactTypeUtil.determineArtifactType(typedContent, ArtifactType.fromValue(xRegistryArtifactType),
                         factory);
             } catch (InvalidArtifactTypeException e) {
                 // Ignore this exception and default to AVRO.  This is what v2 did.
@@ -1088,7 +1088,7 @@ public class GroupsResourceImpl implements GroupsResource {
                     RuleApplicationType.CREATE, toV3Refs(references), resolvedReferences);
 
             // Extract metadata from content, then override extracted values with provided values.
-            EditableArtifactMetaDataDto metaData = extractMetaData(artifactType, content);
+            EditableArtifactMetaDataDto metaData = extractMetaData(artifactType.value(), content);
             if (artifactName != null && !artifactName.trim().isEmpty()) {
                 metaData.setName(artifactName);
             }
@@ -1105,7 +1105,7 @@ public class GroupsResourceImpl implements GroupsResource {
                     defaultGroupIdToNull(groupId), artifactId, artifactType, metaData, xRegistryVersion,
                     contentDto, versionMetaData, List.of(), false, false, owner);
 
-            return V2ApiUtil.dtoToMetaData(groupId, artifactId, artifactType, createResult.getRight());
+            return V2ApiUtil.dtoToMetaData(groupId, artifactId, artifactType.value(), createResult.getRight());
         } catch (ArtifactAlreadyExistsException ex) {
             return handleIfExists(groupId, xRegistryArtifactId, xRegistryVersion, ifExists, artifactName,
                     artifactDescription, content, ct, fcanonical, references);
@@ -1232,7 +1232,7 @@ public class GroupsResourceImpl implements GroupsResource {
 
         final String owner = securityIdentity.getPrincipal().getName();
 
-        String artifactType = lookupArtifactType(groupId, artifactId);
+        ArtifactType artifactType = lookupArtifactType(groupId, artifactId);
         TypedContent typedContent = TypedContent.create(content, ct);
         rulesService.applyRules(defaultGroupIdToNull(groupId), artifactId, artifactType, typedContent,
                 RuleApplicationType.UPDATE, toV3Refs(references), resolvedReferences);
@@ -1251,7 +1251,7 @@ public class GroupsResourceImpl implements GroupsResource {
                 .build();
         storage.updateArtifactMetaData(defaultGroupIdToNull(groupId), artifactId, artifactMD);
 
-        return V2ApiUtil.dtoToVersionMetaData(defaultGroupIdToNull(groupId), artifactId, artifactType,
+        return V2ApiUtil.dtoToVersionMetaData(defaultGroupIdToNull(groupId), artifactId, artifactType.value(),
                 vmdDto);
     }
 
@@ -1261,7 +1261,7 @@ public class GroupsResourceImpl implements GroupsResource {
      * @param groupId
      * @param artifactId
      */
-    private String lookupArtifactType(String groupId, String artifactId) {
+    private ArtifactType lookupArtifactType(String groupId, String artifactId) {
         return storage.getArtifactMetaData(defaultGroupIdToNull(groupId), artifactId).getArtifactType();
     }
 
@@ -1333,7 +1333,7 @@ public class GroupsResourceImpl implements GroupsResource {
             contentType = ContentTypes.APPLICATION_JSON;
         }
 
-        String artifactType = lookupArtifactType(groupId, artifactId);
+        ArtifactType artifactType = lookupArtifactType(groupId, artifactId);
 
         // Transform the given references into dtos and set the contentId, this will also detect if any of the
         // passed references does not exist.
@@ -1347,7 +1347,7 @@ public class GroupsResourceImpl implements GroupsResource {
                 RuleApplicationType.UPDATE, toV3Refs(references), resolvedReferences);
 
         // Extract metadata from content, then override extracted values with provided values.
-        EditableArtifactMetaDataDto artifactMD = extractMetaData(artifactType, content);
+        EditableArtifactMetaDataDto artifactMD = extractMetaData(artifactType.value(), content);
         if (name != null && !name.trim().isEmpty()) {
             artifactMD.setName(name);
         }
@@ -1369,7 +1369,7 @@ public class GroupsResourceImpl implements GroupsResource {
         // those are the semantics of the v2 API. :(
         storage.updateArtifactMetaData(defaultGroupIdToNull(groupId), artifactId, artifactMD);
 
-        return V2ApiUtil.dtoToMetaData(defaultGroupIdToNull(groupId), artifactId, artifactType, dto);
+        return V2ApiUtil.dtoToMetaData(defaultGroupIdToNull(groupId), artifactId, artifactType.value(), dto);
     }
 
     private EditableArtifactMetaDataDto getEditableArtifactMetaData(String name, String description) {
@@ -1409,7 +1409,7 @@ public class GroupsResourceImpl implements GroupsResource {
     }
 
     protected EditableArtifactMetaDataDto extractMetaData(String artifactType, ContentHandle content) {
-        ArtifactTypeUtilProvider provider = factory.getArtifactTypeProvider(artifactType);
+        ArtifactTypeUtilProvider provider = factory.getArtifactTypeProvider(ArtifactType.fromValue(artifactType));
         ContentExtractor extractor = provider.getContentExtractor();
         ExtractedMetaData emd = extractor.extract(content);
         EditableArtifactMetaDataDto metaData;

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/IdsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/IdsResourceImpl.java
@@ -96,7 +96,7 @@ public class IdsResourceImpl implements IdsResource {
         if (dereference && !artifact.getReferences().isEmpty()) {
             if (artifactTypeProvider.supportsReferencesWithContext()) {
                 RegistryContentUtils.RewrittenContentHolder rewrittenContent = RegistryContentUtils
-                        .recursivelyResolveReferencesWithContext(factory, contentToReturn, metaData.getArtifactType(),
+                        .recursivelyResolveReferencesWithContext(factory, contentToReturn, metaData.getArtifactType().value(),
                                 artifact.getReferences(), storage::getContentByReference);
 
                 contentToReturn = artifactTypeProvider.getContentDereferencer().dereference(

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/SearchResourceImpl.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.rest.v2.impl;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.rest.v2.SearchResource;
 
 import io.apicurio.registry.auth.Authorized;
@@ -204,7 +205,7 @@ public class SearchResourceImpl implements SearchResource {
 
     protected TypedContent canonicalizeContent(String artifactType, TypedContent content) {
         try {
-            ArtifactTypeUtilProvider provider = factory.getArtifactTypeProvider(artifactType);
+            ArtifactTypeUtilProvider provider = factory.getArtifactTypeProvider(ArtifactType.fromValue(artifactType));
             ContentCanonicalizer canonicalizer = provider.getContentCanonicalizer();
             TypedContent canonicalContent = canonicalizer.canonicalize(content, Collections.emptyMap());
             return canonicalContent;

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/V2ApiUtil.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/V2ApiUtil.java
@@ -66,7 +66,7 @@ public final class V2ApiUtil {
         if (artifactType != null) {
             metaData.setType(artifactType);
         } else {
-            metaData.setType(dto.getArtifactType());
+            metaData.setType(dto.getArtifactType() == null ? null : dto.getArtifactType().value());
         }
         metaData.setState(ArtifactState.ENABLED); // TODO artifact state has gone away from the storage layer
         metaData.setLabels(toV2Labels(dto.getLabels()));
@@ -155,7 +155,7 @@ public final class V2ApiUtil {
         if (artifactType != null) {
             metaData.setType(artifactType);
         } else {
-            metaData.setType(dto.getArtifactType());
+            metaData.setType(dto.getArtifactType() == null ? null : dto.getArtifactType().value());
         }
         metaData.setVersion(dto.getVersion());
         metaData.setGlobalId(dto.getGlobalId());
@@ -256,7 +256,7 @@ public final class V2ApiUtil {
             sa.setModifiedOn(artifact.getModifiedOn());
             sa.setName(artifact.getName());
             sa.setState(ArtifactState.ENABLED);
-            sa.setType(artifact.getArtifactType());
+            sa.setType(artifact.getArtifactType().value());
             results.getArtifacts().add(sa);
         });
         return results;
@@ -292,7 +292,7 @@ public final class V2ApiUtil {
             sv.setContentId(version.getContentId());
             sv.setName(version.getName());
             sv.setState(ArtifactState.fromValue(version.getState().name()));
-            sv.setType(version.getArtifactType());
+            sv.setType(version.getArtifactType().value());
             sv.setVersion(version.getVersion());
             results.getVersions().add(sv);
         });

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/AbstractResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/AbstractResourceImpl.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.apicurio.registry.types.ArtifactType;
 import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_API;
 
 public abstract class AbstractResourceImpl {
@@ -53,7 +54,7 @@ public abstract class AbstractResourceImpl {
      * Handle the content references based on the value of "HandleReferencesType" - this can either mean we
      * need to fully dereference the content, or we need to rewrite the references, or we do nothing.
      */
-    protected TypedContent handleContentReferences(HandleReferencesType referencesType, String artifactType,
+    protected TypedContent handleContentReferences(HandleReferencesType referencesType, ArtifactType artifactType,
             TypedContent content, List<ArtifactReferenceDto> references) {
         if (!references.isEmpty()) {
             if (referencesType == HandleReferencesType.DEREFERENCE) {
@@ -61,7 +62,7 @@ public abstract class AbstractResourceImpl {
 
                 if (artifactTypeProvider.supportsReferencesWithContext()) {
                     RegistryContentUtils.RewrittenContentHolder rewrittenContent = RegistryContentUtils
-                            .recursivelyResolveReferencesWithContext(factory, content, artifactType, references,
+                            .recursivelyResolveReferencesWithContext(factory, content, artifactType.value(), references,
                                     storage::getContentByReference);
 
                     content = artifactTypeProvider.getContentDereferencer().dereference(

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/AdminResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/AdminResourceImpl.java
@@ -180,7 +180,7 @@ public class AdminResourceImpl implements AdminResource {
     public List<ArtifactTypeInfo> listArtifactTypes() {
         return factory.getAllArtifactTypes().stream().map(t -> {
             ArtifactTypeInfo ati = new ArtifactTypeInfo();
-            ati.setName(t);
+            ati.setName(t.value());
             return ati;
         }).collect(Collectors.toList());
 

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/ContentResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/ContentResourceImpl.java
@@ -14,6 +14,7 @@ import io.apicurio.registry.rest.v3.ContentResource;
 import io.apicurio.registry.rest.v3.beans.ArtifactReference;
 import io.apicurio.registry.rest.v3.beans.VersionContent;
 import io.apicurio.registry.storage.impl.sql.RegistryStorageContentUtils;
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
 import io.apicurio.registry.util.ArtifactTypeUtil;
@@ -60,11 +61,14 @@ public class ContentResourceImpl implements ContentResource {
         TypedContent typedContent = TypedContent.create(content, contentType);
 
         // Auto-detect artifact type if not provided
+        ArtifactType resolvedType;
         if (artifactType == null || artifactType.isBlank()) {
-            artifactType = ArtifactTypeUtil.determineArtifactType(typedContent, null, factory);
+            resolvedType = ArtifactTypeUtil.determineArtifactType(typedContent, null, factory);
+        } else {
+            resolvedType = ArtifactType.fromValue(artifactType);
         }
 
-        ArtifactTypeUtilProvider provider = factory.getArtifactTypeProvider(artifactType);
+        ArtifactTypeUtilProvider provider = factory.getArtifactTypeProvider(resolvedType);
         ReferenceFinder referenceFinder = provider.getReferenceFinder();
         Set<ExternalReference> externalRefs = referenceFinder.findExternalReferences(typedContent);
 
@@ -85,12 +89,13 @@ public class ContentResourceImpl implements ContentResource {
         if (content.bytes().length == 0) {
             throw new BadRequestException("Empty content is not allowed.");
         }
-        if (!factory.getAllArtifactTypes().contains(artifactType)) {
+        ArtifactType resolvedType = ArtifactType.fromValue(artifactType);
+        if (!factory.getAllArtifactTypes().contains(resolvedType)) {
             throw new BadRequestException("Unknown artifact type: " + artifactType);
         }
         String ct = httpHeaders.getMediaType() != null ? httpHeaders.getMediaType().toString() : null;
         TypedContent typedContent = TypedContent.create(content, ct);
-        TypedContent canonicalized = contentUtils.canonicalizeContent(artifactType, typedContent,
+        TypedContent canonicalized = contentUtils.canonicalizeContent(resolvedType, typedContent,
                 Map.of());
         return Response.ok(canonicalized.getContent()).type(canonicalized.getContentType()).build();
     }

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -278,7 +278,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                 .groupId(groupId != null ? groupId : "default")
                 .artifactId(artifactId)
                 .version(version)
-                .artifactType(rootMetadata.getArtifactType())
+                .artifactType(rootMetadata.getArtifactType().value())
                 .name(rootMetadata.getName())
                 .isRoot(true)
                 .isCycleNode(false)
@@ -387,7 +387,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                             .groupId(refGroupId != null ? refGroupId : "default")
                             .artifactId(refArtifactId)
                             .version(refVersion)
-                            .artifactType(refMetadata.getArtifactType())
+                            .artifactType(refMetadata.getArtifactType().value())
                             .name(refMetadata.getName())
                             .isRoot(false)
                             .isCycleNode(isArtifactCycle)
@@ -480,7 +480,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                             .groupId(refGroupId != null ? refGroupId : "default")
                             .artifactId(refArtifactId)
                             .version(refVersion)
-                            .artifactType(refMetadata.getArtifactType())
+                            .artifactType(refMetadata.getArtifactType().value())
                             .name(refMetadata.getName())
                             .isRoot(false)
                             .isCycleNode(isArtifactCycle)
@@ -552,7 +552,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         String rawGroupId = new GroupId(groupId).getRawGroupIdWithNull();
         String artifactType = null;
         try {
-            artifactType = storage.getArtifactMetaData(rawGroupId, artifactId).getArtifactType();
+            artifactType = storage.getArtifactMetaData(rawGroupId, artifactId).getArtifactType().value();
         } catch (ArtifactNotFoundException e) {
             // Artifact may already be gone; proceed with delete and record with null type
         }
@@ -1010,7 +1010,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         }
 
         // Check if the artifact type allows empty content
-        String artifactType = vmd.getArtifactType();
+        ArtifactType artifactType = vmd.getArtifactType();
         ArtifactTypeUtilProvider artifactTypeProvider = factory.getArtifactTypeProvider(artifactType);
         boolean isEmptyContent = artifactTypeProvider.getContentTypes().isEmpty();
         ContentHandle content = ContentHandle.create(resolveContent(data));
@@ -1163,7 +1163,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
 
             TypedContent typedContent = TypedContent.create(artifact.getContent(), artifact.getContentType());
             rulesService.applyRules(gav.getRawGroupIdWithNull(), gav.getRawArtifactId(),
-                    vmd.getArtifactType(), typedContent, RuleApplicationType.UPDATE, references,
+                    ArtifactType.fromValue(vmd.getArtifactType()), typedContent, RuleApplicationType.UPDATE, references,
                     resolvedReferences);
         }
 
@@ -1316,7 +1316,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         if (data.getFirstVersion() != null) {
             boolean contentRequired = true;
             if (data.getArtifactType() != null) {
-                Set<String> contentTypes = factory.getArtifactTypeProvider(data.getArtifactType()).getContentTypes();
+                Set<String> contentTypes = factory.getArtifactTypeProvider(ArtifactType.fromValue(data.getArtifactType())).getContentTypes();
                 contentRequired = !contentTypes.isEmpty();
             }
             if (contentRequired) {
@@ -1397,7 +1397,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
             }
             TypedContent typedContent = TypedContent.create(content, contentType);
 
-            String artifactType = ArtifactTypeUtil.determineArtifactType(typedContent, data.getArtifactType(), factory);
+            ArtifactType artifactType = ArtifactTypeUtil.determineArtifactType(typedContent, ArtifactType.fromValue(data.getArtifactType()), factory);
 
             final String owner = securityIdentity.getPrincipal().getName();
 
@@ -1405,7 +1405,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
             ContentHandle effectiveContent = content;
             String effectiveContentType = contentType;
             List<ArtifactReferenceDto> autoReferences = new ArrayList<>();
-            if ("MODEL_SCHEMA".equals(artifactType)) {
+            if (ArtifactType.BuiltIn.MODEL_SCHEMA.equals(artifactType)) {
                 var extraction = embeddedSchemaService.extractModelSchemaEmbeddedSchemas(
                         storage, new GroupId(groupId).getRawGroupIdWithNull(), artifactId,
                         content, contentType, owner);
@@ -1414,7 +1414,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                     effectiveContentType = extraction.getContentType();
                     autoReferences.addAll(extraction.getReferences());
                 }
-            } else if ("PROMPT_TEMPLATE".equals(artifactType)) {
+            } else if (ArtifactType.BuiltIn.PROMPT_TEMPLATE.equals(artifactType)) {
                 var extraction = embeddedSchemaService.extractPromptTemplateEmbeddedSchemas(
                         storage, new GroupId(groupId).getRawGroupIdWithNull(), artifactId,
                         content, contentType, owner);
@@ -1469,9 +1469,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
 
             if (dryRun == null || !dryRun) {
                 String rawGroupId = new GroupId(groupId).getRawGroupIdWithNull();
-                otelMetrics.recordArtifactCreated(rawGroupId, artifactType);
+                otelMetrics.recordArtifactCreated(rawGroupId, artifactType == null ? null : artifactType.value());
                 if (storageResult.getRight() != null) {
-                    otelMetrics.recordVersionCreated(rawGroupId, artifactType);
+                    otelMetrics.recordVersionCreated(rawGroupId, artifactType == null ? null : artifactType.value());
                 }
             }
 
@@ -1530,7 +1530,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
-        String artifactType = lookupArtifactType(groupId, artifactId);
+        ArtifactType artifactType = lookupArtifactType(groupId, artifactId);
         ArtifactTypeUtilProvider artifactTypeProvider = factory.getArtifactTypeProvider(artifactType);
         boolean isEmptyContent = artifactTypeProvider.getContentTypes().isEmpty();
         if (!isEmptyContent) {
@@ -1558,7 +1558,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         ContentHandle effectiveContent = content;
         String effectiveContentType = ct;
         List<ArtifactReferenceDto> autoReferences = new ArrayList<>();
-        if ("MODEL_SCHEMA".equals(artifactType)) {
+        if (ArtifactType.BuiltIn.MODEL_SCHEMA.equals(artifactType)) {
             var extraction = embeddedSchemaService.extractModelSchemaEmbeddedSchemas(
                     storage, new GroupId(groupId).getRawGroupIdWithNull(), artifactId,
                     content, ct, owner);
@@ -1567,7 +1567,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                 effectiveContentType = extraction.getContentType();
                 autoReferences.addAll(extraction.getReferences());
             }
-        } else if ("PROMPT_TEMPLATE".equals(artifactType)) {
+        } else if (ArtifactType.BuiltIn.PROMPT_TEMPLATE.equals(artifactType)) {
             var extraction = embeddedSchemaService.extractPromptTemplateEmbeddedSchemas(
                     storage, new GroupId(groupId).getRawGroupIdWithNull(), artifactId,
                     content, ct, owner);
@@ -1605,7 +1605,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                 contentDto, metaDataDto, data.getBranches(), isDraft, dryRun != null && dryRun, owner);
 
         if (dryRun == null || !dryRun) {
-            otelMetrics.recordVersionCreated(new GroupId(groupId).getRawGroupIdWithNull(), artifactType);
+            otelMetrics.recordVersionCreated(new GroupId(groupId).getRawGroupIdWithNull(), artifactType.value());
         }
 
         return V3ApiUtil.dtoToVersionMetaData(vmd);
@@ -1757,7 +1757,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
      * @param groupId
      * @param artifactId
      */
-    private String lookupArtifactType(String groupId, String artifactId) {
+    private ArtifactType lookupArtifactType(String groupId, String artifactId) {
         return storage.getArtifactMetaData(new GroupId(groupId).getRawGroupIdWithNull(), artifactId)
                 .getArtifactType();
     }
@@ -1857,7 +1857,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         ContentHandle content = ContentHandle.create(resolveContent(theVersion.getContent()));
         boolean isDraftVersion = theVersion.getIsDraft() != null && theVersion.getIsDraft();
 
-        String artifactType = lookupArtifactType(groupId, artifactId);
+        ArtifactType artifactType = lookupArtifactType(groupId, artifactId);
 
         final String owner = securityIdentity.getPrincipal().getName();
 
@@ -1882,7 +1882,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                 artifactType, contentDto, metaData, branches, isDraftVersion, dryRun != null && dryRun, owner);
 
         if (dryRun == null || !dryRun) {
-            otelMetrics.recordVersionCreated(new GroupId(groupId).getRawGroupIdWithNull(), artifactType);
+            otelMetrics.recordVersionCreated(new GroupId(groupId).getRawGroupIdWithNull(), artifactType.value());
         }
 
         VersionMetaData vmd = V3ApiUtil.dtoToVersionMetaData(vmdDto);
@@ -1926,8 +1926,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         ArtifactVersionMetaDataDto versionMetaData = storage.getArtifactVersionMetaData(
                 gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
 
-        String artifactType = versionMetaData.getArtifactType();
-        if (!"PROMPT_TEMPLATE".equals(artifactType)) {
+        ArtifactType artifactType = versionMetaData.getArtifactType();
+        if (!ArtifactType.BuiltIn.PROMPT_TEMPLATE.equals(artifactType)) {
             throw new BadRequestException(
                     "Artifact type must be PROMPT_TEMPLATE, but was: " + artifactType);
         }
@@ -1966,8 +1966,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         ArtifactVersionMetaDataDto versionMetaData = storage.getArtifactVersionMetaData(
                 gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
 
-        String artifactType = versionMetaData.getArtifactType();
-        if (!"PROTOBUF".equals(artifactType)) {
+        ArtifactType artifactType = versionMetaData.getArtifactType();
+        if (!ArtifactType.BuiltIn.PROTOBUF.equals(artifactType)) {
             throw new BadRequestException(
                     "Export as ZIP is only supported for PROTOBUF artifacts, but artifact type was: " + artifactType);
         }
@@ -2316,7 +2316,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         String version = contract.getInfo() != null ? contract.getInfo().getVersion() : null;
 
         try {
-            storage.createArtifact(rawGroupId, contractId, ArtifactType.ODCS_CONTRACT,
+            storage.createArtifact(rawGroupId, contractId, ArtifactType.BuiltIn.ODCS_CONTRACT,
                     EditableArtifactMetaDataDto.builder()
                             .name(contract.getInfo() != null ? contract.getInfo().getTitle() : contractId)
                             .description(
@@ -2331,7 +2331,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
                     List.of(), false, false, null);
         } catch (ArtifactAlreadyExistsException e) {
             storage.createArtifactVersion(rawGroupId, contractId, version,
-                    ArtifactType.ODCS_CONTRACT,
+                    ArtifactType.BuiltIn.ODCS_CONTRACT,
                     ContentWrapperDto.builder()
                             .contentType(ContentTypes.APPLICATION_YAML)
                             .content(ContentHandle.create(data))
@@ -2365,7 +2365,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         String rawGroupId = new GroupId(groupId).getRawGroupIdWithNull();
         Set<SearchFilter> filters = Set.of(
                 SearchFilter.ofGroupId(rawGroupId),
-                SearchFilter.ofArtifactType(ArtifactType.ODCS_CONTRACT));
+                SearchFilter.ofArtifactType(ArtifactType.BuiltIn.ODCS_CONTRACT.value()));
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(filters,
                 OrderBy.createdOn, OrderDirection.desc, effectiveOffset,
@@ -2415,7 +2415,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
 
         String version = contract.getInfo() != null ? contract.getInfo().getVersion() : null;
         storage.createArtifactVersion(rawGroupId, contractId, version,
-                ArtifactType.ODCS_CONTRACT,
+                ArtifactType.BuiltIn.ODCS_CONTRACT,
                 ContentWrapperDto.builder()
                         .contentType(ContentTypes.APPLICATION_YAML)
                         .content(ContentHandle.create(data))

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/IdsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/IdsResourceImpl.java
@@ -126,7 +126,7 @@ public class IdsResourceImpl extends AbstractResourceImpl implements IdsResource
                 .type(contentToReturn.getContentType())
                 .header(HttpHeaders.CONTENT_DISPOSITION, buildContentDisposition(filename));
         if (returnArtifactType != null && returnArtifactType) {
-            builder.header("X-Registry-ArtifactType", metaData.getArtifactType());
+            builder.header("X-Registry-ArtifactType", metaData.getArtifactType().value());
         }
         checkIfDeprecated(metaData::getState, null, metaData.getArtifactId(), metaData.getVersion(), builder);
         return builder.build();

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.rest.v3.impl;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.rest.v3.SearchResource;
 
 import io.apicurio.registry.auth.Authorized;
@@ -176,7 +177,8 @@ public class SearchResourceImpl implements SearchResource {
 
         Set<SearchFilter> filters = new HashSet<SearchFilter>();
         if (canonical && artifactType != null) {
-            String canonicalHash = contentUtils.getCanonicalContentHash(typedContent, artifactType, null,
+            String canonicalHash = contentUtils.getCanonicalContentHash(typedContent,
+                    ArtifactType.fromValue(artifactType), null,
                     null);
             filters.add(SearchFilter.ofCanonicalHash(canonicalHash));
         } else if (!canonical) {
@@ -376,7 +378,8 @@ public class SearchResourceImpl implements SearchResource {
         TypedContent typedContent = TypedContent.create(content, ct);
 
         if (canonical && artifactType != null) {
-            String canonicalHash = contentUtils.getCanonicalContentHash(typedContent, artifactType, null,
+            String canonicalHash = contentUtils.getCanonicalContentHash(typedContent,
+                    ArtifactType.fromValue(artifactType), null,
                     null);
             filters.add(SearchFilter.ofCanonicalHash(canonicalHash));
         } else if (!canonical) {

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/V3ApiUtil.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/V3ApiUtil.java
@@ -64,7 +64,7 @@ public final class V3ApiUtil {
         metaData.setModifiedBy(dto.getModifiedBy());
         metaData.setModifiedOn(new Date(dto.getModifiedOn()));
         metaData.setName(dto.getName());
-        metaData.setArtifactType(dto.getArtifactType());
+        metaData.setArtifactType(dto.getArtifactType() == null ? null : dto.getArtifactType().value());
         metaData.setLabels(dto.getLabels());
         metaData.setContractMetadata(projectContractMetadata(dto.getLabels()));
         return metaData;
@@ -148,7 +148,7 @@ public final class V3ApiUtil {
         metaData.setModifiedOn(new Date(dto.getModifiedOn()));
         metaData.setDescription(dto.getDescription());
         metaData.setName(dto.getName());
-        metaData.setArtifactType(dto.getArtifactType());
+        metaData.setArtifactType(dto.getArtifactType() == null ? null : dto.getArtifactType().value());
         metaData.setVersion(dto.getVersion());
         metaData.setGlobalId(dto.getGlobalId());
         metaData.setContentId(dto.getContentId());
@@ -195,7 +195,7 @@ public final class V3ApiUtil {
             sa.setModifiedBy(artifact.getModifiedBy());
             sa.setModifiedOn(artifact.getModifiedOn());
             sa.setName(artifact.getName());
-            sa.setArtifactType(artifact.getArtifactType());
+            sa.setArtifactType(artifact.getArtifactType() == null ? null : artifact.getArtifactType().value());
             sa.setLabels(artifact.getLabels());
             results.getArtifacts().add(sa);
         });
@@ -256,7 +256,7 @@ public final class V3ApiUtil {
             sv.setContentId(version.getContentId());
             sv.setName(version.getName());
             sv.setState(version.getState());
-            sv.setArtifactType(version.getArtifactType());
+            sv.setArtifactType(version.getArtifactType() == null ? null : version.getArtifactType().value());
             sv.setLabels(version.getLabels());
             results.getVersions().add(sv);
         });

--- a/app/src/main/java/io/apicurio/registry/rules/RuleContext.java
+++ b/app/src/main/java/io/apicurio/registry/rules/RuleContext.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.rules;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.rest.v3.beans.ArtifactReference;
 import io.apicurio.registry.storage.RegistryStorage;
@@ -22,7 +23,7 @@ import java.util.Map;
 public class RuleContext {
     private final String groupId;
     private final String artifactId;
-    private final String artifactType;
+    private final ArtifactType artifactType;
     private final String configuration;
     private final List<TypedContent> currentContent;
     private final TypedContent updatedContent;

--- a/app/src/main/java/io/apicurio/registry/rules/RulesService.java
+++ b/app/src/main/java/io/apicurio/registry/rules/RulesService.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.rules;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.rest.v3.beans.ArtifactReference;
 import io.apicurio.registry.rules.violation.RuleViolationException;
@@ -27,7 +28,8 @@ public interface RulesService {
      * @param resolvedReferences
      * @throws RuleViolationException
      */
-    public void applyRules(String groupId, String artifactId, String artifactType, TypedContent content,
+    @SuppressWarnings("java:S107")
+    public void applyRules(String groupId, String artifactId, ArtifactType artifactType, TypedContent content,
             RuleApplicationType ruleApplicationType, List<ArtifactReference> references,
             Map<String, TypedContent> resolvedReferences) throws RuleViolationException;
 
@@ -45,7 +47,8 @@ public interface RulesService {
      * @param resolvedReferences
      * @throws RuleViolationException
      */
-    public void applyRule(String groupId, String artifactId, String artifactType, TypedContent content,
+    @SuppressWarnings("java:S107")
+    public void applyRule(String groupId, String artifactId, ArtifactType artifactType, TypedContent content,
             RuleType ruleType, String ruleConfiguration, RuleApplicationType ruleApplicationType,
             List<ArtifactReference> references, Map<String, TypedContent> resolvedReferences)
             throws RuleViolationException;
@@ -62,7 +65,8 @@ public interface RulesService {
      * @param resolvedReferences
      * @throws RuleViolationException
      */
-    public void applyRules(String groupId, String artifactId, String artifactVersion, String artifactType,
+    @SuppressWarnings("java:S107")
+    public void applyRules(String groupId, String artifactId, String artifactVersion, ArtifactType artifactType,
             TypedContent updatedContent, List<ArtifactReference> references,
             Map<String, TypedContent> resolvedReferences) throws RuleViolationException;
 
@@ -71,7 +75,8 @@ public interface RulesService {
      * This allows validation against a different storage (e.g., the inactive database
      * during GitOps blue-green loading).
      */
-    public void applyRules(RegistryStorage storage, String groupId, String artifactId, String artifactType,
+    @SuppressWarnings("java:S107")
+    public void applyRules(RegistryStorage storage, String groupId, String artifactId, ArtifactType artifactType,
             TypedContent content, RuleApplicationType ruleApplicationType,
             List<ArtifactReference> references, Map<String, TypedContent> resolvedReferences)
             throws RuleViolationException;
@@ -81,7 +86,8 @@ public interface RulesService {
      * existing content for comparison (e.g., for compatibility checks during GitOps loading
      * where all versions are already imported into the same storage).
      */
-    public void applyRules(RegistryStorage storage, String groupId, String artifactId, String artifactType,
+    @SuppressWarnings("java:S107")
+    public void applyRules(RegistryStorage storage, String groupId, String artifactId, ArtifactType artifactType,
             TypedContent content, List<TypedContent> existingContent,
             List<ArtifactReference> references, Map<String, TypedContent> resolvedReferences)
             throws RuleViolationException;

--- a/app/src/main/java/io/apicurio/registry/rules/RulesServiceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rules/RulesServiceImpl.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.rules;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.metrics.OTelMetricsProvider;
 import io.apicurio.registry.rest.v3.beans.ArtifactReference;
@@ -48,7 +49,8 @@ public class RulesServiceImpl implements RulesService {
      *      RuleApplicationType, List, Map)
      */
     @Override
-    public void applyRules(String groupId, String artifactId, String artifactType, TypedContent content,
+    @SuppressWarnings("java:S107")
+    public void applyRules(String groupId, String artifactId, ArtifactType artifactType, TypedContent content,
             RuleApplicationType ruleApplicationType, List<ArtifactReference> references,
             Map<String, TypedContent> resolvedReferences) throws RuleViolationException {
         applyRules(storage, groupId, artifactId, artifactType, content, ruleApplicationType,
@@ -56,8 +58,9 @@ public class RulesServiceImpl implements RulesService {
     }
 
     @Override
+    @SuppressWarnings("java:S107")
     public void applyRules(RegistryStorage storageToUse, String groupId, String artifactId,
-            String artifactType, TypedContent content, RuleApplicationType ruleApplicationType,
+            ArtifactType artifactType, TypedContent content, RuleApplicationType ruleApplicationType,
             List<ArtifactReference> references, Map<String, TypedContent> resolvedReferences)
             throws RuleViolationException {
         @SuppressWarnings("unchecked")
@@ -78,8 +81,9 @@ public class RulesServiceImpl implements RulesService {
     }
 
     @Override
+    @SuppressWarnings("java:S107")
     public void applyRules(RegistryStorage storageToUse, String groupId, String artifactId,
-            String artifactType, TypedContent content, List<TypedContent> existingContent,
+            ArtifactType artifactType, TypedContent content, List<TypedContent> existingContent,
             List<ArtifactReference> references, Map<String, TypedContent> resolvedReferences)
             throws RuleViolationException {
         Set<RuleType> artifactRules = new HashSet<>(storageToUse.getArtifactRules(groupId, artifactId));
@@ -88,7 +92,7 @@ public class RulesServiceImpl implements RulesService {
     }
 
     private void applyAllRules(RegistryStorage storageToUse, String groupId, String artifactId,
-            String artifactType, List<TypedContent> currentContent, TypedContent updatedContent,
+            ArtifactType artifactType, List<TypedContent> currentContent, TypedContent updatedContent,
             Set<RuleType> artifactRules, List<ArtifactReference> references,
             Map<String, TypedContent> resolvedReferences) {
 
@@ -124,7 +128,8 @@ public class RulesServiceImpl implements RulesService {
     }
 
     @Override
-    public void applyRule(String groupId, String artifactId, String artifactType, TypedContent content,
+    @SuppressWarnings("java:S107")
+    public void applyRule(String groupId, String artifactId, ArtifactType artifactType, TypedContent content,
             RuleType ruleType, String ruleConfiguration, RuleApplicationType ruleApplicationType,
             List<ArtifactReference> references, Map<String, TypedContent> resolvedReferences)
             throws RuleViolationException {
@@ -140,7 +145,7 @@ public class RulesServiceImpl implements RulesService {
     // Metrics are recorded here even during dry-run requests because rule evaluation genuinely
     // executes during dry-run — only artifact/version creation metrics are suppressed.
     private void applyRule(RegistryStorage storageToUse, String groupId, String artifactId,
-            String artifactType, List<TypedContent> currentContent, TypedContent updatedContent,
+            ArtifactType artifactType, List<TypedContent> currentContent, TypedContent updatedContent,
             RuleType ruleType, String ruleConfiguration, List<ArtifactReference> references,
             Map<String, TypedContent> resolvedReferences) {
         RuleExecutor executor = factory.createExecutor(ruleType);
@@ -152,19 +157,20 @@ public class RulesServiceImpl implements RulesService {
             executor.execute(context);
             otelMetrics.recordRuleEvaluation(ruleType.value(), true);
             if (ruleType == RuleType.VALIDITY) {
-                otelMetrics.recordSchemaValidation(artifactType, true);
+                otelMetrics.recordSchemaValidation(artifactType.value(), true);
             }
         } catch (Exception e) {
             otelMetrics.recordRuleEvaluation(ruleType.value(), false);
             if (ruleType == RuleType.VALIDITY) {
-                otelMetrics.recordSchemaValidation(artifactType, false);
+                otelMetrics.recordSchemaValidation(artifactType.value(), false);
             }
             throw e;
         }
     }
 
     @Override
-    public void applyRules(String groupId, String artifactId, String artifactVersion, String artifactType,
+    @SuppressWarnings("java:S107")
+    public void applyRules(String groupId, String artifactId, String artifactVersion, ArtifactType artifactType,
             TypedContent updatedContent, List<ArtifactReference> references,
             Map<String, TypedContent> resolvedReferences) throws RuleViolationException {
         StoredArtifactVersionDto versionContent = storage.getArtifactVersionContent(groupId, artifactId,

--- a/app/src/main/java/io/apicurio/registry/services/EmbeddedSchemaService.java
+++ b/app/src/main/java/io/apicurio/registry/services/EmbeddedSchemaService.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.services;
 
+import io.apicurio.registry.types.ArtifactType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -217,7 +218,7 @@ public class EmbeddedSchemaService {
                     .references(Collections.emptyList())
                     .build();
 
-            storage.createArtifact(groupId, schemaArtifactId, "JSON", artifactMeta,
+            storage.createArtifact(groupId, schemaArtifactId, ArtifactType.BuiltIn.JSON, artifactMeta,
                     "1", contentWrapper, versionMeta, Collections.emptyList(),
                     false, false, owner);
 

--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
@@ -1,5 +1,7 @@
 package io.apicurio.registry.storage;
 
+import io.apicurio.registry.types.ArtifactType;
+
 import io.apicurio.common.apps.config.DynamicConfigPropertyDto;
 import io.apicurio.common.apps.config.DynamicConfigStorage;
 import io.apicurio.registry.content.TypedContent;
@@ -123,7 +125,7 @@ public interface RegistryStorage extends DynamicConfigStorage {
      * metadata of the first version.
      */
     Pair<ArtifactMetaDataDto, ArtifactVersionMetaDataDto> createArtifact(String groupId, String artifactId,
-            String artifactType, EditableArtifactMetaDataDto artifactMetaData, String version,
+            ArtifactType artifactType, EditableArtifactMetaDataDto artifactMetaData, String version,
             ContentWrapperDto versionContent, EditableVersionMetaDataDto versionMetaData,
             List<String> versionBranches, boolean versionIsDraft, boolean dryRun, String owner)
             throws ArtifactAlreadyExistsException, RegistryStorageException;
@@ -202,7 +204,7 @@ public interface RegistryStorage extends DynamicConfigStorage {
      * @param dryRun
      */
     ArtifactVersionMetaDataDto createArtifactVersion(String groupId, String artifactId, String version,
-            String artifactType, ContentWrapperDto content, EditableVersionMetaDataDto metaData,
+            ArtifactType artifactType, ContentWrapperDto content, EditableVersionMetaDataDto metaData,
             List<String> branches, boolean isDraft, boolean dryRun, String owner)
             throws ArtifactNotFoundException, VersionAlreadyExistsException, RegistryStorageException;
 
@@ -225,7 +227,7 @@ public interface RegistryStorage extends DynamicConfigStorage {
      * @throws CommitFailedException if the current versionOrder does not match expectedBaseVersionOrder
      */
     ArtifactVersionMetaDataDto createArtifactVersionIfLatest(String groupId, String artifactId,
-            String version, String artifactType, ContentWrapperDto content,
+            String version, ArtifactType artifactType, ContentWrapperDto content,
             EditableVersionMetaDataDto metaData, List<String> branches, boolean isDraft, String owner,
             int expectedBaseVersionOrder, EditableArtifactMetaDataDto artifactMetaData)
             throws ArtifactNotFoundException, VersionAlreadyExistsException, CommitFailedException,
@@ -635,7 +637,7 @@ public interface RegistryStorage extends DynamicConfigStorage {
      * @throws VersionNotFoundException
      * @throws RegistryStorageException
      */
-    void updateArtifactVersionContent(String groupId, String artifactId, String version, String artifactType,
+    void updateArtifactVersionContent(String groupId, String artifactId, String version, ArtifactType artifactType,
             ContentWrapperDto content)
             throws ArtifactNotFoundException, VersionNotFoundException, RegistryStorageException;
 

--- a/app/src/main/java/io/apicurio/registry/storage/decorator/ReadOnlyRegistryStorageDecorator.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/ReadOnlyRegistryStorageDecorator.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.decorator;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.common.apps.config.Dynamic;
 import io.apicurio.common.apps.config.DynamicConfigPropertyDto;
 import io.apicurio.common.apps.config.Info;
@@ -69,7 +70,7 @@ public class ReadOnlyRegistryStorageDecorator extends RegistryStorageDecoratorBa
     }
 
     public Pair<ArtifactMetaDataDto, ArtifactVersionMetaDataDto> createArtifact(String groupId,
-            String artifactId, String artifactType, EditableArtifactMetaDataDto artifactMetaData,
+            String artifactId, ArtifactType artifactType, EditableArtifactMetaDataDto artifactMetaData,
             String version, ContentWrapperDto versionContent, EditableVersionMetaDataDto versionMetaData,
             List<String> versionBranches, boolean isVersionDraft, boolean dryRun, String owner)
             throws RegistryStorageException {
@@ -90,7 +91,7 @@ public class ReadOnlyRegistryStorageDecorator extends RegistryStorageDecoratorBa
     }
 
     public ArtifactVersionMetaDataDto createArtifactVersion(String groupId, String artifactId, String version,
-            String artifactType, ContentWrapperDto content, EditableVersionMetaDataDto metaData,
+            ArtifactType artifactType, ContentWrapperDto content, EditableVersionMetaDataDto metaData,
             List<String> branches, boolean isDraft, boolean dryRun, String owner)
             throws RegistryStorageException {
         checkReadOnly();
@@ -99,7 +100,7 @@ public class ReadOnlyRegistryStorageDecorator extends RegistryStorageDecoratorBa
     }
 
     public ArtifactVersionMetaDataDto createArtifactVersionIfLatest(String groupId, String artifactId,
-            String version, String artifactType, ContentWrapperDto content,
+            String version, ArtifactType artifactType, ContentWrapperDto content,
             EditableVersionMetaDataDto metaData, List<String> branches, boolean isDraft, String owner,
             int expectedBaseVersionOrder, EditableArtifactMetaDataDto artifactMetaData) {
         checkReadOnly();
@@ -338,7 +339,7 @@ public class ReadOnlyRegistryStorageDecorator extends RegistryStorageDecoratorBa
     }
 
     public void updateArtifactVersionContent(String groupId, String artifactId, String version,
-            String artifactType, ContentWrapperDto content) throws RegistryStorageException {
+            ArtifactType artifactType, ContentWrapperDto content) throws RegistryStorageException {
         checkReadOnly();
         delegate.updateArtifactVersionContent(groupId, artifactId, version, artifactType, content);
     }

--- a/app/src/main/java/io/apicurio/registry/storage/decorator/SearchIndexEventDecorator.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/SearchIndexEventDecorator.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.decorator;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.dto.ContentWrapperDto;
@@ -76,7 +77,7 @@ public class SearchIndexEventDecorator extends RegistryStorageDecoratorBase
     }
 
     public Pair<ArtifactMetaDataDto, ArtifactVersionMetaDataDto> createArtifact(String groupId,
-            String artifactId, String artifactType, EditableArtifactMetaDataDto artifactMetaData,
+            String artifactId, ArtifactType artifactType, EditableArtifactMetaDataDto artifactMetaData,
             String version, ContentWrapperDto versionContent, EditableVersionMetaDataDto versionMetaData,
             List<String> versionBranches, boolean versionIsDraft, boolean dryRun, String owner)
             throws RegistryStorageException {
@@ -97,7 +98,7 @@ public class SearchIndexEventDecorator extends RegistryStorageDecoratorBase
     }
 
     public ArtifactVersionMetaDataDto createArtifactVersion(String groupId, String artifactId,
-            String version, String artifactType, ContentWrapperDto content,
+            String version, ArtifactType artifactType, ContentWrapperDto content,
             EditableVersionMetaDataDto metaData, List<String> branches, boolean isDraft,
             boolean dryRun, String owner) throws RegistryStorageException {
 
@@ -115,7 +116,7 @@ public class SearchIndexEventDecorator extends RegistryStorageDecoratorBase
     }
 
     public ArtifactVersionMetaDataDto createArtifactVersionIfLatest(String groupId, String artifactId,
-            String version, String artifactType, ContentWrapperDto content,
+            String version, ArtifactType artifactType, ContentWrapperDto content,
             EditableVersionMetaDataDto metaData, List<String> branches, boolean isDraft, String owner,
             int expectedBaseVersionOrder, EditableArtifactMetaDataDto artifactMetaData)
             throws ArtifactNotFoundException, VersionAlreadyExistsException, CommitFailedException,

--- a/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactMetaDataDto.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.dto;
 
+import io.apicurio.registry.types.ArtifactType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -27,11 +28,12 @@ public class ArtifactMetaDataDto {
     private String groupId;
     private String artifactId;
     private String name;
+
     private String description;
     private String owner;
     private long createdOn;
     private String modifiedBy;
     private long modifiedOn;
-    private String artifactType;
+    private ArtifactType artifactType;
     private Map<String, String> labels;
 }

--- a/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactVersionMetaDataDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/ArtifactVersionMetaDataDto.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.dto;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.VersionState;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,6 +28,7 @@ public class ArtifactVersionMetaDataDto {
 
     private String groupId;
     private String artifactId;
+
     private String version;
     private int versionOrder;
     private long globalId;
@@ -37,7 +39,7 @@ public class ArtifactVersionMetaDataDto {
     private long createdOn;
     private String modifiedBy;
     private long modifiedOn;
-    private String artifactType;
+    private ArtifactType artifactType;
     private VersionState state;
     private Map<String, String> labels;
 }

--- a/app/src/main/java/io/apicurio/registry/storage/dto/ContentWrapperDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/ContentWrapperDto.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.dto;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.impl.sql.RegistryContentUtils.HasReferences;
 import lombok.AllArgsConstructor;
@@ -27,7 +28,8 @@ public class ContentWrapperDto implements HasReferences {
 
     private String contentType;
     private ContentHandle content;
+
     private List<ArtifactReferenceDto> references;
-    private String artifactType;
+    private ArtifactType artifactType;
     private transient String contentHash;
 }

--- a/app/src/main/java/io/apicurio/registry/storage/dto/SearchedArtifactDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/SearchedArtifactDto.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.dto;
 
+import io.apicurio.registry.types.ArtifactType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -26,7 +27,8 @@ public class SearchedArtifactDto {
     private String description;
     private Date createdOn;
     private String owner;
-    private String artifactType;
+    private ArtifactType artifactType;
+
     private Date modifiedOn;
     private String modifiedBy;
     private Map<String, String> labels;

--- a/app/src/main/java/io/apicurio/registry/storage/dto/SearchedVersionDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/SearchedVersionDto.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.dto;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.VersionState;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,10 +28,11 @@ public class SearchedVersionDto {
     private String name;
     private String description;
     private Date createdOn;
+
     private String owner;
     private String modifiedBy;
     private Date modifiedOn;
-    private String artifactType;
+    private ArtifactType artifactType;
     private VersionState state;
     private long globalId;
     private long contentId;

--- a/app/src/main/java/io/apicurio/registry/storage/dto/VersionContentDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/VersionContentDto.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.dto;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.types.VersionState;
 import lombok.AllArgsConstructor;
@@ -27,6 +28,7 @@ import java.util.Map;
 public class VersionContentDto {
 
     private String groupId;
+
     private String artifactId;
     private String version;
     private int versionOrder;
@@ -38,7 +40,7 @@ public class VersionContentDto {
     private long createdOn;
     private String modifiedBy;
     private long modifiedOn;
-    private String artifactType;
+    private ArtifactType artifactType;
     private VersionState state;
     private Map<String, String> labels;
     private ContentHandle content;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -28,6 +28,7 @@ import io.apicurio.registry.rules.integrity.IntegrityLevel;
 import io.apicurio.registry.rules.validity.ValidityLevel;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.StorageEvent;
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.storage.StorageEventType;
 import io.apicurio.registry.storage.decorator.ReadOnlyDelegatingStorage;
 import io.apicurio.registry.storage.dto.*;
@@ -445,7 +446,7 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
 
     @Override
     public Pair<ArtifactMetaDataDto, ArtifactVersionMetaDataDto> createArtifact(String groupId,
-            String artifactId, String artifactType, EditableArtifactMetaDataDto artifactMetaData,
+            String artifactId, ArtifactType artifactType, EditableArtifactMetaDataDto artifactMetaData,
             String version, ContentWrapperDto versionContent, EditableVersionMetaDataDto versionMetaData,
             List<String> versionBranches, boolean versionIsDraft, boolean dryRun, String owner)
             throws RegistryStorageException {
@@ -498,7 +499,7 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
 
     @Override
     public ArtifactVersionMetaDataDto createArtifactVersion(String groupId, String artifactId, String version,
-            String artifactType, ContentWrapperDto contentDto, EditableVersionMetaDataDto metaData,
+            ArtifactType artifactType, ContentWrapperDto contentDto, EditableVersionMetaDataDto metaData,
             List<String> branches, boolean isDraft, boolean dryRun, String owner)
             throws RegistryStorageException {
         String content = contentDto != null ? contentDto.getContent().content() : null;
@@ -517,7 +518,7 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
 
     @Override
     public ArtifactVersionMetaDataDto createArtifactVersionIfLatest(String groupId, String artifactId,
-            String version, String artifactType, ContentWrapperDto contentDto,
+            String version, ArtifactType artifactType, ContentWrapperDto contentDto,
             EditableVersionMetaDataDto metaData, List<String> branches, boolean isDraft, String owner,
             int expectedBaseVersionOrder, EditableArtifactMetaDataDto artifactMetaData)
             throws RegistryStorageException {
@@ -536,7 +537,7 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
 
     @Override
     public void updateArtifactVersionContent(String groupId, String artifactId, String version,
-            String artifactType, ContentWrapperDto contentDto) throws RegistryStorageException {
+            ArtifactType artifactType, ContentWrapperDto contentDto) throws RegistryStorageException {
         String content = contentDto != null ? contentDto.getContent().content() : null;
         String contentType = contentDto != null ? contentDto.getContentType() : null;
         List<ArtifactReferenceDto> references = contentDto != null ? contentDto.getReferences() : null;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifact10Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifact10Message.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.kafkasql.messages;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
@@ -29,7 +30,7 @@ public class CreateArtifact10Message extends AbstractMessage {
 
     private String groupId;
     private String artifactId;
-    private String artifactType;
+    private ArtifactType artifactType;
     private EditableArtifactMetaDataDto artifactMetaDataDto;
     private String version;
     private String contentType;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifact11Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifact11Message.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.kafkasql.messages;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
@@ -28,7 +29,7 @@ public class CreateArtifact11Message extends AbstractMessage {
 
     private String groupId;
     private String artifactId;
-    private String artifactType;
+    private ArtifactType artifactType;
     private EditableArtifactMetaDataDto artifactMetaDataDto;
     private String version;
     private String contentType;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifact9Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifact9Message.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.kafkasql.messages;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
@@ -29,7 +30,7 @@ public class CreateArtifact9Message extends AbstractMessage {
 
     private String groupId;
     private String artifactId;
-    private String artifactType;
+    private ArtifactType artifactType;
     private EditableArtifactMetaDataDto artifactMetaDataDto;
     private String version;
     private String contentType;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifactVersion10Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifactVersion10Message.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.kafkasql.messages;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
@@ -28,7 +29,7 @@ public class CreateArtifactVersion10Message extends AbstractMessage {
     private String groupId;
     private String artifactId;
     private String version;
-    private String artifactType;
+    private ArtifactType artifactType;
     private String contentType;
     private String content;
     private List<ArtifactReferenceDto> references;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifactVersion8Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifactVersion8Message.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.kafkasql.messages;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
@@ -29,7 +30,7 @@ public class CreateArtifactVersion8Message extends AbstractMessage {
     private String groupId;
     private String artifactId;
     private String version;
-    private String artifactType;
+    private ArtifactType artifactType;
     private String contentType;
     private String content;
     private List<ArtifactReferenceDto> references;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifactVersion9Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifactVersion9Message.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.kafkasql.messages;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
@@ -29,7 +30,7 @@ public class CreateArtifactVersion9Message extends AbstractMessage {
     private String groupId;
     private String artifactId;
     private String version;
-    private String artifactType;
+    private ArtifactType artifactType;
     private String contentType;
     private String content;
     private List<ArtifactReferenceDto> references;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifactVersionIfLatest11Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateArtifactVersionIfLatest11Message.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.kafkasql.messages;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
@@ -29,7 +30,7 @@ public class CreateArtifactVersionIfLatest11Message extends AbstractMessage {
     private String groupId;
     private String artifactId;
     private String version;
-    private String artifactType;
+    private ArtifactType artifactType;
     private String contentType;
     private String content;
     private List<ArtifactReferenceDto> references;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/UpdateArtifactVersionContent5Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/UpdateArtifactVersionContent5Message.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.kafkasql.messages;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
@@ -27,7 +28,7 @@ public class UpdateArtifactVersionContent5Message extends AbstractMessage {
     private String groupId;
     private String artifactId;
     private String version;
-    private String artifactType;
+    private ArtifactType artifactType;
     private String contentType;
     private String content;
     private List<ArtifactReferenceDto> references;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataSourceManager.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataSourceManager.java
@@ -16,6 +16,7 @@ import io.apicurio.registry.storage.impl.polling.model.v0.Version;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
 import io.apicurio.registry.storage.impl.sql.RegistryContentUtils;
 import io.apicurio.registry.storage.impl.sql.RegistryStorageContentUtils;
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.types.VersionState;
@@ -229,7 +230,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER extends SourceMark
                         ArtifactEntity artifactEntity = new ArtifactEntity();
                         artifactEntity.groupId = artifact.getGroupId();
                         artifactEntity.artifactId = artifact.getArtifactId();
-                        artifactEntity.artifactType = artifact.getArtifactType();
+                        artifactEntity.artifactType = ArtifactType.fromValue(artifact.getArtifactType());
                         artifactEntity.name = artifact.getName();
                         artifactEntity.description = artifact.getDescription();
                         artifactEntity.labels = withSourceLabel(artifact.getLabels(), artifactFile.getSourceId());
@@ -429,7 +430,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER extends SourceMark
             var typedContent = TypedContent.create(data, contentType);
 
             // Determine artifact type from content if not specified
-            String resolvedArtifactType = utils.determineArtifactType(typedContent, artifactType);
+            ArtifactType resolvedArtifactType = utils.determineArtifactType(typedContent, ArtifactType.fromValue(artifactType));
 
             // Calculate content hash for deduplication
             String contentHash = utils.getContentHash(typedContent, null);
@@ -457,7 +458,7 @@ public abstract class AbstractPollingDataSourceManager<MARKER extends SourceMark
             e.contentHash = contentHash;
             e.contentBytes = data.bytes();
             e.canonicalHash = utils.getCanonicalContentHash(typedContent, resolvedArtifactType, null, null);
-            e.artifactType = resolvedArtifactType;
+            e.artifactType = resolvedArtifactType.value();
             e.contentType = contentType;
 
             if (contentMetadata != null && contentMetadata.getReferences() != null

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/PollingDataValidator.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/PollingDataValidator.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.polling;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.util.ContentTypeUtil;
 import io.apicurio.registry.rest.v3.beans.ArtifactReference;
@@ -130,7 +131,7 @@ public class PollingDataValidator {
 
             try {
                 rulesService.applyRules(storage,
-                        artifact.getGroupId(), artifact.getArtifactId(), artifact.getArtifactType(),
+                        artifact.getGroupId(), artifact.getArtifactId(), ArtifactType.fromValue(artifact.getArtifactType()),
                         currentContent, existingContent,
                         references, resolvedReferences);
             } catch (RuleViolationException e) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/sql/AbstractReadOnlyRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/sql/AbstractReadOnlyRegistryStorage.java
@@ -27,6 +27,7 @@ import io.apicurio.registry.storage.dto.UsageSummaryCountsDto;
 import io.apicurio.registry.storage.error.RegistryStorageException;
 import io.apicurio.registry.types.RuleType;
 import io.apicurio.registry.types.VersionState;
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.utils.impexp.EntityInputStream;
 import io.apicurio.registry.utils.impexp.v3.ArtifactEntity;
 import io.apicurio.registry.utils.impexp.v3.ArtifactRuleEntity;
@@ -57,7 +58,7 @@ public abstract class AbstractReadOnlyRegistryStorage implements RegistryStorage
 
     @Override
     public Pair<ArtifactMetaDataDto, ArtifactVersionMetaDataDto> createArtifact(String groupId,
-            String artifactId, String artifactType, EditableArtifactMetaDataDto artifactMetaData,
+            String artifactId, ArtifactType artifactType, EditableArtifactMetaDataDto artifactMetaData,
             String version, ContentWrapperDto versionContent, EditableVersionMetaDataDto versionMetaData,
             List<String> versionBranches, boolean versionIsDraft, boolean dryRun, String owner)
             throws RegistryStorageException {
@@ -67,7 +68,7 @@ public abstract class AbstractReadOnlyRegistryStorage implements RegistryStorage
 
     @Override
     public ArtifactVersionMetaDataDto createArtifactVersion(String groupId, String artifactId, String version,
-            String artifactType, ContentWrapperDto content, EditableVersionMetaDataDto metaData,
+            ArtifactType artifactType, ContentWrapperDto content, EditableVersionMetaDataDto metaData,
             List<String> branches, boolean isDraft, boolean dryRun, String owner)
             throws RegistryStorageException {
         readOnlyViolation();
@@ -76,7 +77,7 @@ public abstract class AbstractReadOnlyRegistryStorage implements RegistryStorage
 
     @Override
     public ArtifactVersionMetaDataDto createArtifactVersionIfLatest(String groupId, String artifactId,
-            String version, String artifactType, ContentWrapperDto content,
+            String version, ArtifactType artifactType, ContentWrapperDto content,
             EditableVersionMetaDataDto metaData, List<String> branches, boolean isDraft, String owner,
             int expectedBaseVersionOrder, EditableArtifactMetaDataDto artifactMetaData)
             throws RegistryStorageException {
@@ -86,7 +87,7 @@ public abstract class AbstractReadOnlyRegistryStorage implements RegistryStorage
 
     @Override
     public void updateArtifactVersionContent(String groupId, String artifactId, String version,
-            String artifactType, ContentWrapperDto contentDto) throws RegistryStorageException {
+            ArtifactType artifactType, ContentWrapperDto contentDto) throws RegistryStorageException {
         readOnlyViolation();
     }
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchDocumentBuilder.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchDocumentBuilder.java
@@ -112,7 +112,7 @@ public class ElasticsearchDocumentBuilder {
 
         // Structured content extraction
         if (extractor != null && versionMetadata.getArtifactType() != null) {
-            indexStructuredElements(doc, contentBytes, versionMetadata.getArtifactType(),
+            indexStructuredElements(doc, contentBytes, versionMetadata.getArtifactType().value(),
                     extractor);
         }
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.search;
 
+import io.apicurio.registry.types.ArtifactType;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.FieldSort;
 import co.elastic.clients.elasticsearch._types.SortOptions;
@@ -421,7 +422,7 @@ public class ElasticsearchSearchService {
         builder.groupId(toStr(source.get("groupId")));
         builder.artifactId(toStr(source.get("artifactId")));
         builder.version(toStr(source.get("version")));
-        builder.artifactType(toStr(source.get("artifactType")));
+        builder.artifactType(ArtifactType.fromValue(toStr(source.get("artifactType"))));
         builder.name(toStr(source.get("name")));
         builder.description(toStr(source.get("description")));
         builder.owner(toStr(source.get("owner")));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -28,6 +28,7 @@ import io.apicurio.registry.storage.error.GroupNotFoundException;
 import io.apicurio.registry.storage.error.RegistryStorageException;
 import io.apicurio.registry.storage.error.RuleAlreadyExistsException;
 import io.apicurio.registry.storage.error.RuleNotFoundException;
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.storage.error.VersionAlreadyExistsException;
 import io.apicurio.registry.storage.error.VersionNotFoundException;
 import io.apicurio.registry.storage.impl.sql.jdb.Handle;
@@ -485,7 +486,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
 
     @Override
     public Pair<ArtifactMetaDataDto, ArtifactVersionMetaDataDto> createArtifact(String groupId,
-            String artifactId, String artifactType, EditableArtifactMetaDataDto artifactMetaData,
+            String artifactId, ArtifactType artifactType, EditableArtifactMetaDataDto artifactMetaData,
             String version, ContentWrapperDto versionContent, EditableVersionMetaDataDto versionMetaData,
             List<String> versionBranches, boolean versionIsDraft, boolean dryRun, String owner)
             throws RegistryStorageException {
@@ -530,7 +531,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
 
                 // Create a row in the artifacts table.
                 handle.createUpdate(sqlStatements.insertArtifact()).bind(0, normalizeGroupId(groupId))
-                        .bind(1, artifactId).bind(2, artifactType).bind(3, owner).bind(4, createdOn)
+                        .bind(1, artifactId).bind(2, artifactType != null ? artifactType.value() : null).bind(3, owner).bind(4, createdOn)
                         .bind(5, owner) // modifiedBy
                         .bind(6, createdOn) // modifiedOn
                         .bind(7, limitStr(amd.getName(), 512))
@@ -583,7 +584,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                 metaData, owner, createdOn, contentId, branches, isDraft);
     }
 
-    private Long ensureContentAndGetId(String artifactType, ContentWrapperDto contentDto, boolean isDraft) {
+    private Long ensureContentAndGetId(ArtifactType artifactType, ContentWrapperDto contentDto, boolean isDraft) {
         return contentRepository.ensureContentAndGetId(artifactType, contentDto, isDraft,
                 restConfig.isDraftProductionModeEnabled());
     }
@@ -603,7 +604,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
 
     @Override
     public ArtifactVersionMetaDataDto createArtifactVersion(String groupId, String artifactId, String version,
-            String artifactType, ContentWrapperDto content, EditableVersionMetaDataDto metaData,
+            ArtifactType artifactType, ContentWrapperDto content, EditableVersionMetaDataDto metaData,
             List<String> branches, boolean isDraft, boolean dryRun, String owner)
             throws VersionAlreadyExistsException, RegistryStorageException {
 
@@ -641,7 +642,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
 
     @Override
     public ArtifactVersionMetaDataDto createArtifactVersionIfLatest(String groupId, String artifactId,
-            String version, String artifactType, ContentWrapperDto content,
+            String version, ArtifactType artifactType, ContentWrapperDto content,
             EditableVersionMetaDataDto metaData, List<String> branches, boolean isDraft, String owner,
             int expectedBaseVersionOrder, EditableArtifactMetaDataDto artifactMetaData) {
 
@@ -1034,7 +1035,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
 
     @Override
     public void updateArtifactVersionContent(String groupId, String artifactId, String version,
-            String artifactType, ContentWrapperDto content) throws RegistryStorageException {
+            ArtifactType artifactType, ContentWrapperDto content) throws RegistryStorageException {
 
         log.debug("Updating content for artifact version: {} {} @ {}", groupId, artifactId, version);
 
@@ -1161,7 +1162,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
                     artifactId, version);
             ContentWrapperDto contentDto = contentRepository.getContentById(versionMeta.getContentId());
             if (contentDto.getContentHash() != null && contentDto.getContentHash().startsWith("draft:")) {
-                String artifactType = versionMeta.getArtifactType();
+                ArtifactType artifactType = versionMeta.getArtifactType();
                 long newContentId = ensureContentAndGetId(artifactType, contentDto, false);
                 if (newContentId != versionMeta.getContentId()) {
                     versionRepository.updateArtifactVersionContent(groupId, artifactId, version,

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryContentUtils.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryContentUtils.java
@@ -1,4 +1,5 @@
 package io.apicurio.registry.storage.impl.sql;
+import io.apicurio.registry.types.ArtifactType;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -121,7 +122,7 @@ public class RegistryContentUtils {
                 () -> references,
                 ArtifactReferenceDto::getName,
                 loader,
-                cw -> TypedContent.create(cw.getContent(), cw.getArtifactType())
+                cw -> TypedContent.create(cw.getContent(), cw.getArtifactType().value())
         );
     }
 
@@ -204,8 +205,8 @@ public class RegistryContentUtils {
                                         .getArtifactTypeProvider(nested.getArtifactType());
                                 RewrittenContentHolder rewrittenContentHolder = resolveReferencesWithContext(
                                         artifactTypeUtilProviderFactory,
-                                        TypedContent.create(nested.getContent(), nested.getArtifactType()),
-                                        nested.getArtifactType(), partialRecursivelyResolvedReferences,
+                                        TypedContent.create(nested.getContent(), nested.getArtifactType().value()),
+                                        nested.getArtifactType().value(), partialRecursivelyResolvedReferences,
                                         nested.getReferences(), loader, referencesRewrites);
                                 referencesRewrites.put(refName, newRefName);
                                 TypedContent rewrittenContent = typeUtilProvider.getContentDereferencer()
@@ -220,7 +221,7 @@ public class RegistryContentUtils {
                 }
             }
         }
-        ArtifactTypeUtilProvider typeUtilProvider = artifactTypeUtilProviderFactory.getArtifactTypeProvider(schemaType);
+        ArtifactTypeUtilProvider typeUtilProvider = artifactTypeUtilProviderFactory.getArtifactTypeProvider(ArtifactType.fromValue(schemaType));
         TypedContent rewrittenContent = typeUtilProvider.getContentDereferencer()
                 .rewriteReferences(mainContent, referencesRewrites);
         return new RewrittenContentHolder(rewrittenContent, partialRecursivelyResolvedReferences);
@@ -232,7 +233,7 @@ public class RegistryContentUtils {
      * WARNING: Fails silently.
      */
     private static TypedContent canonicalizeContent(ArtifactTypeUtilProviderFactory artifactTypeUtilProviderFactory,
-                                                    String artifactType, TypedContent content,
+                                                    ArtifactType artifactType, TypedContent content,
                                                     Map<String, TypedContent> recursivelyResolvedReferences) {
         try {
             return artifactTypeUtilProviderFactory.getArtifactTypeProvider(artifactType).getContentCanonicalizer()
@@ -251,11 +252,11 @@ public class RegistryContentUtils {
      * @throws RegistryException in the case of an error.
      */
     public static TypedContent canonicalizeContent(ArtifactTypeUtilProviderFactory artifactTypeUtilProviderFactory,
-                                                   String artifactType, ContentWrapperDto data,
+                                                   ArtifactType artifactType, ContentWrapperDto data,
                                                    Function<ArtifactReferenceDto, ContentWrapperDto> loader) {
         try {
             return canonicalizeContent(artifactTypeUtilProviderFactory, artifactType,
-                    TypedContent.create(data.getContent(), data.getArtifactType()),
+                    TypedContent.create(data.getContent(), data.getArtifactType().value()),
                     recursivelyResolveReferences(data.getReferences(), loader));
         } catch (Exception ex) {
             throw new RegistryException("Failed to canonicalize content.", ex);
@@ -266,7 +267,7 @@ public class RegistryContentUtils {
      * @param loader can be null *if and only if* references are empty.
      */
     public static String canonicalContentHash(ArtifactTypeUtilProviderFactory artifactTypeUtilProviderFactory,
-                                              String artifactType, ContentWrapperDto data,
+                                              ArtifactType artifactType, ContentWrapperDto data,
                                               Function<ArtifactReferenceDto, ContentWrapperDto> loader) {
         try {
             if (notEmpty(data.getReferences())) {
@@ -276,7 +277,7 @@ public class RegistryContentUtils {
                         serializedReferences));
             } else {
                 TypedContent canonicalContent = canonicalizeContent(artifactTypeUtilProviderFactory, artifactType,
-                        TypedContent.create(data.getContent(), data.getArtifactType()), Map.of());
+                        TypedContent.create(data.getContent(), data.getArtifactType().value()), Map.of());
                 return DigestUtils.sha256Hex(canonicalContent.getContent().bytes());
             }
         } catch (IOException ex) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryStorageContentUtils.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryStorageContentUtils.java
@@ -6,6 +6,7 @@ import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
 import io.apicurio.registry.types.RegistryException;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
 import io.apicurio.registry.util.ArtifactTypeUtil;
+import io.apicurio.registry.types.ArtifactType;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -35,7 +36,7 @@ public class RegistryStorageContentUtils {
      *
      * @throws RegistryException in the case of an error.
      */
-    public TypedContent canonicalizeContent(String artifactType, TypedContent content,
+    public TypedContent canonicalizeContent(ArtifactType artifactType, TypedContent content,
             Map<String, TypedContent> resolvedReferences) {
         try {
             return factory.getArtifactTypeProvider(artifactType).getContentCanonicalizer()
@@ -53,7 +54,7 @@ public class RegistryStorageContentUtils {
      *
      * @throws RegistryException in the case of an error.
      */
-    public TypedContent canonicalizeContent(String artifactType, TypedContent content,
+    public TypedContent canonicalizeContent(ArtifactType artifactType, TypedContent content,
             List<ArtifactReferenceDto> references,
             Function<List<ArtifactReferenceDto>, Map<String, TypedContent>> referenceResolver) {
         try {
@@ -67,7 +68,7 @@ public class RegistryStorageContentUtils {
      * @param references may be null
      * @param referenceResolver may be null if references is null
      */
-    public String getCanonicalContentHash(TypedContent content, String artifactType,
+    public String getCanonicalContentHash(TypedContent content, ArtifactType artifactType,
             List<ArtifactReferenceDto> references,
             Function<List<ArtifactReferenceDto>, Map<String, TypedContent>> referenceResolver) {
         try {
@@ -116,11 +117,11 @@ public class RegistryStorageContentUtils {
         }
     }
 
-    public String determineArtifactType(TypedContent content, String artifactTypeHint) {
+    public ArtifactType determineArtifactType(TypedContent content, ArtifactType artifactTypeHint) {
         return ArtifactTypeUtil.determineArtifactType(content, artifactTypeHint, null, factory);
     }
 
-    public String determineArtifactType(TypedContent content, String artifactTypeHint,
+    public ArtifactType determineArtifactType(TypedContent content, ArtifactType artifactTypeHint,
             Map<String, TypedContent> resolvedReferences) {
         return ArtifactTypeUtil.determineArtifactType(content, artifactTypeHint, resolvedReferences, factory);
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactEntityMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactEntityMapper.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.sql.mappers;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.storage.impl.sql.RegistryContentUtils;
 import io.apicurio.registry.storage.impl.sql.jdb.RowMapper;
 import io.apicurio.registry.utils.impexp.v3.ArtifactEntity;
@@ -25,7 +26,7 @@ public class ArtifactEntityMapper implements RowMapper<ArtifactEntity> {
         ArtifactEntity entity = new ArtifactEntity();
         entity.groupId = RegistryContentUtils.denormalizeGroupId(rs.getString("groupId"));
         entity.artifactId = rs.getString("artifactId");
-        entity.artifactType = rs.getString("type");
+        entity.artifactType = ArtifactType.fromValue(rs.getString("type"));
         entity.name = rs.getString("name");
         entity.description = rs.getString("description");
         entity.labels = RegistryContentUtils.deserializeLabels(rs.getString("labels"));

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactMetaDataDtoMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactMetaDataDtoMapper.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.sql.mappers;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.impl.sql.RegistryContentUtils;
 import io.apicurio.registry.storage.impl.sql.jdb.RowMapper;
@@ -32,7 +33,7 @@ public class ArtifactMetaDataDtoMapper implements RowMapper<ArtifactMetaDataDto>
         dto.setLabels(RegistryContentUtils.deserializeLabels(rs.getString("labels")));
         dto.setModifiedBy(rs.getString("modifiedBy"));
         dto.setModifiedOn(rs.getTimestamp("modifiedOn").getTime());
-        dto.setArtifactType(rs.getString("type"));
+        dto.setArtifactType(ArtifactType.fromValue(rs.getString("type")));
         return dto;
     }
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactVersionMetaDataDtoMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ArtifactVersionMetaDataDtoMapper.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.sql.mappers;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.impl.sql.RegistryContentUtils;
 import io.apicurio.registry.storage.impl.sql.jdb.RowMapper;
@@ -38,7 +39,7 @@ public class ArtifactVersionMetaDataDtoMapper implements RowMapper<ArtifactVersi
         dto.setDescription(rs.getString("description"));
         dto.setVersion(rs.getString("version"));
         dto.setVersionOrder(rs.getInt("versionOrder"));
-        dto.setArtifactType(rs.getString("type"));
+        dto.setArtifactType(ArtifactType.fromValue(rs.getString("type")));
         dto.setLabels(RegistryContentUtils.deserializeLabels(rs.getString("labels")));
         dto.setModifiedBy(rs.getString("modifiedBy"));
         dto.setModifiedOn(rs.getTimestamp("modifiedOn").getTime());

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedArtifactMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedArtifactMapper.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.sql.mappers;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.storage.dto.SearchedArtifactDto;
 import io.apicurio.registry.storage.impl.sql.RegistryContentUtils;
 import io.apicurio.registry.storage.impl.sql.jdb.RowMapper;
@@ -31,7 +32,7 @@ public class SearchedArtifactMapper implements RowMapper<SearchedArtifactDto> {
         dto.setDescription(rs.getString("description"));
         dto.setModifiedBy(rs.getString("modifiedBy"));
         dto.setModifiedOn(rs.getTimestamp("modifiedOn"));
-        dto.setArtifactType(rs.getString("type"));
+        dto.setArtifactType(ArtifactType.fromValue(rs.getString("type")));
         dto.setLabels(RegistryContentUtils.deserializeLabels(rs.getString("labels")));
         return dto;
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedVersionMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/SearchedVersionMapper.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.sql.mappers;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.storage.dto.SearchedVersionDto;
 import io.apicurio.registry.storage.impl.sql.RegistryContentUtils;
 import io.apicurio.registry.storage.impl.sql.jdb.RowMapper;
@@ -37,7 +38,7 @@ public class SearchedVersionMapper implements RowMapper<SearchedVersionDto> {
         dto.setModifiedOn(rs.getTimestamp("modifiedOn"));
         dto.setName(rs.getString("name"));
         dto.setDescription(rs.getString("description"));
-        dto.setArtifactType(rs.getString("type"));
+        dto.setArtifactType(ArtifactType.fromValue(rs.getString("type")));
         dto.setLabels(RegistryContentUtils.deserializeLabels(rs.getString("labels")));
         return dto;
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/VersionContentDtoMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/VersionContentDtoMapper.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.sql.mappers;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.dto.VersionContentDto;
 import io.apicurio.registry.storage.impl.sql.RegistryContentUtils;
@@ -36,7 +37,7 @@ public class VersionContentDtoMapper implements RowMapper<VersionContentDto> {
         dto.setCreatedOn(rs.getTimestamp("createdOn").getTime());
         dto.setModifiedBy(rs.getString("modifiedBy"));
         dto.setModifiedOn(rs.getTimestamp("modifiedOn").getTime());
-        dto.setArtifactType(rs.getString("type"));
+        dto.setArtifactType(ArtifactType.fromValue(rs.getString("type")));
         dto.setLabels(RegistryContentUtils.deserializeLabels(rs.getString("labels")));
         dto.setContent(ContentHandle.create(rs.getBytes("content")));
         return dto;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlArtifactRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlArtifactRepository.java
@@ -324,7 +324,7 @@ public class SqlArtifactRepository {
                 handle.createUpdate(sqlStatements.insertArtifact())
                         .bind(0, normalizeGroupId(entity.groupId))
                         .bind(1, entity.artifactId)
-                        .bind(2, entity.artifactType)
+                        .bind(2, entity.artifactType.value())
                         .bind(3, entity.owner)
                         .bind(4, new Date(entity.createdOn))
                         .bind(5, entity.modifiedBy)

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlContentRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlContentRepository.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import io.apicurio.registry.types.ArtifactType;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -566,7 +567,7 @@ public class SqlContentRepository {
      * @param isDraft Whether this is draft content
      * @param draftProductionMode When true and isDraft is true, use real content hashes instead of draft: prefix
      */
-    public Long ensureContentAndGetId(String artifactType, ContentWrapperDto contentDto, boolean isDraft,
+    public Long ensureContentAndGetId(ArtifactType artifactType, ContentWrapperDto contentDto, boolean isDraft,
             boolean draftProductionMode) {
         List<ArtifactReferenceDto> references = contentDto.getReferences();
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/upgrader/AvroCanonicalHashUpgrader.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/upgrader/AvroCanonicalHashUpgrader.java
@@ -72,9 +72,9 @@ public class AvroCanonicalHashUpgrader implements IDbUpgrader {
         ContentWrapperDto data = ContentWrapperDto.builder()
                 .content(ContentHandle.create(entity.contentEntity.contentBytes))
                 .contentType(entity.contentEntity.contentType).references(references)
-                .artifactType(entity.type).build();
+                .artifactType(ArtifactType.fromValue(entity.type)).build();
 
-        String newCanonicalHash = RegistryContentUtils.canonicalContentHash(factory, entity.type, data,
+        String newCanonicalHash = RegistryContentUtils.canonicalContentHash(factory, ArtifactType.fromValue(entity.type), data,
                 ref -> resolveReference(handle, ref));
 
         if (!newCanonicalHash.equals(entity.contentEntity.canonicalHash)) {
@@ -105,7 +105,7 @@ public class AvroCanonicalHashUpgrader implements IDbUpgrader {
         return ContentWrapperDto.builder().content(ContentHandle.create(result.contentEntity.contentBytes))
                 .contentType(result.contentEntity.contentType)
                 .references(RegistryContentUtils.deserializeReferences(result.contentEntity.serializedReferences))
-                .artifactType(result.type).build();
+                .artifactType(ArtifactType.fromValue(result.type)).build();
     }
 
     private static class ContentWithType {

--- a/app/src/main/java/io/apicurio/registry/storage/importing/v2/SqlDataUpgrader.java
+++ b/app/src/main/java/io/apicurio/registry/storage/importing/v2/SqlDataUpgrader.java
@@ -14,6 +14,7 @@ import io.apicurio.registry.storage.error.InvalidArtifactTypeException;
 import io.apicurio.registry.storage.error.VersionAlreadyExistsException;
 import io.apicurio.registry.storage.impl.sql.RegistryContentUtils;
 import io.apicurio.registry.storage.impl.sql.RegistryStorageContentUtils;
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.types.RegistryException;
 import io.apicurio.registry.types.VersionState;
@@ -38,16 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static io.apicurio.registry.types.ArtifactType.ASYNCAPI;
-import static io.apicurio.registry.types.ArtifactType.AVRO;
-import static io.apicurio.registry.types.ArtifactType.GRAPHQL;
-import static io.apicurio.registry.types.ArtifactType.JSON;
-import static io.apicurio.registry.types.ArtifactType.OPENAPI;
-import static io.apicurio.registry.types.ArtifactType.PROTOBUF;
-import static io.apicurio.registry.types.ArtifactType.THRIFT;
-import static io.apicurio.registry.types.ArtifactType.WSDL;
-import static io.apicurio.registry.types.ArtifactType.XML;
-import static io.apicurio.registry.types.ArtifactType.XSD;
 
 /**
  * This class takes a stream of Registry v2 entities and imports them into the application using
@@ -128,7 +119,7 @@ public class SqlDataUpgrader extends AbstractDataImporter {
             // If the version being imported is the first one, we have to create the artifact first
             if (!storage.isArtifactExists(entity.groupId, entity.artifactId)) {
                 ArtifactEntity artifactEntity = ArtifactEntity.builder().artifactId(entity.artifactId)
-                        .artifactType(entity.artifactType).createdOn(entity.createdOn)
+                        .artifactType(ArtifactType.fromValue(entity.artifactType)).createdOn(entity.createdOn)
                         .description(entity.description).groupId(entity.groupId).labels(artifactVersionLabels)
                         .modifiedBy(entity.createdBy).modifiedOn(entity.createdOn).name(entity.name)
                         .owner(entity.createdBy).build();
@@ -195,10 +186,10 @@ public class SqlDataUpgrader extends AbstractDataImporter {
             try {
                 Map<String, TypedContent> resolvedReferences = RegistryContentUtils
                         .recursivelyResolveReferences(references, storage::getContentByReference);
-                entity.artifactType = utils.determineArtifactType(typedContent, null, resolvedReferences);
+                entity.artifactType = utils.determineArtifactType(typedContent, null, resolvedReferences).value();
 
                 // First we have to recalculate both the canonical hash and the contentHash
-                TypedContent canonicalContent = utils.canonicalizeContent(entity.artifactType, typedContent,
+                TypedContent canonicalContent = utils.canonicalizeContent(ArtifactType.fromValue(entity.artifactType), typedContent,
                         resolvedReferences);
 
                 entity.canonicalHash = DigestUtils.sha256Hex(canonicalContent.getContent().bytes());
@@ -218,7 +209,7 @@ public class SqlDataUpgrader extends AbstractDataImporter {
                 // If this assumption is wrong (e.g. for PROTOBUF) then we'll need an extra step here to
                 // figure
                 // out if the core content is JSON or PROTO.
-                entity.artifactType = AVRO;
+                entity.artifactType = ArtifactType.BuiltIn.AVRO.value();
             }
 
             // Finally, using the information from the old content, a V3 content entity is created.
@@ -323,10 +314,10 @@ public class SqlDataUpgrader extends AbstractDataImporter {
             }
 
             TypedContent content = TypedContent.create(wrapperDto.getContent(), wrapperDto.getContentType());
-            String artifactType = versions.get(0).getArtifactType();
+            String artifactType = versions.get(0).getArtifactType().value();
             Map<String, TypedContent> resolvedReferences = RegistryContentUtils
                     .recursivelyResolveReferences(references, storage::getContentByReference);
-            TypedContent canonicalContent = utils.canonicalizeContent(artifactType, content,
+            TypedContent canonicalContent = utils.canonicalizeContent(ArtifactType.fromValue(artifactType), content,
                     resolvedReferences);
             String canonicalHash = DigestUtils.sha256Hex(canonicalContent.getContent().bytes());
             String contentHash = utils.getContentHash(content, references);
@@ -342,24 +333,21 @@ public class SqlDataUpgrader extends AbstractDataImporter {
         if (content.getContentType() != null) {
             return content.getContentType();
         } else {
-            switch (artifactTypeHint) {
-                case ASYNCAPI:
-                case JSON:
-                case OPENAPI:
-                case AVRO:
-                    // WARNING: This is only safe here. We can safely return JSON because in V2 we were
-                    // transforming all YAML to JSON before storing the content in the database.
-                    return ContentTypes.APPLICATION_JSON;
-                case PROTOBUF:
-                    return ContentTypes.APPLICATION_PROTOBUF;
-                case GRAPHQL:
-                    return ContentTypes.APPLICATION_GRAPHQL;
-                case THRIFT:
-                    return ContentTypes.APPLICATION_THRIFT;
-                case XML:
-                case XSD:
-                case WSDL:
-                    return ContentTypes.APPLICATION_XML;
+            if (ArtifactType.BuiltIn.ASYNCAPI.value().equals(artifactTypeHint) ||
+                ArtifactType.BuiltIn.JSON.value().equals(artifactTypeHint) ||
+                ArtifactType.BuiltIn.OPENAPI.value().equals(artifactTypeHint) ||
+                ArtifactType.BuiltIn.AVRO.value().equals(artifactTypeHint)) {
+                return ContentTypes.APPLICATION_JSON;
+            } else if (ArtifactType.BuiltIn.PROTOBUF.value().equals(artifactTypeHint)) {
+                return ContentTypes.APPLICATION_PROTOBUF;
+            } else if (ArtifactType.BuiltIn.GRAPHQL.value().equals(artifactTypeHint)) {
+                return ContentTypes.APPLICATION_GRAPHQL;
+            } else if (ArtifactType.BuiltIn.THRIFT.value().equals(artifactTypeHint)) {
+                return ContentTypes.APPLICATION_THRIFT;
+            } else if (ArtifactType.BuiltIn.XML.value().equals(artifactTypeHint) ||
+                       ArtifactType.BuiltIn.XSD.value().equals(artifactTypeHint) ||
+                       ArtifactType.BuiltIn.WSDL.value().equals(artifactTypeHint)) {
+                return ContentTypes.APPLICATION_XML;
             }
         }
         throw new InvalidArtifactTypeException("Invalid or unknown artifact type: " + artifactTypeHint);

--- a/app/src/main/java/io/apicurio/registry/storage/importing/v3/SqlDataImporter.java
+++ b/app/src/main/java/io/apicurio/registry/storage/importing/v3/SqlDataImporter.java
@@ -1,4 +1,5 @@
 package io.apicurio.registry.storage.importing.v3;
+import io.apicurio.registry.types.ArtifactType;
 
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.TypedContent;
@@ -115,7 +116,7 @@ public class SqlDataImporter extends AbstractDataImporter {
 
             // We do not need canonicalHash if we have artifactType
             if (entity.canonicalHash == null && entity.artifactType != null) {
-                TypedContent canonicalContent = utils.canonicalizeContent(entity.artifactType, typedContent,
+                TypedContent canonicalContent = utils.canonicalizeContent(ArtifactType.fromValue(entity.artifactType), typedContent,
                         RegistryContentUtils.recursivelyResolveReferences(references,
                                 storage::getContentByReference));
                 entity.canonicalHash = DigestUtils.sha256Hex(canonicalContent.getContent().bytes());

--- a/app/src/main/java/io/apicurio/registry/types/provider/configured/ArtifactTypeUtilProviderImpl.java
+++ b/app/src/main/java/io/apicurio/registry/types/provider/configured/ArtifactTypeUtilProviderImpl.java
@@ -61,7 +61,7 @@ public class ArtifactTypeUtilProviderImpl extends DefaultArtifactTypeUtilProvide
         if (useApitomyJsonSchemaChecker) {
             log.info("Using Apitomy Data Models JSON Schema compatibility checker (experimental).");
             providers.stream()
-                    .filter(p -> ArtifactType.JSON.equals(p.getArtifactType()))
+                    .filter(p -> ArtifactType.BuiltIn.JSON.equals(p.getArtifactType()))
                     .filter(AbstractArtifactTypeUtilProvider.class::isInstance)
                     .map(AbstractArtifactTypeUtilProvider.class::cast)
                     .findFirst()
@@ -88,7 +88,7 @@ public class ArtifactTypeUtilProviderImpl extends DefaultArtifactTypeUtilProvide
     }
 
     private void loadConfiguredProviders(ArtifactTypesConfiguration config) {
-        Set<String> artifactTypes = new HashSet<>();
+        Set<ArtifactType> artifactTypes = new HashSet<>();
 
         if (config.getIncludeStandardArtifactTypes()) {
             loadStandardProviders();
@@ -103,8 +103,8 @@ public class ArtifactTypeUtilProviderImpl extends DefaultArtifactTypeUtilProvide
                     throw new IllegalArgumentException("Invalid configuration: Artifact type '" + artifactType.getArtifactType() + "' found with missing or empty 'name'.");
                 }
 
-                String type = artifactType.getArtifactType();
-                if (Objects.isNull(type) || type.trim().isEmpty()) {
+                ArtifactType type = ArtifactType.fromValue(artifactType.getArtifactType());
+                if (Objects.isNull(type) || type.value().trim().isEmpty()) {
                     throw new IllegalArgumentException("Invalid configuration: Artifact type named '" + artifactType.getName() + "' has missing or empty 'artifactType' property.");
                 }
 

--- a/app/src/main/java/io/apicurio/registry/types/provider/configured/ConfiguredArtifactTypeUtilProvider.java
+++ b/app/src/main/java/io/apicurio/registry/types/provider/configured/ConfiguredArtifactTypeUtilProvider.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.types.provider.configured;
 
+import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.provider.AbstractArtifactTypeUtilProvider;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
 
@@ -42,8 +43,8 @@ public class ConfiguredArtifactTypeUtilProvider extends AbstractArtifactTypeUtil
     }
 
     @Override
-    public String getArtifactType() {
-        return this.artifactType.getArtifactType();
+    public ArtifactType getArtifactType() {
+        return ArtifactType.fromValue(this.artifactType.getArtifactType());
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/util/ArtifactTypeUtil.java
+++ b/app/src/main/java/io/apicurio/registry/util/ArtifactTypeUtil.java
@@ -5,6 +5,7 @@ import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.storage.error.InvalidArtifactTypeException;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
+import io.apicurio.registry.types.ArtifactType;
 
 import java.util.Collections;
 import java.util.Map;
@@ -25,23 +26,20 @@ public final class ArtifactTypeUtil {
      * @param content the content
      * @param artifactType the artifact type
      */
-    public static String determineArtifactType(TypedContent content, String artifactType,
+    public static ArtifactType determineArtifactType(TypedContent content, ArtifactType artifactType,
             ArtifactTypeUtilProviderFactory artifactTypeProviderFactory) {
         return determineArtifactType(content, artifactType, Collections.emptyMap(),
                 artifactTypeProviderFactory);
     }
 
-    public static String determineArtifactType(TypedContent content, String artifactType,
+    public static ArtifactType determineArtifactType(TypedContent content, ArtifactType artifactType,
             Map<String, TypedContent> resolvedReferences,
             ArtifactTypeUtilProviderFactory artifactTypeProviderFactory) {
-        if ("".equals(artifactType)) {
-            artifactType = null;
-        }
         if (artifactType == null && content != null) {
             artifactType = ArtifactTypeUtil.discoverType(content, resolvedReferences,
                     artifactTypeProviderFactory);
         }
-        if (!artifactTypeProviderFactory.getAllArtifactTypes().contains(artifactType)) {
+        if (artifactType != null && !artifactTypeProviderFactory.getAllArtifactTypes().contains(artifactType)) {
             throw new InvalidArtifactTypeException("Invalid or unknown artifact type: " + artifactType);
         }
         return artifactType;
@@ -62,7 +60,7 @@ public final class ArtifactTypeUtil {
      * @param resolvedReferences
      */
     @SuppressWarnings("deprecation")
-    private static String discoverType(TypedContent content, Map<String, TypedContent> resolvedReferences,
+    private static ArtifactType discoverType(TypedContent content, Map<String, TypedContent> resolvedReferences,
             ArtifactTypeUtilProviderFactory artifactTypeProviderFactory) throws InvalidArtifactTypeException {
         for (ArtifactTypeUtilProvider provider : artifactTypeProviderFactory.getAllArtifactTypeProviders()) {
             ContentAccepter contentAccepter = provider.getContentAccepter();

--- a/common/src/main/java/io/apicurio/registry/types/ArtifactType.java
+++ b/common/src/main/java/io/apicurio/registry/types/ArtifactType.java
@@ -1,74 +1,220 @@
-
 package io.apicurio.registry.types;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Defines the supported artifact types in the registry. The artifact type identifies the format or schema
  * language of an artifact's content and determines how the registry parses, validates, and checks
  * compatibility of that content.
  */
-public class ArtifactType {
+@SuppressWarnings("java:S1133")
+public sealed interface ArtifactType permits ArtifactType.BuiltIn, ArtifactType.Custom {
 
-    private ArtifactType() {
+    int CUSTOM_NUMERIC_ID = -1;
+
+    /**
+     * @return the string value of the artifact type
+     */
+    @JsonValue
+    String value();
+
+    /**
+     * @return the numeric identifier for this artifact type, or CUSTOM_NUMERIC_ID if none.
+     */
+    int numericId();
+
+    @JsonCreator
+    static ArtifactType fromValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        ArtifactType builtIn = BuiltIn.CACHE.get(value);
+        if (builtIn != null) {
+            return builtIn;
+        }
+        return new Custom(value);
     }
 
-    // TODO: Turn into enum, which can contain both a string value and a numeric identifier.
-    // See io.apicurio.registry.storage.impl.kafkasql.serde.ArtifactTypeOrdUtil
+    enum BuiltIn implements ArtifactType {
+        AVRO("AVRO", 1),
+        PROTOBUF("PROTOBUF", 2),
+        JSON("JSON", 3),
+        OPENAPI("OPENAPI", 4),
+        ASYNCAPI("ASYNCAPI", 5),
+        GRAPHQL("GRAPHQL", 6),
+        KCONNECT("KCONNECT", 7),
+        WSDL("WSDL", 8),
+        XSD("XSD", 9),
+        XML("XML", 10),
+        AGENT_CARD("AGENT_CARD", 11),
+        MCP_TOOL("MCP_TOOL", 12),
+        ICEBERG_TABLE("ICEBERG_TABLE", 13),
+        ICEBERG_VIEW("ICEBERG_VIEW", 14),
+        OPENRPC("OPENRPC", 15),
+        MODEL_SCHEMA("MODEL_SCHEMA", 16),
+        PROMPT_TEMPLATE("PROMPT_TEMPLATE", 17),
+        ODCS_CONTRACT("ODCS_CONTRACT", 18),
+        THRIFT("THRIFT", 19);
 
-    /** Apache Avro schema. */
-    public static final String AVRO = "AVRO";
+        private final String value;
+        private final int numericId;
 
-    /** Google Protocol Buffers definition. */
-    public static final String PROTOBUF = "PROTOBUF";
+        BuiltIn(String value, int numericId) {
+            this.value = value;
+            this.numericId = numericId;
+        }
 
-    /** JSON Schema. */
-    public static final String JSON = "JSON";
+        @Override
+        public String value() {
+            return value;
+        }
 
-    /** OpenAPI specification. */
-    public static final String OPENAPI = "OPENAPI";
+        @Override
+        public int numericId() {
+            return numericId;
+        }
 
-    /** AsyncAPI specification. */
-    public static final String ASYNCAPI = "ASYNCAPI";
+        private static final Map<String, BuiltIn> CACHE;
+        static {
+            Map<String, BuiltIn> map = new HashMap<>();
+            for (BuiltIn type : values()) {
+                map.put(type.value(), type);
+            }
+            CACHE = Collections.unmodifiableMap(map);
+        }
+    }
 
-    /** GraphQL schema definition language (SDL). */
-    public static final String GRAPHQL = "GRAPHQL";
+    record Custom(String value) implements ArtifactType {
+        public Custom {
+            Objects.requireNonNull(value, "Artifact type value cannot be null");
+            if (BuiltIn.CACHE.containsKey(value)) {
+                throw new IllegalArgumentException("Cannot create Custom artifact type for BuiltIn type: " + value);
+            }
+        }
 
-    /** Apache Kafka Connect schema. */
-    public static final String KCONNECT = "KCONNECT";
+        @Override
+        public int numericId() {
+            return CUSTOM_NUMERIC_ID;
+        }
+    }
 
-    /** Web Services Description Language (WSDL) definition. */
-    public static final String WSDL = "WSDL";
+    /** Apache Avro schema. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String AVRO = BuiltIn.AVRO.value();
 
-    /** XML Schema Definition (XSD). */
-    public static final String XSD = "XSD";
+    /** Google Protocol Buffers definition. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String PROTOBUF = BuiltIn.PROTOBUF.value();
 
-    /** XML document. */
-    public static final String XML = "XML";
+    /** JSON Schema. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String JSON = BuiltIn.JSON.value();
 
-    /** AI Agent Card for the A2A (Agent-to-Agent) protocol. */
-    public static final String AGENT_CARD = "AGENT_CARD";
+    /** OpenAPI specification. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String OPENAPI = BuiltIn.OPENAPI.value();
 
-    /** MCP (Model Context Protocol) tool definition. */
-    public static final String MCP_TOOL = "MCP_TOOL";
+    /** AsyncAPI specification. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String ASYNCAPI = BuiltIn.ASYNCAPI.value();
 
-    /** Apache Iceberg table metadata. */
-    public static final String ICEBERG_TABLE = "ICEBERG_TABLE";
+    /** GraphQL schema definition language (SDL). 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String GRAPHQL = BuiltIn.GRAPHQL.value();
 
-    /** Apache Iceberg view metadata. */
-    public static final String ICEBERG_VIEW = "ICEBERG_VIEW";
+    /** Apache Kafka Connect schema. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String KCONNECT = BuiltIn.KCONNECT.value();
 
-    /** OpenRPC specification for JSON-RPC APIs. */
-    public static final String OPENRPC = "OPENRPC";
+    /** Web Services Description Language (WSDL) definition. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String WSDL = BuiltIn.WSDL.value();
 
-    /** AI/ML model input/output schema definition. */
-    public static final String MODEL_SCHEMA = "MODEL_SCHEMA";
+    /** XML Schema Definition (XSD). 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String XSD = BuiltIn.XSD.value();
 
-    /** Version-controlled prompt template with variable schemas. */
-    public static final String PROMPT_TEMPLATE = "PROMPT_TEMPLATE";
+    /** XML document. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String XML = BuiltIn.XML.value();
 
-    /** Open Data Contract Standard (ODCS) v3.1 contract definition. */
-    public static final String ODCS_CONTRACT = "ODCS_CONTRACT";
+    /** AI Agent Card for the A2A (Agent-to-Agent) protocol. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String AGENT_CARD = BuiltIn.AGENT_CARD.value();
 
-    /** Apache Thrift interface definition language (IDL). */
-    public static final String THRIFT = "THRIFT";
+    /** MCP (Model Context Protocol) tool definition. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String MCP_TOOL = BuiltIn.MCP_TOOL.value();
 
+    /** Apache Iceberg table metadata. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String ICEBERG_TABLE = BuiltIn.ICEBERG_TABLE.value();
+
+    /** Apache Iceberg view metadata. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String ICEBERG_VIEW = BuiltIn.ICEBERG_VIEW.value();
+
+    /** OpenRPC specification for JSON-RPC APIs. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String OPENRPC = BuiltIn.OPENRPC.value();
+
+    /** AI/ML model input/output schema definition. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String MODEL_SCHEMA = BuiltIn.MODEL_SCHEMA.value();
+
+    /** Version-controlled prompt template with variable schemas. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String PROMPT_TEMPLATE = BuiltIn.PROMPT_TEMPLATE.value();
+
+    /** Open Data Contract Standard (ODCS) v3.1 contract definition. 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String ODCS_CONTRACT = BuiltIn.ODCS_CONTRACT.value();
+
+    /** Apache Thrift interface definition language (IDL). 
+     * @deprecated Use {@link BuiltIn} instead.
+     */
+    @Deprecated(forRemoval = true)
+    String THRIFT = BuiltIn.THRIFT.value();
 }

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ArtifactTypeUtilProvider.java
@@ -13,13 +13,15 @@ import io.apicurio.registry.rules.validity.ContentValidator;
 
 import java.util.Set;
 
+import io.apicurio.registry.types.ArtifactType;
+
 /**
  * Interface providing different utils per artifact type * compatibility checker * content canonicalizer *
  * content validator * rules * etc ...
  */
 public interface ArtifactTypeUtilProvider {
 
-    String getArtifactType();
+    ArtifactType getArtifactType();
 
     Set<String> getContentTypes();
 

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ArtifactTypeUtilProviderFactory.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ArtifactTypeUtilProviderFactory.java
@@ -1,12 +1,14 @@
 package io.apicurio.registry.types.provider;
 
+import io.apicurio.registry.types.ArtifactType;
+
 import java.util.List;
 
 public interface ArtifactTypeUtilProviderFactory {
 
-    ArtifactTypeUtilProvider getArtifactTypeProvider(String type);
+    ArtifactTypeUtilProvider getArtifactTypeProvider(ArtifactType type);
 
-    List<String> getAllArtifactTypes();
+    List<ArtifactType> getAllArtifactTypes();
 
     List<ArtifactTypeUtilProvider> getAllArtifactTypeProviders();
 

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ConfigurableArtifactTypeUtilProvider.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/ConfigurableArtifactTypeUtilProvider.java
@@ -12,6 +12,8 @@ import io.apicurio.registry.content.refs.ReferenceFinder;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
 import io.apicurio.registry.rules.validity.ContentValidator;
 
+import io.apicurio.registry.types.ArtifactType;
+
 /**
  * {@link ArtifactTypeUtilProvider} implementation backed by a {@link ProviderConfig}.
  * <p>
@@ -21,7 +23,7 @@ import io.apicurio.registry.rules.validity.ContentValidator;
  */
 public class ConfigurableArtifactTypeUtilProvider extends AbstractArtifactTypeUtilProvider {
 
-    private final String artifactType;
+    private final ArtifactType artifactType;
     private final ProviderConfig config;
 
     /**
@@ -30,7 +32,7 @@ public class ConfigurableArtifactTypeUtilProvider extends AbstractArtifactTypeUt
      * @param artifactType the artifact type identifier
      * @param config the provider configuration
      */
-    public ConfigurableArtifactTypeUtilProvider(String artifactType, ProviderConfig config) {
+    public ConfigurableArtifactTypeUtilProvider(ArtifactType artifactType, ProviderConfig config) {
         this.artifactType = artifactType;
         this.config = config;
     }
@@ -41,7 +43,7 @@ public class ConfigurableArtifactTypeUtilProvider extends AbstractArtifactTypeUt
      * @return the artifact type identifier
      */
     @Override
-    public String getArtifactType() {
+    public ArtifactType getArtifactType() {
         return artifactType;
     }
 

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/DefaultArtifactTypeUtilProviderImpl.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/DefaultArtifactTypeUtilProviderImpl.java
@@ -8,9 +8,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import io.apicurio.registry.types.ArtifactType;
+
 public class DefaultArtifactTypeUtilProviderImpl implements ArtifactTypeUtilProviderFactory {
 
-    protected Map<String, ArtifactTypeUtilProvider> providerMap = new ConcurrentHashMap<>();
+    protected Map<ArtifactType, ArtifactTypeUtilProvider> providerMap = new ConcurrentHashMap<>();
 
     // Intentionally per-factory, not a shared static list: AbstractArtifactTypeUtilProvider caches
     // lazily-created components in mutable fields, so sharing one provider across factories would alias that cache.
@@ -32,14 +34,14 @@ public class DefaultArtifactTypeUtilProviderImpl implements ArtifactTypeUtilProv
     }
 
     @Override
-    public ArtifactTypeUtilProvider getArtifactTypeProvider(String type) {
+    public ArtifactTypeUtilProvider getArtifactTypeProvider(ArtifactType type) {
         return providerMap.computeIfAbsent(type,
                 t -> providers.stream().filter(a -> a.getArtifactType().equals(t)).findFirst().orElseThrow(
                         () -> new IllegalStateException("No such artifact type provider: " + t)));
     }
 
     @Override
-    public List<String> getAllArtifactTypes() {
+    public List<ArtifactType> getAllArtifactTypes() {
         return providers.stream().map(a -> a.getArtifactType()).collect(Collectors.toList());
     }
 

--- a/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/StandardArtifactTypeProviderRegistry.java
+++ b/schema-util/util-provider/src/main/java/io/apicurio/registry/types/provider/StandardArtifactTypeProviderRegistry.java
@@ -119,10 +119,10 @@ import io.apicurio.registry.xsd.rules.validity.XsdContentValidator;
  */
 public class StandardArtifactTypeProviderRegistry {
 
-    private static final Map<String, ProviderConfig> PROVIDERS = new LinkedHashMap<>();
+    private static final Map<ArtifactType, ProviderConfig> PROVIDERS = new LinkedHashMap<>();
 
     static {
-        PROVIDERS.put(ArtifactType.PROTOBUF, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.PROTOBUF, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_PROTOBUF))
                 .accepter(ProtobufContentAccepter::new)
                 .compatibilityChecker(ProtobufCompatibilityChecker::new)
@@ -132,7 +132,7 @@ public class StandardArtifactTypeProviderRegistry {
                 .referenceFinder(ProtobufReferenceFinder::new)
                 .structuredContentExtractor(ProtobufStructuredContentExtractor::new)
                 .build());
-        PROVIDERS.put(ArtifactType.OPENAPI, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.OPENAPI, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON, ContentTypes.APPLICATION_YAML))
                 .accepter(OpenApiContentAccepter::new)
                 .compatibilityChecker(OpenApiCompatibilityChecker::new)
@@ -144,7 +144,7 @@ public class StandardArtifactTypeProviderRegistry {
                 .structuredContentExtractor(OpenApiStructuredContentExtractor::new)
                 .supportsReferencesWithContext(true)
                 .build());
-        PROVIDERS.put(ArtifactType.ASYNCAPI, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.ASYNCAPI, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON, ContentTypes.APPLICATION_YAML))
                 .accepter(AsyncApiContentAccepter::new)
                 .canonicalizer(AsyncApiContentCanonicalizer::new)
@@ -155,7 +155,7 @@ public class StandardArtifactTypeProviderRegistry {
                 .structuredContentExtractor(AsyncApiStructuredContentExtractor::new)
                 .supportsReferencesWithContext(true)
                 .build());
-        PROVIDERS.put(ArtifactType.JSON, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.JSON, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON))
                 .accepter(JsonSchemaContentAccepter::new)
                 .compatibilityChecker(JsonSchemaCompatibilityChecker::new)
@@ -167,7 +167,7 @@ public class StandardArtifactTypeProviderRegistry {
                 .structuredContentExtractor(JsonSchemaStructuredContentExtractor::new)
                 .supportsReferencesWithContext(true)
                 .build());
-        PROVIDERS.put(ArtifactType.AVRO, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.AVRO, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON))
                 .accepter(AvroContentAccepter::new)
                 .compatibilityChecker(AvroCompatibilityChecker::new)
@@ -179,19 +179,19 @@ public class StandardArtifactTypeProviderRegistry {
                 .referenceArtifactIdentifierExtractor(AvroReferenceArtifactIdentifierExtractor::new)
                 .structuredContentExtractor(AvroStructuredContentExtractor::new)
                 .build());
-        PROVIDERS.put(ArtifactType.GRAPHQL, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.GRAPHQL, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_GRAPHQL))
                 .accepter(GraphQLContentAccepter::new)
                 .canonicalizer(GraphQLContentCanonicalizer::new)
                 .validator(GraphQLContentValidator::new)
                 .structuredContentExtractor(GraphQLStructuredContentExtractor::new)
                 .build());
-        PROVIDERS.put(ArtifactType.KCONNECT, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.KCONNECT, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON))
                 .canonicalizer(KafkaConnectContentCanonicalizer::new)
                 .validator(KafkaConnectContentValidator::new)
                 .build());
-        PROVIDERS.put(ArtifactType.WSDL, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.WSDL, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_XML))
                 .accepter(WsdlContentAccepter::new)
                 .canonicalizer(XmlContentCanonicalizer::new)
@@ -199,7 +199,7 @@ public class StandardArtifactTypeProviderRegistry {
                 .extractor(WsdlOrXsdContentExtractor::new)
                 .structuredContentExtractor(WsdlStructuredContentExtractor::new)
                 .build());
-        PROVIDERS.put(ArtifactType.XSD, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.XSD, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_XML))
                 .accepter(XsdContentAccepter::new)
                 .compatibilityChecker(XsdCompatibilityChecker::new)
@@ -208,14 +208,14 @@ public class StandardArtifactTypeProviderRegistry {
                 .extractor(WsdlOrXsdContentExtractor::new)
                 .structuredContentExtractor(XsdStructuredContentExtractor::new)
                 .build());
-        PROVIDERS.put(ArtifactType.XML, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.XML, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_XML))
                 .accepter(XmlContentAccepter::new)
                 .canonicalizer(XmlContentCanonicalizer::new)
                 .validator(XmlContentValidator::new)
                 .structuredContentExtractor(XmlStructuredContentExtractor::new)
                 .build());
-        PROVIDERS.put(ArtifactType.AGENT_CARD, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.AGENT_CARD, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON))
                 .accepter(AgentCardContentAccepter::new)
                 .compatibilityChecker(AgentCardCompatibilityChecker::new)
@@ -224,7 +224,7 @@ public class StandardArtifactTypeProviderRegistry {
                 .extractor(AgentCardContentExtractor::new)
                 .structuredContentExtractor(AgentCardStructuredContentExtractor::new)
                 .build());
-        PROVIDERS.put(ArtifactType.MCP_TOOL, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.MCP_TOOL, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON))
                 .accepter(McpToolContentAccepter::new)
                 .compatibilityChecker(McpToolCompatibilityChecker::new)
@@ -233,7 +233,7 @@ public class StandardArtifactTypeProviderRegistry {
                 .extractor(McpToolContentExtractor::new)
                 .structuredContentExtractor(McpToolStructuredContentExtractor::new)
                 .build());
-        PROVIDERS.put(ArtifactType.ICEBERG_TABLE, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.ICEBERG_TABLE, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON))
                 .accepter(IcebergTableContentAccepter::new)
                 .compatibilityChecker(IcebergCompatibilityChecker::new)
@@ -242,7 +242,7 @@ public class StandardArtifactTypeProviderRegistry {
                 .extractor(() -> new IcebergContentExtractor(true))
                 .structuredContentExtractor(() -> new IcebergStructuredContentExtractor(true))
                 .build());
-        PROVIDERS.put(ArtifactType.ICEBERG_VIEW, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.ICEBERG_VIEW, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON))
                 .accepter(IcebergViewContentAccepter::new)
                 .compatibilityChecker(IcebergCompatibilityChecker::new)
@@ -251,7 +251,7 @@ public class StandardArtifactTypeProviderRegistry {
                 .extractor(() -> new IcebergContentExtractor(false))
                 .structuredContentExtractor(() -> new IcebergStructuredContentExtractor(false))
                 .build());
-        PROVIDERS.put(ArtifactType.OPENRPC, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.OPENRPC, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON, ContentTypes.APPLICATION_YAML))
                 .accepter(OpenRpcContentAccepter::new)
                 .canonicalizer(OpenRpcContentCanonicalizer::new)
@@ -261,7 +261,7 @@ public class StandardArtifactTypeProviderRegistry {
                 .referenceFinder(OpenRpcReferenceFinder::new)
                 .supportsReferencesWithContext(true)
                 .build());
-        PROVIDERS.put(ArtifactType.MODEL_SCHEMA, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.MODEL_SCHEMA, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON, ContentTypes.APPLICATION_YAML))
                 .accepter(ModelSchemaContentAccepter::new)
                 .compatibilityChecker(ModelSchemaCompatibilityChecker::new)
@@ -273,7 +273,7 @@ public class StandardArtifactTypeProviderRegistry {
                 .structuredContentExtractor(ModelSchemaStructuredContentExtractor::new)
                 .supportsReferencesWithContext(true)
                 .build());
-        PROVIDERS.put(ArtifactType.PROMPT_TEMPLATE, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.PROMPT_TEMPLATE, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_JSON, ContentTypes.APPLICATION_YAML, ContentTypes.TEXT_PROMPT_TEMPLATE))
                 .accepter(PromptTemplateContentAccepter::new)
                 .compatibilityChecker(PromptTemplateCompatibilityChecker::new)
@@ -285,14 +285,14 @@ public class StandardArtifactTypeProviderRegistry {
                 .structuredContentExtractor(PromptTemplateStructuredContentExtractor::new)
                 .supportsReferencesWithContext(true)
                 .build());
-        PROVIDERS.put(ArtifactType.ODCS_CONTRACT, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.ODCS_CONTRACT, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_YAML))
                 .accepter(OdcsContractContentAccepter::new)
                 .canonicalizer(YamlContentCanonicalizer::new)
                 .validator(OdcsContractContentValidator::new)
                 .referenceFinder(OdcsContractReferenceFinder::new)
                 .build());
-        PROVIDERS.put(ArtifactType.THRIFT, new ProviderConfig.Builder()
+        PROVIDERS.put(ArtifactType.BuiltIn.THRIFT, new ProviderConfig.Builder()
                 .contentTypes(Set.of(ContentTypes.APPLICATION_THRIFT))
                 .accepter(ThriftContentAccepter::new)
                 .canonicalizer(ThriftContentCanonicalizer::new)

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/types/provider/StandardArtifactTypeProviderRegistryTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/types/provider/StandardArtifactTypeProviderRegistryTest.java
@@ -35,26 +35,26 @@ import io.apicurio.registry.xsd.rules.compatibility.XsdCompatibilityChecker;
  */
 class StandardArtifactTypeProviderRegistryTest {
 
-    private static final List<String> EXPECTED_PROVIDER_ORDER = List.of(
-            ArtifactType.PROTOBUF,
-            ArtifactType.OPENAPI,
-            ArtifactType.ASYNCAPI,
-            ArtifactType.JSON,
-            ArtifactType.AVRO,
-            ArtifactType.GRAPHQL,
-            ArtifactType.KCONNECT,
-            ArtifactType.WSDL,
-            ArtifactType.XSD,
-            ArtifactType.XML,
-            ArtifactType.AGENT_CARD,
-            ArtifactType.MCP_TOOL,
-            ArtifactType.ICEBERG_TABLE,
-            ArtifactType.ICEBERG_VIEW,
-            ArtifactType.OPENRPC,
-            ArtifactType.MODEL_SCHEMA,
-            ArtifactType.PROMPT_TEMPLATE,
-            ArtifactType.ODCS_CONTRACT,
-            ArtifactType.THRIFT
+    private static final List<ArtifactType> EXPECTED_PROVIDER_ORDER = List.of(
+            ArtifactType.BuiltIn.PROTOBUF,
+            ArtifactType.BuiltIn.OPENAPI,
+            ArtifactType.BuiltIn.ASYNCAPI,
+            ArtifactType.BuiltIn.JSON,
+            ArtifactType.BuiltIn.AVRO,
+            ArtifactType.BuiltIn.GRAPHQL,
+            ArtifactType.BuiltIn.KCONNECT,
+            ArtifactType.BuiltIn.WSDL,
+            ArtifactType.BuiltIn.XSD,
+            ArtifactType.BuiltIn.XML,
+            ArtifactType.BuiltIn.AGENT_CARD,
+            ArtifactType.BuiltIn.MCP_TOOL,
+            ArtifactType.BuiltIn.ICEBERG_TABLE,
+            ArtifactType.BuiltIn.ICEBERG_VIEW,
+            ArtifactType.BuiltIn.OPENRPC,
+            ArtifactType.BuiltIn.MODEL_SCHEMA,
+            ArtifactType.BuiltIn.PROMPT_TEMPLATE,
+            ArtifactType.BuiltIn.ODCS_CONTRACT,
+            ArtifactType.BuiltIn.THRIFT
     );
 
     @Test
@@ -66,7 +66,7 @@ class StandardArtifactTypeProviderRegistryTest {
     @Test
     void testCreateStandardProviders_order() {
         List<ArtifactTypeUtilProvider> providers = StandardArtifactTypeProviderRegistry.createStandardProviders();
-        List<String> types = providers.stream().map(ArtifactTypeUtilProvider::getArtifactType).collect(Collectors.toList());
+        List<ArtifactType> types = providers.stream().map(ArtifactTypeUtilProvider::getArtifactType).collect(Collectors.toList());
         assertEquals(EXPECTED_PROVIDER_ORDER, types);
     }
 
@@ -83,28 +83,28 @@ class StandardArtifactTypeProviderRegistryTest {
         DefaultArtifactTypeUtilProviderImpl factory = new DefaultArtifactTypeUtilProviderImpl(true);
         assertEquals(EXPECTED_PROVIDER_ORDER, factory.getAllArtifactTypes());
         assertInstanceOf(ConfigurableArtifactTypeUtilProvider.class,
-                factory.getArtifactTypeProvider(ArtifactType.AVRO));
+                factory.getArtifactTypeProvider(ArtifactType.BuiltIn.AVRO));
     }
 
     @Test
     void testDefaultArtifactTypeUtilProviderImpl_unknownType() {
         DefaultArtifactTypeUtilProviderImpl factory = new DefaultArtifactTypeUtilProviderImpl(true);
-        assertThrows(IllegalStateException.class, () -> factory.getArtifactTypeProvider("GARBAGE"));
+        assertThrows(IllegalStateException.class, () -> factory.getArtifactTypeProvider(ArtifactType.fromValue("GARBAGE")));
     }
 
     @Test
     void testSupportsReferencesWithContext() {
         List<ArtifactTypeUtilProvider> providers = StandardArtifactTypeProviderRegistry.createStandardProviders();
-        assertTrue(findProvider(providers, ArtifactType.JSON).supportsReferencesWithContext());
-        assertFalse(findProvider(providers, ArtifactType.AVRO).supportsReferencesWithContext());
-        assertTrue(findProvider(providers, ArtifactType.OPENRPC).supportsReferencesWithContext());
-        assertFalse(findProvider(providers, ArtifactType.PROTOBUF).supportsReferencesWithContext());
+        assertTrue(findProvider(providers, ArtifactType.BuiltIn.JSON).supportsReferencesWithContext());
+        assertFalse(findProvider(providers, ArtifactType.BuiltIn.AVRO).supportsReferencesWithContext());
+        assertTrue(findProvider(providers, ArtifactType.BuiltIn.OPENRPC).supportsReferencesWithContext());
+        assertFalse(findProvider(providers, ArtifactType.BuiltIn.PROTOBUF).supportsReferencesWithContext());
     }
 
     @Test
     void testAvroCanonicalizer() {
         ArtifactTypeUtilProvider avro = findProvider(
-                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.AVRO);
+                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.BuiltIn.AVRO);
         ContentCanonicalizer canonicalizer = avro.getContentCanonicalizer();
         assertInstanceOf(EnhancedAvroContentCanonicalizer.class, canonicalizer);
     }
@@ -112,7 +112,7 @@ class StandardArtifactTypeProviderRegistryTest {
     @Test
     void testProtobufStructuredContentExtractor() {
         ArtifactTypeUtilProvider protobuf = findProvider(
-                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.PROTOBUF);
+                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.BuiltIn.PROTOBUF);
         StructuredContentExtractor extractor = protobuf.getStructuredContentExtractor();
         assertInstanceOf(ProtobufStructuredContentExtractor.class, extractor);
     }
@@ -120,7 +120,7 @@ class StandardArtifactTypeProviderRegistryTest {
     @Test
     void testKConnectUsesNoopDefaults() {
         ArtifactTypeUtilProvider kconnect = findProvider(
-                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.KCONNECT);
+                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.BuiltIn.KCONNECT);
         ContentAccepter accepter = kconnect.getContentAccepter();
         assertSame(NoOpContentAccepter.INSTANCE, accepter);
         assertInstanceOf(NoopContentExtractor.class, kconnect.getContentExtractor());
@@ -129,7 +129,7 @@ class StandardArtifactTypeProviderRegistryTest {
     @Test
     void testOpenRpcContentTypes() {
         ArtifactTypeUtilProvider openRpc = findProvider(
-                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.OPENRPC);
+                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.BuiltIn.OPENRPC);
         assertEquals(
                 Set.of(ContentTypes.APPLICATION_JSON, ContentTypes.APPLICATION_YAML),
                 openRpc.getContentTypes());
@@ -138,14 +138,14 @@ class StandardArtifactTypeProviderRegistryTest {
     @Test
     void testOpenRpcUsesNoopCompatibilityChecker() {
         ArtifactTypeUtilProvider openRpc = findProvider(
-                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.OPENRPC);
+                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.BuiltIn.OPENRPC);
         assertInstanceOf(NoopCompatibilityChecker.class, openRpc.getCompatibilityChecker());
     }
 
     @Test
     void testXsdCompatibilityChecker() {
         ArtifactTypeUtilProvider xsd = findProvider(
-                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.XSD);
+                StandardArtifactTypeProviderRegistry.createStandardProviders(), ArtifactType.BuiltIn.XSD);
         assertInstanceOf(XsdCompatibilityChecker.class, xsd.getCompatibilityChecker());
     }
 
@@ -153,15 +153,15 @@ class StandardArtifactTypeProviderRegistryTest {
     void testIcebergTableAndViewValidators() {
         List<ArtifactTypeUtilProvider> providers = StandardArtifactTypeProviderRegistry.createStandardProviders();
         IcebergContentValidator tableValidator = (IcebergContentValidator) findProvider(providers,
-                ArtifactType.ICEBERG_TABLE).getContentValidator();
+                ArtifactType.BuiltIn.ICEBERG_TABLE).getContentValidator();
         IcebergContentValidator viewValidator = (IcebergContentValidator) findProvider(providers,
-                ArtifactType.ICEBERG_VIEW).getContentValidator();
+                ArtifactType.BuiltIn.ICEBERG_VIEW).getContentValidator();
         assertInstanceOf(IcebergContentValidator.class, tableValidator);
         assertInstanceOf(IcebergContentValidator.class, viewValidator);
         assertNotSame(tableValidator, viewValidator);
     }
 
-    private static ArtifactTypeUtilProvider findProvider(List<ArtifactTypeUtilProvider> providers, String type) {
+    private static ArtifactTypeUtilProvider findProvider(List<ArtifactTypeUtilProvider> providers, ArtifactType type) {
         return providers.stream()
                 .filter(p -> type.equals(p.getArtifactType()))
                 .findFirst()

--- a/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/ArtifactEntity.java
+++ b/utils/importexport/src/main/java/io/apicurio/registry/utils/impexp/v3/ArtifactEntity.java
@@ -12,6 +12,7 @@ import lombok.ToString;
 import java.util.Map;
 
 import static lombok.AccessLevel.PRIVATE;
+import io.apicurio.registry.types.ArtifactType;
 
 @Builder
 @NoArgsConstructor
@@ -23,7 +24,7 @@ public class ArtifactEntity extends Entity {
 
     public String groupId;
     public String artifactId;
-    public String artifactType;
+    public ArtifactType artifactType;
     public String name;
     public String description;
     public Map<String, String> labels;

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
@@ -488,7 +488,7 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
 
         // Find all references in the content
         ArtifactTypeUtilProvider provider = this.utilProviderFactory
-                .getArtifactTypeProvider(artifact.getArtifactType());
+                .getArtifactTypeProvider(ArtifactType.fromValue(artifact.getArtifactType()));
         ReferenceFinder referenceFinder = provider.getReferenceFinder();
         var referenceArtifactIdentifierExtractor = provider.getReferenceArtifactIdentifierExtractor();
         Set<ExternalReference> externalReferences = referenceFinder


### PR DESCRIPTION
## Description

Refactors `ArtifactType` from a collection of string constants into a strongly typed sealed hierarchy while preserving support for dynamically configured custom artifact types.

This PR builds upon and completes the architectural direction originally explored in the closed PR #7643. Taking the feedback from that review into account, this implementation uses `ArtifactType` throughout the internal domain model and strictly restricts `String` conversion to serialization boundaries.

### Changes

- Replace `ArtifactType` string constants with a sealed interface implemented by:
  - `ArtifactType.BuiltIn` for the built-in artifact types
  - `ArtifactType.Custom` for dynamically configured artifact types
- Add `ArtifactType.fromValue(String)` and `ArtifactType.value()` for canonical conversion between the domain model and serialized representation.
- Update internal services, storage interfaces, storage DTOs, and domain models to use `ArtifactType` instead of raw `String`.
- Preserve the external REST API contract by keeping generated REST DTOs as `String` and translating them at the API layer.
- Update persistence and serialization boundaries (SQL mappers, Kafka SQL messages, `importexport` schemas) to convert between `ArtifactType` and `String` where appropriate.
- Retain the legacy string constants as deprecated compatibility constants.

### Compatibility

- No changes to the external REST API.
- Artifact types continue to be stored as strings in persistence.
- Existing dynamically configured custom artifact types continue to work.

Fixes #7314
Replaces #7643