### PR TITLE
fix(flink): shade utils/flink jar to bundle transitive dependencies

### DIFF
--- a/utils/flink/README.md
+++ b/utils/flink/README.md
@@ -95,6 +95,22 @@ catalog.close();
 mvn clean install -pl utils/flink -am
 ```
 
+The build produces a single self-contained (shaded) JAR. Flink's own libraries
+(`flink-table-api-java`, `flink-table-common`) and `slf4j-api` are intentionally
+excluded from the shaded JAR since Flink provides them on its runtime classpath.
+
+## Deployment
+
+Copy the shaded JAR into Flink's `lib` directory:
+
+```bash
+cp utils/flink/target/apicurio-registry-utils-flink-<version>.jar $FLINK_HOME/lib/
+```
+
+Manually collecting dependencies via `mvn dependency:copy-dependencies` is no
+longer necessary — the JAR already bundles everything it needs except what
+Flink provides.
+
 ## Testing
 
 Unit tests:

--- a/utils/flink/pom.xml
+++ b/utils/flink/pom.xml
@@ -131,6 +131,21 @@
                     <exclude>module-info.class</exclude>
                   </excludes>
                 </filter>
+                <!-- jackson-core ships its vendored FastDoubleParser as a multi-release jar.
+                     maven-shade-plugin's relocator rewrites the class bytecode of the
+                     META-INF/versions/{N}/ variants but doesn't move the jar entry to the
+                     relocated path (MSHADE-406, open/unresolved as of shade-plugin 3.6.2 -
+                     the latest release). That mismatch between entry path and internal class
+                     name makes the leftover entries unloadable, so they're excluded outright;
+                     the relocated base (non-versioned) implementation is a fully functional
+                     fallback on every JDK version, so this only drops a JDK-specific
+                     micro-optimization, not functionality. -->
+                <filter>
+                  <artifact>com.fasterxml.jackson.core:jackson-core</artifact>
+                  <excludes>
+                    <exclude>META-INF/versions/*/com/fasterxml/jackson/core/internal/shaded/fdp/**</exclude>
+                  </excludes>
+                </filter>
               </filters>
               <relocations>
                 <relocation>

--- a/utils/flink/pom.xml
+++ b/utils/flink/pom.xml
@@ -66,9 +66,14 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
+    <!-- Flink's runtime classpath always includes slf4j-api, and relocating slf4j-api
+         (instead of excluding it) would break SLF4J's binding mechanism, since a shaded
+         copy can't locate the logging implementation bound on Flink's classpath.
+         provided scope is the correct fix here, not shading. -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test dependencies -->
@@ -96,6 +101,47 @@
             <goals>
               <goal>test-jar</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Produces a shaded (fat/uber) jar so the module can be dropped directly into
+           $FLINK_HOME/lib without manually collecting transitive dependencies.
+           flink-table-api-java, flink-table-common, and slf4j-api are already excluded
+           automatically because they're scoped "provided". -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>com.fasterxml.jackson</pattern>
+                  <shadedPattern>io.apicurio.registry.flink.shaded.com.fasterxml.jackson</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Deploying the Flink catalog jar to a real cluster throws ClassNotFoundException: io.apicurio.registry.client.common.RegistryClientOptions on startup, because utils/flink was only ever building a thin jar — java-sdk, java-sdk-common, the Avro/JSON Schema serde modules, Avro, and Jackson were all on the compile classpath but never made it into the deployed artifact.

This adds maven-shade-plugin to produce a single self-contained jar. Jackson gets relocated to io.apicurio.registry.flink.shaded.com.fasterxml.jackson since Flink bundles its own Jackson and the two would otherwise clash at runtime; the ServicesResourceTransformer merges META-INF/services entries so Jackson's and Avro's service files don't clobber each other during the merge. The one thing I deliberately did not relocate is slf4j-api — I moved it to provided scope instead. Flink's runtime classpath always has slf4j-api on it, and relocating it would break SLF4J's binding mechanism, since a shaded copy can't find whatever logging implementation is bound on Flink's classpath. flink-table-api-java and flink-table-common were already provided and are excluded the same way.

Verified locally: mvn clean package -pl utils/flink -am and mvn test -pl utils/flink both pass (30/30 unit tests, including AvroFlinkTypeConverterTest). Inspected the built jar directly — RegistryClientOptions.class is present, org/apache/flink/table and org/slf4j are both absent (provided-scope exclusion working), org/apache/avro/Schema.class is present unrelocated as intended, and there are zero unrelocated com/fasterxml/jackson classes anywhere in the jar, including the META-INF/versions multi-release-JAR paths. That last one needed an explicit exclude filter on jackson-core's internal FastDoubleParser fork, since maven-shade-plugin's relocator doesn't rewrite MRJAR entry paths (MSHADE-406). I did not have a live registry instance available to run ApicurioCatalogIT end-to-end, so that's still worth a run before merge.

Closes #8285