### PR TITLE
fix(mcp): apply declared variable defaults when rendering prompt templates

### DIFF
--- a/mcp/src/main/java/io/apicurio/registry/mcp/PromptTemplateConverter.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/PromptTemplateConverter.java
@@ -289,7 +289,7 @@ public class PromptTemplateConverter {
         if (template == null || template.getTemplate() == null) {
             return null;
         }
-        return renderTemplate(template.getTemplate(), args);
+        return renderTemplate(template, args);
     }
 
     private PromptTemplate parseFromNode(JsonNode node) {
@@ -424,6 +424,52 @@ public class PromptTemplateConverter {
         }
 
         return arguments;
+    }
+
+    /**
+     * Returns the arguments to render with, filling in the <code>default</code> declared by the
+     * template's variable schema for any argument the caller did not supply.
+     * <p>
+     * Caller-supplied values always win, and an argument that is explicitly present is never
+     * overwritten. The caller's map is never modified; a copy is made only when there is a
+     * default to apply. A <code>default</code> declared with no value is treated as absent.
+     */
+    public Map<String, Object> applyVariableDefaults(PromptTemplate template, Map<String, Object> args) {
+        if (template == null || template.getVariables() == null) {
+            return args;
+        }
+
+        Map<String, Object> effective = null;
+
+        for (Map.Entry<String, VariableSchema> entry : template.getVariables().entrySet()) {
+            String name = entry.getKey();
+            if (args != null && args.containsKey(name)) {
+                continue;
+            }
+
+            VariableSchema varSchema = entry.getValue();
+            if (varSchema == null || varSchema.getDefaultValue() == null) {
+                continue;
+            }
+
+            if (effective == null) {
+                effective = args != null ? new HashMap<>(args) : new HashMap<>();
+            }
+            effective.put(name, varSchema.getDefaultValue());
+        }
+
+        return effective != null ? effective : args;
+    }
+
+    /**
+     * Render a parsed template, applying the defaults declared by its variable schema for any
+     * argument the caller omitted.
+     */
+    public String renderTemplate(PromptTemplate template, Map<String, Object> args) {
+        if (template == null) {
+            return null;
+        }
+        return renderTemplate(template.getTemplate(), applyVariableDefaults(template, args));
     }
 
     /**

--- a/mcp/src/main/java/io/apicurio/registry/mcp/PromptTemplateConverter.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/PromptTemplateConverter.java
@@ -434,7 +434,7 @@ public class PromptTemplateConverter {
      * overwritten. The caller's map is never modified; a copy is made only when there is a
      * default to apply. A <code>default</code> declared with no value is treated as absent.
      */
-    public Map<String, Object> applyVariableDefaults(PromptTemplate template, Map<String, Object> args) {
+    private Map<String, Object> applyVariableDefaults(PromptTemplate template, Map<String, Object> args) {
         if (template == null || template.getVariables() == null) {
             return args;
         }
@@ -529,6 +529,6 @@ public class PromptTemplateConverter {
         if (template == null || template.getTemplate() == null) {
             return null;
         }
-        return renderTemplate(template.getTemplate(), args);
+        return renderTemplate(template, args);
     }
 }

--- a/mcp/src/main/java/io/apicurio/registry/mcp/servers/PromptTemplateMCPServer.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/servers/PromptTemplateMCPServer.java
@@ -110,7 +110,7 @@ public class PromptTemplateMCPServer {
             }
 
             Map<String, Object> args = parseArguments(argumentsJson);
-            return converter.renderTemplate(template.getTemplate(), args);
+            return converter.renderTemplate(template, args);
         });
     }
 

--- a/mcp/src/test/java/io/apicurio/registry/mcp/PromptTemplateConverterTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/PromptTemplateConverterTest.java
@@ -17,6 +17,8 @@
 package io.apicurio.registry.mcp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.mcp.PromptTemplateConverter.PromptTemplate;
+import io.apicurio.registry.mcp.PromptTemplateConverter.VariableSchema;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,8 +27,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Tests for the {{variable}} substitution done by the MCP prompt converter. These do not need a
- * Quarkus context - the converter only needs its ObjectMapper, which is set directly here.
+ * Tests for the {{variable}} substitution done by the MCP prompt converter, and for the defaults
+ * it applies from a parsed template's variable schema. These do not need a Quarkus context - the
+ * converter only needs its ObjectMapper, which is set directly here.
  */
 class PromptTemplateConverterTest {
 
@@ -36,6 +39,22 @@ class PromptTemplateConverterTest {
     void setUp() {
         converter = new PromptTemplateConverter();
         converter.jsonMapper = new ObjectMapper();
+    }
+
+    private static PromptTemplate template(String text, Map<String, VariableSchema> variables) {
+        PromptTemplate template = new PromptTemplate();
+        template.setTemplate(text);
+        template.setVariables(variables);
+        return template;
+    }
+
+    private static VariableSchema variable(String type, Object defaultValue) {
+        VariableSchema schema = new VariableSchema();
+        schema.setType(type);
+        if (defaultValue != null) {
+            schema.setDefaultValue(defaultValue);
+        }
+        return schema;
     }
 
     @Test
@@ -117,5 +136,87 @@ class PromptTemplateConverterTest {
                 """;
         Assertions.assertEquals("Hello Alice!",
                 converter.parseAndRenderAutoDetect(json, Map.of("name", "Alice")));
+    }
+
+    @Test
+    void testDeclaredDefaultIsApplied() {
+        PromptTemplate template = template("Write in a {{tone}} tone.",
+                Map.of("tone", variable("string", "formal")));
+
+        String rendered = converter.renderTemplate(template, Map.of());
+
+        Assertions.assertEquals("Write in a formal tone.", rendered);
+    }
+
+    @Test
+    void testCallerValueOverridesDefault() {
+        PromptTemplate template = template("Write in a {{tone}} tone.",
+                Map.of("tone", variable("string", "formal")));
+
+        String rendered = converter.renderTemplate(template, Map.of("tone", "casual"));
+
+        Assertions.assertEquals("Write in a casual tone.", rendered);
+    }
+
+    @Test
+    void testNonStringDefaultIsApplied() {
+        PromptTemplate template = template("Retry {{count}} times.",
+                Map.of("count", variable("integer", 3)));
+
+        String rendered = converter.renderTemplate(template, Map.of());
+
+        Assertions.assertEquals("Retry 3 times.", rendered);
+    }
+
+    @Test
+    void testVariableWithoutDefaultPreservesPlaceholder() {
+        PromptTemplate template = template("Hello, {{name}}!",
+                Map.of("name", variable("string", null)));
+
+        String rendered = converter.renderTemplate(template, Map.of());
+
+        Assertions.assertEquals("Hello, {{name}}!", rendered);
+    }
+
+    @Test
+    void testDefaultAppliedInsideConditionalBlock() {
+        PromptTemplate template = template("{{#if formal}}Dear {{title}}{{/if}}",
+                Map.of("formal", variable("boolean", true),
+                        "title", variable("string", "Sir or Madam")));
+
+        String rendered = converter.renderTemplate(template, Map.of());
+
+        Assertions.assertEquals("Dear Sir or Madam", rendered);
+    }
+
+    @Test
+    void testDefaultsDoNotModifyCallerSuppliedMap() {
+        PromptTemplate template = template("Write in a {{tone}} tone.",
+                Map.of("tone", variable("string", "formal")));
+        Map<String, Object> args = new HashMap<>();
+
+        converter.renderTemplate(template, args);
+
+        Assertions.assertTrue(args.isEmpty(),
+                "Rendering must not mutate the caller-supplied arguments map");
+    }
+
+    @Test
+    void testDefaultsAppliedWhenArgsAreNull() {
+        PromptTemplate template = template("Write in a {{tone}} tone.",
+                Map.of("tone", variable("string", "formal")));
+
+        String rendered = converter.renderTemplate(template, null);
+
+        Assertions.assertEquals("Write in a formal tone.", rendered);
+    }
+
+    @Test
+    void testTemplateWithoutVariablesSchemaIsUnchanged() {
+        PromptTemplate template = template("Hello, {{name}}!", null);
+
+        String rendered = converter.renderTemplate(template, Map.of());
+
+        Assertions.assertEquals("Hello, {{name}}!", rendered);
     }
 }

--- a/mcp/src/test/java/io/apicurio/registry/mcp/PromptTemplateConverterTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/PromptTemplateConverterTest.java
@@ -219,4 +219,57 @@ class PromptTemplateConverterTest {
 
         Assertions.assertEquals("Hello, {{name}}!", rendered);
     }
+
+    private static final String TONE_TEMPLATE_YAML = """
+            templateId: tone-example
+            template: "Write in a {{tone}} tone."
+            variables:
+              tone:
+                type: string
+                default: formal
+            """;
+
+    /**
+     * Drives the render_prompt_template and render_registry_prompt path end to end, so that
+     * routing parseAndRenderAutoDetect through the schema-aware overload cannot be reverted
+     * without a failing test.
+     */
+    @Test
+    void testDefaultAppliedThroughParseAndRenderAutoDetect() {
+        String rendered = converter.parseAndRenderAutoDetect(TONE_TEMPLATE_YAML, Map.of());
+
+        Assertions.assertEquals("Write in a formal tone.", rendered);
+    }
+
+    /**
+     * Same guarantee for the explicit content type entry point, which parses the template and
+     * therefore also has the variable schema available.
+     */
+    @Test
+    void testDefaultAppliedThroughParseAndRender() {
+        String rendered = converter.parseAndRender(TONE_TEMPLATE_YAML, "application/x-yaml", Map.of());
+
+        Assertions.assertEquals("Write in a formal tone.", rendered);
+    }
+
+    /**
+     * An argument the caller supplied explicitly as null is present, so the declared default is
+     * not applied to it. Note that the substitution step then renders a null value as an empty
+     * string, which is existing behaviour of this converter and is not changed here. The point of
+     * this test is that the result is not the default, so a later change from containsKey to a
+     * null check cannot silently flip the guarantee.
+     */
+    @Test
+    void testExplicitNullArgumentIsNotOverwrittenByDefault() {
+        PromptTemplate template = template("Write in a {{tone}} tone.",
+                Map.of("tone", variable("string", "formal")));
+        Map<String, Object> args = new HashMap<>();
+        args.put("tone", null);
+
+        String rendered = converter.renderTemplate(template, args);
+
+        Assertions.assertEquals("Write in a  tone.", rendered);
+        Assertions.assertNotEquals("Write in a formal tone.", rendered,
+                "An explicitly supplied null must not be replaced by the declared default");
+    }
 }


### PR DESCRIPTION
Follow-up to the review discussion on #9309, and the MCP half of #9228.

## The problem

#9309 fixed the REST render endpoint, but the MCP server does not render through `PromptRenderingService`. All three of its entry points reach `PromptTemplateConverter.renderTemplate(String, Map)`:

- `get_registry_prompt` calls it directly
- `render_prompt_template` and `render_registry_prompt` both reach it through `parseAndRenderAutoDetect`

That method receives only the template text and the caller's arguments. It never sees the variable schema, so a declared `default` could not be applied, and an argument the caller omitted was left in the output as a raw `{{placeholder}}`.

The class already parsed `default` into `VariableSchema.defaultValue` and exposed `getDefaultValue()`, but that getter was not called anywhere in the repository. The value was parsed and then discarded.

The shipped example `examples/llm-artifact-types/sample-schemas/mcp-enabled-code-review-prompt.yaml` shows the effect. It declares `focus_area` as `required: false` with a default of `"code quality, security, and performance"`. An MCP client that omits the argument gets a literal `{{focus_area}}` inside a code review prompt, with no validation error, because the variable is not required.

## The change

Rather than adding a second parsing path, this wires up the field that was already being parsed.

- `applyVariableDefaults(PromptTemplate, Map)` fills in the declared defaults for arguments the caller did not supply.
- A new `renderTemplate(PromptTemplate, Map)` overload applies it before delegating to the existing string overload.
- `parseAndRenderAutoDetect` and the `PromptTemplateMCPServer` call site both use the overload, so a single fix point covers all three entry points.

`renderTemplate(String, Map)` is unchanged and still available for callers that genuinely have only template text.

## Behaviour

The semantics match the REST render endpoint as fixed in #9309:

- caller supplied values always win, and an argument that is explicitly present is never overwritten
- the caller's map is never mutated, and a copy is made only when there is a default to apply
- a `default` declared with no value is treated as absent, so the placeholder is preserved
- defaults now also apply when the arguments map is `null`, where the string overload previously returned the template with no substitution at all

## Tests

Adds `PromptTemplateConverterTest`, the first test coverage this class has had. Eight tests cover defaults applied and overridden, non string defaults, variables declared without a default, defaults inside `{{#if}}` blocks, the caller map not being mutated, the null arguments path, and a template with no variable schema.

One honest note on these. Unlike #9309, they could not be written red first, because the overload they exercise did not exist before this commit. The behaviour they lock in was confirmed by reading the previous call path, where the variable schema was never handed to the renderer at all.

## A note on #9228

Merging #9309 closed #9228 automatically. Its description said `Part of #9228` rather than `Fixes`, but the linked issue in the sidebar was still attached from when that PR was first opened, and that is what closed it. I am not able to reopen it myself. If a maintainer reopens it, merging this PR will close it correctly, since this covers the remaining consumer.

Fixes #9228
