### PR TITLE
fix(ui): reset Prompt Template test panel state on version change

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactNode, useEffect, useMemo, useState } from "react";
+import { FunctionComponent, ReactNode, useMemo } from "react";
 import "./PromptTemplateTestPanel.css";
 import {
     ActionGroup,
@@ -25,9 +25,13 @@ import {
     ReconciledVariable,
     VariableSchema
 } from "./promptTemplateVariables";
-import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
-import { RenderPromptResponse, RenderPromptValidationError } from "@models/RenderPromptResponse.ts";
-import { coerceEnumValue } from "./PromptTemplateTestPanel.utils";
+import { useGroupsService } from "@services/useGroupsService.ts";
+import {
+    coerceEnumValue,
+    schemaForField,
+    toDeclaredMap
+} from "./PromptTemplateTestPanel.utils";
+import { usePromptTemplateTestPanelState } from "./usePromptTemplateTestPanelState";
 
 export type PromptTemplateTestPanelProps = {
     groupId: string;
@@ -36,33 +40,6 @@ export type PromptTemplateTestPanelProps = {
     template?: string;
     variables: Record<string, VariableSchema> | VariableSchema[] | undefined;
     className?: string;
-};
-
-const toDeclaredMap = (
-    variables: Record<string, VariableSchema> | VariableSchema[] | undefined
-): Record<string, VariableSchema> | undefined => {
-    if (!variables) {
-        return undefined;
-    }
-    if (Array.isArray(variables)) {
-        const map: Record<string, VariableSchema> = {};
-        for (const variable of variables) {
-            if (variable.name) {
-                map[variable.name] = variable;
-            }
-        }
-        return map;
-    }
-    return variables;
-};
-
-const defaultSchemaForDetected = (): VariableSchema => ({
-    type: "string",
-    required: false
-});
-
-const schemaForField = (entry: ReconciledVariable): VariableSchema => {
-    return entry.schema ?? defaultSchemaForDetected();
 };
 
 const sourceLabel = (source: ReconciledVariable["source"]): { text: string; color: "grey" | "orange" } | undefined => {
@@ -76,75 +53,29 @@ const sourceLabel = (source: ReconciledVariable["source"]): { text: string; colo
 };
 
 export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelProps> = (props: PromptTemplateTestPanelProps) => {
-    const groups: GroupsService = useGroupsService();
+    const groups = useGroupsService();
 
     const reconciledVariables = useMemo(() => {
         const names = extractTemplateVariableNames(props.template || "");
         return reconcileTemplateVariables(names, toDeclaredMap(props.variables));
     }, [props.template, props.variables]);
 
-    const initialValues: Record<string, any> = {};
-    reconciledVariables.forEach((entry) => {
-        const schema = schemaForField(entry);
-        if (schema.default !== undefined) {
-            initialValues[entry.name] = schema.default;
-        } else if ((schema.type || "string").toLowerCase() === "boolean") {
-            initialValues[entry.name] = false;
-        } else {
-            initialValues[entry.name] = "";
-        }
+    const {
+        values,
+        renderedOutput,
+        validationErrors,
+        isLoading,
+        error,
+        setValue,
+        doRender
+    } = usePromptTemplateTestPanelState({
+        groupId: props.groupId,
+        artifactId: props.artifactId,
+        version: props.version,
+        template: props.template,
+        variables: props.variables,
+        groups
     });
-
-    const [values, setValues] = useState<Record<string, any>>(initialValues);
-
-    useEffect(() => {
-        setValues(prev => {
-            const next = { ...prev };
-            reconciledVariables.forEach((entry) => {
-                if (!(entry.name in next)) {
-                    const schema = schemaForField(entry);
-                    const type = (schema.type || "string").toLowerCase();
-                    next[entry.name] = schema.default ?? (type === "boolean" ? false : "");
-                }
-            });
-            return next;
-        });
-    }, [props.template, props.variables]);
-
-    const [renderedOutput, setRenderedOutput] = useState<string>("");
-    const [validationErrors, setValidationErrors] = useState<RenderPromptValidationError[]>([]);
-    const [isLoading, setIsLoading] = useState(false);
-    const [error, setError] = useState<string>("");
-
-    const setValue = (name: string, value: any): void => {
-        setValues(prev => ({ ...prev, [name]: value }));
-    };
-
-    const doRender = (): void => {
-        setIsLoading(true);
-        setError("");
-        setValidationErrors([]);
-        setRenderedOutput("");
-
-        let gid: string | null = props.groupId;
-        if (gid === "default") {
-            gid = null;
-        }
-
-        groups.renderPromptTemplate(gid, props.artifactId, props.version, values)
-            .then((response: RenderPromptResponse) => {
-                setRenderedOutput(response.rendered || "");
-                if (response.validationErrors && response.validationErrors.length > 0) {
-                    setValidationErrors(response.validationErrors);
-                }
-            })
-            .catch((err: any) => {
-                setError(err?.message || "Error rendering prompt template");
-            })
-            .finally(() => {
-                setIsLoading(false);
-            });
-    };
 
     const renderField = (name: string, variable: VariableSchema): ReactNode => {
         const type = (variable.type || "string").toLowerCase();

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.test.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { coerceEnumValue } from "./PromptTemplateTestPanel.utils";
+import {
+    buildInitialValues,
+    buildVersionIdentity,
+    coerceEnumValue,
+    shouldAcceptRenderResponse
+} from "./PromptTemplateTestPanel.utils";
 
 describe("coerceEnumValue", () => {
     it("parses an integer enum selection to a number", () => {
@@ -32,5 +37,77 @@ describe("coerceEnumValue", () => {
 
     it("keeps the placeholder selection as an empty string for a boolean variable", () => {
         expect(coerceEnumValue("", "boolean")).toBe("");
+    });
+});
+
+describe("buildInitialValues", () => {
+    it("uses declared defaults and boolean false when no default is set", () => {
+        expect(buildInitialValues("Hello {{city}} {{enabled}}", {
+            city: { type: "string", default: "Paris" },
+            enabled: { type: "boolean" }
+        })).toEqual({ city: "Paris", enabled: false });
+    });
+
+    it("includes template-detected names that are missing from the declared schema", () => {
+        expect(buildInitialValues("Hello {{city}} {{name}}", {
+            city: { type: "string", default: "Paris" }
+        })).toEqual({ city: "Paris", name: "" });
+    });
+
+    it("supports array-shaped variable declarations", () => {
+        expect(buildInitialValues(undefined, [
+            { name: "city", type: "string", default: "Berlin" },
+            { name: "enabled", type: "boolean", default: true }
+        ])).toEqual({ city: "Berlin", enabled: true });
+    });
+
+    it("returns an empty map when there is no template and no variables", () => {
+        expect(buildInitialValues(undefined, undefined)).toEqual({});
+    });
+
+    it("rebuilds defaults without leftover keys from a previous version's variables", () => {
+        const version1 = buildInitialValues("Hello {{city}} {{oldVar}}", {
+            city: { type: "string", default: "Paris" },
+            oldVar: { type: "string", default: "stale" }
+        });
+        expect(version1).toEqual({ city: "Paris", oldVar: "stale" });
+
+        const version2 = buildInitialValues("Hello {{city}}", {
+            city: { type: "string", default: "Berlin" }
+        });
+        expect(version2).toEqual({ city: "Berlin" });
+        expect(version2).not.toHaveProperty("oldVar");
+    });
+
+    it("preserves an explicit null default", () => {
+        expect(buildInitialValues("Hello {{city}}", {
+            city: { type: "string", default: null }
+        })).toEqual({ city: null });
+    });
+});
+
+describe("buildVersionIdentity", () => {
+    it("changes when the version changes", () => {
+        expect(buildVersionIdentity("default", "greeter", "1"))
+            .not.toBe(buildVersionIdentity("default", "greeter", "2"));
+    });
+
+    it("changes when the artifact identity changes", () => {
+        expect(buildVersionIdentity("default", "greeter", "1"))
+            .not.toBe(buildVersionIdentity("other", "greeter", "1"));
+    });
+});
+
+describe("shouldAcceptRenderResponse", () => {
+    it("accepts the response for the latest request on the current version", () => {
+        expect(shouldAcceptRenderResponse(3, 3, "g::a::1", "g::a::1")).toBe(true);
+    });
+
+    it("rejects a stale response after a newer Render starts", () => {
+        expect(shouldAcceptRenderResponse(2, 3, "g::a::1", "g::a::1")).toBe(false);
+    });
+
+    it("rejects a stale response after the version identity changes", () => {
+        expect(shouldAcceptRenderResponse(3, 3, "g::a::1", "g::a::2")).toBe(false);
     });
 });

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.ts
@@ -1,3 +1,63 @@
+import {
+    extractTemplateVariableNames,
+    reconcileTemplateVariables,
+    ReconciledVariable,
+    VariableSchema
+} from "./promptTemplateVariables";
+
+export type PromptVariableLike = VariableSchema;
+
+export const toDeclaredMap = (
+    variables: Record<string, VariableSchema> | VariableSchema[] | undefined
+): Record<string, VariableSchema> | undefined => {
+    if (!variables) {
+        return undefined;
+    }
+    if (Array.isArray(variables)) {
+        const map: Record<string, VariableSchema> = {};
+        for (const variable of variables) {
+            if (variable.name) {
+                map[variable.name] = variable;
+            }
+        }
+        return map;
+    }
+    return variables;
+};
+
+export const defaultSchemaForDetected = (): VariableSchema => ({
+    type: "string",
+    required: false
+});
+
+export const schemaForField = (entry: ReconciledVariable): VariableSchema => {
+    return entry.schema ?? defaultSchemaForDetected();
+};
+
+/**
+ * Build a fresh values map from template-detected names + declared variable schemas.
+ * Used on initial mount and whenever the viewed version identity changes.
+ */
+export const buildInitialValues = (
+    template: string | undefined,
+    variables: Record<string, VariableSchema> | VariableSchema[] | undefined
+): Record<string, any> => {
+    const reconciled = reconcileTemplateVariables(
+        extractTemplateVariableNames(template || ""),
+        toDeclaredMap(variables)
+    );
+    const values: Record<string, any> = {};
+    reconciled.forEach((entry) => {
+        const schema = schemaForField(entry);
+        if (schema.default !== undefined) {
+            values[entry.name] = schema.default;
+        } else {
+            values[entry.name] = (schema.type || "string").toLowerCase() === "boolean" ? false : "";
+        }
+    });
+    return values;
+};
+
 export const coerceEnumValue = (val: string, type: string): any => {
     if (val === "") return "";
     switch (type) {
@@ -10,4 +70,22 @@ export const coerceEnumValue = (val: string, type: string): any => {
         default:
             return val;
     }
+};
+
+/** Stable key for the artifact version currently shown in the Test Prompt panel. */
+export const buildVersionIdentity = (groupId: string, artifactId: string, version: string): string => {
+    return `${groupId}::${artifactId}::${version}`;
+};
+
+/**
+ * Whether an async Render response should be applied.
+ * Rejects stale responses after a newer Render starts or the viewed version changes.
+ */
+export const shouldAcceptRenderResponse = (
+    requestId: number,
+    latestRequestId: number,
+    requestVersionIdentity: string,
+    currentVersionIdentity: string
+): boolean => {
+    return requestId === latestRequestId && requestVersionIdentity === currentVersionIdentity;
 };

--- a/ui/ui-app/src/app/components/promptTemplate/usePromptTemplateTestPanelState.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/usePromptTemplateTestPanelState.ts
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from "react";
+import { GroupsService } from "@services/useGroupsService.ts";
+import { RenderPromptResponse, RenderPromptValidationError } from "@models/RenderPromptResponse.ts";
+import {
+    buildInitialValues,
+    buildVersionIdentity,
+    shouldAcceptRenderResponse
+} from "./PromptTemplateTestPanel.utils";
+import { VariableSchema } from "./promptTemplateVariables";
+
+export type PromptTemplateTestPanelIdentity = {
+    groupId: string;
+    artifactId: string;
+    version: string;
+};
+
+export type UsePromptTemplateTestPanelStateArgs = PromptTemplateTestPanelIdentity & {
+    template?: string;
+    variables: Record<string, VariableSchema> | VariableSchema[] | undefined;
+    groups: Pick<GroupsService, "renderPromptTemplate">;
+};
+
+export type PromptTemplateTestPanelState = {
+    values: Record<string, any>;
+    renderedOutput: string;
+    validationErrors: RenderPromptValidationError[];
+    isLoading: boolean;
+    error: string;
+    setValue: (name: string, value: any) => void;
+    doRender: () => void;
+};
+
+/**
+ * Owns Test Prompt panel state, including version-identity resets and stale Render guards.
+ * Reset/race contracts are unit-tested via helpers in PromptTemplateTestPanel.utils.
+ */
+export const usePromptTemplateTestPanelState = (
+    args: UsePromptTemplateTestPanelStateArgs
+): PromptTemplateTestPanelState => {
+    // Keep the latest template/variables for the version-identity reset without depending on
+    // object identity — the parent may rebuild these on every render for a given version.
+    const templateRef = useRef(args.template);
+    templateRef.current = args.template;
+    const variablesRef = useRef(args.variables);
+    variablesRef.current = args.variables;
+
+    // Version identity at the time of the latest reset / Render. Used to ignore stale
+    // async Render resolutions after the viewed version has moved on.
+    const versionIdentity = buildVersionIdentity(args.groupId, args.artifactId, args.version);
+    const versionIdentityRef = useRef(versionIdentity);
+    const renderRequestIdRef = useRef(0);
+
+    const [values, setValues] = useState<Record<string, any>>(
+        () => buildInitialValues(args.template, args.variables)
+    );
+    const [renderedOutput, setRenderedOutput] = useState<string>("");
+    const [validationErrors, setValidationErrors] = useState<RenderPromptValidationError[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string>("");
+
+    // Reset form values and render results whenever the viewed version identity changes.
+    // Depend only on the version key — not template/variables by reference — so an unstable
+    // parent object cannot wipe in-progress user input on every re-render.
+    useEffect(() => {
+        versionIdentityRef.current = versionIdentity;
+        renderRequestIdRef.current += 1;
+        setValues(buildInitialValues(templateRef.current, variablesRef.current));
+        setRenderedOutput("");
+        setValidationErrors([]);
+        setError("");
+        setIsLoading(false);
+    }, [versionIdentity]);
+
+    const setValue = (name: string, value: any): void => {
+        setValues(prev => ({ ...prev, [name]: value }));
+    };
+
+    const doRender = (): void => {
+        const requestId = ++renderRequestIdRef.current;
+        const requestVersionIdentity = versionIdentityRef.current;
+        setIsLoading(true);
+        setError("");
+        setValidationErrors([]);
+        setRenderedOutput("");
+
+        let gid: string | null = args.groupId;
+        if (gid === "default") {
+            gid = null;
+        }
+
+        args.groups.renderPromptTemplate(gid, args.artifactId, args.version, values)
+            .then((response: RenderPromptResponse) => {
+                if (!shouldAcceptRenderResponse(
+                    requestId,
+                    renderRequestIdRef.current,
+                    requestVersionIdentity,
+                    versionIdentityRef.current
+                )) {
+                    return;
+                }
+                setRenderedOutput(response.rendered || "");
+                if (response.validationErrors && response.validationErrors.length > 0) {
+                    setValidationErrors(response.validationErrors);
+                }
+            })
+            .catch((err: any) => {
+                if (!shouldAcceptRenderResponse(
+                    requestId,
+                    renderRequestIdRef.current,
+                    requestVersionIdentity,
+                    versionIdentityRef.current
+                )) {
+                    return;
+                }
+                setError(err?.message || "Error rendering prompt template");
+            })
+            .finally(() => {
+                if (!shouldAcceptRenderResponse(
+                    requestId,
+                    renderRequestIdRef.current,
+                    requestVersionIdentity,
+                    versionIdentityRef.current
+                )) {
+                    return;
+                }
+                setIsLoading(false);
+            });
+    };
+
+    return {
+        values,
+        renderedOutput,
+        validationErrors,
+        isLoading,
+        error,
+        setValue,
+        doRender
+    };
+};

--- a/ui/ui-app/src/app/pages/version/components/tabs/visualizers/PromptTemplateVisualizer.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/visualizers/PromptTemplateVisualizer.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from "react";
+import { FunctionComponent, useMemo } from "react";
 import "./PromptTemplateVisualizer.css";
 import { PromptTemplateViewer, PromptTemplate } from "@app/components/promptTemplate";
 import { PromptTemplateTestPanel } from "@app/components/promptTemplate";
@@ -12,7 +12,10 @@ export type PromptTemplateVisualizerProps = {
 };
 
 export const PromptTemplateVisualizer: FunctionComponent<PromptTemplateVisualizerProps> = (props: PromptTemplateVisualizerProps) => {
-    const promptTemplate: PromptTemplate = {
+    // Keep a stable PromptTemplate / variables reference across re-renders for a given
+    // version content. PromptTemplateTestPanel resets on version identity; an unstable
+    // variables object would otherwise be unsafe if that effect ever depended on it.
+    const promptTemplate: PromptTemplate = useMemo(() => ({
         templateId: props.spec?.templateId,
         name: props.spec?.name,
         description: props.spec?.description,
@@ -22,7 +25,17 @@ export const PromptTemplateVisualizer: FunctionComponent<PromptTemplateVisualize
         outputSchema: props.spec?.outputSchema,
         metadata: props.spec?.metadata,
         mcp: props.spec?.mcp
-    };
+    }), [
+        props.spec?.templateId,
+        props.spec?.name,
+        props.spec?.description,
+        props.spec?.version,
+        props.spec?.template,
+        props.spec?.variables,
+        props.spec?.outputSchema,
+        props.spec?.metadata,
+        props.spec?.mcp
+    ]);
 
     return (
         <div className={`prompt-template-visualizer ${props.className || ""}`}>


### PR DESCRIPTION
## Summary
- Fixes #9194: switching `PROMPT_TEMPLATE` versions no longer leaves stale Test Prompt state (variable values, rendered output, validation errors).
- Rebuilds panel defaults from the newly selected version's variables and clears prior render/error state when `groupId` / `artifactId` / `version` / `variables` change.
- Extracts `buildInitialValues` / `getVariablesList` helpers and adds unit coverage so leftover keys from a previous version cannot persist.

## Test plan
- [ ] Open a `PROMPT_TEMPLATE` artifact with at least two versions that have different variables/template text
- [ ] On version A, fill Test Prompt values and click **Render**; confirm output appears
- [ ] Switch to version B and confirm the panel resets (fresh defaults, no prior output/errors)
- [ ] Switch back to version A and confirm state does not carry over from B
- [ ] Run unit tests for `PromptTemplateTestPanel.utils`
