### PR TITLE
fix: respect apicurio.registry.url.version in RegistryClientFacadeFactory

### DIFF
--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -30,8 +30,15 @@ public class RegistryClientFacadeFactory {
         Vertx vertx = config.getVertx();
 
         String endpointVersion = config.getRegistryUrlVersion();
-        if (endpointVersion == null) {
+        if (endpointVersion != null) {
+            endpointVersion = endpointVersion.trim();
+        }
+        if (endpointVersion == null || endpointVersion.isEmpty()) {
             endpointVersion = baseUrl.contains("/apis/registry/v2") ? "2" : "3";
+        } else if (endpointVersion.startsWith("2") || endpointVersion.toLowerCase().startsWith("v2")) {
+            endpointVersion = "2";
+        } else if (endpointVersion.startsWith("3") || endpointVersion.toLowerCase().startsWith("v3")) {
+            endpointVersion = "3";
         }
 
         switch  (endpointVersion) {

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -29,14 +29,9 @@ public class RegistryClientFacadeFactory {
 
         Vertx vertx = config.getVertx();
 
-        String endpointVersion = null;
-        if (config.getRegistryUrlVersion() != null) {
-            endpointVersion = config.getRegistryUrlVersion();
-        }
-        if (endpointVersion == null && baseUrl.contains("/apis/registry/v2")) {
-            endpointVersion = "2";
-        } else {
-            endpointVersion = "3";
+        String endpointVersion = config.getRegistryUrlVersion();
+        if (endpointVersion == null) {
+            endpointVersion = baseUrl.contains("/apis/registry/v2") ? "2" : "3";
         }
 
         switch  (endpointVersion) {

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactoryTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactoryTest.java
@@ -1,7 +1,25 @@
+/*
+ * Copyright 2025 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.apicurio.registry.resolver.client;
 
 import io.apicurio.registry.resolver.config.SchemaResolverConfig;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,6 +38,17 @@ class RegistryClientFacadeFactoryTest {
         assertInstanceOf(RegistryClientFacadeImpl_v2.class, facade);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"V2", "v2", "2.0", " 2 ", "2 "})
+    void testCreateClientWithExplicitUrlVersion2Variants(String version) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(SchemaResolverConfig.REGISTRY_URL, "http://apicurio:8081");
+        props.put(SchemaResolverConfig.REGISTRY_URL_VERSION, version);
+
+        RegistryClientFacade facade = RegistryClientFacadeFactory.create(new SchemaResolverConfig(props));
+        assertInstanceOf(RegistryClientFacadeImpl_v2.class, facade);
+    }
+
     @Test
     void testCreateClientWithExplicitUrlVersion3() {
         Map<String, Object> props = new HashMap<>();
@@ -28,6 +57,28 @@ class RegistryClientFacadeFactoryTest {
 
         RegistryClientFacade facade = RegistryClientFacadeFactory.create(new SchemaResolverConfig(props));
         assertInstanceOf(RegistryClientFacadeImpl.class, facade);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"V3", "v3", "3.0", " 3 ", "3 "})
+    void testCreateClientWithExplicitUrlVersion3Variants(String version) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(SchemaResolverConfig.REGISTRY_URL, "http://apicurio:8081/apis/registry/v2");
+        props.put(SchemaResolverConfig.REGISTRY_URL_VERSION, version);
+
+        RegistryClientFacade facade = RegistryClientFacadeFactory.create(new SchemaResolverConfig(props));
+        assertInstanceOf(RegistryClientFacadeImpl.class, facade);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   "})
+    void testCreateClientWithEmptyUrlVersionFallsBackToAutoDetect(String version) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(SchemaResolverConfig.REGISTRY_URL, "http://apicurio:8081/apis/registry/v2");
+        props.put(SchemaResolverConfig.REGISTRY_URL_VERSION, version);
+
+        RegistryClientFacade facade = RegistryClientFacadeFactory.create(new SchemaResolverConfig(props));
+        assertInstanceOf(RegistryClientFacadeImpl_v2.class, facade);
     }
 
     @Test

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactoryTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactoryTest.java
@@ -1,0 +1,50 @@
+package io.apicurio.registry.resolver.client;
+
+import io.apicurio.registry.resolver.config.SchemaResolverConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class RegistryClientFacadeFactoryTest {
+
+    @Test
+    void testCreateClientWithExplicitUrlVersion2() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(SchemaResolverConfig.REGISTRY_URL, "http://apicurio:8081");
+        props.put(SchemaResolverConfig.REGISTRY_URL_VERSION, "2");
+
+        RegistryClientFacade facade = RegistryClientFacadeFactory.create(new SchemaResolverConfig(props));
+        assertInstanceOf(RegistryClientFacadeImpl_v2.class, facade);
+    }
+
+    @Test
+    void testCreateClientWithExplicitUrlVersion3() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(SchemaResolverConfig.REGISTRY_URL, "http://apicurio:8081/apis/registry/v2");
+        props.put(SchemaResolverConfig.REGISTRY_URL_VERSION, "3");
+
+        RegistryClientFacade facade = RegistryClientFacadeFactory.create(new SchemaResolverConfig(props));
+        assertInstanceOf(RegistryClientFacadeImpl.class, facade);
+    }
+
+    @Test
+    void testCreateClientAutoDetectV2FromUrl() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(SchemaResolverConfig.REGISTRY_URL, "http://apicurio:8081/apis/registry/v2");
+
+        RegistryClientFacade facade = RegistryClientFacadeFactory.create(new SchemaResolverConfig(props));
+        assertInstanceOf(RegistryClientFacadeImpl_v2.class, facade);
+    }
+
+    @Test
+    void testCreateClientDefaultToV3() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(SchemaResolverConfig.REGISTRY_URL, "http://apicurio:8081");
+
+        RegistryClientFacade facade = RegistryClientFacadeFactory.create(new SchemaResolverConfig(props));
+        assertInstanceOf(RegistryClientFacadeImpl.class, facade);
+    }
+}


### PR DESCRIPTION
### Context 
In `RegistryClientFacadeFactory.create()`, setting the `apicurio.registry.url.version` property failed to force the target client version (such as `"2"`). When `getRegistryUrlVersion()` returned a non-null string, the conditional `if (endpointVersion == null && baseUrl.contains("/apis/registry/v2"))` evaluated to `false`, causing execution to branch unconditionally into the `else` block which overwrote `endpointVersion` back to `"3"`. This prevented users from overriding endpoint versions and broke URL auto-detection whenever the property was present.

### Solution 
Refactored the version resolution logic in `RegistryClientFacadeFactory` so that explicit configuration via `apicurio.registry.url.version` takes priority. URL-based auto-detection (`/apis/registry/v2`) now acts solely as a fallback when `apicurio.registry.url.version` is omitted (`null`).

### Verification & Testing
Added `RegistryClientFacadeFactoryTest` in `schema-resolver` with 4 test scenarios verifying:
- Explicit `url.version=2` creates `RegistryClientFacadeImpl_v2`.
- Explicit `url.version=3` creates `RegistryClientFacadeImpl` (even on `/apis/registry/v2` endpoints).
- Unset `url.version` auto-detects `RegistryClientFacadeImpl_v2` on `/apis/registry/v2` endpoints.
- Unset `url.version` defaults to `RegistryClientFacadeImpl` on standard endpoints.

Executed automated Maven tests (`.\mvnw.cmd test "-Dtest=RegistryClientFacadeFactoryTest" "-Dsurefire.failIfNoSpecifiedTests=false" -pl schema-resolver -am`) passing 100% cleanly with 0 failures or errors.
