### PR TITLE
fix(serde-protobuf): serialize default message index [0] as Confluent-compatible 0x00

### DIFF
--- a/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/MessageIndexesUtil.java
+++ b/serdes/generic/serde-common-protobuf/src/main/java/io/apicurio/registry/serde/protobuf/MessageIndexesUtil.java
@@ -10,9 +10,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class MessageIndexesUtil {
+
+    // Mirrors Confluent's MessageIndexes.DEFAULT_INDEX: the index of the first message type.
+    public static final List<Integer> DEFAULT_INDEX = Collections.singletonList(0);
 
     private static IllegalArgumentException illegalVarintException(int value) {
         throw new IllegalArgumentException("Varint is too long, the most significant bit in the 5th byte is set, " +
@@ -53,6 +57,12 @@ public class MessageIndexesUtil {
     }
 
     public static void writeTo(List<Integer> indexes, OutputStream out) throws IOException {
+        if (indexes.equals(DEFAULT_INDEX)) {
+            // Confluent-compatible optimization: the default index [0] (the first message
+            // type) is encoded as a single 0x00 var-int instead of [size][indexes].
+            writeVarInt(0, out);
+            return;
+        }
         writeVarInt(indexes.size(), out);
 
         for (Integer index : indexes) {
@@ -96,6 +106,8 @@ public class MessageIndexesUtil {
     public static List<Integer> readFrom(InputStream in) throws IOException {
         int size = readVarInt(in);
         if (size == 0) {
+            // A bare 0x00 var-int is Confluent's optimized encoding for the default
+            // index [0] (the first message type), so it must map to [0], not an empty list.
             return List.of(0);
         }
         List<Integer> indexes = new ArrayList<>(size);

--- a/serdes/generic/serde-common-protobuf/src/test/java/io/apicurio/registry/serde/protobuf/MessageIndexesUtilTest.java
+++ b/serdes/generic/serde-common-protobuf/src/test/java/io/apicurio/registry/serde/protobuf/MessageIndexesUtilTest.java
@@ -1,0 +1,56 @@
+package io.apicurio.registry.serde.protobuf;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for MessageIndexesUtil verifying var-int index (de)serialization and
+ * Confluent wire-format compatibility for the default message index.
+ */
+public class MessageIndexesUtilTest {
+
+    @Test
+    public void testWriteDefaultIndexIsConfluentCompatible() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessageIndexesUtil.writeTo(List.of(0), out);
+        // Confluent encodes the default index [0] (the first message type) as a bare 0x00 var-int.
+        assertArrayEquals(new byte[]{0x00}, out.toByteArray());
+    }
+
+    @Test
+    public void testReadSingleZeroByteIsDefaultIndex() throws IOException {
+        // Confluent's optimized encoding for [0] is a single 0x00 byte.
+        List<Integer> indexes = MessageIndexesUtil.readFrom(new ByteArrayInputStream(new byte[]{0x00}));
+        assertEquals(List.of(0), indexes);
+    }
+
+    @Test
+    public void testWriteReadRoundTripDefaultIndex() throws IOException {
+        roundTrip(List.of(0));
+    }
+
+    @Test
+    public void testWriteReadRoundTripMultipleIndexes() throws IOException {
+        roundTrip(List.of(3, 1, 2, 7));
+    }
+
+    @Test
+    public void testWriteReadRoundTripNegativeIndexes() throws IOException {
+        roundTrip(List.of(0, -1, 42, -100));
+    }
+
+    private void roundTrip(List<Integer> indexes) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessageIndexesUtil.writeTo(indexes, out);
+
+        List<Integer> result = MessageIndexesUtil.readFrom(new ByteArrayInputStream(out.toByteArray()));
+        assertEquals(indexes, result, "Read indexes should match written indexes after a round trip");
+    }
+}


### PR DESCRIPTION
Fixes #9429

## Summary

MessageIndexesUtil.writeTo serialized the default index [0] (the first message type) as [size=1][index=0] (x02 0x00). Confluent's MessageIndexes.toByteArray() optimizes the default index [0] to a single x00 var-int.

This PR makes Apicurio's writer emit the same Confluent-compatible byte layout: [0] is now written as a bare x00, while all other index lists keep the [size][indexes...] encoding.

eadFrom intentionally maps a bare x00 to [0] (Confluent's DEFAULT_INDEX); that behavior is unchanged.

## Tests
Added MessageIndexesUtilTest verifying:
- writeTo(List.of(0)) produces exactly x00 (Confluent-compatible).
- reading a single x00 byte returns List.of(0).
- round-trips for the default, multiple, and negative indexes.