### PR TITLE
fix(kafkasql): register usage event messages so telemetry is not discarded

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/serde/KafkaSqlMessageIndex.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/serde/KafkaSqlMessageIndex.java
@@ -64,7 +64,9 @@ public class KafkaSqlMessageIndex {
                 DeleteGlobalContractRuleset0Message.class,
                 InsertContractAuditEntry1Message.class,
                 MergeArtifactLabels4Message.class,
-                MergeVersionLabels5Message.class);
+                MergeVersionLabels5Message.class,
+                RecordUsageEvent1Message.class,
+                DeleteOldUsageEvents1Message.class);
     }
 
     public static Class<? extends KafkaSqlMessage> lookup(String name) {

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlMessageIndexTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlMessageIndexTest.java
@@ -1,0 +1,156 @@
+package io.apicurio.registry.storage.impl.kafkasql;
+
+import io.apicurio.registry.storage.impl.kafkasql.messages.DeleteOldUsageEvents1Message;
+import io.apicurio.registry.storage.impl.kafkasql.messages.RecordUsageEvent1Message;
+import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlMessageIndex;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+/**
+ * Guards the KafkaSQL journal wire contract.
+ * <p>
+ * Every mutation in the KafkaSQL storage variant is journaled as a {@link KafkaSqlMessage} and replayed
+ * from the beginning of the topic on startup. The message type travels in a Kafka header as the message
+ * class's simple name (see {@link AbstractMessage#getKey()} and
+ * {@link KafkaSqlSubmitter#MESSAGE_TYPE_HEADER}), and the consumer resolves it back to a class through
+ * {@link KafkaSqlMessageIndex#lookup(String)}.
+ * <p>
+ * That index is hand-maintained, and nothing in the compiler or the CDI container links "class extends
+ * AbstractMessage" to "class is registered". A class that is submitted but not registered fails
+ * deserialization on the consume side, where the failure is swallowed and the record is discarded, so
+ * the mutation is lost silently and on every subsequent replay.
+ * <p>
+ * This has happened twice: {@code DeleteAllOrphanedContent0Message} was found unregistered in #7810, and
+ * the usage-event messages covered here. These tests turn the invariant into a build failure instead of a
+ * runtime data-loss bug.
+ */
+public class KafkaSqlMessageIndexTest {
+
+    private static final String MESSAGES_PACKAGE = "io.apicurio.registry.storage.impl.kafkasql.messages";
+
+    private static final String CLASS_SUFFIX = ".class";
+
+    /**
+     * Lower bound on the number of message classes we expect to discover. This exists so the scan below can
+     * never pass vacuously: if the classpath layout changes and the scan finds nothing, the test must fail
+     * loudly rather than silently stop guarding anything.
+     */
+    private static final int MINIMUM_EXPECTED_MESSAGE_CLASSES = 50;
+
+    @Test
+    public void testEveryMessageClassIsRegisteredInTheIndex() throws Exception {
+        List<Class<?>> messageClasses = findConcreteMessageClasses();
+
+        Assertions.assertTrue(messageClasses.size() >= MINIMUM_EXPECTED_MESSAGE_CLASSES,
+                "Expected to discover at least " + MINIMUM_EXPECTED_MESSAGE_CLASSES + " KafkaSqlMessage "
+                        + "classes in " + MESSAGES_PACKAGE + " but found " + messageClasses.size() + ". "
+                        + "The classpath scan is not finding the message classes, so this test is no longer "
+                        + "guarding the journal wire contract. Fix the scan before changing this bound.");
+
+        List<String> unregistered = new ArrayList<>();
+        for (Class<?> messageClass : messageClasses) {
+            if (KafkaSqlMessageIndex.lookup(messageClass.getSimpleName()) == null) {
+                unregistered.add(messageClass.getSimpleName());
+            }
+        }
+
+        Assertions.assertEquals(List.of(), unregistered,
+                "The following KafkaSqlMessage classes are not registered in KafkaSqlMessageIndex: "
+                        + unregistered + ". Any message submitted to the journal but missing from the index "
+                        + "fails to deserialize on the consume side, so the mutation is silently discarded "
+                        + "and lost on every replay. Add each class to the static block in "
+                        + "KafkaSqlMessageIndex.");
+    }
+
+    @Test
+    public void testIndexResolvesEachClassToItself() throws Exception {
+        for (Class<?> messageClass : findConcreteMessageClasses()) {
+            Class<? extends KafkaSqlMessage> resolved = KafkaSqlMessageIndex
+                    .lookup(messageClass.getSimpleName());
+            if (resolved != null) {
+                Assertions.assertEquals(messageClass, resolved,
+                        "KafkaSqlMessageIndex resolves '" + messageClass.getSimpleName()
+                                + "' to a different class (" + resolved.getName() + "). Two message classes "
+                                + "sharing a simple name would collide in the index and silently shadow "
+                                + "each other on the journal.");
+            }
+        }
+    }
+
+    @Test
+    public void testUsageEventMessagesAreRegistered() {
+        // Explicit regression coverage for the two classes this test class was added for. Kept separate
+        // from the scan above so the specific defect stays named even if the scan is ever refactored.
+        Assertions.assertEquals(RecordUsageEvent1Message.class,
+                KafkaSqlMessageIndex.lookup(RecordUsageEvent1Message.class.getSimpleName()),
+                "RecordUsageEvent1Message is submitted by KafkaSqlRegistryStorage.recordUsageEvent() but "
+                        + "was not registered, so all schema usage telemetry was discarded on the consume "
+                        + "side.");
+
+        Assertions.assertEquals(DeleteOldUsageEvents1Message.class,
+                KafkaSqlMessageIndex.lookup(DeleteOldUsageEvents1Message.class.getSimpleName()),
+                "DeleteOldUsageEvents1Message is submitted by "
+                        + "KafkaSqlRegistryStorage.deleteOldUsageEvents() but was not registered, so usage "
+                        + "event retention never ran on the KafkaSQL variant.");
+    }
+
+    @Test
+    public void testMessageKeyTypeResolvesThroughTheIndex() {
+        // Exercises the actual wire path end to end: the type written into the Kafka header by
+        // AbstractMessage.getKey() must be the same string the consumer looks up.
+        KafkaSqlMessage message = RecordUsageEvent1Message.builder().globalId(1L).contentId(2L)
+                .clientId("test-client").operation("READ").eventTimestamp(System.currentTimeMillis()).build();
+
+        String messageType = message.getKey().getMessageType();
+
+        Assertions.assertEquals(RecordUsageEvent1Message.class, KafkaSqlMessageIndex.lookup(messageType),
+                "The message type written to the '" + KafkaSqlSubmitter.MESSAGE_TYPE_HEADER
+                        + "' Kafka header ('" + messageType + "') does not resolve back to its own class "
+                        + "through KafkaSqlMessageIndex.");
+    }
+
+    /**
+     * Finds every concrete {@link KafkaSqlMessage} implementation in the messages package by scanning the
+     * classpath directory that holds it. Deliberately dependency-free: the app module has no classpath
+     * scanning library on the test classpath.
+     */
+    private static List<Class<?>> findConcreteMessageClasses() throws Exception {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        Enumeration<URL> resources = classLoader.getResources(MESSAGES_PACKAGE.replace('.', '/'));
+
+        List<Class<?>> messageClasses = new ArrayList<>();
+        while (resources.hasMoreElements()) {
+            URL resource = resources.nextElement();
+            if (!"file".equals(resource.getProtocol())) {
+                continue;
+            }
+            File[] files = new File(resource.toURI()).listFiles();
+            if (files == null) {
+                continue;
+            }
+            for (File file : files) {
+                String fileName = file.getName();
+                // Skip Lombok-generated builder inner classes, which are not message types themselves.
+                if (!fileName.endsWith(CLASS_SUFFIX) || fileName.contains("$")) {
+                    continue;
+                }
+                String className = MESSAGES_PACKAGE + "."
+                        + fileName.substring(0, fileName.length() - CLASS_SUFFIX.length());
+                // initialize=false: resolving these classes must not run their static initializers.
+                Class<?> candidate = Class.forName(className, false, classLoader);
+                if (KafkaSqlMessage.class.isAssignableFrom(candidate) && !candidate.isInterface()
+                        && !Modifier.isAbstract(candidate.getModifiers())) {
+                    messageClasses.add(candidate);
+                }
+            }
+        }
+        return messageClasses;
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlUsageEventJournalTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlUsageEventJournalTest.java
@@ -1,0 +1,117 @@
+package io.apicurio.registry.storage.impl.kafkasql;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.client.models.CreateArtifactResponse;
+import io.apicurio.registry.storage.dto.SchemaUsageEventDto;
+import io.apicurio.registry.storage.dto.SchemaUsageSummaryDto;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.KafkasqlTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import static org.awaitility.Awaitility.await;
+
+/**
+ * End-to-end coverage for the usage event journal path on the KafkaSQL variant.
+ * <p>
+ * {@link KafkaSqlMessageIndexTest} asserts that the usage event message classes are present in
+ * {@link io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlMessageIndex}, but presence in the index
+ * is not the same thing as the mutation actually surviving the journal. These tests exercise the path that
+ * was broken: submit through {@link KafkaSqlRegistryStorage}, let the record go out to Kafka and come back
+ * through the consumer thread, and then read the applied state back out of the local SQL projection.
+ * <p>
+ * That round trip matters here because both usage event operations are fire-and-forget — neither waits on
+ * {@code KafkaSqlCoordinator} — and {@code KafkaSqlValueDeserializer} swallows a failed lookup into a null
+ * value that the consumer discards as a tombstone. Nothing surfaces to the caller when it breaks, so an
+ * assertion on the read-back side is the only thing that can catch it.
+ */
+@QuarkusTest
+@TestProfile(KafkasqlTestProfile.class)
+public class KafkaSqlUsageEventJournalTest extends AbstractResourceTestBase {
+
+    private static final String GROUP_ID = "KafkaSqlUsageEventJournalTest";
+
+    private static final String SCHEMA = "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"}}}";
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+    private static final Duration POLL_INTERVAL = Duration.ofMillis(250);
+
+    @Inject
+    KafkaSqlRegistryStorage kafkaSqlRegistryStorage;
+
+    @Test
+    public void testRecordUsageEventSurvivesJournalRoundTrip() throws Exception {
+        String artifactId = "record-usage-" + UUID.randomUUID();
+        String clientId = "client-" + UUID.randomUUID();
+        long globalId = createArtifactAndGetGlobalId(artifactId);
+        long eventTimestamp = System.currentTimeMillis();
+
+        // contentId is left at 0 so the read-back query matches on globalId only, keeping the
+        // assertions below unambiguous.
+        kafkaSqlRegistryStorage.recordUsageEvent(SchemaUsageEventDto.builder().globalId(globalId)
+                .contentId(0).clientId(clientId).operation("READ").eventTimestamp(eventTimestamp).build());
+
+        await().atMost(TIMEOUT).pollInterval(POLL_INTERVAL).untilAsserted(() -> {
+            List<SchemaUsageSummaryDto> metrics = kafkaSqlRegistryStorage.getArtifactUsageMetrics(GROUP_ID,
+                    artifactId);
+
+            Assertions.assertEquals(1, metrics.size(),
+                    "Expected exactly one usage summary row after the journal round trip, but got "
+                            + metrics.size() + ". A RecordUsageEvent1Message that cannot be deserialized "
+                            + "is discarded by the consumer, so the event never reaches storage.");
+
+            SchemaUsageSummaryDto summary = metrics.get(0);
+            Assertions.assertEquals(globalId, summary.getGlobalId());
+            Assertions.assertEquals(1, summary.getTotalFetches());
+            Assertions.assertEquals(1, summary.getUniqueClients());
+            Assertions.assertEquals(eventTimestamp, summary.getFirstFetchedOn());
+            Assertions.assertEquals(eventTimestamp, summary.getLastFetchedOn());
+            Assertions.assertTrue(summary.getClientList().contains(clientId),
+                    "Expected the recorded client id '" + clientId + "' in the aggregated client list, but "
+                            + "got '" + summary.getClientList() + "'.");
+        });
+    }
+
+    @Test
+    public void testDeleteOldUsageEventsSurvivesJournalRoundTrip() throws Exception {
+        String artifactId = "delete-old-usage-" + UUID.randomUUID();
+        String clientId = "client-" + UUID.randomUUID();
+        long globalId = createArtifactAndGetGlobalId(artifactId);
+        long oldTimestamp = System.currentTimeMillis() - Duration.ofDays(30).toMillis();
+
+        kafkaSqlRegistryStorage.recordUsageEvent(SchemaUsageEventDto.builder().globalId(globalId)
+                .contentId(0).clientId(clientId).operation("READ").eventTimestamp(oldTimestamp).build());
+
+        await().atMost(TIMEOUT).pollInterval(POLL_INTERVAL)
+                .until(() -> !kafkaSqlRegistryStorage.getArtifactUsageMetrics(GROUP_ID, artifactId).isEmpty());
+
+        // Prune everything older than a day. The recorded event is 30 days old, so it must be removed.
+        kafkaSqlRegistryStorage
+                .deleteOldUsageEvents(System.currentTimeMillis() - Duration.ofDays(1).toMillis());
+
+        await().atMost(TIMEOUT).pollInterval(POLL_INTERVAL).untilAsserted(() -> {
+            List<SchemaUsageSummaryDto> metrics = kafkaSqlRegistryStorage.getArtifactUsageMetrics(GROUP_ID,
+                    artifactId);
+
+            Assertions.assertTrue(metrics.isEmpty(),
+                    "Expected the usage event older than the cutoff to be pruned after the journal round "
+                            + "trip, but " + metrics.size() + " row(s) remain. A DeleteOldUsageEvents1Message "
+                            + "that cannot be deserialized is discarded, so retention never runs.");
+        });
+    }
+
+    private long createArtifactAndGetGlobalId(String artifactId) throws Exception {
+        CreateArtifactResponse response = createArtifact(GROUP_ID, artifactId, ArtifactType.JSON, SCHEMA,
+                ContentTypes.APPLICATION_JSON);
+        return response.getVersion().getGlobalId();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #9532.

`RecordUsageEvent1Message` and `DeleteOldUsageEvents1Message` are submitted to the KafkaSQL journal but were never registered in `KafkaSqlMessageIndex`, so every usage event was discarded on the consume side. Schema usage telemetry has been dead on the kafkasql variant as a result.

There are 77 message classes in `storage/impl/kafkasql/messages/` and 75 were registered. This PR adds the two missing entries, a test that makes the omission impossible to reintroduce, and an end-to-end test that the mutation actually survives the journal.

## Root Cause

`KafkaSqlValueDeserializer` resolves the message type from the `mt` Kafka header via `KafkaSqlMessageIndex.lookup(...)`. For these two types the lookup returned `null`, the deserializer threw, caught its own exception, logged it and returned `null`.

The failure was quiet for three compounding reasons:

1. The message **key** deserializes fine — `KafkaSqlKeyDeserializer` never consults the index — so the record passed the null-key guard in `processRecord` and fell into the branch that treats a null value as a tombstone. A lost mutation was reported at INFO as `Discarded a (presumed) tombstone message`.
2. Neither call site waits on the coordinator (`recordUsageEvent()` at `KafkaSqlRegistryStorage:1316`, `deleteOldUsageEvents()` at `:1322`), so nothing could surface to the caller.
3. It does not self-heal. The journal replays on every startup, so the same records fail again on every restart.

The `ERROR` line from the deserializer does name the class, so the information was technically present — one line above a reassuring `INFO`, in a log that scrolls during replay.

### Why this needs tests, not just two lines

`DeleteAllOrphanedContent0Message` was found missing from the same index and fixed in #7810 ("Fix missing message index entry ... was previously missing"). This is the same defect in the same file, a second time.

Nothing links "class extends `AbstractMessage`" to "class is in the index" — it is a hand-maintained list, the compiler cannot check it, and the failure is swallowed on the consume side. The tests are the part of this PR that stops a third occurrence.

## Changes

**`storage/impl/kafkasql/serde/KafkaSqlMessageIndex.java`** (+3/−1)
- Registered `RecordUsageEvent1Message` and `DeleteOldUsageEvents1Message`, appended to the static block following the pattern used by `InsertContractAuditEntry1Message` (#8919) and the contract ruleset messages (#8866). No import change needed; the file already wildcard-imports the `messages` package.

**`storage/impl/kafkasql/KafkaSqlMessageIndexTest.java`** (new, 156 lines) — guards the index itself. Plain JUnit, no container, ~30ms.
- `testEveryMessageClassIsRegisteredInTheIndex` — scans the messages package via the context ClassLoader, filters to concrete `KafkaSqlMessage` implementations, and asserts each resolves. Dependency-free, since `app` has no classpath-scanning library on the test classpath. Uses `Class.forName(name, false, cl)` so static initializers do not run, and skips `$` inner classes so Lombok builders are not scanned. Asserts a lower bound on the number of classes discovered first, so it can never pass vacuously if the classpath layout changes.
- `testIndexResolvesEachClassToItself` — guards against two message classes sharing a simple name and silently shadowing each other on the journal.
- `testUsageEventMessagesAreRegistered` — explicit regression coverage naming the two classes.
- `testMessageKeyTypeResolvesThroughTheIndex` — the type written into the `mt` header by `AbstractMessage.getKey()` must resolve back through the index.

**`storage/impl/kafkasql/KafkaSqlUsageEventJournalTest.java`** (new, 117 lines) — added in response to review; covers the path that was actually broken. `@QuarkusTest` + `KafkasqlTestProfile`, modelled on `KafkaSqlContractAuditJournalTest`.
- `testRecordUsageEventSurvivesJournalRoundTrip` — creates a real artifact, submits via `recordUsageEvent(...)`, then awaits read-back through `getArtifactUsageMetrics(...)`. Because `KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage` with `setDelegate(sqlStore)`, that read hits the local SQL projection, so it only passes if the record went out to Kafka, returned through the consumer thread, and was applied. Asserts specific values rather than non-emptiness.
- `testDeleteOldUsageEventsSurvivesJournalRoundTrip` — records a 30-day-old event, waits for it to land, prunes with a 1-day cutoff, and awaits removal, covering `DeleteOldUsageEvents1Message` end to end.

Compatible with #7337 (removing deprecated v8/v9/v10 message classes): deleting a class removes it from both the scanned set and the index, so the invariant still holds, and the lower bound leaves headroom.

## Upgrade impact

Two consequences that are not visible in a three-line production diff:

- **Existing journals hold a backlog.** These messages were produced successfully all along; only the consume side failed. After this fix the next restart replays and applies that backlog, so operators will see a burst of usage-event inserts on first upgrade. Journal ordering is preserved, so the `record → record → deleteOld(cutoff) → record` interleaving converges to the correct state.
- **Pre-snapshot usage events are unrecoverable.** If a snapshot was taken while the bug was live it contains no usage rows, and replay resumes from the snapshot offset. Events older than the newest snapshot are permanently lost.

No schema change, no SPI change, no wire-format change. Both message classes and their JSON shape already existed and are unmodified, so no new permanent contract is introduced.

## Scope

- `apicurio.usage.telemetry.enabled` defaults to `false`, so only deployments that explicitly enabled usage telemetry are affected.
- kafkasql only. SQL calls these storage methods directly; GitOps and KubernetesOps are read-only.
- No data corruption — usage events are lost, nothing else is touched.

## Design note

I considered moving `deleteOldUsageEvents` off the journal, since #7810 did exactly that for the other scheduled cleanup jobs. It should not be: `deleteAllExpiredDownloads` and `deleteAllOrphanedContent` operate on node-local or derivable data, whereas usage events *are* journaled data. A pod pruning only its local store would have the next full replay resurrect every pruned row. Journaling the prune is what keeps it deterministic and replay-stable, so the existing design is correct and only the registration was broken.

## Test plan

Verified against a real Kafka container (Strimzi test container, single broker).

- [x] `KafkaSqlUsageEventJournalTest` — 2/2 pass with the fix
- [x] Verified **both** round-trip tests fail without the index registration: `ConditionTimeoutException`, `Expected exactly one usage summary row after the journal round trip, but got 0 ==> expected: <1> but was: <0>`
- [x] `KafkaSqlMessageIndexTest` — 4/4 pass; verified it fails on unpatched code, reporting `[DeleteOldUsageEvents1Message, RecordUsageEvent1Message]`
- [x] `KafkaSqlContractAuditJournalTest` — 1/1 pass, confirming no regression on the existing journal path
- [x] `KafkaSqlConfigurationTest`, `KafkaAdminUtilTest`, `ReadOnlyRegistryStorageTest` — all pass
- [x] `./mvnw checkstyle:check -pl app` — 0 violations
- [x] `./mvnw test-compile -pl app -am -DskipTests` — clean
- [x] Rebased onto current `main`

Storage variants: kafkasql is the only variant this touches. SQL behaviour is unchanged, and the read-only variants inherit no new methods.
