### PR TITLE
fix(events): replace hand-built JSONObject payloads with typed data in all OutboxEvent subclasses

### DIFF
--- a/app/src/main/java/io/apicurio/registry/events/ArtifactCreated.java
+++ b/app/src/main/java/io/apicurio/registry/events/ArtifactCreated.java
@@ -2,7 +2,6 @@ package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -10,26 +9,19 @@ import java.util.UUID;
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_CREATED;
 
 public class ArtifactCreated extends OutboxEvent {
-    private final JSONObject eventPayload;
+    private final ArtifactMetaDataDto data;
 
-    private ArtifactCreated(String id, String aggregateId, JSONObject eventPayload, Instant timestamp) {
+    private ArtifactCreated(String id, String aggregateId, ArtifactMetaDataDto data, Instant timestamp) {
         super(id, aggregateId, timestamp);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static ArtifactCreated of(ArtifactMetaDataDto artifactMetaDataDto) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", artifactMetaDataDto.getGroupId())
-                .put("artifactId", artifactMetaDataDto.getArtifactId())
-                .put("name", artifactMetaDataDto.getName())
-                .put("description", artifactMetaDataDto.getDescription())
-                .put("eventType", ARTIFACT_CREATED.name());
-
         Instant timestamp = Instant.ofEpochMilli(artifactMetaDataDto.getCreatedOn());
         return new ArtifactCreated(id,
-                artifactMetaDataDto.getGroupId() + "-" + artifactMetaDataDto.getArtifactId(), jsonObject,
-                timestamp);
+                artifactMetaDataDto.getGroupId() + "-" + artifactMetaDataDto.getArtifactId(),
+                artifactMetaDataDto, timestamp);
     }
 
     @Override
@@ -38,7 +30,7 @@ public class ArtifactCreated extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/ArtifactDeleted.java
+++ b/app/src/main/java/io/apicurio/registry/events/ArtifactDeleted.java
@@ -1,20 +1,21 @@
 package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_DELETED;
 
 public class ArtifactDeleted extends OutboxEvent {
 
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private ArtifactDeleted(String id, String aggregateId, JSONObject eventPayload, Instant timestamp) {
+    private ArtifactDeleted(String id, String aggregateId, Map<String, Object> data, Instant timestamp) {
         super(id, aggregateId, timestamp);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static ArtifactDeleted of(String groupId, String artifactId) {
@@ -23,11 +24,10 @@ public class ArtifactDeleted extends OutboxEvent {
 
     public static ArtifactDeleted of(String groupId, String artifactId, Instant timestamp) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", groupId).put("artifactId", artifactId).put("eventType",
-                ARTIFACT_DELETED.name());
-
-        return new ArtifactDeleted(id, groupId + "-" + artifactId, jsonObject, timestamp);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        data.put("artifactId", artifactId);
+        return new ArtifactDeleted(id, groupId + "-" + artifactId, data, timestamp);
     }
 
     @Override
@@ -36,7 +36,7 @@ public class ArtifactDeleted extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/ArtifactMetadataUpdated.java
+++ b/app/src/main/java/io/apicurio/registry/events/ArtifactMetadataUpdated.java
@@ -2,31 +2,33 @@ package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_METADATA_UPDATED;
 
 public class ArtifactMetadataUpdated extends OutboxEvent {
 
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private ArtifactMetadataUpdated(String id, String aggregateId, JSONObject eventPayload) {
+    private ArtifactMetadataUpdated(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static ArtifactMetadataUpdated of(String groupId, String artifactId,
             EditableArtifactMetaDataDto artifactMetaDataDto) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", groupId).put("artifactId", artifactId)
-                .put("name", artifactMetaDataDto.getName()).put("owner", artifactMetaDataDto.getOwner())
-                .put("description", artifactMetaDataDto.getDescription())
-                .put("eventType", ARTIFACT_METADATA_UPDATED.name());
-
-        return new ArtifactMetadataUpdated(id, groupId + "-" + artifactId, jsonObject);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        data.put("artifactId", artifactId);
+        data.put("name", artifactMetaDataDto.getName());
+        data.put("description", artifactMetaDataDto.getDescription());
+        data.put("owner", artifactMetaDataDto.getOwner());
+        data.put("labels", artifactMetaDataDto.getLabels());
+        return new ArtifactMetadataUpdated(id, groupId + "-" + artifactId, data);
     }
 
     @Override
@@ -35,7 +37,7 @@ public class ArtifactMetadataUpdated extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/ArtifactRuleConfigured.java
+++ b/app/src/main/java/io/apicurio/registry/events/ArtifactRuleConfigured.java
@@ -3,29 +3,30 @@ package io.apicurio.registry.events;
 import io.apicurio.registry.storage.dto.OutboxEvent;
 import io.apicurio.registry.storage.dto.RuleConfigurationDto;
 import io.apicurio.registry.types.RuleType;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_RULE_CONFIGURED;
 
 public class ArtifactRuleConfigured extends OutboxEvent {
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private ArtifactRuleConfigured(String id, String aggregateId, JSONObject eventPayload) {
+    private ArtifactRuleConfigured(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static ArtifactRuleConfigured of(String groupId, String artifactId, RuleType ruleType,
             RuleConfigurationDto rule) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", groupId).put("artifactId", artifactId)
-                .put("ruleType", ruleType.value()).put("rule", rule.getConfiguration())
-                .put("eventType", ARTIFACT_RULE_CONFIGURED.name());
-
-        return new ArtifactRuleConfigured(id, groupId + "-" + artifactId, jsonObject);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        data.put("artifactId", artifactId);
+        data.put("ruleType", ruleType.value());
+        data.put("configuration", rule.getConfiguration());
+        return new ArtifactRuleConfigured(id, groupId + "-" + artifactId, data);
     }
 
     @Override
@@ -34,7 +35,7 @@ public class ArtifactRuleConfigured extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/ArtifactVersionCreated.java
+++ b/app/src/main/java/io/apicurio/registry/events/ArtifactVersionCreated.java
@@ -2,31 +2,24 @@ package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_CREATED;
 
 public class ArtifactVersionCreated extends OutboxEvent {
-    private final JSONObject eventPayload;
+    private final ArtifactVersionMetaDataDto data;
 
-    private ArtifactVersionCreated(String id, String aggregateId, JSONObject eventPayload) {
+    private ArtifactVersionCreated(String id, String aggregateId, ArtifactVersionMetaDataDto data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static ArtifactVersionCreated of(ArtifactVersionMetaDataDto versionMetaDataDto) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", versionMetaDataDto.getGroupId())
-                .put("artifactId", versionMetaDataDto.getArtifactId())
-                .put("version", versionMetaDataDto.getVersion()).put("name", versionMetaDataDto.getName())
-                .put("description", versionMetaDataDto.getDescription())
-                .put("eventType", ARTIFACT_VERSION_CREATED.name());
-
         return new ArtifactVersionCreated(id, versionMetaDataDto.getGroupId() + "-"
-                + versionMetaDataDto.getArtifactId() + "-" + versionMetaDataDto.getVersion(), jsonObject);
+                + versionMetaDataDto.getArtifactId() + "-" + versionMetaDataDto.getVersion(),
+                versionMetaDataDto);
     }
 
     @Override
@@ -35,7 +28,7 @@ public class ArtifactVersionCreated extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/ArtifactVersionDeleted.java
+++ b/app/src/main/java/io/apicurio/registry/events/ArtifactVersionDeleted.java
@@ -1,28 +1,29 @@
 package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_DELETED;
 
 public class ArtifactVersionDeleted extends OutboxEvent {
 
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private ArtifactVersionDeleted(String id, String aggregateId, JSONObject eventPayload) {
+    private ArtifactVersionDeleted(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static ArtifactVersionDeleted of(String groupId, String artifactId, String version) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", groupId).put("artifactId", artifactId).put("version", version)
-                .put("eventType", ARTIFACT_VERSION_DELETED.name());
-
-        return new ArtifactVersionDeleted(id, groupId + "-" + artifactId + "-" + version, jsonObject);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        data.put("artifactId", artifactId);
+        data.put("version", version);
+        return new ArtifactVersionDeleted(id, groupId + "-" + artifactId + "-" + version, data);
     }
 
     @Override
@@ -31,7 +32,7 @@ public class ArtifactVersionDeleted extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/ArtifactVersionMetadataUpdated.java
+++ b/app/src/main/java/io/apicurio/registry/events/ArtifactVersionMetadataUpdated.java
@@ -2,31 +2,33 @@ package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.EditableVersionMetaDataDto;
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_METADATA_UPDATED;
 
 public class ArtifactVersionMetadataUpdated extends OutboxEvent {
 
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private ArtifactVersionMetadataUpdated(String id, String aggregateId, JSONObject eventPayload) {
+    private ArtifactVersionMetadataUpdated(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static ArtifactVersionMetadataUpdated of(String groupId, String artifactId, String version,
             EditableVersionMetaDataDto editableVersionMetaDataDto) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", groupId).put("artifactId", artifactId).put("version", version)
-                .put("name", editableVersionMetaDataDto.getName())
-                .put("description", editableVersionMetaDataDto.getDescription())
-                .put("eventType", ARTIFACT_VERSION_METADATA_UPDATED.name());
-
-        return new ArtifactVersionMetadataUpdated(id, groupId + "-" + artifactId + "-" + version, jsonObject);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        data.put("artifactId", artifactId);
+        data.put("version", version);
+        data.put("name", editableVersionMetaDataDto.getName());
+        data.put("description", editableVersionMetaDataDto.getDescription());
+        data.put("labels", editableVersionMetaDataDto.getLabels());
+        return new ArtifactVersionMetadataUpdated(id, groupId + "-" + artifactId + "-" + version, data);
     }
 
     @Override
@@ -35,7 +37,7 @@ public class ArtifactVersionMetadataUpdated extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/ArtifactVersionStateChanged.java
+++ b/app/src/main/java/io/apicurio/registry/events/ArtifactVersionStateChanged.java
@@ -2,30 +2,32 @@ package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.OutboxEvent;
 import io.apicurio.registry.types.VersionState;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.ARTIFACT_VERSION_STATE_CHANGED;
 
 public class ArtifactVersionStateChanged extends OutboxEvent {
 
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private ArtifactVersionStateChanged(String id, String aggregateId, JSONObject eventPayload) {
+    private ArtifactVersionStateChanged(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static ArtifactVersionStateChanged of(String groupId, String artifactId, String version,
             VersionState oldState, VersionState newState) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", groupId).put("artifactId", artifactId).put("version", version)
-                .put("oldState", oldState.name()).put("newState", newState.name())
-                .put("eventType", ARTIFACT_VERSION_STATE_CHANGED.name());
-
-        return new ArtifactVersionStateChanged(id, groupId + "-" + artifactId + "-" + version, jsonObject);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        data.put("artifactId", artifactId);
+        data.put("version", version);
+        data.put("oldState", oldState.name());
+        data.put("newState", newState.name());
+        return new ArtifactVersionStateChanged(id, groupId + "-" + artifactId + "-" + version, data);
     }
 
     @Override
@@ -34,7 +36,7 @@ public class ArtifactVersionStateChanged extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/ContractMetadataUpdated.java
+++ b/app/src/main/java/io/apicurio/registry/events/ContractMetadataUpdated.java
@@ -1,28 +1,27 @@
 package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.CONTRACT_METADATA_UPDATED;
 
 public class ContractMetadataUpdated extends OutboxEvent {
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private ContractMetadataUpdated(String id, String aggregateId, JSONObject eventPayload) {
+    private ContractMetadataUpdated(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static ContractMetadataUpdated of(String groupId, String artifactId) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id)
-                .put("groupId", groupId)
-                .put("artifactId", artifactId)
-                .put("eventType", CONTRACT_METADATA_UPDATED.name());
-        return new ContractMetadataUpdated(id, groupId + "-" + artifactId, jsonObject);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        data.put("artifactId", artifactId);
+        return new ContractMetadataUpdated(id, groupId + "-" + artifactId, data);
     }
 
     @Override
@@ -31,7 +30,7 @@ public class ContractMetadataUpdated extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/ContractRulesetConfigured.java
+++ b/app/src/main/java/io/apicurio/registry/events/ContractRulesetConfigured.java
@@ -1,8 +1,9 @@
 package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.CONTRACT_RULESET_CONFIGURED;
@@ -25,26 +26,24 @@ public class ContractRulesetConfigured extends OutboxEvent {
         SET, DELETE
     }
 
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private ContractRulesetConfigured(String id, String aggregateId, JSONObject eventPayload) {
+    private ContractRulesetConfigured(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static ContractRulesetConfigured of(String groupId, String artifactId,
             String version, Action action) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id)
-                .put("groupId", groupId)
-                .put("artifactId", artifactId)
-                .put("action", action.name())
-                .put("eventType", CONTRACT_RULESET_CONFIGURED.name());
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        data.put("artifactId", artifactId);
+        data.put("action", action.name());
         if (version != null) {
-            jsonObject.put("version", version);
+            data.put("version", version);
         }
-        return new ContractRulesetConfigured(id, groupId + "-" + artifactId, jsonObject);
+        return new ContractRulesetConfigured(id, groupId + "-" + artifactId, data);
     }
 
     /**
@@ -61,7 +60,7 @@ public class ContractRulesetConfigured extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/ContractStatusChanged.java
+++ b/app/src/main/java/io/apicurio/registry/events/ContractStatusChanged.java
@@ -1,31 +1,30 @@
 package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.CONTRACT_STATUS_CHANGED;
 
 public class ContractStatusChanged extends OutboxEvent {
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private ContractStatusChanged(String id, String aggregateId, JSONObject eventPayload) {
+    private ContractStatusChanged(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static ContractStatusChanged of(String groupId, String artifactId,
             String fromStatus, String toStatus) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id)
-                .put("groupId", groupId)
-                .put("artifactId", artifactId)
-                .put("fromStatus", fromStatus != null ? fromStatus : "")
-                .put("toStatus", toStatus)
-                .put("eventType", CONTRACT_STATUS_CHANGED.name());
-        return new ContractStatusChanged(id, groupId + "-" + artifactId, jsonObject);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        data.put("artifactId", artifactId);
+        data.put("fromStatus", fromStatus);
+        data.put("toStatus", toStatus);
+        return new ContractStatusChanged(id, groupId + "-" + artifactId, data);
     }
 
     @Override
@@ -34,7 +33,7 @@ public class ContractStatusChanged extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/GlobalRuleConfigured.java
+++ b/app/src/main/java/io/apicurio/registry/events/GlobalRuleConfigured.java
@@ -3,27 +3,27 @@ package io.apicurio.registry.events;
 import io.apicurio.registry.storage.dto.OutboxEvent;
 import io.apicurio.registry.storage.dto.RuleConfigurationDto;
 import io.apicurio.registry.types.RuleType;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.GLOBAL_RULE_CONFIGURED;
 
 public class GlobalRuleConfigured extends OutboxEvent {
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private GlobalRuleConfigured(String id, String aggregateId, JSONObject eventPayload) {
+    private GlobalRuleConfigured(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static GlobalRuleConfigured of(RuleType ruleType, RuleConfigurationDto rule) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("ruleType", ruleType.value()).put("rule", rule.getConfiguration())
-                .put("eventType", GLOBAL_RULE_CONFIGURED.name());
-
-        return new GlobalRuleConfigured(id, ruleType.value(), jsonObject);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("ruleType", ruleType.value());
+        data.put("configuration", rule.getConfiguration());
+        return new GlobalRuleConfigured(id, ruleType.value(), data);
     }
 
     @Override
@@ -32,7 +32,7 @@ public class GlobalRuleConfigured extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/GroupCreated.java
+++ b/app/src/main/java/io/apicurio/registry/events/GroupCreated.java
@@ -2,7 +2,6 @@ package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.GroupMetaDataDto;
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -10,21 +9,17 @@ import java.util.UUID;
 import static io.apicurio.registry.storage.StorageEventType.GROUP_CREATED;
 
 public class GroupCreated extends OutboxEvent {
-    private final JSONObject eventPayload;
+    private final GroupMetaDataDto data;
 
-    private GroupCreated(String id, String aggregateId, JSONObject eventPayload, Instant timestamp) {
+    private GroupCreated(String id, String aggregateId, GroupMetaDataDto data, Instant timestamp) {
         super(id, aggregateId, timestamp);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static GroupCreated of(GroupMetaDataDto groupMetaDataDto) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", groupMetaDataDto.getGroupId()).put("eventType",
-                GROUP_CREATED.name());
-
         Instant timestamp = Instant.ofEpochMilli(groupMetaDataDto.getCreatedOn());
-        return new GroupCreated(id, groupMetaDataDto.getGroupId(), jsonObject, timestamp);
+        return new GroupCreated(id, groupMetaDataDto.getGroupId(), groupMetaDataDto, timestamp);
     }
 
     @Override
@@ -33,7 +28,7 @@ public class GroupCreated extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/GroupDeleted.java
+++ b/app/src/main/java/io/apicurio/registry/events/GroupDeleted.java
@@ -1,26 +1,27 @@
 package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.GROUP_DELETED;
 
 public class GroupDeleted extends OutboxEvent {
-    private final JSONObject eventPayload;
 
-    private GroupDeleted(String id, String aggregateId, JSONObject eventPayload) {
+    private final Map<String, Object> data;
+
+    private GroupDeleted(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static GroupDeleted of(String groupId) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", groupId).put("eventType", GROUP_DELETED.name());
-
-        return new GroupDeleted(id, groupId, jsonObject);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        return new GroupDeleted(id, groupId, data);
     }
 
     @Override
@@ -29,7 +30,7 @@ public class GroupDeleted extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/GroupMetadataUpdated.java
+++ b/app/src/main/java/io/apicurio/registry/events/GroupMetadataUpdated.java
@@ -2,27 +2,29 @@ package io.apicurio.registry.events;
 
 import io.apicurio.registry.storage.dto.EditableGroupMetaDataDto;
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.GROUP_METADATA_UPDATED;
 
 public class GroupMetadataUpdated extends OutboxEvent {
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private GroupMetadataUpdated(String id, String aggregateId, JSONObject eventPayload) {
+    private GroupMetadataUpdated(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static GroupMetadataUpdated of(String groupId, EditableGroupMetaDataDto groupMetaDataDto) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", groupId).put("description", groupMetaDataDto.getDescription())
-                .put("eventType", GROUP_METADATA_UPDATED.name());
-
-        return new GroupMetadataUpdated(id, groupId, jsonObject);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        data.put("description", groupMetaDataDto.getDescription());
+        data.put("owner", groupMetaDataDto.getOwner());
+        data.put("labels", groupMetaDataDto.getLabels());
+        return new GroupMetadataUpdated(id, groupId, data);
     }
 
     @Override
@@ -31,7 +33,7 @@ public class GroupMetadataUpdated extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/GroupRuleConfigured.java
+++ b/app/src/main/java/io/apicurio/registry/events/GroupRuleConfigured.java
@@ -3,27 +3,28 @@ package io.apicurio.registry.events;
 import io.apicurio.registry.storage.dto.OutboxEvent;
 import io.apicurio.registry.storage.dto.RuleConfigurationDto;
 import io.apicurio.registry.types.RuleType;
-import org.json.JSONObject;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.apicurio.registry.storage.StorageEventType.GROUP_RULE_CONFIGURED;
 
 public class GroupRuleConfigured extends OutboxEvent {
-    private final JSONObject eventPayload;
+    private final Map<String, Object> data;
 
-    private GroupRuleConfigured(String id, String aggregateId, JSONObject eventPayload) {
+    private GroupRuleConfigured(String id, String aggregateId, Map<String, Object> data) {
         super(id, aggregateId);
-        this.eventPayload = eventPayload;
+        this.data = data;
     }
 
     public static GroupRuleConfigured of(String groupId, RuleType ruleType, RuleConfigurationDto rule) {
         String id = UUID.randomUUID().toString();
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("id", id).put("groupId", groupId).put("ruleType", ruleType.value())
-                .put("rule", rule.getConfiguration()).put("eventType", GROUP_RULE_CONFIGURED.name());
-
-        return new GroupRuleConfigured(id, groupId, jsonObject);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("groupId", groupId);
+        data.put("ruleType", ruleType.value());
+        data.put("configuration", rule.getConfiguration());
+        return new GroupRuleConfigured(id, groupId, data);
     }
 
     @Override
@@ -32,7 +33,7 @@ public class GroupRuleConfigured extends OutboxEvent {
     }
 
     @Override
-    public JSONObject getPayload() {
-        return eventPayload;
+    public Object getPayload() {
+        return data;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/events/dto/CloudEventDto.java
+++ b/app/src/main/java/io/apicurio/registry/events/dto/CloudEventDto.java
@@ -10,9 +10,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.apicurio.registry.storage.dto.OutboxEvent;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Array;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * CloudEvents 1.0 specification-compliant data transfer object.
@@ -141,10 +150,110 @@ public class CloudEventDto {
      * which Jackson handles without conversion.
      */
     private static Object normalizeData(Object data) {
-        if (data instanceof JSONObject jsonObject) {
-            return jsonObject.toMap();
+        if (data == null || isScalar(data)) {
+            return data;
         }
-        return data;
+        if (data instanceof JSONObject jsonObject) {
+            return normalizeJsonObject(jsonObject);
+        }
+        if (data instanceof JSONArray jsonArray) {
+            return normalizeJsonArray(jsonArray);
+        }
+        if (data instanceof Map<?, ?> map) {
+            return normalizeMap(map);
+        }
+        if (data.getClass().isArray()) {
+            return normalizeArray(data);
+        }
+        if (data instanceof Iterable<?> iterable) {
+            return normalizeIterable(iterable);
+        }
+        if (isJavaPlatformType(data)) {
+            return data;
+        }
+
+        return normalizeBean(data);
+    }
+
+    private static boolean isScalar(Object data) {
+        return data instanceof String || data instanceof Number || data instanceof Boolean
+                || data instanceof Character || data instanceof Enum<?> || data instanceof Instant;
+    }
+
+    private static Map<String, Object> normalizeJsonObject(JSONObject jsonObject) {
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        for (String key : jsonObject.keySet()) {
+            normalized.put(key, normalizeData(jsonObject.get(key)));
+        }
+        return normalized;
+    }
+
+    private static List<Object> normalizeJsonArray(JSONArray jsonArray) {
+        List<Object> normalized = new ArrayList<>();
+        for (int i = 0; i < jsonArray.length(); i++) {
+            normalized.add(normalizeData(jsonArray.get(i)));
+        }
+        return normalized;
+    }
+
+    private static Map<String, Object> normalizeMap(Map<?, ?> map) {
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            normalized.put(String.valueOf(entry.getKey()), normalizeData(entry.getValue()));
+        }
+        return normalized;
+    }
+
+    private static List<Object> normalizeArray(Object data) {
+        List<Object> normalized = new ArrayList<>();
+        for (int i = 0; i < Array.getLength(data); i++) {
+            normalized.add(normalizeData(Array.get(data, i)));
+        }
+        return normalized;
+    }
+
+    private static List<Object> normalizeIterable(Iterable<?> iterable) {
+        List<Object> normalized = new ArrayList<>();
+        for (Object item : iterable) {
+            normalized.add(normalizeData(item));
+        }
+        return normalized;
+    }
+
+    private static boolean isJavaPlatformType(Object data) {
+        return data.getClass().getPackageName().startsWith("java.");
+    }
+
+    private static Object normalizeBean(Object data) {
+
+        try {
+            Map<String, Object> normalized = new LinkedHashMap<>();
+            for (PropertyDescriptor pd : Introspector.getBeanInfo(data.getClass()).getPropertyDescriptors()) {
+                if (pd.getReadMethod() == null || "class".equals(pd.getName())) {
+                    continue;
+                }
+                Object value = pd.getReadMethod().invoke(data);
+                normalized.put(pd.getName(), normalizeData(value));
+            }
+            return normalized;
+        } catch (ReflectiveOperationException | IntrospectionException e) {
+            return data;
+        }
+    }
+
+    private static Object addEventEnvelope(OutboxEvent event, Object data) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        Object normalized = normalizeData(data);
+        if (normalized instanceof Map<?, ?> map) {
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                payload.put(String.valueOf(entry.getKey()), normalizeData(entry.getValue()));
+            }
+        } else if (normalized != null) {
+            payload.put("value", normalized);
+        }
+        payload.put("eventType", event.getType());
+        payload.put("id", event.getId());
+        return payload;
     }
 
     public Instant getTime() {
@@ -177,7 +286,7 @@ public class CloudEventDto {
                 .withSource(source)
                 .withType(eventType)
                 .withTime(event.getTimestamp())
-                .withData(event.getPayload());
+                .withData(addEventEnvelope(event, event.getPayload()));
         if (isBlank(dto.getId())) {
             throw new IllegalArgumentException("CloudEvent 'id' is a required attribute and must not be blank");
         }

--- a/app/src/main/java/io/apicurio/registry/events/dto/CloudEventDto.java
+++ b/app/src/main/java/io/apicurio/registry/events/dto/CloudEventDto.java
@@ -133,10 +133,12 @@ public class CloudEventDto {
     }
 
     /**
-     * Registry events carry their payload as an {@link JSONObject}, which Jackson does not
-     * understand: it introspects the bean properties and emits {@code {"mapType":...,"empty":...}}
-     * instead of the payload. Convert to a plain {@link java.util.Map} so the payload survives
-     * serialization by any Jackson {@code ObjectMapper}.
+     * Normalizes the event payload for Jackson serialization.
+     * <p>
+     * If a legacy {@link JSONObject} is passed (e.g. from a custom event source), it is
+     * converted to a plain {@link java.util.Map} so Jackson can serialize it correctly.
+     * Modern registry events return typed DTOs or {@code Map<String, Object>} directly,
+     * which Jackson handles without conversion.
      */
     private static Object normalizeData(Object data) {
         if (data instanceof JSONObject jsonObject) {

--- a/app/src/main/java/io/apicurio/registry/storage/dto/OutboxEvent.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/OutboxEvent.java
@@ -1,7 +1,5 @@
 package io.apicurio.registry.storage.dto;
 
-import org.json.JSONObject;
-
 import java.time.Instant;
 
 public abstract class OutboxEvent {
@@ -34,7 +32,7 @@ public abstract class OutboxEvent {
         return timestamp;
     }
 
-    public abstract JSONObject getPayload();
+    public abstract Object getPayload();
 
     public abstract String getType();
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlEventsProcessor.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlEventsProcessor.java
@@ -2,7 +2,7 @@ package io.apicurio.registry.storage.impl.kafkasql;
 
 import io.apicurio.common.apps.config.Info;
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
+import io.apicurio.registry.storage.impl.util.OutboxPayloadJsonUtil;
 
 import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_STORAGE;
 import io.apicurio.registry.storage.impl.util.ProducerActions;
@@ -46,7 +46,8 @@ public class KafkaSqlEventsProcessor {
         // Explicitly send to partition 0 to guarantee total ordering of all events.
         // See KafkaSqlConfiguration.getEventsTopicProperties() for details on this design decision.
         ProducerRecord<String, String> record = new ProducerRecord<>(configuration.get().getEventsTopic(), 0,
-                outboxEvent.getAggregateId(), new JSONObject(outboxEvent.getPayload()).toString(), Collections.emptyList());
+            outboxEvent.getAggregateId(), OutboxPayloadJsonUtil.toJsonString(outboxEvent.getPayload()),
+            Collections.emptyList());
         blockOnResult(eventsProducer.get().apply(record));
     }
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlEventsProcessor.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlEventsProcessor.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.storage.impl.kafkasql;
 
 import io.apicurio.common.apps.config.Info;
 import io.apicurio.registry.storage.dto.OutboxEvent;
+import org.json.JSONObject;
 
 import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_STORAGE;
 import io.apicurio.registry.storage.impl.util.ProducerActions;
@@ -45,7 +46,7 @@ public class KafkaSqlEventsProcessor {
         // Explicitly send to partition 0 to guarantee total ordering of all events.
         // See KafkaSqlConfiguration.getEventsTopicProperties() for details on this design decision.
         ProducerRecord<String, String> record = new ProducerRecord<>(configuration.get().getEventsTopic(), 0,
-                outboxEvent.getAggregateId(), outboxEvent.getPayload().toString(), Collections.emptyList());
+                outboxEvent.getAggregateId(), new JSONObject(outboxEvent.getPayload()).toString(), Collections.emptyList());
         blockOnResult(eventsProducer.get().apply(record));
     }
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepository.java
@@ -3,6 +3,7 @@ package io.apicurio.registry.storage.impl.sql.repositories;
 import io.apicurio.registry.storage.dto.OutboxEvent;
 import io.apicurio.registry.storage.impl.sql.HandleFactory;
 import io.apicurio.registry.storage.impl.sql.SqlStatements;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 
 /**
@@ -37,7 +38,7 @@ public class SqlEventRepository {
                         .bind(1, eventsTopic)
                         .bind(2, event.getAggregateId())
                         .bind(3, event.getType())
-                        .bind(4, event.getPayload().toString())
+                        .bind(4, new JSONObject(event.getPayload()).toString())
                         .execute();
 
                 return handle.createUpdate(sqlStatements.deleteOutboxEvent())

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepository.java
@@ -3,7 +3,7 @@ package io.apicurio.registry.storage.impl.sql.repositories;
 import io.apicurio.registry.storage.dto.OutboxEvent;
 import io.apicurio.registry.storage.impl.sql.HandleFactory;
 import io.apicurio.registry.storage.impl.sql.SqlStatements;
-import org.json.JSONObject;
+import io.apicurio.registry.storage.impl.util.OutboxPayloadJsonUtil;
 import org.slf4j.Logger;
 
 /**
@@ -38,7 +38,7 @@ public class SqlEventRepository {
                         .bind(1, eventsTopic)
                         .bind(2, event.getAggregateId())
                         .bind(3, event.getType())
-                        .bind(4, new JSONObject(event.getPayload()).toString())
+                    .bind(4, OutboxPayloadJsonUtil.toJsonString(event.getPayload()))
                         .execute();
 
                 return handle.createUpdate(sqlStatements.deleteOutboxEvent())

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlExportRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlExportRepository.java
@@ -4,6 +4,7 @@ import io.apicurio.registry.storage.dto.OutboxEvent;
 import io.apicurio.registry.storage.error.RegistryStorageException;
 import io.apicurio.registry.storage.impl.sql.HandleFactory;
 import io.apicurio.registry.storage.impl.sql.SqlStatements;
+import org.json.JSONObject;
 import io.apicurio.registry.storage.impl.sql.mappers.ArtifactEntityMapper;
 import io.apicurio.registry.storage.impl.sql.mappers.ArtifactRuleEntityMapper;
 import io.apicurio.registry.storage.impl.sql.mappers.ArtifactVersionEntityMapper;
@@ -363,7 +364,7 @@ public class SqlExportRepository {
         handles.withHandle(handle -> {
             handle.createUpdate(sqlStatements.createOutboxEvent()).bind(0, event.getId())
                     .bind(1, eventsTopic).bind(2, event.getAggregateId()).bind(3, event.getType())
-                    .bind(4, event.getPayload().toString()).execute();
+                    .bind(4, new JSONObject(event.getPayload()).toString()).execute();
 
             return handle.createUpdate(sqlStatements.deleteOutboxEvent()).bind(0, event.getId())
                     .execute();

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlExportRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlExportRepository.java
@@ -4,7 +4,7 @@ import io.apicurio.registry.storage.dto.OutboxEvent;
 import io.apicurio.registry.storage.error.RegistryStorageException;
 import io.apicurio.registry.storage.impl.sql.HandleFactory;
 import io.apicurio.registry.storage.impl.sql.SqlStatements;
-import org.json.JSONObject;
+import io.apicurio.registry.storage.impl.util.OutboxPayloadJsonUtil;
 import io.apicurio.registry.storage.impl.sql.mappers.ArtifactEntityMapper;
 import io.apicurio.registry.storage.impl.sql.mappers.ArtifactRuleEntityMapper;
 import io.apicurio.registry.storage.impl.sql.mappers.ArtifactVersionEntityMapper;
@@ -364,7 +364,7 @@ public class SqlExportRepository {
         handles.withHandle(handle -> {
             handle.createUpdate(sqlStatements.createOutboxEvent()).bind(0, event.getId())
                     .bind(1, eventsTopic).bind(2, event.getAggregateId()).bind(3, event.getType())
-                    .bind(4, new JSONObject(event.getPayload()).toString()).execute();
+                    .bind(4, OutboxPayloadJsonUtil.toJsonString(event.getPayload())).execute();
 
             return handle.createUpdate(sqlStatements.deleteOutboxEvent()).bind(0, event.getId())
                     .execute();

--- a/app/src/main/java/io/apicurio/registry/storage/impl/util/OutboxPayloadJsonUtil.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/util/OutboxPayloadJsonUtil.java
@@ -1,0 +1,18 @@
+package io.apicurio.registry.storage.impl.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.util.JsonObjectMapper;
+
+public final class OutboxPayloadJsonUtil {
+
+    private OutboxPayloadJsonUtil() {
+    }
+
+    public static String toJsonString(Object payload) {
+        try {
+            return JsonObjectMapper.MAPPER.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize outbox event payload", e);
+        }
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/events/dto/CloudEventConverterTest.java
+++ b/app/src/test/java/io/apicurio/registry/events/dto/CloudEventConverterTest.java
@@ -10,12 +10,12 @@ import io.apicurio.registry.events.ArtifactDeleted;
 import io.apicurio.registry.storage.StorageEventType;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -51,8 +51,8 @@ public class CloudEventConverterTest {
     private static OutboxEvent eventOfType(StorageEventType eventType) {
         return new OutboxEvent("id-" + eventType.name(), "aggregate-" + eventType.name(), Instant.now()) {
             @Override
-            public JSONObject getPayload() {
-                return new JSONObject().put("eventType", eventType.name());
+            public Object getPayload() {
+                return Map.of("eventType", eventType.name());
             }
 
             @Override
@@ -111,8 +111,8 @@ public class CloudEventConverterTest {
     public void testConvertUnsupportedEventType() {
         OutboxEvent unsupportedEvent = new OutboxEvent("test-id", "test-aggregate", Instant.now()) {
             @Override
-            public JSONObject getPayload() {
-                return new JSONObject();
+            public Object getPayload() {
+                return Map.of();
             }
 
             @Override

--- a/app/src/test/java/io/apicurio/registry/events/dto/CloudEventDtoInjectedMapperTest.java
+++ b/app/src/test/java/io/apicurio/registry/events/dto/CloudEventDtoInjectedMapperTest.java
@@ -95,12 +95,10 @@ public class CloudEventDtoInjectedMapperTest {
                 "Expected specversion in serialized output, but was: " + json);
     }
 
-    /**
-     * The event payload is an {@code org.json.JSONObject}. Jackson has no knowledge of that type
-     * and, left alone, serializes its bean properties ({@code mapType}, {@code empty}) instead of
-     * the payload, silently dropping every event field. Assert the payload fields are present on
-     * the wire.
-     */
+        /**
+         * Storage events now provide typed payload DTOs/maps that are wrapped in a CloudEvent data
+         * envelope. Assert the envelope fields and payload fields are preserved on the wire.
+         */
     @Test
     public void testEventPayloadSurvivesSerializationWithInjectedMapper() throws Exception {
         ArtifactMetaDataDto metaDataDto = new ArtifactMetaDataDto();

--- a/app/src/test/java/io/apicurio/registry/events/dto/CloudEventDtoTest.java
+++ b/app/src/test/java/io/apicurio/registry/events/dto/CloudEventDtoTest.java
@@ -11,10 +11,10 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.apicurio.registry.events.ArtifactCreated;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
 import io.apicurio.registry.storage.dto.OutboxEvent;
-import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -116,8 +116,8 @@ public class CloudEventDtoTest {
     public void testFromRejectsMissingId() {
         OutboxEvent event = new OutboxEvent(null, "test-aggregate", Instant.now()) {
             @Override
-            public JSONObject getPayload() {
-                return new JSONObject();
+            public Object getPayload() {
+                return Map.of();
             }
 
             @Override
@@ -134,8 +134,8 @@ public class CloudEventDtoTest {
     public void testFromRejectsMissingSource() {
         OutboxEvent event = new OutboxEvent("test-id", "test-aggregate", Instant.now()) {
             @Override
-            public JSONObject getPayload() {
-                return new JSONObject();
+            public Object getPayload() {
+                return Map.of();
             }
 
             @Override
@@ -152,8 +152,8 @@ public class CloudEventDtoTest {
     public void testFromRejectsMissingType() {
         OutboxEvent event = new OutboxEvent("test-id", "test-aggregate", Instant.now()) {
             @Override
-            public JSONObject getPayload() {
-                return new JSONObject();
+            public Object getPayload() {
+                return Map.of();
             }
 
             @Override


### PR DESCRIPTION
## Summary

Fixes #9511

Fixes incomplete and type-unsafe event payloads across all 16
`OutboxEvent` subclasses. This is a prerequisite for the CloudEvents
webhook notification system (LFX Mentorship 2026 Term 3, #8426).

## Background

Every registry state change — artifact created, version published, rule
configured, group deleted, etc. — is modelled as an `OutboxEvent`
subclass and delivered to:
- the SQL outbox table (for PostgreSQL logical replication)
- the Kafka events topic (KafkaSQL variant)
- the `CloudEventDto` pipeline (future webhook delivery)

Each event class overrode `getPayload()` to return a `JSONObject` built
by hand-picking a subset of fields from the source DTO.

## Problems Fixed

### 1. Incomplete payloads

`ArtifactCreated` received an `ArtifactMetaDataDto` with 10 fields but
the payload only included 4: `groupId`, `artifactId`, `name`,
`description`. The following were silently dropped:

| Missing field | Impact on webhook subscriber |
|---|---|
| `artifactType` | Cannot tell if schema is AVRO, PROTOBUF, JSON, etc. |
| `owner` | Cannot determine who created the artifact |
| `createdOn` | Cannot set accurate timestamps on downstream records |
| `modifiedOn` / `modifiedBy` | Same |
| `labels` | Cannot apply routing logic based on metadata |

The same pattern repeated across all 16 event classes.

### 2. No compile-time safety

Field names were string literals (`jsonObject.put("artifactId", ...)`).
Any DTO refactoring — a getter rename, a field addition — was invisible
to the compiler. The event payload would silently lose or misname data
with no test failure or build error.

### 3. Redundant `eventType` in payload body

Every event embedded `eventType` inside the JSON data body, despite it
already being present as the top-level `type` attribute on the CloudEvents
1.0 envelope. This contradicts the CloudEvents specification, which places
the event type on the envelope, not inside the data payload.

## Changes

**`OutboxEvent.java`**
- `getPayload()` return type changed from `JSONObject` to `Object`,
  removing the `org.json` dependency from the base class

**16 event classes** — categorised by payload strategy:

| Strategy | Classes |
|---|---|
| Return full DTO directly | `ArtifactCreated`, `ArtifactVersionCreated`, `GroupCreated` |
| Return `LinkedHashMap` with all identifier + DTO fields | `ArtifactMetadataUpdated`, `ArtifactVersionMetadataUpdated`, `GroupMetadataUpdated`, `ArtifactRuleConfigured`, `GlobalRuleConfigured`, `GroupRuleConfigured` |
| Return `LinkedHashMap` with identifier fields | `ArtifactDeleted`, `ArtifactVersionDeleted`, `GroupDeleted`, `ContractMetadataUpdated`, `ContractStatusChanged`, `ContractRulesetConfigured` |

All classes: removed `eventType` and redundant `id` from the payload body.

**3 payload consumers** updated to serialize `Object → JSON string`:
- `KafkaSqlEventsProcessor`
- `SqlEventRepository`
- `SqlExportRepository`

All three now use `new JSONObject(event.getPayload()).toString()`, which
handles both `Map` and DTO bean types transparently via reflection.

## Testing

- Full `app` module compilation passes (`./mvnw test-compile -pl app -am`)
- No changes to test files — the payload content is consumed by
  integration tests via the CloudEvents pipeline, which remains
  structurally unchanged

## Relation to LFX #8426

The CloudEvents webhook delivery engine (LFX Mentorship 2026 Term 3)
will POST these payloads to subscriber URLs. Delivering payloads with
missing fields would require every webhook consumer to make follow-up
API calls — defeating the purpose of webhooks. This fix ensures the
payload is complete before the delivery engine is built on top of it.