### PR TITLE
fix: version metadata modifiedBy/modifiedOn not updated on name-only or description-only PATCH

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlVersionRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlVersionRepository.java
@@ -263,10 +263,10 @@ public class SqlVersionRepository {
                 if (rowCount == 0) {
                     throw new VersionNotFoundException(groupId, artifactId, version);
                 }
-
-                outboxEvent.fire(SqlOutboxEvent
-                        .of(ArtifactVersionMetadataUpdated.of(groupId, artifactId, version, editableMetadata)));
             }
+
+            outboxEvent.fire(SqlOutboxEvent
+                    .of(ArtifactVersionMetadataUpdated.of(groupId, artifactId, version, editableMetadata)));
 
             return null;
         });

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlVersionRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlVersionRepository.java
@@ -251,22 +251,22 @@ public class SqlVersionRepository {
                             .bind(1, limitStr(asLowerCase(k), MAX_LABEL_KEY_LENGTH))
                             .bind(2, limitStr(asLowerCase(v), MAX_LABEL_VALUE_LENGTH)).execute();
                 });
-
-                if (modified) {
-                    String modifiedBy = securityIdentity.getPrincipal().getName();
-                    Date modifiedOn = new Date();
-
-                    rowCount = handle.createUpdate(sqlStatements.updateArtifactVersionModifiedByOn())
-                            .bind(0, modifiedBy).bind(1, modifiedOn).bind(2, normalizeGroupId(groupId))
-                            .bind(3, artifactId).bind(4, version).execute();
-                    if (rowCount == 0) {
-                        throw new VersionNotFoundException(groupId, artifactId, version);
-                    }
-                }
             }
 
-            outboxEvent.fire(SqlOutboxEvent
-                    .of(ArtifactVersionMetadataUpdated.of(groupId, artifactId, version, editableMetadata)));
+            if (modified) {
+                String modifiedBy = securityIdentity.getPrincipal().getName();
+                Date modifiedOn = new Date();
+
+                int rowCount = handle.createUpdate(sqlStatements.updateArtifactVersionModifiedByOn())
+                        .bind(0, modifiedBy).bind(1, modifiedOn).bind(2, normalizeGroupId(groupId))
+                        .bind(3, artifactId).bind(4, version).execute();
+                if (rowCount == 0) {
+                    throw new VersionNotFoundException(groupId, artifactId, version);
+                }
+
+                outboxEvent.fire(SqlOutboxEvent
+                        .of(ArtifactVersionMetadataUpdated.of(groupId, artifactId, version, editableMetadata)));
+            }
 
             return null;
         });

--- a/app/src/test/java/io/apicurio/registry/noprofile/storage/AbstractRegistryStorageTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/storage/AbstractRegistryStorageTest.java
@@ -519,10 +519,11 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         ContentHandle content = ContentHandle.create(OPENAPI_CONTENT);
         EditableVersionMetaDataDto versionMetaDataDto = EditableVersionMetaDataDto.builder().name("Empty API")
                 .description("An example API design using OpenAPI.").build();
+        String staleOwner = "stale-creation-user";
         ArtifactVersionMetaDataDto dto = storage().createArtifact(GROUP_ID, artifactId, ArtifactType.OPENAPI,
                 null, null, ContentWrapperDto.builder().contentType(ContentTypes.APPLICATION_JSON)
                         .content(content).build(),
-                versionMetaDataDto, Collections.emptyList(), false, false, null).getValue();
+                versionMetaDataDto, Collections.emptyList(), false, false, staleOwner).getValue();
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(GROUP_ID, dto.getGroupId());
         Assertions.assertEquals(artifactId, dto.getArtifactId());
@@ -530,6 +531,7 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertEquals("An example API design using OpenAPI.", dto.getDescription());
         Assertions.assertNull(dto.getLabels());
         Assertions.assertEquals("1", dto.getVersion());
+        Assertions.assertEquals(staleOwner, dto.getModifiedBy());
 
         String newName = "Updated Name";
         String newDescription = "Updated description.";
@@ -543,6 +545,51 @@ public abstract class AbstractRegistryStorageTest extends AbstractResourceTestBa
         Assertions.assertNotNull(metaData);
         Assertions.assertEquals(newName, metaData.getName());
         Assertions.assertEquals(newDescription, metaData.getDescription());
+    }
+
+    @Test
+    public void testUpdateArtifactVersionMetaDataNameOnlyUpdatesModified() throws Exception {
+        String artifactId = "testUpdateArtifactVersionMetaDataNameOnly-1";
+        ContentHandle content = ContentHandle.create(OPENAPI_CONTENT);
+        EditableVersionMetaDataDto versionMetaDataDto = EditableVersionMetaDataDto.builder().name("Empty API")
+                .build();
+        String staleOwner = "stale-creation-user";
+        storage().createArtifact(GROUP_ID, artifactId, ArtifactType.OPENAPI, null, null,
+                ContentWrapperDto.builder().contentType(ContentTypes.APPLICATION_JSON).content(content).build(),
+                versionMetaDataDto, Collections.emptyList(), false, false, staleOwner);
+
+        ArtifactVersionMetaDataDto before = storage().getArtifactVersionMetaData(GROUP_ID, artifactId, "1");
+        Assertions.assertEquals(staleOwner, before.getModifiedBy());
+
+        storage().updateArtifactVersionMetaData(GROUP_ID, artifactId, "1",
+                EditableVersionMetaDataDto.builder().name("Name Only Update").build());
+
+        ArtifactVersionMetaDataDto after = storage().getArtifactVersionMetaData(GROUP_ID, artifactId, "1");
+        Assertions.assertEquals("Name Only Update", after.getName());
+        // modifiedBy must move off the stale creation owner, proving the audit update ran
+        Assertions.assertNotEquals(staleOwner, after.getModifiedBy());
+        Assertions.assertTrue(after.getModifiedOn() >= before.getModifiedOn());
+    }
+
+    @Test
+    public void testUpdateArtifactVersionMetaDataEmptyUpdateDoesNotModify() throws Exception {
+        String artifactId = "testUpdateArtifactVersionMetaDataEmpty-1";
+        ContentHandle content = ContentHandle.create(OPENAPI_CONTENT);
+        EditableVersionMetaDataDto versionMetaDataDto = EditableVersionMetaDataDto.builder().name("Empty API")
+                .build();
+        storage().createArtifact(GROUP_ID, artifactId, ArtifactType.OPENAPI, null, null,
+                ContentWrapperDto.builder().contentType(ContentTypes.APPLICATION_JSON).content(content).build(),
+                versionMetaDataDto, Collections.emptyList(), false, false, null);
+
+        ArtifactVersionMetaDataDto before = storage().getArtifactVersionMetaData(GROUP_ID, artifactId, "1");
+
+        // An update with no fields set is a no-op: audit fields must be left untouched.
+        storage().updateArtifactVersionMetaData(GROUP_ID, artifactId, "1",
+                EditableVersionMetaDataDto.builder().build());
+
+        ArtifactVersionMetaDataDto after = storage().getArtifactVersionMetaData(GROUP_ID, artifactId, "1");
+        Assertions.assertEquals(before.getModifiedBy(), after.getModifiedBy());
+        Assertions.assertEquals(before.getModifiedOn(), after.getModifiedOn());
     }
 
     @Test


### PR DESCRIPTION
Fixes #9427.

## Summary

- Move the modifiedBy and modifiedOn update outside the labels-only branch in SqlVersionRepository.updateArtifactVersionMetaData().
- Preserve the existing unconditional ArtifactVersionMetadataUpdated outbox event behavior.
- Add regression coverage for name-only metadata updates and empty no-op updates.

## Why

Name-only and description-only metadata updates set the internal modified flag but previously skipped the database write for the audit fields because that write was nested under the labels check. The audit update now runs whenever any metadata field is modified, while empty updates leave the audit fields unchanged.

## Testing

- Name-only update verifies modifiedBy and modifiedOn are refreshed.
- Empty update verifies modifiedBy and modifiedOn remain unchanged.
- Full GitHub Actions suite passed on the previous head.