### PR TITLE
fix(rest): return 400 for null contract status

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -2142,6 +2142,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
 
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
+        ParameterValidationUtils.requireParameter("status", data.getStatus());
 
         String rawGroupId = new GroupId(groupId).getRawGroupIdWithNull();
         ContractStatus targetStatus = ContractStatus.valueOf(data.getStatus().value());

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/DataContractsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/DataContractsResourceTest.java
@@ -560,6 +560,32 @@ public class DataContractsResourceTest extends AbstractResourceTestBase {
     // -- Status Transition Tests --
 
     @Test
+    public void testStatusTransition_MissingStatus_Returns400() throws Exception {
+        String artifactId = "testStatusTransition_MissingStatus-" + UUID.randomUUID();
+        String content = resourceToString("openapi-empty.json");
+        createArtifact(GROUP, artifactId, ArtifactType.OPENAPI, content, ContentTypes.APPLICATION_JSON);
+
+        given().when().contentType(CT_JSON)
+                .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
+                .body("{}") // missing status
+                .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/status")
+                .then().statusCode(400);
+    }
+
+    @Test
+    public void testStatusTransition_NullStatus_Returns400() throws Exception {
+        String artifactId = "testStatusTransition_NullStatus-" + UUID.randomUUID();
+        String content = resourceToString("openapi-empty.json");
+        createArtifact(GROUP, artifactId, ArtifactType.OPENAPI, content, ContentTypes.APPLICATION_JSON);
+
+        given().when().contentType(CT_JSON)
+                .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
+                .body("{\"status\": null}") // explicit null status
+                .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/contract/status")
+                .then().statusCode(400);
+    }
+
+    @Test
     public void testStatusTransition_DraftToStable() throws Exception {
         String artifactId = "testStatusTransition_DraftToStable-" + UUID.randomUUID();
         String content = resourceToString("openapi-empty.json");


### PR DESCRIPTION
## What

Added validation for the required `status` field in the contract status transition endpoint.
The validation is performed in `transitionContractStatus()` before `data.getStatus().value()` is accessed. This ensures that requests with a missing or explicitly null `status` are rejected as invalid input rather than resulting in a `NullPointerException`.
The implementation follows the existing `ParameterValidationUtils.requireParameter(...)` validation pattern used for other required parameters.

## Why

Previously, requests containing either `{}` or `{"status": null}` caused `data.getStatus()` to return `null`. The subsequent call to `.value()` resulted in a `NullPointerException`, causing the endpoint to return HTTP 500.
Since `status` is a required request field, these requests should be rejected with HTTP 400 Bad Request instead.
This change validates `status` before it is accessed, preventing the exception and ensuring consistent request validation behavior.

## Tests

Added regression tests covering both cases:
- Missing `status`: `{}`
- Explicitly null `status`: `{"status": null}`
Both tests verify that the endpoint returns HTTP 400 Bad Request.
The tests pass successfully, and `git diff --check` reports no formatting issues.

## Issue

Fixes #9329