### PR TITLE
fix(rest): validate comment value before persistence

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
@@ -787,6 +787,7 @@ public class GroupsResourceImpl implements GroupsResource {
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("version", version);
+        ParameterValidationUtils.requireParameter("value", data.getValue());
 
         CommentDto newComment = storage.createArtifactVersionComment(defaultGroupIdToNull(groupId),
                 artifactId, version, data.getValue());

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -1244,6 +1244,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
+        ParameterValidationUtils.requireParameter("value", data.getValue());
 
         var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), versionExpression,
                 (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.ALL_STATES));

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
@@ -1789,6 +1789,29 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void testArtifactCommentsNullValueValidation() throws Exception {
+        String artifactId = "testArtifactCommentsNullValueValidation/EmptyAPI";
+        String artifactContent = resourceToString("openapi-empty.json");
+
+        // Create OpenAPI artifact
+        createArtifact(GROUP, artifactId, ArtifactType.OPENAPI, artifactContent,
+                ContentTypes.APPLICATION_JSON);
+
+        // Try to add a comment with null value (should return 400)
+        NewComment nc = NewComment.builder().value(null).build();
+        given().when().contentType(CT_JSON).pathParam("groupId", GROUP)
+                .pathParam("artifactId", artifactId).body(nc)
+                .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/comments")
+                .then().statusCode(400);
+
+        // Try to add a comment with empty object body (should return 400)
+        given().when().contentType(CT_JSON).pathParam("groupId", GROUP)
+                .pathParam("artifactId", artifactId).body("{}")
+                .post("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/comments")
+                .then().statusCode(400);
+    }
+
+    @Test
     public void testCreateArtifactIntegrityRuleViolation() throws Exception {
         String artifactContent = resourceToString("jsonschema-valid.json");
         String artifactId = "testCreateArtifact/IntegrityRuleViolation";


### PR DESCRIPTION
## What

This pull request is a follow-up to issue #9449
The `addArtifactVersionComment()` implementations in both the v2 and v3 REST APIs did not validate the comment `value` before passing it to the storage layer. As a result, requests with a missing or `null` value could reach the database, where the `version_comments.cvalue` column is defined as `NOT NULL`.
This change adds the existing `ParameterValidationUtils.requireParameter("value", data.getValue())` validation to both v2 and v3 `addArtifactVersionComment()` implementations, ensuring invalid requests are rejected before persistence.

## Why

A request such as:

`{"value": null}`
or:
`{}`

previously reached the persistence layer and caused a database integrity constraint violation, resulting in an HTTP `500 Internal Server Error`.
The expected behavior is to reject the invalid request at the REST layer with an HTTP `400 Bad Request` using the existing `MissingRequiredParameterException` / `ProblemDetails` handling.
This also makes the add-comment behavior consistent with the existing `updateArtifactVersionComment()` validation.

## Test

Added a regression test covering both invalid request payloads:

- `{"value": null}` → HTTP `400 Bad Request`
- `{}` → HTTP `400 Bad Request`

The test verifies that invalid comment values are rejected before reaching the database.

