### PR TITLE
test(cli): prevent vacuous type-filter search assertion

### DIFF
--- a/cli/src/test/java/io/apicurio/registry/cli/SearchCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/SearchCommandTest.java
@@ -194,6 +194,7 @@ public class SearchCommandTest extends AbstractCLITest {
 
         assertThat(results.getArtifacts())
                 .as(withCliOutput("Type-filtered search should return JSON artifacts"))
+                .isNotEmpty()
                 .allMatch(a -> "JSON".equals(a.getArtifactType()));
     }
 


### PR DESCRIPTION
The current test uses `allMatch()`, which can pass even when the search returns no artifacts. This means the test may not catch a problem with the type filter.
I added `isNotEmpty()` before `allMatch()` so the test now checks that:
1. The search returns at least one artifact.
2. All returned artifacts have the expected `JSON` type.

This also follows the same pattern used by the other search tests in the file.
