### PR TITLE
Improve clarity for getting-started documentation

### DIFF
--- a/docs/readme.adoc
+++ b/docs/readme.adoc
@@ -25,7 +25,8 @@ The `apicurio-registry/docs` directory structure includes the following:
 |Component
 |Description
 |`getting-started`
-|AsciiDoc directory for the Getting Started guide. Includes the `master.adoc` file which defines what content assembly files are included, and symlinks to the `modules` directory. This is not required for building with Antora. 
+|AsciiDoc directory for the Getting Started guide. Includes the `master.adoc` file which defines what content assembly files are included, and symlinks to the `modules` directory.
+Note: This directory is optional and is not required when building documentation with Antora.
 | `modules`
 a|Includes all the assemblies and content modules required for Antora:  
 


### PR DESCRIPTION
Improved clarity in documentation for the getting-started directory.

Added a note to clearly mention that this directory is optional and not required for Antora builds.

Closes #7768