### PR TITLE
feat(schema-resolver): expose client retry config and retry registry outages

### DIFF
--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -83,17 +83,14 @@ public class RegistryClientRequestAdapterFactory {
 
         // Wrap with retry proxy if retry is enabled
         if (options.isRetryEnabled()) {
-            log.log(Level.INFO,
-                    "[apicurio-pr9091] wrapping RequestAdapter with retry maxAttempts={0} delayMs={1} backoff={2} maxDelayMs={3}",
+            log.log(Level.FINE,
+                    "Enabling registry HTTP client retry: maxAttempts={0}, delayMs={1}, backoffMultiplier={2}, maxDelayMs={3}",
                     new Object[]{
                             options.getMaxRetryAttempts(),
                             options.getRetryDelayMs(),
                             options.getBackoffMultiplier(),
                             options.getMaxRetryDelayMs()
                     });
-            System.out.println("[apicurio-pr9091] RequestAdapter retry proxy maxAttempts="
-                    + options.getMaxRetryAttempts()
-                    + " delayMs=" + options.getRetryDelayMs());
             adapter = createRetryProxy(adapter, options);
         }
 
@@ -215,8 +212,8 @@ public class RegistryClientRequestAdapterFactory {
                     if (isRetryable(cause) && attempt < maxRetryAttempts) {
                         attempt++;
                         long delayMs = calculateRetryDelay(attempt);
-                        log.log(Level.WARNING,
-                                "[apicurio-pr9091] HTTP retry {0}/{1} after {2}: {3}; sleeping {4}ms",
+                        log.log(Level.FINE,
+                                "Retryable registry HTTP failure on attempt {0}/{1} ({2}: {3}); sleeping {4}ms before retry",
                                 new Object[]{
                                         attempt,
                                         maxRetryAttempts,
@@ -224,9 +221,6 @@ public class RegistryClientRequestAdapterFactory {
                                         cause.getMessage(),
                                         delayMs
                                 });
-                        System.out.println("[apicurio-pr9091] HTTP retry " + attempt + "/" + maxRetryAttempts
-                                + " sleepMs=" + delayMs + " err=" + cause.getClass().getSimpleName()
-                                + ": " + cause.getMessage());
                         try {
                             Thread.sleep(delayMs);
                         } catch (InterruptedException interruptedException) {
@@ -235,13 +229,9 @@ public class RegistryClientRequestAdapterFactory {
                         }
                     } else {
                         if (isRetryable(cause) && attempt >= maxRetryAttempts) {
-                            log.log(Level.WARNING, "Maximum retry attempts ({0}) exceeded for {1}: {2}",
+                            log.log(Level.WARNING,
+                                    "Registry HTTP client exhausted {0} retry attempts due to {1}: {2}",
                                     new Object[]{maxRetryAttempts, cause.getClass().getName(), cause.getMessage()});
-                            System.out.println("[apicurio-pr9091] HTTP retry EXHAUSTED maxAttempts="
-                                    + maxRetryAttempts + " last=" + cause.getMessage());
-                        } else if (!isRetryable(cause)) {
-                            System.out.println("[apicurio-pr9091] HTTP error NOT retryable: "
-                                    + cause.getClass().getName() + ": " + cause.getMessage());
                         }
                         throw originalCause;
                     }

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -83,6 +83,17 @@ public class RegistryClientRequestAdapterFactory {
 
         // Wrap with retry proxy if retry is enabled
         if (options.isRetryEnabled()) {
+            log.log(Level.INFO,
+                    "[apicurio-pr9091] wrapping RequestAdapter with retry maxAttempts={0} delayMs={1} backoff={2} maxDelayMs={3}",
+                    new Object[]{
+                            options.getMaxRetryAttempts(),
+                            options.getRetryDelayMs(),
+                            options.getBackoffMultiplier(),
+                            options.getMaxRetryDelayMs()
+                    });
+            System.out.println("[apicurio-pr9091] RequestAdapter retry proxy maxAttempts="
+                    + options.getMaxRetryAttempts()
+                    + " delayMs=" + options.getRetryDelayMs());
             adapter = createRetryProxy(adapter, options);
         }
 
@@ -204,6 +215,18 @@ public class RegistryClientRequestAdapterFactory {
                     if (isRetryable(cause) && attempt < maxRetryAttempts) {
                         attempt++;
                         long delayMs = calculateRetryDelay(attempt);
+                        log.log(Level.WARNING,
+                                "[apicurio-pr9091] HTTP retry {0}/{1} after {2}: {3}; sleeping {4}ms",
+                                new Object[]{
+                                        attempt,
+                                        maxRetryAttempts,
+                                        cause.getClass().getName(),
+                                        cause.getMessage(),
+                                        delayMs
+                                });
+                        System.out.println("[apicurio-pr9091] HTTP retry " + attempt + "/" + maxRetryAttempts
+                                + " sleepMs=" + delayMs + " err=" + cause.getClass().getSimpleName()
+                                + ": " + cause.getMessage());
                         try {
                             Thread.sleep(delayMs);
                         } catch (InterruptedException interruptedException) {
@@ -214,6 +237,11 @@ public class RegistryClientRequestAdapterFactory {
                         if (isRetryable(cause) && attempt >= maxRetryAttempts) {
                             log.log(Level.WARNING, "Maximum retry attempts ({0}) exceeded for {1}: {2}",
                                     new Object[]{maxRetryAttempts, cause.getClass().getName(), cause.getMessage()});
+                            System.out.println("[apicurio-pr9091] HTTP retry EXHAUSTED maxAttempts="
+                                    + maxRetryAttempts + " last=" + cause.getMessage());
+                        } else if (!isRetryable(cause)) {
+                            System.out.println("[apicurio-pr9091] HTTP error NOT retryable: "
+                                    + cause.getClass().getName() + ": " + cause.getMessage());
                         }
                         throw originalCause;
                     }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -438,15 +438,15 @@ public class ERCache<V> {
                             "Could not retrieve schema for the cache. " + "Loading function returned null."));
                 }
             } catch (RuntimeException e) {
-                // TODO: verify if this is really needed, retries are already baked into the adapter ...
-                // if (i == retries || !(e.getCause() != null && e.getCause() instanceof ExecutionException
-                // && e.getCause().getCause() != null && e.getCause().getCause() instanceof ApiException
-                // && (((ApiException) e.getCause().getCause()).getResponseStatusCode() == 429)))
-                if (i == retries || !(e.getCause() != null && e.getCause() instanceof ApiException
-                        && (((ApiException) e.getCause()).getResponseStatusCode() == 429))) {
-                    log.error("Cache load failed after {} retries", i, e);
+                // Lab: retry rate-limits AND registry outages (connect refused / timeouts).
+                // Stock Apicurio only retried HTTP 429 here.
+                if (i == retries || !isRetriableCacheLoadFailure(e)) {
+                    log.error("Cache load failed after {} retries (retriable={})", i,
+                            isRetriableCacheLoadFailure(e), e);
                     return Result.error(new RuntimeException(e));
                 }
+                log.warn("Cache load attempt {}/{} failed with retriable error, backing off {}ms: {}",
+                        i + 1, retries + 1, backoff.toMillis(), rootMessage(e));
             }
             try {
                 Thread.sleep(backoff.toMillis());
@@ -456,6 +456,43 @@ public class ERCache<V> {
             }
         }
         return Result.error(new IllegalStateException("Unreachable."));
+    }
+
+    /**
+     * Retriable = rate-limit (429) OR transient network / registry-down errors.
+     * Stock upstream only treated 429 as retriable.
+     */
+    private static boolean isRetriableCacheLoadFailure(Throwable e) {
+        Throwable current = e;
+        while (current != null) {
+            if (current instanceof ApiException
+                    && ((ApiException) current).getResponseStatusCode() == 429) {
+                return true;
+            }
+            if (current instanceof java.net.ConnectException) {
+                return true;
+            }
+            if (current instanceof java.net.SocketTimeoutException) {
+                return true;
+            }
+            if (current instanceof java.io.IOException && current.getMessage() != null
+                    && current.getMessage().contains("Connection reset")) {
+                return true;
+            }
+            if ("io.vertx.core.http.HttpClosedException".equals(current.getClass().getName())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static String rootMessage(Throwable e) {
+        Throwable current = e;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current.getClass().getSimpleName() + ": " + current.getMessage();
     }
 
     private static class WrappedValue<V> {

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -438,14 +438,12 @@ public class ERCache<V> {
                             "Could not retrieve schema for the cache. " + "Loading function returned null."));
                 }
             } catch (RuntimeException e) {
-                // Lab: retry rate-limits AND registry outages (connect refused / timeouts).
-                // Stock Apicurio only retried HTTP 429 here.
+                // Retry rate-limits (429) and transient network / registry-down failures.
                 if (i == retries || !isRetriableCacheLoadFailure(e)) {
-                    log.error("Cache load failed after {} retries (retriable={})", i,
-                            isRetriableCacheLoadFailure(e), e);
+                    log.error("Schema cache load failed after {} retries", i, e);
                     return Result.error(new RuntimeException(e));
                 }
-                log.warn("Cache load attempt {}/{} failed with retriable error, backing off {}ms: {}",
+                log.debug("Schema cache load attempt {}/{} failed with retriable error; backing off {}ms: {}",
                         i + 1, retries + 1, backoff.toMillis(), rootMessage(e));
             }
             try {
@@ -459,8 +457,8 @@ public class ERCache<V> {
     }
 
     /**
-     * Retriable = rate-limit (429) OR transient network / registry-down errors.
-     * Stock upstream only treated 429 as retriable.
+     * Whether a schema-cache load failure should be retried: HTTP 429, connection
+     * failures, timeouts, connection resets, and Vert.x HTTP closed errors.
      */
     private static boolean isRetriableCacheLoadFailure(Throwable e) {
         Throwable current = e;

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -101,9 +101,28 @@ public class RegistryClientFacadeFactory {
             throw new IllegalStateException(e);
         }
 
-        // FIXME push retry options into the SchemaResolverConfig
-        if (Boolean.TRUE) {
-            clientOptions.retry();
+        // PR #9091 + lab diagnostics: log effective HTTP client retry knobs so
+        // Connect logs show whether SerDes config actually reached RegistryClientOptions.
+        if (config.getClientRetryEnabled()) {
+            int maxAttempts = (int) config.getClientRetryMaxAttempts();
+            long delayMs = config.getClientRetryDelayMs();
+            double backoff = config.getClientRetryBackoffMultiplier();
+            long maxDelayMs = config.getClientRetryMaxDelayMs();
+            logger.info(String.format(
+                    "Apicurio registry HTTP client retry ENABLED url=%s maxAttempts=%d delayMs=%d backoff=%s maxDelayMs=%d (cache retry-count=%d retry-backoff-ms=%d)",
+                    config.getRegistryUrl(), maxAttempts, delayMs, backoff, maxDelayMs,
+                    config.getRetryCount(), config.getRetryBackoff().toMillis()));
+            System.out.println("[apicurio-pr9091] HTTP client retry ENABLED"
+                    + " maxAttempts=" + maxAttempts
+                    + " delayMs=" + delayMs
+                    + " backoff=" + backoff
+                    + " maxDelayMs=" + maxDelayMs
+                    + " cacheRetryCount=" + config.getRetryCount());
+            clientOptions.retry(true, maxAttempts, delayMs, backoff, maxDelayMs);
+        } else {
+            logger.info("Apicurio registry HTTP client retry DISABLED for url=" + config.getRegistryUrl());
+            System.out.println("[apicurio-pr9091] HTTP client retry DISABLED");
+            clientOptions.disableRetry();
         }
 
         // Configure TLS/SSL

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -7,6 +7,7 @@ import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.resolver.config.SchemaResolverConfig;
 import io.vertx.core.Vertx;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -101,27 +102,18 @@ public class RegistryClientFacadeFactory {
             throw new IllegalStateException(e);
         }
 
-        // PR #9091 + lab diagnostics: log effective HTTP client retry knobs so
-        // Connect logs show whether SerDes config actually reached RegistryClientOptions.
         if (config.getClientRetryEnabled()) {
             int maxAttempts = (int) config.getClientRetryMaxAttempts();
             long delayMs = config.getClientRetryDelayMs();
             double backoff = config.getClientRetryBackoffMultiplier();
             long maxDelayMs = config.getClientRetryMaxDelayMs();
-            logger.info(String.format(
-                    "Apicurio registry HTTP client retry ENABLED url=%s maxAttempts=%d delayMs=%d backoff=%s maxDelayMs=%d (cache retry-count=%d retry-backoff-ms=%d)",
-                    config.getRegistryUrl(), maxAttempts, delayMs, backoff, maxDelayMs,
-                    config.getRetryCount(), config.getRetryBackoff().toMillis()));
-            System.out.println("[apicurio-pr9091] HTTP client retry ENABLED"
-                    + " maxAttempts=" + maxAttempts
-                    + " delayMs=" + delayMs
-                    + " backoff=" + backoff
-                    + " maxDelayMs=" + maxDelayMs
-                    + " cacheRetryCount=" + config.getRetryCount());
+            logger.log(Level.INFO,
+                    "Registry HTTP client retry enabled: url={0}, maxAttempts={1}, delayMs={2}, backoffMultiplier={3}, maxDelayMs={4}",
+                    new Object[]{config.getRegistryUrl(), maxAttempts, delayMs, backoff, maxDelayMs});
             clientOptions.retry(true, maxAttempts, delayMs, backoff, maxDelayMs);
         } else {
-            logger.info("Apicurio registry HTTP client retry DISABLED for url=" + config.getRegistryUrl());
-            System.out.println("[apicurio-pr9091] HTTP client retry DISABLED");
+            logger.log(Level.INFO,
+                    "Registry HTTP client retry disabled: url={0}", config.getRegistryUrl());
             clientOptions.disableRetry();
         }
 

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -208,6 +208,36 @@ public class SchemaResolverConfig extends AbstractConfig {
     public static final long RETRY_BACKOFF_MS_DEFAULT = 300;
 
     /**
+     * Enable or disable retry for the underlying registry client.
+     */
+    public static final String CLIENT_RETRY_ENABLED = "apicurio.registry.client.retry.enabled";
+    public static final boolean CLIENT_RETRY_ENABLED_DEFAULT = true;
+
+    /**
+     * Maximum number of retry attempts for the underlying registry client.
+     */
+    public static final String CLIENT_RETRY_MAX_ATTEMPTS = "apicurio.registry.client.retry.max-attempts";
+    public static final long CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT = 3;
+
+    /**
+     * Initial retry delay in milliseconds for the underlying registry client.
+     */
+    public static final String CLIENT_RETRY_DELAY_MS = "apicurio.registry.client.retry.delay-ms";
+    public static final long CLIENT_RETRY_DELAY_MS_DEFAULT = 250;
+
+    /**
+     * Exponential backoff multiplier for the underlying registry client.
+     */
+    public static final String CLIENT_RETRY_BACKOFF_MULTIPLIER = "apicurio.registry.client.retry.backoff-multiplier";
+    public static final double CLIENT_RETRY_BACKOFF_MULTIPLIER_DEFAULT = 2.0;
+
+    /**
+     * Maximum retry delay in milliseconds for the underlying registry client.
+     */
+    public static final String CLIENT_RETRY_MAX_DELAY_MS = "apicurio.registry.client.retry.max-delay-ms";
+    public static final long CLIENT_RETRY_MAX_DELAY_MS_DEFAULT = 10000;
+
+    /**
      * Used to indicate the serdes to dereference the schema. This is used in two different situation, once
      * the schema is registered, instructs the serdes to ask the server for the schema dereferenced. It is
      * also used to instruct the serializer to dereference the schema before registering it Registry, but this
@@ -434,6 +464,44 @@ public class SchemaResolverConfig extends AbstractConfig {
         return getDurationNonNegativeMillis(RETRY_BACKOFF_MS);
     }
 
+    public boolean getClientRetryEnabled() {
+        return getBoolean(CLIENT_RETRY_ENABLED);
+    }
+
+    public long getClientRetryMaxAttempts() {
+        return getLongNonNegative(CLIENT_RETRY_MAX_ATTEMPTS);
+    }
+
+    public long getClientRetryDelayMs() {
+        return getDurationNonNegativeMillis(CLIENT_RETRY_DELAY_MS).toMillis();
+    }
+
+    public double getClientRetryBackoffMultiplier() {
+        Object value = getObject(CLIENT_RETRY_BACKOFF_MULTIPLIER);
+        if (value == null) {
+            return CLIENT_RETRY_BACKOFF_MULTIPLIER_DEFAULT;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        } else if (value instanceof String) {
+            try {
+                return Double.parseDouble((String) value);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid configuration property value for '"
+                        + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a number-like value, but got a '"
+                        + value + "'.", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Invalid configuration property value for '"
+                    + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a number-like value, but got a '"
+                    + value + "'.");
+        }
+    }
+
+    public long getClientRetryMaxDelayMs() {
+        return getDurationNonNegativeMillis(CLIENT_RETRY_MAX_DELAY_MS).toMillis();
+    }
+
     public String getExplicitArtifactGroupId() {
         return getString(EXPLICIT_ARTIFACT_GROUP_ID);
     }
@@ -569,6 +637,11 @@ public class SchemaResolverConfig extends AbstractConfig {
             entry(FIND_LATEST_ARTIFACT, FIND_LATEST_ARTIFACT_DEFAULT),
             entry(CHECK_PERIOD_MS, CHECK_PERIOD_MS_DEFAULT), entry(RETRY_COUNT, RETRY_COUNT_DEFAULT),
             entry(RETRY_BACKOFF_MS, RETRY_BACKOFF_MS_DEFAULT),
+            entry(CLIENT_RETRY_ENABLED, CLIENT_RETRY_ENABLED_DEFAULT),
+            entry(CLIENT_RETRY_MAX_ATTEMPTS, CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT),
+            entry(CLIENT_RETRY_DELAY_MS, CLIENT_RETRY_DELAY_MS_DEFAULT),
+            entry(CLIENT_RETRY_BACKOFF_MULTIPLIER, CLIENT_RETRY_BACKOFF_MULTIPLIER_DEFAULT),
+            entry(CLIENT_RETRY_MAX_DELAY_MS, CLIENT_RETRY_MAX_DELAY_MS_DEFAULT),
             entry(DEREFERENCE_SCHEMA, DEREFERENCE_DEFAULT),
             entry(TLS_TRUSTSTORE_TYPE, TLS_TRUSTSTORE_TYPE_DEFAULT),
             entry(TLS_TRUST_ALL, TLS_TRUST_ALL_DEFAULT),


### PR DESCRIPTION
## Summary
- Exposes HTTP client retry settings via SerDes/converter config (based on #9091 / #8995): `apicurio.registry.client.retry.{enabled,max-attempts,delay-ms,backoff-multiplier,max-delay-ms}` and wires them into `RegistryClientOptions` instead of hardcoded `clientOptions.retry()`.
- Extends `ERCache` retries beyond HTTP 429 to transient network / registry-down failures (`ConnectException`, timeouts, connection reset, Vert.x `HttpClosedException`), controlled by existing `apicurio.registry.retry-count` / `retry-backoff-ms`.
- Adds production-style logging: INFO for effective client retry config, FINE/debug for per-attempt retries, WARNING/error when retries are exhausted.

## Motivation
Kafka Connect / Debezium converters fail hard on short Apicurio outages even when operators set `retry-count`. The existing cache retry only covers rate-limits, and HTTP client retries were not configurable from SerDes keys.

## Test plan
- [ ] `mvn -pl schema-resolver,java-sdk/common -am test`
- [ ] Configure converter with elevated `apicurio.registry.client.retry.max-attempts` / `delay-ms` and `apicurio.registry.retry-count`; confirm INFO log shows the configured values at client create
- [ ] Stop Apicurio briefly during auto-register / schema resolve; confirm retries occur and the task recovers when the registry returns (instead of failing after ~2s of default HTTP retries)
- [ ] Confirm non-retriable errors still fail without spinning


Made with [Cursor](https://cursor.com)