### PR TITLE
fix(ui): render agent endpoint URL from supportedInterfaces (#8730)

### DIFF
--- a/ui/ui-app/src/app/pages/agents/AgentsPage.css
+++ b/ui/ui-app/src/app/pages/agents/AgentsPage.css
@@ -65,6 +65,10 @@
     font-size: 10px;
 }
 
+.agent-card .agent-url .agent-protocol-binding {
+    margin-left: 8px;
+}
+
 .agent-card .agent-capabilities {
     margin-bottom: 8px;
 }

--- a/ui/ui-app/src/app/pages/agents/AgentsPage.tsx
+++ b/ui/ui-app/src/app/pages/agents/AgentsPage.tsx
@@ -168,6 +168,7 @@ export const AgentsPage: FunctionComponent<PageProperties> = () => {
     }, []);
 
     const renderAgentCard = (agent: AgentSearchResult): React.ReactElement => {
+        const primaryInterface = agent.supportedInterfaces?.[0];
         return (
             <Card
                 key={`${agent.groupId}-${agent.artifactId}`}
@@ -191,12 +192,17 @@ export const AgentsPage: FunctionComponent<PageProperties> = () => {
                         {agent.description || <span className="no-description">No description</span>}
                     </div>
 
-                    {agent.url && (
+                    {primaryInterface?.url && (
                         <div className="agent-url">
-                            <a href={agent.url} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()}>
-                                {agent.url}
+                            <a href={primaryInterface.url} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()}>
+                                {primaryInterface.url}
                                 <ExternalLinkAltIcon className="external-icon" />
                             </a>
+                            {primaryInterface.protocolBinding && (
+                                <Label color="teal" isCompact className="agent-protocol-binding">
+                                    {primaryInterface.protocolBinding}
+                                </Label>
+                            )}
                         </div>
                     )}
 

--- a/ui/ui-app/src/app/pages/agents/AgentsPage.tsx
+++ b/ui/ui-app/src/app/pages/agents/AgentsPage.tsx
@@ -171,6 +171,7 @@ export const AgentsPage: FunctionComponent<PageProperties> = () => {
     }, []);
 
     const renderAgentCard = (agent: AgentSearchResult): React.ReactElement => {
+        const primaryInterface = agent.supportedInterfaces?.[0];
         return (
             <Card
                 key={`${agent.groupId}-${agent.artifactId}`}
@@ -194,12 +195,17 @@ export const AgentsPage: FunctionComponent<PageProperties> = () => {
                         {agent.description || <span className="no-description">No description</span>}
                     </div>
 
-                    {agent.url && (
+                    {primaryInterface?.url && (
                         <div className="agent-url">
-                            <a href={agent.url} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()}>
-                                {agent.url}
+                            <a href={primaryInterface.url} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()}>
+                                {primaryInterface.url}
                                 <ExternalLinkAltIcon className="external-icon" />
                             </a>
+                            {primaryInterface.protocolBinding && (
+                                <Label color="teal" isCompact className="agent-protocol-binding">
+                                    {primaryInterface.protocolBinding}
+                                </Label>
+                            )}
                         </div>
                     )}
 

--- a/ui/ui-app/src/services/useAgentService.ts
+++ b/ui/ui-app/src/services/useAgentService.ts
@@ -13,6 +13,16 @@ export interface AgentCapabilities {
 }
 
 /**
+ * Agent interface structure
+ */
+export interface AgentInterface {
+    url: string;
+    protocolBinding: string;
+    protocolVersion?: string;
+    tenant?: string;
+}
+
+/**
  * Agent search result structure
  */
 export interface AgentSearchResult {
@@ -21,7 +31,7 @@ export interface AgentSearchResult {
     name: string;
     description?: string;
     version?: string;
-    url?: string;
+    supportedInterfaces?: AgentInterface[];
     skills?: string[];
     capabilities?: AgentCapabilities;
     createdOn?: number;


### PR DESCRIPTION
## What

The `AgentSearchResult` TypeScript interface declared a phantom `url?: string` field that the backend never sends. The actual endpoint URL lives inside `supportedInterfaces[].url`, but the TS interface didn't declare `supportedInterfaces` at all — so `agent.url` was always `undefined` and the agent URL link never rendered on the Agents page.

## Changes

- **`useAgentService.ts`**: add `AgentInterface` type (`url`, `protocolBinding`, `protocolVersion`, `tenant`) matching the Java bean; replace the phantom `url?: string` with `supportedInterfaces?: AgentInterface[]` on `AgentSearchResult`
- **`AgentsPage.tsx`**: render the URL from `agent.supportedInterfaces?.[0]?.url` (with empty/undefined handling) and show the `protocolBinding` (e.g. `http+json`) as a label
- **`AgentsPage.css`**: spacing for the protocol-binding label

## Why

Fixes #8730. The backend `AgentSearchResult` bean and the `.well-known/agents` response already include `supportedInterfaces`; the UI just read the wrong field.

## Verification

- `tsc --noEmit` clean for both changed files (remaining repo errors are pre-existing SDK build issues on `main`)
- `eslint` passes on both changed files

No other code referenced `agent.url` (verified by grep).