### PR TITLE
fix(a2a): return bad request for structure search without index

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
@@ -38,6 +38,10 @@ public class SqlSearchRepository {
             "Content search requires the search index, which is not enabled. "
             + "Enable the search index to use content search.";
 
+    private static final String STRUCTURE_SEARCH_UNSUPPORTED_MESSAGE =
+            "Structure search requires the search index, which is not enabled. "
+                    + "Enable the search index to use structure search.";
+
     private final Logger log;
 
     private final SqlStatements sqlStatements;
@@ -168,6 +172,8 @@ public class SqlSearchRepository {
                         break;
                     case content:
                         throw new ContentSearchNotSupportedException(CONTENT_SEARCH_UNSUPPORTED_MESSAGE);
+                    case structure:
+                        throw new ContentSearchNotSupportedException(STRUCTURE_SEARCH_UNSUPPORTED_MESSAGE);
                     default:
                         throw new RegistryStorageException("Filter type not supported: " + filter.getType());
                 }
@@ -347,6 +353,8 @@ public class SqlSearchRepository {
                         break;
                     case content:
                         throw new ContentSearchNotSupportedException(CONTENT_SEARCH_UNSUPPORTED_MESSAGE);
+                    case structure:
+                        throw new ContentSearchNotSupportedException(STRUCTURE_SEARCH_UNSUPPORTED_MESSAGE);
                     default:
                         throw new RegistryStorageException("Filter type not supported: " + filter.getType());
                 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
@@ -5,6 +5,7 @@ import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
 import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.SearchFilter;
+import io.apicurio.registry.storage.dto.SearchFilterType;
 import io.apicurio.registry.storage.dto.SearchedArtifactDto;
 import io.apicurio.registry.storage.dto.SearchedVersionDto;
 import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
@@ -34,13 +35,12 @@ import static io.apicurio.registry.storage.impl.sql.RegistryContentUtils.normali
  */
 public class SqlSearchRepository {
 
-    private static final String CONTENT_SEARCH_UNSUPPORTED_MESSAGE =
-            "Content search requires the search index, which is not enabled. "
-            + "Enable the search index to use content search.";
-
-    private static final String STRUCTURE_SEARCH_UNSUPPORTED_MESSAGE =
-            "Structure search requires the search index, which is not enabled. "
-                    + "Enable the search index to use structure search.";
+    private static void throwIndexOnlyFilterException(SearchFilterType type) {
+        String filterName = type == SearchFilterType.structure ? "Structure" : "Content";
+        throw new ContentSearchNotSupportedException(
+                filterName + " search requires the search index, which is not enabled. "
+                        + "Enable the search index to use " + filterName.toLowerCase(Locale.ROOT) + " search.");
+    }
 
     private final Logger log;
 
@@ -171,9 +171,8 @@ public class SqlSearchRepository {
                         where.append(")");
                         break;
                     case content:
-                        throw new ContentSearchNotSupportedException(CONTENT_SEARCH_UNSUPPORTED_MESSAGE);
                     case structure:
-                        throw new ContentSearchNotSupportedException(STRUCTURE_SEARCH_UNSUPPORTED_MESSAGE);
+                        throwIndexOnlyFilterException(filter.getType());
                     default:
                         throw new RegistryStorageException("Filter type not supported: " + filter.getType());
                 }
@@ -352,9 +351,8 @@ public class SqlSearchRepository {
                         where.append(")");
                         break;
                     case content:
-                        throw new ContentSearchNotSupportedException(CONTENT_SEARCH_UNSUPPORTED_MESSAGE);
                     case structure:
-                        throw new ContentSearchNotSupportedException(STRUCTURE_SEARCH_UNSUPPORTED_MESSAGE);
+                        throwIndexOnlyFilterException(filter.getType());
                     default:
                         throw new RegistryStorageException("Filter type not supported: " + filter.getType());
                 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
@@ -35,9 +35,9 @@ import static io.apicurio.registry.storage.impl.sql.RegistryContentUtils.normali
  */
 public class SqlSearchRepository {
 
-    private static void throwIndexOnlyFilterException(SearchFilterType type) {
+    private static ContentSearchNotSupportedException indexOnlyFilterException(SearchFilterType type) {
         String filterName = type == SearchFilterType.structure ? "Structure" : "Content";
-        throw new ContentSearchNotSupportedException(
+        return new ContentSearchNotSupportedException(
                 filterName + " search requires the search index, which is not enabled. "
                         + "Enable the search index to use " + filterName.toLowerCase(Locale.ROOT) + " search.");
     }
@@ -170,9 +170,8 @@ public class SqlSearchRepository {
                         });
                         where.append(")");
                         break;
-                    case content:
-                    case structure:
-                        throwIndexOnlyFilterException(filter.getType());
+                    case content, structure:
+                        throw indexOnlyFilterException(filter.getType());
                     default:
                         throw new RegistryStorageException("Filter type not supported: " + filter.getType());
                 }
@@ -350,9 +349,8 @@ public class SqlSearchRepository {
                         });
                         where.append(")");
                         break;
-                    case content:
-                    case structure:
-                        throwIndexOnlyFilterException(filter.getType());
+                    case content, structure:
+                        throw indexOnlyFilterException(filter.getType());
                     default:
                         throw new RegistryStorageException("Filter type not supported: " + filter.getType());
                 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/VersionSearchTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/VersionSearchTest.java
@@ -11,6 +11,7 @@ import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.SearchFilter;
 import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
+import io.apicurio.registry.storage.error.ContentSearchNotSupportedException;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.tests.TestUtils;
@@ -162,6 +163,21 @@ public class VersionSearchTest extends AbstractResourceTestBase {
             Assertions.assertEquals(car2.getVersion().getContentId(),
                     negatedResults.getVersions().get(0).getContentId());
         });
+    }
+
+    @Test
+    void testFilterByStructureWithoutSearchIndex() {
+        ContentSearchNotSupportedException exception = Assertions.assertThrows(
+                ContentSearchNotSupportedException.class,
+                () -> storage.searchVersions(
+                        Set.of(SearchFilter.ofStructure("schema-validation")),
+                        OrderBy.globalId,
+                        OrderDirection.asc,
+                        0,
+                        10,
+                        false));
+
+        Assertions.assertTrue(exception.getMessage().contains("search index"));
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -21,6 +21,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -777,5 +780,29 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
         createArtifact.setFirstVersion(createVersion);
 
         clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+    }
+
+    @Test
+    public void testSearchAgentsAdvancedWithSkillsFilterWithoutIndexIsBadRequest() {
+        String requestBody = """
+            {
+                "filters": {
+                    "skills": ["schema-validation"]
+                },
+                "limit": 10,
+                "offset": 0
+            }
+            """;
+
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(400)
+                .body("detail", allOf(
+                        containsString("search index"),
+                        not(containsStringIgnoringCase("select"))));
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -803,6 +803,7 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
                 .statusCode(400)
                 .body("detail", allOf(
                         containsString("search index"),
+                        // Guard: error body must not leak SQL/stacktrace
                         not(containsStringIgnoringCase("select"))));
     }
 }


### PR DESCRIPTION
## Description

Fixes an issue where A2A advanced agent search requests using structure-based filters, such as `skills`, returned HTTP 500 when the search index was not enabled.

For example:

POST /.well-known/agents/search

{
  "filters": {
    "skills": ["schema-validation"]
  }
}

Previously, the SQL search repository did not handle the `structure` filter type and fell through to the default case, resulting in:

HTTP 500
RegistryStorageException: Filter type not supported: structure

This change treats structure search consistently with content search when the search index is not enabled and returns HTTP 400 with a clear message.

## Changes

- Added a structure-search unsupported message to `SqlSearchRepository`.
- Added `structure` handling to artifact searches.
- Added `structure` handling to version searches.
- Added a regression test for A2A advanced search with a skills filter.

## Testing

- `.\mvnw.cmd test -pl app -Dtest=WellKnownResourceTest`
- Tests run: 34
- Failures: 0
- Errors: 0
- Skipped: 0