### PR TITLE
docs: remove nonexistent local-tests profile from testing rules

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -13,8 +13,8 @@ paths:
 
 ## Integration Tests
 - Located in `integration-tests/` module
-- Profiles: `local-tests`, `remote-mem`, `remote-sql`, `remote-kafka`
-- Run: `./mvnw verify -pl integration-tests -P<profile>`
+- Profiles: `integration-tests`, `remote-mem`, `remote-sql`, `remote-kafka`, `remote-kubernetesops`
+- Run: `./mvnw verify -Pintegration-tests -pl integration-tests -am`
 
 ## Storage Variant Coverage
 - Features touching storage MUST work across all variants (sql, kafkasql, gitops, kubernetesops)


### PR DESCRIPTION
Fixes #9219

The main docs called out in this issue (`DEVELOPING.md`, `CLAUDE.md`, `CONTRIBUTING.md`) were already corrected in #9223. The last remaining `local-tests` reference was in `.claude/rules/testing.md`, which also had an incomplete integration-test run command.

This updates that file to list the real profiles and the working verify command from `integration-tests/README.md`.

Documentation only, no code or build changes.