### PR TITLE
Fixed the bug where the Editor is loosing the unsaved changes

### DIFF
--- a/ui/ui-editors/src/app/editor/_components/forms/source-form.base.ts
+++ b/ui/ui-editors/src/app/editor/_components/forms/source-form.base.ts
@@ -186,7 +186,7 @@ export abstract class SourceFormComponent<T extends Node> extends AbstractBaseCo
             if (this.isSourceFormatJson()) {
                 newSource = JSON.stringify(parsedSource, null, 4);
             } else {
-                newSource = YAML.dump(this.sourceJs(), {
+                newSource = YAML.dump(parsedSource, {
                     indent: 4,
                     lineWidth: 110,
                     noRefs: true
@@ -215,7 +215,7 @@ export abstract class SourceFormComponent<T extends Node> extends AbstractBaseCo
             if (this.isSourceFormatJson()) {
                 newSource = JSON.stringify(parsedSource, null, 4);
             } else {
-                newSource = YAML.dump(this.sourceJs(), {
+                newSource = YAML.dump(parsedSource, {
                     indent: 4,
                     lineWidth: 110,
                     noRefs: true


### PR DESCRIPTION
Fixes #9478 

When editing an OpenAPI document in the Source editor, unsaved changes were lost when switching between YAML and JSON format

The bug was:

1) User edits YAML → unsaved change is stored in parsedSource.
2) YAML/JSON conversion ignored parsedSource.
3)  When I traced till end Found that the  this.sourceJs() in source-form.base.ts , which contained the old saved value is being dumped in YAML hence we loose our unsaved changes while switching the format between YAML to JSON.
hence the unsaved change disappeared.