### PR TITLE
docs: remove nonexistent Maven profiles (-Plocal-tests, -Psql/-Pmssql/-Pkafkasql)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -13,8 +13,9 @@ paths:
 
 ## Integration Tests
 - Located in `integration-tests/` module
-- Profiles: `local-tests`, `remote-mem`, `remote-sql`, `remote-kafka`
-- Run: `./mvnw verify -pl integration-tests -P<profile>`
+- Base profile: `integration-tests` (required to build/run this module)
+- Optional Kubernetes deployment profiles: `remote-mem`, `remote-sql`, `remote-kafka`, `remote-kubernetesops`
+- Run: `./mvnw verify -Pintegration-tests -pl integration-tests -am`
 
 ## Storage Variant Coverage
 - Features touching storage MUST work across all variants (sql, kafkasql, gitops, kubernetesops)


### PR DESCRIPTION
Fixes #9219

## Summary

The issue originally pointed to four files (`DEVELOPING.md`, `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`) as containing references to nonexistent Maven profiles (`-Plocal-tests`, `-Psql`, `-Pmssql`, `-Pkafkasql`). After searching the current `main` branch, I found these four files no longer contain those references — they appear to have already been fixed in a previous commit.

However, a full repository search turned up the same underlying problem in a file not listed in the original issue: **`.claude/rules/testing.md`**. It referenced a nonexistent `local-tests` profile.

## Change

Updated `.claude/rules/testing.md` to reflect the actual Maven profiles, verified against `pom.xml` and `integration-tests/pom.xml`:

- **Before:** `Profiles: local-tests, remote-mem, remote-sql, remote-kafka`
- **After:** Base profile `integration-tests` (required to build/run the module), plus optional Kubernetes deployment profiles `remote-mem`, `remote-sql`, `remote-kafka`, `remote-kubernetesops` (the last one was also missing from the original list).

Also updated the example run command to match the documented pattern already used in `DEVELOPING.md` and `integration-tests/README.md`: