### PR TITLE
ui: replace hardcoded colors with PatternFly theme tokens in PromptTemplateViewer.css

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.css
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateViewer.css
@@ -40,16 +40,16 @@
 }
 
 .prompt-template-viewer .template-variable {
-    background-color: #0066cc;
-    color: white;
+    background-color: var(--pf-t--global--color--brand--default);
+    color: var(--pf-t--global--text--color--inverse);
     padding: 1px 5px;
     border-radius: 3px;
     font-weight: 600;
 }
 
 .prompt-template-viewer .template-block {
-    background-color: #6a3d9a;
-    color: white;
+    background-color: var(--pf-t--global--color--purple--default);
+    color: var(--pf-t--global--text--color--inverse);
     padding: 1px 5px;
     border-radius: 3px;
     font-weight: 600;


### PR DESCRIPTION
## Description

The `PromptTemplateViewer.css` uses hardcoded hex values (`#0066cc` for variables and `#6a3d9a` for blocks) instead of PatternFly CSS tokens. This breaks dark mode compatibility and prevents custom theme adaptation.

This PR replaces the hardcoded hex colors with standard PatternFly theme tokens:
- `var(--pf-t--global--color--brand--default)`
- `var(--pf-t--global--color--purple--default)`
- `var(--pf-t--global--text--color--inverse)`

Fixes #9418

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Code style

## Verification
- Verified variable (`.template-variable`) and block (`.template-block`) highlights adapt to theme tokens consistent with lines 12, 31, 34, and 72 in `PromptTemplateViewer.css`.

Signed-off-by: Surbhi Agarwal <SurbhiAgarwal1@users.noreply.github.com>