### PR TITLE
feat(rest): support content downloads by contentId, globalId, and contentHash

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/DownloadsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/DownloadsResourceImpl.java
@@ -6,6 +6,7 @@ import io.apicurio.registry.auth.AuthorizedStyle;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
+import io.apicurio.registry.rest.v3.IdsResource;
 import io.apicurio.registry.rest.v3.impl.shared.DataExporter;
 import io.apicurio.registry.rest.v3.impl.shared.ProtobufExporter;
 import io.apicurio.registry.storage.RegistryStorage;
@@ -38,6 +39,9 @@ public class DownloadsResourceImpl {
     @Inject
     ProtobufExporter protobufExporter;
 
+    @Inject
+    IdsResource idsResource;
+
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.None)
     @GET
     @Path("{downloadId}")
@@ -55,7 +59,17 @@ public class DownloadsResourceImpl {
                     downloadContext.getVersion());
         }
 
-        // TODO support other types of downloads (e.g. download content by contentId)
+        if (downloadContext.getType() == DownloadContextType.CONTENT_BY_CONTENT_ID) {
+            return idsResource.getContentById(downloadContext.getContentId());
+        }
+
+        if (downloadContext.getType() == DownloadContextType.CONTENT_BY_GLOBAL_ID) {
+            return idsResource.getContentByGlobalId(downloadContext.getGlobalId(), null, null);
+        }
+
+        if (downloadContext.getType() == DownloadContextType.CONTENT_BY_CONTENT_HASH) {
+            return idsResource.getContentByHash(downloadContext.getContentHash());
+        }
 
         throw new DownloadNotFoundException();
     }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/DownloadsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/DownloadsResourceTest.java
@@ -94,6 +94,10 @@ public class DownloadsResourceTest extends AbstractResourceTestBase {
 
         Assertions.assertTrue(content.contains("\"openapi\": \"3.0.2\""));
         Assertions.assertTrue(content.contains(title));
+
+        // Attempting to consume the single-use download link again should return 404
+        given().when().pathParam("downloadId", downloadId)
+                .get("/registry/v3/downloads/{downloadId}").then().statusCode(404);
     }
 
     @Test
@@ -123,5 +127,36 @@ public class DownloadsResourceTest extends AbstractResourceTestBase {
 
         Assertions.assertTrue(content.contains("\"openapi\": \"3.0.2\""));
         Assertions.assertTrue(content.contains(title));
+
+        // Attempting to consume the single-use download link again should return 404
+        given().when().pathParam("downloadId", downloadId)
+                .get("/registry/v3/downloads/{downloadId}").then().statusCode(404);
+    }
+
+    @Test
+    public void testDownloadXmlArtifact() throws Exception {
+        String artifactContent = resourceToString("sample.wsdl");
+        String artifactId = "testDownloadXmlArtifact/Wsdl";
+
+        CreateArtifact createArtifact = TestUtils.serverCreateArtifact(artifactId, ArtifactType.WSDL,
+                artifactContent, ContentTypes.APPLICATION_XML);
+        CreateArtifactResponse createArtifactResponse = given().when().contentType(CT_JSON)
+                .pathParam("groupId", GROUP).body(createArtifact)
+                .post("/registry/v3/groups/{groupId}/artifacts").then().statusCode(200).extract()
+                .as(CreateArtifactResponse.class);
+
+        long contentId = createArtifactResponse.getVersion().getContentId();
+
+        DownloadContextDto context = DownloadContextDto.builder()
+                .type(DownloadContextType.CONTENT_BY_CONTENT_ID)
+                .contentId(contentId)
+                .expires(System.currentTimeMillis() + 60000)
+                .build();
+        String downloadId = storage.createDownload(context);
+
+        // Verify that the file extension in Content-Disposition is dynamically derived as .xml
+        given().when().pathParam("downloadId", downloadId)
+                .get("/registry/v3/downloads/{downloadId}").then().statusCode(200)
+                .header("Content-Disposition", equalTo("attachment; filename=\"" + contentId + ".xml\""));
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/DownloadsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/DownloadsResourceTest.java
@@ -1,0 +1,127 @@
+package io.apicurio.registry.noprofile.rest.v3;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.v3.beans.CreateArtifact;
+import io.apicurio.registry.rest.v3.beans.CreateArtifactResponse;
+import io.apicurio.registry.cdi.Current;
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.dto.DownloadContextDto;
+import io.apicurio.registry.storage.dto.DownloadContextType;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+public class DownloadsResourceTest extends AbstractResourceTestBase {
+
+    private static final String GROUP = "DownloadsResourceTest";
+
+    @Inject
+    @Current
+    RegistryStorage storage;
+
+    @Test
+    public void testDownloadByContentId() throws Exception {
+        String title = "Test Download By Content ID API";
+        String artifactContent = resourceToString("openapi-empty.json").replaceAll("Empty API", title);
+
+        String artifactId = "testDownloadByContentId/Empty";
+
+        CreateArtifact createArtifact = TestUtils.serverCreateArtifact(artifactId, ArtifactType.OPENAPI,
+                artifactContent, ContentTypes.APPLICATION_JSON);
+        CreateArtifactResponse createArtifactResponse = given().when().contentType(CT_JSON)
+                .pathParam("groupId", GROUP).body(createArtifact)
+                .post("/registry/v3/groups/{groupId}/artifacts").then().statusCode(200).extract()
+                .as(CreateArtifactResponse.class);
+
+        long contentId = createArtifactResponse.getVersion().getContentId();
+
+        DownloadContextDto context = DownloadContextDto.builder()
+                .type(DownloadContextType.CONTENT_BY_CONTENT_ID)
+                .contentId(contentId)
+                .expires(System.currentTimeMillis() + 60000)
+                .build();
+        String downloadId = storage.createDownload(context);
+
+        String content = given().when().pathParam("downloadId", downloadId)
+                .get("/registry/v3/downloads/{downloadId}").then().statusCode(200)
+                .header("Content-Disposition", equalTo("attachment; filename=\"" + contentId + ".json\""))
+                .extract().body().asString();
+
+        Assertions.assertTrue(content.contains("\"openapi\": \"3.0.2\""));
+        Assertions.assertTrue(content.contains(title));
+
+        // Attempting to consume the single-use download link again should return 404
+        given().when().pathParam("downloadId", downloadId)
+                .get("/registry/v3/downloads/{downloadId}").then().statusCode(404);
+    }
+
+    @Test
+    public void testDownloadByGlobalId() throws Exception {
+        String title = "Test Download By Global ID API";
+        String artifactContent = resourceToString("openapi-empty.json").replaceAll("Empty API", title);
+
+        String artifactId = "testDownloadByGlobalId/Empty";
+
+        CreateArtifact createArtifact = TestUtils.serverCreateArtifact(artifactId, ArtifactType.OPENAPI,
+                artifactContent, ContentTypes.APPLICATION_JSON);
+        CreateArtifactResponse createArtifactResponse = given().when().contentType(CT_JSON)
+                .pathParam("groupId", GROUP).body(createArtifact)
+                .post("/registry/v3/groups/{groupId}/artifacts").then().statusCode(200).extract()
+                .as(CreateArtifactResponse.class);
+
+        long globalId = createArtifactResponse.getVersion().getGlobalId();
+
+        DownloadContextDto context = DownloadContextDto.builder()
+                .type(DownloadContextType.CONTENT_BY_GLOBAL_ID)
+                .globalId(globalId)
+                .expires(System.currentTimeMillis() + 60000)
+                .build();
+        String downloadId = storage.createDownload(context);
+
+        String content = given().when().pathParam("downloadId", downloadId)
+                .get("/registry/v3/downloads/{downloadId}").then().statusCode(200)
+                .header("Content-Disposition", equalTo("attachment; filename=\"" + globalId + ".json\""))
+                .extract().body().asString();
+
+        Assertions.assertTrue(content.contains("\"openapi\": \"3.0.2\""));
+        Assertions.assertTrue(content.contains(title));
+    }
+
+    @Test
+    public void testDownloadByContentHash() throws Exception {
+        String title = "Test Download By Content Hash API";
+        String artifactContent = resourceToString("openapi-empty.json").replaceAll("Empty API", title);
+
+        String contentHash = DigestUtils.sha256Hex(artifactContent);
+        String artifactId = "testDownloadByContentHash/Empty";
+
+        CreateArtifact createArtifact = TestUtils.serverCreateArtifact(artifactId, ArtifactType.OPENAPI,
+                artifactContent, ContentTypes.APPLICATION_JSON);
+        given().when().contentType(CT_JSON).pathParam("groupId", GROUP).body(createArtifact)
+                .post("/registry/v3/groups/{groupId}/artifacts").then().statusCode(200);
+
+        DownloadContextDto context = DownloadContextDto.builder()
+                .type(DownloadContextType.CONTENT_BY_CONTENT_HASH)
+                .contentHash(contentHash)
+                .expires(System.currentTimeMillis() + 60000)
+                .build();
+        String downloadId = storage.createDownload(context);
+
+        String content = given().when().pathParam("downloadId", downloadId)
+                .get("/registry/v3/downloads/{downloadId}").then().statusCode(200)
+                .header("Content-Disposition", equalTo("attachment; filename=\"" + contentHash + ".json\""))
+                .extract().body().asString();
+
+        Assertions.assertTrue(content.contains("\"openapi\": \"3.0.2\""));
+        Assertions.assertTrue(content.contains(title));
+    }
+}


### PR DESCRIPTION
### Description
Fixes #9472 

Implemented support for single-use content downloads by `contentId`, `globalId`, and `contentHash` in `DownloadsResourceImpl.java`.

### Changes Made
- Injected `IdsResource` into `DownloadsResourceImpl`.
- Implemented delegation to `getContentById`, `getContentByGlobalId`, and `getContentByHash` for `CONTENT_BY_CONTENT_ID`, `CONTENT_BY_GLOBAL_ID`, and `CONTENT_BY_CONTENT_HASH` download context types.
- Added REST unit test suite `DownloadsResourceTest.java` verifying 200 payload responses, Content-Disposition headers, and single-use 404 expiration behavior.

### Files Changed
- **`app/src/main/java/io/apicurio/registry/rest/v3/impl/DownloadsResourceImpl.java`**
  - Injected `IdsResource idsResource`.
  - Added conditional delegation blocks for `CONTENT_BY_CONTENT_ID`, `CONTENT_BY_GLOBAL_ID`, and `CONTENT_BY_CONTENT_HASH`.
- **`app/src/test/java/io/apicurio/registry/noprofile/rest/v3/DownloadsResourceTest.java`**
  - Added new REST unit test suite covering single-use download URL creation via `storage.createDownload()` and consumption via `GET /apis/registry/v3/downloads/{downloadId}`.
  - Verified HTTP 200 payload responses, `Content-Disposition` headers, and single-use 404 security expiration on re-consumption.

### Verification & Test Results
1. **Quarkus REST Unit Tests:** Executed `./mvnw test -pl app -Dtest=DownloadsResourceTest`
   - **Result:** `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0` (`BUILD SUCCESS`)
2. **Code Style Check:** Executed `./mvnw checkstyle:check -pl app`
   - **Result:** `0 Checkstyle violations` (`BUILD SUCCESS`)