### PR TITLE
docs: fix examples/docker-compose README paths and .yml file extensions

### DIFF
--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -15,14 +15,14 @@ Install *Docker*. You can either build *Apicurio Registry* images locally
 or use the pre-built images from a public registry.
 
 In order to provide configuration files to the containers, create a *config* docker volume `docker volume create config` 
-and copy the content of the `./config` directory to the volume - `docker volume inspect config | jq -r '.[0].Mountpoint'`.
+and copy the content of the `./src/main/resources/config` directory to the volume - `docker volume inspect config | jq -r '.[0].Mountpoint'`.
 
 ## Use-cases
 
 ### Metrics with Prometheus and Grafana
 
-Run `compose-metrics.yaml` together with a base compose file, e.g. 
-`docker compose -f compose-metrics.yaml -f compose-base-sql.yaml up --abort-on-container-exit`.
+Run `compose-metrics.yml` together with a base compose file, e.g. 
+`docker compose -f compose-metrics.yml -f compose-base-sql.yml up --abort-on-container-exit`.
 
 *Grafana* console should be available at `http://localhost:3000` after logging in as *admin/password*.
 


### PR DESCRIPTION
Fixes #9355

This PR updates the `examples/docker-compose/README.md` to accurately reflect the configuration directory path (`./src/main/resources/config`) and corrects the Docker Compose file extensions from `.yaml` to `.yml`, ensuring the documented commands execute correctly.

---

*Note to Maintainers:*
Hello! I am highly interested in the Apicurio Registry project and have recently applied to contribute through the LFX Mentorship program. I am very eager to dive deeper into the codebase, help resolve open issues, and I would love the opportunity to join your organization as an active contributor. Thank you for your time and for maintaining such an excellent project!