### PR TITLE
fix(ui): resolve CWE-346 postMessage targetOrigin vulnerability (#9396)

### DIFF
--- a/ui/ui-app/src/app/pages/version/components/tabs/visualizers/OpenApiVisualizer.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/visualizers/OpenApiVisualizer.tsx
@@ -1,6 +1,7 @@
-import { FunctionComponent, useEffect, useRef } from "react";
+import { FunctionComponent, useEffect, useRef, useMemo } from "react";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { LoggerService, useLoggerService } from "@services/useLoggerService.ts";
+import { deriveOrigin } from "@utils/url.utils.ts";
 
 export type OpenApiVisualizerProps = {
     spec: any;
@@ -24,6 +25,10 @@ export const OpenApiVisualizer: FunctionComponent<OpenApiVisualizerProps> = (pro
 
     logger.info("[OpenApiVisualizer] OAI docs URL: ", oaiDocsUrl());
 
+    const expectedOrigin = useMemo(() => {
+        return deriveOrigin(oaiDocsUrl(), window.location.origin);
+    }, [config]);
+
     const sendSpecToIframe = (spec: Record<string, unknown>): void => {
         if (ref.current?.contentWindow) {
             const message = {
@@ -33,7 +38,9 @@ export const OpenApiVisualizer: FunctionComponent<OpenApiVisualizerProps> = (pro
                     content: spec
                 }
             };
-            ref.current.contentWindow.postMessage(message, "*");
+            if (expectedOrigin) {
+                ref.current.contentWindow.postMessage(message, expectedOrigin);
+            }
         }
     };
 
@@ -47,6 +54,9 @@ export const OpenApiVisualizer: FunctionComponent<OpenApiVisualizerProps> = (pro
     // message listener is set up, causing the initial postMessage to be lost.
     useEffect(() => {
         const handler = (evt: MessageEvent): void => {
+            if (!expectedOrigin || evt.origin !== expectedOrigin) {
+                return;
+            }
             if (evt.data?.type === "apicurio-docs-ready" && props.spec && Object.keys(props.spec).length > 0) {
                 sendSpecToIframe(props.spec);
             }

--- a/ui/ui-app/src/editors/AsyncApiEditor.tsx
+++ b/ui/ui-app/src/editors/AsyncApiEditor.tsx
@@ -1,10 +1,10 @@
-import React, { RefObject, useEffect } from "react";
+import React, { RefObject, useEffect, useMemo } from "react";
 import "./AsyncApiEditor.css";
 import { Editor as DraftEditor, EditorProps } from "./editor-types";
 import { parseJson, parseYaml, toJsonString, toYamlString } from "@utils/content.utils.ts";
 import { useConfigService } from "@services/useConfigService.ts";
 import { ContentTypes } from "@models/ContentTypes.ts";
-
+import { deriveOrigin } from "@utils/url.utils.ts";
 
 export type AsyncApiEditorProps = {
     className?: string;
@@ -26,10 +26,16 @@ export const AsyncApiEditor: DraftEditor = (props: AsyncApiEditorProps) => {
     }
 
     // TODO we have a lot of common functionality between the asyncapi and openapi editors.  Need to share!
+    const expectedOrigin = useMemo(() => {
+        return deriveOrigin(editorsUrl, window.location.origin);
+    }, [editorsUrl]);
     useEffect(() => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        const eventListener: any = (event) => {
+        const eventListener = (event: MessageEvent) => {
+            if (!expectedOrigin || event.origin !== expectedOrigin) {
+                return;
+            }
             if (event.data && event.data.type === "apicurio_onChange") {
                 let newContent: any = event.data.data.content;
                 if (typeof newContent === "object") {
@@ -84,7 +90,9 @@ export const AsyncApiEditor: DraftEditor = (props: AsyncApiEditorProps) => {
                 }
             }
         };
-        ref.current.contentWindow.postMessage(message, "*");
+        if (expectedOrigin) {
+            ref.current.contentWindow.postMessage(message, expectedOrigin);
+        }
     };
 
     return (

--- a/ui/ui-app/src/editors/OpenApiEditor.tsx
+++ b/ui/ui-app/src/editors/OpenApiEditor.tsx
@@ -1,10 +1,11 @@
-import React, { RefObject, useEffect, useState } from "react";
+import React, { RefObject, useEffect, useState, useMemo } from "react";
 import { Editor as DraftEditor, EditorProps } from "./editor-types";
 import "./OpenApiEditor.css";
 import { parseJson, parseYaml, toJsonString, toYamlString } from "@utils/content.utils.ts";
 import { IfNotLoading } from "@apicurio/common-ui-components";
 import { useConfigService } from "@services/useConfigService.ts";
 import { ContentTypes } from "@models/ContentTypes.ts";
+import { deriveOrigin } from "@utils/url.utils.ts";
 
 
 export type OpenApiEditorProps = {
@@ -30,6 +31,10 @@ export const OpenApiEditor: DraftEditor = (props: OpenApiEditorProps) => {
     }
     const ref: RefObject<any> = React.createRef();
 
+    const expectedOrigin = useMemo(() => {
+        return deriveOrigin(editorsUrl, window.location.origin);
+    }, [editorsUrl]);
+
     useEffect(() => {
         setIsLoading(false);
         // systemSvc.getOpenApiVendorExtensions().then(extensions => {
@@ -47,7 +52,10 @@ export const OpenApiEditor: DraftEditor = (props: OpenApiEditorProps) => {
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        const eventListener: any = (event) => {
+        const eventListener = (event: MessageEvent) => {
+            if (!expectedOrigin || event.origin !== expectedOrigin) {
+                return;
+            }
             if (event.data && event.data.type === "apicurio_onChange") {
                 let newContent: any = event.data.data.content;
                 if (typeof newContent === "object") {
@@ -105,7 +113,9 @@ export const OpenApiEditor: DraftEditor = (props: OpenApiEditorProps) => {
                 }
             }
         };
-        ref.current.contentWindow.postMessage(message, "*");
+        if (expectedOrigin) {
+            ref.current.contentWindow.postMessage(message, expectedOrigin);
+        }
     };
 
     return (

--- a/ui/ui-app/src/utils/url.utils.ts
+++ b/ui/ui-app/src/utils/url.utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Safely derives the origin from a configured URL, handling potential malformed URLs gracefully.
+ * @param url The configured URL (e.g. from config.js)
+ * @param fallbackOrigin The origin to fallback to if the URL is relative (usually window.location.origin)
+ * @returns The parsed origin, or undefined if parsing fails
+ */
+export const deriveOrigin = (url: string | undefined | null, fallbackOrigin: string): string | undefined => {
+    if (!url) {
+        return undefined;
+    }
+    try {
+        return new URL(url, fallbackOrigin).origin;
+    } catch (e) {
+        console.error("[url.utils] Failed to parse origin from URL: ", url, e);
+        return undefined;
+    }
+};


### PR DESCRIPTION
Fixes #9396

This PR addresses the CWE-346 cross-origin `postMessage` vulnerability identified in the Registry UI's iframe-based API editor and visualizer integrations.

The affected components previously used `postMessage(message, "*")` when sending API schema content to external iframe applications. The corresponding `message` event handlers also did not explicitly validate the origin of incoming messages.

This change introduces **defense-in-depth origin validation** for all three affected integrations.

### Changes Made

Updated:

* `ui/ui-app/src/editors/OpenApiEditor.tsx`
* `ui/ui-app/src/editors/AsyncApiEditor.tsx`
* `ui/ui-app/src/app/pages/version/components/tabs/visualizers/OpenApiVisualizer.tsx`

#### 1. Strict `targetOrigin`

Replaced the wildcard `"*"` `targetOrigin` with the origin derived from the configured editor/visualizer URL.

For example:

```typescript
const targetOrigin = new URL(
    editorAppUrl(),
    window.location.origin
).origin;

ref.current.contentWindow?.postMessage(
    message,
    targetOrigin
);
```

This ensures that API schema data is only sent to the expected iframe origin.

#### 2. Incoming `event.origin` validation

Added validation of `event.origin` to the corresponding `message` event handlers.

Messages received from origins other than the configured editor/visualizer origin are rejected before being processed.

This provides defense-in-depth by validating both:

* the destination of outgoing messages
* the origin of incoming messages

### Security Impact

The previous wildcard `targetOrigin` allowed the browser to deliver the schema payload regardless of the origin currently loaded inside the iframe.

The updated implementation restricts cross-origin communication to the configured trusted origin, reducing the risk of API schema data being exposed if an iframe destination is unexpectedly redirected or controlled by an unintended origin.

The fix preserves support for externally hosted editor and visualizer deployments because the expected origin is derived dynamically from the configured URL rather than being hard-coded.

### Verification

* `npm run build` completed successfully.
* No TypeScript compilation errors were reported.
* Verified that the changes are applied consistently across all three affected iframe integrations.
* Confirmed that the existing iframe communication flow continues to use the configured editor/visualizer URLs.

### How to Test / Reviewer Checklist

Since I do not have a full local Apicurio Studio deployment set up to test the live iframe integration, I verified this via static code analysis and a clean `npm run build`.

Reviewers with a local environment can manually confirm the following:
- OpenAPI Editor continues to load API schemas correctly.
- AsyncAPI Editor continues to load API schemas correctly.
- OpenAPI Visualizer continues to render API schemas correctly.
- Changes from the expected iframe origin continue to be processed.
- Messages from unexpected origins are rejected.

