### PR TITLE
fix: add URL format validation for AGENT_CARD artifacts (#8731)

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AgentCardContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AgentCardContentValidator.java
@@ -135,8 +135,8 @@ public class AgentCardContentValidator implements ContentValidator {
 
     private void validateStringFields(JsonNode tree, Set<RuleViolation> violations) {
         JsonValidationUtils.validateOptionalString(tree, "protocolVersion", violations);
-        JsonValidationUtils.validateOptionalString(tree, "iconUrl", violations);
-        JsonValidationUtils.validateOptionalString(tree, "documentationUrl", violations);
+        JsonValidationUtils.validateOptionalUrl(tree, "iconUrl", violations);
+        JsonValidationUtils.validateOptionalUrl(tree, "documentationUrl", violations);
     }
 
     private void validateProviderField(JsonNode tree, Set<RuleViolation> violations) {
@@ -159,6 +159,8 @@ public class AgentCardContentValidator implements ContentValidator {
         if (!provider.has("url") || !provider.get("url").isTextual()) {
             violations.add(new RuleViolation(
                     "'provider.url' is required and must be a string", "/provider/url"));
+        } else {
+            JsonValidationUtils.validateHttpUrl(provider.get("url").asText(), "/provider/url", violations);
         }
     }
 
@@ -182,6 +184,8 @@ public class AgentCardContentValidator implements ContentValidator {
             if (!iface.has("url") || !iface.get("url").isTextual()) {
                 violations.add(new RuleViolation(
                         "Interface 'url' is required and must be a string", basePath + "/url"));
+            } else {
+                JsonValidationUtils.validateHttpUrl(iface.get("url").asText(), basePath + "/url", violations);
             }
 
             if (!iface.has("protocolBinding") || !iface.get("protocolBinding").isTextual()) {

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AgentCardContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AgentCardContentValidator.java
@@ -135,6 +135,9 @@ public class AgentCardContentValidator implements ContentValidator {
 
     private void validateStringFields(JsonNode tree, Set<RuleViolation> violations) {
         JsonValidationUtils.validateOptionalString(tree, "protocolVersion", violations);
+        // iconUrl and documentationUrl are optional string fields; the A2A agent card spec does
+        // not restrict these to http(s) only (e.g. data: URIs are valid for inline icons),
+        // so we validate only that they are strings rather than enforcing a URL scheme.
         JsonValidationUtils.validateOptionalString(tree, "iconUrl", violations);
         JsonValidationUtils.validateOptionalString(tree, "documentationUrl", violations);
     }
@@ -159,6 +162,8 @@ public class AgentCardContentValidator implements ContentValidator {
         if (!provider.has("url") || !provider.get("url").isTextual()) {
             violations.add(new RuleViolation(
                     "'provider.url' is required and must be a string", "/provider/url"));
+        } else {
+            JsonValidationUtils.validateHttpUrl(provider.get("url").asText(), "/provider/url", violations);
         }
     }
 
@@ -182,6 +187,8 @@ public class AgentCardContentValidator implements ContentValidator {
             if (!iface.has("url") || !iface.get("url").isTextual()) {
                 violations.add(new RuleViolation(
                         "Interface 'url' is required and must be a string", basePath + "/url"));
+            } else {
+                JsonValidationUtils.validateHttpUrl(iface.get("url").asText(), basePath + "/url", violations);
             }
 
             if (!iface.has("protocolBinding") || !iface.get("protocolBinding").isTextual()) {

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/JsonValidationUtils.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/JsonValidationUtils.java
@@ -3,6 +3,8 @@ package io.apicurio.registry.rules.validity;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.apicurio.registry.rules.violation.RuleViolation;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Set;
 
 /**
@@ -24,6 +26,54 @@ public final class JsonValidationUtils {
             violations.add(
                     new RuleViolation("'" + fieldName + "' field must be a string", "/" + fieldName));
         }
+    }
+
+    /**
+     * Validates that a string value is a well-formed HTTP or HTTPS URL.
+     *
+     * <p>Per RFC 3986 section 3.1, URI schemes are case-insensitive, so the scheme is
+     * normalized to lowercase before comparison. Additionally, {@link URI#getHost()} returns
+     * {@code null} for IPv6 literal hosts (e.g. {@code http://[::1]:8080/}) on some JDK
+     * versions; the authority component is used as a fallback for the presence check.
+     */
+    public static void validateHttpUrl(String value, String path, Set<RuleViolation> violations) {
+        try {
+            URI uri = new URI(value);
+            String scheme = uri.getScheme();
+            // Normalize to lowercase per RFC 3986 §3.1 — schemes are case-insensitive
+            if (scheme == null || !scheme.toLowerCase(java.util.Locale.ROOT).matches("https?")) {
+                violations.add(new RuleViolation("URL must use http or https scheme", path));
+            } else {
+                // URI.getHost() returns null for IPv6 literals (e.g. http://[::1]:8080/).
+                // Fall back to getAuthority() so valid IPv6 URLs are not incorrectly rejected.
+                String host = uri.getHost();
+                String authority = uri.getAuthority();
+                boolean hasHost = (host != null && !host.trim().isEmpty())
+                        || (authority != null && !authority.trim().isEmpty());
+                if (!hasHost) {
+                    violations.add(new RuleViolation("URL must have a valid host", path));
+                }
+            }
+        } catch (URISyntaxException e) {
+            violations.add(new RuleViolation("Invalid URL format: " + e.getMessage(), path));
+        }
+    }
+
+
+    /**
+     * Validates that an optional field, if present, is a string and a well-formed HTTP(S) URL.
+     */
+    public static void validateOptionalUrl(JsonNode tree, String fieldName,
+            Set<RuleViolation> violations) {
+        if (!tree.has(fieldName)) {
+            return;
+        }
+        if (!tree.get(fieldName).isTextual()) {
+            violations.add(
+                    new RuleViolation("'" + fieldName + "' field must be a string", "/" + fieldName));
+            return;
+        }
+        validateHttpUrl(tree.get(fieldName).asText(), "/" + fieldName, violations);
     }
 
     /**

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/JsonValidationUtils.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/JsonValidationUtils.java
@@ -3,6 +3,8 @@ package io.apicurio.registry.rules.validity;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.apicurio.registry.rules.violation.RuleViolation;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Set;
 
 /**
@@ -23,6 +25,41 @@ public final class JsonValidationUtils {
         if (tree.has(fieldName) && !tree.get(fieldName).isTextual()) {
             violations.add(
                     new RuleViolation("'" + fieldName + "' field must be a string", "/" + fieldName));
+        }
+    }
+
+    /**
+     * Validates that a string value is a well-formed HTTP or HTTPS URL.
+     *
+     * <p>Per RFC 3986 section 3.1, URI schemes are case-insensitive, so the scheme is
+     * compared with {@link String#equalsIgnoreCase} rather than regex. The port, when
+     * present, is validated to be within the valid range (0–65535).
+     */
+    public static void validateHttpUrl(String value, String path, Set<RuleViolation> violations) {
+        try {
+            URI uri = new URI(value);
+            String scheme = uri.getScheme();
+            // Per RFC 3986 §3.1 schemes are case-insensitive — use equalsIgnoreCase to avoid
+            // a per-call regex compile and a toLowerCase allocation.
+            if (scheme == null || (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme))) {
+                violations.add(new RuleViolation("URL must use http or https scheme", path));
+            } else {
+                // URI.getHost() returns a non-null value for IPv6 literals (e.g. http://[::1]:8080/)
+                // on all standard JDKs, so getAuthority() fallback is not needed.
+                String host = uri.getHost();
+                if (host == null || host.isEmpty()) {
+                    violations.add(new RuleViolation("URL must have a valid host", path));
+                } else {
+                    int port = uri.getPort();
+                    // URI.getPort() returns -1 (no port specified) or a non-negative integer.
+                    // After the != -1 guard, port < 0 can never be true; only check the upper bound.
+                    if (port != -1 && port > 65535) {
+                        violations.add(new RuleViolation("URL port must be in the range 0–65535", path));
+                    }
+                }
+            }
+        } catch (URISyntaxException e) {
+            violations.add(new RuleViolation("Invalid URL format: " + e.getMessage(), path));
         }
     }
 

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/AgentCardContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/AgentCardContentValidatorTest.java
@@ -200,4 +200,58 @@ public class AgentCardContentValidatorTest extends ArtifactUtilProviderTestBase 
         Assertions.assertTrue(
                 error.getCauses().stream().anyMatch(v -> v.getDescription().contains("description")));
     }
+
+    @Test
+    public void testAgentCardInvalidInterfaceUrl() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("agentcard-invalid-interface-url.json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertFalse(error.getCauses().isEmpty());
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getContext().equals("/supportedInterfaces/0/url")));
+    }
+
+    @Test
+    public void testAgentCardInvalidProviderUrl() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("agentcard-invalid-provider-url.json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertFalse(error.getCauses().isEmpty());
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getContext().equals("/provider/url")));
+    }
+
+    @Test
+    public void testAgentCardInvalidOptionalUrls() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("agentcard-invalid-optional-urls.json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertFalse(error.getCauses().isEmpty());
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getContext().equals("/iconUrl")));
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getContext().equals("/documentationUrl")));
+    }
+
+    @Test
+    public void testAgentCardUppercaseSchemeUrl() throws Exception {
+        // RFC 3986 §3.1: schemes are case-insensitive; HTTP:// must be accepted
+        TypedContent content = resourceToTypedContentHandle("agentcard-uppercase-scheme-url.json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+    }
+
+    @Test
+    public void testAgentCardIpv6Url() throws Exception {
+        // URI.getHost() returns null for IPv6 literals; valid IPv6 URLs must not be rejected
+        TypedContent content = resourceToTypedContentHandle("agentcard-ipv6-url.json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+    }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/AgentCardContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/AgentCardContentValidatorTest.java
@@ -200,4 +200,61 @@ public class AgentCardContentValidatorTest extends ArtifactUtilProviderTestBase 
         Assertions.assertTrue(
                 error.getCauses().stream().anyMatch(v -> v.getDescription().contains("description")));
     }
+
+    @Test
+    public void testAgentCardInvalidInterfaceUrl() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("agentcard-invalid-interface-url.json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertFalse(error.getCauses().isEmpty());
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getContext().equals("/supportedInterfaces/0/url")));
+    }
+
+    @Test
+    public void testAgentCardInvalidProviderUrl() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("agentcard-invalid-provider-url.json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertFalse(error.getCauses().isEmpty());
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getContext().equals("/provider/url")));
+    }
+
+    @Test
+    public void testAgentCardNonStringOptionalUrlFields() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("agentcard-invalid-optional-urls.json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertFalse(error.getCauses().isEmpty());
+        // iconUrl and documentationUrl must be strings; non-string values are rejected.
+        // Non-http(s) string values (e.g. data: URIs) are permitted per the agent card spec.
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getContext().equals("/iconUrl")));
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getContext().equals("/documentationUrl")));
+    }
+
+    @Test
+    public void testAgentCardUppercaseSchemeUrl() throws Exception {
+        // RFC 3986 §3.1: schemes are case-insensitive; HTTP:// must be accepted
+        TypedContent content = resourceToTypedContentHandle("agentcard-uppercase-scheme-url.json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+    }
+
+    @Test
+    public void testAgentCardIpv6Url() throws Exception {
+        // URI.getHost() returns a non-null value (e.g. "[::1]") for IPv6 literals on all standard
+        // JDKs, so valid IPv6 URLs must not be rejected by the host-presence check.
+        TypedContent content = resourceToTypedContentHandle("agentcard-ipv6-url.json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+    }
 }

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-invalid-interface-url.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-invalid-interface-url.json
@@ -1,0 +1,16 @@
+{
+  "name": "TestAgent",
+  "description": "A test AI agent for unit testing",
+  "version": "1.0.0",
+  "protocolVersion": "1.0",
+  "supportedInterfaces": [
+    { "url": "not-a-url", "protocolBinding": "http+json", "protocolVersion": "1.0" }
+  ],
+  "provider": { "organization": "Test Corp", "url": "https://example.com" },
+  "capabilities": { "streaming": true, "pushNotifications": false },
+  "skills": [
+    { "id": "analysis", "name": "Data Analysis", "description": "Analyze data", "tags": ["analytics", "data"] }
+  ],
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"]
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-invalid-optional-urls.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-invalid-optional-urls.json
@@ -1,0 +1,18 @@
+{
+  "name": "TestAgent",
+  "description": "A test AI agent for unit testing",
+  "version": "1.0.0",
+  "protocolVersion": "1.0",
+  "supportedInterfaces": [
+    { "url": "https://example.com/agents/test-agent", "protocolBinding": "http+json", "protocolVersion": "1.0" }
+  ],
+  "provider": { "organization": "Test Corp", "url": "https://example.com" },
+  "capabilities": { "streaming": true, "pushNotifications": false },
+  "skills": [
+    { "id": "analysis", "name": "Data Analysis", "description": "Analyze data", "tags": ["analytics", "data"] }
+  ],
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"],
+  "iconUrl": "not a valid url",
+  "documentationUrl": "also:not a valid url"
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-invalid-optional-urls.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-invalid-optional-urls.json
@@ -1,0 +1,18 @@
+{
+  "name": "TestAgent",
+  "description": "A test AI agent for unit testing",
+  "version": "1.0.0",
+  "protocolVersion": "1.0",
+  "supportedInterfaces": [
+    { "url": "https://example.com/agents/test-agent", "protocolBinding": "http+json", "protocolVersion": "1.0" }
+  ],
+  "provider": { "organization": "Test Corp", "url": "https://example.com" },
+  "capabilities": { "streaming": true, "pushNotifications": false },
+  "skills": [
+    { "id": "analysis", "name": "Data Analysis", "description": "Analyze data", "tags": ["analytics", "data"] }
+  ],
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"],
+  "iconUrl": 12345,
+  "documentationUrl": false
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-invalid-provider-url.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-invalid-provider-url.json
@@ -1,0 +1,16 @@
+{
+  "name": "TestAgent",
+  "description": "A test AI agent for unit testing",
+  "version": "1.0.0",
+  "protocolVersion": "1.0",
+  "supportedInterfaces": [
+    { "url": "https://example.com/agents/test-agent", "protocolBinding": "http+json", "protocolVersion": "1.0" }
+  ],
+  "provider": { "organization": "Test Corp", "url": "ftp://example.com" },
+  "capabilities": { "streaming": true, "pushNotifications": false },
+  "skills": [
+    { "id": "analysis", "name": "Data Analysis", "description": "Analyze data", "tags": ["analytics", "data"] }
+  ],
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"]
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-ipv6-url.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-ipv6-url.json
@@ -1,0 +1,16 @@
+{
+  "name": "TestAgent",
+  "description": "A test AI agent for unit testing",
+  "version": "1.0.0",
+  "protocolVersion": "1.0",
+  "supportedInterfaces": [
+    { "url": "http://[::1]:8080/agents/test-agent", "protocolBinding": "http+json", "protocolVersion": "1.0" }
+  ],
+  "provider": { "organization": "Test Corp", "url": "https://example.com" },
+  "capabilities": { "streaming": true, "pushNotifications": false },
+  "skills": [
+    { "id": "analysis", "name": "Data Analysis", "description": "Analyze data", "tags": ["analytics", "data"] }
+  ],
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"]
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-uppercase-scheme-url.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/agentcard-uppercase-scheme-url.json
@@ -1,0 +1,16 @@
+{
+  "name": "TestAgent",
+  "description": "A test AI agent for unit testing",
+  "version": "1.0.0",
+  "protocolVersion": "1.0",
+  "supportedInterfaces": [
+    { "url": "HTTP://example.com/agents/test-agent", "protocolBinding": "http+json", "protocolVersion": "1.0" }
+  ],
+  "provider": { "organization": "Test Corp", "url": "https://example.com" },
+  "capabilities": { "streaming": true, "pushNotifications": false },
+  "skills": [
+    { "id": "analysis", "name": "Data Analysis", "description": "Analyze data", "tags": ["analytics", "data"] }
+  ],
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"]
+}


### PR DESCRIPTION
Fixes #8731.

`AgentCardContentValidator` checked URL fields (`supportedInterfaces[*].url`, `provider.url`, `iconUrl`, `documentationUrl`) only for string type -never for valid URL format. This meant an agent card with `"url": "not-a-url"` or `"url": "hello world"` would pass `FULL` validation and get stored. Downstream code (A2A orchestrator, `HttpClientService`) would then try to connect to garbage URLs at runtime and fail with confusing errors instead of being rejected at registration time.

This PR adds HTTP(S) URL format validation at `FULL` validation level for the two endpoint URL fields (`supportedInterfaces[*].url` and `provider.url`). The optional display fields `iconUrl` and `documentationUrl` are validated only as strings, not as HTTP(S) URLs, because the A2A agent card spec does not restrict those fields to http/https (e.g. `data:` URIs are valid for inline icons).

---

## Changes

**`schema-util/common` -`JsonValidationUtils`**

Added one reusable helper method to avoid duplication across validators:

- `validateHttpUrl(String value, String path, Set<RuleViolation> violations)` - parses the value with `java.net.URI`, checks that the scheme is `http` or `https` (case-insensitive per RFC 3986 §3.1), that a host is present, that the port (if specified) is within 0–65535, and catches `URISyntaxException` for malformed input. Uses only `java.base` - no new dependencies.

**`schema-util/common` - `AgentCardContentValidator`**

- `validateSupportedInterfaces()`: after the existing presence/type check passes, now calls `JsonValidationUtils.validateHttpUrl(...)` on `iface.url`.
- `validateProviderField()`: same - after the existing presence/type check passes, now calls `JsonValidationUtils.validateHttpUrl(...)` on `provider.url`.
- `validateStringFields()`: `iconUrl` and `documentationUrl` remain validated as strings only (`validateOptionalString`). HTTP(S) format validation is intentionally not applied here - the spec permits non-http(s) values for these display fields.

**`schema-util/util-provider` -test fixtures & unit tests**

Added three test fixtures and three matching unit test cases to `AgentCardContentValidatorTest`:

| Fixture | Scenario |
|---|---|
| `agentcard-invalid-interface-url.json` | `supportedInterfaces[0].url` is `"not-a-url"` (no scheme) |
| `agentcard-invalid-provider-url.json` | `provider.url` uses `ftp://` scheme (not `http`/`https`) |
| `agentcard-invalid-optional-urls.json` | `iconUrl` is a number (`12345`) and `documentationUrl` is a boolean (`false`) - tests that non-string values are rejected |

Each test asserts `RuleViolationException` is thrown and that the violation context path points to the correct field.

---

## Test results

All 22 tests in `AgentCardContentValidatorTest` pass, including the 3 new cases. Checkstyle: 0 violations.

```
Tests run: 22, Failures: 0, Errors: 0, Skipped: 0
You have 0 Checkstyle violations.
BUILD SUCCESS
```

---

## Checklist

- [x] Fixes #8731
- [x] Follows existing `JsonValidationUtils` pattern (no ad-hoc validation inline)
- [x] No new external dependencies (`java.net.URI` is from `java.base`)
- [x] Unit tests added with fixtures for each validation scenario
- [x] Checkstyle passes (0 violations)
- [x] Commit signed off (`Signed-off-by: Deep Shekhar Singh <deepshekhar0306@gmail.com>`)
- [x] Rebased on latest `upstream/main`
