### PR TITLE
feat(cli): print raw request and response details with --verbose

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -192,6 +192,29 @@ Use `--verbose` to enable debug logging:
 acr --verbose artifact get my-artifact -g my-group
 ```
 
+Verbose output includes the raw request and response of every Registry call, with requests
+prefixed by `>` and responses by `<`:
+
+```
+HTTP request:
+> GET http://localhost:8080/apis/registry/v3/groups/my-group
+> Authorization: <redacted>
+
+HTTP response:
+< 200 OK
+< Content-Type: application/json
+<
+< {"groupId":"my-group", ...}
+```
+
+Headers that carry credentials (`Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`)
+are redacted, and bodies longer than 8192 characters are truncated. HTTP traffic is logged under
+the `io.apicurio.registry.client.http` category, so it can be quieted on its own:
+
+```bash
+acr config set 'quarkus.log.category."io.apicurio.registry.client.http".level=WARNING'
+```
+
 Verbose output can be noisy. To quiet a specific package while keeping the rest, set a
 per-package level using the `quarkus.log.category."<package>".level` config key:
 
@@ -482,7 +505,7 @@ All filters are optional and can be combined. Additional filters include `--desc
 
 These options work with most commands:
 
-- `--verbose, -v` - Enable verbose output for debugging
+- `--verbose, -v` - Enable verbose output for debugging, including raw HTTP requests and responses
 - `--help, -h` - Show help information
 - `--output-type, -o` - Set output format (table or json)
 

--- a/cli/src/main/java/io/apicurio/registry/cli/Acr.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/Acr.java
@@ -61,7 +61,7 @@ public class Acr {
 
     @Option(
             names = {"--verbose"},
-            description = "Enable verbose output.",
+            description = "Enable verbose output, including the raw request and response of every Registry call.",
             scope = INHERIT
     )
     @Getter

--- a/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/AbstractCommand.java
@@ -46,7 +46,9 @@ public abstract class AbstractCommand implements Callable<Integer> {
     public Integer call() {
         var output = new OutputBuffer(config.getStdOut(), config.getStdErr());
         try {
-            configureLogging();
+            var verbose = isVerbose();
+            configureLogging(verbose);
+            client.setHttpLoggingEnabled(verbose);
             updateNotifier.checkAndNotify(getTopLevelCommandName());
             run(output);
             return OK_RETURN_CODE;
@@ -103,6 +105,10 @@ public abstract class AbstractCommand implements Callable<Integer> {
     private static final String LOG_CATEGORY_PREFIX = "quarkus.log.category.\"";
     private static final String LOG_CATEGORY_SUFFIX = "\".level";
 
+    private boolean isVerbose() {
+        return spec.root().userObject() instanceof Acr acr && acr.isVerbose();
+    }
+
     /**
      * Configures logging for the current command.
      * <p>
@@ -115,9 +121,8 @@ public abstract class AbstractCommand implements Callable<Integer> {
      * and Quarkus resolves {@code quarkus.log.*} at build time, so per-package levels in the CLI
      * config are never picked up by Quarkus's own logging setup.
      */
-    private void configureLogging() {
-        var root = spec.root().userObject();
-        if (!(root instanceof Acr acr) || !acr.isVerbose()) {
+    private void configureLogging(boolean verbose) {
+        if (!verbose) {
             return;
         }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/services/Client.java
@@ -12,6 +12,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import lombok.Setter;
 
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +41,13 @@ public class Client {
 
     private HttpClient httpClient;
 
+    /**
+     * Set from {@code --verbose}, before the command runs. Makes the Registry client log the raw
+     * request and response of every call it makes.
+     */
+    @Setter
+    private boolean httpLoggingEnabled;
+
     public RegistryClient getRegistryClient() {
         var currentContext = config.read();
         if (isBlank(currentContext.getCurrentContext())) {
@@ -54,6 +62,9 @@ public class Client {
                         uri = uri.resolve("/apis/registry/v3");
                     }
                     final var options = RegistryClientOptions.create(uri.toString(), vertx);
+                    if (httpLoggingEnabled) {
+                        options.enableHttpLogging();
+                    }
                     final var context = currentContext.getContext().get(currentContext.getCurrentContext());
                     configureAuth(options, context, currentContext.getCurrentContext());
                     registryClient = RegistryClientFactory.create(options);
@@ -116,5 +127,6 @@ public class Client {
     public void reset() {
         registryClient = null;
         httpClient = null;
+        httpLoggingEnabled = false;
     }
 }

--- a/cli/src/test/java/io/apicurio/registry/cli/VerboseHttpLoggingTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/VerboseHttpLoggingTest.java
@@ -1,0 +1,177 @@
+package io.apicurio.registry.cli;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.apicurio.registry.cli.config.Config;
+import io.apicurio.registry.cli.services.Client;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code --verbose} makes the CLI log the raw request and response of a Registry call.
+ */
+@QuarkusTest
+public class VerboseHttpLoggingTest {
+
+    private static final String HTTP_LOGGER = "io.apicurio.registry.client.http";
+
+    private static final String GROUP_PATH = "/apis/registry/v3/groups/test-group";
+
+    private static final String GROUP_BODY = """
+            {"groupId":"test-group","description":"A test group",\
+            "createdOn":"2026-01-01T00:00:00Z","owner":"tester",\
+            "modifiedOn":"2026-01-01T00:00:00Z","modifiedBy":"tester","labels":{}}""";
+
+    private static final String CONFIG_JSON = """
+            {
+              "installation-version": 1,
+              "config": {
+                "update.check-enabled": "false"
+              },
+              "context": {}
+            }""";
+
+    private static WireMockServer wireMock;
+
+    @TempDir
+    Path acrHome;
+
+    @Inject
+    Config config;
+
+    @Inject
+    Client client;
+
+    @Inject
+    CommandLine.IFactory factory;
+
+    private final List<String> logged = new CopyOnWriteArrayList<>();
+
+    private CommandLine cmd;
+    private StringWriter out;
+    private StringWriter err;
+    private Handler captureHandler;
+    private Level originalRootLevel;
+    private Level originalHttpLevel;
+
+    @BeforeAll
+    public static void startWireMock() {
+        wireMock = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMock.start();
+    }
+
+    @AfterAll
+    public static void stopWireMock() {
+        if (wireMock != null) {
+            wireMock.stop();
+        }
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        wireMock.resetAll();
+        wireMock.stubFor(get(urlEqualTo(GROUP_PATH))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(GROUP_BODY)));
+
+        Files.writeString(acrHome.resolve("config.json"), CONFIG_JSON);
+        config.reset();
+        config.setAcrCurrentHomePath(acrHome);
+        client.reset();
+
+        originalRootLevel = Logger.getLogger("").getLevel();
+        originalHttpLevel = Logger.getLogger(HTTP_LOGGER).getLevel();
+        captureHandler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logged.add(record.getMessage());
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        captureHandler.setLevel(Level.ALL);
+        Logger.getLogger(HTTP_LOGGER).addHandler(captureHandler);
+        // Enabled up front, so that a test without records proves the interceptor was not installed,
+        // rather than that the logger happened to be too coarse.
+        Logger.getLogger(HTTP_LOGGER).setLevel(Level.FINE);
+
+        cmd = new CommandLine(new Acr(), factory);
+        out = new StringWriter();
+        err = new StringWriter();
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(err));
+        config.setStdOut(value -> out.write(value));
+        config.setStdErr(value -> err.write(value));
+
+        assertThat(cmd.execute("context", "create", "test", "http://localhost:" + wireMock.port())).isZero();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Logger.getLogger(HTTP_LOGGER).removeHandler(captureHandler);
+        Logger.getLogger(HTTP_LOGGER).setLevel(originalHttpLevel);
+        Logger.getLogger("").setLevel(originalRootLevel);
+        logged.clear();
+        config.reset();
+        client.reset();
+    }
+
+    @Test
+    public void verboseLogsRawRequestAndResponse() {
+        assertThat(cmd.execute("--verbose", "group", "get", "test-group")).isZero();
+
+        var request = recordStartingWith("HTTP request:");
+        assertThat(request).contains("> GET http://localhost:" + wireMock.port() + GROUP_PATH);
+
+        var response = recordStartingWith("HTTP response:");
+        assertThat(response).contains("< 200 OK");
+        assertThat(response).contains("< Content-Type: application/json");
+        assertThat(response).contains("< " + GROUP_BODY);
+    }
+
+    @Test
+    public void withoutVerboseNothingIsLogged() {
+        assertThat(cmd.execute("group", "get", "test-group")).isZero();
+
+        assertThat(logged).isEmpty();
+    }
+
+    private String recordStartingWith(String prefix) {
+        return logged.stream()
+                .filter(record -> record.startsWith(prefix))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "No log record starting with '" + prefix + "' in " + logged));
+    }
+}

--- a/java-sdk/adapter-vertx/pom.xml
+++ b/java-sdk/adapter-vertx/pom.xml
@@ -36,5 +36,11 @@
       <artifactId>vertx-auth-oauth2</artifactId>
       <optional>true</optional>
     </dependency>
+    <!-- Test only -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/HttpLoggingInterceptor.java
+++ b/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/HttpLoggingInterceptor.java
@@ -1,0 +1,135 @@
+package io.apicurio.registry.client.common;
+
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.impl.HttpContext;
+import io.vertx.ext.web.client.impl.WebClientInternal;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A {@link WebClient} interceptor that logs the raw HTTP request and response of every call.
+ *
+ * <p>The request is logged just before it is sent, so the headers include everything added by
+ * the client itself, and the response is logged when it is dispatched back to the caller.
+ * Requests are prefixed with {@code >} and responses with {@code <}.</p>
+ *
+ * <p>Headers listed in {@link #REDACTED_HEADERS} never have their value logged, and bodies longer
+ * than {@link #MAX_BODY_CHARS} are truncated so that large artifact content does not flood the log.</p>
+ */
+final class HttpLoggingInterceptor implements Handler<HttpContext<?>> {
+
+    /**
+     * Dedicated logger name, so that HTTP traffic can be enabled or quieted independently of the
+     * rest of the SDK.
+     */
+    static final String LOGGER_NAME = "io.apicurio.registry.client.http";
+
+    private static final Logger log = Logger.getLogger(LOGGER_NAME);
+
+    /** Headers that carry credentials, and whose values are therefore never logged. */
+    private static final Set<String> REDACTED_HEADERS = Set.of(
+            "authorization", "proxy-authorization", "cookie", "set-cookie");
+
+    private static final String REDACTED_VALUE = "<redacted>";
+
+    private static final int MAX_BODY_CHARS = 8192;
+
+    /**
+     * Installs the interceptor on the given client. Clients that are not built on top of the Vert.x
+     * web client implementation do not support interceptors, in which case logging is skipped.
+     *
+     * @param webClient the client to log the traffic of
+     */
+    static void install(WebClient webClient) {
+        if (webClient instanceof WebClientInternal internal) {
+            internal.addInterceptor(new HttpLoggingInterceptor());
+        } else {
+            log.log(Level.WARNING, "HTTP logging was enabled, but the web client implementation {0} "
+                    + "does not support interceptors. No HTTP traffic will be logged.",
+                    webClient.getClass().getName());
+        }
+    }
+
+    @Override
+    public void handle(HttpContext<?> context) {
+        if (log.isLoggable(Level.FINE)) {
+            switch (context.phase()) {
+                case SEND_REQUEST -> log.fine(formatRequest(context));
+                case DISPATCH_RESPONSE -> log.fine(formatResponse(context.response()));
+                default -> {
+                    // Other phases carry no request or response details worth logging.
+                }
+            }
+        }
+        context.next();
+    }
+
+    private static String formatRequest(HttpContext<?> context) {
+        var request = context.clientRequest();
+        var out = new StringBuilder("HTTP request:\n");
+        out.append("> ").append(request.getMethod()).append(' ').append(request.absoluteURI()).append('\n');
+        appendHeaders(out, '>', request.headers());
+        appendBody(out, '>', bodyAsText(context.body()));
+        return out.toString();
+    }
+
+    private static String formatResponse(HttpResponse<?> response) {
+        var out = new StringBuilder("HTTP response:\n");
+        out.append("< ").append(response.statusCode());
+        if (response.statusMessage() != null) {
+            out.append(' ').append(response.statusMessage());
+        }
+        out.append('\n');
+        appendHeaders(out, '<', response.headers());
+        appendBody(out, '<', bodyAsText(response.bodyAsBuffer()));
+        return out.toString();
+    }
+
+    private static void appendHeaders(StringBuilder out, char prefix, MultiMap headers) {
+        if (headers == null) {
+            return;
+        }
+        for (Map.Entry<String, String> header : headers) {
+            var value = REDACTED_HEADERS.contains(header.getKey().toLowerCase(Locale.ROOT))
+                    ? REDACTED_VALUE : header.getValue();
+            out.append(prefix).append(' ').append(header.getKey()).append(": ").append(value).append('\n');
+        }
+    }
+
+    private static void appendBody(StringBuilder out, char prefix, String body) {
+        if (body == null || body.isEmpty()) {
+            return;
+        }
+        out.append(prefix).append('\n');
+        body.lines().forEach(line -> out.append(prefix).append(' ').append(line).append('\n'));
+    }
+
+    /**
+     * Renders a request or response body as text. Bodies that are not buffered, for example a
+     * streamed upload, are represented by their type only, because consuming them here would
+     * take them away from the client.
+     */
+    private static String bodyAsText(Object body) {
+        if (body == null) {
+            return null;
+        }
+        if (!(body instanceof Buffer buffer)) {
+            return "<" + body.getClass().getSimpleName() + ">";
+        }
+        var text = buffer.toString(StandardCharsets.UTF_8);
+        if (text.length() > MAX_BODY_CHARS) {
+            return text.substring(0, MAX_BODY_CHARS)
+                    + "... (truncated, " + text.length() + " characters total)";
+        }
+        return text;
+    }
+}

--- a/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/VertxAdapterFactory.java
+++ b/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/VertxAdapterFactory.java
@@ -44,19 +44,31 @@ public final class VertxAdapterFactory {
         Vertx vertxToUse = getVertx(options);
         WebClientOptions webClientOptions = buildWebClientOptions(options);
 
+        WebClient webClient;
         switch (options.getAuthType()) {
             case ANONYMOUS:
-                return createVertxAnonymous(vertxToUse, webClientOptions);
+                webClient = createVertxAnonymous(vertxToUse, webClientOptions);
+                break;
             case BASIC:
-                return createVertxBasicAuth(options.getUsername(), options.getPassword(), vertxToUse, webClientOptions);
+                webClient = createVertxBasicAuth(options.getUsername(), options.getPassword(), vertxToUse, webClientOptions);
+                break;
             case OAUTH2:
-                return createVertxOAuth2(options.getTokenEndpoint(), options.getClientId(),
+                webClient = createVertxOAuth2(options.getTokenEndpoint(), options.getClientId(),
                         options.getClientSecret(), options.getScope(), vertxToUse, webClientOptions);
+                break;
             case CUSTOM_WEBCLIENT:
-                return createVertxCustomWebClient(options);
+                webClient = createVertxCustomWebClient(options);
+                break;
             default:
                 throw new IllegalArgumentException("Unsupported authentication type: " + options.getAuthType());
         }
+
+        // Added last, so that headers contributed by the auth clients above are logged too.
+        if (options.isHttpLoggingEnabled()) {
+            HttpLoggingInterceptor.install(webClient);
+        }
+
+        return new VertXRequestAdapter(webClient);
     }
 
     private static Vertx getVertxFromCDI(String CDIClassName, String InstanceClassName) {
@@ -91,28 +103,25 @@ public final class VertxAdapterFactory {
         return DefaultVertxInstance.get();
     }
 
-    private static RequestAdapter createVertxAnonymous(Vertx vertx, WebClientOptions webClientOptions) {
-        WebClient webClient = webClientOptions == null ? WebClient.create(vertx) : WebClient.create(vertx, webClientOptions);
-        return new VertXRequestAdapter(webClient);
+    private static WebClient createVertxAnonymous(Vertx vertx, WebClientOptions webClientOptions) {
+        return webClientOptions == null ? WebClient.create(vertx) : WebClient.create(vertx, webClientOptions);
     }
 
-    private static RequestAdapter createVertxBasicAuth(String username, String password, Vertx vertx, WebClientOptions webClientOptions) {
-        WebClient webClient = VertXAuthFactory.buildSimpleAuthWebClient(vertx, webClientOptions, username, password);
-        return new VertXRequestAdapter(webClient);
+    private static WebClient createVertxBasicAuth(String username, String password, Vertx vertx, WebClientOptions webClientOptions) {
+        return VertXAuthFactory.buildSimpleAuthWebClient(vertx, webClientOptions, username, password);
     }
 
-    private static RequestAdapter createVertxOAuth2(String tokenEndpoint,
+    private static WebClient createVertxOAuth2(String tokenEndpoint,
                                                      String clientId, String clientSecret, String scope, Vertx vertx, WebClientOptions webClientOptions) {
-        WebClient webClient = VertXAuthFactory.buildOIDCWebClient(vertx, webClientOptions, tokenEndpoint, clientId, clientSecret, scope);
-        return new VertXRequestAdapter(webClient);
+        return VertXAuthFactory.buildOIDCWebClient(vertx, webClientOptions, tokenEndpoint, clientId, clientSecret, scope);
     }
 
-    private static RequestAdapter createVertxCustomWebClient(RegistryClientOptions options) {
+    private static WebClient createVertxCustomWebClient(RegistryClientOptions options) {
         WebClient webClient = options.getWebClient();
         if (webClient == null) {
             throw new IllegalArgumentException("WebClient cannot be null");
         }
-        return new VertXRequestAdapter(webClient);
+        return webClient;
     }
 
     private static WebClientOptions buildWebClientOptions(RegistryClientOptions options) {

--- a/java-sdk/adapter-vertx/src/test/java/io/apicurio/registry/client/common/HttpLoggingInterceptorTest.java
+++ b/java-sdk/adapter-vertx/src/test/java/io/apicurio/registry/client/common/HttpLoggingInterceptorTest.java
@@ -1,0 +1,183 @@
+package io.apicurio.registry.client.common;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.web.client.WebClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies what {@link HttpLoggingInterceptor} logs for a real HTTP round trip.
+ */
+class HttpLoggingInterceptorTest {
+
+    private static final String RESPONSE_BODY = "{\"ok\":true}";
+
+    private static Vertx vertx;
+    private static HttpServer server;
+    private static int port;
+
+    private final List<String> logged = new CopyOnWriteArrayList<>();
+
+    private Logger logger;
+    private Handler captureHandler;
+    private Level originalLevel;
+    private boolean originalUseParentHandlers;
+
+    @BeforeAll
+    static void startServer() throws Exception {
+        vertx = Vertx.vertx();
+        server = vertx.createHttpServer()
+                .requestHandler(request -> request.body().onSuccess(body -> request.response()
+                        .setStatusCode(201)
+                        .putHeader("Content-Type", "application/json")
+                        .putHeader("Set-Cookie", "session=super-secret")
+                        .end(RESPONSE_BODY)))
+                .listen(0)
+                .toCompletionStage()
+                .toCompletableFuture()
+                .get(30, TimeUnit.SECONDS);
+        port = server.actualPort();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (server != null) {
+            server.close();
+        }
+        if (vertx != null) {
+            vertx.close();
+        }
+    }
+
+    @BeforeEach
+    void captureLogRecords() {
+        logger = Logger.getLogger(HttpLoggingInterceptor.LOGGER_NAME);
+        originalLevel = logger.getLevel();
+        originalUseParentHandlers = logger.getUseParentHandlers();
+        captureHandler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logged.add(record.getMessage());
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        captureHandler.setLevel(Level.ALL);
+        logger.addHandler(captureHandler);
+        logger.setLevel(Level.FINE);
+        logger.setUseParentHandlers(false);
+    }
+
+    @AfterEach
+    void restoreLogger() {
+        logger.removeHandler(captureHandler);
+        logger.setLevel(originalLevel);
+        logger.setUseParentHandlers(originalUseParentHandlers);
+        logged.clear();
+    }
+
+    @Test
+    void logsRequestMethodUrlHeadersAndBody() throws Exception {
+        post("/apis/registry/v3/groups", "{\"groupId\":\"g\"}");
+
+        var request = recordStartingWith("HTTP request:");
+        assertTrue(request.contains("> POST http://localhost:" + port + "/apis/registry/v3/groups"), request);
+        assertTrue(request.contains("> Content-Type: application/json"), request);
+        assertTrue(request.contains("> {\"groupId\":\"g\"}"), request);
+    }
+
+    @Test
+    void logsResponseStatusHeadersAndBody() throws Exception {
+        post("/apis/registry/v3/groups", "{\"groupId\":\"g\"}");
+
+        var response = recordStartingWith("HTTP response:");
+        assertTrue(response.contains("< 201 Created"), response);
+        assertTrue(response.contains("< Content-Type: application/json"), response);
+        assertTrue(response.contains("< " + RESPONSE_BODY), response);
+    }
+
+    @Test
+    void redactsCredentialHeaders() throws Exception {
+        post("/apis/registry/v3/groups", "{\"groupId\":\"g\"}");
+
+        var request = recordStartingWith("HTTP request:");
+        assertTrue(request.contains("> Authorization: <redacted>"), request);
+        assertFalse(request.contains("Bearer super-secret-token"), request);
+
+        var response = recordStartingWith("HTTP response:");
+        assertTrue(response.contains("< Set-Cookie: <redacted>"), response);
+        assertFalse(response.contains("session=super-secret"), response);
+    }
+
+    @Test
+    void truncatesLongBodies() throws Exception {
+        var body = "x".repeat(10_000);
+        post("/apis/registry/v3/groups", body);
+
+        var request = recordStartingWith("HTTP request:");
+        assertTrue(request.contains("... (truncated, 10000 characters total)"), request);
+        assertFalse(request.contains("x".repeat(8193)), request);
+    }
+
+    @Test
+    void logsNothingWhenNotInstalled() throws Exception {
+        var webClient = WebClient.create(vertx);
+        try {
+            webClient.post(port, "localhost", "/apis/registry/v3/groups")
+                    .sendBuffer(Buffer.buffer("{}"))
+                    .toCompletionStage()
+                    .toCompletableFuture()
+                    .get(30, TimeUnit.SECONDS);
+        } finally {
+            webClient.close();
+        }
+
+        assertEquals(List.of(), logged);
+    }
+
+    private void post(String path, String body) throws Exception {
+        var webClient = WebClient.create(vertx);
+        HttpLoggingInterceptor.install(webClient);
+        try {
+            webClient.post(port, "localhost", path)
+                    .putHeader("Content-Type", "application/json")
+                    .putHeader("Authorization", "Bearer super-secret-token")
+                    .sendBuffer(Buffer.buffer(body))
+                    .toCompletionStage()
+                    .toCompletableFuture()
+                    .get(30, TimeUnit.SECONDS);
+        } finally {
+            webClient.close();
+        }
+    }
+
+    private String recordStartingWith(String prefix) {
+        return logged.stream()
+                .filter(record -> record.startsWith(prefix))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No log record starting with '" + prefix + "' in " + logged));
+    }
+}

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientOptions.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientOptions.java
@@ -123,6 +123,8 @@ public class RegistryClientOptions {
     private HttpAdapterType httpAdapterType = HttpAdapterType.AUTO;
     // OpenTelemetry config
     private boolean otelEnabled = false;
+    // HTTP logging config
+    private boolean httpLoggingEnabled = false;
 
     private RegistryClientOptions() {
     }
@@ -269,6 +271,10 @@ public class RegistryClientOptions {
 
     public boolean isOtelEnabled() {
         return otelEnabled;
+    }
+
+    public boolean isHttpLoggingEnabled() {
+        return httpLoggingEnabled;
     }
 
     /**
@@ -827,6 +833,25 @@ public class RegistryClientOptions {
      */
     public RegistryClientOptions enableOpenTelemetry() {
         this.otelEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables logging of the raw HTTP requests and responses exchanged with the Registry.
+     * Every call is logged with its method, URL, headers and body, followed by the response
+     * status code, headers and body.
+     *
+     * <p>Records are written to the {@code io.apicurio.registry.client.http} logger at
+     * {@code FINE} level, so the logger has to be enabled for anything to be printed.
+     * Headers that carry credentials are redacted, and long bodies are truncated.</p>
+     *
+     * <p><strong>Note:</strong> this is currently implemented by the Vert.x adapter only.
+     * With the JDK adapter the option has no effect.</p>
+     *
+     * @return this builder
+     */
+    public RegistryClientOptions enableHttpLogging() {
+        this.httpLoggingEnabled = true;
         return this;
     }
 }


### PR DESCRIPTION
Fixes #8027 (item 8 of the parent epic #7162).

## What

`--verbose` now prints the raw HTTP exchange with the Registry: request method, URL, headers and body, and response status code, headers and body.

```
HTTP request:
> GET http://localhost:8080/apis/registry/v3/groups/my-group
> Authorization: <redacted>

HTTP response:
< 200 OK
< Content-Type: application/json
<
< {"groupId":"my-group", ...}
```

## Why

`--verbose` already raises log levels (#7641), but the Registry client itself logged nothing, so there was no way to see what the CLI actually sent or what came back. That is the first thing you want when debugging a failing call against a real server.

## How

The Kiota `RequestAdapter` only sees deserialized models, so it cannot show a raw response. The logging therefore sits at the HTTP layer, as a Vert.x web client interceptor:

- `RegistryClientOptions.enableHttpLogging()` — new opt-in flag, following the existing `enableOpenTelemetry()` pattern. Off by default, so nothing changes for existing SDK users.
- `HttpLoggingInterceptor` (adapter-vertx) — logs the request at `SEND_REQUEST` and the response at `DISPATCH_RESPONSE`. Installed after the auth web clients are built, so headers they contribute are logged too.
- The CLI turns the flag on when `--verbose` is set.

Records go to a dedicated `io.apicurio.registry.client.http` category at `FINE`, so HTTP traffic can be quieted on its own with the existing per-package config mechanism:

```bash
acr config set 'quarkus.log.category."io.apicurio.registry.client.http".level=WARNING'
```

The JDK adapter has no equivalent hook; the flag is a no-op there and the javadoc says so.

## Safety

- `Authorization`, `Proxy-Authorization`, `Cookie` and `Set-Cookie` values are replaced with `<redacted>`, so bearer tokens and basic credentials never reach the log.
- Bodies are truncated at 8192 characters, so artifact content does not flood the terminal.
- Non-buffered bodies (streamed uploads) are logged by type only, so they are not consumed away from the client.

## Tests

- `HttpLoggingInterceptorTest` (adapter-vertx, new test source set) — real HTTP round trip against a Vert.x server: asserts the logged method/URL/headers/body, the response status/headers/body, that credential headers are redacted, that a 10000 character body is truncated, and that nothing is logged when the interceptor is not installed.
- `VerboseHttpLoggingTest` (cli) — end-to-end through picocli against WireMock: `acr --verbose group get` logs the request and response, and the same command without `--verbose` logs nothing even with the category enabled.

Both are Docker-free. Full non-Docker CLI suite passes (102 tests), checkstyle clean on all touched modules.

## Notes for review

- `HttpLoggingInterceptor` uses `WebClientInternal.addInterceptor`, which lives in Vert.x's `impl` package. It is the only interceptor hook the web client offers, and it is what Vert.x's own OAuth2 and session-aware clients are built on. Guarded with an `instanceof` so a custom `WebClient` that is not a `WebClientBase` degrades to a warning instead of a `ClassCastException`.
- The `VertxAdapterFactory` diff looks larger than it is: the private `createVertx*` helpers now return `WebClient` instead of `RequestAdapter`, so the adapter can be constructed once after the interceptor is attached.
- I have not run a native CLI build locally; that path is covered in CI.
