### PR TITLE
fix(mcp): copy-paste typos in tool descriptions

### DIFF
--- a/mcp/src/main/java/io/apicurio/registry/mcp/servers/ArtifactsMCPServer.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/servers/ArtifactsMCPServer.java
@@ -99,7 +99,7 @@ public class ArtifactsMCPServer {
 
     @Tool(description = """
             Search for artifacts in the Apicurio Registry server. \
-            Returns metadata of the groups that fit the search criteria.""")
+            Returns metadata of the artifacts that fit the search criteria.""")
     List<SearchedArtifact> search_artifacts(
             @ToolArg(description = GROUP_ID) String groupId,
             @ToolArg(description = ARTIFACT_ID, required = false) String artifactId,

--- a/mcp/src/main/java/io/apicurio/registry/mcp/servers/GroupsMCPServer.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/servers/GroupsMCPServer.java
@@ -68,7 +68,7 @@ public class GroupsMCPServer {
     }
 
     @Tool(description = """
-            Update group metadata in the Apicurio Registry server.""")
+            Retrieve metadata of a specific group in the Apicurio Registry server.""")
     GroupMetaData get_group_metadata(
             @ToolArg(description = GROUP_ID) String groupId
     ) {


### PR DESCRIPTION
Fixes #8907

## Summary

Two `@Tool(description = ...)` annotations in the MCP module had copy-paste typos:

1. `GroupsMCPServer.java` — `get_group_metadata` (a read-only GET) described itself as "Update group metadata...". Fixed to correctly describe it as a retrieval operation.
2. `ArtifactsMCPServer.java` — `search_artifacts` described itself as returning "metadata of the groups..." instead of artifacts. Fixed to say "artifacts".

## Change

Text-only changes inside existing `@Tool` description strings. No method signatures, logic, or behavior affected.

## Testing

This is a description/text-only change — no functional impact. Existing tests should pass unchanged.