### PR TITLE
fix(ui): reset pagination to page 1 on filter criteria change

### DIFF
--- a/ui/ui-app/src/app/pages/drafts/DraftsPage.tsx
+++ b/ui/ui-app/src/app/pages/drafts/DraftsPage.tsx
@@ -217,6 +217,7 @@ export const DraftsPage: FunctionComponent<PageProperties> = () => {
         if (!updated) {
             newCriteria.push(dsf);
         }
+        setPaging(prev => ({ ...prev, page: 1 }));
         setCriteria(newCriteria);
     };
 
@@ -247,7 +248,10 @@ export const DraftsPage: FunctionComponent<PageProperties> = () => {
                 setSortBy(by);
                 setSortOrder(dir);
             }}
-            onCriteriaChange={setCriteria}
+            onCriteriaChange={newCriteria => {
+                setPaging(prev => ({ ...prev, page: 1 }));
+                setCriteria(newCriteria);
+            }}
             onRefresh={() => {
                 search(criteria, sortBy, sortOrder, paging);
             }}


### PR DESCRIPTION
## Description
Resets the pagination page index back to 1 whenever search filters or criteria change in the UI (DraftsPage).

## Why
Previously, if a user navigated to a non-first page (e.g., Page 2 or Page 3) of a list and subsequently applied a search filter or clicked a Group ID tag filter, the pagination state paging.page remained unchanged at the higher page index.

This caused the UI to send an out-of-bounds offset query to the backend for filtered result sets containing fewer items than the current page offset, incorrectly presenting a "No results found" empty state to the user even when matching items existed on Page 1.

## Changes Made


DraftsPage.tsx
: Updated filterByGroupId and onCriteriaChange in DraftsPageToolbar to update paging state with page: 1 alongside criteria updates.
How to Test / Verification Steps
Navigate to the Drafts page.
Ensure there are enough drafts to span across multiple pages and navigate to Page 2.
Apply a filter (e.g., type a filter keyword in the toolbar or click a Group ID filter tag).
Expected Outcome: The pagination resets to Page 1 and displays matching filtered results instead of a false "No results found" empty state.

## issue closes : #9534 