### PR TITLE
fix(schema-util): remove unchecked generic varargs warning in unionOf

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AbstractCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AbstractCompatibilityChecker.java
@@ -95,11 +95,9 @@ public abstract class AbstractCompatibilityChecker<D> implements CompatibilityCh
 
     protected abstract CompatibilityDifference transform(D original);
 
-    private Set<D> unionOf(Set<D>... from) {
-        Set<D> rval = new HashSet<>();
-        for (Set<D> f : from) {
-            rval.addAll(f);
-        }
+    private Set<D> unionOf(Set<D> first, Set<D> second) {
+        Set<D> rval = new HashSet<>(first);
+        rval.addAll(second);
         return rval;
     }
 


### PR DESCRIPTION
## What

`AbstractCompatibilityChecker.unionOf` took a generic varargs parameter:

```java
private Set<D> unionOf(Set<D>... from) {
```

`Set<D>` isn't reifiable, so the compiler has to create a generic array for the varargs and emits an `unchecked` warning at every call site. The method carried neither `@SafeVarargs` nor `@SuppressWarnings`, so the warning shows up on an ordinary build.

## Why this shape

Both callers — the `FULL` and `FULL_TRANSITIVE` branches of `testCompatibility` — pass exactly two sets, so the varargs was never buying anything. Taking two explicit `Set<D>` parameters removes the warning at the source rather than suppressing it, and keeps the method honest about what it actually accepts.

```java
private Set<D> unionOf(Set<D> first, Set<D> second) {
    Set<D> rval = new HashSet<>(first);
    rval.addAll(second);
    return rval;
}
```

Behaviour is unchanged: the result is still a new `HashSet` containing the union of the two inputs, and neither argument is mutated.

Fixes #8905

## Testing

- `./mvnw checkstyle:check -pl schema-util/common` passes.
- `./mvnw test-compile -pl schema-util/common -am -DskipTests` compiles cleanly (JDK 21+, per the build enforcer).
- Verified `unionOf` has exactly two call sites repo-wide (`AbstractCompatibilityChecker` lines 52 and 59), both passing exactly two arguments, so the narrowed signature covers every use. The method is `private`, so there are no external callers or subclass overrides.

No behavioural change, so no new tests — this removes a compiler warning and the existing compatibility-checker tests continue to cover the `FULL` / `FULL_TRANSITIVE` paths that call it.

## Note on history

This change was originally part of #8912, which I closed to respect the one-open-PR-per-contributor rule, and it then travelled into #8917 by accident when I branched from the wrong base. @paoloantinori reviewed it there, confirmed the change itself looks fine, and suggested splitting it into its own PR — this is that split. Apologies to @ajmani-x, who offered to pick this up on the issue a few days ago; I'd already implemented it and committed to resubmitting it here, so I've gone ahead, but I'm happy to defer to your version if you'd prefer.
