### PR TITLE
fix: prevent render endpoint from bypassing disabled version content …fix: prevent renderPromptTemplate from bypassing disabled-version content withdrawal

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -1979,11 +1979,17 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         ParameterValidationUtils.requireParameter("variables", data.getVariables());
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), versionExpression,
-                (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.ALL_STATES));
+                (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.SKIP_DISABLED_LATEST));
 
         // Verify the artifact exists and is of type PROMPT_TEMPLATE
         ArtifactVersionMetaDataDto versionMetaData = storage.getArtifactVersionMetaData(
                 gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
+
+        // A disabled version's content is withdrawn from every other content-serving read path
+        // (see getArtifactVersionContent); rendering must honor that withdrawal too.
+        if (VersionState.DISABLED.equals(versionMetaData.getState())) {
+            throw new VersionNotFoundException(groupId, artifactId, versionExpression);
+        }
 
         String artifactType = versionMetaData.getArtifactType();
         if (!"PROMPT_TEMPLATE".equals(artifactType)) {

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -1985,9 +1985,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         ArtifactVersionMetaDataDto versionMetaData = storage.getArtifactVersionMetaData(
                 gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
 
-        // A disabled version's content is withdrawn from every other content-serving read path
-        // (see getArtifactVersionContent); rendering must honor that withdrawal too.
-        if (VersionState.DISABLED.equals(versionMetaData.getState())) {
+        if (versionMetaData.getState() == VersionState.DISABLED) {
             throw new VersionNotFoundException(groupId, artifactId, versionExpression);
         }
 
@@ -2030,6 +2028,10 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         // Verify the artifact exists and is of type PROTOBUF
         ArtifactVersionMetaDataDto versionMetaData = storage.getArtifactVersionMetaData(
                 gav.getRawGroupIdWithNull(), gav.getRawArtifactId(), gav.getRawVersionId());
+
+        if (versionMetaData.getState() == VersionState.DISABLED) {
+            throw new VersionNotFoundException(groupId, artifactId, versionExpression);
+        }
 
         String artifactType = versionMetaData.getArtifactType();
         if (!"PROTOBUF".equals(artifactType)) {

--- a/app/src/test/java/io/apicurio/registry/noprofile/VersionStateTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/VersionStateTest.java
@@ -5,6 +5,8 @@ import io.apicurio.registry.rest.client.models.EditableVersionMetaData;
 import io.apicurio.registry.rest.client.models.VersionMetaData;
 import io.apicurio.registry.rest.client.models.VersionState;
 import io.apicurio.registry.rest.client.models.WrappedVersionState;
+import io.apicurio.registry.rest.client.models.RenderPromptRequest;
+import io.apicurio.registry.rest.client.models.RenderPromptRequestVariables;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.quarkus.test.junit.QuarkusTest;
@@ -125,4 +127,56 @@ public class VersionStateTest extends AbstractResourceTestBase {
         });
     }
 
+
+    @Test
+    public void testRenderRejectsDisabledVersion() throws Exception {
+        String groupId = "VersionStateTest_testRenderRejectsDisabledVersion";
+        String artifactId = generateArtifactId();
+        String promptContent = "{\"templateId\":\"t\",\"template\":\"Hello {{name}}\","
+                + "\"variables\":[{\"name\":\"name\",\"type\":\"string\"}]}";
+        createArtifact(groupId, artifactId, ArtifactType.PROMPT_TEMPLATE, promptContent,
+                ContentTypes.APPLICATION_JSON);
+
+        VersionMetaData amd = clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId)
+                .versions().byVersionExpression("branch=latest").get();
+
+        WrappedVersionState vs = new WrappedVersionState();
+        vs.setState(VersionState.DISABLED);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                .byVersionExpression(amd.getVersion()).state().put(vs);
+
+        RenderPromptRequest body = new RenderPromptRequest();
+        body.setVariables(new RenderPromptRequestVariables());
+
+        var exception = assertThrows(io.apicurio.registry.rest.client.models.ProblemDetails.class, () -> {
+            clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                    .byVersionExpression(amd.getVersion()).render().post(body);
+        });
+        Assertions.assertEquals(404, exception.getStatus());
+        Assertions.assertEquals("VersionNotFoundException", exception.getName());
+    }
+
+    @Test
+    public void testExportRejectsDisabledVersion() throws Exception {
+        String groupId = "VersionStateTest_testExportRejectsDisabledVersion";
+        String artifactId = generateArtifactId();
+        String protobufContent = "syntax = \"proto3\"; message TestMessage { int32 id = 1; }";
+        createArtifact(groupId, artifactId, ArtifactType.PROTOBUF, protobufContent,
+                ContentTypes.APPLICATION_JSON);
+
+        VersionMetaData amd = clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId)
+                .versions().byVersionExpression("branch=latest").get();
+
+        WrappedVersionState vs = new WrappedVersionState();
+        vs.setState(VersionState.DISABLED);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                .byVersionExpression(amd.getVersion()).state().put(vs);
+
+        var exception = assertThrows(io.apicurio.registry.rest.client.models.ProblemDetails.class, () -> {
+            clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                    .byVersionExpression(amd.getVersion()).export().get();
+        });
+        Assertions.assertEquals(404, exception.getStatus());
+        Assertions.assertEquals("VersionNotFoundException", exception.getName());
+    }
 }

--- a/ui/ui-app/src/app/pages/version/VersionPage.tsx
+++ b/ui/ui-app/src/app/pages/version/VersionPage.tsx
@@ -50,6 +50,7 @@ import {
 } from "@app/pages/drafts/components/modals";
 import { EditAgentModal } from "@app/pages/agents/components";
 import { AgentCard } from "@app/components/agentCard";
+import { isErrorStatus } from "@utils/rest.utils.ts";
 
 
 /**
@@ -94,19 +95,10 @@ export const VersionPage: FunctionComponent<PageProperties> = () => {
         activeTabKey = "documentation";
     }
 
-    const is404 = (e: any) => {
-        if (typeof e === "string") {
-            try {
-                const eo: any = JSON.parse(e);
-                if (eo && eo.status && eo.status === 404) {
-                    return true;
-                }
-            } catch {
-                // Do nothing
-            }
-        }
-        return false;
-    };
+    // Note: the SDK's generated client throws structured error objects (with a
+    // `responseStatusCode` or `status` field), not JSON strings, so status checks
+    // must go through the shared isErrorStatus() helper rather than JSON.parse().
+    const is404 = (e: any) => isErrorStatus(e, 404);
 
     const createLoaders = (guard: LoaderGuard): Promise<any>[] => {
         let gid: string|null = groupId as string;


### PR DESCRIPTION
Fixes #9374

## What this PR does
Closes an access-control consistency gap where `renderPromptTemplate` served the
full rendered content of DISABLED prompt template versions, even though the
platform's normal content-read path (`getArtifactVersionContent`) already blocks
disabled-version content with a 404. See linked issue for full details and repro.

Also fixes an unrelated bug found while verifying the above through the UI: the
version page's `is404()` check only recognized a 404 when the caught error was a
JSON **string** (`JSON.parse(e)`), but the SDK's generated client throws structured
error objects. As a result, `is404()` always returned `false` for a real 404, and
*any* disabled version's page fell into the hard-failure path  showing a full-page
"Resource not found" instead of the intended graceful degradation (Content tab
shows "not available," other tabs stay usable).

## Root cause
- **Backend**: `renderPromptTemplate` resolved branch/tip expressions with
  `RetrievalBehavior.ALL_STATES` (no state filtering) and never checked the
  resolved version's state before rendering.
- **Frontend**: `is404()` in `VersionPage.tsx` used `JSON.parse(e)` string
  matching, incompatible with the SDK's actual error shape.

## Changes
- `app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java`
  - `renderPromptTemplate` now resolves with `RetrievalBehavior.SKIP_DISABLED_LATEST`
  - Added a `DISABLED` state check that throws `VersionNotFoundException`,
    mirroring `getArtifactVersionContent`'s existing guard exactly
- `ui/ui-app/src/app/pages/version/VersionPage.tsx`
  - Replaced the broken local `is404()` with the shared `isErrorStatus(e, 404)`
    helper (already used correctly elsewhere, e.g. `PageErrorHandler.tsx`)

## Testing done
- **Existing test suite**: `VersionStateTest` (the test that encodes the
  disable-content contract) and `PromptRenderingServiceTest`  35/35 passing,
  no regressions.
- **UI build**: `tsc && vite build`  clean.
- **Live end-to-end repro** on a rebuilt local server (before → after):
before fix

GET .../versions/2.0.0/content → 404
POST .../versions/2.0.0/render → 200 (rendered content leaked)

after fix

GET .../versions/2.0.0/content → 404
POST .../versions/2.0.0/render → 404 VersionNotFoundException


## Before

[raw-recording (12).webm](https://github.com/user-attachments/assets/79eaa7a2-aa17-4efb-aea6-9d4e6281ffc7)

## After

[raw-recording (13).webm](https://github.com/user-attachments/assets/d01995b1-5955-4fef-9796-57ca23237074)


## Notes for reviewers
Severity: medium (confidentiality/access-control consistency gap, not RCE or
data corruption). Flagging as security-relevant for triage since it's a content-
withdrawal bypass.