### PR TITLE
feat(ui): add icons + mappings for MCP_TOOL, OPENRPC, ICEBERG*, ODCS_CONTRACT

### DIFF
--- a/ui/ui-app/src/app/components/common/ArtifactTypeIcon.css
+++ b/ui/ui-app/src/app/components/common/ArtifactTypeIcon.css
@@ -122,31 +122,27 @@
 }
 
 .mcp-tool-icon24 {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Ccircle cx='12' cy='12' r='5.5' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M12 3.5v2.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M12 18v2.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M3.5 12h2.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M18 12h2.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M5.8 5.8l1.8 1.8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M16.4 16.4l1.8 1.8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M5.8 18.2l1.8-1.8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M16.4 7.6l1.8-1.8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjNjM2NmYxIj48cGF0aCBkPSJNNyAyaDJ2NGg2VjJoMnY0aDFhMiAyIDAgMCAxIDIgMnYzYTYgNiAwIDAgMS01IDUuOTJWMjFoLTJ2LTQuMDhBNiA2IDAgMCAxIDggMTFWOEg3YTIgMiAwIDAgMS0yLTJWNGEyIDIgMCAwIDEgMi0yem0xIDZ2M2E0IDQgMCAwIDAgOCAwVjhIOHoiLz48L3N2Zz4=');
     background-repeat: no-repeat;
-    background-size: 30px 30px;
-    background-position: center;
 }
 
 .iceberg-table-icon24 {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Crect x='4' y='4' width='16' height='16' rx='2' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M4 9h16' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M4 14h16' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M9 4v16' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M15 4v16' stroke='%236366f1' stroke-width='1.5'/%3E%3C/svg%3E");
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjZDk3NzA2Ij48cGF0aCBkPSJNNCA0aDE2djRINHptMCA2aDd2MTBINHptOSAwaDd2MTBoLTd6Ii8+PC9zdmc+');
     background-repeat: no-repeat;
 }
 
 .iceberg-view-icon24 {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6Z' stroke='%236366f1' stroke-width='1.5'/%3E%3Ccircle cx='12' cy='12' r='3' stroke='%236366f1' stroke-width='1.5'/%3E%3C/svg%3E");
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjZTExZDQ4Ij48cGF0aCBkPSJNMTIgNUM2IDUgMi43IDkuNCAyIDEyYy43IDIuNiA0IDcgMTAgN3M5LjMtNC40IDEwLTdjLS43LTIuNi00LTctMTAtN3ptMCAxMS41QTQuNSA0LjUgMCAxIDEgMTIgNy41YTQuNSA0LjUgMCAwIDEgMCA5em0wLTdhMi41IDIuNSAwIDEgMCAwIDUgMi41IDIuNSAwIDAgMCAwLTV6Ii8+PC9zdmc+');
     background-repeat: no-repeat;
 }
 
 .openrpc-icon24 {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Crect x='4.5' y='4.5' width='15' height='15' rx='2' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M7.5 8.5h9' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M7.5 12h6.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M12.5 15.5 14.5 13.5 16.5 15.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjMGQ5NDg4Ij48cGF0aCBkPSJNOS40IDQuNiA0IDEybDUuNCA3LjQgMS42LTEuMkw2LjYgMTJsNC40LTYuMnptNS4yIDAtMS42IDEuMkwxNy40IDEybC00LjQgNi4yIDEuNiAxLjJMMjAgMTJ6Ii8+PC9zdmc+');
     background-repeat: no-repeat;
-    background-size: 30px 30px;
-    background-position: center;
 }
 
 .odcs-contract-icon24 {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Crect x='5' y='3' width='14' height='18' rx='2' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M8 7h8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M8 11h8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M8 15h5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M15 15 17 17 20 14' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjNDc1NTY5Ij48cGF0aCBkPSJNNiAyaDlsNSA1djE1SDZ6bTggMS41VjhoNC41ek04LjcgMTUuM2wyIDIgNC42LTQuNi0xLjEtMS4xLTMuNSAzLjUtLjktLjl6Ii8+PC9zdmc+');
     background-repeat: no-repeat;
 }
 

--- a/ui/ui-app/src/app/components/common/ArtifactTypeIcon.css
+++ b/ui/ui-app/src/app/components/common/ArtifactTypeIcon.css
@@ -121,6 +121,35 @@
     background-repeat: no-repeat;
 }
 
+.mcp-tool-icon24 {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Ccircle cx='12' cy='12' r='5.5' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M12 3.5v2.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M12 18v2.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M3.5 12h2.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M18 12h2.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M5.8 5.8l1.8 1.8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M16.4 16.4l1.8 1.8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M5.8 18.2l1.8-1.8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M16.4 7.6l1.8-1.8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-size: 30px 30px;
+    background-position: center;
+}
+
+.iceberg-table-icon24 {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Crect x='4' y='4' width='16' height='16' rx='2' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M4 9h16' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M4 14h16' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M9 4v16' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M15 4v16' stroke='%236366f1' stroke-width='1.5'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+}
+
+.iceberg-view-icon24 {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6Z' stroke='%236366f1' stroke-width='1.5'/%3E%3Ccircle cx='12' cy='12' r='3' stroke='%236366f1' stroke-width='1.5'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+}
+
+.openrpc-icon24 {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Crect x='4.5' y='4.5' width='15' height='15' rx='2' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M7.5 8.5h9' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M7.5 12h6.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M12.5 15.5 14.5 13.5 16.5 15.5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-size: 30px 30px;
+    background-position: center;
+}
+
+.odcs-contract-icon24 {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Crect x='5' y='3' width='14' height='18' rx='2' stroke='%236366f1' stroke-width='1.5'/%3E%3Cpath d='M8 7h8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M8 11h8' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M8 15h5' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M15 15 17 17 20 14' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+}
+
 .thrift-icon24 {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjMjMxZjIwIj48cGF0aCBkPSJNMyA0aDE4djMuMmgtNy4xVjIwaC0zLjhWNy4ySDN6Ij48L3BhdGg+PC9zdmc+');
     background-repeat: no-repeat;

--- a/ui/ui-app/src/services/useArtifactTypesService.ts
+++ b/ui/ui-app/src/services/useArtifactTypesService.ts
@@ -20,6 +20,10 @@ export class ArtifactTypes {
     public static THRIFT = "THRIFT";
     public static AGENT_CARD = "AGENT_CARD";
     public static MCP_TOOL = "MCP_TOOL";
+    public static ICEBERG_TABLE = "ICEBERG_TABLE";
+    public static ICEBERG_VIEW = "ICEBERG_VIEW";
+    public static OPENRPC = "OPENRPC";
+    public static ODCS_CONTRACT = "ODCS_CONTRACT";
     public static MODEL_SCHEMA = "MODEL_SCHEMA";
     public static PROMPT_TEMPLATE = "PROMPT_TEMPLATE";
 
@@ -64,6 +68,18 @@ export class ArtifactTypes {
                 break;
             case "MCP_TOOL":
                 title = "MCP Tool Definition";
+                break;
+            case "ICEBERG_TABLE":
+                title = "Iceberg Table";
+                break;
+            case "ICEBERG_VIEW":
+                title = "Iceberg View";
+                break;
+            case "OPENRPC":
+                title = "OpenRPC Definition";
+                break;
+            case "ODCS_CONTRACT":
+                title = "ODCS Contract";
                 break;
             case "MODEL_SCHEMA":
                 title = "AI Model Schema";
@@ -116,6 +132,18 @@ export class ArtifactTypes {
                 break;
             case "MCP_TOOL":
                 title = "MCP Tool";
+                break;
+            case "ICEBERG_TABLE":
+                title = "Iceberg Table";
+                break;
+            case "ICEBERG_VIEW":
+                title = "Iceberg View";
+                break;
+            case "OPENRPC":
+                title = "OpenRPC";
+                break;
+            case "ODCS_CONTRACT":
+                title = "ODCS Contract";
                 break;
             case "MODEL_SCHEMA":
                 title = "Model Schema";
@@ -180,7 +208,19 @@ export class ArtifactTypes {
                 classes += " agentcard-icon24";
                 break;
             case "MCP_TOOL":
-                classes += " mcptool-icon24";
+                classes += " mcp-tool-icon24";
+                break;
+            case "ICEBERG_TABLE":
+                classes += " iceberg-table-icon24";
+                break;
+            case "ICEBERG_VIEW":
+                classes += " iceberg-view-icon24";
+                break;
+            case "OPENRPC":
+                classes += " openrpc-icon24";
+                break;
+            case "ODCS_CONTRACT":
+                classes += " odcs-contract-icon24";
                 break;
             case "MODEL_SCHEMA":
                 classes += " modelschema-icon24";


### PR DESCRIPTION
## Summary

Implements missing artifact-type icon mappings and CSS SVG icons for `MCP_TOOL`, `OPENRPC`, `ICEBERG_TABLE`, `ICEBERG_VIEW`, and `ODCS_CONTRACT`. Refines the `MCP_TOOL` and `OPENRPC` glyphs for visual consistency with existing icons.

## Related Issue

Closes #9561

## Files Changed

- **useArtifactTypesService.ts** artifact type constants and mapping
- **ArtifactTypeIcon.css**  SVG icon classes

**Before Video:**

[raw-recording (5).webm](https://github.com/user-attachments/assets/0130bbef-ecb9-437f-bb2c-8d1fff5ec527)


**After Video:**

[raw-recording (6).webm](https://github.com/user-attachments/assets/004084f9-491b-435f-bbfc-cffdd7939914)


## Notes for Reviewers

- Visual review is important please check icons at 24px and at typical list/compact sizes.
- No backend changes this is a UI-only change; should be safe across storage variants.
- Icons are CSS background SVGs  ensure any build step that minifies CSS preserves data-URIs.