### PR TITLE
fix(ci): pre-create CNI directory before setup-minikube to prevent chmod error

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -131,7 +131,10 @@ jobs:
           name: operator-test-images
           path: /tmp/
 
-
+      - name: Create CNI directory
+        run: |
+          sudo mkdir -p /etc/cni/net.d
+          sudo chmod 755 /etc/cni/net.d
 
       - uses: apicurio/apicurio-github-actions/setup-minikube@97d452c41f1abd7142c0ce2ac37e87922e35e71d # v2
         with:
@@ -240,7 +243,10 @@ jobs:
           name: operator-test-images
           path: /tmp/
 
-
+      - name: Create CNI directory
+        run: |
+          sudo mkdir -p /etc/cni/net.d
+          sudo chmod 755 /etc/cni/net.d
 
       # driver=none: Kubernetes runs directly on the host, sharing all runner
       # resources (4 vCPU / 16 GB) and the host network (localhost:5000 registry).

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -236,7 +236,10 @@ jobs:
           name: operator-test-artifacts
           path: registry/operator/
 
-
+      - name: Create CNI directory
+        run: |
+          sudo mkdir -p /etc/cni/net.d
+          sudo chmod 755 /etc/cni/net.d
 
       - uses: apicurio/apicurio-github-actions/setup-minikube@97d452c41f1abd7142c0ce2ac37e87922e35e71d # v2
         with:


### PR DESCRIPTION
# Description
When `setup-minikube` runs with `driver: 'none'` (via medyagh/setup-minikube), it unconditionally executes `sudo chmod 755 /etc/cni/net.d`. On GitHub Actions runner images, `/etc/cni/net.d` does not exist by default, causing the step to fail with:

>  chmod: cannot access '/etc/cni/net.d': No such file or directory
>   Error: The process '/usr/bin/sudo' failed with exit code 1

# Reason for Regression
In PR #8824 (commit 00f714e28), this issue was identified and referenced in the commit message, but the step pre-creating `/etc/cni/net.d` was accidentally omitted/dropped during PR review revisions, leaving empty lines before setup-minikube. 

# Changes
Pre-created `/etc/cni/net.d` with 755 permissions before `setup-minikube` in:
`.github/workflows/operator.yaml`
`.github/workflows/release-operator.yaml`