### PR TITLE
test(mcp): add comprehensive edge-case tests for MCP_TOOL validation and compatibility

### DIFF
--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -344,4 +344,92 @@ class McpToolCompatibilityCheckerTest {
 
         assertTrue(result.isCompatible(), "Identical schema with description change should be fully compatible");
     }
+
+    @Test
+    void testForwardCompatibleRemovingOptionalProperty() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" },
+                            "limit": { "type": "integer" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        // Proposed removes optional "limit" - forward incompatible (producers using new version
+        // won't send "limit" but old consumers might need it)
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult backwardResult = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(backwardResult.isCompatible(),
+                "Removing any property should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardCompatibleNoChanges() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "description": "A tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(existing), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Identical schemas should be backward compatible");
+    }
+
+    @Test
+    void testIncompatibleWithParseError() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": { "type": "object" }
+                }
+                """;
+
+        String malformed = "{ this is not valid json }";
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(TypedContent.create(
+                        io.apicurio.registry.content.ContentHandle.create(existing),
+                        ContentTypes.APPLICATION_JSON)),
+                TypedContent.create(
+                        io.apicurio.registry.content.ContentHandle.create(malformed),
+                        ContentTypes.APPLICATION_JSON),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Malformed proposed content should be incompatible");
+    }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
@@ -8,7 +8,9 @@ import io.apicurio.registry.rules.violation.RuleViolationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.apicurio.registry.rest.v3.beans.ArtifactReference;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Tests the MCP tool content validator, accepter, and extractor.
@@ -131,5 +133,60 @@ public class McpToolContentValidatorTest extends ArtifactUtilProviderTestBase {
         TypedContent content = resourceToTypedContentHandle("mcptool-invalid-json.json");
         McpToolContentValidator validator = new McpToolContentValidator();
         validator.validate(ValidityLevel.NONE, content, Collections.emptyMap());
+    }
+
+    @Test
+    public void testMcpToolEmptyName() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-empty-name.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+    }
+
+    @Test
+    public void testMcpToolInvalidPriority() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-invalid-priority.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+    }
+
+    @Test
+    public void testMcpToolInvalidOutputSchema() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-invalid-outputschema.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+    }
+
+    @Test
+    public void testMcpToolInvalidRequiredArray() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-invalid-required-array.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+    }
+
+    @Test
+    public void testMcpToolReferencesRejected() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-valid.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        ArtifactReference ref = new ArtifactReference();
+        ref.setName("some-ref");
+        Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validateReferences(content, List.of(ref));
+        }, "MCP tool definitions should not support references");
+    }
+
+    @Test
+    public void testMcpToolSyntaxOnlyPassesStructurallyInvalid() throws Exception {
+        // Valid JSON object but missing required MCP fields - SYNTAX_ONLY should pass
+        TypedContent content = resourceToTypedContentHandle("mcptool-missing-inputschema.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        validator.validate(ValidityLevel.SYNTAX_ONLY, content, Collections.emptyMap());
     }
 }

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-empty-name.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-empty-name.json
@@ -1,0 +1,6 @@
+{
+  "name": "   ",
+  "inputSchema": {
+    "type": "object"
+  }
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-outputschema.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-outputschema.json
@@ -1,0 +1,7 @@
+{
+  "name": "outputschema_tool",
+  "inputSchema": {
+    "type": "object"
+  },
+  "outputSchema": "this-should-be-an-object"
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-priority.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-priority.json
@@ -1,0 +1,9 @@
+{
+  "name": "priority_tool",
+  "inputSchema": {
+    "type": "object"
+  },
+  "annotations": {
+    "priority": 1.5
+  }
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-required-array.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-required-array.json
@@ -1,0 +1,10 @@
+{
+  "name": "required_tool",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "query": { "type": "string" }
+    },
+    "required": [42, true]
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive edge-case unit tests for `MCP_TOOL` artifact type
validation and compatibility checking, as part of Issue #9406.

## Changes

### New Test Fixtures
- `mcptool-empty-name.json` - whitespace-only name
- `mcptool-invalid-priority.json` - priority > 1.0 (out of range)
- `mcptool-invalid-outputschema.json` - non-object outputSchema
- `mcptool-invalid-required-array.json` - non-string entries in required array

### McpToolContentValidatorTest (6 new tests)
- Empty/whitespace name rejection
- Priority out-of-bounds (> 1.0) rejection
- Invalid outputSchema type rejection
- Non-string required array entries rejection
- References rejection via validateReferences()
- SYNTAX_ONLY level passes structurally invalid but JSON-valid content

### McpToolCompatibilityCheckerTest (3 new tests)
- Removing optional property is backward incompatible
- Identical schemas are always compatible
- Malformed proposed JSON is always incompatible

Closes #9406