### PR TITLE
fix(ui): reset pagination to page 1 on Drafts and Explore page filter…

### DIFF
--- a/ui/ui-app/src/app/pages/drafts/DraftsPage.tsx
+++ b/ui/ui-app/src/app/pages/drafts/DraftsPage.tsx
@@ -217,6 +217,7 @@ export const DraftsPage: FunctionComponent<PageProperties> = () => {
         if (!updated) {
             newCriteria.push(dsf);
         }
+        setPaging(prev => ({ ...prev, page: 1 }));
         setCriteria(newCriteria);
     };
 
@@ -247,7 +248,10 @@ export const DraftsPage: FunctionComponent<PageProperties> = () => {
                 setSortBy(by);
                 setSortOrder(dir);
             }}
-            onCriteriaChange={setCriteria}
+            onCriteriaChange={newCriteria => {
+                setPaging(prev => ({ ...prev, page: 1 }));
+                setCriteria(newCriteria);
+            }}
             onRefresh={() => {
                 search(criteria, sortBy, sortOrder, paging);
             }}

--- a/ui/ui-app/src/app/pages/explore/ExplorePage.tsx
+++ b/ui/ui-app/src/app/pages/explore/ExplorePage.tsx
@@ -225,7 +225,9 @@ export const ExplorePage: FunctionComponent<ExplorePageProps> = () => {
                     setImporting(false);
                     setImportProgress(100);
                     setImportModalOpen(false);
-                    search(criteria, paging);
+                    const resetPaging: Paging = { page: 1, pageSize: paging.pageSize };
+                    setPaging(resetPaging);
+                    search(criteria, resetPaging);
                 }, 1500);
             }).catch(error => {
                 setPageError(toPageError(error, "Error importing multiple artifacts"));
@@ -253,7 +255,9 @@ export const ExplorePage: FunctionComponent<ExplorePageProps> = () => {
         pleaseWait(true, "Deleting group, please wait.");
         groups.deleteGroup(groupToDelete?.groupId as string).then( () => {
             pleaseWait(false);
-            search(criteria, paging);
+            const resetPaging: Paging = { page: 1, pageSize: paging.pageSize };
+            setPaging(resetPaging);
+            search(criteria, resetPaging);
         }).catch(error => {
             setPageError(toPageError(error, "Error deleting group."));
         });


### PR DESCRIPTION
## What
Resets the active pagination page index back to 1 whenever search filters/criteria change or list data is mutated (via deletion or import) in both DraftsPage and ExplorePage.

## Why
Previously, when users navigated to a higher page (e.g., Page 2 or Page 3) on the Drafts or Explore pages and subsequently:

Applied a new search filter or clicked a Group ID tag filter.
Deleted an item or performed a bulk ZIP import.
The pagination state (paging.page) remained locked at the previous higher page index. As a result, subsequent search requests were sent to the backend with an out-of-bounds offset (e.g. offset = 20).

When the resulting filtered dataset or post-mutation list had fewer total items than the current page offset, the UI incorrectly rendered a "No results found" empty state, even though valid matching items existed on Page 1.

## Changes Made


DraftsPage.tsx
:
Updated filterByGroupId to set paging.page: 1 when filtering by Group ID.
Updated onCriteriaChange in DraftsPageToolbar to reset paging.page to 1 when filter chips/search terms change.


ExplorePage.tsx
:
Updated doDeleteGroup to reset paging to Page 1 upon successful group deletion before fetching updated results.
Updated doImport to reset paging to Page 1 upon completion of ZIP import before fetching updated results.
Verification / How to Test
Scenario 1: Filtering on Drafts Page
Open the Drafts page with enough drafts to span multiple pages.
Navigate to Page 2.
Apply a filter (e.g., type a filter term or click a Group ID chip).
Expected Outcome: The pagination resets to Page 1 and displays matching filtered drafts instead of a false "No results found" state.
Scenario 2: Group Deletion / Import on Explore Page
Open the Explore page and navigate to Page 2.
Delete a group or complete a ZIP file import.
Expected Outcome: The list re-fetches starting from Page 1, avoiding out-of-bounds offset queries.

Issue Closes : #9534 