### PR TITLE
docs: fix broken markdown and Kafka Compose paths in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,14 +10,16 @@ There are numerous options available when integrating with the registry, and the
 of examples found here may not cover every configuration permutation.
 
 These examples rely on an Apicurio Registry server being available, you can start one with the latest build by running:
-``
+
+```bash
 docker run -p 8080:8080 -it apicurio/apicurio-registry:latest-snapshot
-``
+```
+
 This command will start an Apicurio Registry server and make it available at the port 8080 of localhost.
 
-Some examples also require a Kafka Cluster available, you can very easily run one using the [docker-compose resources available in the tools folder](/tools/kafka-compose/kafka-compose.yaml)
+Some examples also require a Kafka Cluster available, you can very easily run one using the [docker-compose resources available in the tools folder](tools/kafka-compose/kafka-compose.yaml)
 
-Simply run ``docker-compose  -f examples/tools/kafka-compose/kafka-compose.yaml up`` and you'll have a Kafka broker available at the port 9092.
+Simply run `docker compose -f examples/tools/kafka-compose/kafka-compose.yaml up` from the repository root and you'll have a Kafka broker available at the port 9092.
 
 # List of Examples
 A list of examples is included below, with descriptions and explanations of each covered use-case.


### PR DESCRIPTION
## Summary

Fixes broken code fences and an incorrect Kafka Compose link in `examples/README.md`.

Closes #9491 

## Changes

1. replace the invalid code fences with a proper fenced `bash` block for the Docker run command
2. fix the Kafka Compose link to use the correct relative path from the `examples` directory
3. update the Compose command to use `docker compose` and clarify that it should be run from the repository root

## Test

- [x] verified `examples/tools/kafka-compose/kafka-compose.yaml` exists.
- [x] verified the relative link `tools/kafka-compose/kafka-compose.yaml` resolves from `examples/README.md`.
- [x] documentation only change.