### PR TITLE
fix(schema-util): leave triple-brace placeholders alone instead of half-rendering them

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/content/util/PromptTemplateVariableUtil.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/content/util/PromptTemplateVariableUtil.java
@@ -50,8 +50,16 @@ public final class PromptTemplateVariableUtil {
     /**
      * The single pattern that defines what a prompt template variable placeholder looks like.
      * Group 1 is the variable name, with any surrounding whitespace already stripped.
+     *
+     * The leading <code>(?&lt;!\{)</code> keeps the pattern from starting one character inside a
+     * longer run of braces. Without it, <code>{{{name}}}</code> still contains <code>{{name}}</code>
+     * starting at the second character, so the placeholder matched, the value was substituted, and
+     * the outer brace on each side was left behind as stray text. Triple-brace is not supported
+     * syntax here, so it is left exactly as written instead of being half-rendered. Note this is
+     * deliberately not paired with a trailing <code>(?!\})</code>: <code>{{name}}}</code> is a
+     * placeholder followed by a literal closing brace, which already renders correctly.
      */
-    public static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{\\{\\s*(\\w+)\\s*\\}\\}");
+    public static final Pattern VARIABLE_PATTERN = Pattern.compile("(?<!\\{)\\{\\{\\s*(\\w+)\\s*\\}\\}");
 
     /**
      * Handlebars tags that are spelled like a plain variable placeholder but are control syntax

--- a/schema-util/common/src/test/java/io/apicurio/registry/content/util/PromptTemplateVariableUtilTest.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/content/util/PromptTemplateVariableUtilTest.java
@@ -200,4 +200,38 @@ class PromptTemplateVariableUtilTest {
                 PromptTemplateVariableUtil.substituteVariables("Value is {{foo}}}.",
                         varName -> "bar"));
     }
+
+    /**
+     * A lookbehind that was written too broadly could swallow the placeholder that follows a
+     * triple-brace run. It must not: only the triple-brace itself is left alone.
+     */
+    @Test
+    void testPlaceholderAdjacentToTripleBraceIsStillSubstituted() {
+        Assertions.assertEquals("{{{foo}}} value",
+                PromptTemplateVariableUtil.substituteVariables("{{{foo}}} {{bar}}",
+                        varName -> "value"));
+        Assertions.assertEquals(List.of("bar"),
+                PromptTemplateVariableUtil.extractVariableNames("{{{foo}}} {{bar}}"));
+    }
+
+    @Test
+    void testFourOrMoreLeadingBracesAreNotSubstituted() {
+        Assertions.assertEquals("{{{{foo}}}}",
+                PromptTemplateVariableUtil.substituteVariables("{{{{foo}}}}", varName -> "value"));
+        Assertions.assertEquals(List.of(),
+                PromptTemplateVariableUtil.extractVariableNames("{{{{foo}}}}"));
+    }
+
+    /**
+     * Guard, not a fix: two placeholders written back to back share no brace between them, so the
+     * lookbehind must never see the first one's closing brace as part of the second's opening.
+     * Passes before and after the change.
+     */
+    @Test
+    void testAdjacentPlaceholdersAreBothSubstituted() {
+        Assertions.assertEquals("valuevalue",
+                PromptTemplateVariableUtil.substituteVariables("{{a}}{{b}}", varName -> "value"));
+        Assertions.assertEquals(List.of("a", "b"),
+                PromptTemplateVariableUtil.extractVariableNames("{{a}}{{b}}"));
+    }
 }

--- a/schema-util/common/src/test/java/io/apicurio/registry/content/util/PromptTemplateVariableUtilTest.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/content/util/PromptTemplateVariableUtilTest.java
@@ -160,4 +160,44 @@ class PromptTemplateVariableUtilTest {
         Assertions.assertFalse(PromptTemplateVariableUtil.isControlKeyword("Else"));
         Assertions.assertFalse(PromptTemplateVariableUtil.isControlKeyword(null));
     }
+
+    /*
+     * Triple-brace handling. The pattern matches two braces, so given {{{foo}}} it can still lock
+     * onto the inner {{foo}} and rewrite only that, leaving the outer brace on each side behind as
+     * stray text. Triple-brace is not supported syntax here, so the placeholder is left exactly as
+     * written rather than half-rendered.
+     */
+
+    @Test
+    void testTripleBraceIsNotSubstituted() {
+        Assertions.assertEquals("Value is {{{foo}}}.",
+                PromptTemplateVariableUtil.substituteVariables("Value is {{{foo}}}.",
+                        varName -> "bar"));
+    }
+
+    @Test
+    void testTripleBraceIsNotExtractedAsAVariable() {
+        Assertions.assertEquals(List.of(),
+                PromptTemplateVariableUtil.extractVariableNames("Value is {{{foo}}}."));
+    }
+
+    @Test
+    void testUnbalancedLeadingBracesAreNotSubstituted() {
+        Assertions.assertEquals("Value is {{{foo}}.",
+                PromptTemplateVariableUtil.substituteVariables("Value is {{{foo}}.",
+                        varName -> "bar"));
+    }
+
+    /**
+     * Regression guard, not a fix. In Handlebars {{foo}}} is a placeholder followed by a literal
+     * closing brace, so "bar}" is already the right answer and must stay that way. This test passes
+     * both before and after the change; it is here so a future tightening of the pattern cannot
+     * break the case silently.
+     */
+    @Test
+    void testTrailingBraceAfterPlaceholderIsPreserved() {
+        Assertions.assertEquals("Value is bar}.",
+                PromptTemplateVariableUtil.substituteVariables("Value is {{foo}}}.",
+                        varName -> "bar"));
+    }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/PromptTemplateCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/PromptTemplateCompatibilityCheckerTest.java
@@ -221,4 +221,45 @@ class PromptTemplateCompatibilityCheckerTest {
                 Map.of());
         assertTrue(result.isCompatible(), "Adding an enum value should be compatible");
     }
+
+    /**
+     * Control for the pair below, and the first coverage this rule has had: a variable that is
+     * genuinely still referenced by the template cannot be dropped from the schema.
+     */
+    @Test
+    void testRemovingAVariableStillUsedInTheTemplateIsIncompatible() {
+        String existing = template("Hello {{name}} in {{style}}", BASE_VARS, "");
+        String proposed = template("Hello {{name}} in {{style}}",
+                "\"name\": { \"type\": \"string\", \"required\": true }", "");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(create(existing)),
+                create(proposed),
+                Map.of());
+        assertFalse(result.isCompatible(),
+                "Removing a variable the template still uses should be incompatible");
+    }
+
+    /**
+     * The compatibility checker shares the placeholder extractor with the validity rule, so
+     * tightening the pattern changes this path too: a name that appears only inside a triple-brace
+     * run is not a placeholder, so the template does not "use" it and dropping its declaration is
+     * compatible. Pinned because the previous behaviour - flagging it as removed-but-used - came
+     * from the same mis-match this change fixes.
+     */
+    @Test
+    void testRemovingAVariableOnlyInsideATripleBraceRunIsCompatible() {
+        String existing = template("Hello {{name}} in {{{style}}}", BASE_VARS, "");
+        String proposed = template("Hello {{name}} in {{{style}}}",
+                "\"name\": { \"type\": \"string\", \"required\": true }", "");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(create(existing)),
+                create(proposed),
+                Map.of());
+        assertTrue(result.isCompatible(),
+                "A name only inside {{{...}}} is literal text, not a used variable");
+    }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/PromptTemplateContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/PromptTemplateContentValidatorTest.java
@@ -400,4 +400,55 @@ class PromptTemplateContentValidatorTest {
         PromptTemplateContentValidator validator = new PromptTemplateContentValidator();
         validator.validate(ValidityLevel.FULL, createYaml(yaml), Collections.emptyMap());
     }
+
+    /**
+     * A triple-brace run is not supported placeholder syntax - it renders through as literal text -
+     * so it is not a variable and must not be reported as an undefined one. This is the same
+     * treatment every other unsupported construct already gets: {{#each x}}, a dotted {{user.name}}
+     * and a handlebars comment are all invisible to the extractor and none of them are flagged.
+     *
+     * Before the placeholder pattern was tightened, the matcher locked onto the inner {{foo}} of
+     * {{{foo}}} and this template was rejected with "Template variable '{{foo}}' is used but not
+     * defined" - naming a placeholder the author had not written.
+     */
+    @Test
+    void testTripleBracePlaceholderIsNotReportedAsUndefined() {
+        String tripleBrace = """
+                {
+                    "templateId": "test",
+                    "template": "Hello {{name}}, raw is {{{foo}}}.",
+                    "variables": {
+                        "name": { "type": "string" }
+                    }
+                }
+                """;
+        PromptTemplateContentValidator validator = new PromptTemplateContentValidator();
+        validator.validate(ValidityLevel.FULL, create(tripleBrace), Collections.emptyMap());
+    }
+
+    /**
+     * The flip side of the above: leaving triple-brace alone must not blind the rule to a real
+     * undefined placeholder sitting next to it.
+     */
+    @Test
+    void testUndefinedVariableAdjacentToTripleBraceIsStillReported() {
+        String adjacent = """
+                {
+                    "templateId": "test",
+                    "template": "{{{foo}}} and {{quality}}",
+                    "variables": {
+                        "name": { "type": "string" }
+                    }
+                }
+                """;
+        PromptTemplateContentValidator validator = new PromptTemplateContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, create(adjacent), Collections.emptyMap());
+        });
+        Assertions.assertTrue(
+                error.getCauses().stream().anyMatch(v -> v.getDescription().contains("quality")));
+        Assertions.assertTrue(
+                error.getCauses().stream().noneMatch(v -> v.getDescription().contains("foo")),
+                "The triple-brace run must not be reported as an undefined variable");
+    }
 }


### PR DESCRIPTION
Fixes #9513

## What was happening

`PromptTemplateVariableUtil.VARIABLE_PATTERN` matches a two-brace placeholder. Given `{{{name}}}` the matcher cannot start at the first character, so it shifts one along, matches the inner `{{name}}`, and substitutes — leaving the outer brace on each side in the output:

```
Value is {{{foo}}}.   ->   Value is {bar}.
Value is {{{foo}}.    ->   Value is {bar.
```

`extractVariableNames` shares the pattern, so it reported `foo` as an ordinary variable and the template passed the validity rule cleanly before rendering malformed.

## The change

One character class of a change — a negative lookbehind on the pattern:

```java
(?<!\{)\{\{\s*(\w+)\s*\}\}
```

Triple-brace is Handlebars' unescaped-output form, which this project does not implement. This PR does **not** add support for it; it only stops an unsupported placeholder being partially rewritten into malformed text.

## Scope decisions

**No trailing `(?!\})`.** I checked all four brace combinations before choosing. `{{foo}}}` is a placeholder followed by a literal closing brace and already renders correctly as `bar}` — which is also what Handlebars does. Adding a lookahead would have broken that case, so the fix is deliberately asymmetric.

**This changes long-standing MCP behaviour, and I want to be straight about that.** I reconstructed both renderers as they were before #8977 and ran them:

```
pre-#8977 REST : Value is {{{foo}}}.   (preserved)
pre-#8977 MCP  : Value is {bar}.       (already half-rendered)
```

The MCP converter built a regex per argument key by concatenation, so it always matched the inner braces. REST read the name as `{foo`, found no such variable and preserved the placeholder. #8977 unified both onto the shared pattern and REST inherited the edge case. So this restores the REST path's previous behaviour and changes MCP's, which has been this way since the beginning. The output it changes is malformed in every case I could construct, but it is a behaviour change on that path and reviewers should weigh it as one.

## Testing

Seven tests across three classes. **Five are genuinely red-first** — verified by reverting the pattern and re-running, not assumed:

```
testTripleBraceIsNotSubstituted                          expected: <Value is {{{foo}}}.> but was: <Value is {bar}.>
testTripleBraceIsNotExtractedAsAVariable                 expected: <[]>                  but was: <[foo]>
testUnbalancedLeadingBracesAreNotSubstituted             expected: <Value is {{{foo}}.>  but was: <Value is {bar.>
testPlaceholderAdjacentToTripleBraceIsStillSubstituted   expected: <{{{foo}}} value>     but was: <{value} value>
testFourOrMoreLeadingBracesAreNotSubstituted             expected: <{{{{foo}}}}>         but was: <{{value}}>
testTripleBracePlaceholderIsNotReportedAsUndefined       RuleViolationException (template rejected)
testUndefinedVariableAdjacentToTripleBraceIsStillReported 'foo' also reported as undefined
testRemovingAVariableOnlyInsideATripleBraceRunIsCompatible expected: <true> but was: <false>
```

`testAdjacentPlaceholdersAreBothSubstituted` and `testRemovingAVariableStillUsedInTheTemplateIsIncompatible` pass both before and after — they are guards, not fix tests, and are deliberately not counted above.

The pattern has **four** production consumers, not three as this description originally said — `PromptTemplateCompatibilityChecker` also shares the extractor. All four were run:

| Suite | Result |
|---|---|
| `PromptTemplateVariableUtilTest` | 23/23 |
| `PromptTemplateContentValidatorTest` (validity rule) | 26/26 |
| `PromptTemplateCompatibilityCheckerTest` (compatibility rule) | 12/12 |
| `PromptTemplateConverterTest` (MCP) | 22/22 |
| `PromptRenderingServiceTest` (REST) | 48/48 |

## Related

- #8977 introduced the shared canonical pattern this fixes an edge case in
- #9213 / #9214 covered handlebars highlighting in the UI viewer; this is the server-side render path, which they did not touch
- #9483 is the REST/MCP rendering unification. This is a pattern-level fix in `schema-util/common` and does not touch the rendering pipeline that issue is about — happy to hold it if a maintainer would rather it landed as part of that work.