### PR TITLE
feat(ui): support OIDC providers that require the nonce parameter

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/SystemResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/SystemResourceImpl.java
@@ -109,6 +109,8 @@ public class SystemResourceImpl implements SystemResource {
             }
             // Only include loadUserInfo if explicitly configured
             uiConfig.loadUserInfo.ifPresent(loadUserInfo -> options.put("loadUserInfo", String.valueOf(loadUserInfo)));
+            // Only include useNonce if explicitly configured
+            uiConfig.useNonce.ifPresent(useNonce -> options.put("useNonce", String.valueOf(useNonce)));
             rval.setOptions(options);
         }
         return rval;

--- a/app/src/main/java/io/apicurio/registry/ui/UserInterfaceConfigProperties.java
+++ b/app/src/main/java/io/apicurio/registry/ui/UserInterfaceConfigProperties.java
@@ -61,7 +61,7 @@ public class UserInterfaceConfigProperties {
     public Optional<Boolean> loadUserInfo;
 
     @ConfigProperty(name = "apicurio.ui.auth.oidc.use-nonce")
-    @Info(category = CATEGORY_UI, description = "Whether to include a nonce parameter in OIDC authorization requests. Required for providers that enforce nonce (e.g. Keycloak with FAPI policies). Defaults to false if not specified.", availableSince = "3.2.0")
+    @Info(category = CATEGORY_UI, description = "Whether to include a nonce parameter in OIDC authorization requests. Required for providers that enforce nonce (e.g. Keycloak with FAPI policies). Defaults to false if not specified.", availableSince = "3.3.2")
     public Optional<Boolean> useNonce;
 
 }

--- a/app/src/main/java/io/apicurio/registry/ui/UserInterfaceConfigProperties.java
+++ b/app/src/main/java/io/apicurio/registry/ui/UserInterfaceConfigProperties.java
@@ -60,4 +60,8 @@ public class UserInterfaceConfigProperties {
     @Info(category = CATEGORY_UI, description = "Whether to load user info from the OIDC userinfo endpoint. Defaults to true if not specified. Set to false for OIDC providers like Azure Entra ID where the userinfo endpoint has incompatible audience requirements.", availableSince = "3.1.6")
     public Optional<Boolean> loadUserInfo;
 
+    @ConfigProperty(name = "apicurio.ui.auth.oidc.use-nonce")
+    @Info(category = CATEGORY_UI, description = "Whether to include a nonce parameter in OIDC authorization requests. Required for providers that enforce nonce (e.g. Keycloak with FAPI policies). Defaults to false if not specified.", availableSince = "3.2.0")
+    public Optional<Boolean> useNonce;
+
 }

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -1554,7 +1554,7 @@ The following {registry} configuration options are available for each component 
 |`apicurio.ui.auth.oidc.use-nonce`
 |`optional<boolean>`
 |
-|`3.2.0`
+|`3.3.2`
 |Whether to include a nonce parameter in OIDC authorization requests. Required for providers that enforce nonce (e.g. Keycloak with FAPI policies). Defaults to false if not specified.
 |`apicurio.ui.contextPath`
 |`string`

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -1551,6 +1551,11 @@ The following {registry} configuration options are available for each component 
 |`openid profile email`
 |`3.0.8`
 |UI auth OIDC scope value
+|`apicurio.ui.auth.oidc.use-nonce`
+|`optional<boolean>`
+|
+|`3.2.0`
+|Whether to include a nonce parameter in OIDC authorization requests. Required for providers that enforce nonce (e.g. Keycloak with FAPI policies). Defaults to false if not specified.
 |`apicurio.ui.contextPath`
 |`string`
 |`/`

--- a/ui/.docker-scripts/create-config.cjs
+++ b/ui/.docker-scripts/create-config.cjs
@@ -24,6 +24,7 @@ const AUTH_LOGOUT_URL=process.env["REGISTRY_AUTH_LOGOUT_URL"];
 const AUTH_LOAD_USER_INFO=process.env["REGISTRY_AUTH_LOAD_USER_INFO"];
 const AUTH_TOKEN_TYPE=process.env["REGISTRY_AUTH_TOKEN_TYPE"];
 const AUTH_LOG_TOKENS=process.env["REGISTRY_AUTH_LOG_TOKENS"];
+const AUTH_USE_NONCE=process.env["REGISTRY_AUTH_USE_NONCE"];
 
 const FEATURE_READ_ONLY=process.env["REGISTRY_FEATURE_READ_ONLY"];
 const FEATURE_BREADCRUMBS=process.env["REGISTRY_FEATURE_BREADCRUMBS"];
@@ -97,6 +98,9 @@ if (AUTH_TYPE === "oidc") {
     }
     if (AUTH_LOG_TOKENS) {
         CONFIG.auth.options.logTokens = AUTH_LOG_TOKENS;
+    }
+    if (AUTH_USE_NONCE) {
+        CONFIG.auth.options.useNonce = AUTH_USE_NONCE === "true";
     }
 }
 

--- a/ui/ui-app/package-lock.json
+++ b/ui/ui-app/package-lock.json
@@ -14,8 +14,8 @@
       ],
       "dependencies": {
         "@apicurio/apicurio-registry-sdk": "3.3.2-Dev",
-        "@apicurio/common-ui-components": "4.0.2",
         "@apicurio/data-models": "1.1.33",
+        "@apitomy/common-ui-components": "4.1.2",
         "@microsoft/kiota-abstractions": "1.0.0-preview.99",
         "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.99",
         "@microsoft/kiota-serialization-form": "1.0.0-preview.99",
@@ -91,22 +91,6 @@
       "resolved": "../../typescript-sdk",
       "link": true
     },
-    "node_modules/@apicurio/common-ui-components": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@apicurio/common-ui-components/-/common-ui-components-4.0.2.tgz",
-      "integrity": "sha512-CxmawobcuXUa0dWXJ2UYgdpk/T9MKdGbRUXxjY8u4SE5/bb7AN/R9VMw4+SAJQ8khgHq7OzLB5uievvxO1PAhg==",
-      "peerDependencies": {
-        "@patternfly/patternfly": "~6",
-        "@patternfly/react-core": "~6",
-        "@patternfly/react-icons": "~6",
-        "@patternfly/react-table": "~6",
-        "luxon": "~3",
-        "oidc-client-ts": "~3",
-        "react": "~19",
-        "react-dom": "~19",
-        "react-router": "~7"
-      }
-    },
     "node_modules/@apicurio/data-models": {
       "version": "1.1.33",
       "resolved": "https://registry.npmjs.org/@apicurio/data-models/-/data-models-1.1.33.tgz",
@@ -128,6 +112,22 @@
       },
       "peerDependencies": {
         "eslint": "^9"
+      }
+    },
+    "node_modules/@apitomy/common-ui-components": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@apitomy/common-ui-components/-/common-ui-components-4.1.2.tgz",
+      "integrity": "sha512-e39bfYMgO/nN2QgWmh5fmPf17csc+zR6P+rDTErT3oM6VdkzlQ8FgL2Dx0LheyJGlKUpXOTrFD3iyFG6vmB5zg==",
+      "peerDependencies": {
+        "@patternfly/patternfly": "~6",
+        "@patternfly/react-core": "~6",
+        "@patternfly/react-icons": "~6",
+        "@patternfly/react-table": "~6",
+        "luxon": "~3",
+        "oidc-client-ts": "~3",
+        "react": "~19",
+        "react-dom": "~19",
+        "react-router": "~7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/ui/ui-app/package.json
+++ b/ui/ui-app/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@apicurio/apicurio-registry-sdk": "3.3.2-Dev",
-    "@apicurio/common-ui-components": "4.0.2",
+    "@apitomy/common-ui-components": "4.1.2",
     "@apicurio/data-models": "1.1.33",
     "@microsoft/kiota-abstractions": "1.0.0-preview.99",
     "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.99",

--- a/ui/ui-app/src/app/MainPageWithAuth.tsx
+++ b/ui/ui-app/src/app/MainPageWithAuth.tsx
@@ -20,7 +20,7 @@ import {
 } from "@app/pages";
 import { RolesPage, SettingsPage } from "./pages";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
-import { ApplicationAuth, AuthConfig, AuthConfigContext } from "@apicurio/common-ui-components";
+import { ApplicationAuth, AuthConfig, AuthConfigContext } from "@apitomy/common-ui-components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 
 export type MainPageWithAuthProps = object;

--- a/ui/ui-app/src/app/components/agentCard/AgentCardSkills.tsx
+++ b/ui/ui-app/src/app/components/agentCard/AgentCardSkills.tsx
@@ -11,7 +11,7 @@ import {
     Title,
     Tooltip
 } from "@patternfly/react-core";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 /**
  * Agent skill structure

--- a/ui/ui-app/src/app/components/agentCard/SkillEditor.tsx
+++ b/ui/ui-app/src/app/components/agentCard/SkillEditor.tsx
@@ -24,7 +24,7 @@ import {
 } from "@patternfly/react-core";
 import { PlusCircleIcon, TrashIcon } from "@patternfly/react-icons";
 import { AgentSkill } from "./AgentCardSkills";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 /**
  * Properties

--- a/ui/ui-app/src/app/components/auth/IfAuth.tsx
+++ b/ui/ui-app/src/app/components/auth/IfAuth.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 import { useUserService } from "@services/useUserService.ts";
 
 /**

--- a/ui/ui-app/src/app/components/common/ArtifactGroup.tsx
+++ b/ui/ui-app/src/app/components/common/ArtifactGroup.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { Tooltip } from "@patternfly/react-core";
 import { DesktopIcon } from "@patternfly/react-icons";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 let testIdCounter: number = 1;
 

--- a/ui/ui-app/src/app/components/common/UsageClassificationBadge.tsx
+++ b/ui/ui-app/src/app/components/common/UsageClassificationBadge.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react";
 import { Label } from "@patternfly/react-core";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 export type UsageClassificationBadgeProps = {
     classification: string | undefined | null;

--- a/ui/ui-app/src/app/components/common/VersionStateBadge.tsx
+++ b/ui/ui-app/src/app/components/common/VersionStateBadge.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react";
 import { Label } from "@patternfly/react-core";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 import { SearchedVersion, VersionMetaData } from "@sdk/lib/generated-client/models";
 
 export type VersionStateBadgeProps = {

--- a/ui/ui-app/src/app/components/header/AppHeaderToolbar.tsx
+++ b/ui/ui-app/src/app/components/header/AppHeaderToolbar.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useState } from "react";
 import { Button, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from "@patternfly/react-core";
 import { QuestionCircleIcon, SunIcon, MoonIcon } from "@patternfly/react-icons";
 import { AvatarDropdown, IfAuth } from "@app/components";
-import { AppAboutModal, BackendInfo, FrontendInfo } from "@apicurio/common-ui-components";
+import { AppAboutModal, BackendInfo, FrontendInfo } from "@apitomy/common-ui-components";
 import { useVersionService, VersionService } from "@services/useVersionService.ts";
 import { SystemService, useSystemService } from "@services/useSystemService.ts";
 

--- a/ui/ui-app/src/app/components/header/AvatarDropdown.tsx
+++ b/ui/ui-app/src/app/components/header/AvatarDropdown.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useState } from "react";
 import { Avatar, Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement } from "@patternfly/react-core";
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 import { UserService, useUserService } from "@services/useUserService.ts";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 

--- a/ui/ui-app/src/app/components/modals/AddVersionToBranchModal.tsx
+++ b/ui/ui-app/src/app/components/modals/AddVersionToBranchModal.tsx
@@ -11,7 +11,7 @@ import {
     Modal
 } from "@patternfly/react-core/deprecated";
 import { SearchedBranch, SearchedVersion } from "@sdk/lib/generated-client/models";
-import { IfNotEmpty, IfNotLoading, ObjectSelect } from "@apicurio/common-ui-components";
+import { IfNotEmpty, IfNotLoading, ObjectSelect } from "@apitomy/common-ui-components";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
 import { shash } from "@utils/string.utils.ts";
 import { PlusCircleIcon } from "@patternfly/react-icons";

--- a/ui/ui-app/src/app/components/modals/ChangeVersionStateModal.tsx
+++ b/ui/ui-app/src/app/components/modals/ChangeVersionStateModal.tsx
@@ -12,7 +12,7 @@ import {
     Modal
 } from "@patternfly/react-core/deprecated";
 import { VersionState, VersionStateObject } from "@sdk/lib/generated-client/models";
-import { ObjectSelect } from "@apicurio/common-ui-components";
+import { ObjectSelect } from "@apitomy/common-ui-components";
 
 
 /**

--- a/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
+++ b/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
@@ -28,7 +28,7 @@ import {
     Modal
 } from "@patternfly/react-core/deprecated";
 import { CreateArtifact } from "@sdk/lib/generated-client/models";
-import { If, UrlUpload } from "@apicurio/common-ui-components";
+import { If, UrlUpload } from "@apitomy/common-ui-components";
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
 import { UrlService, useUrlService } from "@services/useUrlService.ts";
 import { ArtifactTypesService, useArtifactTypesService } from "@services/useArtifactTypesService.ts";

--- a/ui/ui-app/src/app/components/modals/CreateVersionModal.tsx
+++ b/ui/ui-app/src/app/components/modals/CreateVersionModal.tsx
@@ -12,7 +12,7 @@ import {
 import {
     Modal
 } from "@patternfly/react-core/deprecated";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 import { isStringEmptyOrUndefined } from "@utils/string.utils.ts";
 import { detectContentType, detectVersionInContent } from "@utils/content.utils.ts";
 import { CreateVersion } from "@sdk/lib/generated-client/models";

--- a/ui/ui-app/src/app/components/modals/EditMetaDataModal.tsx
+++ b/ui/ui-app/src/app/components/modals/EditMetaDataModal.tsx
@@ -12,7 +12,7 @@ import {
 import {
     Modal
 } from "@patternfly/react-core/deprecated";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 import { ArtifactLabel, LabelsFormGroup } from "@app/components";
 import { Labels } from "@sdk/lib/generated-client/models";
 import { labelsToList, listToLabels } from "@utils/labels.utils.ts";

--- a/ui/ui-app/src/app/components/modals/GenerateClientModal.tsx
+++ b/ui/ui-app/src/app/components/modals/GenerateClientModal.tsx
@@ -14,7 +14,7 @@ import {
 import {
     Modal
 } from "@patternfly/react-core/deprecated";
-import { If, ObjectSelect } from "@apicurio/common-ui-components";
+import { If, ObjectSelect } from "@apitomy/common-ui-components";
 import { ClientGeneration } from "@services/useGroupsService.ts";
 import { DownloadService, useDownloadService } from "@services/useDownloadService.ts";
 import { CheckCircleIcon } from "@patternfly/react-icons";

--- a/ui/ui-app/src/app/components/ruleList/CompatibilityLabel.tsx
+++ b/ui/ui-app/src/app/components/ruleList/CompatibilityLabel.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from "react";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 import { Label } from "@patternfly/react-core";
 
 

--- a/ui/ui-app/src/app/components/ruleList/CompatibilitySelect.tsx
+++ b/ui/ui-app/src/app/components/ruleList/CompatibilitySelect.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, useState } from "react";
-import { ObjectSelect } from "@apicurio/common-ui-components";
+import { ObjectSelect } from "@apitomy/common-ui-components";
 
 
 /**

--- a/ui/ui-app/src/app/components/ruleList/IntegrityLabel.tsx
+++ b/ui/ui-app/src/app/components/ruleList/IntegrityLabel.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useEffect, useState } from "react";
 import { Label } from "@patternfly/react-core";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 
 /**

--- a/ui/ui-app/src/app/components/ruleList/RuleValue.tsx
+++ b/ui/ui-app/src/app/components/ruleList/RuleValue.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 import { useUserService } from "@services/useUserService.ts";
 import { useConfigService } from "@services/useConfigService.ts";
 import { RuleListType } from "@app/components";

--- a/ui/ui-app/src/app/components/ruleList/ValidityLabel.tsx
+++ b/ui/ui-app/src/app/components/ruleList/ValidityLabel.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from "react";
 import { Label } from "@patternfly/react-core";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 
 /**

--- a/ui/ui-app/src/app/components/ruleList/ValiditySelect.tsx
+++ b/ui/ui-app/src/app/components/ruleList/ValiditySelect.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, useState } from "react";
-import { ObjectSelect } from "@apicurio/common-ui-components";
+import { ObjectSelect } from "@apitomy/common-ui-components";
 
 
 /**

--- a/ui/ui-app/src/app/pages/agents/AgentsPage.tsx
+++ b/ui/ui-app/src/app/pages/agents/AgentsPage.tsx
@@ -38,7 +38,7 @@ import {
 } from "@services/useAgentService";
 import { Paging } from "@models/Paging.ts";
 import { useAppNavigation } from "@services/useAppNavigation.ts";
-import { FromNow, PleaseWaitModal } from "@apicurio/common-ui-components";
+import { FromNow, PleaseWaitModal } from "@apitomy/common-ui-components";
 import { CreateAgentModal, ImportAgentModal } from "@app/pages/agents/components";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
 import { CreateArtifact } from "@sdk/lib/generated-client/models";

--- a/ui/ui-app/src/app/pages/agents/components/modals/ImportAgentModal.tsx
+++ b/ui/ui-app/src/app/pages/agents/components/modals/ImportAgentModal.tsx
@@ -16,7 +16,7 @@ import {
 } from "@patternfly/react-core";
 import { Modal } from "@patternfly/react-core/deprecated";
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
-import { UrlUpload } from "@apicurio/common-ui-components";
+import { UrlUpload } from "@apitomy/common-ui-components";
 import { AgentCard, AgentCardViewer } from "@app/components/agentCard";
 import { UrlService, useUrlService } from "@services/useUrlService.ts";
 import { CreateArtifact } from "@sdk/lib/generated-client/models";

--- a/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
+++ b/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
@@ -15,7 +15,7 @@ import {
     MetaData,
     RootPageHeader
 } from "@app/components";
-import { PleaseWaitModal } from "@apicurio/common-ui-components";
+import { PleaseWaitModal } from "@apitomy/common-ui-components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { LoggerService, useLoggerService } from "@services/useLoggerService.ts";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";

--- a/ui/ui-app/src/app/pages/artifact/components/pageheader/ArtifactPageHeader.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/pageheader/ArtifactPageHeader.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from "react";
 import "./ArtifactPageHeader.css";
 import { Button, Flex, FlexItem, Content, ContentVariants } from "@patternfly/react-core";
 import { IfAuth, IfFeature } from "@app/components";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 import { ArtifactMetaData } from "@sdk/lib/generated-client/models";
 
 

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactBranchesTabContent.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactBranchesTabContent.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useEffect, useState } from "react";
 import "./ArtifactBranchesTabContent.css";
 import "@app/styles/empty.css";
-import { ListWithToolbar } from "@apicurio/common-ui-components";
+import { ListWithToolbar } from "@apitomy/common-ui-components";
 import { Paging } from "@models/Paging.ts";
 import { LoggerService, useLoggerService } from "@services/useLoggerService.ts";
 import {

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactOverviewTabContent.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/ArtifactOverviewTabContent.tsx
@@ -22,7 +22,7 @@ import {
     Truncate
 } from "@patternfly/react-core";
 import { PencilAltIcon, PlusCircleIcon } from "@patternfly/react-icons";
-import { FromNow, If, ListWithToolbar } from "@apicurio/common-ui-components";
+import { FromNow, If, ListWithToolbar } from "@apitomy/common-ui-components";
 import { isStringEmptyOrUndefined } from "@utils/string.utils.ts";
 import {
     ArtifactMetaData,

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/BranchesTable.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/BranchesTable.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 import "./BranchesTable.css";
 import { Link } from "react-router";
-import { FromNow, If, ObjectDropdown, ResponsiveTable } from "@apicurio/common-ui-components";
+import { FromNow, If, ObjectDropdown, ResponsiveTable } from "@apitomy/common-ui-components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { shash } from "@utils/string.utils.ts";
 import { ArtifactDescription } from "@app/components";

--- a/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTable.tsx
+++ b/ui/ui-app/src/app/pages/artifact/components/tabs/VersionsTable.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import "./VersionsTable.css";
 import { Link } from "react-router";
 import { SortByDirection, ThProps } from "@patternfly/react-table";
-import { FromNow, If, ObjectDropdown, ResponsiveTable } from "@apicurio/common-ui-components";
+import { FromNow, If, ObjectDropdown, ResponsiveTable } from "@apitomy/common-ui-components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { shash } from "@utils/string.utils.ts";
 import { ArtifactDescription, VersionStateBadge } from "@app/components";

--- a/ui/ui-app/src/app/pages/branch/BranchPage.tsx
+++ b/ui/ui-app/src/app/pages/branch/BranchPage.tsx
@@ -12,7 +12,7 @@ import {
     toPageError
 } from "@app/pages";
 import { ConfirmDeleteModal, EditMetaDataModal, IfFeature, MetaData, RootPageHeader } from "@app/components";
-import { PleaseWaitModal } from "@apicurio/common-ui-components";
+import { PleaseWaitModal } from "@apitomy/common-ui-components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { LoggerService, useLoggerService } from "@services/useLoggerService.ts";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";

--- a/ui/ui-app/src/app/pages/branch/components/pageheader/BranchPageHeader.tsx
+++ b/ui/ui-app/src/app/pages/branch/components/pageheader/BranchPageHeader.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from "react";
 import "./BranchPageHeader.css";
 import { Button, Flex, FlexItem, Content, ContentVariants } from "@patternfly/react-core";
 import { IfAuth, IfFeature } from "@app/components";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 import { ArtifactMetaData, BranchMetaData } from "@sdk/lib/generated-client/models";
 
 

--- a/ui/ui-app/src/app/pages/branch/components/tabs/BranchOverviewTabContent.tsx
+++ b/ui/ui-app/src/app/pages/branch/components/tabs/BranchOverviewTabContent.tsx
@@ -22,7 +22,7 @@ import {
     FlexItem
 } from "@patternfly/react-core";
 import { CodeBranchIcon, PencilAltIcon, PlusCircleIcon } from "@patternfly/react-icons";
-import { FromNow, If, ListWithToolbar } from "@apicurio/common-ui-components";
+import { FromNow, If, ListWithToolbar } from "@apitomy/common-ui-components";
 import {
     ArtifactMetaData,
     BranchMetaData,

--- a/ui/ui-app/src/app/pages/branch/components/tabs/BranchVersionsTable.tsx
+++ b/ui/ui-app/src/app/pages/branch/components/tabs/BranchVersionsTable.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 import "./BranchVersionsTable.css";
 import { Link } from "react-router";
-import { FromNow, If, ObjectDropdown, ResponsiveTable } from "@apicurio/common-ui-components";
+import { FromNow, If, ObjectDropdown, ResponsiveTable } from "@apitomy/common-ui-components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { shash } from "@utils/string.utils.ts";
 import { ArtifactDescription } from "@app/components";

--- a/ui/ui-app/src/app/pages/dashboard/components/RecentArtifacts.tsx
+++ b/ui/ui-app/src/app/pages/dashboard/components/RecentArtifacts.tsx
@@ -13,7 +13,7 @@ import {
     EmptyStateVariant
 } from "@patternfly/react-core";
 import { InfoCircleIcon } from "@patternfly/react-icons";
-import { FromNow } from "@apicurio/common-ui-components";
+import { FromNow } from "@apitomy/common-ui-components";
 import { SearchedArtifact } from "@sdk/lib/generated-client/models";
 import { ArtifactTypeIcon } from "@app/components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";

--- a/ui/ui-app/src/app/pages/drafts/DraftsPage.tsx
+++ b/ui/ui-app/src/app/pages/drafts/DraftsPage.tsx
@@ -24,7 +24,7 @@ import { SortOrder } from "@models/SortOrder.ts";
 import { RuleViolationProblemDetails, SearchedVersion } from "@sdk/lib/generated-client/models";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { DraftsService, useDraftsService } from "@services/useDraftsService.ts";
-import { ListWithToolbar, PleaseWaitModal } from "@apicurio/common-ui-components";
+import { ListWithToolbar, PleaseWaitModal } from "@apitomy/common-ui-components";
 import {
     ConfirmFinalizeModal,
     CreateDraftModal,

--- a/ui/ui-app/src/app/pages/drafts/components/empty/DraftsPageEmptyState.tsx
+++ b/ui/ui-app/src/app/pages/drafts/components/empty/DraftsPageEmptyState.tsx
@@ -9,7 +9,7 @@ import {
     EmptyStateVariant
 } from "@patternfly/react-core";
 import { PlusCircleIcon } from "@patternfly/react-icons";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 /**
  * Properties

--- a/ui/ui-app/src/app/pages/drafts/components/list/DraftId.tsx
+++ b/ui/ui-app/src/app/pages/drafts/components/list/DraftId.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 import { Link } from "react-router";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 export type DraftIdProps = {
     groupId: string|null;

--- a/ui/ui-app/src/app/pages/drafts/components/list/DraftsList.tsx
+++ b/ui/ui-app/src/app/pages/drafts/components/list/DraftsList.tsx
@@ -10,7 +10,7 @@ import {
     Label,
     Truncate
 } from "@patternfly/react-core";
-import { FromNow, If, ObjectDropdown } from "@apicurio/common-ui-components";
+import { FromNow, If, ObjectDropdown } from "@apitomy/common-ui-components";
 import { DraftId } from "@app/pages/drafts/components/list/DraftId.tsx";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { DraftTypeIcon } from "@app/pages/drafts/components/DraftTypeIcon.tsx";

--- a/ui/ui-app/src/app/pages/drafts/components/modals/CreateDraftModal.tsx
+++ b/ui/ui-app/src/app/pages/drafts/components/modals/CreateDraftModal.tsx
@@ -26,7 +26,7 @@ import {
 import {
     Modal
 } from "@patternfly/react-core/deprecated";
-import { If, ObjectSelect, UrlUpload } from "@apicurio/common-ui-components";
+import { If, ObjectSelect, UrlUpload } from "@apitomy/common-ui-components";
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
 import { UrlService, useUrlService } from "@services/useUrlService.ts";
 import { detectContentType } from "@utils/content.utils.ts";

--- a/ui/ui-app/src/app/pages/drafts/components/modals/NewDraftFromModal.tsx
+++ b/ui/ui-app/src/app/pages/drafts/components/modals/NewDraftFromModal.tsx
@@ -15,7 +15,7 @@ import {
 } from "@patternfly/react-core/deprecated";
 import { SearchedVersion } from "@apicurio/apicurio-registry-sdk/dist/generated-client/models";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
 import { VersionMetaData } from "@sdk/lib/generated-client/models";
 

--- a/ui/ui-app/src/app/pages/drafts/components/toolbar/DraftsPageToolbar.tsx
+++ b/ui/ui-app/src/app/pages/drafts/components/toolbar/DraftsPageToolbar.tsx
@@ -7,7 +7,7 @@ import {
     ChipFilterType,
     FilterChips,
     ObjectSelect
-} from "@apicurio/common-ui-components";
+} from "@apitomy/common-ui-components";
 import { DraftsFilterBy, DraftsSearchFilter, DraftsSearchResults, DraftsSortBy } from "@models/drafts";
 import { Paging } from "@models/Paging.ts";
 import { SortOrder } from "@models/SortOrder.ts";

--- a/ui/ui-app/src/app/pages/editor/EditorPage.tsx
+++ b/ui/ui-app/src/app/pages/editor/EditorPage.tsx
@@ -26,7 +26,7 @@ import { Link } from "react-router";
 import { Button } from "@patternfly/react-core";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { ContentTypes } from "@models/ContentTypes.ts";
-import { PleaseWaitModal } from "@apicurio/common-ui-components";
+import { PleaseWaitModal } from "@apitomy/common-ui-components";
 import { Draft, DraftContent } from "@models/drafts";
 import { useDraftsService } from "@services/useDraftsService.ts";
 import { useDownloadService } from "@services/useDownloadService.ts";

--- a/ui/ui-app/src/app/pages/editor/components/EditorContext.tsx
+++ b/ui/ui-app/src/app/pages/editor/components/EditorContext.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from "react";
 import "./EditorContext.css";
 import { Breadcrumb, BreadcrumbItem, Button, Icon, Popover } from "@patternfly/react-core";
-import { FromNow, If, ObjectDropdown } from "@apicurio/common-ui-components";
+import { FromNow, If, ObjectDropdown } from "@apitomy/common-ui-components";
 import { Draft } from "@models/drafts";
 import { Link } from "react-router";
 import { ExclamationTriangleIcon } from "@patternfly/react-icons";

--- a/ui/ui-app/src/app/pages/editor/useEditorReauthentication.ts
+++ b/ui/ui-app/src/app/pages/editor/useEditorReauthentication.ts
@@ -1,5 +1,5 @@
 import { RefObject, useEffect, useState } from "react";
-import { useAuth } from "@apicurio/common-ui-components";
+import { useAuth } from "@apitomy/common-ui-components";
 import { useReauthenticationService } from "@services/useReauthenticationService.ts";
 import { isErrorStatus } from "@utils/rest.utils.ts";
 import { SnapshotPersistenceResult } from "./useEditorDraftRecovery.ts";

--- a/ui/ui-app/src/app/pages/explore/ExplorePage.tsx
+++ b/ui/ui-app/src/app/pages/explore/ExplorePage.tsx
@@ -13,7 +13,7 @@ import {
     toPageError
 } from "@app/pages";
 import { ConfirmDeleteModal, CreateGroupModal, InvalidContentModal, RootPageHeader } from "@app/components";
-import { ListWithToolbar, PleaseWaitModal, ProgressModal } from "@apicurio/common-ui-components";
+import { ListWithToolbar, PleaseWaitModal, ProgressModal } from "@apitomy/common-ui-components";
 import { FilterBy, SearchFilter, SearchService, useSearchService } from "@services/useSearchService.ts";
 import { GroupSearchResults } from "@apicurio/apicurio-registry-sdk/dist/generated-client/models";
 import { Paging } from "@models/Paging.ts";

--- a/ui/ui-app/src/app/pages/explore/components/empty/ExplorePageEmptyState.tsx
+++ b/ui/ui-app/src/app/pages/explore/components/empty/ExplorePageEmptyState.tsx
@@ -7,7 +7,7 @@ import {
     EmptyStateVariant
 } from "@patternfly/react-core";
 import { PlusCircleIcon } from "@patternfly/react-icons";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 /**
  * Properties

--- a/ui/ui-app/src/app/pages/explore/components/groupList/ExploreGroupList.tsx
+++ b/ui/ui-app/src/app/pages/explore/components/groupList/ExploreGroupList.tsx
@@ -12,7 +12,7 @@ import {
 import { OutlinedFolderIcon } from "@patternfly/react-icons";
 import { SearchedGroup } from "@apicurio/apicurio-registry-sdk/dist/generated-client/models";
 import { ArtifactGroup } from "@app/components";
-import { If, ObjectDropdown } from "@apicurio/common-ui-components";
+import { If, ObjectDropdown } from "@apitomy/common-ui-components";
 import { UserService, useUserService } from "@services/useUserService.ts";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 

--- a/ui/ui-app/src/app/pages/explore/components/toolbar/ExplorePageToolbar.tsx
+++ b/ui/ui-app/src/app/pages/explore/components/toolbar/ExplorePageToolbar.tsx
@@ -12,7 +12,7 @@ import {
 } from "@patternfly/react-core";
 import { SortAlphaDownAltIcon, SortAlphaDownIcon } from "@patternfly/react-icons";
 import { OnPerPageSelect, OnSetPage } from "@patternfly/react-core/dist/js/components/Pagination/Pagination";
-import { ObjectDropdown } from "@apicurio/common-ui-components";
+import { ObjectDropdown } from "@apitomy/common-ui-components";
 import { Paging } from "@models/Paging.ts";
 import { FilterBy } from "@services/useSearchService.ts";
 import { GroupSearchResults } from "@apicurio/apicurio-registry-sdk/dist/generated-client/models";

--- a/ui/ui-app/src/app/pages/group/GroupPage.tsx
+++ b/ui/ui-app/src/app/pages/group/GroupPage.tsx
@@ -22,7 +22,7 @@ import {
     InvalidContentModal,
     MetaData, RootPageHeader
 } from "@app/components";
-import { PleaseWaitModal } from "@apicurio/common-ui-components";
+import { PleaseWaitModal } from "@apitomy/common-ui-components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { LoggerService, useLoggerService } from "@services/useLoggerService.ts";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";

--- a/ui/ui-app/src/app/pages/group/components/pageheader/GroupPageHeader.tsx
+++ b/ui/ui-app/src/app/pages/group/components/pageheader/GroupPageHeader.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from "react";
 import "./GroupPageHeader.css";
 import { Button, Flex, FlexItem, Content, ContentVariants } from "@patternfly/react-core";
 import { IfAuth, IfFeature } from "@app/components";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 
 /**

--- a/ui/ui-app/src/app/pages/group/components/tabs/GroupArtifactsTable.tsx
+++ b/ui/ui-app/src/app/pages/group/components/tabs/GroupArtifactsTable.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import "./GroupArtifactsTable.css";
 import { Link } from "react-router";
 import { SortByDirection, ThProps } from "@patternfly/react-table";
-import { FromNow, ObjectDropdown, ResponsiveTable } from "@apicurio/common-ui-components";
+import { FromNow, ObjectDropdown, ResponsiveTable } from "@apitomy/common-ui-components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { ArtifactDescription, ArtifactTypeIcon } from "@app/components";
 import { shash } from "@utils/string.utils.ts";

--- a/ui/ui-app/src/app/pages/group/components/tabs/GroupOverviewTabContent.tsx
+++ b/ui/ui-app/src/app/pages/group/components/tabs/GroupOverviewTabContent.tsx
@@ -24,7 +24,7 @@ import {
     Truncate
 } from "@patternfly/react-core";
 import { OutlinedFolderIcon, PencilAltIcon, PlusCircleIcon } from "@patternfly/react-icons";
-import { FromNow, If, ListWithToolbar } from "@apicurio/common-ui-components";
+import { FromNow, If, ListWithToolbar } from "@apitomy/common-ui-components";
 import { isStringEmptyOrUndefined } from "@utils/string.utils.ts";
 import {
     ArtifactSearchResults,

--- a/ui/ui-app/src/app/pages/group/components/tabs/GroupRulesTabContent.tsx
+++ b/ui/ui-app/src/app/pages/group/components/tabs/GroupRulesTabContent.tsx
@@ -15,7 +15,7 @@ import {
 } from "@patternfly/react-core";
 import { GroupMetaData, Rule } from "@sdk/lib/generated-client/models";
 import { WarningTriangleIcon } from "@patternfly/react-icons";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 /**
  * Properties

--- a/ui/ui-app/src/app/pages/roles/RolesPage.tsx
+++ b/ui/ui-app/src/app/pages/roles/RolesPage.tsx
@@ -14,7 +14,7 @@ import {
 } from "@app/pages";
 import { RootPageHeader } from "@app/components";
 import { GrantAccessModal } from "@app/pages/roles/components/modals/GrantAccessModal.tsx";
-import { If, PleaseWaitModal } from "@apicurio/common-ui-components";
+import { If, PleaseWaitModal } from "@apitomy/common-ui-components";
 import { AdminService, useAdminService } from "@services/useAdminService.ts";
 import { Principal } from "@services/useConfigService.ts";
 import { Paging } from "@models/Paging.ts";

--- a/ui/ui-app/src/app/pages/roles/components/empty/RoleMappingsEmptyState.tsx
+++ b/ui/ui-app/src/app/pages/roles/components/empty/RoleMappingsEmptyState.tsx
@@ -7,7 +7,7 @@ import {
     EmptyStateVariant
 } from "@patternfly/react-core";
 import { PlusCircleIcon } from "@patternfly/react-icons";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 /**
  * Properties

--- a/ui/ui-app/src/app/pages/roles/components/roleToolbar/RoleToolbar.tsx
+++ b/ui/ui-app/src/app/pages/roles/components/roleToolbar/RoleToolbar.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useState } from "react";
 import "./RoleToolbar.css";
-import { If, ObjectSelect } from "@apicurio/common-ui-components";
+import { If, ObjectSelect } from "@apitomy/common-ui-components";
 import {
     Button,
     ButtonVariant,

--- a/ui/ui-app/src/app/pages/search/SearchPage.tsx
+++ b/ui/ui-app/src/app/pages/search/SearchPage.tsx
@@ -14,7 +14,7 @@ import {
     toPageError, SearchGroupList, SearchVersionList
 } from "@app/pages";
 import { RootPageHeader } from "@app/components";
-import { If, ListWithToolbar } from "@apicurio/common-ui-components";
+import { If, ListWithToolbar } from "@apitomy/common-ui-components";
 import { SearchType } from "@app/pages/search/SearchType.ts";
 import { Paging } from "@models/Paging.ts";
 import { FilterBy, SearchFilter, useSearchService } from "@services/useSearchService.ts";

--- a/ui/ui-app/src/app/pages/search/components/artifactList/SearchArtifactList.tsx
+++ b/ui/ui-app/src/app/pages/search/components/artifactList/SearchArtifactList.tsx
@@ -12,7 +12,7 @@ import { ArtifactGroup, ArtifactTypeIcon, ListedItemLabels } from "@app/componen
 import { SearchArtifactName } from "@app/pages";
 import { SearchedVersion } from "@sdk/lib/generated-client/models";
 import { shash } from "@utils/string.utils.ts";
-import { ObjectDropdown } from "@apicurio/common-ui-components";
+import { ObjectDropdown } from "@apitomy/common-ui-components";
 
 /**
  * Properties

--- a/ui/ui-app/src/app/pages/search/components/artifactList/SearchArtifactName.tsx
+++ b/ui/ui-app/src/app/pages/search/components/artifactList/SearchArtifactName.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 import { Link } from "react-router";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 let testIdCounter: number = 1;
 

--- a/ui/ui-app/src/app/pages/search/components/empty/SearchPageEmptyState.tsx
+++ b/ui/ui-app/src/app/pages/search/components/empty/SearchPageEmptyState.tsx
@@ -7,7 +7,7 @@ import {
     EmptyStateVariant
 } from "@patternfly/react-core";
 import { PlusCircleIcon } from "@patternfly/react-icons";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 import { SearchType } from "@app/pages/search/SearchType.ts";
 
 /**

--- a/ui/ui-app/src/app/pages/search/components/groupList/SearchGroupList.tsx
+++ b/ui/ui-app/src/app/pages/search/components/groupList/SearchGroupList.tsx
@@ -12,7 +12,7 @@ import {
 import { OutlinedFolderIcon } from "@patternfly/react-icons";
 import { SearchedGroup } from "@sdk/lib/generated-client/models";
 import { ArtifactGroup, ListedItemLabels } from "@app/components";
-import { ObjectDropdown } from "@apicurio/common-ui-components";
+import { ObjectDropdown } from "@apitomy/common-ui-components";
 
 /**
  * Properties

--- a/ui/ui-app/src/app/pages/search/components/toolbar/FilterInput.tsx
+++ b/ui/ui-app/src/app/pages/search/components/toolbar/FilterInput.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useEffect, useState } from "react";
 import { Button, ButtonVariant, Form, InputGroup, InputGroupItem, TextInput } from "@patternfly/react-core";
 import { SearchIcon } from "@patternfly/react-icons";
-import { ChipFilterCriteria, ChipFilterType, ObjectSelect } from "@apicurio/common-ui-components";
+import { ChipFilterCriteria, ChipFilterType, ObjectSelect } from "@apitomy/common-ui-components";
 
 /**
  * Extended filter type that can optionally render as a dropdown (select)
@@ -19,7 +19,7 @@ export type FilterInputProps = {
 };
 
 /**
- * A filter input component that extends @apicurio/common-ui-components ChipFilterInput.
+ * A filter input component that extends @apitomy/common-ui-components ChipFilterInput.
  *
  * When a filter type has `type: "select"` and an `options` list, the value input
  * is rendered as a dropdown. Otherwise, the standard free-text input is shown.

--- a/ui/ui-app/src/app/pages/search/components/toolbar/SearchPageToolbar.tsx
+++ b/ui/ui-app/src/app/pages/search/components/toolbar/SearchPageToolbar.tsx
@@ -16,7 +16,7 @@ import {
     ChipFilterType,
     FilterChips,
     ObjectSelect
-} from "@apicurio/common-ui-components";
+} from "@apitomy/common-ui-components";
 import { FilterInput, EnhancedFilterType } from "./FilterInput";
 import { SearchType } from "@app/pages/search/SearchType.ts";
 import { plural } from "pluralize";

--- a/ui/ui-app/src/app/pages/search/components/versionList/SearchVersionList.tsx
+++ b/ui/ui-app/src/app/pages/search/components/versionList/SearchVersionList.tsx
@@ -12,7 +12,7 @@ import { ArtifactGroup, ArtifactTypeIcon, ListedItemLabels, VersionStateBadge } 
 import { SearchVersionName } from "@app/pages";
 import { SearchedVersion } from "@sdk/lib/generated-client/models";
 import { shash } from "@utils/string.utils.ts";
-import { ObjectDropdown } from "@apicurio/common-ui-components";
+import { ObjectDropdown } from "@apitomy/common-ui-components";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { UserService, useUserService } from "@services/useUserService.ts";
 

--- a/ui/ui-app/src/app/pages/search/components/versionList/SearchVersionName.tsx
+++ b/ui/ui-app/src/app/pages/search/components/versionList/SearchVersionName.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 import { Link } from "react-router";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 
 let testIdCounter: number = 1;
 

--- a/ui/ui-app/src/app/pages/settings/SettingsPage.tsx
+++ b/ui/ui-app/src/app/pages/settings/SettingsPage.tsx
@@ -19,7 +19,7 @@ import {
     SETTINGS_PAGE_IDX,
     toPageError
 } from "@app/pages";
-import { If, IfNotEmpty } from "@apicurio/common-ui-components";
+import { If, IfNotEmpty } from "@apitomy/common-ui-components";
 import { AdminService, useAdminService } from "@services/useAdminService.ts";
 import { AlertsService, useAlertsService } from "@services/useAlertsService.tsx";
 import { ConfigurationProperty } from "@sdk/lib/generated-client/models";

--- a/ui/ui-app/src/app/pages/settings/components/ConfigProperty.tsx
+++ b/ui/ui-app/src/app/pages/settings/components/ConfigProperty.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useState } from "react";
 import "./ConfigProperty.css";
 import { Button, Flex, FlexItem, Switch } from "@patternfly/react-core";
 import { PropertyInput } from "@app/pages";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 import { CheckIcon, CloseIcon, PencilAltIcon } from "@patternfly/react-icons";
 import { ConfigurationProperty } from "@sdk/lib/generated-client/models";
 

--- a/ui/ui-app/src/app/pages/version/VersionPage.tsx
+++ b/ui/ui-app/src/app/pages/version/VersionPage.tsx
@@ -27,7 +27,7 @@ import {
     RootPageHeader
 } from "@app/components";
 import { ContentTypes } from "@models/ContentTypes.ts";
-import { PleaseWaitModal } from "@apicurio/common-ui-components";
+import { PleaseWaitModal } from "@apitomy/common-ui-components";
 import { AppNavigation, useAppNavigation } from "@services/useAppNavigation.ts";
 import { LoggerService, useLoggerService } from "@services/useLoggerService.ts";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";

--- a/ui/ui-app/src/app/pages/version/components/pageheader/VersionPageHeader.tsx
+++ b/ui/ui-app/src/app/pages/version/components/pageheader/VersionPageHeader.tsx
@@ -9,7 +9,7 @@ import {
     Content,
     ContentVariants
 } from "@patternfly/react-core";
-import { If, ObjectDropdown } from "@apicurio/common-ui-components";
+import { If, ObjectDropdown } from "@apitomy/common-ui-components";
 import { ArtifactMetaData, VersionMetaData } from "@sdk/lib/generated-client/models";
 import { useUserService } from "@services/useUserService.ts";
 import { useConfigService } from "@services/useConfigService.ts";

--- a/ui/ui-app/src/app/pages/version/components/tabs/ContentTabContent.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/ContentTabContent.tsx
@@ -5,7 +5,7 @@ import YAML from "yaml";
 import Editor from "@monaco-editor/react";
 import { detectContentType } from "@utils/content.utils.ts";
 import { ContentTypes } from "@models/ContentTypes.ts";
-import { useResizeObserver } from "@apicurio/common-ui-components";
+import { useResizeObserver } from "@apitomy/common-ui-components";
 import { registerCustomLanguages } from "@editors/registerLanguages.ts";
 
 

--- a/ui/ui-app/src/app/pages/version/components/tabs/DocumentationTabContent.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/DocumentationTabContent.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useEffect, useState } from "react";
 import { ErrorTabContent } from "@app/pages";
-import { If } from "@apicurio/common-ui-components";
+import { If } from "@apitomy/common-ui-components";
 import { isJson, parseJson, isYaml, parseYaml } from "@utils/content.utils";
 import {
     AgentCardVisualizer,

--- a/ui/ui-app/src/app/pages/version/components/tabs/ReferenceList.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/ReferenceList.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import "./ReferenceList.css";
 import { Link } from "react-router";
 import { ThProps } from "@patternfly/react-table";
-import { ResponsiveTable } from "@apicurio/common-ui-components";
+import { ResponsiveTable } from "@apitomy/common-ui-components";
 import { ArtifactReference } from "@sdk/lib/generated-client/models";
 
 export type SortDirection = "asc" | "desc";

--- a/ui/ui-app/src/app/pages/version/components/tabs/ReferencesTabContent.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/ReferencesTabContent.tsx
@@ -9,7 +9,7 @@ import {
     ViewMode
 } from "@app/pages/version/components/tabs/ReferencesToolbar.tsx";
 import { ReferenceGraphView } from "./ReferenceGraphView.tsx";
-import { ListWithToolbar } from "@apicurio/common-ui-components";
+import { ListWithToolbar } from "@apitomy/common-ui-components";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
 import { LoggerService, useLoggerService } from "@services/useLoggerService.ts";
 import { LocalStorageService, useLocalStorageService } from "@services/useLocalStorageService.ts";

--- a/ui/ui-app/src/app/pages/version/components/tabs/ReferencesToolbar.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/ReferencesToolbar.tsx
@@ -16,7 +16,7 @@ import {
 } from "@patternfly/react-core";
 import { ListIcon, SearchIcon, TopologyIcon } from "@patternfly/react-icons";
 import { OnPerPageSelect, OnSetPage } from "@patternfly/react-core/dist/js/components/Pagination/Pagination";
-import { ObjectSelect } from "@apicurio/common-ui-components";
+import { ObjectSelect } from "@apitomy/common-ui-components";
 import { Paging } from "@models/Paging.ts";
 import { ArtifactReference, ReferenceType, ReferenceTypeObject } from "@sdk/lib/generated-client/models";
 

--- a/ui/ui-app/src/app/pages/version/components/tabs/VersionComments.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/VersionComments.tsx
@@ -22,7 +22,7 @@ import {
     Alert,
     AlertActionCloseButton
 } from "@patternfly/react-core";
-import { FromNow, ListWithToolbar, ObjectDropdown, PleaseWaitModal } from "@apicurio/common-ui-components";
+import { FromNow, ListWithToolbar, ObjectDropdown, PleaseWaitModal } from "@apitomy/common-ui-components";
 import { ConfirmDeleteModal, CreateCommentModal, EditCommentModal, IfAuth, IfFeature } from "@app/components";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
 

--- a/ui/ui-app/src/app/pages/version/components/tabs/VersionOverviewTabContent.tsx
+++ b/ui/ui-app/src/app/pages/version/components/tabs/VersionOverviewTabContent.tsx
@@ -17,7 +17,7 @@ import {
     Truncate
 } from "@patternfly/react-core";
 import { PencilAltIcon } from "@patternfly/react-icons";
-import { FromNow, If } from "@apicurio/common-ui-components";
+import { FromNow, If } from "@apitomy/common-ui-components";
 import { ArtifactMetaData, VersionMetaData } from "@sdk/lib/generated-client/models";
 import { labelsToAny } from "@utils/rest.utils.ts";
 import { VersionComments } from "@app/pages";

--- a/ui/ui-app/src/editors/OpenApiEditor.tsx
+++ b/ui/ui-app/src/editors/OpenApiEditor.tsx
@@ -2,7 +2,7 @@ import React, { RefObject, useEffect, useState } from "react";
 import { Editor as DraftEditor, EditorProps } from "./editor-types";
 import "./OpenApiEditor.css";
 import { parseJson, parseYaml, toJsonString, toYamlString } from "@utils/content.utils.ts";
-import { IfNotLoading } from "@apicurio/common-ui-components";
+import { IfNotLoading } from "@apitomy/common-ui-components";
 import { useConfigService } from "@services/useConfigService.ts";
 import { ContentTypes } from "@models/ContentTypes.ts";
 

--- a/ui/ui-app/src/services/useAdminService.test.ts
+++ b/ui/ui-app/src/services/useAdminService.test.ts
@@ -11,7 +11,7 @@ const { getRegistryClientMock } = vi.hoisted(() => {
     return { getRegistryClientMock: vi.fn() };
 });
 
-vi.mock("@apicurio/common-ui-components", () => ({
+vi.mock("@apitomy/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 

--- a/ui/ui-app/src/services/useAdminService.ts
+++ b/ui/ui-app/src/services/useAdminService.ts
@@ -1,4 +1,4 @@
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { createAuthOptions, createEndpoint, getRegistryClient, httpPost } from "@utils/rest.utils.ts";
 import { Paging } from "@models/Paging.ts";

--- a/ui/ui-app/src/services/useAgentService.ts
+++ b/ui/ui-app/src/services/useAgentService.ts
@@ -1,5 +1,5 @@
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 import { Paging } from "@models/Paging.ts";
 import { createAuthOptions } from "@utils/rest.utils.ts";
 

--- a/ui/ui-app/src/services/useConfigService.ts
+++ b/ui/ui-app/src/services/useConfigService.ts
@@ -92,6 +92,7 @@ export interface OidcJsAuthOptions {
     scope: string;
     logoutUrl?: string;
     loadUserInfo?: boolean;
+    useNonce?: boolean;
 }
 
 // Used when `type=oidc`

--- a/ui/ui-app/src/services/useContractsService.ts
+++ b/ui/ui-app/src/services/useContractsService.ts
@@ -1,6 +1,6 @@
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { createAuthOptions, createEndpoint } from "@utils/rest.utils.ts";
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 import axios from "axios";
 
 export interface ContractMetadata {

--- a/ui/ui-app/src/services/useDraftsService.test.ts
+++ b/ui/ui-app/src/services/useDraftsService.test.ts
@@ -11,7 +11,7 @@ const { getRegistryClientMock } = vi.hoisted(() => {
     return { getRegistryClientMock: vi.fn() };
 });
 
-vi.mock("@apicurio/common-ui-components", () => ({
+vi.mock("@apitomy/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 

--- a/ui/ui-app/src/services/useDraftsService.ts
+++ b/ui/ui-app/src/services/useDraftsService.ts
@@ -1,4 +1,4 @@
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { getRegistryClient, labelsToAny } from "@utils/rest.utils.ts";
 import { ApicurioRegistryClient } from "@apicurio/apicurio-registry-sdk";

--- a/ui/ui-app/src/services/useGroupsService.test.ts
+++ b/ui/ui-app/src/services/useGroupsService.test.ts
@@ -11,7 +11,7 @@ const { getRegistryClientMock } = vi.hoisted(() => {
     return { getRegistryClientMock: vi.fn() };
 });
 
-vi.mock("@apicurio/common-ui-components", () => ({
+vi.mock("@apitomy/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 

--- a/ui/ui-app/src/services/useGroupsService.ts
+++ b/ui/ui-app/src/services/useGroupsService.ts
@@ -1,6 +1,6 @@
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { createAuthOptions, createEndpoint, getRegistryClient } from "@utils/rest.utils.ts";
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 import { RenderPromptResponse } from "@models/RenderPromptResponse.ts";
 import axios from "axios";
 import { Paging } from "@models/Paging.ts";

--- a/ui/ui-app/src/services/useReauthenticationService.test.ts
+++ b/ui/ui-app/src/services/useReauthenticationService.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { getReauthenticationService } from "./useReauthenticationService";
-import { AuthService } from "@apicurio/common-ui-components";
+import { AuthService } from "@apitomy/common-ui-components";
 
 describe("useReauthenticationService", () => {
     const service = getReauthenticationService();

--- a/ui/ui-app/src/services/useReauthenticationService.ts
+++ b/ui/ui-app/src/services/useReauthenticationService.ts
@@ -1,4 +1,4 @@
-import { AuthService } from "@apicurio/common-ui-components";
+import { AuthService } from "@apitomy/common-ui-components";
 
 type ReauthenticationInterceptor = () => Promise<boolean>;
 type ReauthenticationListener = (isPending: boolean) => void;

--- a/ui/ui-app/src/services/useSearchService.test.ts
+++ b/ui/ui-app/src/services/useSearchService.test.ts
@@ -11,7 +11,7 @@ const { getRegistryClientMock } = vi.hoisted(() => {
     return { getRegistryClientMock: vi.fn() };
 });
 
-vi.mock("@apicurio/common-ui-components", () => ({
+vi.mock("@apitomy/common-ui-components", () => ({
     useAuth: () => ({})
 }));
 

--- a/ui/ui-app/src/services/useSearchService.ts
+++ b/ui/ui-app/src/services/useSearchService.ts
@@ -1,6 +1,6 @@
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { getRegistryClient } from "@utils/rest.utils.ts";
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 import { Paging } from "@models/Paging.ts";
 import {
     ArtifactSearchResults,

--- a/ui/ui-app/src/services/useSystemService.ts
+++ b/ui/ui-app/src/services/useSystemService.ts
@@ -1,7 +1,7 @@
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { getRegistryClient } from "@utils/rest.utils.ts";
 import { SystemInfo } from "@sdk/lib/generated-client/models";
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 
 
 const getInfo = async (config: ConfigService, auth: AuthService): Promise<SystemInfo> => {

--- a/ui/ui-app/src/services/useUsageService.ts
+++ b/ui/ui-app/src/services/useUsageService.ts
@@ -1,4 +1,4 @@
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { getRegistryClient } from "@utils/rest.utils.ts";
 import { ArtifactUsageMetrics, ConsumerVersionHeatmap, DeprecationReadiness, UsageSummary } from "@sdk/lib/generated-client/models";

--- a/ui/ui-app/src/services/useUserService.ts
+++ b/ui/ui-app/src/services/useUserService.ts
@@ -1,4 +1,4 @@
-import { AuthService, useAuth } from "@apicurio/common-ui-components";
+import { AuthService, useAuth } from "@apitomy/common-ui-components";
 import { getRegistryClient } from "@utils/rest.utils.ts";
 import { ConfigService, useConfigService } from "@services/useConfigService.ts";
 import { UserInfo } from "@sdk/lib/generated-client/models";

--- a/ui/ui-app/src/utils/rest.utils.ts
+++ b/ui/ui-app/src/utils/rest.utils.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { ContentTypes } from "@models/ContentTypes.ts";
-import { AuthService } from "@apicurio/common-ui-components";
+import { AuthService } from "@apitomy/common-ui-components";
 import { Buffer } from "buffer";
 import { AuthenticationProvider, Headers, RequestInformation, type RequestOption } from "@microsoft/kiota-abstractions";
 import { ConfigService } from "@services/useConfigService";


### PR DESCRIPTION
## Summary

- Upgrade `@apicurio/common-ui-components` to `@apitomy/common-ui-components` 4.1.2, which adds
  opt-in OIDC nonce support via a `useNonce` boolean config option
- Add `apicurio.ui.auth.oidc.use-nonce` backend config property and wire it through the
  `/system/uiConfig` endpoint so the UI receives the setting
- Add `REGISTRY_AUTH_USE_NONCE` environment variable support for Docker deployments

## Related Issue

Fixes #9346

## Test Plan

- [ ] `npm test` in `ui/ui-app/` passes with no regressions from the dependency bump
- [ ] `./mvnw test-compile -pl app -am -DskipTests` compiles cleanly
- [ ] `./mvnw checkstyle:check -pl app` passes
- [ ] With `apicurio.ui.auth.oidc.use-nonce=true` configured, verify the OIDC authorization
  redirect URL includes a `nonce` query parameter
- [ ] Without `useNonce` configured (default), verify no nonce is included (backward-compatible)
- [ ] Docker deployment with `REGISTRY_AUTH_USE_NONCE=true` env var correctly enables nonce