### PR TITLE
fix(search): route structure filter artifact searches through the search index

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecorator.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecorator.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.decorator;
 
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
 import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
@@ -14,6 +15,8 @@ import io.apicurio.registry.storage.impl.search.ElasticsearchSearchService;
 import io.apicurio.registry.storage.impl.search.ElasticsearchStartupIndexer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,6 +32,8 @@ import java.util.Set;
 @ApplicationScoped
 public class ElasticsearchSearchDecorator extends RegistryStorageDecoratorBase
         implements RegistryStorageDecorator {
+
+    private static final Logger log = LoggerFactory.getLogger(ElasticsearchSearchDecorator.class);
 
     private static final String INDEX_NOT_AVAILABLE_MESSAGE =
             "Content search requires the Elasticsearch search index, which is not "
@@ -68,7 +73,7 @@ public class ElasticsearchSearchDecorator extends RegistryStorageDecoratorBase
             try {
                 return searchService.searchVersions(filters, orderBy, orderDirection,
                         offset, limit, skipCount);
-            } catch (IOException e) {
+            } catch (IOException | ElasticsearchException e) {
                 throw new RegistryStorageException(
                         "Elasticsearch search failed for index-only filters.", e);
             }
@@ -90,9 +95,15 @@ public class ElasticsearchSearchDecorator extends RegistryStorageDecoratorBase
      * name matching, case-normalized labels) on the SQL side, where the behavior matches
      * non-index searches.</p>
      *
-     * <p>Both the index scan and the SQL scan are capped at
-     * {@link ElasticsearchSearchService#MAX_ARTIFACT_SEARCH_HITS} entries, so results beyond
-     * that many candidates are not included.</p>
+     * <p><b>Hard cap (part of the search contract):</b> both the index scan and the SQL scan
+     * retrieve at most {@link ElasticsearchSearchService#MAX_ARTIFACT_SEARCH_HITS} candidates,
+     * and the returned result count is computed from their intersection. When more artifacts
+     * than the cap match, results beyond the cap are omitted and the count understates the true
+     * total — a paginating client will stop early. A warning is logged when either scan hits
+     * the cap. Callers should scope index-backed searches (e.g. with an artifact-type filter,
+     * as the well-known A2A endpoints always do) so the candidate sets stay below the cap; a
+     * request carrying only index-only filters leaves the SQL scan unscoped and it degrades to
+     * a full-catalog scan up to the cap.</p>
      */
     public ArtifactSearchResultsDto searchArtifacts(Set<SearchFilter> filters, OrderBy orderBy,
             OrderDirection orderDirection, int offset, int limit, boolean skipCount)
@@ -121,7 +132,7 @@ public class ElasticsearchSearchDecorator extends RegistryStorageDecoratorBase
         Set<String> matchedIdentities;
         try {
             matchedIdentities = searchService.searchArtifactIdentities(esFilters);
-        } catch (IOException e) {
+        } catch (IOException | ElasticsearchException e) {
             throw new RegistryStorageException(
                     "Elasticsearch search failed for index-only filters.", e);
         }
@@ -133,6 +144,11 @@ public class ElasticsearchSearchDecorator extends RegistryStorageDecoratorBase
 
         ArtifactSearchResultsDto sqlResults = delegate.searchArtifacts(sqlFilters, orderBy,
                 orderDirection, 0, ElasticsearchSearchService.MAX_ARTIFACT_SEARCH_HITS, true);
+        if (sqlResults.getArtifacts().size() >= ElasticsearchSearchService.MAX_ARTIFACT_SEARCH_HITS) {
+            log.warn("Artifact search SQL scan reached the cap of {} artifacts; matches beyond "
+                    + "the cap are not included and the reported count may understate the true "
+                    + "total.", ElasticsearchSearchService.MAX_ARTIFACT_SEARCH_HITS);
+        }
 
         List<SearchedArtifactDto> matched = new ArrayList<>();
         for (SearchedArtifactDto artifact : sqlResults.getArtifacts()) {

--- a/app/src/main/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecorator.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecorator.java
@@ -4,6 +4,8 @@ import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
 import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.SearchFilter;
+import io.apicurio.registry.storage.dto.SearchFilterType;
+import io.apicurio.registry.storage.dto.SearchedArtifactDto;
 import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
 import io.apicurio.registry.storage.error.ContentSearchNotSupportedException;
 import io.apicurio.registry.storage.error.RegistryStorageException;
@@ -14,6 +16,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -24,6 +29,10 @@ import java.util.Set;
 @ApplicationScoped
 public class ElasticsearchSearchDecorator extends RegistryStorageDecoratorBase
         implements RegistryStorageDecorator {
+
+    private static final String INDEX_NOT_AVAILABLE_MESSAGE =
+            "Content search requires the Elasticsearch search index, which is not "
+            + "available. Enable the Elasticsearch search index to use content search.";
 
     @Inject
     ElasticsearchSearchConfig config;
@@ -54,9 +63,7 @@ public class ElasticsearchSearchDecorator extends RegistryStorageDecoratorBase
             throws RegistryStorageException {
         if (searchService.requiresSearchIndex(filters)) {
             if (!startupIndexer.isReady()) {
-                throw new ContentSearchNotSupportedException(
-                        "Content search requires the Elasticsearch search index, which is not "
-                        + "available. Enable the Elasticsearch search index to use content search.");
+                throw new ContentSearchNotSupportedException(INDEX_NOT_AVAILABLE_MESSAGE);
             }
             try {
                 return searchService.searchVersions(filters, orderBy, orderDirection,
@@ -69,23 +76,77 @@ public class ElasticsearchSearchDecorator extends RegistryStorageDecoratorBase
         return delegate.searchVersions(filters, orderBy, orderDirection, offset, limit, skipCount);
     }
 
+    /**
+     * Intercepts artifact search requests that include index-only filters (content or structure,
+     * e.g. A2A agent skill/capability filters). The search index resolves which artifacts have a
+     * matching version, while the underlying SQL storage evaluates the remaining filters and
+     * supplies the authoritative artifact metadata (name, labels, timestamps) and ordering; the
+     * two result sets are intersected and paginated in memory. Searches without index-only
+     * filters fall through to the underlying SQL-based storage unchanged.
+     *
+     * <p>Only the index-only filters (plus the artifact-type filter, which has identical
+     * exact-match semantics in both backends) are evaluated by the index; every other filter is
+     * evaluated by SQL. This keeps filters with backend-specific semantics (wildcard-wrapped
+     * name matching, case-normalized labels) on the SQL side, where the behavior matches
+     * non-index searches.</p>
+     *
+     * <p>Both the index scan and the SQL scan are capped at
+     * {@link ElasticsearchSearchService#MAX_ARTIFACT_SEARCH_HITS} entries, so results beyond
+     * that many candidates are not included.</p>
+     */
     public ArtifactSearchResultsDto searchArtifacts(Set<SearchFilter> filters, OrderBy orderBy,
             OrderDirection orderDirection, int offset, int limit, boolean skipCount)
             throws RegistryStorageException {
-        if (searchService.requiresSearchIndex(filters)) {
-            if (!startupIndexer.isReady()) {
-                throw new ContentSearchNotSupportedException(
-                        "Content search requires the Elasticsearch search index, which is not "
-                        + "available. Enable the Elasticsearch search index to use content search.");
-            }
-            try {
-                return searchService.searchArtifacts(filters, orderBy, orderDirection,
-                        offset, limit, skipCount);
-            } catch (IOException e) {
-                throw new RegistryStorageException(
-                        "Elasticsearch search failed for index-only filters.", e);
+        if (!searchService.requiresSearchIndex(filters)) {
+            return delegate.searchArtifacts(filters, orderBy, orderDirection, offset, limit,
+                    skipCount);
+        }
+        if (!startupIndexer.isReady()) {
+            throw new ContentSearchNotSupportedException(INDEX_NOT_AVAILABLE_MESSAGE);
+        }
+
+        Set<SearchFilter> esFilters = new HashSet<>();
+        Set<SearchFilter> sqlFilters = new HashSet<>();
+        for (SearchFilter filter : filters) {
+            if (searchService.isIndexOnlyFilter(filter)) {
+                esFilters.add(filter);
+            } else {
+                sqlFilters.add(filter);
+                if (filter.getType() == SearchFilterType.artifactType) {
+                    esFilters.add(filter);
+                }
             }
         }
-        return delegate.searchArtifacts(filters, orderBy, orderDirection, offset, limit, skipCount);
+
+        Set<String> matchedIdentities;
+        try {
+            matchedIdentities = searchService.searchArtifactIdentities(esFilters);
+        } catch (IOException e) {
+            throw new RegistryStorageException(
+                    "Elasticsearch search failed for index-only filters.", e);
+        }
+
+        ArtifactSearchResultsDto results = new ArtifactSearchResultsDto();
+        if (matchedIdentities.isEmpty()) {
+            return results;
+        }
+
+        ArtifactSearchResultsDto sqlResults = delegate.searchArtifacts(sqlFilters, orderBy,
+                orderDirection, 0, ElasticsearchSearchService.MAX_ARTIFACT_SEARCH_HITS, true);
+
+        List<SearchedArtifactDto> matched = new ArrayList<>();
+        for (SearchedArtifactDto artifact : sqlResults.getArtifacts()) {
+            if (matchedIdentities.contains(ElasticsearchSearchService.identityKey(
+                    artifact.getGroupId(), artifact.getArtifactId()))) {
+                matched.add(artifact);
+            }
+        }
+
+        int total = matched.size();
+        int fromIndex = Math.min(Math.max(0, offset), total);
+        int toIndex = Math.min(fromIndex + Math.max(0, limit), total);
+        results.setArtifacts(new ArrayList<>(matched.subList(fromIndex, toIndex)));
+        results.setCount(skipCount ? 0 : total);
+        return results;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -51,6 +52,14 @@ public class ElasticsearchSearchService {
      */
     private static final Set<SearchFilterType> INDEX_ONLY_FILTER_TYPES = EnumSet.of(
             SearchFilterType.content, SearchFilterType.structure);
+
+    /**
+     * Maximum number of version documents scanned when resolving artifact identities for an
+     * artifact-level search with index-only filters. Kept at Elasticsearch's default
+     * {@code index.max_result_window} (10,000) so a single request can retrieve the full scan
+     * window without paging.
+     */
+    public static final int MAX_ARTIFACT_SEARCH_HITS = 10000;
 
     @Inject
     ElasticsearchClient client;
@@ -196,6 +205,73 @@ public class ElasticsearchSearchService {
                 .artifacts(artifacts)
                 .count(totalCount)
                 .build();
+    }
+
+    /**
+     * Checks whether the given filter can only be served by the search index (no SQL fallback).
+     *
+     * @param filter the search filter to check
+     * @return true if the filter requires the search index, false otherwise
+     */
+    public boolean isIndexOnlyFilter(SearchFilter filter) {
+        return INDEX_ONLY_FILTER_TYPES.contains(filter.getType());
+    }
+
+    /**
+     * Searches the Elasticsearch index for versions matching the given filters and returns the
+     * identity keys (see {@link #identityKey(String, String)}) of the distinct artifacts those
+     * versions belong to. Because the index stores one document per artifact <em>version</em>,
+     * an artifact matches when <em>any</em> of its versions matches the filters — consistent
+     * with how SQL artifact search evaluates other version-level filters ({@code EXISTS} over
+     * versions).
+     *
+     * <p>At most {@link #MAX_ARTIFACT_SEARCH_HITS} version documents are scanned; a warning is
+     * logged when the cap is reached.</p>
+     *
+     * @param filters the search filters to apply
+     * @return the identity keys of artifacts with at least one matching version
+     * @throws IOException if an error occurs during search
+     */
+    public Set<String> searchArtifactIdentities(Set<SearchFilter> filters) throws IOException {
+        Query query = buildEsQuery(filters);
+
+        SearchResponse<Map> response = client.search(s -> s
+                .index(config.getIndexName())
+                .query(query)
+                .from(0)
+                .size(MAX_ARTIFACT_SEARCH_HITS)
+                .source(src -> src.filter(f -> f.includes("groupId", "artifactId")))
+                .trackTotalHits(t -> t.enabled(false)), Map.class);
+
+        Set<String> identities = new LinkedHashSet<>();
+        for (Hit<Map> hit : response.hits().hits()) {
+            Map<String, Object> source = hit.source();
+            if (source != null && source.get("artifactId") != null) {
+                identities.add(identityKey(toStr(source.get("groupId")),
+                        toStr(source.get("artifactId"))));
+            }
+        }
+
+        if (response.hits().hits().size() >= MAX_ARTIFACT_SEARCH_HITS) {
+            log.warn("Artifact identity search reached the scan cap of {} version documents; "
+                    + "matches beyond the cap are not included.", MAX_ARTIFACT_SEARCH_HITS);
+        }
+
+        return identities;
+    }
+
+    /**
+     * Builds a normalized identity key for an artifact. The index stores {@code "default"} for
+     * the default group while SQL search results use {@code null}; both normalize to the same
+     * key so identities from either source can be compared.
+     *
+     * @param groupId the group ID (may be null for the default group)
+     * @param artifactId the artifact ID
+     * @return the identity key
+     */
+    public static String identityKey(String groupId, String artifactId) {
+        String normalizedGroupId = groupId == null ? "default" : groupId;
+        return normalizedGroupId + '\0' + artifactId;
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSearchRepository.java
@@ -38,6 +38,11 @@ public class SqlSearchRepository {
             "Content search requires the search index, which is not enabled. "
             + "Enable the search index to use content search.";
 
+    private static final String STRUCTURE_SEARCH_UNSUPPORTED_MESSAGE =
+            "Structured-content search (e.g. A2A agent skill, capability, or mode filters) "
+            + "requires the search index, which is not enabled. "
+            + "Enable the search index to use structured search.";
+
     private final Logger log;
 
     private final SqlStatements sqlStatements;
@@ -168,6 +173,8 @@ public class SqlSearchRepository {
                         break;
                     case content:
                         throw new ContentSearchNotSupportedException(CONTENT_SEARCH_UNSUPPORTED_MESSAGE);
+                    case structure:
+                        throw new ContentSearchNotSupportedException(STRUCTURE_SEARCH_UNSUPPORTED_MESSAGE);
                     default:
                         throw new RegistryStorageException("Filter type not supported: " + filter.getType());
                 }
@@ -347,6 +354,8 @@ public class SqlSearchRepository {
                         break;
                     case content:
                         throw new ContentSearchNotSupportedException(CONTENT_SEARCH_UNSUPPORTED_MESSAGE);
+                    case structure:
+                        throw new ContentSearchNotSupportedException(STRUCTURE_SEARCH_UNSUPPORTED_MESSAGE);
                     default:
                         throw new RegistryStorageException("Filter type not supported: " + filter.getType());
                 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/a2a/WellKnownResourceTest.java
@@ -261,6 +261,55 @@ public class WellKnownResourceTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void testSearchAgentsBySkillWithoutSearchIndexReturns400() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        createAgentCard(groupId, "skill-filter-agent", AGENT_CARD_CONTENT);
+
+        // Skill/capability/mode filters require the search index, which is not enabled in this
+        // profile. The request must fail with a clear 400, not a 500.
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("skill", "test-skill")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(400);
+
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("capability", "streaming:true")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(400);
+
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("inputMode", "text")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void testAdvancedSearchAgentsBySkillWithoutSearchIndexReturns400() {
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "filters": {
+                                "skills": ["test-skill"]
+                            }
+                        }
+                        """)
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
     public void testSearchAgentsPartialNameMatch() throws Exception {
         String groupId = TestUtils.generateGroupId();
 

--- a/app/src/test/java/io/apicurio/registry/search/ElasticsearchA2ATestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/search/ElasticsearchA2ATestProfile.java
@@ -1,0 +1,19 @@
+package io.apicurio.registry.search;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test profile that enables the Elasticsearch search index (via Dev Services) together with A2A
+ * protocol support, so that well-known agent searches with skill/capability/mode filters can be
+ * served by the search index.
+ */
+public class ElasticsearchA2ATestProfile extends ElasticsearchSearchTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> overrides = new HashMap<>(super.getConfigOverrides());
+        overrides.put("apicurio.a2a.enabled", "true");
+        return overrides;
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/search/WellKnownAgentSearchViaIndexTest.java
+++ b/app/src/test/java/io/apicurio/registry/search/WellKnownAgentSearchViaIndexTest.java
@@ -1,0 +1,248 @@
+package io.apicurio.registry.search;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import io.apicurio.registry.storage.impl.search.ElasticsearchIndexUpdater;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Integration tests for well-known A2A agent searches that use skill/capability/mode filters.
+ * These filters are translated into structure filters, which can only be served by the
+ * Elasticsearch search index; this test verifies the artifact search path is routed through
+ * the index (see {@code ElasticsearchSearchDecorator#searchArtifacts}).
+ */
+@QuarkusTest
+@TestProfile(ElasticsearchA2ATestProfile.class)
+public class WellKnownAgentSearchViaIndexTest extends AbstractResourceTestBase {
+
+    @Inject
+    ElasticsearchIndexUpdater indexUpdater;
+
+    private String serverRootUrl;
+
+    @BeforeEach
+    public void setUpWellKnown() {
+        int port = ConfigProvider.getConfig().getValue("quarkus.http.test-port", Integer.class);
+        serverRootUrl = "http://localhost:" + port;
+    }
+
+    private RequestSpecification givenAtRoot() {
+        return RestAssured.given().baseUri(serverRootUrl);
+    }
+
+    private static String agentCard(String name, String skillId, boolean streaming) {
+        return """
+                {
+                    "name": "%s",
+                    "description": "Agent for skill %s",
+                    "version": "1.0.0",
+                    "supportedInterfaces": [
+                        { "url": "https://example.com/%s", "protocolBinding": "http+json", "protocolVersion": "1.0" }
+                    ],
+                    "capabilities": {
+                        "streaming": %s,
+                        "pushNotifications": false
+                    },
+                    "skills": [
+                        {
+                            "id": "%s",
+                            "name": "Skill %s",
+                            "description": "A skill",
+                            "tags": ["testing"]
+                        }
+                    ],
+                    "defaultInputModes": ["text"],
+                    "defaultOutputModes": ["text"]
+                }
+                """.formatted(name, skillId, name, streaming, skillId, skillId);
+    }
+
+    private void createAgentCard(String groupId, String artifactId, String content) throws Exception {
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactId(artifactId);
+        createArtifact.setArtifactType(ArtifactType.AGENT_CARD);
+
+        CreateVersion createVersion = new CreateVersion();
+        VersionContent versionContent = new VersionContent();
+        versionContent.setContent(content);
+        versionContent.setContentType(ContentTypes.APPLICATION_JSON);
+        createVersion.setContent(versionContent);
+        createArtifact.setFirstVersion(createVersion);
+
+        clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+    }
+
+    @Test
+    public void testSearchAgentsBySkill() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        // Skill IDs must be unique across the shared index, since skill search is not
+        // scoped to a group
+        String skillA = "skill-a-" + TestUtils.generateArtifactId();
+        String skillB = "skill-b-" + TestUtils.generateArtifactId();
+
+        createAgentCard(groupId, "skill-search-agent-1", agentCard("SkillAgentOne", skillA, true));
+        createAgentCard(groupId, "skill-search-agent-2", agentCard("SkillAgentTwo", skillB, true));
+
+        indexUpdater.awaitIdle(10, TimeUnit.SECONDS);
+
+        // Searching by skill A must return exactly the first agent
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("skill", skillA)
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("agents[0].artifactId", equalTo("skill-search-agent-1"))
+                .body("agents[0].groupId", equalTo(groupId))
+                .body("agents[0].skills", hasItem(skillA));
+
+        // Searching for an unknown skill must return no results
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("skill", "no-such-skill-" + TestUtils.generateArtifactId())
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(0));
+    }
+
+    @Test
+    public void testSearchAgentsBySkillAndName() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String sharedSkill = "shared-skill-" + TestUtils.generateArtifactId();
+
+        createAgentCard(groupId, "combined-agent-alpha", agentCard("CombinedAlpha", sharedSkill, true));
+        createAgentCard(groupId, "combined-agent-beta", agentCard("CombinedBeta", sharedSkill, true));
+
+        indexUpdater.awaitIdle(10, TimeUnit.SECONDS);
+
+        // The skill matches both agents; the name filter narrows to one. As in the other
+        // well-known search tests, the name filter matches against the artifactId.
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("skill", sharedSkill)
+                .queryParam("name", "combined-agent-alpha")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("agents[0].artifactId", equalTo("combined-agent-alpha"));
+
+        // The skill alone matches both
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("skill", sharedSkill)
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(2));
+    }
+
+    @Test
+    public void testSearchAgentsByCapability() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String skillStreaming = "cap-skill-" + TestUtils.generateArtifactId();
+        String skillPlain = "cap-skill-" + TestUtils.generateArtifactId();
+
+        createAgentCard(groupId, "capability-agent-streaming",
+                agentCard("CapabilityStreamingAgent", skillStreaming, true));
+        createAgentCard(groupId, "capability-agent-plain",
+                agentCard("CapabilityPlainAgent", skillPlain, false));
+
+        indexUpdater.awaitIdle(10, TimeUnit.SECONDS);
+
+        // capability=streaming:true must include the streaming agent and exclude the other
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("capability", "streaming:true")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem("capability-agent-streaming"))
+                .body("agents.artifactId", not(hasItem("capability-agent-plain")));
+
+        // capability=streaming:false must include the non-streaming agent and exclude the other
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("capability", "streaming:false")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("agents.artifactId", hasItem("capability-agent-plain"))
+                .body("agents.artifactId", not(hasItem("capability-agent-streaming")));
+    }
+
+    @Test
+    public void testAdvancedSearchAgentsBySkill() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String skillId = "advanced-skill-" + TestUtils.generateArtifactId();
+
+        createAgentCard(groupId, "advanced-search-agent", agentCard("AdvancedSearchAgent", skillId, true));
+
+        indexUpdater.awaitIdle(10, TimeUnit.SECONDS);
+
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .body("""
+                        {
+                            "filters": {
+                                "skills": ["%s"]
+                            }
+                        }
+                        """.formatted(skillId))
+                .post("/.well-known/agents/search")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("agents[0].artifactId", equalTo("advanced-search-agent"));
+    }
+
+    @Test
+    public void testSearchAgentsByInputMode() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String skillId = "mode-skill-" + TestUtils.generateArtifactId();
+
+        createAgentCard(groupId, "input-mode-agent", agentCard("InputModeAgent", skillId, true));
+
+        indexUpdater.awaitIdle(10, TimeUnit.SECONDS);
+
+        // All test agent cards declare the "text" input mode; combine with the unique skill
+        // to isolate this test's agent
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("skill", skillId)
+                .queryParam("inputMode", "text")
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("agents[0].artifactId", equalTo("input-mode-agent"));
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/search/WellKnownAgentSearchViaIndexTest.java
+++ b/app/src/test/java/io/apicurio/registry/search/WellKnownAgentSearchViaIndexTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Integration tests for well-known A2A agent searches that use skill/capability/mode filters.
@@ -159,6 +160,28 @@ public class WellKnownAgentSearchViaIndexTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200)
                 .body("count", equalTo(2));
+    }
+
+    @Test
+    public void testSearchAgentsBySkillInDefaultGroup() throws Exception {
+        String artifactId = "default-group-agent-" + TestUtils.generateArtifactId();
+        String skillId = "default-group-skill-" + TestUtils.generateArtifactId();
+
+        createAgentCard("default", artifactId, agentCard("DefaultGroupAgent", skillId, true));
+
+        indexUpdater.awaitIdle(10, TimeUnit.SECONDS);
+
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .queryParam("skill", skillId)
+                .get("/.well-known/agents")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(1))
+                .body("agents[0].artifactId", equalTo(artifactId))
+                .body("agents[0].groupId", nullValue())
+                .body("agents[0].skills", hasItem(skillId));
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecoratorTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecoratorTest.java
@@ -1,10 +1,11 @@
 package io.apicurio.registry.storage.decorator;
 
 import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
 import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.SearchFilter;
-import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
+import io.apicurio.registry.storage.dto.SearchedArtifactDto;
 import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
 import io.apicurio.registry.storage.error.ContentSearchNotSupportedException;
 import io.apicurio.registry.storage.impl.search.ElasticsearchSearchConfig;
@@ -14,11 +15,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -92,44 +102,114 @@ public class ElasticsearchSearchDecoratorTest {
 
     @Test
     void searchArtifactsThrowsContentSearchNotSupportedWhenIndexerNotReady() {
-        Set<SearchFilter> filters = Set.of(SearchFilter.ofContent("test"));
+        Set<SearchFilter> filters = Set.of(SearchFilter.ofStructure("agent_card:skill:test-skill"));
         when(searchService.requiresSearchIndex(filters)).thenReturn(true);
         when(startupIndexer.isReady()).thenReturn(false);
 
         assertThrows(ContentSearchNotSupportedException.class,
-                () -> decorator.searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10, false));
+                () -> decorator.searchArtifacts(filters, OrderBy.createdOn, OrderDirection.desc, 0, 10, false));
 
-        verifyNoInteractions(delegate);
-    }
-
-    @Test
-    void searchArtifactsDelegatesToSearchServiceWhenIndexerReady() throws IOException {
-        Set<SearchFilter> filters = Set.of(SearchFilter.ofContent("test"));
-        ArtifactSearchResultsDto results = ArtifactSearchResultsDto.builder().count(1).build();
-        when(searchService.requiresSearchIndex(filters)).thenReturn(true);
-        when(startupIndexer.isReady()).thenReturn(true);
-        when(searchService.searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10, false))
-                .thenReturn(results);
-
-        ArtifactSearchResultsDto actual = decorator.searchArtifacts(filters, OrderBy.name, OrderDirection.asc,
-                0, 10, false);
-
-        assertEquals(results, actual);
         verifyNoInteractions(delegate);
     }
 
     @Test
     void searchArtifactsFallsThroughToDelegateWhenIndexNotRequired() {
         Set<SearchFilter> filters = Set.of(SearchFilter.ofName("test"));
-        ArtifactSearchResultsDto results = ArtifactSearchResultsDto.builder().count(1).build();
+        ArtifactSearchResultsDto results = new ArtifactSearchResultsDto();
         when(searchService.requiresSearchIndex(filters)).thenReturn(false);
-        when(delegate.searchArtifacts(filters, OrderBy.name, OrderDirection.asc, 0, 10, false))
+        when(delegate.searchArtifacts(filters, OrderBy.createdOn, OrderDirection.desc, 0, 10, false))
                 .thenReturn(results);
 
-        ArtifactSearchResultsDto actual = decorator.searchArtifacts(filters, OrderBy.name, OrderDirection.asc,
-                0, 10, false);
+        ArtifactSearchResultsDto actual = decorator.searchArtifacts(filters, OrderBy.createdOn,
+                OrderDirection.desc, 0, 10, false);
 
         assertEquals(results, actual);
         verifyNoInteractions(startupIndexer);
+    }
+
+    @Test
+    void searchArtifactsReturnsEmptyWithoutSqlQueryWhenIndexHasNoMatches() throws IOException {
+        SearchFilter structureFilter = SearchFilter.ofStructure("agent_card:skill:no-such-skill");
+        Set<SearchFilter> filters = Set.of(structureFilter);
+        when(searchService.requiresSearchIndex(filters)).thenReturn(true);
+        when(startupIndexer.isReady()).thenReturn(true);
+        when(searchService.isIndexOnlyFilter(structureFilter)).thenReturn(true);
+        when(searchService.searchArtifactIdentities(filters)).thenReturn(Set.of());
+
+        ArtifactSearchResultsDto actual = decorator.searchArtifacts(filters, OrderBy.createdOn,
+                OrderDirection.desc, 0, 10, false);
+
+        assertEquals(0, actual.getCount());
+        assertEquals(0, actual.getArtifacts().size());
+        verify(delegate, never()).searchArtifacts(anySet(), any(), any(), anyInt(), anyInt(), anyBoolean());
+    }
+
+    @Test
+    void searchArtifactsIntersectsIndexMatchesWithSqlResults() throws IOException {
+        SearchFilter structureFilter = SearchFilter.ofStructure("agent_card:skill:test-skill");
+        SearchFilter typeFilter = SearchFilter.ofArtifactType("AGENT_CARD");
+        Set<SearchFilter> filters = Set.of(structureFilter, typeFilter);
+        when(searchService.requiresSearchIndex(filters)).thenReturn(true);
+        when(startupIndexer.isReady()).thenReturn(true);
+        when(searchService.isIndexOnlyFilter(structureFilter)).thenReturn(true);
+        when(searchService.isIndexOnlyFilter(typeFilter)).thenReturn(false);
+        when(searchService.searchArtifactIdentities(filters)).thenReturn(Set.of(
+                ElasticsearchSearchService.identityKey(null, "agent-1"),
+                ElasticsearchSearchService.identityKey("group-1", "agent-3")));
+
+        // SQL returns three artifacts; only two of them have a matching version in the index
+        ArtifactSearchResultsDto sqlResults = new ArtifactSearchResultsDto();
+        sqlResults.setArtifacts(new ArrayList<>(List.of(
+                searchedArtifact(null, "agent-1"),
+                searchedArtifact(null, "agent-2"),
+                searchedArtifact("group-1", "agent-3"))));
+        when(delegate.searchArtifacts(eq(Set.of(typeFilter)), eq(OrderBy.createdOn),
+                eq(OrderDirection.desc), eq(0), eq(ElasticsearchSearchService.MAX_ARTIFACT_SEARCH_HITS),
+                eq(true))).thenReturn(sqlResults);
+
+        ArtifactSearchResultsDto actual = decorator.searchArtifacts(filters, OrderBy.createdOn,
+                OrderDirection.desc, 0, 10, false);
+
+        assertEquals(2, actual.getCount());
+        assertEquals(2, actual.getArtifacts().size());
+        assertEquals("agent-1", actual.getArtifacts().get(0).getArtifactId());
+        assertEquals("agent-3", actual.getArtifacts().get(1).getArtifactId());
+        assertEquals("group-1", actual.getArtifacts().get(1).getGroupId());
+    }
+
+    @Test
+    void searchArtifactsAppliesOffsetAndLimitAfterIntersection() throws IOException {
+        SearchFilter structureFilter = SearchFilter.ofStructure("agent_card:skill:test-skill");
+        Set<SearchFilter> filters = Set.of(structureFilter);
+        when(searchService.requiresSearchIndex(filters)).thenReturn(true);
+        when(startupIndexer.isReady()).thenReturn(true);
+        when(searchService.isIndexOnlyFilter(structureFilter)).thenReturn(true);
+        when(searchService.searchArtifactIdentities(filters)).thenReturn(Set.of(
+                ElasticsearchSearchService.identityKey(null, "agent-1"),
+                ElasticsearchSearchService.identityKey(null, "agent-2"),
+                ElasticsearchSearchService.identityKey(null, "agent-3")));
+
+        ArtifactSearchResultsDto sqlResults = new ArtifactSearchResultsDto();
+        sqlResults.setArtifacts(new ArrayList<>(List.of(
+                searchedArtifact(null, "agent-1"),
+                searchedArtifact(null, "agent-2"),
+                searchedArtifact(null, "agent-3"))));
+        when(delegate.searchArtifacts(eq(Set.of()), eq(OrderBy.createdOn), eq(OrderDirection.desc),
+                eq(0), eq(ElasticsearchSearchService.MAX_ARTIFACT_SEARCH_HITS), eq(true)))
+                .thenReturn(sqlResults);
+
+        ArtifactSearchResultsDto actual = decorator.searchArtifacts(filters, OrderBy.createdOn,
+                OrderDirection.desc, 1, 1, false);
+
+        assertEquals(3, actual.getCount());
+        assertEquals(1, actual.getArtifacts().size());
+        assertEquals("agent-2", actual.getArtifacts().get(0).getArtifactId());
+    }
+
+    private static SearchedArtifactDto searchedArtifact(String groupId, String artifactId) {
+        SearchedArtifactDto dto = new SearchedArtifactDto();
+        dto.setGroupId(groupId);
+        dto.setArtifactId(artifactId);
+        return dto;
     }
 }

--- a/app/src/test/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecoratorTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/decorator/ElasticsearchSearchDecoratorTest.java
@@ -1,5 +1,7 @@
 package io.apicurio.registry.storage.decorator;
 
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.ErrorResponse;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactSearchResultsDto;
 import io.apicurio.registry.storage.dto.OrderBy;
@@ -8,6 +10,7 @@ import io.apicurio.registry.storage.dto.SearchFilter;
 import io.apicurio.registry.storage.dto.SearchedArtifactDto;
 import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
 import io.apicurio.registry.storage.error.ContentSearchNotSupportedException;
+import io.apicurio.registry.storage.error.RegistryStorageException;
 import io.apicurio.registry.storage.impl.search.ElasticsearchSearchConfig;
 import io.apicurio.registry.storage.impl.search.ElasticsearchSearchService;
 import io.apicurio.registry.storage.impl.search.ElasticsearchStartupIndexer;
@@ -204,6 +207,47 @@ public class ElasticsearchSearchDecoratorTest {
         assertEquals(3, actual.getCount());
         assertEquals(1, actual.getArtifacts().size());
         assertEquals("agent-2", actual.getArtifacts().get(0).getArtifactId());
+    }
+
+    @Test
+    void searchVersionsWrapsElasticsearchExceptionAsStorageException() throws IOException {
+        Set<SearchFilter> filters = Set.of(SearchFilter.ofContent("test"));
+        ElasticsearchException esException = esException();
+        when(searchService.requiresSearchIndex(filters)).thenReturn(true);
+        when(startupIndexer.isReady()).thenReturn(true);
+        when(searchService.searchVersions(filters, OrderBy.name, OrderDirection.asc, 0, 10, false))
+                .thenThrow(esException);
+
+        RegistryStorageException exception = assertThrows(RegistryStorageException.class,
+                () -> decorator.searchVersions(filters, OrderBy.name, OrderDirection.asc, 0, 10, false));
+
+        assertEquals("Elasticsearch search failed for index-only filters.", exception.getMessage());
+        assertEquals(esException, exception.getCause());
+        verifyNoInteractions(delegate);
+    }
+
+    @Test
+    void searchArtifactsWrapsElasticsearchExceptionAsStorageException() throws IOException {
+        SearchFilter structureFilter = SearchFilter.ofStructure("agent_card:skill:test-skill");
+        Set<SearchFilter> filters = Set.of(structureFilter);
+        ElasticsearchException esException = esException();
+        when(searchService.requiresSearchIndex(filters)).thenReturn(true);
+        when(startupIndexer.isReady()).thenReturn(true);
+        when(searchService.isIndexOnlyFilter(structureFilter)).thenReturn(true);
+        when(searchService.searchArtifactIdentities(filters)).thenThrow(esException);
+
+        RegistryStorageException exception = assertThrows(RegistryStorageException.class,
+                () -> decorator.searchArtifacts(filters, OrderBy.createdOn, OrderDirection.desc, 0, 10, false));
+
+        assertEquals("Elasticsearch search failed for index-only filters.", exception.getMessage());
+        assertEquals(esException, exception.getCause());
+        verify(delegate, never()).searchArtifacts(anySet(), any(), any(), anyInt(), anyInt(), anyBoolean());
+    }
+
+    private static ElasticsearchException esException() {
+        return new ElasticsearchException("search", ErrorResponse.of(r -> r
+                .error(e -> e.type("transport_error").reason("connection refused"))
+                .status(500)));
     }
 
     private static SearchedArtifactDto searchedArtifact(String groupId, String artifactId) {

--- a/app/src/test/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchServiceTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -103,5 +104,17 @@ public class ElasticsearchSearchServiceTest {
 
         assertNotNull(query.bool());
         assertEquals(2, query.bool().must().size());
+    }
+
+    @Test
+    void identityKeyNormalizesDefaultGroup() {
+        // SQL search results use null for the default group while the index stores "default";
+        // both must map to the same identity key.
+        assertEquals(ElasticsearchSearchService.identityKey("default", "artifact-1"),
+                ElasticsearchSearchService.identityKey(null, "artifact-1"));
+        assertNotEquals(ElasticsearchSearchService.identityKey("group-1", "artifact-1"),
+                ElasticsearchSearchService.identityKey("group-2", "artifact-1"));
+        assertNotEquals(ElasticsearchSearchService.identityKey("group-1", "artifact-1"),
+                ElasticsearchSearchService.identityKey("group-1", "artifact-2"));
     }
 }


### PR DESCRIPTION
## Description

A2A agent searches with skill/capability/inputMode/outputMode filters returned HTTP 500 on every configuration: the filters become structure search filters, but ElasticsearchSearchDecorator only intercepted searchVersions(), so artifact searches always fell through to SQL, which rejects structure filters.


### Changes
- ElasticsearchSearchDecorator now intercepts searchArtifacts(): the index resolves which artifacts match the structure/content filters, SQL evaluates the remaining filters and supplies authoritative metadata/ordering, and the results are intersected.
- ElasticsearchSearchService: new searchArtifactIdentities() (dedupes version docs to artifacts, 10k scan cap) and group-normalizing identityKey().
- SqlSearchRepository: structure filters now fail with a clear 400 (ContentSearchNotSupportedException) instead of a 500 when the search index is disabled.
- **Outcome**: GET /.well-known/agents?skill(and capability/mode filters, plus POST /.well-known/agents/search) return correct results with the search index enabled, and a clear 400 without it. Previously: 500 always.

### Issue
fixes #9562 