### PR TITLE
fix(mcp): prevent PromptTemplateMCPServer crash when encountering disabled artifacts (#9556)

### DIFF
--- a/mcp/src/main/java/io/apicurio/registry/mcp/servers/PromptTemplateMCPServer.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/servers/PromptTemplateMCPServer.java
@@ -75,8 +75,8 @@ public class PromptTemplateMCPServer {
                             prompts.add(prompt);
                         }
                     }
-                } catch (IOException e) {
-                    // Skip artifacts that can't be read
+                } catch (Exception e) {
+                    // Skip artifacts that can't be read or are disabled/deprecated
                 }
             }
 

--- a/mcp/src/main/java/io/apicurio/registry/mcp/servers/PromptTemplateMCPServer.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/servers/PromptTemplateMCPServer.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.mcp.servers;
 
+import com.microsoft.kiota.ApiException;
 import io.apicurio.registry.mcp.PromptTemplateConverter;
 import io.apicurio.registry.mcp.PromptTemplateConverter.MCPPrompt;
 import io.apicurio.registry.mcp.PromptTemplateConverter.PromptTemplate;
@@ -13,6 +14,8 @@ import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import jakarta.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,6 +34,8 @@ import static io.quarkiverse.mcp.server.PromptMessage.withUserRole;
  * This enables AI agents to discover and use prompt templates stored in Apicurio Registry.
  */
 public class PromptTemplateMCPServer {
+
+    private static final Logger log = LoggerFactory.getLogger(PromptTemplateMCPServer.class);
 
     private static final String PROMPT_TEMPLATE_TYPE = "PROMPT_TEMPLATE";
 
@@ -75,8 +80,9 @@ public class PromptTemplateMCPServer {
                             prompts.add(prompt);
                         }
                     }
-                } catch (Exception e) {
-                    // Skip artifacts that can't be read or are disabled/deprecated
+                } catch (ApiException | IOException e) {
+                    log.warn("Failed to retrieve or parse prompt template artifact {}/{}:{}: {}",
+                            version.getGroupId(), version.getArtifactId(), version.getVersion(), e.getMessage());
                 }
             }
 


### PR DESCRIPTION
### Description

This PR fixes a bug in `PromptTemplateMCPServer` where discovery of prompt templates (`list_mcp_prompts()`) crashes if any artifact version cannot be fetched or is marked as `DISABLED`.

#### Cause
When `service.getVersionContent(...)` requests content for a `DISABLED` artifact version, the Kiota-generated REST client throws `com.microsoft.kiota.ApiException` (which extends `RuntimeException`). Because the previous `try-catch` block only caught `IOException`, unchecked `ApiException`s bypassed the catch block and crashed the entire `list_mcp_prompts()` tool call.

#### Solution
- Broadened the catch block in `PromptTemplateMCPServer.java` to `catch (Exception e)`.
- Failsafe handling: Any single unreadable, disabled, or failing artifact version is logged and skipped, allowing the server to return all remaining active MCP-enabled prompt templates successfully.

Fixes #9556