### PR TITLE
fix(rules): compare agent card definitions, not just identifiers

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AgentCardCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AgentCardCompatibilityChecker.java
@@ -6,6 +6,7 @@ import io.apicurio.registry.content.TypedContent;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -21,8 +22,15 @@ import java.util.Set;
  * - Removing capability extensions (by uri): Backward incompatible
  * - Removing interfaces (by url+protocolBinding): Backward incompatible
  * - Changing protocolVersion on existing interface: Backward incompatible
+ * - Removing protocolVersion from an existing interface: Backward incompatible
+ * - Changing the card-level protocolVersion: Backward incompatible
+ * - Adding a card-level protocolVersion where there was none: Always compatible
  * - Adding security schemes: Always compatible
  * - Removing security schemes: Backward incompatible
+ * - Changing an existing security scheme's definition: Backward incompatible
+ * - Changing an existing security scheme's description: Always compatible
+ * - Withdrawing an OAuth2 scope: Backward incompatible
+ * - Rewording an OAuth2 scope's description: Always compatible
  * - Adding input/output modes: Always compatible
  * - Removing input/output modes: Backward incompatible
  */
@@ -34,11 +42,24 @@ public class AgentCardCompatibilityChecker
     private static final String CONTEXT_CAPABILITIES = "/capabilities";
     private static final String CONTEXT_CAPABILITY_EXTENSIONS = "/capabilities/extensions";
     private static final String CONTEXT_SECURITY_SCHEMES = "/securitySchemes";
+    private static final String CONTEXT_PROTOCOL_VERSION = "/protocolVersion";
     private static final String CONTEXT_MODES = "/modes";
     private static final String CONTEXT_DOCUMENT = "/document";
     private static final String MSG_WAS_REMOVED = "' was removed";
 
     private static final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * Security scheme fields whose value defines how a client must authenticate. The description
+     * field is documentation, and fields outside this list are ignored on purpose: the schema
+     * permits vendor extensions, and churn in one of those must not fail a publish.
+     */
+    private static final List<String> SECURITY_SCHEME_FIELDS = List.of("type", "scheme",
+            "bearerFormat", "name", "location", "oauth2MetadataUrl", "openIdConnectUrl");
+
+    private static final String FLOWS_FIELD = "flows";
+
+    private static final String SCOPES_FIELD = "scopes";
 
     @Override
     protected Set<SimpleCompatibilityDifference> isBackwardsCompatibleWith(String existing,
@@ -53,6 +74,8 @@ public class AgentCardCompatibilityChecker
             checkSkillRemovals(existingNode, proposedNode, differences);
             checkCapabilityRemovals(existingNode, proposedNode, differences);
             checkSecuritySchemeRemovals(existingNode, proposedNode, differences);
+            checkSecuritySchemeDefinitionChanges(existingNode, proposedNode, differences);
+            checkCardProtocolVersionChange(existingNode, proposedNode, differences);
             checkModeRemovals(existingNode, proposedNode, "defaultInputModes", "input mode",
                     differences);
             checkModeRemovals(existingNode, proposedNode, "defaultOutputModes", "output mode",
@@ -93,24 +116,53 @@ public class AgentCardCompatibilityChecker
         for (JsonNode existingIface : existingInterfaces) {
             String url = getTextValue(existingIface, "url");
             String binding = getTextValue(existingIface, "protocolBinding");
-            String existingVersion = getTextValue(existingIface, "protocolVersion");
+            String existingVersion = getComparableValue(existingIface, "protocolVersion");
 
             if (url == null || binding == null || existingVersion == null) {
                 continue;
             }
 
-            for (JsonNode proposedIface : proposedInterfaces) {
-                String pUrl = getTextValue(proposedIface, "url");
-                String pBinding = getTextValue(proposedIface, "protocolBinding");
-                String pVersion = getTextValue(proposedIface, "protocolVersion");
+            // Neither the schema nor validateSupportedInterfaces requires url+protocolBinding to be
+            // unique, so weigh every matching entry before concluding: one of them keeping the
+            // version means nothing was withdrawn, and duplicates must not multiply the difference.
+            boolean matched = false;
+            boolean versionRetained = false;
+            String changedVersion = null;
 
-                if (url.equals(pUrl) && binding.equals(pBinding)
-                        && pVersion != null && !existingVersion.equals(pVersion)) {
-                    differences.add(new SimpleCompatibilityDifference(
-                            "Protocol version changed from '" + existingVersion + "' to '"
-                                    + pVersion + "' for interface " + url + " (" + binding + ")",
-                            CONTEXT_INTERFACES));
+            for (JsonNode proposedIface : proposedInterfaces) {
+                if (!url.equals(getTextValue(proposedIface, "url"))
+                        || !binding.equals(getTextValue(proposedIface, "protocolBinding"))) {
+                    continue;
                 }
+
+                matched = true;
+                String pVersion = getComparableValue(proposedIface, "protocolVersion");
+                if (existingVersion.equals(pVersion)) {
+                    versionRetained = true;
+                    break;
+                }
+                if (pVersion != null) {
+                    changedVersion = pVersion;
+                }
+            }
+
+            // An interface with no match at all is already reported as an interface removal.
+            if (!matched || versionRetained) {
+                continue;
+            }
+
+            if (changedVersion != null) {
+                differences.add(new SimpleCompatibilityDifference(
+                        "Protocol version changed from '" + existingVersion + "' to '"
+                                + changedVersion + "' for interface " + url + " (" + binding + ")",
+                        CONTEXT_INTERFACES));
+            } else {
+                // A retained interface that drops its protocolVersion withdraws a guarantee the
+                // client had. The validity rule requires the field, but it is opt-in, so the card
+                // can reach this checker without it.
+                differences.add(new SimpleCompatibilityDifference(
+                        "Protocol version '" + existingVersion + "' was removed from interface "
+                                + url + " (" + binding + ")", CONTEXT_INTERFACES));
             }
         }
     }
@@ -191,6 +243,204 @@ public class AgentCardCompatibilityChecker
                         "Security scheme '" + scheme + MSG_WAS_REMOVED, CONTEXT_SECURITY_SCHEMES));
             }
         }
+    }
+
+    /**
+     * A retained scheme name says nothing about how a client authenticates: the definition behind
+     * it can change completely. checkSecuritySchemeRemovals only diffs the names, so compare the
+     * fields that carry the meaning.
+     */
+    private void checkSecuritySchemeDefinitionChanges(JsonNode existing, JsonNode proposed,
+            Set<SimpleCompatibilityDifference> differences) {
+        JsonNode existingSchemes = existing.get("securitySchemes");
+        JsonNode proposedSchemes = proposed.get("securitySchemes");
+
+        if (existingSchemes == null || !existingSchemes.isObject() || proposedSchemes == null
+                || !proposedSchemes.isObject()) {
+            return;
+        }
+
+        Iterator<String> schemeNames = existingSchemes.fieldNames();
+        while (schemeNames.hasNext()) {
+            String schemeName = schemeNames.next();
+            JsonNode existingScheme = existingSchemes.get(schemeName);
+            JsonNode proposedScheme = proposedSchemes.get(schemeName);
+
+            // A scheme that is gone entirely is already reported as a removal, and one the
+            // existing card never defined as an object promised nothing to take away.
+            if (proposedScheme == null || !existingScheme.isObject()) {
+                continue;
+            }
+
+            if (!proposedScheme.isObject()) {
+                // The name survives, so checkSecuritySchemeRemovals stays quiet, but the
+                // definition behind it is gone. The validity rule rejects this, and it is opt-in.
+                differences.add(new SimpleCompatibilityDifference(
+                        "Security scheme '" + schemeName + "' is no longer defined as an object",
+                        CONTEXT_SECURITY_SCHEMES));
+                continue;
+            }
+
+            for (String field : SECURITY_SCHEME_FIELDS) {
+                String existingValue = getComparableValue(existingScheme, field);
+                if (existingValue == null) {
+                    // Nothing was promised, so whatever the proposed card says cannot break a
+                    // client that was written against the existing one.
+                    continue;
+                }
+                String proposedValue = getComparableValue(proposedScheme, field);
+                if (!existingValue.equals(proposedValue)) {
+                    differences.add(new SimpleCompatibilityDifference(
+                            describeSchemeFieldChange(schemeName, field, existingValue,
+                                    proposedValue),
+                            CONTEXT_SECURITY_SCHEMES));
+                }
+            }
+
+            JsonNode existingFlows = existingScheme.get(FLOWS_FIELD);
+            if (existingFlows != null && !existingFlows.isNull()) {
+                checkRetainedValues(schemeName, FLOWS_FIELD, existingFlows,
+                        proposedScheme.get(FLOWS_FIELD), differences);
+            }
+        }
+    }
+
+    /**
+     * flows is a free-form object in the schema and the validity rule does not inspect it, so
+     * compare it structurally rather than by known field names: whatever the existing card
+     * declared must still be there, unchanged. Additions - a new grant type, a new scope - are
+     * ignored, so they stay compatible. Reports the outermost point at which the two stop
+     * matching rather than every leaf beneath it, which keeps the number of differences
+     * proportional to the edit.
+     */
+    private void checkRetainedValues(String schemeName, String path, JsonNode existing,
+            JsonNode proposed, Set<SimpleCompatibilityDifference> differences) {
+        if (proposed == null) {
+            differences.add(new SimpleCompatibilityDifference(
+                    "Security scheme '" + schemeName + "' no longer declares '" + path + "'",
+                    CONTEXT_SECURITY_SCHEMES));
+            return;
+        }
+
+        if (path.endsWith("/" + SCOPES_FIELD) && existing.isObject() && proposed.isObject()) {
+            checkRetainedScopeNames(schemeName, path, existing, proposed, differences);
+            return;
+        }
+
+        if (existing.isObject() && proposed.isObject()) {
+            Iterator<String> fieldNames = existing.fieldNames();
+            while (fieldNames.hasNext()) {
+                String fieldName = fieldNames.next();
+                checkRetainedValues(schemeName, path + "/" + fieldName, existing.get(fieldName),
+                        proposed.get(fieldName), differences);
+            }
+            return;
+        }
+
+        if (existing.isArray() && proposed.isArray()) {
+            checkRetainedArrayValues(schemeName, path, existing, proposed, differences);
+            return;
+        }
+
+        if (!existing.equals(proposed)) {
+            differences.add(new SimpleCompatibilityDifference(
+                    describeSchemeFieldChange(schemeName, path, renderValue(existing),
+                            renderValue(proposed)),
+                    CONTEXT_SECURITY_SCHEMES));
+        }
+    }
+
+    /**
+     * A scopes map is name -> short description, so only the names are contract: withdrawing one
+     * breaks a client, rewording one does not. Comparing the values would contradict the
+     * description exemption applied to the scheme's own fields, and would judge the map form more
+     * harshly than the array form that checkRetainedArrayValues already treats as a set.
+     */
+    private void checkRetainedScopeNames(String schemeName, String path, JsonNode existing,
+            JsonNode proposed, Set<SimpleCompatibilityDifference> differences) {
+        Iterator<String> scopeNames = existing.fieldNames();
+        while (scopeNames.hasNext()) {
+            String scopeName = scopeNames.next();
+            if (!proposed.has(scopeName)) {
+                differences.add(new SimpleCompatibilityDifference(
+                        "Security scheme '" + schemeName + "' no longer offers '" + scopeName
+                                + "' in '" + path + "'", CONTEXT_SECURITY_SCHEMES));
+            }
+        }
+    }
+
+    /**
+     * An array inside flows is a set of offered values - a scope list is the usual case - so only
+     * losing an entry is a break. This mirrors how checkModeRemovals treats defaultInputModes:
+     * comparing the arrays whole would report a purely additive edit as incompatible.
+     */
+    private void checkRetainedArrayValues(String schemeName, String path, JsonNode existing,
+            JsonNode proposed, Set<SimpleCompatibilityDifference> differences) {
+        for (JsonNode existingItem : existing) {
+            boolean retained = false;
+            for (JsonNode proposedItem : proposed) {
+                if (existingItem.equals(proposedItem)) {
+                    retained = true;
+                    break;
+                }
+            }
+            if (!retained) {
+                differences.add(new SimpleCompatibilityDifference(
+                        "Security scheme '" + schemeName + "' no longer offers '"
+                                + renderValue(existingItem) + "' in '" + path + "'",
+                        CONTEXT_SECURITY_SCHEMES));
+            }
+        }
+    }
+
+    /**
+     * The card-level protocolVersion is the version the agent as a whole speaks -
+     * RegistryAgentCardBuilder fills it from the same config value as the per-interface one - so a
+     * client can rely on it without reading supportedInterfaces. It is optional, so an existing
+     * card that did not declare one promised nothing that a proposed card could take away.
+     */
+    private void checkCardProtocolVersionChange(JsonNode existing, JsonNode proposed,
+            Set<SimpleCompatibilityDifference> differences) {
+        String existingVersion = getComparableValue(existing, "protocolVersion");
+        if (existingVersion == null) {
+            return;
+        }
+
+        String proposedVersion = getComparableValue(proposed, "protocolVersion");
+        if (existingVersion.equals(proposedVersion)) {
+            return;
+        }
+
+        differences.add(new SimpleCompatibilityDifference(
+                "The agent protocolVersion " + describeChange(existingVersion, proposedVersion),
+                CONTEXT_PROTOCOL_VERSION));
+    }
+
+    private String describeSchemeFieldChange(String schemeName, String field, String existingValue,
+            String proposedValue) {
+        return "Security scheme '" + schemeName + "' field '" + field + "' "
+                + describeChange(existingValue, proposedValue);
+    }
+
+    private String describeChange(String existingValue, String proposedValue) {
+        return proposedValue == null
+                ? "was removed (was '" + existingValue + "')"
+                : "changed from '" + existingValue + "' to '" + proposedValue + "'";
+    }
+
+    /**
+     * Compares whatever value is present rather than textual values alone. getTextValue yields null
+     * for a non-textual node, which is indistinguishable from an absent one, so a field that turns
+     * into a number would otherwise be reported as having been removed when it was changed. The
+     * validity rule would reject those shapes, but it is opt-in.
+     */
+    private String getComparableValue(JsonNode node, String fieldName) {
+        JsonNode field = node.get(fieldName);
+        return (field == null || field.isNull()) ? null : renderValue(field);
+    }
+
+    private String renderValue(JsonNode node) {
+        return node.isTextual() ? node.asText() : node.toString();
     }
 
     private void checkModeRemovals(JsonNode existing, JsonNode proposed, String fieldName,

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/AgentCardCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/AgentCardCompatibilityCheckerTest.java
@@ -517,4 +517,540 @@ class AgentCardCompatibilityCheckerTest {
         assertEquals(2, result.getIncompatibleDifferences().size(),
                 "Both the disabled boolean capability and the removed extension should be reported");
     }
+
+    private static final String BEARER_SCHEME =
+            "{ \"type\": \"httpAuth\", \"scheme\": \"Bearer\" }";
+    private static final String APIKEY_HEADER_SCHEME =
+            "{ \"type\": \"apiKey\", \"name\": \"X-API-Key\", \"location\": \"header\" }";
+    private static final String OAUTH_SCHEME =
+            "{ \"type\": \"oauth2\", \"flows\": { \"clientCredentials\": {"
+                    + " \"tokenUrl\": \"https://example.com/token\","
+                    + " \"scopes\": { \"read\": \"Read access\" } } } }";
+
+    private static String cardWithSchemes(String schemes) {
+        return baseCard(SKILL1, ", \"securitySchemes\": " + schemes);
+    }
+
+    private static String cardWithScheme(String name, String body) {
+        return cardWithSchemes("{ \"" + name + "\": " + body + " }");
+    }
+
+    private static boolean reports(CompatibilityExecutionResult result, String text) {
+        return result.getIncompatibleDifferences().stream()
+                .anyMatch(d -> d.asRuleViolation().getDescription().contains(text));
+    }
+
+    @Test
+    void testBackwardIncompatibleSecuritySchemeTypeChange() {
+        String existing = cardWithScheme("bearer", BEARER_SCHEME);
+        String proposed = cardWithScheme("bearer", APIKEY_HEADER_SCHEME);
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Redefining a retained security scheme should be backward incompatible");
+        assertEquals(2, result.getIncompatibleDifferences().size(),
+                "Both the changed type and the dropped scheme should be reported");
+        assertTrue(reports(result,
+                "Security scheme 'bearer' field 'type' changed from 'httpAuth' to 'apiKey'"));
+        assertTrue(reports(result,
+                "Security scheme 'bearer' field 'scheme' was removed (was 'Bearer')"));
+    }
+
+    @Test
+    void testSecuritySchemeViolationIsReportedAgainstSecuritySchemesPath() {
+        String existing = cardWithScheme("bearer", BEARER_SCHEME);
+        String proposed = cardWithScheme("bearer", "{ \"type\": \"mutualTls\" }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible());
+        assertEquals(2, result.getIncompatibleDifferences().size(),
+                "Both the changed type and the dropped scheme should be reported");
+        assertTrue(result.getIncompatibleDifferences().stream()
+                .allMatch(d -> "/securitySchemes".equals(d.asRuleViolation().getContext())),
+                "Security scheme differences belong to /securitySchemes");
+    }
+
+    @Test
+    void testBackwardIncompatibleSecuritySchemeLocationChange() {
+        String existing = cardWithScheme("apikey", APIKEY_HEADER_SCHEME);
+        String proposed = cardWithScheme("apikey",
+                "{ \"type\": \"apiKey\", \"name\": \"X-API-Key\", \"location\": \"query\" }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Moving an API key from a header to a query parameter breaks existing clients");
+        assertEquals(1, result.getIncompatibleDifferences().size(),
+                "Only the location field changed");
+        assertTrue(reports(result,
+                "Security scheme 'apikey' field 'location' changed from 'header' to 'query'"));
+    }
+
+    @Test
+    void testBackwardIncompatibleRemovingSecuritySchemeField() {
+        String existing = cardWithScheme("bearer",
+                "{ \"type\": \"httpAuth\", \"scheme\": \"Bearer\", \"bearerFormat\": \"JWT\" }");
+        String proposed = cardWithScheme("bearer", BEARER_SCHEME);
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Dropping a declared security scheme field should be backward incompatible");
+        assertEquals(1, result.getIncompatibleDifferences().size(),
+                "Only the dropped bearerFormat should be reported");
+        assertTrue(reports(result,
+                "Security scheme 'bearer' field 'bearerFormat' was removed (was 'JWT')"));
+    }
+
+    @Test
+    void testBackwardIncompatibleOAuth2FlowTokenUrlChange() {
+        String existing = cardWithScheme("oauth", OAUTH_SCHEME);
+        String proposed = cardWithScheme("oauth", OAUTH_SCHEME.replace(
+                "https://example.com/token", "https://auth.example.com/token"));
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Moving the OAuth2 token endpoint should be backward incompatible");
+        assertEquals(1, result.getIncompatibleDifferences().size(),
+                "Only the changed leaf should be reported, not every field under flows");
+        assertTrue(reports(result,
+                "Security scheme 'oauth' field 'flows/clientCredentials/tokenUrl' changed from"
+                        + " 'https://example.com/token' to 'https://auth.example.com/token'"));
+    }
+
+    @Test
+    void testBackwardIncompatibleRemovingOAuth2Flow() {
+        String existing = cardWithScheme("oauth", OAUTH_SCHEME.replace(
+                "\"flows\": {", "\"flows\": { \"authorizationCode\": {"
+                        + " \"authorizationUrl\": \"https://example.com/authorize\" },"));
+        String proposed = cardWithScheme("oauth", OAUTH_SCHEME);
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Withdrawing an OAuth2 grant type should be backward incompatible");
+        assertEquals(1, result.getIncompatibleDifferences().size(),
+                "The whole flow is reported once, not once per field beneath it");
+        assertTrue(reports(result,
+                "Security scheme 'oauth' no longer declares 'flows/authorizationCode'"));
+    }
+
+    @Test
+    void testBackwardCompatibleSecuritySchemeDescriptionChange() {
+        String existing = cardWithScheme("bearer",
+                "{ \"type\": \"httpAuth\", \"scheme\": \"Bearer\","
+                        + " \"description\": \"Bearer token\" }");
+        String proposed = cardWithScheme("bearer",
+                "{ \"type\": \"httpAuth\", \"scheme\": \"Bearer\","
+                        + " \"description\": \"Bearer token, JWT encoded\" }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(),
+                "A security scheme description is documentation, so editing it stays compatible");
+    }
+
+    @Test
+    void testFullCompatibleSecuritySchemeDescriptionChange() {
+        String existing = cardWithScheme("bearer",
+                "{ \"type\": \"httpAuth\", \"scheme\": \"Bearer\","
+                        + " \"description\": \"Bearer token\" }");
+        String proposed = cardWithScheme("bearer",
+                "{ \"type\": \"httpAuth\", \"scheme\": \"Bearer\","
+                        + " \"description\": \"Bearer token, JWT encoded\" }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.FULL,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(),
+                "The description exemption must hold in both directions");
+    }
+
+    @Test
+    void testBackwardCompatibleSecuritySchemeUnknownFieldChange() {
+        String existing = cardWithScheme("bearer",
+                "{ \"type\": \"httpAuth\", \"scheme\": \"Bearer\", \"x-owner\": \"team-a\" }");
+        String proposed = cardWithScheme("bearer",
+                "{ \"type\": \"httpAuth\", \"scheme\": \"Bearer\", \"x-owner\": \"team-b\" }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(),
+                "The schema allows vendor fields, so churn in one must not fail a publish");
+    }
+
+    @Test
+    void testBackwardCompatibleAddingSecurityScheme() {
+        String existing = cardWithScheme("bearer", BEARER_SCHEME);
+        String proposed = cardWithSchemes("{ \"bearer\": " + BEARER_SCHEME + ", \"apikey\": "
+                + APIKEY_HEADER_SCHEME + " }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Offering an additional security scheme should be backward compatible");
+    }
+
+    @Test
+    void testBackwardCompatibleAddingOAuth2FlowAndScope() {
+        String existing = cardWithScheme("oauth", OAUTH_SCHEME);
+        String proposed = cardWithScheme("oauth", OAUTH_SCHEME
+                .replace("\"scopes\": { \"read\": \"Read access\" }",
+                        "\"scopes\": { \"read\": \"Read access\", \"write\": \"Write access\" }")
+                .replace("\"flows\": {", "\"flows\": { \"authorizationCode\": {"
+                        + " \"authorizationUrl\": \"https://example.com/authorize\" },"));
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Adding an OAuth2 grant type or scope is additive, so it stays compatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleSecuritySchemeReplacedByNull() {
+        String existing = cardWithScheme("bearer", BEARER_SCHEME);
+        String proposed = cardWithScheme("bearer", "null");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "The scheme name survives, so this is not caught as a removal, but the definition"
+                        + " behind it is gone");
+        assertEquals(1, result.getIncompatibleDifferences().size());
+        assertTrue(reports(result,
+                "Security scheme 'bearer' is no longer defined as an object"));
+    }
+
+    @Test
+    void testBackwardIncompatibleSecuritySchemeReplacedByScalar() {
+        String existing = cardWithScheme("bearer", BEARER_SCHEME);
+        String proposed = cardWithScheme("bearer", "\"httpAuth\"");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Collapsing a scheme definition to a scalar should be backward incompatible");
+        assertTrue(reports(result,
+                "Security scheme 'bearer' is no longer defined as an object"));
+    }
+
+    @Test
+    void testBackwardIncompatibleSecuritySchemeFieldBecomingNonTextual() {
+        String existing = cardWithScheme("bearer", BEARER_SCHEME);
+        String proposed = cardWithScheme("bearer",
+                "{ \"type\": \"httpAuth\", \"scheme\": 42 }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "The validator never type-checks scheme fields, so a field that turns into a"
+                        + " number still has to be compared");
+        assertTrue(reports(result,
+                "Security scheme 'bearer' field 'scheme' changed from 'Bearer' to '42'"),
+                "The value changed, so it must not be described as removed");
+    }
+
+    @Test
+    void testBackwardCompatibleAddingArrayValuedOAuth2Scope() {
+        String existing = cardWithScheme("oauth", "{ \"type\": \"oauth2\", \"flows\": {"
+                + " \"clientCredentials\": { \"scopes\": [\"read\"] } } }");
+        String proposed = cardWithScheme("oauth", "{ \"type\": \"oauth2\", \"flows\": {"
+                + " \"clientCredentials\": { \"scopes\": [\"read\", \"write\"] } } }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(),
+                "An array of scopes is a set of offered values, so adding one stays compatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleRemovingArrayValuedOAuth2Scope() {
+        String existing = cardWithScheme("oauth", "{ \"type\": \"oauth2\", \"flows\": {"
+                + " \"clientCredentials\": { \"scopes\": [\"read\", \"write\"] } } }");
+        String proposed = cardWithScheme("oauth", "{ \"type\": \"oauth2\", \"flows\": {"
+                + " \"clientCredentials\": { \"scopes\": [\"read\"] } } }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Withdrawing an offered scope should be backward incompatible");
+        assertEquals(1, result.getIncompatibleDifferences().size(),
+                "Only the withdrawn scope should be reported");
+        assertTrue(reports(result, "Security scheme 'oauth' no longer offers 'write' in"
+                + " 'flows/clientCredentials/scopes'"));
+    }
+
+    private static String cardWithoutInterfaceProtocolVersion() {
+        return baseCard(SKILL1, "").replace(", \"protocolVersion\": \"1.0\" }", " }");
+    }
+
+    private static final String IFACE_V1 = "{ \"url\": \"https://example.com/agent\","
+            + " \"protocolBinding\": \"http+json\", \"protocolVersion\": \"1.0\" }";
+    private static final String IFACE_NO_VERSION = "{ \"url\": \"https://example.com/agent\","
+            + " \"protocolBinding\": \"http+json\" }";
+
+    private static String cardWithInterfaces(String interfaces) {
+        return baseCard(SKILL1, "").replace(IFACE_V1, interfaces);
+    }
+
+    private static String cardWithScopes(String scopes) {
+        return cardWithScheme("oauth", "{ \"type\": \"oauth2\", \"flows\": {"
+                + " \"clientCredentials\": { \"scopes\": " + scopes + " } } }");
+    }
+
+    @Test
+    void testBackwardCompatibleEditingOAuth2ScopeDescription() {
+        String existing = cardWithScopes("{ \"read\": \"Read access\" }");
+        String proposed = cardWithScopes("{ \"read\": \"Read-only access\" }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(),
+                "An OAuth2 scope map holds a short description per scope name, so rewording one is"
+                        + " documentation and must stay compatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleRemovingMapValuedOAuth2Scope() {
+        String existing = cardWithScopes("{ \"read\": \"Read access\", \"write\": \"Write access\" }");
+        String proposed = cardWithScopes("{ \"read\": \"Read access\" }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Withdrawing a scope name should still be backward incompatible");
+        assertEquals(1, result.getIncompatibleDifferences().size());
+        assertTrue(reports(result, "Security scheme 'oauth' no longer offers 'write' in"
+                + " 'flows/clientCredentials/scopes'"));
+    }
+
+    @Test
+    void testBackwardCompatibleDuplicateInterfaceRetainingProtocolVersion() {
+        String existing = cardWithInterfaces(IFACE_V1);
+        String proposed = cardWithInterfaces(IFACE_V1 + ", " + IFACE_NO_VERSION);
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(),
+                "url+protocolBinding is not unique, so a matching interface that keeps the version"
+                        + " means nothing was withdrawn");
+    }
+
+    @Test
+    void testBackwardIncompatibleDuplicateInterfacesAllDroppingProtocolVersion() {
+        String existing = cardWithInterfaces(IFACE_V1);
+        String proposed = cardWithInterfaces(IFACE_NO_VERSION + ", " + IFACE_NO_VERSION);
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "When no matching interface keeps the version it really was withdrawn");
+        assertEquals(1, result.getIncompatibleDifferences().size(),
+                "Duplicate entries must not multiply the difference");
+    }
+
+    @Test
+    void testBackwardIncompatibleInterfaceProtocolVersionBecomingNonTextual() {
+        String existing = cardWithInterfaces(IFACE_V1);
+        String proposed = cardWithInterfaces("{ \"url\": \"https://example.com/agent\","
+                + " \"protocolBinding\": \"http+json\", \"protocolVersion\": 2 }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible());
+        assertTrue(reports(result, "Protocol version changed from '1.0' to '2'"),
+                "The value changed, so it must not be reported as a removal");
+    }
+
+    @Test
+    void testBackwardIncompatibleCardProtocolVersionBecomingNonTextual() {
+        String existing = baseCard(SKILL1, ", \"protocolVersion\": \"1.0\"");
+        String proposed = baseCard(SKILL1, ", \"protocolVersion\": 2");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible());
+        assertTrue(reports(result, "The agent protocolVersion changed from '1.0' to '2'"),
+                "The value changed, so it must not be reported as a removal");
+    }
+
+    @Test
+    void testBackwardCompatibleWhenBothInterfacesOmitProtocolVersion() {
+        String existing = cardWithoutInterfaceProtocolVersion();
+        String proposed = cardWithoutInterfaceProtocolVersion();
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(),
+                "An interface that never declared a protocolVersion has none to lose, so this must"
+                        + " not be reported as a removal");
+        assertEquals(0, result.getIncompatibleDifferences().size());
+    }
+
+    @Test
+    void testBackwardCompatibleWhenProposedInterfaceAddsProtocolVersion() {
+        String existing = cardWithoutInterfaceProtocolVersion();
+        String proposed = baseCard(SKILL1, "");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Declaring a protocolVersion on an interface that lacked one is additive");
+        assertEquals(0, result.getIncompatibleDifferences().size());
+    }
+
+    @Test
+    void testBackwardIncompatibleCardProtocolVersionChange() {
+        String existing = baseCard(SKILL1, ", \"protocolVersion\": \"1.0\"");
+        String proposed = baseCard(SKILL1, ", \"protocolVersion\": \"2.0\"");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Changing the card-level protocolVersion should be backward incompatible");
+        assertEquals(1, result.getIncompatibleDifferences().size(),
+                "The interfaces are unchanged, so only the card-level version is reported");
+        assertTrue(reports(result, "The agent protocolVersion changed from '1.0' to '2.0'"));
+        assertEquals("/protocolVersion",
+                result.getIncompatibleDifferences().iterator().next().asRuleViolation()
+                        .getContext(),
+                "The card-level version is not part of /supportedInterfaces");
+    }
+
+    @Test
+    void testBackwardCompatibleAddingCardProtocolVersion() {
+        String existing = baseCard(SKILL1, "");
+        String proposed = baseCard(SKILL1, ", \"protocolVersion\": \"1.0\"");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(),
+                "The card-level protocolVersion is optional, so declaring one is compatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleRemovingInterfaceProtocolVersion() {
+        String existing = baseCard(SKILL1, "");
+        String proposed = baseCard(SKILL1, "").replace(
+                ", \"protocolVersion\": \"1.0\" }", " }");
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCard(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Dropping an interface protocolVersion withdraws a guarantee clients relied on");
+        assertEquals(1, result.getIncompatibleDifferences().size(),
+                "The interface itself is retained, so only the lost version is reported");
+        assertTrue(reports(result, "Protocol version '1.0' was removed from interface "
+                + "https://example.com/agent (http+json)"));
+    }
 }


### PR DESCRIPTION
Fixes #9455

`AgentCardCompatibilityChecker` already looks past identifiers in two places: a boolean capability that flips to `false` is caught, and so is a changed `protocolVersion` on an interface that is kept. That treatment is incomplete. Everywhere else — skill ids, interface `url|protocolBinding` keys, capability extension uris, security scheme names, mode strings — only the identifier is compared, so three changes that break existing A2A clients pass as compatible under a BACKWARD rule.

### Security scheme definitions

A security scheme kept by name can be redefined completely. `checkSecuritySchemeRemovals` diffs the output of `extractSecuritySchemeNames`, which collects `securitySchemes` field names, so changing `"bearer"` from `{"type":"httpAuth","scheme":"Bearer"}` to `{"type":"apiKey","name":"X-API-Key","location":"header"}` produces no differences at all. Every client authenticating with a Bearer token breaks.

Compare the fields that decide how a client authenticates: `type`, `scheme`, `bearerFormat`, `name`, `location`, `oauth2MetadataUrl` and `openIdConnectUrl`. A field the existing card declared that changes or disappears is a difference. `description` is documentation and is not compared, and fields outside that list are ignored deliberately — the schema permits vendor extensions on a scheme, and churn in one of those must not fail a publish.

`bearerFormat` is the debatable member: OpenAPI calls it documentation, but the A2A schema gives it no such wording and lists it beside `scheme`, and a client reading JWT claims locally does break when the format goes opaque.

A retained name can also hide the definition disappearing entirely. `"bearer": {...}` becoming `"bearer": null` or a bare string keeps the name, so the removal check stays quiet. `validateSecuritySchemes` would reject that, but validity rules are opt-in, so the card reaches the compatibility checker either way.

`flows` is typed as a bare object in the schema and the validator never looks inside it, so it is compared structurally rather than by known field names: whatever the existing card declared must still be there, unchanged. Comparing the whole `flows` node instead would report additions as breaking, so adding a grant type or a scope stays compatible. Differences are reported at the outermost point where the two stop matching, so withdrawing a grant type is one difference rather than one per field beneath it. Arrays inside `flows` are treated as sets of offered values, the way `checkModeRemovals` already treats `defaultInputModes`.

A `scopes` map is the one place under `flows` where the value is documentation rather than contract — A2A types it as name to "a short description for it" — so only the scope names are compared. Withdrawing a scope is still reported; rewording one is not. Comparing those values would contradict the `description` exemption above and would judge the map form more harshly than the array form.

### Dropping an interface's protocolVersion

An interface that keeps its `url` and `protocolBinding` but drops its `protocolVersion` was silently allowed. The guard read:

```java
if (url.equals(pUrl) && binding.equals(pBinding)
        && pVersion != null && !existingVersion.equals(pVersion))
```

so a null `pVersion` short-circuited the comparison and nothing was reported, even though the client loses a version guarantee it had. Split into the dropped case and the changed case, keeping the existing `PROTOCOL_VERSION_CHANGED` wording for the latter.

That case only surfaces when the VALIDITY rule is unset, `NONE` or `SYNTAX_ONLY`, since `protocolVersion` is required for an interface by both `validateSupportedInterfaces` and `supportedInterfaces.items.required` in `a2a-agent-card-schema.json`. Validity rules are opt-in, so a compatibility checker cannot assume one ran.

### Card-level protocolVersion

The card-level `protocolVersion` is never compared either, so bumping it from `"1.0"` to `"2.0"` passes while the same change on an interface is rejected. `RegistryAgentCardBuilder` fills the card-level field and each interface's from the same `a2aConfig.getProtocolVersion()`, so it is a real declaration rather than a vestigial one. It is optional, so a card that never declared one promises nothing to take away and adding one stays compatible.

This is the case I am least attached to — one can argue the field exists in order to change — and it is one self-contained method and its tests if you would rather it came out.

### Direction semantics and difference types

All three checks are written one-directional: existing lost or changed something. `AbstractCompatibilityChecker` calls `isBackwardsCompatibleWith(existing, proposed)` for BACKWARD and swaps the arguments for FORWARD, so FORWARD and FULL follow without a symmetric check, which would have flagged legitimate additions.

#8634 has since merged and removed the per-type difference classes, so each violation is a `SimpleCompatibilityDifference` carrying its context path directly: security scheme changes under `/securitySchemes`, an interface that drops its `protocolVersion` under `/supportedInterfaces`, and the card-level `protocolVersion` under `/protocolVersion`, since that field is not part of `/supportedInterfaces`. Those are the paths the deleted `AgentCardCompatibilityDifference.Type` constants carried.

### Tests

Adding a security scheme, editing a scheme's description, adding a grant type or a scope, and declaring a card-level `protocolVersion` where there was none all remain compatible, each with a test.

27 tests added to `AgentCardCompatibilityCheckerTest`, and the class Javadoc rule list updated to match. Among them: an interface that never declared a `protocolVersion` (both-sides-absent and proposed-adds-one stay compatible), a duplicated `url|protocolBinding` where one entry keeps the version, and a `protocolVersion` that turns non-textual, which must report a change rather than a removal.

The same identifier-only comparison pattern appears in `McpToolCompatibilityChecker`, which is out of scope here.


