### PR TITLE
fix(ui): clean up remaining stale PatternFly 5 (pf-v5) CSS classes and variables in ui-app

### DIFF
--- a/ui/ui-app/src/app/App.css
+++ b/ui/ui-app/src/app/App.css
@@ -3,7 +3,7 @@
   --registry-page-canvas-bg: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
 }
 
-.pf-c-page {
+.pf-v6-c-page {
   width: 100%;
   height: 100vh;
 }

--- a/ui/ui-app/src/app/App.css
+++ b/ui/ui-app/src/app/App.css
@@ -15,8 +15,8 @@
   background-color: var(--registry-page-canvas-bg);
 }
 
-.artifact-details-main .pf-c-tab-content,
-.branch-details-main .pf-c-tab-content,
+.artifact-details-main .pf-v6-c-tab-content,
+.branch-details-main .pf-v6-c-tab-content,
 .artifact-details-main .pf-v6-c-tab-content,
 .branch-details-main .pf-v6-c-tab-content,
 #pf-tab-section-content-artifact-page-tabs,
@@ -28,10 +28,10 @@
 /* Secondary cards inside detail tabs add a redundant gray frame on the canvas. */
 .artifact-details-main [class*="-tab-content"] .pf-v6-c-card.pf-m-secondary,
 .branch-details-main [class*="-tab-content"] .pf-v6-c-card.pf-m-secondary,
-.artifact-details-main [class*="-tab-content"] .pf-c-card.pf-m-secondary,
-.branch-details-main [class*="-tab-content"] .pf-c-card.pf-m-secondary {
+.artifact-details-main [class*="-tab-content"] .pf-v6-c-card.pf-m-secondary,
+.branch-details-main [class*="-tab-content"] .pf-v6-c-card.pf-m-secondary {
   --pf-v6-c-card--BackgroundColor: transparent;
-  --pf-c-card--BackgroundColor: transparent;
+  --pf-v6-c-card--BackgroundColor: transparent;
   border: none;
   box-shadow: none;
 }

--- a/ui/ui-app/src/app/App.css
+++ b/ui/ui-app/src/app/App.css
@@ -1,6 +1,6 @@
 :root {
   --myApp-global--spacer--md: 30px;
-  --registry-page-canvas-bg: var(--pf-v5-global--BackgroundColor--200, #f0f0f0);
+  --registry-page-canvas-bg: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
 }
 
 .pf-c-page {

--- a/ui/ui-app/src/app/components/errorPage/ErrorPage.css
+++ b/ui/ui-app/src/app/components/errorPage/ErrorPage.css
@@ -15,6 +15,6 @@
     border: 1px solid #ccc;
 }
 
-.pf-v5-c-code-editor__code {
+.pf-v6-c-code-editor__code {
     background: #fff;
 }

--- a/ui/ui-app/src/app/components/modals/CreateArtifactModal.css
+++ b/ui/ui-app/src/app/components/modals/CreateArtifactModal.css
@@ -1,4 +1,4 @@
-.pf-v5-c-page__main-wizard .pf-v5-c-wizard__footer, .pf-v5-c-modal-box .pf-v5-c-wizard__footer, .pf-v5-c-drawer > .pf-v5-c-wizard__footer {
+.pf-v6-c-page__main-wizard .pf-v6-c-wizard__footer, .pf-v6-c-modal-box .pf-v6-c-wizard__footer, .pf-v6-c-drawer > .pf-v6-c-wizard__footer {
     box-shadow: none;
     border-top: 1px solid #ccc;
 }

--- a/ui/ui-app/src/app/components/modals/ReferencesFormGroup.css
+++ b/ui/ui-app/src/app/components/modals/ReferencesFormGroup.css
@@ -5,10 +5,10 @@
     align-items: flex-start;
 }
 
-.ref-field-group .pf-v5-c-form__group {
+.ref-field-group .pf-v6-c-form__group {
     flex: 1;
 }
 
-.ref-field-group .pf-v5-c-button {
+.ref-field-group .pf-v6-c-button {
     margin-top: 4px;
 }

--- a/ui/ui-app/src/app/pages/artifact/ArtifactPage.css
+++ b/ui/ui-app/src/app/pages/artifact/ArtifactPage.css
@@ -7,7 +7,7 @@ div.artifact-page-tabs > ul > li.pf-v6-c-tabs__item.pf-m-current > button.pf-v6-
     flex-direction: column;
 }
 
-.artifact-details-main .pf-c-tab-content,
+.artifact-details-main .pf-v6-c-tab-content,
 .artifact-details-main .pf-v6-c-tab-content {
     flex-grow: 1;
     display: flex;

--- a/ui/ui-app/src/app/pages/artifact/ArtifactPage.css
+++ b/ui/ui-app/src/app/pages/artifact/ArtifactPage.css
@@ -22,7 +22,7 @@ div.artifact-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs
     padding: 12px 24px 0;
 }
 
-.pf-v5-c-breadcrumb__item-divider {
+.pf-v6-c-breadcrumb__item-divider {
     color: #666;
 }
 

--- a/ui/ui-app/src/app/pages/artifact/ArtifactPage.css
+++ b/ui/ui-app/src/app/pages/artifact/ArtifactPage.css
@@ -1,4 +1,4 @@
-div.artifact-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs__button::before {
+div.artifact-page-tabs > ul > li.pf-v6-c-tabs__item.pf-m-current > button.pf-v6-c-tabs__link::before {
     border-bottom-color: transparent;
 }
 

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/BranchesTabToolbar.css
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/BranchesTabToolbar.css
@@ -8,7 +8,7 @@
     width: 100%;
 }
 
-.branches-toolbar .filter-types-toggle span.pf-v5-c-menu-toggle__text {
+.branches-toolbar .filter-types-toggle span.pf-v6-c-menu-toggle__text {
     width: 125px;
     text-align: left;
 }

--- a/ui/ui-app/src/app/pages/branch/BranchPage.css
+++ b/ui/ui-app/src/app/pages/branch/BranchPage.css
@@ -1,4 +1,4 @@
-div.branch-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs__button::before {
+div.branch-page-tabs > ul > li.pf-v6-c-tabs__item.pf-m-current > button.pf-v6-c-tabs__link::before {
     border-bottom-color: transparent;
 }
 

--- a/ui/ui-app/src/app/pages/branch/BranchPage.css
+++ b/ui/ui-app/src/app/pages/branch/BranchPage.css
@@ -22,7 +22,7 @@ div.branch-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs__
     padding: 12px 24px 0;
 }
 
-.pf-v5-c-breadcrumb__item-divider {
+.pf-v6-c-breadcrumb__item-divider {
     color: #666;
 }
 

--- a/ui/ui-app/src/app/pages/branch/BranchPage.css
+++ b/ui/ui-app/src/app/pages/branch/BranchPage.css
@@ -7,7 +7,7 @@ div.branch-page-tabs > ul > li.pf-v6-c-tabs__item.pf-m-current > button.pf-v6-c-
     flex-direction: column;
 }
 
-.branch-details-main .pf-c-tab-content,
+.branch-details-main .pf-v6-c-tab-content,
 .branch-details-main .pf-v6-c-tab-content {
     flex-grow: 1;
     display: flex;

--- a/ui/ui-app/src/app/pages/dashboard/components/QuickActions.css
+++ b/ui/ui-app/src/app/pages/dashboard/components/QuickActions.css
@@ -2,6 +2,6 @@
     height: 100%;
 }
 
-.quick-actions-card .pf-v5-c-card__body {
+.quick-actions-card .pf-v6-c-card__body {
     padding-top: 8px;
 }

--- a/ui/ui-app/src/app/pages/drafts/components/modals/CreateDraftModal.css
+++ b/ui/ui-app/src/app/pages/drafts/components/modals/CreateDraftModal.css
@@ -1,4 +1,4 @@
-.pf-v5-c-page__main-wizard .pf-v5-c-wizard__footer, .pf-v5-c-modal-box .pf-v5-c-wizard__footer, .pf-v5-c-drawer > .pf-v5-c-wizard__footer {
+.pf-v6-c-page__main-wizard .pf-v6-c-wizard__footer, .pf-v6-c-modal-box .pf-v6-c-wizard__footer, .pf-v6-c-drawer > .pf-v6-c-wizard__footer {
     box-shadow: none;
     border-top: 1px solid #ccc;
 }

--- a/ui/ui-app/src/app/pages/drafts/components/toolbar/DraftsPageToolbar.css
+++ b/ui/ui-app/src/app/pages/drafts/components/toolbar/DraftsPageToolbar.css
@@ -7,7 +7,7 @@
     width: 100%;
 }
 
-.drafts-toolbar .filter-types-toggle span.pf-v5-c-menu-toggle__text {
+.drafts-toolbar .filter-types-toggle span.pf-v6-c-menu-toggle__text {
     width: 125px;
     text-align: left;
 }

--- a/ui/ui-app/src/app/pages/editor/components/EditorContext.css
+++ b/ui/ui-app/src/app/pages/editor/components/EditorContext.css
@@ -44,7 +44,7 @@
 }
 
 #action-toggle > span {
-    color: var(--pf-c-dropdown__toggle--Color);
+    color: var(--pf-v6-c-dropdown__toggle--Color);
 }
 
 #action-toggle {

--- a/ui/ui-app/src/app/pages/explore/ExplorePage.css
+++ b/ui/ui-app/src/app/pages/explore/ExplorePage.css
@@ -1,4 +1,4 @@
-.upload-artifact-modal .pf-c-modal-box__body {
+.upload-artifact-modal .pf-v6-c-modal-box__body {
     overflow-x: initial;
     overflow-y: visible;
 }

--- a/ui/ui-app/src/app/pages/explore/components/toolbar/ExplorePageToolbar.css
+++ b/ui/ui-app/src/app/pages/explore/components/toolbar/ExplorePageToolbar.css
@@ -9,7 +9,7 @@
     width: 100%;
 }
 
-.artifacts-toolbar .filter-types-toggle span.pf-v5-c-menu-toggle__text {
+.artifacts-toolbar .filter-types-toggle span.pf-v6-c-menu-toggle__text {
     width: 125px;
     text-align: left;
 }

--- a/ui/ui-app/src/app/pages/group/GroupPage.css
+++ b/ui/ui-app/src/app/pages/group/GroupPage.css
@@ -23,7 +23,7 @@ div.group-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs__b
     padding: 12px 24px 0;
 }
 
-.pf-v5-c-breadcrumb__item-divider {
+.pf-v6-c-breadcrumb__item-divider {
     color: #666;
 }
 

--- a/ui/ui-app/src/app/pages/group/GroupPage.css
+++ b/ui/ui-app/src/app/pages/group/GroupPage.css
@@ -8,7 +8,7 @@ div.group-page-tabs > ul > li.pf-v6-c-tabs__item.pf-m-current > button.pf-v6-c-t
     gap: 0;
 }
 
-.artifact-details-main .pf-c-tab-content,
+.artifact-details-main .pf-v6-c-tab-content,
 .artifact-details-main .pf-v6-c-tab-content {
     flex-grow: 1;
     display: flex;

--- a/ui/ui-app/src/app/pages/group/GroupPage.css
+++ b/ui/ui-app/src/app/pages/group/GroupPage.css
@@ -1,4 +1,4 @@
-div.group-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs__button::before {
+div.group-page-tabs > ul > li.pf-v6-c-tabs__item.pf-m-current > button.pf-v6-c-tabs__link::before {
     border-bottom-color: transparent;
 }
 

--- a/ui/ui-app/src/app/pages/roles/components/roleToolbar/RoleToolbar.css
+++ b/ui/ui-app/src/app/pages/roles/components/roleToolbar/RoleToolbar.css
@@ -1,9 +1,9 @@
-.roles-toolbar .filter-types-toggle span.pf-v5-c-menu-toggle__text {
+.roles-toolbar .filter-types-toggle span.pf-v6-c-menu-toggle__text {
     width: 125px;
     text-align: left;
 }
 
-.roles-toolbar .role-types-toggle span.pf-v5-c-menu-toggle__text {
+.roles-toolbar .role-types-toggle span.pf-v6-c-menu-toggle__text {
     width: 200px;
     text-align: left;
 }

--- a/ui/ui-app/src/app/pages/search/components/toolbar/SearchPageToolbar.css
+++ b/ui/ui-app/src/app/pages/search/components/toolbar/SearchPageToolbar.css
@@ -7,7 +7,7 @@
     width: 100%;
 }
 
-.search-toolbar .filter-types-toggle span.pf-v5-c-menu-toggle__text {
+.search-toolbar .filter-types-toggle span.pf-v6-c-menu-toggle__text {
     width: 125px;
     text-align: left;
 }

--- a/ui/ui-app/src/app/pages/version/VersionPage.css
+++ b/ui/ui-app/src/app/pages/version/VersionPage.css
@@ -7,7 +7,7 @@ div.artifact-page-tabs > ul > li.pf-v6-c-tabs__item.pf-m-current > button.pf-v6-
     flex-direction: column;
 }
 
-.artifact-details-main .pf-c-tab-content,
+.artifact-details-main .pf-v6-c-tab-content,
 .artifact-details-main .pf-v6-c-tab-content {
     flex-grow: 1;
     display: flex;

--- a/ui/ui-app/src/app/pages/version/VersionPage.css
+++ b/ui/ui-app/src/app/pages/version/VersionPage.css
@@ -22,7 +22,7 @@ div.artifact-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs
     padding: 12px 24px 0;
 }
 
-.pf-v5-c-breadcrumb__item-divider {
+.pf-v6-c-breadcrumb__item-divider {
     color: #666;
 }
 

--- a/ui/ui-app/src/app/pages/version/VersionPage.css
+++ b/ui/ui-app/src/app/pages/version/VersionPage.css
@@ -1,4 +1,4 @@
-div.artifact-page-tabs > ul > li.pf-c-tabs__item.pf-m-current > button.pf-c-tabs__button::before {
+div.artifact-page-tabs > ul > li.pf-v6-c-tabs__item.pf-m-current > button.pf-v6-c-tabs__link::before {
     border-bottom-color: transparent;
 }
 

--- a/ui/ui-app/src/app/pages/version/components/tabs/ReferenceGraphView.css
+++ b/ui/ui-app/src/app/pages/version/components/tabs/ReferenceGraphView.css
@@ -1,9 +1,9 @@
 .reference-graph-container {
     height: 500px;
     width: 100%;
-    border: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
     border-radius: 4px;
-    background: var(--pf-v5-global--BackgroundColor--100, #ffffff);
+    background: var(--pf-t--global--background--color--primary--default, #ffffff);
     position: relative;
 }
 
@@ -14,25 +14,25 @@
     justify-content: center;
     height: 300px;
     gap: 16px;
-    color: var(--pf-v5-global--Color--200, #6a6e73);
+    color: var(--pf-t--global--text--color--secondary--default, #6a6e73);
 }
 
 /* Override React Flow default styles to match PatternFly */
 .reference-graph-container .react-flow__controls {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
     border-radius: 4px;
-    border: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
 }
 
 .reference-graph-container .react-flow__controls-button {
-    background: var(--pf-v5-global--BackgroundColor--100, #ffffff);
-    border-bottom: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+    background: var(--pf-t--global--background--color--primary--default, #ffffff);
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
     width: 28px;
     height: 28px;
 }
 
 .reference-graph-container .react-flow__controls-button:hover {
-    background: var(--pf-v5-global--BackgroundColor--200, #f0f0f0);
+    background: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
 }
 
 .reference-graph-container .react-flow__controls-button:last-child {
@@ -40,7 +40,7 @@
 }
 
 .reference-graph-container .react-flow__minimap {
-    border: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
     border-radius: 4px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
@@ -51,12 +51,12 @@
 
 /* Edge styling */
 .reference-graph-container .react-flow__edge-path {
-    stroke: var(--pf-v5-global--BorderColor--200, #8a8d90);
+    stroke: var(--pf-t--global--border--color--100, #8a8d90);
     stroke-width: 1.5;
 }
 
 .reference-graph-container .react-flow__edge.selected .react-flow__edge-path {
-    stroke: var(--pf-v5-global--primary-color--100, #0066cc);
+    stroke: var(--pf-t--global--color--brand--default, #0066cc);
     stroke-width: 2;
 }
 
@@ -65,15 +65,15 @@
     position: absolute;
     bottom: 12px;
     right: 12px;
-    background: var(--pf-v5-global--BackgroundColor--100, #ffffff);
-    border: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+    background: var(--pf-t--global--background--color--primary--default, #ffffff);
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
     border-radius: 4px;
     padding: 8px 12px;
     display: flex;
     flex-direction: column;
     gap: 6px;
     font-size: 11px;
-    color: var(--pf-v5-global--Color--200, #6a6e73);
+    color: var(--pf-t--global--text--color--secondary--default, #6a6e73);
     z-index: 5;
 }
 
@@ -87,22 +87,22 @@
     width: 12px;
     height: 12px;
     border-radius: 2px;
-    border: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
 }
 
 .legend-color.root {
-    background: var(--pf-v5-global--BackgroundColor--light-200, #fafafa);
-    border-color: var(--pf-v5-global--primary-color--100, #0066cc);
+    background: var(--pf-t--global--background--color--secondary--default, #fafafa);
+    border-color: var(--pf-t--global--color--brand--default, #0066cc);
     border-width: 2px;
 }
 
 .legend-color.reference {
-    background: var(--pf-v5-global--BackgroundColor--100, #ffffff);
+    background: var(--pf-t--global--background--color--primary--default, #ffffff);
 }
 
 .legend-color.cycle {
-    background: var(--pf-v5-global--BackgroundColor--100, #ffffff);
-    border-color: var(--pf-v5-global--danger-color--100, #c9190b);
+    background: var(--pf-t--global--background--color--primary--default, #ffffff);
+    border-color: var(--pf-t--global--color--status--danger--default, #c9190b);
     border-width: 2px;
 }
 
@@ -120,7 +120,7 @@
     width: 100vw;
     height: 100vh;
     z-index: 1000;
-    background: var(--pf-v5-global--BackgroundColor--100, #ffffff);
+    background: var(--pf-t--global--background--color--primary--default, #ffffff);
 }
 
 .reference-graph-wrapper.fullscreen .reference-graph-container {
@@ -132,13 +132,13 @@
 /* Graph controls toolbar */
 .graph-controls-toolbar {
     padding: 8px 16px;
-    border-bottom: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
-    background: var(--pf-v5-global--BackgroundColor--100, #ffffff);
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    background: var(--pf-t--global--background--color--primary--default, #ffffff);
 }
 
 .depth-label {
     font-weight: 500;
-    color: var(--pf-v5-global--Color--100, #151515);
+    color: var(--pf-t--global--text--color--primary--default, #151515);
 }
 
 .depth-slider-item {
@@ -151,7 +151,7 @@
 
 .hint-text {
     font-size: 12px;
-    color: var(--pf-v5-global--Color--200, #6a6e73);
+    color: var(--pf-t--global--text--color--secondary--default, #6a6e73);
     font-style: italic;
 }
 
@@ -159,8 +159,8 @@
 .graph-action-panel {
     display: flex;
     gap: 4px;
-    background: var(--pf-v5-global--BackgroundColor--100, #ffffff);
-    border: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+    background: var(--pf-t--global--background--color--primary--default, #ffffff);
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
     border-radius: 4px;
     padding: 4px;
 }
@@ -175,8 +175,8 @@
     position: absolute;
     top: 12px;
     left: 12px;
-    background: var(--pf-v5-global--BackgroundColor--100, #ffffff);
-    border: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+    background: var(--pf-t--global--background--color--primary--default, #ffffff);
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
     border-radius: 4px;
     padding: 12px;
     min-width: 250px;
@@ -191,9 +191,9 @@
     gap: 8px;
     margin-bottom: 12px;
     padding-bottom: 8px;
-    border-bottom: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
     font-weight: 600;
-    color: var(--pf-v5-global--Color--100, #151515);
+    color: var(--pf-t--global--text--color--primary--default, #151515);
 }
 
 .node-details-header button {
@@ -201,6 +201,6 @@
 }
 
 .cycle-warning {
-    color: var(--pf-v5-global--danger-color--100, #c9190b);
+    color: var(--pf-t--global--color--status--danger--default, #c9190b);
     font-weight: 500;
 }

--- a/ui/ui-app/src/app/pages/version/components/tabs/ReferenceGraphView.css
+++ b/ui/ui-app/src/app/pages/version/components/tabs/ReferenceGraphView.css
@@ -51,7 +51,7 @@
 
 /* Edge styling */
 .reference-graph-container .react-flow__edge-path {
-    stroke: var(--pf-t--global--border--color--100, #8a8d90);
+    stroke: var(--pf-t--global--border--color--300, #8a8d90);
     stroke-width: 1.5;
 }
 

--- a/ui/ui-app/src/app/pages/version/components/tabs/ReferencesToolbar.css
+++ b/ui/ui-app/src/app/pages/version/components/tabs/ReferencesToolbar.css
@@ -8,7 +8,7 @@
     width: 100%;
 }
 
-.references-toolbar .filter-types-toggle span.pf-v5-c-menu-toggle__text {
+.references-toolbar .filter-types-toggle span.pf-v6-c-menu-toggle__text {
     width: 125px;
     text-align: left;
 }
@@ -21,7 +21,7 @@
     margin-left: 16px;
 }
 
-.references-toolbar .view-mode-toggle-item .pf-v5-c-toggle-group__button {
+.references-toolbar .view-mode-toggle-item .pf-v6-c-toggle-group__button {
     padding-left: 12px;
     padding-right: 12px;
 }


### PR DESCRIPTION
Fixes #9400

Replaces all remaining `pf-v5-c-*` CSS classes with `pf-v6-c-*` and legacy `--pf-v5-global--*` design tokens with PatternFly 6 semantic tokens (`--pf-t--global--*`) across the 17 stylesheets in `ui/ui-app`. This restores styling fidelity for borders, backgrounds, and structural components (like breadcrumb dividers and graph views) that degraded during the PF5 -> PF6 migration.