### PR TITLE
fix(sql): Add null guards and logging to SqlEventRepository.createEvent

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlEventsProcessor.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlEventsProcessor.java
@@ -14,7 +14,9 @@ public class SqlEventsProcessor {
     public void processEvent(@Observes SqlOutboxEvent event) {
         if (sqlStore.supportsDatabaseEvents() && sqlStore.isReady()) {
             OutboxEvent outboxEvent = event.getOutboxEvent();
-            sqlStore.createEvent(outboxEvent);
+            if (outboxEvent != null) {
+                sqlStore.createEvent(outboxEvent);
+            }
         }
     }
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepository.java
@@ -31,17 +31,18 @@ public class SqlEventRepository {
      * Create an outbox event for database-driven event publishing.
      */
     public String createEvent(OutboxEvent event) {
-        if(event == null)
-        {
-            log.warn("Cannot create outbox event: event is null");
-            return null;
+        if (event == null) {
+            throw new IllegalArgumentException("OutboxEvent must not be null");
+        }
+        if (event.getPayload() == null) {
+            throw new IllegalArgumentException("OutboxEvent payload must not be null");
         }
         if (supportsDatabaseEvents()) {
             handles.withHandle(handle -> {
                 handle.createUpdate(sqlStatements.createOutboxEvent()).bind(0, event.getId())
                         .bind(1, eventsTopic).bind(2, event.getAggregateId()).bind(3, event.getType())
-                        .bind(4, (event.getPayload() != null ? event.getPayload().toString() : null)).execute();
-
+                        .bind(4, event.getPayload().toString()).execute();
+                
                 return handle.createUpdate(sqlStatements.deleteOutboxEvent()).bind(0, event.getId())
                         .execute();
             });

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepository.java
@@ -19,7 +19,8 @@ public class SqlEventRepository {
 
     private final String eventsTopic;
 
-    public SqlEventRepository(HandleFactory handles, SqlStatements sqlStatements, Logger log, String eventsTopic) {
+    public SqlEventRepository(HandleFactory handles, SqlStatements sqlStatements, Logger log,
+            String eventsTopic) {
         this.handles = handles;
         this.sqlStatements = sqlStatements;
         this.log = log;
@@ -30,20 +31,26 @@ public class SqlEventRepository {
      * Create an outbox event for database-driven event publishing.
      */
     public String createEvent(OutboxEvent event) {
+        if(event == null)
+        {
+            log.warn("Cannot create outbox event: event is null");
+            return null;
+        }
         if (supportsDatabaseEvents()) {
             handles.withHandle(handle -> {
-                handle.createUpdate(sqlStatements.createOutboxEvent())
-                        .bind(0, event.getId())
-                        .bind(1, eventsTopic)
-                        .bind(2, event.getAggregateId())
-                        .bind(3, event.getType())
-                        .bind(4, event.getPayload().toString())
-                        .execute();
+                handle.createUpdate(sqlStatements.createOutboxEvent()).bind(0, event.getId())
+                        .bind(1, eventsTopic).bind(2, event.getAggregateId()).bind(3, event.getType())
+                        .bind(4, (event.getPayload() != null ? event.getPayload().toString() : null)).execute();
 
-                return handle.createUpdate(sqlStatements.deleteOutboxEvent())
-                        .bind(0, event.getId())
+                return handle.createUpdate(sqlStatements.deleteOutboxEvent()).bind(0, event.getId())
                         .execute();
             });
+            log.trace("Created outbox event {} of type {} for aggregate {}", event.getId(), event.getType(),
+                    event.getAggregateId());
+        } else {
+            log.debug(
+                    "Database-driven events are not supported for db type '{}'; event {} of type {} was not persisted to the outbox",
+                    sqlStatements.dbType(), event.getId(), event.getType());
         }
         return event.getId();
     }
@@ -56,10 +63,10 @@ public class SqlEventRepository {
     }
 
     private boolean isPostgresql() {
-        return sqlStatements.dbType().equals("postgresql");
+        return "postgresql".equals(sqlStatements.dbType());
     }
 
     private boolean isMssql() {
-        return sqlStatements.dbType().equals("mssql");
+        return "mssql".equals(sqlStatements.dbType());
     }
 }

--- a/app/src/test/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepositoryTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/sql/repositories/SqlEventRepositoryTest.java
@@ -1,0 +1,51 @@
+package io.apicurio.registry.storage.impl.sql.repositories;
+
+import io.apicurio.registry.storage.dto.OutboxEvent;
+import io.apicurio.registry.storage.impl.sql.HandleFactory;
+import io.apicurio.registry.storage.impl.sql.SqlStatements;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SqlEventRepositoryTest {
+    @Test
+    public void testCreateNullEvent() {
+        SqlEventRepository repository = new SqlEventRepository(
+                Mockito.mock(HandleFactory.class),
+                Mockito.mock(SqlStatements.class),
+                Mockito.mock(Logger.class),
+                "events-topic"
+        );
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> repository.createEvent(null));
+        assertEquals("OutboxEvent must not be null", exception.getMessage());
+    }
+
+    @Test
+    public void testCreateEventWithNullPayload() {
+        SqlEventRepository repository = new SqlEventRepository(
+                Mockito.mock(HandleFactory.class),
+                Mockito.mock(SqlStatements.class),
+                Mockito.mock(Logger.class),
+                "events-topic"
+        );
+
+        OutboxEvent eventWithNullPayload = new OutboxEvent("id-123", "agg-123") {
+            @Override public JSONObject getPayload() {
+                return null;
+            }
+
+            @Override public String getType() {
+                return "TEST_TYPE";
+            }
+        };
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> repository.createEvent(eventWithNullPayload));
+        assertEquals("OutboxEvent payload must not be null", exception.getMessage());
+    }
+}


### PR DESCRIPTION
Add null checks against a null event and a null event.getPayload() to prevent NullPointerException, utilizes the previously unused log field, debug level logging when a db type doesn't support outbox events (expected for H2/MySQL), and trace-level logging on successful writes. Flips dbType().equals(...) to constant first to guard against a null dbType().


Closes: #9550 