### PR TITLE
fix(rest): normalize pagination parameters in v2 REST endpoints

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/ParameterValidationUtils.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ParameterValidationUtils.java
@@ -81,4 +81,17 @@ public final class ParameterValidationUtils {
         return limit.signum() < 0 ? 1 : limit.min(MAX_LIMIT).intValue();
     }
 
+    /**
+     * Normalizes a pagination limit so it never reaches the storage layer as an invalid value,
+     * without imposing an upper bound on the result set size. A negative limit is normalized to 1
+     * (limit=0 keeps its existing empty-page semantics); otherwise the limit is clamped to
+     * Integer.MAX_VALUE to prevent BigInteger-to-int overflow.
+     *
+     * @param limit the raw limit value provided by the client
+     * @return the normalized limit, safe to pass to the storage layer
+     */
+    public static int normalizeLimitUnbounded(BigInteger limit) {
+        return limit.signum() < 0 ? 1 : limit.min(MAX_INT_VALUE).intValue();
+    }
+
 }

--- a/app/src/main/java/io/apicurio/registry/rest/ParameterValidationUtils.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ParameterValidationUtils.java
@@ -1,10 +1,15 @@
 package io.apicurio.registry.rest;
 
+import java.math.BigInteger;
+
 /**
  * Utility class providing common parameter validation methods for REST API resources.
  * Centralizes validation logic that was previously duplicated across multiple resource implementations.
  */
 public final class ParameterValidationUtils {
+
+    private static final BigInteger MAX_INT_VALUE = BigInteger.valueOf(Integer.MAX_VALUE);
+    private static final BigInteger MAX_LIMIT = BigInteger.valueOf(1000);
 
     private ParameterValidationUtils() {
         // Utility class - prevent instantiation
@@ -51,6 +56,29 @@ public final class ParameterValidationUtils {
         if (actualValue != null && expectedValue != null && !actualValue.equals(expectedValue)) {
             throw new InvalidParameterValueException(parameterName, actualValue, expectedValue);
         }
+    }
+
+    /**
+     * Normalizes a pagination offset so it never reaches the storage layer as an invalid value.
+     * Clamps the offset to the range [0, Integer.MAX_VALUE].
+     *
+     * @param offset the raw offset value provided by the client
+     * @return the normalized offset, safe to pass to the storage layer
+     */
+    public static int normalizeOffset(BigInteger offset) {
+        return offset.max(BigInteger.ZERO).min(MAX_INT_VALUE).intValue();
+    }
+
+    /**
+     * Normalizes a pagination limit so it never reaches the storage layer as an invalid value.
+     * A negative limit is normalized to 1 (limit=0 keeps its existing empty-page semantics);
+     * otherwise the limit is capped to bound the size of the result set.
+     *
+     * @param limit the raw limit value provided by the client
+     * @return the normalized limit, safe to pass to the storage layer
+     */
+    public static int normalizeLimit(BigInteger limit) {
+        return limit.signum() < 0 ? 1 : limit.min(MAX_LIMIT).intValue();
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/rest/ParameterValidationUtils.java
+++ b/app/src/main/java/io/apicurio/registry/rest/ParameterValidationUtils.java
@@ -74,7 +74,7 @@ public final class ParameterValidationUtils {
      * A negative limit is normalized to 1 (limit=0 keeps its existing empty-page semantics);
      * otherwise the limit is capped to bound the size of the result set.
      *
-     * @param limit the raw limit value provided by the client
+     * @param limit the raw limit value provided by the client; must not be {@code null}
      * @return the normalized limit, safe to pass to the storage layer
      */
     public static int normalizeLimit(BigInteger limit) {
@@ -87,7 +87,7 @@ public final class ParameterValidationUtils {
      * (limit=0 keeps its existing empty-page semantics); otherwise the limit is clamped to
      * Integer.MAX_VALUE to prevent BigInteger-to-int overflow.
      *
-     * @param limit the raw limit value provided by the client
+     * @param limit the raw limit value provided by the client; must not be {@code null}
      * @return the normalized limit, safe to pass to the storage layer
      */
     public static int normalizeLimitUnbounded(BigInteger limit) {

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
@@ -401,8 +401,8 @@ public class GroupsResourceImpl implements GroupsResource {
 
         Set<SearchFilter> filters = Collections.emptySet();
 
-        GroupSearchResultsDto resultsDto = storage.searchGroups(filters, oBy, oDir, offset.intValue(),
-                limit.intValue());
+        GroupSearchResultsDto resultsDto = storage.searchGroups(filters, oBy, oDir,
+                ParameterValidationUtils.normalizeOffset(offset), ParameterValidationUtils.normalizeLimit(limit));
         return V2ApiUtil.dtoToSearchResults(resultsDto);
     }
 
@@ -901,8 +901,9 @@ public class GroupsResourceImpl implements GroupsResource {
         Set<SearchFilter> filters = new HashSet<>();
         filters.add(SearchFilter.ofGroupId(defaultGroupIdToNull(groupId)));
 
-        ArtifactSearchResultsDto resultsDto = storage.searchArtifacts(filters, oBy, oDir, offset.intValue(),
-                limit.intValue(), false);
+        ArtifactSearchResultsDto resultsDto = storage.searchArtifacts(filters, oBy, oDir,
+                ParameterValidationUtils.normalizeOffset(offset), ParameterValidationUtils.normalizeLimit(limit),
+                false);
         return V2ApiUtil.dtoToSearchResults(resultsDto);
     }
 
@@ -1136,7 +1137,8 @@ public class GroupsResourceImpl implements GroupsResource {
         Set<SearchFilter> filters = Set.of(SearchFilter.ofGroupId(defaultGroupIdToNull(groupId)),
                 SearchFilter.ofArtifactId(artifactId));
         VersionSearchResultsDto resultsDto = storage.searchVersions(filters, OrderBy.createdOn,
-                OrderDirection.asc, offset.intValue(), limit.intValue(), false);
+                OrderDirection.asc, ParameterValidationUtils.normalizeOffset(offset),
+                ParameterValidationUtils.normalizeLimit(limit), false);
         return V2ApiUtil.dtoToSearchResults(resultsDto);
     }
 

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
@@ -402,7 +402,8 @@ public class GroupsResourceImpl implements GroupsResource {
         Set<SearchFilter> filters = Collections.emptySet();
 
         GroupSearchResultsDto resultsDto = storage.searchGroups(filters, oBy, oDir,
-                ParameterValidationUtils.normalizeOffset(offset), ParameterValidationUtils.normalizeLimit(limit));
+                ParameterValidationUtils.normalizeOffset(offset),
+                ParameterValidationUtils.normalizeLimitUnbounded(limit));
         return V2ApiUtil.dtoToSearchResults(resultsDto);
     }
 
@@ -902,8 +903,8 @@ public class GroupsResourceImpl implements GroupsResource {
         filters.add(SearchFilter.ofGroupId(defaultGroupIdToNull(groupId)));
 
         ArtifactSearchResultsDto resultsDto = storage.searchArtifacts(filters, oBy, oDir,
-                ParameterValidationUtils.normalizeOffset(offset), ParameterValidationUtils.normalizeLimit(limit),
-                false);
+                ParameterValidationUtils.normalizeOffset(offset),
+                ParameterValidationUtils.normalizeLimitUnbounded(limit), false);
         return V2ApiUtil.dtoToSearchResults(resultsDto);
     }
 
@@ -1138,7 +1139,7 @@ public class GroupsResourceImpl implements GroupsResource {
                 SearchFilter.ofArtifactId(artifactId));
         VersionSearchResultsDto resultsDto = storage.searchVersions(filters, OrderBy.createdOn,
                 OrderDirection.asc, ParameterValidationUtils.normalizeOffset(offset),
-                ParameterValidationUtils.normalizeLimit(limit), false);
+                ParameterValidationUtils.normalizeLimitUnbounded(limit), false);
         return V2ApiUtil.dtoToSearchResults(resultsDto);
     }
 

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/SearchResourceImpl.java
@@ -12,6 +12,7 @@ import io.apicurio.registry.content.util.ContentTypeUtil;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
+import io.apicurio.registry.rest.ParameterValidationUtils;
 import io.apicurio.registry.rest.v2.beans.ArtifactSearchResults;
 import io.apicurio.registry.rest.v2.beans.SortBy;
 import io.apicurio.registry.rest.v2.beans.SortOrder;
@@ -126,8 +127,9 @@ public class SearchResourceImpl implements SearchResource {
             filters.add(SearchFilter.ofContentId(contentId));
         }
 
-        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, offset.intValue(),
-                limit.intValue(), false);
+        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir,
+                ParameterValidationUtils.normalizeOffset(offset), ParameterValidationUtils.normalizeLimit(limit),
+                false);
         return V2ApiUtil.dtoToSearchResults(results);
     }
 
@@ -177,8 +179,9 @@ public class SearchResourceImpl implements SearchResource {
         } else {
             throw new BadRequestException(CANONICAL_QUERY_PARAM_ERROR_MESSAGE);
         }
-        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, offset.intValue(),
-                limit.intValue(), false);
+        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir,
+                ParameterValidationUtils.normalizeOffset(offset), ParameterValidationUtils.normalizeLimit(limit),
+                false);
         return V2ApiUtil.dtoToSearchResults(results);
     }
 

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/SearchResourceImpl.java
@@ -128,8 +128,8 @@ public class SearchResourceImpl implements SearchResource {
         }
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir,
-                ParameterValidationUtils.normalizeOffset(offset), ParameterValidationUtils.normalizeLimit(limit),
-                false);
+                ParameterValidationUtils.normalizeOffset(offset),
+                ParameterValidationUtils.normalizeLimitUnbounded(limit), false);
         return V2ApiUtil.dtoToSearchResults(results);
     }
 
@@ -180,8 +180,8 @@ public class SearchResourceImpl implements SearchResource {
             throw new BadRequestException(CANONICAL_QUERY_PARAM_ERROR_MESSAGE);
         }
         ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir,
-                ParameterValidationUtils.normalizeOffset(offset), ParameterValidationUtils.normalizeLimit(limit),
-                false);
+                ParameterValidationUtils.normalizeOffset(offset),
+                ParameterValidationUtils.normalizeLimitUnbounded(limit), false);
         return V2ApiUtil.dtoToSearchResults(results);
     }
 

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
@@ -13,6 +13,7 @@ import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
 import io.apicurio.registry.model.GroupId;
 import io.apicurio.registry.rest.MissingRequiredParameterException;
+import io.apicurio.registry.rest.ParameterValidationUtils;
 import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
 import io.apicurio.registry.rest.v3.beans.ArtifactSortBy;
 import io.apicurio.registry.rest.v3.beans.ContractRule;
@@ -58,8 +59,6 @@ public class SearchResourceImpl implements SearchResource {
 
     private static final String EMPTY_CONTENT_ERROR_MESSAGE = "Empty content is not allowed.";
     private static final String CANONICAL_QUERY_PARAM_ERROR_MESSAGE = "When setting 'canonical' to 'true', the 'artifactType' query parameter is also required.";
-    private static final BigInteger MAX_INT_VALUE = BigInteger.valueOf(Integer.MAX_VALUE);
-    private static final BigInteger MAX_LIMIT = BigInteger.valueOf(1000);
 
     @Inject
     @Current
@@ -139,8 +138,8 @@ public class SearchResourceImpl implements SearchResource {
             filters.add(SearchFilter.ofContentId(contentId));
         }
 
-        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, normalizeOffset(offset),
-                normalizeLimit(limit), skipCount != null && skipCount);
+        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, ParameterValidationUtils.normalizeOffset(offset),
+                ParameterValidationUtils.normalizeLimit(limit), skipCount != null && skipCount);
         otelMetrics.recordSearchRequest("artifacts");
         return V3ApiUtil.dtoToSearchResults(results);
     }
@@ -189,8 +188,8 @@ public class SearchResourceImpl implements SearchResource {
             filters.add(SearchFilter.ofGroupId(new GroupId(groupId).getRawGroupIdWithNull()));
         }
 
-        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, normalizeOffset(offset),
-                normalizeLimit(limit), skipCount != null && skipCount);
+        ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir, ParameterValidationUtils.normalizeOffset(offset),
+                ParameterValidationUtils.normalizeLimit(limit), skipCount != null && skipCount);
         otelMetrics.recordSearchRequest("artifactsByContent");
         return V3ApiUtil.dtoToSearchResults(results);
     }
@@ -246,8 +245,8 @@ public class SearchResourceImpl implements SearchResource {
             }).forEach(filters::add);
         }
 
-        GroupSearchResultsDto results = storage.searchGroups(filters, oBy, oDir, normalizeOffset(offset),
-                normalizeLimit(limit));
+        GroupSearchResultsDto results = storage.searchGroups(filters, oBy, oDir, ParameterValidationUtils.normalizeOffset(offset),
+                ParameterValidationUtils.normalizeLimit(limit));
         otelMetrics.recordSearchRequest("groups");
         return V3ApiUtil.dtoToSearchResults(results);
     }
@@ -331,8 +330,8 @@ public class SearchResourceImpl implements SearchResource {
             filters.add(SearchFilter.ofStructure(structure));
         }
 
-        VersionSearchResultsDto results = storage.searchVersions(filters, oBy, oDir, normalizeOffset(offset),
-                normalizeLimit(limit), skipCount != null && skipCount);
+        VersionSearchResultsDto results = storage.searchVersions(filters, oBy, oDir, ParameterValidationUtils.normalizeOffset(offset),
+                ParameterValidationUtils.normalizeLimit(limit), skipCount != null && skipCount);
         otelMetrics.recordSearchRequest("versions");
         return V3ApiUtil.dtoToSearchResults(results);
     }
@@ -386,8 +385,8 @@ public class SearchResourceImpl implements SearchResource {
             throw new BadRequestException(CANONICAL_QUERY_PARAM_ERROR_MESSAGE);
         }
 
-        VersionSearchResultsDto results = storage.searchVersions(filters, oBy, oDir, normalizeOffset(offset),
-                normalizeLimit(limit), skipCount != null && skipCount);
+        VersionSearchResultsDto results = storage.searchVersions(filters, oBy, oDir, ParameterValidationUtils.normalizeOffset(offset),
+                ParameterValidationUtils.normalizeLimit(limit), skipCount != null && skipCount);
         otelMetrics.recordSearchRequest("versionsByContent");
         return V3ApiUtil.dtoToSearchResults(results);
     }
@@ -478,19 +477,10 @@ public class SearchResourceImpl implements SearchResource {
         }
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir,
-                normalizeOffset(offset), normalizeLimit(limit), false);
+                ParameterValidationUtils.normalizeOffset(offset), ParameterValidationUtils.normalizeLimit(limit),
+                false);
         otelMetrics.recordSearchRequest("contracts");
         return V3ApiUtil.dtoToSearchResults(results);
-    }
-
-    // Clamp the offset to [0, Integer.MAX_VALUE] so it never reaches storage as an invalid SQL query (500). See #8611.
-    private static int normalizeOffset(BigInteger offset) {
-        return offset.max(BigInteger.ZERO).min(MAX_INT_VALUE).intValue();
-    }
-
-    // Negative limit -> 1 (limit=0 keeps its empty-page semantics); cap at MAX_LIMIT to bound result size. See #8611.
-    private static int normalizeLimit(BigInteger limit) {
-        return limit.signum() < 0 ? 1 : limit.min(MAX_LIMIT).intValue();
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/PaginationV2Test.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/PaginationV2Test.java
@@ -1,0 +1,276 @@
+package io.apicurio.registry.noprofile.rest.v2;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.client.models.CreateGroup;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Regression tests for issue #9369: the v2 pagination endpoints must normalize negative and
+ * overflowing offset/limit values instead of forwarding them to storage, matching the behavior
+ * already covered for the v3 API in SearchArtifactsTest, SearchVersionsTest, and SearchGroupsTest.
+ */
+@QuarkusTest
+public class PaginationV2Test extends AbstractResourceTestBase {
+
+    @Test
+    public void testSearchArtifactsLimitAndOffsetEdgeCases() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String artifactContent = resourceToString("openapi-empty.json");
+
+        for (int idx = 0; idx < 3; idx++) {
+            String artifactId = "Empty-" + idx;
+            String name = "empty-" + idx;
+            this.createArtifact(group, artifactId, ArtifactType.OPENAPI,
+                    artifactContent.replaceAll("Empty API", name), ContentTypes.APPLICATION_JSON);
+        }
+
+        // A negative limit is normalized to 1, not passed to storage as an invalid query (#9369).
+        given().when().queryParam("group", group).queryParam("limit", -1)
+                .get("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
+
+        // A negative offset is normalized to 0, returning the full result set.
+        given().when().queryParam("group", group).queryParam("offset", -1)
+                .get("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+
+        // Both parameters invalid at once: offset -> 0, limit -> 1.
+        given().when().queryParam("group", group).queryParam("offset", -1).queryParam("limit", -1)
+                .get("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
+
+        // limit=0 keeps its current semantics (empty page); only negative values are normalized.
+        given().when().queryParam("group", group).queryParam("limit", 0)
+                .get("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(0));
+
+        // Boundary values: offset=0 and limit=1 are valid and behave normally.
+        given().when().queryParam("group", group).queryParam("offset", 0)
+                .get("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+        given().when().queryParam("group", group).queryParam("limit", 1)
+                .get("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
+
+        // Omitted offset/limit fall back to the endpoint's defaults (0 / 20).
+        given().when().queryParam("group", group).get("/registry/v2/search/artifacts").then()
+                .statusCode(200).body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+
+        // Oversized values are capped (offset at Integer.MAX_VALUE, limit at MAX_LIMIT) instead of
+        // wrapping to a negative int, which would have produced a 500.
+        given().when().queryParam("group", group).queryParam("offset", 2147483648L)
+                .get("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(0));
+        given().when().queryParam("group", group).queryParam("limit", 2147483648L)
+                .get("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+    }
+
+    @Test
+    public void testSearchArtifactsByContentLimitAndOffsetEdgeCases() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String artifactContent = resourceToString("openapi-empty.json")
+                .replaceAll("Empty API", "PaginationV2Test-searchByContent");
+
+        for (int idx = 0; idx < 3; idx++) {
+            String artifactId = "Empty-" + idx;
+            this.createArtifact(group, artifactId, ArtifactType.OPENAPI, artifactContent,
+                    ContentTypes.APPLICATION_JSON);
+        }
+
+        // A negative offset is normalized to 0, returning the full result set.
+        given().when().body(artifactContent).queryParam("offset", -1)
+                .post("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+
+        // A negative limit is normalized to 1, not passed to storage as an invalid query (#9369).
+        given().when().body(artifactContent).queryParam("limit", -1)
+                .post("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
+
+        // Both parameters invalid at once: offset -> 0, limit -> 1.
+        given().when().body(artifactContent).queryParam("offset", -1).queryParam("limit", -1)
+                .post("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
+
+        // limit=0 keeps its current semantics (empty page); only negative values are normalized.
+        given().when().body(artifactContent).queryParam("limit", 0)
+                .post("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(0));
+
+        // Omitted offset/limit fall back to the endpoint's defaults (0 / 20).
+        given().when().body(artifactContent).post("/registry/v2/search/artifacts").then()
+                .statusCode(200).body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+
+        // Oversized values are capped instead of wrapping to a negative int, which would have
+        // produced a 500.
+        given().when().body(artifactContent).queryParam("offset", 2147483648L)
+                .post("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(0));
+        given().when().body(artifactContent).queryParam("limit", 2147483648L)
+                .post("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+    }
+
+    @Test
+    public void testListGroupsLimitAndOffsetEdgeCases() throws Exception {
+        // listGroups (v2) has no group-id filter, unlike the v3 search endpoints, so this test
+        // cannot isolate an exact total count the way SearchGroupsTest (v3) does: other tests
+        // running in the same JVM may also have created groups. Instead, the assertions below
+        // rely only on relative/clamped sizes, which hold regardless of how many other groups
+        // exist, while still proving the fix (a negative or overflowing value no longer causes a
+        // 500 and pagination is still bounded correctly).
+        for (int idx = 0; idx < 3; idx++) {
+            CreateGroup createGroup = new CreateGroup();
+            createGroup.setGroupId("PaginationV2Test_listGroups_" + UUID.randomUUID());
+            clientV3.groups().post(createGroup);
+        }
+
+        // A negative limit is normalized to 1, not passed to storage as an invalid query (#9369).
+        given().when().queryParam("limit", -1).get("/registry/v2/groups").then().statusCode(200)
+                .body("groups.size()", equalTo(1));
+
+        // limit=0 keeps its current semantics (empty page); only negative values are normalized.
+        given().when().queryParam("limit", 0).get("/registry/v2/groups").then().statusCode(200)
+                .body("groups.size()", equalTo(0));
+
+        // A negative offset is normalized to 0: identical to an explicit offset=0 request.
+        int baselineSize = given().when().queryParam("offset", 0).queryParam("limit", 20)
+                .get("/registry/v2/groups").then().statusCode(200).extract()
+                .path("groups.size()");
+        given().when().queryParam("offset", -1).queryParam("limit", 20)
+                .get("/registry/v2/groups").then().statusCode(200)
+                .body("groups.size()", equalTo(baselineSize));
+
+        // Both parameters invalid at once: offset -> 0, limit -> 1.
+        given().when().queryParam("offset", -1).queryParam("limit", -1)
+                .get("/registry/v2/groups").then().statusCode(200)
+                .body("groups.size()", equalTo(1));
+
+        // Omitted offset/limit fall back to the endpoint's defaults (0 / 20) - must not 500.
+        given().when().get("/registry/v2/groups").then().statusCode(200);
+
+        // An oversized offset is capped at Integer.MAX_VALUE instead of wrapping to a negative
+        // int, which would have produced a 500; no real deployment has that many groups.
+        given().when().queryParam("offset", 2147483648L).get("/registry/v2/groups").then()
+                .statusCode(200).body("groups.size()", equalTo(0));
+
+        // An oversized limit is capped at MAX_LIMIT instead of wrapping to a negative int.
+        given().when().queryParam("limit", 2147483648L).get("/registry/v2/groups").then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void testListArtifactsInGroupLimitAndOffsetEdgeCases() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String artifactContent = resourceToString("openapi-empty.json");
+
+        for (int idx = 0; idx < 3; idx++) {
+            String artifactId = "Empty-" + idx;
+            this.createArtifact(group, artifactId, ArtifactType.OPENAPI, artifactContent,
+                    ContentTypes.APPLICATION_JSON);
+        }
+
+        // A negative limit is normalized to 1, not passed to storage as an invalid query (#9369).
+        given().when().pathParam("groupId", group).queryParam("limit", -1)
+                .get("/registry/v2/groups/{groupId}/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
+
+        // A negative offset is normalized to 0, returning the full result set.
+        given().when().pathParam("groupId", group).queryParam("offset", -1)
+                .get("/registry/v2/groups/{groupId}/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+
+        // Both parameters invalid at once: offset -> 0, limit -> 1.
+        given().when().pathParam("groupId", group).queryParam("offset", -1)
+                .queryParam("limit", -1).get("/registry/v2/groups/{groupId}/artifacts").then()
+                .statusCode(200).body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
+
+        // limit=0 keeps its current semantics (empty page); only negative values are normalized.
+        given().when().pathParam("groupId", group).queryParam("limit", 0)
+                .get("/registry/v2/groups/{groupId}/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(0));
+
+        // Omitted offset/limit fall back to the endpoint's defaults (0 / 20).
+        given().when().pathParam("groupId", group).get("/registry/v2/groups/{groupId}/artifacts")
+                .then().statusCode(200).body("count", equalTo(3))
+                .body("artifacts.size()", equalTo(3));
+
+        // Oversized values are capped instead of wrapping to a negative int, which would have
+        // produced a 500.
+        given().when().pathParam("groupId", group).queryParam("offset", 2147483648L)
+                .get("/registry/v2/groups/{groupId}/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(0));
+        given().when().pathParam("groupId", group).queryParam("limit", 2147483648L)
+                .get("/registry/v2/groups/{groupId}/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+    }
+
+    @Test
+    public void testListArtifactVersionsLimitAndOffsetEdgeCases() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String artifactId = "PaginationV2Test-versions";
+        String artifactContent = resourceToString("openapi-empty.json");
+
+        this.createArtifact(group, artifactId, ArtifactType.OPENAPI, artifactContent,
+                ContentTypes.APPLICATION_JSON);
+        this.createArtifactVersion(group, artifactId, artifactContent, ContentTypes.APPLICATION_JSON);
+        this.createArtifactVersion(group, artifactId, artifactContent, ContentTypes.APPLICATION_JSON);
+
+        // A negative limit is normalized to 1, not passed to storage as an invalid query (#9369).
+        given().when().pathParam("groupId", group).pathParam("artifactId", artifactId)
+                .queryParam("limit", -1)
+                .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions").then()
+                .statusCode(200).body("count", equalTo(3)).body("versions.size()", equalTo(1));
+
+        // A negative offset is normalized to 0, returning the full result set.
+        given().when().pathParam("groupId", group).pathParam("artifactId", artifactId)
+                .queryParam("offset", -1)
+                .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions").then()
+                .statusCode(200).body("count", equalTo(3)).body("versions.size()", equalTo(3));
+
+        // Both parameters invalid at once: offset -> 0, limit -> 1.
+        given().when().pathParam("groupId", group).pathParam("artifactId", artifactId)
+                .queryParam("offset", -1).queryParam("limit", -1)
+                .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions").then()
+                .statusCode(200).body("count", equalTo(3)).body("versions.size()", equalTo(1));
+
+        // limit=0 keeps its current semantics (empty page); only negative values are normalized.
+        given().when().pathParam("groupId", group).pathParam("artifactId", artifactId)
+                .queryParam("limit", 0)
+                .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions").then()
+                .statusCode(200).body("count", equalTo(3)).body("versions.size()", equalTo(0));
+
+        // Omitted offset/limit fall back to the endpoint's defaults (0 / 20).
+        given().when().pathParam("groupId", group).pathParam("artifactId", artifactId)
+                .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions").then()
+                .statusCode(200).body("count", equalTo(3)).body("versions.size()", equalTo(3));
+
+        // Oversized values are capped instead of wrapping to a negative int, which would have
+        // produced a 500.
+        given().when().pathParam("groupId", group).pathParam("artifactId", artifactId)
+                .queryParam("offset", 2147483648L)
+                .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions").then()
+                .statusCode(200).body("count", equalTo(3)).body("versions.size()", equalTo(0));
+        given().when().pathParam("groupId", group).pathParam("artifactId", artifactId)
+                .queryParam("limit", 2147483648L)
+                .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions").then()
+                .statusCode(200).body("count", equalTo(3)).body("versions.size()", equalTo(3));
+
+        // A non-existent artifact must still 404 before pagination normalization runs, confirming
+        // the fix did not reorder the pre-existing artifact-existence check.
+        given().when().pathParam("groupId", group).pathParam("artifactId", "does-not-exist")
+                .queryParam("offset", -1)
+                .get("/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions").then()
+                .statusCode(404);
+    }
+
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/PaginationV2Test.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/PaginationV2Test.java
@@ -87,35 +87,36 @@ public class PaginationV2Test extends AbstractResourceTestBase {
         }
 
         // A negative offset is normalized to 0, returning the full result set.
-        given().when().body(artifactContent).queryParam("offset", -1)
+        given().when().contentType(CT_JSON).body(artifactContent).queryParam("offset", -1)
                 .post("/registry/v2/search/artifacts").then().statusCode(200)
                 .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
 
         // A negative limit is normalized to 1, not passed to storage as an invalid query (#9369).
-        given().when().body(artifactContent).queryParam("limit", -1)
+        given().when().contentType(CT_JSON).body(artifactContent).queryParam("limit", -1)
                 .post("/registry/v2/search/artifacts").then().statusCode(200)
                 .body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
 
         // Both parameters invalid at once: offset -> 0, limit -> 1.
-        given().when().body(artifactContent).queryParam("offset", -1).queryParam("limit", -1)
-                .post("/registry/v2/search/artifacts").then().statusCode(200)
-                .body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
+        given().when().contentType(CT_JSON).body(artifactContent).queryParam("offset", -1)
+                .queryParam("limit", -1).post("/registry/v2/search/artifacts").then()
+                .statusCode(200).body("count", equalTo(3)).body("artifacts.size()", equalTo(1));
 
         // limit=0 keeps its current semantics (empty page); only negative values are normalized.
-        given().when().body(artifactContent).queryParam("limit", 0)
+        given().when().contentType(CT_JSON).body(artifactContent).queryParam("limit", 0)
                 .post("/registry/v2/search/artifacts").then().statusCode(200)
                 .body("count", equalTo(3)).body("artifacts.size()", equalTo(0));
 
         // Omitted offset/limit fall back to the endpoint's defaults (0 / 20).
-        given().when().body(artifactContent).post("/registry/v2/search/artifacts").then()
-                .statusCode(200).body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
+        given().when().contentType(CT_JSON).body(artifactContent)
+                .post("/registry/v2/search/artifacts").then().statusCode(200)
+                .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
 
         // Oversized values are capped instead of wrapping to a negative int, which would have
         // produced a 500.
-        given().when().body(artifactContent).queryParam("offset", 2147483648L)
+        given().when().contentType(CT_JSON).body(artifactContent).queryParam("offset", 2147483648L)
                 .post("/registry/v2/search/artifacts").then().statusCode(200)
                 .body("count", equalTo(3)).body("artifacts.size()", equalTo(0));
-        given().when().body(artifactContent).queryParam("limit", 2147483648L)
+        given().when().contentType(CT_JSON).body(artifactContent).queryParam("limit", 2147483648L)
                 .post("/registry/v2/search/artifacts").then().statusCode(200)
                 .body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
     }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/PaginationV2Test.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v2/PaginationV2Test.java
@@ -64,8 +64,8 @@ public class PaginationV2Test extends AbstractResourceTestBase {
         given().when().queryParam("group", group).get("/registry/v2/search/artifacts").then()
                 .statusCode(200).body("count", equalTo(3)).body("artifacts.size()", equalTo(3));
 
-        // Oversized values are capped (offset at Integer.MAX_VALUE, limit at MAX_LIMIT) instead of
-        // wrapping to a negative int, which would have produced a 500.
+        // Oversized values are clamped to Integer.MAX_VALUE instead of wrapping to a negative int,
+        // which would have produced a 500. Unlike v3, v2 does not cap limit at a fixed maximum.
         given().when().queryParam("group", group).queryParam("offset", 2147483648L)
                 .get("/registry/v2/search/artifacts").then().statusCode(200)
                 .body("count", equalTo(3)).body("artifacts.size()", equalTo(0));
@@ -163,7 +163,8 @@ public class PaginationV2Test extends AbstractResourceTestBase {
         given().when().queryParam("offset", 2147483648L).get("/registry/v2/groups").then()
                 .statusCode(200).body("groups.size()", equalTo(0));
 
-        // An oversized limit is capped at MAX_LIMIT instead of wrapping to a negative int.
+        // An oversized limit is clamped to Integer.MAX_VALUE instead of wrapping to a negative
+        // int. Unlike v3, v2 does not cap limit at a fixed maximum.
         given().when().queryParam("limit", 2147483648L).get("/registry/v2/groups").then()
                 .statusCode(200);
     }

--- a/app/src/test/java/io/apicurio/registry/rest/ParameterValidationUtilsTest.java
+++ b/app/src/test/java/io/apicurio/registry/rest/ParameterValidationUtilsTest.java
@@ -1,0 +1,69 @@
+package io.apicurio.registry.rest;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for the pagination normalization helpers in {@link ParameterValidationUtils}.
+ * Covers issue #9369: negative and overflowing offset/limit values must be normalized rather
+ * than propagated to the storage layer, and v2's normalizeLimitUnbounded must not apply v3's
+ * 1000-row cap.
+ */
+class ParameterValidationUtilsTest {
+
+    @Test
+    void normalizeOffsetClampsNegativeToZero() {
+        assertEquals(0, ParameterValidationUtils.normalizeOffset(BigInteger.valueOf(-1)));
+    }
+
+    @Test
+    void normalizeOffsetClampsOverflowToMaxInt() {
+        BigInteger overflow = BigInteger.valueOf(Integer.MAX_VALUE).add(BigInteger.ONE);
+        assertEquals(Integer.MAX_VALUE, ParameterValidationUtils.normalizeOffset(overflow));
+    }
+
+    @Test
+    void normalizeOffsetPassesThroughValidValue() {
+        assertEquals(42, ParameterValidationUtils.normalizeOffset(BigInteger.valueOf(42)));
+    }
+
+    @Test
+    void normalizeLimitNormalizesNegativeToOne() {
+        assertEquals(1, ParameterValidationUtils.normalizeLimit(BigInteger.valueOf(-1)));
+    }
+
+    @Test
+    void normalizeLimitPreservesZero() {
+        assertEquals(0, ParameterValidationUtils.normalizeLimit(BigInteger.ZERO));
+    }
+
+    @Test
+    void normalizeLimitCapsAboveOneThousand() {
+        assertEquals(1000, ParameterValidationUtils.normalizeLimit(BigInteger.valueOf(5000)));
+    }
+
+    @Test
+    void normalizeLimitUnboundedNormalizesNegativeToOne() {
+        assertEquals(1, ParameterValidationUtils.normalizeLimitUnbounded(BigInteger.valueOf(-1)));
+    }
+
+    @Test
+    void normalizeLimitUnboundedPreservesZero() {
+        assertEquals(0, ParameterValidationUtils.normalizeLimitUnbounded(BigInteger.ZERO));
+    }
+
+    @Test
+    void normalizeLimitUnboundedDoesNotCapAboveOneThousand() {
+        assertEquals(5000, ParameterValidationUtils.normalizeLimitUnbounded(BigInteger.valueOf(5000)));
+    }
+
+    @Test
+    void normalizeLimitUnboundedClampsOverflowToMaxInt() {
+        BigInteger overflow = BigInteger.valueOf(Integer.MAX_VALUE).add(BigInteger.ONE);
+        assertEquals(Integer.MAX_VALUE, ParameterValidationUtils.normalizeLimitUnbounded(overflow));
+    }
+
+}


### PR DESCRIPTION
## Summary

Fixes #9369

This PR aligns pagination parameter handling in the v2 REST API with the existing normalization behavior already used by the equivalent v3 endpoints.

Previously, several v2 REST endpoints forwarded `offset` and `limit` directly to the storage layer after only performing null checks. Invalid values (negative values or values large enough to overflow `intValue()`) could therefore propagate to the storage implementation and result in HTTP 500 responses instead of being normalized before execution.

This change extracts the existing pagination normalization logic into a shared utility and updates all affected v2 endpoints to reuse it.

## What Changed

### Shared pagination normalization

- Added shared pagination normalization methods to `ParameterValidationUtils`
  - `normalizeOffset(BigInteger)`
  - `normalizeLimit(BigInteger)`
- Centralized the normalization logic to avoid duplication across API versions.

### v3 refactoring

- Updated the v3 `SearchResourceImpl` to use the shared helper.
- Removed the now-duplicated private normalization methods while preserving existing behavior.

### v2 fixes

Updated all affected v2 REST endpoints to normalize pagination parameters before reaching the storage layer:

- `GET /apis/registry/v2/search/artifacts`
- `POST /apis/registry/v2/search/artifacts`
- `GET /apis/registry/v2/groups`
- `GET /apis/registry/v2/groups/{groupId}/artifacts`
- `GET /apis/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions`

These endpoints normalize negative and overflowing values the same way v3 does, but preserve v2's pre-existing unbounded limit (v2 never had a page-size cap at any layer - REST annotation, OpenAPI spec, or storage). v3's existing 1000-row cap (from #8611) is untouched and does not apply to v2, to avoid introducing an undocumented breaking change on a stable API.

## Tests

Added regression coverage for the v2 pagination behavior, including:

- negative offset
- negative limit
- offset overflow
- limit overflow
- omitted pagination parameters
- boundary values
- preservation of existing `limit=0` semantics

Also verified that the existing v3 test suite continues to pass after the helper extraction.

## Result

Invalid pagination parameters are now normalized consistently across both v2 and v3 REST APIs, preventing invalid values from propagating to the storage layer and eliminating the HTTP 500 behavior described in #9369.