### PR TITLE
fix(storage): enable GZIP compression for H2 snapshot dumps

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -17,6 +17,7 @@ import io.apicurio.registry.events.GroupDeleted;
 import io.apicurio.registry.events.GroupMetadataUpdated;
 import io.apicurio.registry.events.GroupRuleConfigured;
 import io.apicurio.registry.logging.Logged;
+import io.apicurio.registry.storage.impl.sql.SqlStatements;
 import io.apicurio.registry.metrics.StorageMetricsApply;
 import io.apicurio.registry.metrics.health.liveness.PersistenceExceptionLivenessApply;
 import io.apicurio.registry.metrics.health.readiness.PersistenceTimeoutReadinessApply;
@@ -1286,7 +1287,7 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         // First we generate an identifier for the snapshot, then we send a snapshot marker to the journal
         // topic.
         String snapshotId = UUID.randomUUID().toString();
-        Path path = Path.of(configuration.getSnapshotStoreLocation(), snapshotId + ".sql");
+        Path path = Path.of(configuration.getSnapshotStoreLocation(), snapshotId + SqlStatements.COMPRESSED_SNAPSHOT_EXTENSION);
         var message = new CreateSnapshot1Message(path.toString(), snapshotId);
         this.lastTriggeredSnapshot = snapshotId;
         log.debug("Snapshot with id {} triggered.", snapshotId);

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/H2SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/H2SqlStatements.java
@@ -82,8 +82,24 @@ public class H2SqlStatements extends CommonSqlStatements {
     }
 
     @Override
+    public String createDataSnapshot(String location) {
+        if (location != null && location.endsWith(COMPRESSED_SNAPSHOT_EXTENSION)) {
+            return "SCRIPT TO ? COMPRESSION GZIP";
+        }
+        return createDataSnapshot();
+    }
+
+    @Override
     public String restoreFromSnapshot() {
         return "RUNSCRIPT FROM ?";
+    }
+
+    @Override
+    public String restoreFromSnapshot(String location) {
+        if (location != null && location.endsWith(COMPRESSED_SNAPSHOT_EXTENSION)) {
+            return "RUNSCRIPT FROM ? COMPRESSION GZIP";
+        }
+        return restoreFromSnapshot();
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlRegistryStorage.java
@@ -35,7 +35,7 @@ public class SqlRegistryStorage extends AbstractSqlRegistryStorage {
     }
 
     public void restoreFromSnapshot(String snapshotLocation) {
-        handleFactory.withHandle(handle -> handle.createUpdate(sqlStatements.restoreFromSnapshot())
+        handleFactory.withHandle(handle -> handle.createUpdate(sqlStatements.restoreFromSnapshot(snapshotLocation))
                 .bind(0, snapshotLocation).execute());
     }
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -8,6 +8,8 @@ import java.util.List;
  */
 public interface SqlStatements {
 
+    String COMPRESSED_SNAPSHOT_EXTENSION = ".sql.gz";
+
     /**
      * Gets the database type associated with these statements.
      */
@@ -726,7 +728,23 @@ public interface SqlStatements {
 
     public String createDataSnapshot();
 
+    /**
+     * Returns the SQL statement to create a data snapshot at the given location, optionally
+     * applying compression based on the file extension.
+     */
+    default String createDataSnapshot(String location) {
+        return createDataSnapshot();
+    }
+
     public String restoreFromSnapshot();
+
+    /**
+     * Returns the SQL statement to restore from a snapshot at the given location, optionally
+     * applying decompression based on the file extension.
+     */
+    default String restoreFromSnapshot(String location) {
+        return restoreFromSnapshot();
+    }
 
     // ========== Events ==========
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlExportRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlExportRepository.java
@@ -346,7 +346,7 @@ public class SqlExportRepository {
         if (!StringUtil.isEmpty(location)) {
             log.debug("Creating internal database snapshot to location {}.", location);
             handles.withHandleNoException(handle -> {
-                handle.createQuery(sqlStatements.createDataSnapshot()).bind(0, location).mapTo(String.class)
+                handle.createQuery(sqlStatements.createDataSnapshot(location)).bind(0, location).mapTo(String.class)
                         .first();
             });
             return location;

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSnapshotTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSnapshotTest.java
@@ -4,6 +4,8 @@ import io.apicurio.registry.AbstractResourceTestBase;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateRule;
 import io.apicurio.registry.rest.client.models.RuleType;
+import io.apicurio.registry.storage.impl.sql.SqlRegistryStorage;
+import io.apicurio.registry.storage.impl.sql.SqlStatements;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.tests.KafkasqlTestProfile;
@@ -16,9 +18,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
+import java.util.zip.GZIPInputStream;
 
 @QuarkusTest
 @TestProfile(KafkasqlTestProfile.class)
@@ -28,6 +32,9 @@ public class KafkaSqlSnapshotTest extends AbstractResourceTestBase {
 
     @Inject
     KafkaSqlRegistryStorage kafkaSqlRegistryStorage;
+
+    @Inject
+    SqlRegistryStorage sqlRegistryStorage;
 
     @BeforeAll
     public void init() {
@@ -53,7 +60,55 @@ public class KafkaSqlSnapshotTest extends AbstractResourceTestBase {
     public void testSnapshotCreation() throws IOException {
         String snapshotLocation = kafkaSqlRegistryStorage.triggerSnapshotCreation();
         Path path = Path.of(snapshotLocation);
-        Assertions.assertTrue(Files.exists(path));
-        Files.delete(path);
+        try {
+            Assertions.assertTrue(Files.exists(path));
+            Assertions.assertTrue(snapshotLocation.endsWith(SqlStatements.COMPRESSED_SNAPSHOT_EXTENSION),
+                    "Snapshot file should use the .sql.gz extension");
+            Assertions.assertTrue(Files.size(path) > 0, "Snapshot file should not be empty");
+            assertGzipCompressed(path);
+        } finally {
+            Files.deleteIfExists(path);
+        }
+    }
+
+    @Test
+    public void testSnapshotRestoreRoundTrip() throws IOException {
+        long artifactCountBefore = clientV3.groups().byGroupId(NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID)
+                .artifacts().get(config -> config.queryParameters.limit = 1).getCount();
+        Assertions.assertTrue(artifactCountBefore > 0, "Artifacts should exist before snapshot");
+
+        String snapshotLocation = kafkaSqlRegistryStorage.triggerSnapshotCreation();
+        Path path = Path.of(snapshotLocation);
+        try {
+            Assertions.assertTrue(Files.exists(path));
+
+            // Restore from the compressed snapshot into the same database. This exercises
+            // H2's RUNSCRIPT FROM ? COMPRESSION GZIP path and verifies the snapshot is valid.
+            sqlRegistryStorage.restoreFromSnapshot(snapshotLocation);
+
+            long artifactCountAfter = clientV3.groups().byGroupId(NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID)
+                    .artifacts().get(config -> config.queryParameters.limit = 1).getCount();
+            Assertions.assertEquals(artifactCountBefore, artifactCountAfter,
+                    "Artifact count should be the same after restoring from snapshot");
+        } finally {
+            Files.deleteIfExists(path);
+        }
+    }
+
+    /**
+     * Asserts that the file at the given path is valid GZIP data by attempting to read it
+     * through a GZIPInputStream.
+     */
+    private void assertGzipCompressed(Path path) throws IOException {
+        try (InputStream fis = Files.newInputStream(path);
+             GZIPInputStream gzis = new GZIPInputStream(fis)) {
+            byte[] buffer = new byte[1024];
+            int totalRead = 0;
+            int bytesRead;
+            while ((bytesRead = gzis.read(buffer)) != -1) {
+                totalRead += bytesRead;
+            }
+            Assertions.assertTrue(totalRead > 0, "GZIP content should decompress to non-empty data");
+        }
     }
 }

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSnapshotTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSnapshotTest.java
@@ -4,7 +4,6 @@ import io.apicurio.registry.AbstractResourceTestBase;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateRule;
 import io.apicurio.registry.rest.client.models.RuleType;
-import io.apicurio.registry.storage.impl.sql.SqlRegistryStorage;
 import io.apicurio.registry.storage.impl.sql.SqlStatements;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
@@ -17,8 +16,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
@@ -32,9 +33,6 @@ public class KafkaSqlSnapshotTest extends AbstractResourceTestBase {
 
     @Inject
     KafkaSqlRegistryStorage kafkaSqlRegistryStorage;
-
-    @Inject
-    SqlRegistryStorage sqlRegistryStorage;
 
     @BeforeAll
     public void init() {
@@ -72,24 +70,19 @@ public class KafkaSqlSnapshotTest extends AbstractResourceTestBase {
     }
 
     @Test
-    public void testSnapshotRestoreRoundTrip() throws IOException {
-        long artifactCountBefore = clientV3.groups().byGroupId(NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID)
-                .artifacts().get(config -> config.queryParameters.limit = 1).getCount();
-        Assertions.assertTrue(artifactCountBefore > 0, "Artifacts should exist before snapshot");
-
+    public void testSnapshotContainsDatabaseContent() throws IOException {
         String snapshotLocation = kafkaSqlRegistryStorage.triggerSnapshotCreation();
         Path path = Path.of(snapshotLocation);
         try {
             Assertions.assertTrue(Files.exists(path));
 
-            // Restore from the compressed snapshot into the same database. This exercises
-            // H2's RUNSCRIPT FROM ? COMPRESSION GZIP path and verifies the snapshot is valid.
-            sqlRegistryStorage.restoreFromSnapshot(snapshotLocation);
-
-            long artifactCountAfter = clientV3.groups().byGroupId(NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID)
-                    .artifacts().get(config -> config.queryParameters.limit = 1).getCount();
-            Assertions.assertEquals(artifactCountBefore, artifactCountAfter,
-                    "Artifact count should be the same after restoring from snapshot");
+            // Decompress and read the snapshot content to verify it contains valid H2 SQL
+            // statements including the data we created.
+            String content = readGzipContent(path);
+            Assertions.assertTrue(content.contains("CREATE MEMORY TABLE"),
+                    "Snapshot should contain H2 CREATE TABLE statements");
+            Assertions.assertTrue(content.contains("SNAPSHOT_TEST_GROUP_ID"),
+                    "Snapshot should contain the test group's artifact data");
         } finally {
             Files.deleteIfExists(path);
         }
@@ -100,15 +93,23 @@ public class KafkaSqlSnapshotTest extends AbstractResourceTestBase {
      * through a GZIPInputStream.
      */
     private void assertGzipCompressed(Path path) throws IOException {
+        String content = readGzipContent(path);
+        Assertions.assertFalse(content.isEmpty(), "GZIP content should decompress to non-empty data");
+    }
+
+    /**
+     * Reads and decompresses a GZIP file, returning the content as a string.
+     */
+    private String readGzipContent(Path path) throws IOException {
         try (InputStream fis = Files.newInputStream(path);
-             GZIPInputStream gzis = new GZIPInputStream(fis)) {
-            byte[] buffer = new byte[1024];
-            int totalRead = 0;
+             GZIPInputStream gzis = new GZIPInputStream(fis);
+             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[4096];
             int bytesRead;
             while ((bytesRead = gzis.read(buffer)) != -1) {
-                totalRead += bytesRead;
+                baos.write(buffer, 0, bytesRead);
             }
-            Assertions.assertTrue(totalRead > 0, "GZIP content should decompress to non-empty data");
+            return baos.toString(StandardCharsets.UTF_8);
         }
     }
 }

--- a/app/src/test/java/io/apicurio/registry/storage/impl/sql/H2SqlStatementsTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/sql/H2SqlStatementsTest.java
@@ -1,0 +1,45 @@
+package io.apicurio.registry.storage.impl.sql;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class H2SqlStatementsTest {
+
+    private final H2SqlStatements statements = new H2SqlStatements();
+
+    @Test
+    void testCreateDataSnapshotWithGzipExtension() {
+        String sql = statements.createDataSnapshot("/tmp/snapshot.sql.gz");
+        Assertions.assertEquals("SCRIPT TO ? COMPRESSION GZIP", sql);
+    }
+
+    @Test
+    void testCreateDataSnapshotWithPlainExtension() {
+        String sql = statements.createDataSnapshot("/tmp/snapshot.sql");
+        Assertions.assertEquals("SCRIPT TO ?", sql);
+    }
+
+    @Test
+    void testCreateDataSnapshotWithNullLocation() {
+        String sql = statements.createDataSnapshot(null);
+        Assertions.assertEquals("SCRIPT TO ?", sql);
+    }
+
+    @Test
+    void testRestoreFromSnapshotWithGzipExtension() {
+        String sql = statements.restoreFromSnapshot("/tmp/snapshot.sql.gz");
+        Assertions.assertEquals("RUNSCRIPT FROM ? COMPRESSION GZIP", sql);
+    }
+
+    @Test
+    void testRestoreFromSnapshotWithPlainExtension() {
+        String sql = statements.restoreFromSnapshot("/tmp/snapshot.sql");
+        Assertions.assertEquals("RUNSCRIPT FROM ?", sql);
+    }
+
+    @Test
+    void testRestoreFromSnapshotWithNullLocation() {
+        String sql = statements.restoreFromSnapshot(null);
+        Assertions.assertEquals("RUNSCRIPT FROM ?", sql);
+    }
+}


### PR DESCRIPTION
Fixes #8961

### What
Enables GZIP compression for H2 database snapshots used by the KafkaSQL storage variant.

### Why
Uncompressed `.sql` snapshot dumps can grow large, consuming significant disk space
(especially in `/tmp`) and slowing down replica startup times. This is particularly
problematic in ephemeral environments like Kubernetes without persistent volumes.

### How
- Added a `COMPRESSED_SNAPSHOT_EXTENSION` constant (`.sql.gz`) to `SqlStatements`.
- Added location-aware `default` overloads of `createDataSnapshot(String)` and
  `restoreFromSnapshot(String)` to the `SqlStatements` interface. The defaults delegate
  to the no-arg versions, so PostgreSQL/MySQL/MSSQL implementations are unaffected.
- Overrode both methods in `H2SqlStatements` to append H2's native `COMPRESSION GZIP`
  clause when the snapshot location ends with `.sql.gz`.
- Updated `SqlExportRepository` and `SqlRegistryStorage` to pass the snapshot location
  through to the new overloads so the correct SQL is generated.
- Changed `KafkaSqlRegistryStorage.triggerSnapshotCreation()` to generate snapshot
  files with the `.sql.gz` extension.
- Backward compatible: the restore path in `consumeSnapshotsTopic()` handles both old
  `.sql` and new `.sql.gz` snapshots transparently based on the file extension.

### Testing
- Added `H2SqlStatementsTest` with unit tests covering GZIP and plain extensions for
  both create and restore, including null location handling.