### PR TITLE
fix(backend): Explicitly throw RegistryException on content canonical…

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryContentUtils.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryContentUtils.java
@@ -238,10 +238,8 @@ public class RegistryContentUtils {
             return artifactTypeUtilProviderFactory.getArtifactTypeProvider(artifactType).getContentCanonicalizer()
                     .canonicalize(content, recursivelyResolvedReferences);
         } catch (Exception ex) {
-            // TODO: We should consider explicitly failing when a content could not be canonicalized.
-            // throw new RegistryException("Failed to canonicalize content.", ex);
-            log.debug("Failed to canonicalize content: {}", content.getContent());
-            return content;
+            log.debug("Failed to canonicalize content.", ex);
+            throw new RegistryException("Failed to canonicalize content.", ex);
         }
     }
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryStorageContentUtils.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/RegistryStorageContentUtils.java
@@ -41,10 +41,8 @@ public class RegistryStorageContentUtils {
             return factory.getArtifactTypeProvider(artifactType).getContentCanonicalizer()
                     .canonicalize(content, resolvedReferences);
         } catch (Exception ex) {
-            // TODO: We should consider explicitly failing when a content could not be canonicalized.
-            // throw new RegistryException("Failed to canonicalize content.", ex);
-            log.debug("Failed to canonicalize content: {}", artifactType);
-            return content;
+            log.debug("Failed to canonicalize content: {}", artifactType, ex);
+            throw new RegistryException("Failed to canonicalize content.", ex);
         }
     }
 


### PR DESCRIPTION
### Description
In `RegistryStorageContentUtils.java` and `RegistryContentUtils.java`, when `canonicalizeContent` encounters an exception during schema parsing/canonicalization (e.g., due to malformed AST or unresolvable nested references), the system catches the exception, emits a `debug` log, and silently falls back to returning the raw, un-canonicalized content.

This is highly problematic for data integrity in the storage layer:
1. **Deduplication Failure**: Content IDs and hashes are computed on this output. By silently falling back to raw content, structurally identical schemas with differing whitespace/metadata will yield different SHA-256 hashes, bypassing the deduplication mechanism and causing storage bloat.
2. **Silent State Corruption**: The REST API effectively swallows fundamental structural errors in the uploaded artifact, masking the failure from the client.

### Proposed Solution
This PR hardens the canonicalization path by removing the silent fallback. We now throw a `RegistryException` when content fails to canonicalize, ensuring the storage layer maintains strict content hashing and deduplication integrity.
