### PR TITLE
fix(prompt): add {{#if}}/{{#unless}}/{{else}} support to PromptRender…

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
+++ b/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
@@ -43,21 +43,21 @@ public class PromptRenderingService {
      * Group 1 = variable name, Group 2 = inner content.
      */
     private static final Pattern IF_BLOCK_PATTERN =
-            Pattern.compile("\\{\\{#if\\s+(\\w+)\\}\\}([\\s\\S]*?)\\{\\{/if\\}\\}");
+            Pattern.compile("\\{\\{#if\\s+(\\w+)\\}\\}((?:(?!\\{\\{/if\\}\\})[\\s\\S])*?)\\{\\{/if\\}\\}");
 
     /**
-     * Matches {{#if var}} ... {{else}} ... {{/if}} blocks.
+     * Matches if-else blocks: opening tag, truthy branch, else tag, falsy branch, closing tag.
      * Group 1 = variable name, Group 2 = truthy branch, Group 3 = falsy branch.
      */
     private static final Pattern IF_ELSE_BLOCK_PATTERN =
-            Pattern.compile("\\{\\{#if\\s+(\\w+)\\}\\}([\\s\\S]*?)\\{\\{else\\}\\}([\\s\\S]*?)\\{\\{/if\\}\\}");
+            Pattern.compile("\\{\\{#if\\s+(\\w+)\\}\\}((?:(?!\\{\\{else\\}\\})[\\s\\S])*?)\\{\\{else\\}\\}((?:(?!\\{\\{/if\\}\\})[\\s\\S])*?)\\{\\{/if\\}\\}");
 
     /**
-     * Matches {{#unless var}} ... {{/unless}} blocks.
+     * Matches unless blocks: opening tag, inner content, closing tag.
      * Group 1 = variable name, Group 2 = inner content.
      */
     private static final Pattern UNLESS_BLOCK_PATTERN =
-            Pattern.compile("\\{\\{#unless\\s+(\\w+)\\}\\}([\\s\\S]*?)\\{\\{/unless\\}\\}");
+            Pattern.compile("\\{\\{#unless\\s+(\\w+)\\}\\}((?:(?!\\{\\{/unless\\}\\})[\\s\\S])*?)\\{\\{/unless\\}\\}");
 
     /**
      * Renders a prompt template by substituting variables.
@@ -394,7 +394,7 @@ public class PromptRenderingService {
     private boolean isTruthy(Object value) {
         return value != null
                 && !Boolean.FALSE.equals(value)
-                && !(value instanceof String && ((String) value).isEmpty());
+                && !(value instanceof String s && s.isEmpty());
     }
 
     /**
@@ -408,7 +408,7 @@ public class PromptRenderingService {
      * </ol>
      */
     private String processConditionalBlocks(String template, Map<String, Object> variables) {
-        // 1. {{#if var}} ... {{else}} ... {{/if}}  (must run before plain {{#if}} to avoid partial match)
+        // Step 1: resolve if-else blocks first to prevent the plain-if pattern from partially matching them
         Matcher ifElseMatcher = IF_ELSE_BLOCK_PATTERN.matcher(template);
         StringBuffer ifElseResult = new StringBuffer();
         while (ifElseMatcher.find()) {
@@ -421,7 +421,7 @@ public class PromptRenderingService {
         ifElseMatcher.appendTail(ifElseResult);
         template = ifElseResult.toString();
 
-        // 2. {{#if var}} ... {{/if}}
+        // Step 2: resolve plain if blocks
         Matcher ifMatcher = IF_BLOCK_PATTERN.matcher(template);
         StringBuffer ifResult = new StringBuffer();
         while (ifMatcher.find()) {
@@ -433,7 +433,7 @@ public class PromptRenderingService {
         ifMatcher.appendTail(ifResult);
         template = ifResult.toString();
 
-        // 3. {{#unless var}} ... {{/unless}}
+        // Step 3: resolve unless blocks (logical complement of if)
         Matcher unlessMatcher = UNLESS_BLOCK_PATTERN.matcher(template);
         StringBuffer unlessResult = new StringBuffer();
         while (unlessMatcher.find()) {

--- a/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
+++ b/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
@@ -13,15 +13,51 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static io.apicurio.registry.util.JsonObjectMapper.MAPPER;
 import static io.apicurio.registry.util.YAMLObjectMapper.YAML_MAPPER;
 
 /**
- * Service for rendering prompt templates by substituting variables.
+ * Service for rendering prompt templates by substituting variables and evaluating
+ * Handlebars-style conditional blocks.
+ *
+ * <p>Supported syntax:</p>
+ * <ul>
+ *   <li>{@code {{variable}}} — substituted with the variable value, or kept verbatim when absent</li>
+ *   <li>{@code {{#if variable}} ... {{/if}}} — block rendered when variable is truthy</li>
+ *   <li>{@code {{#if variable}} ... {{else}} ... {{/if}}} — if/else branch</li>
+ *   <li>{@code {{#unless variable}} ... {{/unless}}} — block rendered when variable is falsy</li>
+ * </ul>
+ *
+ * <p>Truthy semantics (matching the MCP render path): a value is truthy when it is
+ * non-null, not {@code Boolean.FALSE}, and not an empty string.</p>
  */
 @ApplicationScoped
 public class PromptRenderingService {
+
+
+    /**
+     * Matches {{#if var}} ... {{/if}} blocks, including multi-line content.
+     * Group 1 = variable name, Group 2 = inner content.
+     */
+    private static final Pattern IF_BLOCK_PATTERN =
+            Pattern.compile("\\{\\{#if\\s+(\\w+)\\}\\}([\\s\\S]*?)\\{\\{/if\\}\\}");
+
+    /**
+     * Matches {{#if var}} ... {{else}} ... {{/if}} blocks.
+     * Group 1 = variable name, Group 2 = truthy branch, Group 3 = falsy branch.
+     */
+    private static final Pattern IF_ELSE_BLOCK_PATTERN =
+            Pattern.compile("\\{\\{#if\\s+(\\w+)\\}\\}([\\s\\S]*?)\\{\\{else\\}\\}([\\s\\S]*?)\\{\\{/if\\}\\}");
+
+    /**
+     * Matches {{#unless var}} ... {{/unless}} blocks.
+     * Group 1 = variable name, Group 2 = inner content.
+     */
+    private static final Pattern UNLESS_BLOCK_PATTERN =
+            Pattern.compile("\\{\\{#unless\\s+(\\w+)\\}\\}([\\s\\S]*?)\\{\\{/unless\\}\\}");
 
     /**
      * Renders a prompt template by substituting variables.
@@ -57,8 +93,9 @@ public class PromptRenderingService {
         // range is reported instead of being rendered silently.
         validateAppliedDefaults(variables, effectiveVariables, variablesSchema, validationErrors);
 
-        // Render the template by substituting variables
-        String rendered = substituteVariables(templateText, effectiveVariables);
+        // Process conditional blocks first, then substitute plain variables
+        String withBlocksResolved = processConditionalBlocks(templateText, effectiveVariables);
+        String rendered = substituteVariables(withBlocksResolved, effectiveVariables);
 
         return RenderPromptResponse.builder()
                 .rendered(rendered)
@@ -345,6 +382,69 @@ public class PromptRenderingService {
         if (value instanceof List) return "array";
         if (value instanceof Map) return "object";
         return value.getClass().getSimpleName();
+    }
+
+    /**
+     * Determine whether a value is truthy for conditional evaluation.
+     *
+     * <p>A value is falsy when it is null, {@code Boolean.FALSE}, or an empty string.
+     * All other values are truthy. This matches the MCP render path semantics in
+     * {@code PromptTemplateConverter.processConditionalBlocks()}.</p>
+     */
+    private boolean isTruthy(Object value) {
+        return value != null
+                && !Boolean.FALSE.equals(value)
+                && !(value instanceof String && ((String) value).isEmpty());
+    }
+
+    /**
+     * Process Handlebars-style conditional blocks before plain variable substitution.
+     *
+     * <p>Handles three forms in evaluation order:</p>
+     * <ol>
+     *   <li>{@code {{#if var}} ... {{else}} ... {{/if}}} — if/else (must be matched before plain if)</li>
+     *   <li>{@code {{#if var}} ... {{/if}}} — simple if</li>
+     *   <li>{@code {{#unless var}} ... {{/unless}}} — unless (logical complement of if)</li>
+     * </ol>
+     */
+    private String processConditionalBlocks(String template, Map<String, Object> variables) {
+        // 1. {{#if var}} ... {{else}} ... {{/if}}  (must run before plain {{#if}} to avoid partial match)
+        Matcher ifElseMatcher = IF_ELSE_BLOCK_PATTERN.matcher(template);
+        StringBuffer ifElseResult = new StringBuffer();
+        while (ifElseMatcher.find()) {
+            String varName = ifElseMatcher.group(1);
+            String truthyBranch = ifElseMatcher.group(2);
+            String falsyBranch = ifElseMatcher.group(3);
+            String chosen = isTruthy(variables.get(varName)) ? truthyBranch : falsyBranch;
+            ifElseMatcher.appendReplacement(ifElseResult, Matcher.quoteReplacement(chosen));
+        }
+        ifElseMatcher.appendTail(ifElseResult);
+        template = ifElseResult.toString();
+
+        // 2. {{#if var}} ... {{/if}}
+        Matcher ifMatcher = IF_BLOCK_PATTERN.matcher(template);
+        StringBuffer ifResult = new StringBuffer();
+        while (ifMatcher.find()) {
+            String varName = ifMatcher.group(1);
+            String content = ifMatcher.group(2);
+            String chosen = isTruthy(variables.get(varName)) ? content : "";
+            ifMatcher.appendReplacement(ifResult, Matcher.quoteReplacement(chosen));
+        }
+        ifMatcher.appendTail(ifResult);
+        template = ifResult.toString();
+
+        // 3. {{#unless var}} ... {{/unless}}
+        Matcher unlessMatcher = UNLESS_BLOCK_PATTERN.matcher(template);
+        StringBuffer unlessResult = new StringBuffer();
+        while (unlessMatcher.find()) {
+            String varName = unlessMatcher.group(1);
+            String content = unlessMatcher.group(2);
+            String chosen = isTruthy(variables.get(varName)) ? "" : content;
+            unlessMatcher.appendReplacement(unlessResult, Matcher.quoteReplacement(chosen));
+        }
+        unlessMatcher.appendTail(unlessResult);
+
+        return unlessResult.toString();
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
@@ -761,9 +761,10 @@ public class PromptRenderingServiceTest {
         RenderPromptResponse response = renderingService.render(content, variables,
                 "default", "conditional", "1.0");
 
-        // The render endpoint does not process {{#if}} blocks (see #8728); it must at least leave
-        // the markers alone rather than mangling them while substituting the variable inside.
-        Assertions.assertEquals("{{#if premium}}Hello Alice{{/if}}", response.getRendered());
+        // PR #9391 (#8728): the render endpoint now processes {{#if}} blocks.
+        // With premium=true the block is truthy, so the inner content is rendered
+        // and the markers themselves are removed.
+        Assertions.assertEquals("Hello Alice", response.getRendered());
     }
 
     @Test
@@ -1003,4 +1004,180 @@ public class PromptRenderingServiceTest {
             renderingService.render(content, variables, "default", "comment", "1.0");
         });
     }
+    // ===== Conditional Block Tests =====
+    // Verifies parity with MCP PromptTemplateConverter.processConditionalBlocks() semantics.
+
+    @Test
+    public void testIfBlockRenderedWhenVariableTruthy() {
+        // A non-null, non-false, non-empty-string value is truthy — the block must be included.
+        String yamlContent = """
+            templateId: if-truthy
+            template: "Start.{{#if showExtra}} Extra content.{{/if}} End."
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of("showExtra", true);
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "if-truthy", "1.0");
+
+        Assertions.assertEquals("Start. Extra content. End.", response.getRendered());
+    }
+
+    @Test
+    public void testIfBlockOmittedWhenVariableFalsy() {
+        // Boolean false → falsy → block removed entirely.
+        String yamlContent = """
+            templateId: if-falsy
+            template: "Start.{{#if showExtra}} Extra content.{{/if}} End."
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of("showExtra", false);
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "if-falsy", "1.0");
+
+        Assertions.assertEquals("Start. End.", response.getRendered());
+    }
+
+    @Test
+    public void testIfBlockOmittedWhenVariableMissing() {
+        // Missing variable → null → falsy → block removed.
+        String yamlContent = """
+            templateId: if-missing
+            template: "Before.{{#if optionalSection}} Optional.{{/if}} After."
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = new HashMap<>(); // no optionalSection
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "if-missing", "1.0");
+
+        Assertions.assertEquals("Before. After.", response.getRendered());
+    }
+
+    @Test
+    public void testIfBlockOmittedWhenVariableEmptyString() {
+        // Empty string → falsy → block removed.
+        String yamlContent = """
+            templateId: if-empty-string
+            template: "A.{{#if tag}} Tagged.{{/if}} B."
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of("tag", "");
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "if-empty-string", "1.0");
+
+        Assertions.assertEquals("A. B.", response.getRendered());
+    }
+
+    @Test
+    public void testUnlessBlockRenderedWhenVariableFalsy() {
+        // Unless = logical complement: block shown when variable is falsy.
+        String yamlContent = """
+            templateId: unless-falsy
+            template: "{{#unless premium}}Free plan — upgrade to unlock.{{/unless}}"
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of("premium", false);
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "unless-falsy", "1.0");
+
+        Assertions.assertEquals("Free plan \u2014 upgrade to unlock.", response.getRendered());
+    }
+
+    @Test
+    public void testUnlessBlockOmittedWhenVariableTruthy() {
+        // Unless with truthy var → block removed.
+        String yamlContent = """
+            templateId: unless-truthy
+            template: "{{#unless premium}}Upgrade now.{{/unless}}"
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of("premium", true);
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "unless-truthy", "1.0");
+
+        Assertions.assertEquals("", response.getRendered());
+    }
+
+    @Test
+    public void testIfElseBlockTruthyBranch() {
+        // Truthy var → truthy (first) branch rendered.
+        String yamlContent = """
+            templateId: if-else-truthy
+            template: "Mode: {{#if verbose}}detailed{{else}}brief{{/if}}."
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of("verbose", true);
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "if-else-truthy", "1.0");
+
+        Assertions.assertEquals("Mode: detailed.", response.getRendered());
+    }
+
+    @Test
+    public void testIfElseBlockFalsyBranch() {
+        // Falsy var → else (second) branch rendered.
+        String yamlContent = """
+            templateId: if-else-falsy
+            template: "Mode: {{#if verbose}}detailed{{else}}brief{{/if}}."
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = Map.of("verbose", false);
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "if-else-falsy", "1.0");
+
+        Assertions.assertEquals("Mode: brief.", response.getRendered());
+    }
+
+    @Test
+    public void testConditionalBlockCombinedWithVariableSubstitution() {
+        // Conditional blocks and plain {{variable}} substitution must both work in one template.
+        String yamlContent = """
+            templateId: combined
+            template: "You are a {{role}} assistant.{{#if includeContext}} Context: {{context}}.{{/if}} Question: {{question}}"
+            variables:
+              role:
+                type: string
+              includeContext:
+                type: boolean
+              context:
+                type: string
+              question:
+                type: string
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("role", "helpful");
+        variables.put("includeContext", true);
+        variables.put("context", "Java programming");
+        variables.put("question", "What is a lambda?");
+
+        RenderPromptResponse response = renderingService.render(content, variables,
+                "default", "combined", "1.0");
+
+        String rendered = response.getRendered();
+        Assertions.assertTrue(rendered.contains("You are a helpful assistant."),
+                "Should contain role substitution");
+        Assertions.assertTrue(rendered.contains("Context: Java programming."),
+                "Should render if-block content when truthy, with inner variable substituted");
+        Assertions.assertTrue(rendered.contains("Question: What is a lambda?"),
+                "Should contain question substitution");
+        Assertions.assertTrue(response.getValidationErrors().isEmpty());
+    }
 }
+


### PR DESCRIPTION
fix(prompt): add {{#if}}/{{#unless}}/{{else}} conditional block support to PromptRenderingService…ingService

The REST render endpoint (POST .../versions/{version}/render) processed only plain {{variable}} substitution via substituteVariables(). The MCP render path (PromptTemplateConverter.renderTemplate()) additionally calls processConditionalBlocks(), which supports Handlebars-style:

  {{#if var}} ... {{/if}}
  {{#if var}} ... {{else}} ... {{/if}}
  {{#unless var}} ... {{/unless}}

This divergence meant the same registered PROMPT_TEMPLATE artifact produced different output depending on whether it was rendered through the REST API (and the UI 'Test Prompt' panel, which calls it) or through the MCP server.

This commit ports the conditional block logic into PromptRenderingService:

- Adds IF_BLOCK_PATTERN, IF_ELSE_BLOCK_PATTERN and UNLESS_BLOCK_PATTERN compiled Pattern constants.
- Adds isTruthy() helper with the## Summary
- 
- The REST render endpoint (`POST .../versions/{version}/render`) processed only plain `{{variable}}` substitution. The MCP render path (`PromptTemplateConverter.renderTemplate()`) additionally supports Handlebars-style conditional blocks via `processConditionalBlocks()`. This divergence caused the same registered `PROMPT_TEMPLATE` artifact to produce different output depending on the render path - a bug reported in #8728.
- 
- ## Changes
- 
- - Added three compiled `Pattern` constants to `PromptRenderingService`:
-   - `IF_BLOCK_PATTERN` - matches `{{#if var}} ... {{/if}}`
-   - `IF_ELSE_BLOCK_PATTERN` - matches `{{#if var}} ... {{else}} ... {{/if}}`
-   - `UNLESS_BLOCK_PATTERN` - matches `{{#unless var}} ... {{/unless}}`
- - Added `isTruthy(Object value)` helper with identical truthy semantics to the MCP path:
-   - falsy: `null`, `Boolean.FALSE`, empty `String`
-   - truthy: everything else
- - Added `processConditionalBlocks(String template, Map<String, Object> variables)` that resolves all three block forms before plain variable substitution, so variables *inside* conditional branches are also substituted correctly
- - Updated `render()` to call `processConditionalBlocks()` first, then `substituteVariables()`
- - Updated class Javadoc to document all supported syntax forms
- 
- **Backward compatible:** templates with no conditional blocks are unaffected.
- 
- ## Tests Added (9 new tests in `PromptRenderingServiceTest`)
- 
- | Test | What it covers |
- |------|---------------|
- | `testIfBlockRenderedWhenVariableTruthy` | `{{#if}}` with truthy value renders block |
- | `testIfBlockOmittedWhenVariableFalsy` | `{{#if}}` with `false` removes block |
- | `testIfBlockOmittedWhenVariableMissing` | `{{#if}}` with missing var (null) removes block |
- | `testIfBlockOmittedWhenVariableEmptyString` | `{{#if}}` with `""` removes block |
- | `testUnlessBlockRenderedWhenVariableFalsy` | `{{#unless}}` shown when variable is falsy |
- | `testUnlessBlockOmittedWhenVariableTruthy` | `{{#unless}}` hidden when variable is truthy |
- | `testIfElseBlockTruthyBranch` | `{{#if}}...{{else}}...{{/if}}` takes truthy branch |
- | `testIfElseBlockFalsyBranch` | `{{#if}}...{{else}}...{{/if}}` takes falsy branch |
- | `testConditionalBlockCombinedWithVariableSubstitution` | Mixed conditionals + `{{var}}` in same template |
- 
- ## Related Issue
- Fixes #8728## Summary
- 
- The REST render endpoint (`POST .../versions/{version}/render`) processed only plain `{{variable}}` substitution. The MCP render path (`PromptTemplateConverter.renderTemplate()`) additionally supports Handlebars-style conditional blocks via `processConditionalBlocks()`. This divergence caused the same registered `PROMPT_TEMPLATE` artifact to produce different output depending on the render path  same truthy semantics as MCP: a value is falsy when null, Boolean.FALSE, or empty string; everything else is truthy.
- Adds processConditionalBlocks() that resolves if/else/unless blocks in one pass before plain variable substitution, matching evaluation order in PromptTemplateConverter.
- Updates render() to call processConditionalBlocks() first so that variables inside conditional branches are substituted correctly.
- Updates the class Javadoc to document all supported syntax forms.
- Adds 9 new test cases in PromptRenderingServiceTest covering all block types, truthy/falsy semantics, missing/empty-string variables, and combined conditional + variable substitution in the same template.

Fixes #8728