### PR TITLE
fix(ui): add navigation link to "Not a Draft" empty state in EditorPage

### DIFF
--- a/ui/ui-app/src/app/pages/editor/EditorPage.tsx
+++ b/ui/ui-app/src/app/pages/editor/EditorPage.tsx
@@ -22,6 +22,9 @@ import {
     toPageError
 } from "@app/pages";
 import { RootPageHeader } from "@app/components";
+import { Link } from "react-router";
+import { Button } from "@patternfly/react-core";
+import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { ContentTypes } from "@models/ContentTypes.ts";
 import { PleaseWaitModal } from "@apicurio/common-ui-components";
 import { Draft, DraftContent } from "@models/drafts";
@@ -106,6 +109,7 @@ export const EditorPage: FunctionComponent<PageProperties> = () => {
     const [referencesLoadFailed, setReferencesLoadFailed] = useState(false);
 
     const params = useParams();
+    const appNavigation: AppNavigation = useAppNavigation();
     const groupId = params.groupId as string;
     const draftId: string = params.artifactId || "";
     const version = params.version as string;
@@ -408,6 +412,17 @@ export const EditorPage: FunctionComponent<PageProperties> = () => {
             <EmptyStateBody>
                 This artifact is not in <em>DRAFT</em> status and so its content cannot be edited.
             </EmptyStateBody>
+            <Button
+                variant="primary"
+                component={(props: any) => (
+                    <Link
+                        {...props}
+                        to={appNavigation.createLink(`/explore/${groupId}/${draftId}/versions/${version}`)}
+                    />
+                )}
+            >
+                Go to version page
+            </Button>
         </EmptyState>
     );
 

--- a/ui/ui-app/src/app/pages/editor/EditorPage.tsx
+++ b/ui/ui-app/src/app/pages/editor/EditorPage.tsx
@@ -50,6 +50,7 @@ import { useEditorDraftRecovery } from "./useEditorDraftRecovery.ts";
 import { useEditorReauthentication } from "./useEditorReauthentication.ts";
 import { ArtifactReference, ReferenceTypeObject } from "@sdk/lib/generated-client/models";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
+import { buildNonDraftVersionLink } from "./EditorPage.utils.ts";
 
 const sectionContextStyle: CSSProperties = {
     borderBottom: "1px solid #ccc",
@@ -417,7 +418,7 @@ export const EditorPage: FunctionComponent<PageProperties> = () => {
                 component={(props: any) => (
                     <Link
                         {...props}
-                        to={appNavigation.createLink(`/explore/${groupId}/${draftId}/versions/${version}`)}
+                        to={appNavigation.createLink(buildNonDraftVersionLink(groupId, draftId, version))}
                     />
                 )}
             >

--- a/ui/ui-app/src/app/pages/editor/EditorPage.utils.test.ts
+++ b/ui/ui-app/src/app/pages/editor/EditorPage.utils.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { buildNonDraftVersionLink } from "./EditorPage.utils.ts";
+
+describe("buildNonDraftVersionLink", () => {
+
+    it("builds the version page path from groupId, artifactId, and version", () => {
+        const link = buildNonDraftVersionLink("default", "my-artifact", "1");
+        expect(link).toBe("/explore/default/my-artifact/versions/1");
+    });
+
+});

--- a/ui/ui-app/src/app/pages/editor/EditorPage.utils.ts
+++ b/ui/ui-app/src/app/pages/editor/EditorPage.utils.ts
@@ -1,0 +1,3 @@
+export function buildNonDraftVersionLink(groupId: string, artifactId: string, version: string): string {
+    return `/explore/${groupId}/${artifactId}/versions/${version}`;
+}


### PR DESCRIPTION
Fixes #9460

## What this PR does
Adds a "Go to version page" button to the "Not a Draft" empty state shown
in `EditorPage.tsx` when a version's editor is accessed but the version is
no longer in DRAFT status.

## Why
Previously, if a user's editor session became stale  for example, the
version was transitioned from DRAFT to ENABLED (by another tab or another
user) while the editor was open  refreshing the editor showed a dead-end
screen with no way to navigate away except the browser's back button.

## Changes
- `ui/ui-app/src/app/pages/editor/EditorPage.tsx`
  - Added imports: `Link` (react-router), `Button` (PatternFly),
    `useAppNavigation`
  - Added `appNavigation` hook usage
  - Added a "Go to version page" button inside `notDraftEmptyState`,
    linking to `/explore/:groupId/:artifactId/versions/:version`

## Testing done
- `tsc && vite build` clean
- Manually reproduced the dead-end via UI (draft → edit → enable in
  another tab → refresh editor) and confirmed the button now appears
  and correctly navigates back to the version page

## Screenshots
**Before:**

<img width="1285" height="633" alt="Screenshot From 2026-08-10 14-08-35" src="https://github.com/user-attachments/assets/583ce4a4-981e-4ccf-ba01-0bdc15586b27" />


**After:**

<img width="1285" height="633" alt="Screenshot From 2026-08-10 13-57-42" src="https://github.com/user-attachments/assets/8bcdcb0b-c2b9-4afc-b1f1-785dba40c6ce" />
