### PR TITLE
feat(ui): add direct path to create artifact from empty search page

### DIFF
--- a/ui/tests/specs/search.spec.ts
+++ b/ui/tests/specs/search.spec.ts
@@ -1,19 +1,56 @@
 import { test, expect } from "@playwright/test";
 
 const REGISTRY_UI_URL: string = process.env["REGISTRY_UI_URL"] || "http://localhost:8888/";
+const NON_EXISTENT_SEARCH = "e2e-non-existent-artifact-9f8c7a2b";
 
 test.beforeEach(async ({ page }) => {
-    await page.goto(REGISTRY_UI_URL);
+    test.setTimeout(45000);
+    let targetUrl = REGISTRY_UI_URL;
+
+    if (!process.env.CI) {
+        // Rewrite localhost to 127.0.0.1 to avoid macOS IPv6 connection resolution issues in local dev
+        if (targetUrl.includes("localhost")) {
+            targetUrl = targetUrl.replace("localhost", "127.0.0.1");
+        }
+
+        // Reroute backend API localhost requests to 127.0.0.1
+        await page.route("**", async (route) => {
+            const url = route.request().url();
+            if (url.includes("localhost:8080")) {
+                await route.continue({ url: url.replace("localhost:8080", "127.0.0.1:8080") });
+            } else if (url.includes("localhost:8888")) {
+                await route.continue({ url: url.replace("localhost:8888", "127.0.0.1:8888") });
+            } else {
+                await route.continue();
+            }
+        });
+    }
+
+    await page.goto(targetUrl);
     await expect(page).toHaveTitle(/Apicurio Registry/);
+
+    const responsePromise = page.waitForResponse(/\/search\/artifacts/);
     await page.getByTestId("search-tab").click();
+    await responsePromise;
+    await page.waitForTimeout(200);
 });
 
 test("Search - Empty state has Create Artifact button for ARTIFACT, not for GROUP or VERSION", async ({ page }) => {
-    // 1. By default, Search Type is "Artifacts" and search list is empty.
-    // Verify that the "Create artifact" button is visible in empty state.
+    // 1. ARTIFACT Empty State
+    // Explicitly perform a search using a stable value that is extremely unlikely to exist to trigger the empty state.
+    let responsePromise = page.waitForResponse(/\/search\/artifacts/);
+    await page.getByTestId("chip-filter-value").fill(NON_EXISTENT_SEARCH);
+    await page.getByTestId("chip-filter-search").click();
+    await responsePromise;
+    await page.waitForTimeout(200);
+
+    // Verify empty state text
+    await expect(page.getByText("No artifacts found")).toBeVisible();
+
+    // Verify Create Artifact button is visible
     await expect(page.getByTestId("empty-btn-create")).toBeVisible();
 
-    // 2. Click the "Create artifact" button and verify it opens the Create Artifact modal.
+    // Verify clicking it opens the modal
     await page.getByTestId("empty-btn-create").click();
     await expect(page.getByTestId("create-artifact-modal-id")).toBeVisible();
 
@@ -21,17 +58,41 @@ test("Search - Empty state has Create Artifact button for ARTIFACT, not for GROU
     await page.getByRole("button", { name: "Close" }).first().click();
     await expect(page.getByTestId("create-artifact-modal-id")).toBeHidden();
 
-    // 3. Switch search type to "Groups"
+    // 2. GROUP Empty State
+    responsePromise = page.waitForResponse(/\/search\/groups/);
     await page.getByTestId("search-type-select").click();
     await page.getByTestId("search-type-groups").click();
+    await responsePromise;
+    await page.waitForTimeout(200);
 
-    // Verify that the "Create artifact" button is NOT visible.
-    await expect(page.getByTestId("empty-btn-create")).toBeHidden();
+    responsePromise = page.waitForResponse(/\/search\/groups/);
+    await page.getByTestId("chip-filter-value").fill(NON_EXISTENT_SEARCH);
+    await page.getByTestId("chip-filter-search").click();
+    await responsePromise;
+    await page.waitForTimeout(200);
 
-    // 4. Switch search type to "Versions"
+    // Verify empty state text
+    await expect(page.getByText("No groups found")).toBeVisible();
+
+    // Verify Create Artifact button is not rendered
+    await expect(page.getByTestId("empty-btn-create")).toHaveCount(0);
+
+    // 3. VERSION Empty State
+    responsePromise = page.waitForResponse(/\/search\/versions/);
     await page.getByTestId("search-type-select").click();
     await page.getByTestId("search-type-versions").click();
+    await responsePromise;
+    await page.waitForTimeout(200);
 
-    // Verify that the "Create artifact" button is NOT visible.
-    await expect(page.getByTestId("empty-btn-create")).toBeHidden();
+    responsePromise = page.waitForResponse(/\/search\/versions/);
+    await page.getByTestId("chip-filter-value").fill(NON_EXISTENT_SEARCH);
+    await page.getByTestId("chip-filter-search").click();
+    await responsePromise;
+    await page.waitForTimeout(200);
+
+    // Verify empty state text
+    await expect(page.getByText("No versions found")).toBeVisible();
+
+    // Verify Create Artifact button is not rendered
+    await expect(page.getByTestId("empty-btn-create")).toHaveCount(0);
 });

--- a/ui/tests/specs/search.spec.ts
+++ b/ui/tests/specs/search.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+const REGISTRY_UI_URL: string = process.env["REGISTRY_UI_URL"] || "http://localhost:8888/";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto(REGISTRY_UI_URL);
+    await expect(page).toHaveTitle(/Apicurio Registry/);
+    await page.getByTestId("search-tab").click();
+});
+
+test("Search - Empty state has Create Artifact button for ARTIFACT, not for GROUP or VERSION", async ({ page }) => {
+    // 1. By default, Search Type is "Artifacts" and search list is empty.
+    // Verify that the "Create artifact" button is visible in empty state.
+    await expect(page.getByTestId("empty-btn-create")).toBeVisible();
+
+    // 2. Click the "Create artifact" button and verify it opens the Create Artifact modal.
+    await page.getByTestId("empty-btn-create").click();
+    await expect(page.getByTestId("create-artifact-modal-id")).toBeVisible();
+
+    // Close the modal
+    await page.getByRole("button", { name: "Close" }).first().click();
+    await expect(page.getByTestId("create-artifact-modal-id")).toBeHidden();
+
+    // 3. Switch search type to "Groups"
+    await page.getByTestId("search-type-select").click();
+    await page.getByTestId("search-type-groups").click();
+
+    // Verify that the "Create artifact" button is NOT visible.
+    await expect(page.getByTestId("empty-btn-create")).toBeHidden();
+
+    // 4. Switch search type to "Versions"
+    await page.getByTestId("search-type-select").click();
+    await page.getByTestId("search-type-versions").click();
+
+    // Verify that the "Create artifact" button is NOT visible.
+    await expect(page.getByTestId("empty-btn-create")).toBeHidden();
+});

--- a/ui/ui-app/src/app/pages/search/SearchPage.tsx
+++ b/ui/ui-app/src/app/pages/search/SearchPage.tsx
@@ -18,7 +18,7 @@ import { If, ListWithToolbar } from "@apitomy/common-ui-components";
 import { SearchType } from "@app/pages/search/SearchType.ts";
 import { Paging } from "@models/Paging.ts";
 import { FilterBy, SearchFilter, useSearchService } from "@services/useSearchService.ts";
-import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
+import { useGroupsService } from "@services/useGroupsService.ts";
 import {
     ArtifactSearchResults,
     ArtifactSortBy,
@@ -264,7 +264,11 @@ export const SearchPage: FunctionComponent<PageProperties> = () => {
         <SearchPageEmptyState
             searchType={searchType}
             isFiltered={isFiltered()}
-            onCreateArtifact={() => setIsCreateArtifactModalOpen(true)}/>
+            onCreateArtifact={
+                searchType === SearchType.ARTIFACT
+                    ? () => setIsCreateArtifactModalOpen(true)
+                    : undefined
+            }/>
     );
 
     return (

--- a/ui/ui-app/src/app/pages/search/SearchPage.tsx
+++ b/ui/ui-app/src/app/pages/search/SearchPage.tsx
@@ -13,15 +13,17 @@ import {
     SearchPageToolbar,
     toPageError, SearchGroupList, SearchVersionList
 } from "@app/pages";
-import { RootPageHeader } from "@app/components";
+import { CreateArtifactModal, RootPageHeader } from "@app/components";
 import { If, ListWithToolbar } from "@apitomy/common-ui-components";
 import { SearchType } from "@app/pages/search/SearchType.ts";
 import { Paging } from "@models/Paging.ts";
 import { FilterBy, SearchFilter, useSearchService } from "@services/useSearchService.ts";
+import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
 import {
     ArtifactSearchResults,
     ArtifactSortBy,
     ArtifactSortByObject,
+    CreateArtifact,
     GroupSearchResults,
     GroupSortBy,
     GroupSortByObject, SearchedGroup, SearchedVersion,
@@ -85,9 +87,24 @@ export const SearchPage: FunctionComponent<PageProperties> = () => {
     const [isSearching, setSearching] = useState<boolean>(false);
     const [paging, setPaging] = useState<Paging>(DEFAULT_PAGING);
     const [results, setResults] = useState<ArtifactSearchResults | GroupSearchResults | VersionSearchResults>(EMPTY_RESULTS);
+    const [isCreateArtifactModalOpen, setIsCreateArtifactModalOpen] = useState<boolean>(false);
 
     const searchSvc = useSearchService();
     const appNav = useAppNavigation();
+    const groups = useGroupsService();
+
+    const doCreateArtifact = (groupId: string | undefined, data: CreateArtifact): void => {
+        setIsCreateArtifactModalOpen(false);
+        groups.createArtifact(groupId ?? null, data)
+            .then((response) => {
+                const gid = encodeURIComponent(response.artifact?.groupId || "default");
+                const aid = encodeURIComponent(response.artifact?.artifactId || "");
+                appNav.navigateTo(`/explore/${gid}/${aid}`);
+            })
+            .catch((error) => {
+                setPageError(toPageError(error, "Error creating artifact."));
+            });
+    };
 
     const createLoaders = (): Promise<any> => {
         return search(searchType, filters, sortBy, sortOrder, paging);
@@ -246,7 +263,8 @@ export const SearchPage: FunctionComponent<PageProperties> = () => {
     const emptyState = (
         <SearchPageEmptyState
             searchType={searchType}
-            isFiltered={isFiltered()}/>
+            isFiltered={isFiltered()}
+            onCreateArtifact={() => setIsCreateArtifactModalOpen(true)}/>
     );
 
     return (
@@ -294,6 +312,11 @@ export const SearchPage: FunctionComponent<PageProperties> = () => {
                     </ListWithToolbar>
                 </PageSection>
             </PageDataLoader>
+            <CreateArtifactModal
+                isOpen={isCreateArtifactModalOpen}
+                onClose={() => setIsCreateArtifactModalOpen(false)}
+                onCreate={doCreateArtifact}
+            />
         </PageErrorHandler>
     );
 

--- a/ui/ui-app/src/app/pages/search/components/empty/SearchPageEmptyState.tsx
+++ b/ui/ui-app/src/app/pages/search/components/empty/SearchPageEmptyState.tsx
@@ -1,9 +1,9 @@
 import { FunctionComponent } from "react";
 import "./SearchPageEmptyState.css";
 import {
-    Button, 
+    Button,
     EmptyState,
-    EmptyStateActions, 
+    EmptyStateActions,
     EmptyStateBody,
     EmptyStateFooter,
     EmptyStateVariant
@@ -18,7 +18,8 @@ import { SearchType } from "@app/pages/search/SearchType.ts";
 export type SearchPageEmptyStateProps = {
     searchType: SearchType;
     isFiltered: boolean;
-    onAction?: () => void; 
+    onAction?: () => void;
+    onCreateArtifact?: () => void;
 };
 
 /**
@@ -56,7 +57,6 @@ export const SearchPageEmptyState: FunctionComponent<SearchPageEmptyStateProps> 
                 </EmptyStateBody>
             </If>
             <EmptyStateFooter>
-                
                 <If condition={() => !props.isFiltered && props.searchType === SearchType.GROUP}>
                     <EmptyStateActions>
                         <Button variant="primary" data-testid="empty-btn-create-group" onClick={props.onAction}>
@@ -64,7 +64,13 @@ export const SearchPageEmptyState: FunctionComponent<SearchPageEmptyStateProps> 
                         </Button>
                     </EmptyStateActions>
                 </If>
-                
+                <If condition={() => !!props.onCreateArtifact}>
+                    <EmptyStateActions>
+                        <Button className="empty-btn-create" variant="primary"
+                            icon={<PlusCircleIcon />}
+                            data-testid="empty-btn-create" onClick={props.onCreateArtifact}>Create artifact</Button>
+                    </EmptyStateActions>
+                </If>
             </EmptyStateFooter>
         </EmptyState>
     );


### PR DESCRIPTION
## What does this PR do?

When there are no artifacts, the Search page currently shows the empty state but doesn't give the user a direct way to create one.

This PR adds a more direct way to start creating an artifact from the empty state, so users don't have to go back to the Dashboard first.

## Before

<img width="1512" height="859" alt="Screenshot 2026-08-11 at 6 45 52 PM" src="https://github.com/user-attachments/assets/3e1b87f1-b6e8-4f41-823d-5a1d1efe767f" />


## After

<img width="1512" height="859" alt="Screenshot 2026-08-11 at 8 09 16 PM" src="https://github.com/user-attachments/assets/71545590-886e-4f05-b440-2eac89ac4b33" />


## Testing

- Tested the empty Search page.
- Tested opening the Create Artifact flow.
- Verified the existing artifact creation flow still works.

## Related Issue

Fixes #9475